### PR TITLE
[jQuery] Added documentation URLs to JSDoc

### DIFF
--- a/jquery/index.d.ts
+++ b/jquery/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for jQuery 1.10.x / 2.0.x
 // Project: http://jquery.com/
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Christian Hoffmeister <https://github.com/choffmeister>, Steve Fenton <https://github.com/Steve-Fenton>, Diullei Gomes <https://github.com/Diullei>, Tass Iliopoulos <https://github.com/tasoili>, Jason Swearingen <https://github.com/jasons-novaleaf>, Sean Hill <https://github.com/seanski>, Guus Goossens <https://github.com/Guuz>, Kelly Summerlin <https://github.com/ksummerlin>, Basarat Ali Syed <https://github.com/basarat>, Nicholas Wolverson <https://github.com/nwolverson>, Derek Cicerone <https://github.com/derekcicerone>, Andrew Gaspar <https://github.com/AndrewGaspar>, James Harrison Fisher <https://github.com/jameshfisher>, Seikichi Kondo <https://github.com/seikichi>, Benjamin Jackman <https://github.com/benjaminjackman>, Poul Sorensen <https://github.com/s093294>, Josh Strobl <https://github.com/JoshStrobl>, John Reilly <https://github.com/johnnyreilly/>, Dick van den Brink <https://github.com/DickvdBrink>
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Christian Hoffmeister <https://github.com/choffmeister>, Steve Fenton <https://github.com/Steve-Fenton>, Diullei Gomes <https://github.com/Diullei>, Tass Iliopoulos <https://github.com/tasoili>, Jason Swearingen <https://github.com/jasons-novaleaf>, Sean Hill <https://github.com/seanski>, Guus Goossens <https://github.com/Guuz>, Kelly Summerlin <https://github.com/ksummerlin>, Basarat Ali Syed <https://github.com/basarat>, Nicholas Wolverson <https://github.com/nwolverson>, Derek Cicerone <https://github.com/derekcicerone>, Andrew Gaspar <https://github.com/AndrewGaspar>, James Harrison Fisher <https://github.com/jameshfisher>, Seikichi Kondo <https://github.com/seikichi>, Benjamin Jackman <https://github.com/benjaminjackman>, Poul Sorensen <https://github.com/s093294>, Josh Strobl <https://github.com/JoshStrobl>, John Reilly <https://github.com/johnnyreilly/>, Dick van den Brink <https://github.com/DickvdBrink>, Thomas Schulz <https://github.com/King2500>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /* *****************************************************************************
@@ -21,6 +21,7 @@ and limitations under the License.
 
 /**
  * Interface for the AJAX setting that will configure the AJAX request
+ * @see {@link https://api.jquery.com/jQuery.ajax/#jQuery-ajax-settings}
  */
 interface JQueryAjaxSettings {
     /**
@@ -165,6 +166,7 @@ interface JQueryAjaxSettings {
 
 /**
  * Interface for the jqXHR object
+ * @see {@link https://api.jquery.com/jQuery.ajax/#jqXHR}
  */
 interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
     /**
@@ -193,33 +195,39 @@ interface JQueryXHR extends XMLHttpRequest, JQueryPromise<any> {
 
 /**
  * Interface for the JQuery callback
+ * @see {@link https://api.jquery.com/category/callbacks-object/}
  */
 interface JQueryCallback {
     /**
      * Add a callback or a collection of callbacks to a callback list.
      *
      * @param callbacks A function, or array of functions, that are to be added to the callback list.
+     * @see {@link https://api.jquery.com/callbacks.add/}
      */
     add(callbacks: Function): JQueryCallback;
     /**
      * Add a callback or a collection of callbacks to a callback list.
      *
      * @param callbacks A function, or array of functions, that are to be added to the callback list.
+     * @see {@link https://api.jquery.com/callbacks.add/}
      */
     add(callbacks: Function[]): JQueryCallback;
 
     /**
      * Disable a callback list from doing anything more.
+     * @see {@link https://api.jquery.com/callbacks.disable/}
      */
     disable(): JQueryCallback;
 
     /**
      * Determine if the callbacks list has been disabled.
+     * @see {@link https://api.jquery.com/callbacks.disabled/}
      */
     disabled(): boolean;
 
     /**
      * Remove all of the callbacks from a list.
+     * @see {@link https://api.jquery.com/callbacks.empty/}
      */
     empty(): JQueryCallback;
 
@@ -227,11 +235,13 @@ interface JQueryCallback {
      * Call all of the callbacks with the given arguments
      *
      * @param arguments The argument or list of arguments to pass back to the callback list.
+     * @see {@link https://api.jquery.com/callbacks.fire/}
      */
     fire(...arguments: any[]): JQueryCallback;
 
     /**
      * Determine if the callbacks have already been called at least once.
+     * @see {@link https://api.jquery.com/callbacks.fired/}
      */
     fired(): boolean;
 
@@ -240,6 +250,7 @@ interface JQueryCallback {
      *
      * @param context A reference to the context in which the callbacks in the list should be fired.
      * @param arguments An argument, or array of arguments, to pass to the callbacks in the list.
+     * @see {@link https://api.jquery.com/callbacks.fireWith/}
      */
     fireWith(context?: any, args?: any[]): JQueryCallback;
 
@@ -247,16 +258,19 @@ interface JQueryCallback {
      * Determine whether a supplied callback is in a list
      *
      * @param callback The callback to search for.
+     * @see {@link https://api.jquery.com/callbacks.has/}
      */
     has(callback: Function): boolean;
 
     /**
      * Lock a callback list in its current state.
+     * @see {@link https://api.jquery.com/callbacks.lock/}
      */
     lock(): JQueryCallback;
 
     /**
      * Determine if the callbacks list has been locked.
+     * @see {@link https://api.jquery.com/callbacks.locked/}
      */
     locked(): boolean;
 
@@ -264,12 +278,14 @@ interface JQueryCallback {
      * Remove a callback or a collection of callbacks from a callback list.
      *
      * @param callbacks A function, or array of functions, that are to be removed from the callback list.
+     * @see {@link https://api.jquery.com/callbacks.remove/}
      */
     remove(callbacks: Function): JQueryCallback;
     /**
      * Remove a callback or a collection of callbacks from a callback list.
      *
      * @param callbacks A function, or array of functions, that are to be removed from the callback list.
+     * @see {@link https://api.jquery.com/callbacks.remove/}
      */
     remove(callbacks: Function[]): JQueryCallback;
 }
@@ -283,6 +299,7 @@ interface JQueryGenericPromise<T> {
      *
      * @param doneFilter A function that is called when the Deferred is resolved.
      * @param failFilter An optional function that is called when the Deferred is rejected.
+     * @see {@link https://api.jquery.com/deferred.then/#deferred-then-doneFilter-failFilter-progressFilter}
      */
     then<U>(doneFilter: (value?: T, ...values: any[]) => U|JQueryPromise<U>, failFilter?: (...reasons: any[]) => any, progressFilter?: (...progression: any[]) => any): JQueryPromise<U>;
 
@@ -291,6 +308,7 @@ interface JQueryGenericPromise<T> {
      *
      * @param doneFilter A function that is called when the Deferred is resolved.
      * @param failFilter An optional function that is called when the Deferred is rejected.
+     * @see {@link https://api.jquery.com/deferred.then/#deferred-then-doneFilter-failFilter-progressFilter}
      */
     then(doneFilter: (value?: T, ...values: any[]) => void, failFilter?: (...reasons: any[]) => any, progressFilter?: (...progression: any[]) => any): JQueryPromise<void>;
 }
@@ -308,10 +326,12 @@ interface JQueryPromiseOperator<T, U> {
 
 /**
  * Interface for the JQuery promise, part of callbacks
+ * @see {@link https://api.jquery.com/category/deferred-object/}
  */
 interface JQueryPromise<T> extends JQueryGenericPromise<T> {
     /**
      * Determine the current state of a Deferred object.
+     * @see {@link https://api.jquery.com/deferred.state/}
      */
     state(): string;
     /**
@@ -319,6 +339,7 @@ interface JQueryPromise<T> extends JQueryGenericPromise<T> {
      *
      * @param alwaysCallback1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
      * @param alwaysCallbackN Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
+     * @see {@link https://api.jquery.com/deferred.always/}
      */
     always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
     /**
@@ -326,6 +347,7 @@ interface JQueryPromise<T> extends JQueryGenericPromise<T> {
      *
      * @param doneCallback1 A function, or array of functions, that are called when the Deferred is resolved.
      * @param doneCallbackN Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
+     * @see {@link https://api.jquery.com/deferred.done/}
      */
     done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryPromise<T>;
     /**
@@ -333,6 +355,7 @@ interface JQueryPromise<T> extends JQueryGenericPromise<T> {
      *
      * @param failCallback1 A function, or array of functions, that are called when the Deferred is rejected.
      * @param failCallbackN Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
+     * @see {@link https://api.jquery.com/deferred.fail/}
      */
     fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
     /**
@@ -340,6 +363,7 @@ interface JQueryPromise<T> extends JQueryGenericPromise<T> {
      *
      * @param progressCallback1 A function, or array of functions, to be called when the Deferred generates progress notifications.
      * @param progressCallbackN Optional additional functions, or arrays of functions, to be called when the Deferred generates progress notifications.
+     * @see {@link https://api.jquery.com/deferred.progress/}
      */
     progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryPromise<T>;
 
@@ -350,16 +374,19 @@ interface JQueryPromise<T> extends JQueryGenericPromise<T> {
      * Return a Deferred's Promise object.
      *
      * @param target Object onto which the promise methods have to be attached
+     * @see {@link https://api.jquery.com/deferred.promise/}
      */
     promise(target?: any): JQueryPromise<T>;
 }
 
 /**
  * Interface for the JQuery deferred, part of callbacks
+ * @see {@link https://api.jquery.com/category/deferred-object/}
  */
 interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
     /**
      * Determine the current state of a Deferred object.
+     * @see {@link https://api.jquery.com/deferred.state/}
      */
     state(): string;
     /**
@@ -367,6 +394,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      *
      * @param alwaysCallback1 A function, or array of functions, that is called when the Deferred is resolved or rejected.
      * @param alwaysCallbackN Optional additional functions, or arrays of functions, that are called when the Deferred is resolved or rejected.
+     * @see {@link https://api.jquery.com/deferred.always/}
      */
     always(alwaysCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...alwaysCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
     /**
@@ -374,6 +402,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      *
      * @param doneCallback1 A function, or array of functions, that are called when the Deferred is resolved.
      * @param doneCallbackN Optional additional functions, or arrays of functions, that are called when the Deferred is resolved.
+     * @see {@link https://api.jquery.com/deferred.done/}
      */
     done(doneCallback1?: JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[], ...doneCallbackN: Array<JQueryPromiseCallback<T>|JQueryPromiseCallback<T>[]>): JQueryDeferred<T>;
     /**
@@ -381,6 +410,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      *
      * @param failCallback1 A function, or array of functions, that are called when the Deferred is rejected.
      * @param failCallbackN Optional additional functions, or arrays of functions, that are called when the Deferred is rejected.
+     * @see {@link https://api.jquery.com/deferred.fail/}
      */
     fail(failCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...failCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
     /**
@@ -388,6 +418,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      *
      * @param progressCallback1 A function, or array of functions, to be called when the Deferred generates progress notifications.
      * @param progressCallbackN Optional additional functions, or arrays of functions, to be called when the Deferred generates progress notifications.
+     * @see {@link https://api.jquery.com/deferred.progress/}
      */
     progress(progressCallback1?: JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[], ...progressCallbackN: Array<JQueryPromiseCallback<any>|JQueryPromiseCallback<any>[]>): JQueryDeferred<T>;
 
@@ -395,6 +426,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      * Call the progressCallbacks on a Deferred object with the given args.
      *
      * @param args Optional arguments that are passed to the progressCallbacks.
+     * @see {@link https://api.jquery.com/deferred.notify/}
      */
     notify(value?: any, ...args: any[]): JQueryDeferred<T>;
 
@@ -403,6 +435,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      *
      * @param context Context passed to the progressCallbacks as the this object.
      * @param args Optional arguments that are passed to the progressCallbacks.
+     * @see {@link https://api.jquery.com/deferred.notifyWith/}
      */
     notifyWith(context: any, args?: any[]): JQueryDeferred<T>;
 
@@ -410,6 +443,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      * Reject a Deferred object and call any failCallbacks with the given args.
      *
      * @param args Optional arguments that are passed to the failCallbacks.
+     * @see {@link https://api.jquery.com/deferred.reject/}
      */
     reject(value?: any, ...args: any[]): JQueryDeferred<T>;
     /**
@@ -417,6 +451,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      *
      * @param context Context passed to the failCallbacks as the this object.
      * @param args An optional array of arguments that are passed to the failCallbacks.
+     * @see {@link https://api.jquery.com/deferred.rejectWith/}
      */
     rejectWith(context: any, args?: any[]): JQueryDeferred<T>;
 
@@ -425,6 +460,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      *
      * @param value First argument passed to doneCallbacks.
      * @param args Optional subsequent arguments that are passed to the doneCallbacks.
+     * @see {@link https://api.jquery.com/deferred.resolve/}
      */
     resolve(value?: T, ...args: any[]): JQueryDeferred<T>;
 
@@ -433,6 +469,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      *
      * @param context Context passed to the doneCallbacks as the this object.
      * @param args An optional array of arguments that are passed to the doneCallbacks.
+     * @see {@link https://api.jquery.com/deferred.resolveWith/}
      */
     resolveWith(context: any, args?: T[]): JQueryDeferred<T>;
 
@@ -440,6 +477,7 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
      * Return a Deferred's Promise object.
      *
      * @param target Object onto which the promise methods have to be attached
+     * @see {@link https://api.jquery.com/deferred.promise/}
      */
     promise(target?: any): JQueryPromise<T>;
 
@@ -449,25 +487,98 @@ interface JQueryDeferred<T> extends JQueryGenericPromise<T> {
 
 /**
  * Interface of the JQuery extension of the W3C event object
+ * @see {@link https://api.jquery.com/category/events/event-object/}
  */
 interface BaseJQueryEventObject extends Event {
+    /**
+     * The current DOM element within the event bubbling phase.
+     * @see {@link https://api.jquery.com/event.currentTarget/}
+     */
     currentTarget: Element;
+    /**
+     * An optional object of data passed to an event method when the current executing handler is bound.
+     * @see {@link https://api.jquery.com/event.data/}
+     */
     data: any;
+    /**
+     * The element where the currently-called jQuery event handler was attached.
+     * @see {@link https://api.jquery.com/event.delegateTarget/}
+     */
     delegateTarget: Element;
+    /**
+     * Returns whether event.preventDefault() was ever called on this event object.
+     * @see {@link https://api.jquery.com/event.isDefaultPrevented/}
+     */
     isDefaultPrevented(): boolean;
+    /**
+     * Returns whether event.stopImmediatePropagation() was ever called on this event object.
+     * @see {@link https://api.jquery.com/event.isImmediatePropagationStopped/}
+     */
     isImmediatePropagationStopped(): boolean;
+    /**
+     * Returns whether event.stopPropagation() was ever called on this event object.
+     * @see {@link https://api.jquery.com/event.isPropagationStopped/}
+     */
     isPropagationStopped(): boolean;
+    /**
+     * The namespace specified when the event was triggered.
+     * @see {@link https://api.jquery.com/event.namespace/}
+     */
     namespace: string;
+    /**
+     * The browser's original Event object.
+     * @see {@link https://api.jquery.com/category/events/event-object/}
+     */
     originalEvent: Event;
+    /**
+     * If this method is called, the default action of the event will not be triggered.
+     * @see {@link https://api.jquery.com/event.preventDefault/}
+     */
     preventDefault(): any;
+    /**
+     * The other DOM element involved in the event, if any.
+     * @see {@link https://api.jquery.com/event.relatedTarget/}
+     */
     relatedTarget: Element;
+    /**
+     * The last value returned by an event handler that was triggered by this event, unless the value was undefined.
+     * @see {@link https://api.jquery.com/event.result/}
+     */
     result: any;
+    /**
+     * Keeps the rest of the handlers from being executed and prevents the event from bubbling up the DOM tree.
+     * @see {@link https://api.jquery.com/event.stopImmediatePropagation/}
+     */
     stopImmediatePropagation(): void;
+    /**
+     * Prevents the event from bubbling up the DOM tree, preventing any parent handlers from being notified of the event.
+     * @see {@link https://api.jquery.com/event.stopPropagation/}
+     */
     stopPropagation(): void;
+    /**
+     * The DOM element that initiated the event.
+     * @see {@link https://api.jquery.com/event.target/}
+     */
     target: Element;
+    /**
+     * The mouse position relative to the left edge of the document.
+     * @see {@link https://api.jquery.com/event.pageX/}
+     */
     pageX: number;
+    /**
+     * The mouse position relative to the top edge of the document.
+     * @see {@link https://api.jquery.com/event.pageY/}
+     */
     pageY: number;
+    /**
+     * For key or mouse events, this property indicates the specific key or button that was pressed.
+     * @see {@link https://api.jquery.com/event.which/}
+     */
     which: number;
+    /**
+     * Indicates whether the META key was pressed when the event fired.
+     * @see {@link https://api.jquery.com/event.metaKey/}
+     */
     metaKey: boolean;
 }
 
@@ -500,10 +611,16 @@ interface JQueryKeyEventObject extends JQueryInputEventObject {
 interface JQueryEventObject extends BaseJQueryEventObject, JQueryInputEventObject, JQueryMouseEventObject, JQueryKeyEventObject{
 }
 
-/*
-    Collection of properties of the current browser
-*/
-
+/**
+ * A collection of properties that represent the presence of different browser features or bugs.
+ *
+ * Intended for jQuery's internal use; specific properties may be removed when they are no longer needed internally
+ * to improve page startup performance. For your own project's feature-detection needs, we strongly recommend the
+ * use of an external library such as {@link http://modernizr.com/|Modernizr} instead of dependency on properties
+ * in jQuery.support.
+ *
+ * @deprecated since version 1.9
+ */
 interface JQuerySupport {
     ajax?: boolean;
     boxModel?: boolean;
@@ -570,6 +687,9 @@ interface JQuerySerializeArrayElement {
     value: string;
 }
 
+/**
+ * @see {@link https://api.jquery.com/animate/}
+ */
 interface JQueryAnimationOptions {
     /**
      * A string or number determining how long the animation will run.
@@ -629,6 +749,8 @@ interface JQueryEasingFunctions {
 
 /**
  * Static members of jQuery (those on $ and jQuery themselves)
+ *
+ * @see {@link https://api.jquery.com/Types/#jQuery}
  */
 interface JQueryStatic {
 
@@ -636,6 +758,7 @@ interface JQueryStatic {
      * Perform an asynchronous HTTP (Ajax) request.
      *
      * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can be set for any option with $.ajaxSetup().
+     * @see {@link https://api.jquery.com/jQuery.ajax/#jQuery-ajax-settings}
      */
     ajax(settings: JQueryAjaxSettings): JQueryXHR;
     /**
@@ -643,6 +766,7 @@ interface JQueryStatic {
      *
      * @param url A string containing the URL to which the request is sent.
      * @param settings A set of key/value pairs that configure the Ajax request. All settings are optional. A default can be set for any option with $.ajaxSetup().
+     * @see {@link https://api.jquery.com/jQuery.ajax/#jQuery-ajax-url-settings}
      */
     ajax(url: string, settings?: JQueryAjaxSettings): JQueryXHR;
 
@@ -651,12 +775,14 @@ interface JQueryStatic {
      *
      * @param dataTypes An optional string containing one or more space-separated dataTypes
      * @param handler A handler to set default values for future Ajax requests.
+     * @see {@link https://api.jquery.com/jQuery.ajaxPrefilter/}
      */
     ajaxPrefilter(dataTypes: string, handler: (opts: any, originalOpts: JQueryAjaxSettings, jqXHR: JQueryXHR) => any): void;
     /**
      * Handle custom Ajax options or modify existing options before each request is sent and before they are processed by $.ajax().
      *
      * @param handler A handler to set default values for future Ajax requests.
+     * @see {@link https://api.jquery.com/jQuery.ajaxPrefilter/}
      */
     ajaxPrefilter(handler: (opts: any, originalOpts: JQueryAjaxSettings, jqXHR: JQueryXHR) => any): void;
 
@@ -666,6 +792,7 @@ interface JQueryStatic {
       * Set default values for future Ajax requests. Its use is not recommended.
       *
       * @param options A set of key/value pairs that configure the default Ajax request. All options are optional.
+      * @see {@link https://api.jquery.com/jQuery.ajaxSetup/}
       */
     ajaxSetup(options: JQueryAjaxSettings): void;
 
@@ -675,6 +802,7 @@ interface JQueryStatic {
      * @param url A string containing the URL to which the request is sent.
      * @param success A callback function that is executed if the request succeeds.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, or html).
+     * @see {@link https://api.jquery.com/jQuery.get/#jQuery-get-url-data-success-dataType}
      */
     get(url: string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
     /**
@@ -684,12 +812,14 @@ interface JQueryStatic {
      * @param data A plain object or string that is sent to the server with the request.
      * @param success A callback function that is executed if the request succeeds.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, or html).
+     * @see {@link https://api.jquery.com/jQuery.get/#jQuery-get-url-data-success-dataType}
      */
     get(url: string, data?: Object|string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
     /**
      * Load data from the server using a HTTP GET request.
      *
      * @param settings The JQueryAjaxSettings to be used for the request
+     * @see {@link https://api.jquery.com/jQuery.get/#jQuery-get-settings}
      */
     get(settings : JQueryAjaxSettings): JQueryXHR;
     /**
@@ -697,6 +827,7 @@ interface JQueryStatic {
      *
      * @param url A string containing the URL to which the request is sent.
      * @param success A callback function that is executed if the request succeeds.
+     * @see {@link https://api.jquery.com/jQuery.getJSON/}
      */
     getJSON(url: string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any): JQueryXHR;
     /**
@@ -705,6 +836,7 @@ interface JQueryStatic {
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
      * @param success A callback function that is executed if the request succeeds.
+     * @see {@link https://api.jquery.com/jQuery.getJSON/}
      */
     getJSON(url: string, data?: Object|string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any): JQueryXHR;
     /**
@@ -712,11 +844,14 @@ interface JQueryStatic {
      *
      * @param url A string containing the URL to which the request is sent.
      * @param success A callback function that is executed if the request succeeds.
+     * @see {@link https://api.jquery.com/jQuery.getScript/}
      */
     getScript(url: string, success?: (script: string, textStatus: string, jqXHR: JQueryXHR) => any): JQueryXHR;
 
     /**
      * Create a serialized representation of an array or object, suitable for use in a URL query string or Ajax request.
+     *
+     * @see {@link https://api.jquery.com/jQuery.param/}
      */
     param: JQueryParam;
 
@@ -726,6 +861,7 @@ interface JQueryStatic {
      * @param url A string containing the URL to which the request is sent.
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
+     * @see {@link https://api.jquery.com/jQuery.post/#jQuery-post-url-data-success-dataType}
      */
     post(url: string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
     /**
@@ -735,18 +871,21 @@ interface JQueryStatic {
      * @param data A plain object or string that is sent to the server with the request.
      * @param success A callback function that is executed if the request succeeds. Required if dataType is provided, but can be null in that case.
      * @param dataType The type of data expected from the server. Default: Intelligent Guess (xml, json, script, text, html).
+     * @see {@link https://api.jquery.com/jQuery.post/#jQuery-post-url-data-success-dataType}
      */
     post(url: string, data?: Object|string, success?: (data: any, textStatus: string, jqXHR: JQueryXHR) => any, dataType?: string): JQueryXHR;
     /**
      * Load data from the server using a HTTP POST request.
      *
      * @param settings The JQueryAjaxSettings to be used for the request
+     * @see {@link https://api.jquery.com/jQuery.post/#jQuery-post-settings}
      */
     post(settings : JQueryAjaxSettings): JQueryXHR;
     /**
      * A multi-purpose callbacks list object that provides a powerful way to manage callback lists.
      *
      * @param flags An optional list of space-separated flags that change how the callback list behaves.
+     * @see {@link https://api.jquery.com/jQuery.Callbacks/}
      */
     Callbacks(flags?: string): JQueryCallback;
 
@@ -754,6 +893,7 @@ interface JQueryStatic {
      * Holds or releases the execution of jQuery's ready event.
      *
      * @param hold Indicates whether the ready hold is being requested or released
+     * @see {@link https://api.jquery.com/jQuery.holdReady/}
      */
     holdReady(hold: boolean): void;
 
@@ -762,6 +902,7 @@ interface JQueryStatic {
      *
      * @param selector A string containing a selector expression
      * @param context A DOM Element, Document, or jQuery to use as context
+     * @see {@link https://api.jquery.com/jQuery/#jQuery-selector-context}
      */
     (selector: string, context?: Element|JQuery): JQuery;
 
@@ -769,6 +910,7 @@ interface JQueryStatic {
      * Accepts a string containing a CSS selector which is then used to match a set of elements.
      *
      * @param element A DOM element to wrap in a jQuery object.
+     * @see {@link https://api.jquery.com/jQuery/#jQuery-element}
      */
     (element: Element): JQuery;
 
@@ -776,6 +918,7 @@ interface JQueryStatic {
      * Accepts a string containing a CSS selector which is then used to match a set of elements.
      *
      * @param elementArray An array containing a set of DOM elements to wrap in a jQuery object.
+     * @see {@link https://api.jquery.com/jQuery/#jQuery-elementArray}
      */
     (elementArray: Element[]): JQuery;
 
@@ -783,6 +926,7 @@ interface JQueryStatic {
      * Binds a function to be executed when the DOM has finished loading.
      *
      * @param callback A function to execute after the DOM is ready.
+     * @see {@link https://api.jquery.com/jQuery/#jQuery-callback}
      */
     (callback: (jQueryAlias?: JQueryStatic) => any): JQuery;
 
@@ -790,6 +934,7 @@ interface JQueryStatic {
      * Accepts a string containing a CSS selector which is then used to match a set of elements.
      *
      * @param object A plain object to wrap in a jQuery object.
+     * @see {@link https://api.jquery.com/jQuery/#jQuery-object}
      */
     (object: {}): JQuery;
 
@@ -797,11 +942,13 @@ interface JQueryStatic {
      * Accepts a string containing a CSS selector which is then used to match a set of elements.
      *
      * @param object An existing jQuery object to clone.
+     * @see {@link https://api.jquery.com/jQuery/#jQuery-object}
      */
     (object: JQuery): JQuery;
 
     /**
      * Specify a function to execute when the DOM is fully loaded.
+     * @see {@link https://api.jquery.com/jQuery/#jQuery}
      */
     (): JQuery;
 
@@ -810,6 +957,7 @@ interface JQueryStatic {
      *
      * @param html A string of HTML to create on the fly. Note that this parses HTML, not XML.
      * @param ownerDocument A document in which the new elements will be created.
+     * @see {@link https://api.jquery.com/jQuery/#jQuery-html-ownerDocument}
      */
     (html: string, ownerDocument?: Document): JQuery;
 
@@ -818,6 +966,7 @@ interface JQueryStatic {
      *
      * @param html A string defining a single, standalone, HTML element (e.g. <div/> or <div></div>).
      * @param attributes An object of attributes, events, and methods to call on the newly-created element.
+     * @see {@link https://api.jquery.com/jQuery/#jQuery-html-attributes}
      */
     (html: string, attributes: Object): JQuery;
 
@@ -825,6 +974,7 @@ interface JQueryStatic {
      * Relinquish jQuery's control of the $ variable.
      *
      * @param removeAll A Boolean indicating whether to remove all jQuery variables from the global scope (including jQuery itself).
+     * @see {@link https://api.jquery.com/jQuery.noConflict/}
      */
     noConflict(removeAll?: boolean): JQueryStatic;
 
@@ -832,13 +982,20 @@ interface JQueryStatic {
      * Provides a way to execute callback functions based on one or more objects, usually Deferred objects that represent asynchronous events.
      *
      * @param deferreds One or more Deferred objects, or plain JavaScript objects.
+     * @see {@link https://api.jquery.com/jQuery.when/}
      */
     when<T>(...deferreds: Array<T|JQueryPromise<T>/* as JQueryDeferred<T> */>): JQueryPromise<T>;
 
     /**
      * Hook directly into jQuery to override how particular CSS properties are retrieved or set, normalize CSS property naming, or create custom properties.
+     * @see {@link https://api.jquery.com/jQuery.cssHooks/}
      */
     cssHooks: { [key: string]: any; };
+
+    /**
+     * An object containing all CSS properties that may be used without a unit. The .css() method uses this object to see if it may append px to unitless values.
+     * @see {@link https://api.jquery.com/jQuery.cssNumber/}
+     */
     cssNumber: any;
 
     /**
@@ -847,6 +1004,7 @@ interface JQueryStatic {
      * @param element The DOM element to associate with the data.
      * @param key A string naming the piece of data to set.
      * @param value The new data value.
+     * @see {@link https://api.jquery.com/jQuery.data/#jQuery-data-element-key-value}
      */
     data<T>(element: Element, key: string, value: T): T;
     /**
@@ -854,12 +1012,14 @@ interface JQueryStatic {
      *
      * @param element The DOM element to associate with the data.
      * @param key A string naming the piece of data to set.
+     * @see {@link https://api.jquery.com/jQuery.data/#jQuery-data-element-key}
      */
     data(element: Element, key: string): any;
     /**
      * Returns value at named data store for the element, as set by jQuery.data(element, name, value), or the full data store for the element.
      *
      * @param element The DOM element to associate with the data.
+     * @see {@link https://api.jquery.com/jQuery.data/#jQuery-data-element}
      */
     data(element: Element): any;
 
@@ -868,6 +1028,7 @@ interface JQueryStatic {
      *
      * @param element A DOM element from which to remove and execute a queued function.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @see {@link https://api.jquery.com/jQuery.dequeue/}
      */
     dequeue(element: Element, queueName?: string): void;
 
@@ -875,6 +1036,7 @@ interface JQueryStatic {
      * Determine whether an element has any jQuery data associated with it.
      *
      * @param element A DOM element to be checked for data.
+     * @see {@link https://api.jquery.com/jQuery.hasData/}
      */
     hasData(element: Element): boolean;
 
@@ -883,6 +1045,7 @@ interface JQueryStatic {
      *
      * @param element A DOM element to inspect for an attached queue.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @see {@link https://api.jquery.com/jQuery.queue/#jQuery-queue-element-queueName}
      */
     queue(element: Element, queueName?: string): any[];
     /**
@@ -891,6 +1054,7 @@ interface JQueryStatic {
      * @param element A DOM element where the array of queued functions is attached.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param newQueue An array of functions to replace the current queue contents.
+     * @see {@link https://api.jquery.com/jQuery.queue/#jQuery-queue-element-queueName-newQueue}
      */
     queue(element: Element, queueName: string, newQueue: Function[]): JQuery;
     /**
@@ -899,6 +1063,7 @@ interface JQueryStatic {
      * @param element A DOM element on which to add a queued function.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param callback The new function to add to the queue.
+     * @see {@link https://api.jquery.com/jQuery.queue/#jQuery-queue-element-queueName-callback}
      */
     queue(element: Element, queueName: string, callback: Function): JQuery;
 
@@ -907,6 +1072,7 @@ interface JQueryStatic {
      *
      * @param element A DOM element from which to remove data.
      * @param name A string naming the piece of data to remove.
+     * @see {@link https://api.jquery.com/jQuery.removeData/}
      */
     removeData(element: Element, name?: string): JQuery;
 
@@ -914,6 +1080,7 @@ interface JQueryStatic {
      * A constructor function that returns a chainable utility object with methods to register multiple callbacks into callback queues, invoke callback queues, and relay the success or failure state of any synchronous or asynchronous function.
      *
      * @param beforeStart A function that is called just before the constructor returns.
+     * @see {@link https://api.jquery.com/jQuery.Deferred/}
      */
     Deferred<T>(beforeStart?: (deferred: JQueryDeferred<T>) => any): JQueryDeferred<T>;
 
@@ -927,12 +1094,14 @@ interface JQueryStatic {
         tick: () => void;
         /**
          * The rate (in milliseconds) at which animations fire.
+         * @see {@link https://api.jquery.com/jQuery.fx.interval/}
          */
         interval: number;
         stop: () => void;
         speeds: { slow: number; fast: number; };
         /**
          * Globally disable all animations.
+         * @see {@link https://api.jquery.com/jQuery.fx.off/}
          */
         off: boolean;
         step: any;
@@ -941,17 +1110,19 @@ interface JQueryStatic {
     /**
      * Takes a function and returns a new one that will always have a particular context.
      *
-     * @param fnction The function whose context will be changed.
+     * @param func The function whose context will be changed.
      * @param context The object to which the context (this) of the function should be set.
      * @param additionalArguments Any number of arguments to be passed to the function referenced in the function argument.
+     * @see {@link https://api.jquery.com/jQuery.proxy/#jQuery-proxy-function-context-additionalArguments}
      */
-    proxy(fnction: (...args: any[]) => any, context: Object, ...additionalArguments: any[]): any;
+    proxy(func: (...args: any[]) => any, context: Object, ...additionalArguments: any[]): any;
     /**
      * Takes a function and returns a new one that will always have a particular context.
      *
      * @param context The object to which the context (this) of the function should be set.
      * @param name The name of the function whose context will be changed (should be a property of the context object).
      * @param additionalArguments Any number of arguments to be passed to the function named in the name argument.
+     * @see {@link https://api.jquery.com/jQuery.proxy/#jQuery-proxy-context-name-additionalArguments}
      */
     proxy(context: Object, name: string, ...additionalArguments: any[]): any;
 
@@ -961,6 +1132,7 @@ interface JQueryStatic {
      * Takes a string and throws an exception containing it.
      *
      * @param message The message to send out.
+     * @see {@link https://api.jquery.com/jQuery.error/}
      */
     error(message: any): JQuery;
 
@@ -977,6 +1149,7 @@ interface JQueryStatic {
      *
      * @param container The DOM element that may contain the other element.
      * @param contained The DOM element that may be contained by (a descendant of) the other element.
+     * @see {@link https://api.jquery.com/jQuery.contains/}
      */
     contains(container: Element, contained: Element): boolean;
 
@@ -985,6 +1158,7 @@ interface JQueryStatic {
      *
      * @param collection The object or array to iterate over.
      * @param callback The function that will be executed on every object.
+     * @see {@link https://api.jquery.com/jQuery.each/#jQuery-each-array-callback}
      */
     each<T>(
         collection: T[],
@@ -996,6 +1170,7 @@ interface JQueryStatic {
      *
      * @param collection The object or array to iterate over.
      * @param callback The function that will be executed on every object.
+     * @see {@link https://api.jquery.com/jQuery.each/#jQuery-each-object-callback}
      */
     each(
         collection: any,
@@ -1008,6 +1183,7 @@ interface JQueryStatic {
      * @param target An object that will receive the new properties if additional objects are passed in or that will extend the jQuery namespace if it is the sole argument.
      * @param object1 An object containing additional properties to merge in.
      * @param objectN Additional objects containing properties to merge in.
+     * @see {@link https://api.jquery.com/jQuery.extend/#jQuery-extend-target-object1-objectN}
      */
     extend(target: any, object1?: any, ...objectN: any[]): any;
     /**
@@ -1017,6 +1193,7 @@ interface JQueryStatic {
      * @param target The object to extend. It will receive the new properties.
      * @param object1 An object containing additional properties to merge in.
      * @param objectN Additional objects containing properties to merge in.
+     * @see {@link https://api.jquery.com/jQuery.extend/#jQuery-extend-deep-target-object1-objectN}
      */
     extend(deep: boolean, target: any, object1?: any, ...objectN: any[]): any;
 
@@ -1024,6 +1201,7 @@ interface JQueryStatic {
      * Execute some JavaScript code globally.
      *
      * @param code The JavaScript code to execute.
+     * @see {@link https://api.jquery.com/jQuery.globalEval/}
      */
     globalEval(code: string): any;
 
@@ -1033,6 +1211,7 @@ interface JQueryStatic {
      * @param array The array to search through.
      * @param func The function to process each item against. The first argument to the function is the item, and the second argument is the index. The function should return a Boolean value.  this will be the global window object.
      * @param invert If "invert" is false, or not provided, then the function returns an array consisting of all elements for which "callback" returns true. If "invert" is true, then the function returns an array consisting of all elements for which "callback" returns false.
+     * @see {@link https://api.jquery.com/jQuery.grep/}
      */
     grep<T>(array: T[], func: (elementOfArray?: T, indexInArray?: number) => boolean, invert?: boolean): T[];
 
@@ -1042,6 +1221,7 @@ interface JQueryStatic {
      * @param value The value to search for.
      * @param array An array through which to search.
      * @param fromIndex he index of the array at which to begin the search. The default is 0, which will search the whole array.
+     * @see {@link https://api.jquery.com/jQuery.inArray/}
      */
     inArray<T>(value: T, array: T[], fromIndex?: number): number;
 
@@ -1049,42 +1229,49 @@ interface JQueryStatic {
      * Determine whether the argument is an array.
      *
      * @param obj Object to test whether or not it is an array.
+     * @see {@link https://api.jquery.com/jQuery.isArray/}
      */
     isArray(obj: any): boolean;
     /**
      * Check to see if an object is empty (contains no enumerable properties).
      *
      * @param obj The object that will be checked to see if it's empty.
+     * @see {@link https://api.jquery.com/jQuery.isEmptyObject/}
      */
     isEmptyObject(obj: any): boolean;
     /**
      * Determine if the argument passed is a Javascript function object.
      *
      * @param obj Object to test whether or not it is a function.
+     * @see {@link https://api.jquery.com/jQuery.isFunction/}
      */
     isFunction(obj: any): boolean;
     /**
      * Determines whether its argument is a number.
      *
      * @param value The value to be tested.
+     * @see {@link https://api.jquery.com/jQuery.isNumeric/}
      */
     isNumeric(value: any): boolean;
     /**
      * Check to see if an object is a plain object (created using "{}" or "new Object").
      *
      * @param obj The object that will be checked to see if it's a plain object.
+     * @see {@link https://api.jquery.com/jQuery.isPlainObject/}
      */
     isPlainObject(obj: any): boolean;
     /**
      * Determine whether the argument is a window.
      *
      * @param obj Object to test whether or not it is a window.
+     * @see {@link https://api.jquery.com/jQuery.isWindow/}
      */
     isWindow(obj: any): boolean;
     /**
      * Check to see if a DOM node is within an XML document (or is an XML document).
      *
      * @param node he DOM node that will be checked to see if it's in an XML document.
+     * @see {@link https://api.jquery.com/jQuery.isXMLDoc/}
      */
     isXMLDoc(node: Node): boolean;
 
@@ -1092,6 +1279,7 @@ interface JQueryStatic {
      * Convert an array-like object into a true JavaScript array.
      *
      * @param obj Any object to turn into a native Array.
+     * @see {@link https://api.jquery.com/jQuery.makeArray/}
      */
     makeArray(obj: any): any[];
 
@@ -1100,6 +1288,7 @@ interface JQueryStatic {
      *
      * @param array The Array to translate.
      * @param callback The function to process each item against. The first argument to the function is the array item, the second argument is the index in array The function can return any value. Within the function, this refers to the global (window) object.
+     * @see {@link https://api.jquery.com/jQuery.map/#jQuery-map-array-callback}
      */
     map<T, U>(array: T[], callback: (elementOfArray?: T, indexInArray?: number) => U): U[];
     /**
@@ -1107,6 +1296,7 @@ interface JQueryStatic {
      *
      * @param arrayOrObject The Array or Object to translate.
      * @param callback The function to process each item against. The first argument to the function is the value; the second argument is the index or key of the array or object property. The function can return any value to add to the array. A returned array will be flattened into the resulting array. Within the function, this refers to the global (window) object.
+     * @see {@link https://api.jquery.com/jQuery.map/#jQuery-map-object-callback}
      */
     map(arrayOrObject: any, callback: (value?: any, indexOrKey?: any) => any): any;
 
@@ -1115,16 +1305,19 @@ interface JQueryStatic {
      *
      * @param first The first array to merge, the elements of second added.
      * @param second The second array to merge into the first, unaltered.
+     * @see {@link https://api.jquery.com/jQuery.merge/}
      */
     merge<T>(first: T[], second: T[]): T[];
 
     /**
      * An empty function.
+     * @see {@link https://api.jquery.com/jQuery.noop/}
      */
     noop(): any;
 
     /**
      * Return a number representing the current time.
+     * @see {@link https://api.jquery.com/jQuery.now/}
      */
     now(): number;
 
@@ -1132,6 +1325,7 @@ interface JQueryStatic {
      * Takes a well-formed JSON string and returns the resulting JavaScript object.
      *
      * @param json The JSON string to parse.
+     * @see {@link https://api.jquery.com/jQuery.parseJSON/}
      */
     parseJSON(json: string): any;
 
@@ -1139,6 +1333,7 @@ interface JQueryStatic {
      * Parses a string into an XML document.
      *
      * @param data a well-formed XML string to be parsed
+     * @see {@link https://api.jquery.com/jQuery.parseXML/}
      */
     parseXML(data: string): XMLDocument;
 
@@ -1146,6 +1341,7 @@ interface JQueryStatic {
      * Remove the whitespace from the beginning and end of a string.
      *
      * @param str Remove the whitespace from the beginning and end of a string.
+     * @see {@link https://api.jquery.com/jQuery.trim/}
      */
     trim(str: string): string;
 
@@ -1153,6 +1349,7 @@ interface JQueryStatic {
      * Determine the internal JavaScript [[Class]] of an object.
      *
      * @param obj Object to get the internal JavaScript [[Class]] of.
+     * @see {@link https://api.jquery.com/jQuery.type/}
      */
     type(obj: any): string;
 
@@ -1160,6 +1357,7 @@ interface JQueryStatic {
      * Sorts an array of DOM elements, in place, with the duplicates removed. Note that this only works on arrays of DOM elements, not strings or numbers.
      *
      * @param array The Array of DOM elements.
+     * @see {@link https://api.jquery.com/jQuery.unique/}
      */
     unique(array: Element[]): Element[];
 
@@ -1169,6 +1367,7 @@ interface JQueryStatic {
      * @param data HTML string to be parsed
      * @param context DOM element to serve as the context in which the HTML fragment will be created
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
+     * @see {@link https://api.jquery.com/jQuery.parseHTML/}
      */
     parseHTML(data: string, context?: HTMLElement, keepScripts?: boolean): any[];
 
@@ -1178,48 +1377,57 @@ interface JQueryStatic {
      * @param data HTML string to be parsed
      * @param context DOM element to serve as the context in which the HTML fragment will be created
      * @param keepScripts A Boolean indicating whether to include scripts passed in the HTML string
+     * @see {@link https://api.jquery.com/jQuery.parseHTML/}
      */
     parseHTML(data: string, context?: Document, keepScripts?: boolean): any[];
 }
 
 /**
  * The jQuery instance members
+ *
+ * @see {@link https://api.jquery.com/Types/#jQuery}
  */
 interface JQuery {
     /**
      * Register a handler to be called when Ajax requests complete. This is an AjaxEvent.
      *
      * @param handler The function to be invoked.
+     * @see {@link https://api.jquery.com/ajaxComplete/}
      */
     ajaxComplete(handler: (event: JQueryEventObject, XMLHttpRequest: XMLHttpRequest, ajaxOptions: any) => any): JQuery;
     /**
      * Register a handler to be called when Ajax requests complete with an error. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
+     * @see {@link https://api.jquery.com/ajaxError/}
      */
     ajaxError(handler: (event: JQueryEventObject, jqXHR: JQueryXHR, ajaxSettings: JQueryAjaxSettings, thrownError: any) => any): JQuery;
     /**
      * Attach a function to be executed before an Ajax request is sent. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
+     * @see {@link https://api.jquery.com/ajaxSend/}
      */
     ajaxSend(handler: (event: JQueryEventObject, jqXHR: JQueryXHR, ajaxOptions: JQueryAjaxSettings) => any): JQuery;
     /**
      * Register a handler to be called when the first Ajax request begins. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
+     * @see {@link https://api.jquery.com/ajaxStart/}
      */
     ajaxStart(handler: () => any): JQuery;
     /**
      * Register a handler to be called when all Ajax requests have completed. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
+     * @see {@link https://api.jquery.com/ajaxStop/}
      */
     ajaxStop(handler: () => any): JQuery;
     /**
      * Attach a function to be executed whenever an Ajax request completes successfully. This is an Ajax Event.
      *
      * @param handler The function to be invoked.
+     * @see {@link https://api.jquery.com/ajaxSuccess/}
      */
     ajaxSuccess(handler: (event: JQueryEventObject, XMLHttpRequest: XMLHttpRequest, ajaxOptions: JQueryAjaxSettings) => any): JQuery;
 
@@ -1229,15 +1437,18 @@ interface JQuery {
      * @param url A string containing the URL to which the request is sent.
      * @param data A plain object or string that is sent to the server with the request.
      * @param complete A callback function that is executed when the request completes.
+     * @see {@link https://api.jquery.com/load/}
      */
     load(url: string, data?: string|Object, complete?: (responseText: string, textStatus: string, XMLHttpRequest: XMLHttpRequest) => any): JQuery;
 
     /**
      * Encode a set of form elements as a string for submission.
+     * @see {@link https://api.jquery.com/serialize/}
      */
     serialize(): string;
     /**
      * Encode a set of form elements as an array of names and values.
+     * @see {@link https://api.jquery.com/serializeArray/}
      */
     serializeArray(): JQuerySerializeArrayElement[];
 
@@ -1245,17 +1456,20 @@ interface JQuery {
      * Adds the specified class(es) to each of the set of matched elements.
      *
      * @param className One or more space-separated classes to be added to the class attribute of each matched element.
+     * @see {@link https://api.jquery.com/addClass/#addClass-className}
      */
     addClass(className: string): JQuery;
     /**
      * Adds the specified class(es) to each of the set of matched elements.
      *
      * @param func A function returning one or more space-separated class names to be added to the existing class name(s). Receives the index position of the element in the set and the existing class name(s) as arguments. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/addClass/#addClass-function}
      */
     addClass(func: (index: number, className: string) => string): JQuery;
 
     /**
      * Add the previous set of elements on the stack to the current set, optionally filtered by a selector.
+     * @see {@link https://api.jquery.com/addBack/}
      */
     addBack(selector?: string): JQuery;
 
@@ -1263,6 +1477,7 @@ interface JQuery {
      * Get the value of an attribute for the first element in the set of matched elements.
      *
      * @param attributeName The name of the attribute to get.
+     * @see {@link https://api.jquery.com/attr/#attr-attributeName}
      */
     attr(attributeName: string): string;
     /**
@@ -1270,6 +1485,7 @@ interface JQuery {
      *
      * @param attributeName The name of the attribute to set.
      * @param value A value to set for the attribute. If this is `null`, the attribute will be deleted.
+     * @see {@link https://api.jquery.com/attr/#attr-attributeName-value}
      */
     attr(attributeName: string, value: string|number|null): JQuery;
     /**
@@ -1277,12 +1493,14 @@ interface JQuery {
      *
      * @param attributeName The name of the attribute to set.
      * @param func A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old attribute value as arguments.
+     * @see {@link https://api.jquery.com/attr/#attr-attributeName-function}
      */
     attr(attributeName: string, func: (index: number, attr: string) => string|number): JQuery;
     /**
      * Set one or more attributes for the set of matched elements.
      *
      * @param attributes An object of attribute-value pairs to set.
+     * @see {@link https://api.jquery.com/attr/#attr-attributes}
      */
     attr(attributes: Object): JQuery;
 
@@ -1290,35 +1508,35 @@ interface JQuery {
      * Determine whether any of the matched elements are assigned the given class.
      *
      * @param className The class name to search for.
+     * @see {@link https://api.jquery.com/hasClass/}
      */
     hasClass(className: string): boolean;
 
     /**
      * Get the HTML contents of the first element in the set of matched elements.
+     * @see {@link https://api.jquery.com/html/#html}
      */
     html(): string;
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *
      * @param htmlString A string of HTML to set as the content of each matched element.
+     * @see {@link https://api.jquery.com/html/#html-htmlString}
      */
     html(htmlString: string): JQuery;
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *
      * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/html/#html-function}
      */
     html(func: (index: number, oldhtml: string) => string): JQuery;
-    /**
-     * Set the HTML contents of each element in the set of matched elements.
-     *
-     * @param func A function returning the HTML content to set. Receives the index position of the element in the set and the old HTML value as arguments. jQuery empties the element before calling the function; use the oldhtml argument to reference the previous content. Within the function, this refers to the current element in the set.
-     */
 
     /**
      * Get the value of a property for the first element in the set of matched elements.
      *
      * @param propertyName The name of the property to get.
+     * @see {@link https://api.jquery.com/prop/#prop-propertyName}
      */
     prop(propertyName: string): any;
     /**
@@ -1326,12 +1544,14 @@ interface JQuery {
      *
      * @param propertyName The name of the property to set.
      * @param value A value to set for the property.
+     * @see {@link https://api.jquery.com/prop/#prop-propertyName-value}
      */
     prop(propertyName: string, value: string|number|boolean): JQuery;
     /**
      * Set one or more properties for the set of matched elements.
      *
      * @param properties An object of property-value pairs to set.
+     * @see {@link https://api.jquery.com/prop/#prop-properties}
      */
     prop(properties: Object): JQuery;
     /**
@@ -1339,6 +1559,7 @@ interface JQuery {
      *
      * @param propertyName The name of the property to set.
      * @param func A function returning the value to set. Receives the index position of the element in the set and the old property value as arguments. Within the function, the keyword this refers to the current element.
+     * @see {@link https://api.jquery.com/prop/#prop-propertyName-function}
      */
     prop(propertyName: string, func: (index: number, oldPropertyValue: any) => any): JQuery;
 
@@ -1346,6 +1567,7 @@ interface JQuery {
      * Remove an attribute from each element in the set of matched elements.
      *
      * @param attributeName An attribute to remove; as of version 1.7, it can be a space-separated list of attributes.
+     * @see {@link https://api.jquery.com/removeAttr/}
      */
     removeAttr(attributeName: string): JQuery;
 
@@ -1353,12 +1575,14 @@ interface JQuery {
      * Remove a single class, multiple classes, or all classes from each element in the set of matched elements.
      *
      * @param className One or more space-separated classes to be removed from the class attribute of each matched element.
+     * @see {@link https://api.jquery.com/removeClass/#removeClass-className}
      */
     removeClass(className?: string): JQuery;
     /**
      * Remove a single class, multiple classes, or all classes from each element in the set of matched elements.
      *
      * @param func A function returning one or more space-separated class names to be removed. Receives the index position of the element in the set and the old class value as arguments.
+     * @see {@link https://api.jquery.com/removeClass/#removeClass-function}
      */
     removeClass(func: (index: number, className: string) => string): JQuery;
 
@@ -1366,6 +1590,7 @@ interface JQuery {
      * Remove a property for the set of matched elements.
      *
      * @param propertyName The name of the property to remove.
+     * @see {@link https://api.jquery.com/removeProp/}
      */
     removeProp(propertyName: string): JQuery;
 
@@ -1374,12 +1599,14 @@ interface JQuery {
      *
      * @param className One or more class names (separated by spaces) to be toggled for each element in the matched set.
      * @param swtch A Boolean (not just truthy/falsy) value to determine whether the class should be added or removed.
+     * @see {@link https://api.jquery.com/toggleClass/#toggleClass-className}
      */
     toggleClass(className: string, swtch?: boolean): JQuery;
     /**
      * Add or remove one or more classes from each element in the set of matched elements, depending on either the class's presence or the value of the switch argument.
      *
      * @param swtch A boolean value to determine whether the class should be added or removed.
+     * @see {@link https://api.jquery.com/toggleClass/#toggleClass-state}
      */
     toggleClass(swtch?: boolean): JQuery;
     /**
@@ -1387,31 +1614,35 @@ interface JQuery {
      *
      * @param func A function that returns class names to be toggled in the class attribute of each element in the matched set. Receives the index position of the element in the set, the old class value, and the switch as arguments.
      * @param swtch A boolean value to determine whether the class should be added or removed.
+     * @see {@link https://api.jquery.com/toggleClass/#toggleClass-function-state}
      */
     toggleClass(func: (index: number, className: string, swtch: boolean) => string, swtch?: boolean): JQuery;
 
     /**
      * Get the current value of the first element in the set of matched elements.
+     * @see {@link https://api.jquery.com/val/#val}
      */
     val(): any;
     /**
      * Set the value of each element in the set of matched elements.
      *
      * @param value A string of text, an array of strings or number corresponding to the value of each matched element to set as selected/checked.
+     * @see {@link https://api.jquery.com/val/#val-value}
      */
     val(value: string|string[]|number): JQuery;
     /**
      * Set the value of each element in the set of matched elements.
      *
      * @param func A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old value as arguments.
+     * @see {@link https://api.jquery.com/val/#val-function}
      */
     val(func: (index: number, value: string) => string): JQuery;
-
 
     /**
      * Get the value of style properties for the first element in the set of matched elements.
      *
      * @param propertyName A CSS property.
+     * @see {@link https://api.jquery.com/css/#css-propertyName}
      */
     css(propertyName: string): string;
     /**
@@ -1419,6 +1650,7 @@ interface JQuery {
      *
      * @param propertyName A CSS property name.
      * @param value A value to set for the property.
+     * @see {@link https://api.jquery.com/css/#css-propertyName-value}
      */
     css(propertyName: string, value: string|number): JQuery;
     /**
@@ -1426,34 +1658,40 @@ interface JQuery {
      *
      * @param propertyName A CSS property name.
      * @param value A function returning the value to set. this is the current element. Receives the index position of the element in the set and the old value as arguments.
+     * @see {@link https://api.jquery.com/css/#css-propertyName-function}
      */
     css(propertyName: string, value: (index: number, value: string) => string|number): JQuery;
     /**
      * Set one or more CSS properties for the set of matched elements.
      *
      * @param properties An object of property-value pairs to set.
+     * @see {@link https://api.jquery.com/css/#css-properties}
      */
     css(properties: Object): JQuery;
 
     /**
      * Get the current computed height for the first element in the set of matched elements.
+     * @see {@link https://api.jquery.com/height/#height}
      */
     height(): number;
     /**
      * Set the CSS height of every matched element.
      *
      * @param value An integer representing the number of pixels, or an integer with an optional unit of measure appended (as a string).
+     * @see {@link https://api.jquery.com/height/#height-value}
      */
     height(value: number|string): JQuery;
     /**
      * Set the CSS height of every matched element.
      *
      * @param func A function returning the height to set. Receives the index position of the element in the set and the old height as arguments. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/height/#height-function}
      */
     height(func: (index: number, height: number) => number|string): JQuery;
 
     /**
      * Get the current computed height for the first element in the set of matched elements, including padding but not border.
+     * @see {@link https://api.jquery.com/innerHeight/#innerHeight}
      */
     innerHeight(): number;
 
@@ -1461,11 +1699,13 @@ interface JQuery {
      * Sets the inner height on elements in the set of matched elements, including padding but not border.
      *
      * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     * @see {@link https://api.jquery.com/innerHeight/#innerHeight-value}
      */
     innerHeight(value: number|string): JQuery;
 
     /**
      * Get the current computed width for the first element in the set of matched elements, including padding but not border.
+     * @see {@link https://api.jquery.com/innerWidth/#innerWidth}
      */
     innerWidth(): number;
 
@@ -1473,23 +1713,27 @@ interface JQuery {
      * Sets the inner width on elements in the set of matched elements, including padding but not border.
      *
      * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     * @see {@link https://api.jquery.com/innerWidth/#innerWidth-value}
      */
     innerWidth(value: number|string): JQuery;
 
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the document.
+     * @see {@link https://api.jquery.com/offset/#offset}
      */
     offset(): JQueryCoordinates;
     /**
      * An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
      *
      * @param coordinates An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
+     * @see {@link https://api.jquery.com/offset/#offset-coordinates}
      */
     offset(coordinates: JQueryCoordinates): JQuery;
     /**
      * An object containing the properties top and left, which are integers indicating the new top and left coordinates for the elements.
      *
      * @param func A function to return the coordinates to set. Receives the index of the element in the collection as the first argument and the current coordinates as the second argument. The function should return an object with the new top and left properties.
+     * @see {@link https://api.jquery.com/offset/#offset-function}
      */
     offset(func: (index: number, coords: JQueryCoordinates) => JQueryCoordinates): JQuery;
 
@@ -1497,6 +1741,7 @@ interface JQuery {
      * Get the current computed height for the first element in the set of matched elements, including padding, border, and optionally margin. Returns an integer (without "px") representation of the value or null if called on an empty set of elements.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
+     * @see {@link https://api.jquery.com/outerHeight/#outerHeight-includeMargin}
      */
     outerHeight(includeMargin?: boolean): number;
 
@@ -1504,6 +1749,7 @@ interface JQuery {
      * Sets the outer height on elements in the set of matched elements, including padding and border.
      *
      * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     * @see {@link https://api.jquery.com/outerHeight/#outerHeight-value}
      */
     outerHeight(value: number|string): JQuery;
 
@@ -1511,6 +1757,7 @@ interface JQuery {
      * Get the current computed width for the first element in the set of matched elements, including padding and border.
      *
      * @param includeMargin A Boolean indicating whether to include the element's margin in the calculation.
+     * @see {@link https://api.jquery.com/outerWidth/#outerWidth-includeMargin}
      */
     outerWidth(includeMargin?: boolean): number;
 
@@ -1518,50 +1765,59 @@ interface JQuery {
      * Sets the outer width on elements in the set of matched elements, including padding and border.
      *
      * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     * @see {@link https://api.jquery.com/outerWidth/#outerWidth-value}
      */
     outerWidth(value: number|string): JQuery;
 
     /**
      * Get the current coordinates of the first element in the set of matched elements, relative to the offset parent.
+     * @see {@link https://api.jquery.com/position/}
      */
     position(): JQueryCoordinates;
 
     /**
      * Get the current horizontal position of the scroll bar for the first element in the set of matched elements or set the horizontal position of the scroll bar for every matched element.
+     * @see {@link https://api.jquery.com/scrollLeft/#scrollLeft}
      */
     scrollLeft(): number;
     /**
      * Set the current horizontal position of the scroll bar for each of the set of matched elements.
      *
      * @param value An integer indicating the new position to set the scroll bar to.
+     * @see {@link https://api.jquery.com/scrollLeft/#scrollLeft-value}
      */
     scrollLeft(value: number): JQuery;
 
     /**
      * Get the current vertical position of the scroll bar for the first element in the set of matched elements or set the vertical position of the scroll bar for every matched element.
+     * @see {@link https://api.jquery.com/scrollTop/#scrollTop}
      */
     scrollTop(): number;
     /**
      * Set the current vertical position of the scroll bar for each of the set of matched elements.
      *
      * @param value An integer indicating the new position to set the scroll bar to.
+     * @see {@link https://api.jquery.com/scrollTop/#scrollTop-value}
      */
     scrollTop(value: number): JQuery;
 
     /**
      * Get the current computed width for the first element in the set of matched elements.
+     * @see {@link https://api.jquery.com/width/#width}
      */
     width(): number;
     /**
      * Set the CSS width of each element in the set of matched elements.
      *
      * @param value An integer representing the number of pixels, or an integer along with an optional unit of measure appended (as a string).
+     * @see {@link https://api.jquery.com/width/#width-value}
      */
     width(value: number|string): JQuery;
     /**
      * Set the CSS width of each element in the set of matched elements.
      *
      * @param func A function returning the width to set. Receives the index position of the element in the set and the old width as arguments. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/width/#width-function}
      */
     width(func: (index: number, width: number) => number|string): JQuery;
 
@@ -1569,6 +1825,7 @@ interface JQuery {
      * Remove from the queue all items that have not yet been run.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @see {@link https://api.jquery.com/clearQueue/}
      */
     clearQueue(queueName?: string): JQuery;
 
@@ -1577,22 +1834,26 @@ interface JQuery {
      *
      * @param key A string naming the piece of data to set.
      * @param value The new data value; it can be any Javascript type including Array or Object.
+     * @see {@link https://api.jquery.com/data/#data-key-value}
      */
     data(key: string, value: any): JQuery;
     /**
      * Return the value at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
      *
      * @param key Name of the data stored.
+     * @see {@link https://api.jquery.com/data/#data-key}
      */
     data(key: string): any;
     /**
      * Store arbitrary data associated with the matched elements.
      *
      * @param obj An object of key-value pairs of data to update.
+     * @see {@link https://api.jquery.com/data/#data-obj}
      */
     data(obj: { [key: string]: any; }): JQuery;
     /**
      * Return the value at the named data store for the first element in the jQuery collection, as set by data(name, value) or by an HTML5 data-* attribute.
+     * @see {@link https://api.jquery.com/data/#data}
      */
     data(): any;
 
@@ -1600,6 +1861,7 @@ interface JQuery {
      * Execute the next function on the queue for the matched elements.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @see {@link https://api.jquery.com/dequeue/}
      */
     dequeue(queueName?: string): JQuery;
 
@@ -1607,16 +1869,19 @@ interface JQuery {
      * Remove a previously-stored piece of data.
      *
      * @param name A string naming the piece of data to delete or space-separated string naming the pieces of data to delete.
+     * @see {@link https://api.jquery.com/removeData/#removeData-name}
      */
     removeData(name: string): JQuery;
     /**
      * Remove a previously-stored piece of data.
      *
      * @param list An array of strings naming the pieces of data to delete.
+     * @see {@link https://api.jquery.com/removeData/#removeData-list}
      */
     removeData(list: string[]): JQuery;
     /**
      * Remove all previously-stored piece of data.
+     * @see {@link https://api.jquery.com/removeData/}
      */
     removeData(): JQuery;
 
@@ -1625,6 +1890,7 @@ interface JQuery {
      *
      * @param type The type of queue that needs to be observed. (default: fx)
      * @param target Object onto which the promise methods have to be attached
+     * @see {@link https://api.jquery.com/promise/}
      */
     promise(type?: string, target?: Object): JQueryPromise<any>;
 
@@ -1634,6 +1900,7 @@ interface JQuery {
      * @param properties An object of CSS properties and values that the animation will move toward.
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/animate/#animate-properties-duration-easing-complete}
      */
     animate(properties: Object, duration?: string|number, complete?: Function): JQuery;
     /**
@@ -1643,6 +1910,7 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition. (default: swing)
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/animate/#animate-properties-duration-easing-complete}
      */
     animate(properties: Object, duration?: string|number, easing?: string, complete?: Function): JQuery;
     /**
@@ -1650,6 +1918,7 @@ interface JQuery {
      *
      * @param properties An object of CSS properties and values that the animation will move toward.
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/animate/#animate-properties-options}
      */
     animate(properties: Object, options: JQueryAnimationOptions): JQuery;
 
@@ -1658,6 +1927,7 @@ interface JQuery {
      *
      * @param duration An integer indicating the number of milliseconds to delay execution of the next item in the queue.
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @see {@link https://api.jquery.com/delay/}
      */
     delay(duration: number, queueName?: string): JQuery;
 
@@ -1666,6 +1936,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/fadeIn/#fadeIn-duration-complete}
      */
     fadeIn(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1674,12 +1945,14 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/fadeIn/#fadeIn-duration-easing-complete}
      */
     fadeIn(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Display the matched elements by fading them to opaque.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/fadeIn/#fadeIn-options}
      */
     fadeIn(options: JQueryAnimationOptions): JQuery;
 
@@ -1688,6 +1961,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/fadeOut/#fadeOut-duration-complete}
      */
     fadeOut(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1696,12 +1970,14 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/fadeOut/#fadeOut-duration-easing-complete}
      */
     fadeOut(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Hide the matched elements by fading them to transparent.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/fadeOut/#fadeOut-options}
      */
     fadeOut(options: JQueryAnimationOptions): JQuery;
 
@@ -1711,6 +1987,7 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param opacity A number between 0 and 1 denoting the target opacity.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/fadeTo/#fadeTo-duration-opacity-complete}
      */
     fadeTo(duration: string|number, opacity: number, complete?: Function): JQuery;
     /**
@@ -1720,6 +1997,7 @@ interface JQuery {
      * @param opacity A number between 0 and 1 denoting the target opacity.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/fadeTo/#fadeTo-duration-opacity-easing-complete}
      */
     fadeTo(duration: string|number, opacity: number, easing?: string, complete?: Function): JQuery;
 
@@ -1728,6 +2006,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/fadeToggle/#fadeToggle-duration-easing-complete}
      */
     fadeToggle(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1736,12 +2015,14 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/fadeToggle/#fadeToggle-duration-easing-complete}
      */
     fadeToggle(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Display or hide the matched elements by animating their opacity.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/fadeToggle/#fadeToggle-options}
      */
     fadeToggle(options: JQueryAnimationOptions): JQuery;
 
@@ -1749,6 +2030,7 @@ interface JQuery {
      * Stop the currently-running animation, remove all queued animations, and complete all animations for the matched elements.
      *
      * @param queue The name of the queue in which to stop animations.
+     * @see {@link https://api.jquery.com/finish/}
      */
     finish(queue?: string): JQuery;
 
@@ -1757,6 +2039,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/hide/#hide}
      */
     hide(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1765,12 +2048,14 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/hide/#hide-duration-easing-complete}
      */
     hide(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Hide the matched elements.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/hide/#hide-options}
      */
     hide(options: JQueryAnimationOptions): JQuery;
 
@@ -1779,6 +2064,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/show/#show}
      */
     show(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1787,12 +2073,14 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/show/#show-duration-easing-complete}
      */
     show(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Display the matched elements.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/show/#show-options}
      */
     show(options: JQueryAnimationOptions): JQuery;
 
@@ -1801,6 +2089,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/slideDown/#slideDown-duration-complete}
      */
     slideDown(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1809,12 +2098,14 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/slideDown/#slideDown-duration-easing-complete}
      */
     slideDown(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Display the matched elements with a sliding motion.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/slideDown/#slideDown-options}
      */
     slideDown(options: JQueryAnimationOptions): JQuery;
 
@@ -1823,6 +2114,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/slideToggle/#slideToggle-duration-complete}
      */
     slideToggle(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1831,12 +2123,14 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/slideToggle/#slideToggle-duration-easing-complete}
      */
     slideToggle(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Display or hide the matched elements with a sliding motion.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/slideToggle/#slideToggle-options}
      */
     slideToggle(options: JQueryAnimationOptions): JQuery;
 
@@ -1845,6 +2139,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/slideUp/#slideUp-duration-complete}
      */
     slideUp(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1853,12 +2148,14 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/slideUp/#slideUp-duration-easing-complete}
      */
     slideUp(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Hide the matched elements with a sliding motion.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/slideUp/#slideUp-options}
      */
     slideUp(options: JQueryAnimationOptions): JQuery;
 
@@ -1867,6 +2164,7 @@ interface JQuery {
      *
      * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
+     * @see {@link https://api.jquery.com/stop/#stop-clearQueue-jumpToEnd}
      */
     stop(clearQueue?: boolean, jumpToEnd?: boolean): JQuery;
     /**
@@ -1875,6 +2173,7 @@ interface JQuery {
      * @param queue The name of the queue in which to stop animations.
      * @param clearQueue A Boolean indicating whether to remove queued animation as well. Defaults to false.
      * @param jumpToEnd A Boolean indicating whether to complete the current animation immediately. Defaults to false.
+     * @see {@link https://api.jquery.com/stop/#stop-queue-clearQueue-jumpToEnd}
      */
     stop(queue?: string, clearQueue?: boolean, jumpToEnd?: boolean): JQuery;
 
@@ -1883,6 +2182,7 @@ interface JQuery {
      *
      * @param duration A string or number determining how long the animation will run.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/toggle/#toggle-duration-complete}
      */
     toggle(duration?: number|string, complete?: Function): JQuery;
     /**
@@ -1891,18 +2191,21 @@ interface JQuery {
      * @param duration A string or number determining how long the animation will run.
      * @param easing A string indicating which easing function to use for the transition.
      * @param complete A function to call once the animation is complete.
+     * @see {@link https://api.jquery.com/toggle/#toggle-duration-easing-complete}
      */
     toggle(duration?: number|string, easing?: string, complete?: Function): JQuery;
     /**
      * Display or hide the matched elements.
      *
      * @param options A map of additional options to pass to the method.
+     * @see {@link https://api.jquery.com/toggle/#toggle-options}
      */
     toggle(options: JQueryAnimationOptions): JQuery;
     /**
      * Display or hide the matched elements.
      *
      * @param showOrHide A Boolean indicating whether to show or hide the elements.
+     * @see {@link https://api.jquery.com/toggle/#toggle-display}
      */
     toggle(showOrHide: boolean): JQuery;
 
@@ -1912,6 +2215,7 @@ interface JQuery {
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/bind/#bind-eventType-eventData-handler}
      */
     bind(eventType: string, eventData: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -1919,6 +2223,7 @@ interface JQuery {
      *
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/bind/#bind-eventType-eventData-handler}
      */
     bind(eventType: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -1927,6 +2232,7 @@ interface JQuery {
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param eventData An object containing data that will be passed to the event handler.
      * @param preventBubble Setting the third argument to false will attach a function that prevents the default action from occurring and stops the event from bubbling. The default is true.
+     * @see {@link https://api.jquery.com/bind/#bind-eventType-eventData-preventBubble}
      */
     bind(eventType: string, eventData: any, preventBubble: boolean): JQuery;
     /**
@@ -1934,23 +2240,27 @@ interface JQuery {
      *
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param preventBubble Setting the third argument to false will attach a function that prevents the default action from occurring and stops the event from bubbling. The default is true.
+     * @see {@link https://api.jquery.com/bind/#bind-eventType-eventData-preventBubble}
      */
     bind(eventType: string, preventBubble: boolean): JQuery;
     /**
      * Attach a handler to an event for the elements.
      *
      * @param events An object containing one or more DOM event types and functions to execute for them.
+     * @see {@link https://api.jquery.com/bind/#bind-events}
      */
     bind(events: any): JQuery;
 
     /**
      * Trigger the "blur" event on an element
+     * @see {@link https://api.jquery.com/blur/#blur}
      */
     blur(): JQuery;
     /**
      * Bind an event handler to the "blur" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/blur/#blur-handler}
      */
     blur(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -1958,17 +2268,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/blur/#blur-eventData-handler}
      */
     blur(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "change" event on an element.
+     * @see {@link https://api.jquery.com/change/#change}
      */
     change(): JQuery;
     /**
      * Bind an event handler to the "change" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/change/#change-handler}
      */
     change(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -1976,17 +2289,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/change/#change-eventData-handler}
      */
     change(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "click" event on an element.
+     * @see {@link https://api.jquery.com/click/#click}
      */
     click(): JQuery;
     /**
      * Bind an event handler to the "click" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/click/#click-handler}
      */
     click(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -1994,17 +2310,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/click/#click-eventData-handler}
      */
     click(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "contextmenu" event on an element.
+     * @see {@link https://api.jquery.com/contextmenu/#contextmenu}
      */
     contextmenu(): JQuery;
     /**
      * Bind an event handler to the "contextmenu" JavaScript event.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/contextmenu/#contextmenu-handler}
      */
     contextmenu(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
     /**
@@ -2012,17 +2331,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/contextmenu/#contextmenu-eventData-handler}
      */
     contextmenu(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
 
     /**
      * Trigger the "dblclick" event on an element.
+     * @see {@link https://api.jquery.com/dblclick/#dblclick}
      */
     dblclick(): JQuery;
     /**
      * Bind an event handler to the "dblclick" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/dblclick/#dblclick-handler}
      */
     dblclick(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2030,20 +2352,31 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/dblclick/#dblclick-eventData-handler}
      */
     dblclick(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
+    /**
+     * Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.
+     * @see {@link https://api.jquery.com/delegate/#delegate-selector-eventType-handler}
+     */
     delegate(selector: any, eventType: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
+    /**
+     * Attach a handler to one or more events for all elements that match the selector, now or in the future, based on a specific set of root elements.
+     * @see {@link https://api.jquery.com/delegate/#delegate-selector-eventType-eventData-handler}
+     */
     delegate(selector: any, eventType: string, eventData: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "focus" event on an element.
+     * @see {@link https://api.jquery.com/focus/#focus}
      */
     focus(): JQuery;
     /**
      * Bind an event handler to the "focus" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/focus/#focus-handler}
      */
     focus(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2051,17 +2384,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/focus/#focus-eventData-handler}
      */
     focus(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "focusin" event on an element.
+     * @see {@link https://api.jquery.com/focusin/#focusin}
      */
     focusin(): JQuery;
     /**
      * Bind an event handler to the "focusin" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/focusin/#focusin-handler}
      */
     focusin(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2069,17 +2405,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/focusin/#focusin-eventData-handler}
      */
     focusin(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "focusout" event on an element.
+     * @see {@link https://api.jquery.com/focusout/#focusout}
      */
     focusout(): JQuery;
     /**
      * Bind an event handler to the "focusout" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/focusout/#focusout-handler}
      */
     focusout(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2087,6 +2426,7 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/focusout/#focusout-eventData-handler}
      */
     focusout(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
@@ -2095,23 +2435,27 @@ interface JQuery {
      *
      * @param handlerIn A function to execute when the mouse pointer enters the element.
      * @param handlerOut A function to execute when the mouse pointer leaves the element.
+     * @see {@link https://api.jquery.com/hover/#hover-handlerIn-handlerOut}
      */
     hover(handlerIn: (eventObject: JQueryEventObject) => any, handlerOut: (eventObject: JQueryEventObject) => any): JQuery;
     /**
      * Bind a single handler to the matched elements, to be executed when the mouse pointer enters or leaves the elements.
      *
      * @param handlerInOut A function to execute when the mouse pointer enters or leaves the element.
+     * @see {@link https://api.jquery.com/hover/#hover-handlerInOut}
      */
     hover(handlerInOut: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "keydown" event on an element.
+     * @see {@link https://api.jquery.com/keydown/#keydown}
      */
     keydown(): JQuery;
     /**
      * Bind an event handler to the "keydown" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/keydown/#keydown-handler}
      */
     keydown(handler: (eventObject: JQueryKeyEventObject) => any): JQuery;
     /**
@@ -2119,17 +2463,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/keydown/#keydown-eventData-handler}
      */
     keydown(eventData?: any, handler?: (eventObject: JQueryKeyEventObject) => any): JQuery;
 
     /**
      * Trigger the "keypress" event on an element.
+     * @see {@link https://api.jquery.com/keypress/#keypress}
      */
     keypress(): JQuery;
     /**
      * Bind an event handler to the "keypress" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/keypress/#keypress-handler}
      */
     keypress(handler: (eventObject: JQueryKeyEventObject) => any): JQuery;
     /**
@@ -2137,17 +2484,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/keypress/#keypress-eventData-handler}
      */
     keypress(eventData?: any, handler?: (eventObject: JQueryKeyEventObject) => any): JQuery;
 
     /**
      * Trigger the "keyup" event on an element.
+     * @see {@link https://api.jquery.com/keyup/#keyup}
      */
     keyup(): JQuery;
     /**
      * Bind an event handler to the "keyup" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/keyup/#keyup-handler}
      */
     keyup(handler: (eventObject: JQueryKeyEventObject) => any): JQuery;
     /**
@@ -2155,6 +2505,7 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/keyup/#keyup-eventData-handler}
      */
     keyup(eventData?: any, handler?: (eventObject: JQueryKeyEventObject) => any): JQuery;
 
@@ -2162,6 +2513,7 @@ interface JQuery {
      * Bind an event handler to the "load" JavaScript event.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/load/}
      */
     load(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2169,17 +2521,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/load/}
      */
     load(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "mousedown" event on an element.
+     * @see {@link https://api.jquery.com/mousedown/#mousedown}
      */
     mousedown(): JQuery;
     /**
      * Bind an event handler to the "mousedown" JavaScript event.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mousedown/#mousedown-handler}
      */
     mousedown(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
     /**
@@ -2187,17 +2542,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mousedown/#mousedown-eventData-handler}
      */
     mousedown(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
 
     /**
      * Trigger the "mouseenter" event on an element.
+     * @see {@link https://api.jquery.com/mouseenter/#mouseenter}
      */
     mouseenter(): JQuery;
     /**
      * Bind an event handler to be fired when the mouse enters an element.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseenter/#mouseenter-handler}
      */
     mouseenter(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
     /**
@@ -2205,17 +2563,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseenter/#mouseenter-eventData-handler}
      */
     mouseenter(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
 
     /**
      * Trigger the "mouseleave" event on an element.
+     * @see {@link https://api.jquery.com/mouseleave/#mouseleave}
      */
     mouseleave(): JQuery;
     /**
      * Bind an event handler to be fired when the mouse leaves an element.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseleave/#mouseleave-handler}
      */
     mouseleave(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
     /**
@@ -2223,17 +2584,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseleave/#mouseleave-eventData-handler}
      */
     mouseleave(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
 
     /**
      * Trigger the "mousemove" event on an element.
+     * @see {@link https://api.jquery.com/mousemove/#mousemove}
      */
     mousemove(): JQuery;
     /**
      * Bind an event handler to the "mousemove" JavaScript event.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mousemove/#mousemove-handler}
      */
     mousemove(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
     /**
@@ -2241,17 +2605,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mousemove/#mousemove-eventData-handler}
      */
     mousemove(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
 
     /**
      * Trigger the "mouseout" event on an element.
+     * @see {@link https://api.jquery.com/mouseout/#mouseout}
      */
     mouseout(): JQuery;
     /**
      * Bind an event handler to the "mouseout" JavaScript event.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseout/#mouseout-handler}
      */
     mouseout(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
     /**
@@ -2259,17 +2626,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseout/#mouseout-eventData-handler}
      */
     mouseout(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
 
     /**
      * Trigger the "mouseover" event on an element.
+     * @see {@link https://api.jquery.com/mouseover/#mouseover}
      */
     mouseover(): JQuery;
     /**
      * Bind an event handler to the "mouseover" JavaScript event.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseover/#mouseover-handler}
      */
     mouseover(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
     /**
@@ -2277,17 +2647,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseover/#mouseover-eventData-handler}
      */
     mouseover(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
 
     /**
      * Trigger the "mouseup" event on an element.
+     * @see {@link https://api.jquery.com/mouseup/#mouseup}
      */
     mouseup(): JQuery;
     /**
      * Bind an event handler to the "mouseup" JavaScript event.
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseup/#mouseup-handler}
      */
     mouseup(handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
     /**
@@ -2295,11 +2668,13 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/mouseup/#mouseup-eventData-handler}
      */
     mouseup(eventData: Object, handler: (eventObject: JQueryMouseEventObject) => any): JQuery;
 
     /**
      * Remove an event handler.
+     * @see {@link https://api.jquery.com/off/#off}
      */
     off(): JQuery;
     /**
@@ -2308,6 +2683,7 @@ interface JQuery {
      * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
      * @param handler A handler function previously attached for the event(s), or the special value false.
+     * @see {@link https://api.jquery.com/off/#off-events-selector-handler}
      */
     off(events: string, selector?: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2315,6 +2691,7 @@ interface JQuery {
      *
      * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
      * @param handler A handler function previously attached for the event(s), or the special value false. Takes handler with extra args that can be attached with on().
+     * @see {@link https://api.jquery.com/off/#off-events-selector-handler}
      */
     off(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
     /**
@@ -2322,6 +2699,7 @@ interface JQuery {
      *
      * @param events One or more space-separated event types and optional namespaces, or just namespaces, such as "click", "keydown.myPlugin", or ".myPlugin".
      * @param handler A handler function previously attached for the event(s), or the special value false.
+     * @see {@link https://api.jquery.com/off/#off-events-selector-handler}
      */
     off(events: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2329,6 +2707,7 @@ interface JQuery {
      *
      * @param events An object where the string keys represent one or more space-separated event types and optional namespaces, and the values represent handler functions previously attached for the event(s).
      * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
+     * @see {@link https://api.jquery.com/off/#off-events-selector}
      */
     off(events: { [key: string]: any; }, selector?: string): JQuery;
 
@@ -2337,6 +2716,7 @@ interface JQuery {
      *
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false. Rest parameter args is for optional parameters passed to jQuery.trigger(). Note that the actual parameters on the event handler function must be marked as optional (? syntax).
+     * @see {@link https://api.jquery.com/on/#on-events-selector-data-handler}
      */
     on(events: string, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
     /**
@@ -2345,6 +2725,7 @@ interface JQuery {
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @see {@link https://api.jquery.com/on/#on-events-selector-data-handler}
     */
     on(events: string, data : any, handler: (eventObject: JQueryEventObject, ...args: any[]) => any): JQuery;
     /**
@@ -2353,6 +2734,7 @@ interface JQuery {
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @see {@link https://api.jquery.com/on/#on-events-selector-data-handler}
      */
     on(events: string, selector: string, handler: (eventObject: JQueryEventObject, ...eventData: any[]) => any): JQuery;
     /**
@@ -2362,6 +2744,7 @@ interface JQuery {
      * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @see {@link https://api.jquery.com/on/#on-events-selector-data-handler}
      */
     on(events: string, selector: string, data: any, handler: (eventObject: JQueryEventObject, ...eventData: any[]) => any): JQuery;
     /**
@@ -2370,6 +2753,7 @@ interface JQuery {
      * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @see {@link https://api.jquery.com/on/#on-events-selector-data}
      */
     on(events: { [key: string]: any; }, selector?: string, data?: any): JQuery;
     /**
@@ -2377,6 +2761,7 @@ interface JQuery {
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
      * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @see {@link https://api.jquery.com/on/#on-events-selector-data}
      */
     on(events: { [key: string]: any; }, data?: any): JQuery;
 
@@ -2385,6 +2770,7 @@ interface JQuery {
      *
      * @param events A string containing one or more JavaScript event types, such as "click" or "submit," or custom event names.
      * @param handler A function to execute at the time the event is triggered.
+     * @see {@link https://api.jquery.com/one/#one-events-data-handler}
      */
     one(events: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2393,6 +2779,7 @@ interface JQuery {
      * @param events A string containing one or more JavaScript event types, such as "click" or "submit," or custom event names.
      * @param data An object containing data that will be passed to the event handler.
      * @param handler A function to execute at the time the event is triggered.
+     * @see {@link https://api.jquery.com/one/#one-events-data-handler}
      */
     one(events: string, data: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
@@ -2402,6 +2789,7 @@ interface JQuery {
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
      * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @see {@link https://api.jquery.com/one/#one-events-selector-data-handler}
      */
     one(events: string, selector: string, handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2411,6 +2799,7 @@ interface JQuery {
      * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand for a function that simply does return false.
+     * @see {@link https://api.jquery.com/one/#one-events-selector-data-handler}
      */
     one(events: string, selector: string, data: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
@@ -2420,6 +2809,7 @@ interface JQuery {
      * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
      * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If the selector is null or omitted, the handler is always called when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @see {@link https://api.jquery.com/one/#one-events-selector-data}
      */
     one(events: { [key: string]: any; }, selector?: string, data?: any): JQuery;
 
@@ -2428,6 +2818,7 @@ interface JQuery {
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional namespaces, and the values represent a handler function to be called for the event(s).
      * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @see {@link https://api.jquery.com/one/#one-events-selector-data}
      */
     one(events: { [key: string]: any; }, data?: any): JQuery;
 
@@ -2436,17 +2827,20 @@ interface JQuery {
      * Specify a function to execute when the DOM is fully loaded.
      *
      * @param handler A function to execute after the DOM is ready.
+     * @see {@link https://api.jquery.com/ready/}
      */
     ready(handler: (jQueryAlias?: JQueryStatic) => any): JQuery;
 
     /**
      * Trigger the "resize" event on an element.
+     * @see {@link https://api.jquery.com/resize/#resize}
      */
     resize(): JQuery;
     /**
      * Bind an event handler to the "resize" JavaScript event.
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/resize/#resize-handler}
      */
     resize(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2454,17 +2848,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/resize/#resize-eventData-handler}
      */
     resize(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "scroll" event on an element.
+     * @see {@link https://api.jquery.com/scroll/#scroll}
      */
     scroll(): JQuery;
     /**
      * Bind an event handler to the "scroll" JavaScript event.
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/scroll/#scroll-handler}
      */
     scroll(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2472,17 +2869,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/scroll/#scroll-eventData-handler}
      */
     scroll(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "select" event on an element.
+     * @see {@link https://api.jquery.com/select/#select}
      */
     select(): JQuery;
     /**
      * Bind an event handler to the "select" JavaScript event.
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/select/#select-handler}
      */
     select(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2490,17 +2890,20 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/select/#select-eventData-handler}
      */
     select(eventData: Object, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * Trigger the "submit" event on an element.
+     * @see {@link https://api.jquery.com/submit/#submit}
      */
     submit(): JQuery;
     /**
      * Bind an event handler to the "submit" JavaScript event
      *
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/submit/#submit-handler}
      */
     submit(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2508,6 +2911,7 @@ interface JQuery {
      *
      * @param eventData An object containing data that will be passed to the event handler.
      * @param handler A function to execute each time the event is triggered.
+     * @see {@link https://api.jquery.com/submit/#submit-eventData-handler}
      */
     submit(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
@@ -2516,6 +2920,7 @@ interface JQuery {
      *
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      * @param extraParameters Additional parameters to pass along to the event handler.
+     * @see {@link https://api.jquery.com/trigger/#trigger-eventType-extraParameters}
      */
     trigger(eventType: string, extraParameters?: any[]|Object): JQuery;
     /**
@@ -2523,6 +2928,7 @@ interface JQuery {
      *
      * @param event A jQuery.Event object.
      * @param extraParameters Additional parameters to pass along to the event handler.
+     * @see {@link https://api.jquery.com/trigger/#trigger-event-extraParameters}
      */
     trigger(event: JQueryEventObject, extraParameters?: any[]|Object): JQuery;
 
@@ -2531,6 +2937,7 @@ interface JQuery {
      *
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      * @param extraParameters An array of additional parameters to pass along to the event handler.
+     * @see {@link https://api.jquery.com/triggerHandler/#triggerHandler-eventType-extraParameters}
      */
     triggerHandler(eventType: string, ...extraParameters: any[]): Object;
 
@@ -2539,6 +2946,7 @@ interface JQuery {
      *
      * @param event A jQuery.Event object.
      * @param extraParameters An array of additional parameters to pass along to the event handler.
+     * @see {@link https://api.jquery.com/triggerHandler/#triggerHandler-event-extraParameters}
      */
     triggerHandler(event: JQueryEventObject, ...extraParameters: any[]): Object;
 
@@ -2547,6 +2955,7 @@ interface JQuery {
      *
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      * @param handler The function that is to be no longer executed.
+     * @see {@link https://api.jquery.com/unbind/#unbind-eventType-handler}
      */
     unbind(eventType?: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2554,17 +2963,20 @@ interface JQuery {
      *
      * @param eventType A string containing a JavaScript event type, such as click or submit.
      * @param fls Unbinds the corresponding 'return false' function that was bound using .bind( eventType, false ).
+     * @see {@link https://api.jquery.com/unbind/#unbind-eventType-false}
      */
     unbind(eventType: string, fls: boolean): JQuery;
     /**
      * Remove a previously-attached event handler from the elements.
      *
      * @param evt A JavaScript event object as passed to an event handler.
+     * @see {@link https://api.jquery.com/unbind/#unbind-event}
      */
     unbind(evt: any): JQuery;
 
     /**
      * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
+     * @see {@link https://api.jquery.com/undelegate/#undelegate}
      */
     undelegate(): JQuery;
     /**
@@ -2573,6 +2985,7 @@ interface JQuery {
      * @param selector A selector which will be used to filter the event results.
      * @param eventType A string containing a JavaScript event type, such as "click" or "keydown"
      * @param handler A function to execute at the time the event is triggered.
+     * @see {@link https://api.jquery.com/undelegate/#undelegate-selector-eventType}
      */
     undelegate(selector: string, eventType: string, handler?: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2580,12 +2993,14 @@ interface JQuery {
      *
      * @param selector A selector which will be used to filter the event results.
      * @param events An object of one or more event types and previously bound functions to unbind from them.
+     * @see {@link https://api.jquery.com/undelegate/#undelegate-selector-events}
      */
     undelegate(selector: string, events: Object): JQuery;
     /**
      * Remove a handler from the event for all elements which match the current selector, based upon a specific set of root elements.
      *
      * @param namespace A string containing a namespace to unbind all events from.
+     * @see {@link https://api.jquery.com/undelegate/#undelegate-namespace}
      */
     undelegate(namespace: string): JQuery;
 
@@ -2593,6 +3008,7 @@ interface JQuery {
      * Bind an event handler to the "unload" JavaScript event. (DEPRECATED from v1.8)
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/unload/#unload-handler}
      */
     unload(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2600,11 +3016,13 @@ interface JQuery {
      *
      * @param eventData A plain object of data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/unload/#unload-eventData-handler}
      */
     unload(eventData?: any, handler?: (eventObject: JQueryEventObject) => any): JQuery;
 
     /**
      * The DOM node context originally passed to jQuery(); if none was passed then context will likely be the document. (DEPRECATED from v1.10)
+     * @see {@link https://api.jquery.com/context/}
      */
     context: Element;
 
@@ -2614,6 +3032,7 @@ interface JQuery {
      * Bind an event handler to the "error" JavaScript event. (DEPRECATED from v1.8)
      *
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/error/#error-handler}
      */
     error(handler: (eventObject: JQueryEventObject) => any): JQuery;
     /**
@@ -2621,6 +3040,7 @@ interface JQuery {
      *
      * @param eventData A plain object of data that will be passed to the event handler.
      * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/error/#error-eventData-handler}
      */
     error(eventData: any, handler: (eventObject: JQueryEventObject) => any): JQuery;
 
@@ -2628,6 +3048,7 @@ interface JQuery {
      * Add a collection of DOM elements onto the jQuery stack.
      *
      * @param elements An array of elements to push onto the stack and make into a new jQuery object.
+     * @see {@link https://api.jquery.com/pushStack/#pushStack-elements}
      */
     pushStack(elements: any[]): JQuery;
     /**
@@ -2636,34 +3057,39 @@ interface JQuery {
      * @param elements An array of elements to push onto the stack and make into a new jQuery object.
      * @param name The name of a jQuery method that generated the array of elements.
      * @param arguments The arguments that were passed in to the jQuery method (for serialization).
+     * @see {@link https://api.jquery.com/pushStack/#pushStack-elements-name-arguments}
      */
     pushStack(elements: any[], name: string, arguments: any[]): JQuery;
 
     /**
      * Insert content, specified by the parameter, after each element in the set of matched elements.
      *
-     * param content1 HTML string, DOM element, DocumentFragment, array of elements, or jQuery object to insert after each element in the set of matched elements.
-     * param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert after each element in the set of matched elements.
+     * @param content1 HTML string, DOM element, DocumentFragment, array of elements, or jQuery object to insert after each element in the set of matched elements.
+     * @param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert after each element in the set of matched elements.
+     * @see {@link https://api.jquery.com/after/#after-content-content}
      */
     after(content1: JQuery|any[]|Element|DocumentFragment|Text|string, ...content2: any[]): JQuery;
     /**
      * Insert content, specified by the parameter, after each element in the set of matched elements.
      *
-     * param func A function that returns an HTML string, DOM element(s), or jQuery object to insert after each element in the set of matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     * @param func A function that returns an HTML string, DOM element(s), or jQuery object to insert after each element in the set of matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/after/#after-function}
      */
     after(func: (index: number, html: string) => string|Element|JQuery): JQuery;
 
     /**
      * Insert content, specified by the parameter, to the end of each element in the set of matched elements.
      *
-     * param content1 DOM element, DocumentFragment, array of elements, HTML string, or jQuery object to insert at the end of each element in the set of matched elements.
-     * param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert at the end of each element in the set of matched elements.
+     * @param content1 DOM element, DocumentFragment, array of elements, HTML string, or jQuery object to insert at the end of each element in the set of matched elements.
+     * @param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert at the end of each element in the set of matched elements.
+     * @see {@link https://api.jquery.com/append/#append-content-content}
      */
     append(content1: JQuery|any[]|Element|DocumentFragment|Text|string, ...content2: any[]): JQuery;
     /**
      * Insert content, specified by the parameter, to the end of each element in the set of matched elements.
      *
-     * param func A function that returns an HTML string, DOM element(s), or jQuery object to insert at the end of each element in the set of matched elements. Receives the index position of the element in the set and the old HTML value of the element as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function that returns an HTML string, DOM element(s), or jQuery object to insert at the end of each element in the set of matched elements. Receives the index position of the element in the set and the old HTML value of the element as arguments. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/append/#append-function}
      */
     append(func: (index: number, html: string) => string|Element|JQuery): JQuery;
 
@@ -2671,68 +3097,78 @@ interface JQuery {
      * Insert every element in the set of matched elements to the end of the target.
      *
      * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements will be inserted at the end of the element(s) specified by this parameter.
+     * @see {@link https://api.jquery.com/appendTo/}
      */
     appendTo(target: JQuery|any[]|Element|string): JQuery;
 
     /**
      * Insert content, specified by the parameter, before each element in the set of matched elements.
      *
-     * param content1 HTML string, DOM element, DocumentFragment, array of elements, or jQuery object to insert before each element in the set of matched elements.
-     * param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert before each element in the set of matched elements.
+     * @param content1 HTML string, DOM element, DocumentFragment, array of elements, or jQuery object to insert before each element in the set of matched elements.
+     * @param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert before each element in the set of matched elements.
+     * @see {@link https://api.jquery.com/before/#before-content-content}
      */
     before(content1: JQuery|any[]|Element|DocumentFragment|Text|string, ...content2: any[]): JQuery;
     /**
      * Insert content, specified by the parameter, before each element in the set of matched elements.
      *
-     * param func A function that returns an HTML string, DOM element(s), or jQuery object to insert before each element in the set of matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     * @param func A function that returns an HTML string, DOM element(s), or jQuery object to insert before each element in the set of matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/before/#before-function}
      */
     before(func: (index: number, html: string) => string|Element|JQuery): JQuery;
 
     /**
      * Create a deep copy of the set of matched elements.
      *
-     * param withDataAndEvents A Boolean indicating whether event handlers and data should be copied along with the elements. The default value is false.
-     * param deepWithDataAndEvents A Boolean indicating whether event handlers and data for all children of the cloned element should be copied. By default its value matches the first argument's value (which defaults to false).
+     * @param withDataAndEvents A Boolean indicating whether event handlers and data should be copied along with the elements. The default value is false.
+     * @param deepWithDataAndEvents A Boolean indicating whether event handlers and data for all children of the cloned element should be copied. By default its value matches the first argument's value (which defaults to false).
+     * @see {@link https://api.jquery.com/clone/}
      */
     clone(withDataAndEvents?: boolean, deepWithDataAndEvents?: boolean): JQuery;
 
     /**
      * Remove the set of matched elements from the DOM.
      *
-     * param selector A selector expression that filters the set of matched elements to be removed.
+     * @param selector A selector expression that filters the set of matched elements to be removed.
+     * @see {@link https://api.jquery.com/detach/}
      */
     detach(selector?: string): JQuery;
 
     /**
      * Remove all child nodes of the set of matched elements from the DOM.
+     * @see {@link https://api.jquery.com/empty/}
      */
     empty(): JQuery;
 
     /**
      * Insert every element in the set of matched elements after the target.
      *
-     * param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements will be inserted after the element(s) specified by this parameter.
+     * @param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements will be inserted after the element(s) specified by this parameter.
+     * @see {@link https://api.jquery.com/insertAfter/}
      */
     insertAfter(target: JQuery|any[]|Element|Text|string): JQuery;
 
     /**
      * Insert every element in the set of matched elements before the target.
      *
-     * param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements will be inserted before the element(s) specified by this parameter.
+     * @param target A selector, element, array of elements, HTML string, or jQuery object; the matched set of elements will be inserted before the element(s) specified by this parameter.
+     * @see {@link https://api.jquery.com/insertBefore/}
      */
     insertBefore(target: JQuery|any[]|Element|Text|string): JQuery;
 
     /**
      * Insert content, specified by the parameter, to the beginning of each element in the set of matched elements.
      *
-     * param content1 DOM element, DocumentFragment, array of elements, HTML string, or jQuery object to insert at the beginning of each element in the set of matched elements.
-     * param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert at the beginning of each element in the set of matched elements.
+     * @param content1 DOM element, DocumentFragment, array of elements, HTML string, or jQuery object to insert at the beginning of each element in the set of matched elements.
+     * @param content2 One or more additional DOM elements, arrays of elements, HTML strings, or jQuery objects to insert at the beginning of each element in the set of matched elements.
+     * @see {@link https://api.jquery.com/prepend/#prepend-content-content}
      */
     prepend(content1: JQuery|any[]|Element|DocumentFragment|Text|string, ...content2: any[]): JQuery;
     /**
      * Insert content, specified by the parameter, to the beginning of each element in the set of matched elements.
      *
-     * param func A function that returns an HTML string, DOM element(s), or jQuery object to insert at the beginning of each element in the set of matched elements. Receives the index position of the element in the set and the old HTML value of the element as arguments. Within the function, this refers to the current element in the set.
+     * @param func A function that returns an HTML string, DOM element(s), or jQuery object to insert at the beginning of each element in the set of matched elements. Receives the index position of the element in the set and the old HTML value of the element as arguments. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/prepend/#prepend-function}
      */
     prepend(func: (index: number, html: string) => string|Element|JQuery): JQuery;
 
@@ -2740,6 +3176,7 @@ interface JQuery {
      * Insert every element in the set of matched elements to the beginning of the target.
      *
      * @param target A selector, element, HTML string, array of elements, or jQuery object; the matched set of elements will be inserted at the beginning of the element(s) specified by this parameter.
+     * @see {@link https://api.jquery.com/prependTo/}
      */
     prependTo(target: JQuery|any[]|Element|string): JQuery;
 
@@ -2747,6 +3184,7 @@ interface JQuery {
      * Remove the set of matched elements from the DOM.
      *
      * @param selector A selector expression that filters the set of matched elements to be removed.
+     * @see {@link https://api.jquery.com/remove/}
      */
     remove(selector?: string): JQuery;
 
@@ -2754,47 +3192,55 @@ interface JQuery {
      * Replace each target element with the set of matched elements.
      *
      * @param target A selector string, jQuery object, DOM element, or array of elements indicating which element(s) to replace.
+     * @see {@link https://api.jquery.com/replaceAll/}
      */
     replaceAll(target: JQuery|any[]|Element|string): JQuery;
 
     /**
      * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
      *
-     * param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
+     * @param newContent The content to insert. May be an HTML string, DOM element, array of DOM elements, or jQuery object.
+     * @see {@link https://api.jquery.com/replaceWith/#replaceWith-newContent}
      */
     replaceWith(newContent: JQuery|any[]|Element|Text|string): JQuery;
     /**
      * Replace each element in the set of matched elements with the provided new content and return the set of elements that was removed.
      *
-     * param func A function that returns content with which to replace the set of matched elements.
+     * @param func A function that returns content with which to replace the set of matched elements.
+     * @see {@link https://api.jquery.com/replaceWith/#replaceWith-function}
      */
     replaceWith(func: () => Element|JQuery): JQuery;
 
     /**
      * Get the combined text contents of each element in the set of matched elements, including their descendants.
+     * @see {@link https://api.jquery.com/text/#text}
      */
     text(): string;
     /**
      * Set the content of each element in the set of matched elements to the specified text.
      *
      * @param text The text to set as the content of each matched element. When Number or Boolean is supplied, it will be converted to a String representation.
+     * @see {@link https://api.jquery.com/text/#text-text}
      */
     text(text: string|number|boolean): JQuery;
     /**
      * Set the content of each element in the set of matched elements to the specified text.
      *
      * @param func A function returning the text content to set. Receives the index position of the element in the set and the old text value as arguments.
+     * @see {@link https://api.jquery.com/text/#text-function}
      */
     text(func: (index: number, text: string) => string): JQuery;
 
     /**
      * Retrieve all the elements contained in the jQuery set, as an array.
      * @name toArray
+     * @see {@link https://api.jquery.com/toArray/}
      */
     toArray(): HTMLElement[];
 
     /**
      * Remove the parents of the set of matched elements from the DOM, leaving the matched elements in their place.
+     * @see {@link https://api.jquery.com/unwrap/}
      */
     unwrap(): JQuery;
 
@@ -2802,12 +3248,14 @@ interface JQuery {
      * Wrap an HTML structure around each element in the set of matched elements.
      *
      * @param wrappingElement A selector, element, HTML string, or jQuery object specifying the structure to wrap around the matched elements.
+     * @see {@link https://api.jquery.com/wrap/#wrap-wrappingElement}
      */
     wrap(wrappingElement: JQuery|Element|string): JQuery;
     /**
      * Wrap an HTML structure around each element in the set of matched elements.
      *
      * @param func A callback function returning the HTML content or jQuery object to wrap around the matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/wrap/#wrap-function}
      */
     wrap(func: (index: number) => string|JQuery): JQuery;
 
@@ -2815,20 +3263,29 @@ interface JQuery {
      * Wrap an HTML structure around all elements in the set of matched elements.
      *
      * @param wrappingElement A selector, element, HTML string, or jQuery object specifying the structure to wrap around the matched elements.
+     * @see {@link https://api.jquery.com/wrapAll/#wrapAll-wrappingElement}
      */
     wrapAll(wrappingElement: JQuery|Element|string): JQuery;
+    /**
+     * Wrap an HTML structure around all elements in the set of matched elements.
+     *
+     * @param func A callback function returning the HTML content or jQuery object to wrap around all the matched elements. Within the function, this refers to the first element in the set.
+     * @see {@link https://api.jquery.com/wrapAll/#wrapAll-function}
+     */
     wrapAll(func: (index: number) => string): JQuery;
 
     /**
      * Wrap an HTML structure around the content of each element in the set of matched elements.
      *
      * @param wrappingElement An HTML snippet, selector expression, jQuery object, or DOM element specifying the structure to wrap around the content of the matched elements.
+     * @see {@link https://api.jquery.com/wrapInner/#wrapInner-wrappingElement}
      */
     wrapInner(wrappingElement: JQuery|Element|string): JQuery;
     /**
      * Wrap an HTML structure around the content of each element in the set of matched elements.
      *
      * @param func A callback function which generates a structure to wrap around the content of the matched elements. Receives the index position of the element in the set as an argument. Within the function, this refers to the current element in the set.
+     * @see {@link https://api.jquery.com/wrapInner/#wrapInner-function}
      */
     wrapInner(func: (index: number) => string): JQuery;
 
@@ -2836,6 +3293,7 @@ interface JQuery {
      * Iterate over a jQuery object, executing a function for each matched element.
      *
      * @param func A function to execute for each matched element.
+     * @see {@link https://api.jquery.com/each/}
      */
     each(func: (index: number, elem: Element) => any): JQuery;
 
@@ -2843,32 +3301,38 @@ interface JQuery {
      * Retrieve one of the elements matched by the jQuery object.
      *
      * @param index A zero-based integer indicating which element to retrieve.
+     * @see {@link https://api.jquery.com/get/#get-index}
      */
     get(index: number): HTMLElement;
     /**
      * Retrieve the elements matched by the jQuery object.
      * @alias toArray
+     * @see {@link https://api.jquery.com/get/#get}
      */
     get(): HTMLElement[];
 
     /**
      * Search for a given element from among the matched elements.
+     * @see {@link https://api.jquery.com/index/#index}
      */
     index(): number;
     /**
      * Search for a given element from among the matched elements.
      *
      * @param selector A selector representing a jQuery collection in which to look for an element.
+     * @see {@link https://api.jquery.com/index/#index-selector}
      */
     index(selector: string|JQuery|Element): number;
 
     /**
      * The number of elements in the jQuery object.
+     * @see {@link https://api.jquery.com/length/}
      */
     length: number;
     /**
      * A selector representing selector passed to jQuery(), if any, when creating the original set.
      * version deprecated: 1.7, removed: 1.9
+     * @see {@link https://api.jquery.com/selector/}
      */
     selector: string;
     [index: string]: any;
@@ -2879,24 +3343,28 @@ interface JQuery {
      *
      * @param selector A string representing a selector expression to find additional elements to add to the set of matched elements.
      * @param context The point in the document at which the selector should begin matching; similar to the context argument of the $(selector, context) method.
+     * @see {@link https://api.jquery.com/add/#add-selector}
      */
     add(selector: string, context?: Element): JQuery;
     /**
      * Add elements to the set of matched elements.
      *
      * @param elements One or more elements to add to the set of matched elements.
+     * @see {@link https://api.jquery.com/add/#add-elements}
      */
     add(...elements: Element[]): JQuery;
     /**
      * Add elements to the set of matched elements.
      *
      * @param html An HTML fragment to add to the set of matched elements.
+     * @see {@link https://api.jquery.com/add/#add-html}
      */
     add(html: string): JQuery;
     /**
      * Add elements to the set of matched elements.
      *
      * @param obj An existing jQuery object to add to the set of matched elements.
+     * @see {@link https://api.jquery.com/add/#add-selection}
      */
     add(obj: JQuery): JQuery;
 
@@ -2904,6 +3372,7 @@ interface JQuery {
      * Get the children of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/children/}
      */
     children(selector?: string): JQuery;
 
@@ -2911,6 +3380,7 @@ interface JQuery {
      * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/closest/#closest-selector}
      */
     closest(selector: string): JQuery;
     /**
@@ -2918,18 +3388,21 @@ interface JQuery {
      *
      * @param selector A string containing a selector expression to match elements against.
      * @param context A DOM element within which a matching element may be found. If no context is passed in then the context of the jQuery set will be used instead.
+     * @see {@link https://api.jquery.com/closest/#closest-selector-context}
      */
     closest(selector: string, context?: Element): JQuery;
     /**
      * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
      *
      * @param obj A jQuery object to match elements against.
+     * @see {@link https://api.jquery.com/closest/#closest-selection}
      */
     closest(obj: JQuery): JQuery;
     /**
      * For each element in the set, get the first element that matches the selector by testing the element itself and traversing up through its ancestors in the DOM tree.
      *
      * @param element An element to match elements against.
+     * @see {@link https://api.jquery.com/closest/#closest-element}
      */
     closest(element: Element): JQuery;
 
@@ -2938,16 +3411,19 @@ interface JQuery {
      *
      * @param selectors An array or string containing a selector expression to match elements against (can also be a jQuery object).
      * @param context A DOM element within which a matching element may be found. If no context is passed in then the context of the jQuery set will be used instead.
+     * @see {@link https://api.jquery.com/closest/#closest-selectors-context}
      */
     closest(selectors: any, context?: Element): any[];
 
     /**
      * Get the children of each element in the set of matched elements, including text and comment nodes.
+     * @see {@link https://api.jquery.com/contents/}
      */
     contents(): JQuery;
 
     /**
      * End the most recent filtering operation in the current chain and return the set of matched elements to its previous state.
+     * @see {@link https://api.jquery.com/end/}
      */
     end(): JQuery;
 
@@ -2955,7 +3431,7 @@ interface JQuery {
      * Reduce the set of matched elements to the one at the specified index.
      *
      * @param index An integer indicating the 0-based position of the element. OR An integer indicating the position of the element, counting backwards from the last element in the set.
-     *
+     * @see {@link https://api.jquery.com/eq/}
      */
     eq(index: number): JQuery;
 
@@ -2963,24 +3439,28 @@ interface JQuery {
      * Reduce the set of matched elements to those that match the selector or pass the function's test.
      *
      * @param selector A string containing a selector expression to match the current set of elements against.
+     * @see {@link https://api.jquery.com/filter/#filter-selector}
      */
     filter(selector: string): JQuery;
     /**
      * Reduce the set of matched elements to those that match the selector or pass the function's test.
      *
      * @param func A function used as a test for each element in the set. this is the current DOM element.
+     * @see {@link https://api.jquery.com/filter/#filter-function}
      */
     filter(func: (index: number, element: Element) => any): JQuery;
     /**
      * Reduce the set of matched elements to those that match the selector or pass the function's test.
      *
      * @param element An element to match the current set of elements against.
+     * @see {@link https://api.jquery.com/filter/#filter-elements}
      */
     filter(element: Element): JQuery;
     /**
      * Reduce the set of matched elements to those that match the selector or pass the function's test.
      *
      * @param obj An existing jQuery object to match the current set of elements against.
+     * @see {@link https://api.jquery.com/filter/#filter-selection}
      */
     filter(obj: JQuery): JQuery;
 
@@ -2988,23 +3468,27 @@ interface JQuery {
      * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/find/#find-selector}
      */
     find(selector: string): JQuery;
     /**
      * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
      *
      * @param element An element to match elements against.
+     * @see {@link https://api.jquery.com/find/#find-element}
      */
     find(element: Element): JQuery;
     /**
      * Get the descendants of each element in the current set of matched elements, filtered by a selector, jQuery object, or element.
      *
      * @param obj A jQuery object to match elements against.
+     * @see {@link https://api.jquery.com/find/#find-element}
      */
     find(obj: JQuery): JQuery;
 
     /**
      * Reduce the set of matched elements to the first in the set.
+     * @see {@link https://api.jquery.com/first/}
      */
     first(): JQuery;
 
@@ -3012,12 +3496,14 @@ interface JQuery {
      * Reduce the set of matched elements to those that have a descendant that matches the selector or DOM element.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/has/#has-selector}
      */
     has(selector: string): JQuery;
     /**
      * Reduce the set of matched elements to those that have a descendant that matches the selector or DOM element.
      *
      * @param contained A DOM element to match elements against.
+     * @see {@link https://api.jquery.com/has/#has-contained}
      */
     has(contained: Element): JQuery;
 
@@ -3025,29 +3511,34 @@ interface JQuery {
      * Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/is/#is-selector}
      */
     is(selector: string): boolean;
     /**
      * Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.
      *
      * @param func A function used as a test for the set of elements. It accepts one argument, index, which is the element's index in the jQuery collection.Within the function, this refers to the current DOM element.
+     * @see {@link https://api.jquery.com/is/#is-function}
      */
     is(func: (index: number, element: Element) => boolean): boolean;
     /**
      * Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.
      *
      * @param obj An existing jQuery object to match the current set of elements against.
+     * @see {@link https://api.jquery.com/is/#is-selection}
      */
     is(obj: JQuery): boolean;
     /**
      * Check the current matched set of elements against a selector, element, or jQuery object and return true if at least one of these elements matches the given arguments.
      *
      * @param elements One or more elements to match the current set of elements against.
+     * @see {@link https://api.jquery.com/is/#is-elements}
      */
     is(elements: any): boolean;
 
     /**
      * Reduce the set of matched elements to the final one in the set.
+     * @see {@link https://api.jquery.com/last/}
      */
     last(): JQuery;
 
@@ -3055,6 +3546,7 @@ interface JQuery {
      * Pass each element in the current matched set through a function, producing a new jQuery object containing the return values.
      *
      * @param callback A function object that will be invoked for each element in the current set.
+     * @see {@link https://api.jquery.com/map/}
      */
     map(callback: (index: number, domElement: Element) => any): JQuery;
 
@@ -3062,6 +3554,7 @@ interface JQuery {
      * Get the immediately following sibling of each element in the set of matched elements. If a selector is provided, it retrieves the next sibling only if it matches that selector.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/next/}
      */
     next(selector?: string): JQuery;
 
@@ -3069,6 +3562,7 @@ interface JQuery {
      * Get all following siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/nextAll/}
      */
     nextAll(selector?: string): JQuery;
 
@@ -3077,6 +3571,7 @@ interface JQuery {
      *
      * @param selector A string containing a selector expression to indicate where to stop matching following sibling elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/nextUntil/#nextUntil-selector-filter}
      */
     nextUntil(selector?: string, filter?: string): JQuery;
     /**
@@ -3084,6 +3579,7 @@ interface JQuery {
      *
      * @param element A DOM node or jQuery object indicating where to stop matching following sibling elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/nextUntil/#nextUntil-element-filter}
      */
     nextUntil(element?: Element, filter?: string): JQuery;
     /**
@@ -3091,6 +3587,7 @@ interface JQuery {
      *
      * @param obj A DOM node or jQuery object indicating where to stop matching following sibling elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/nextUntil/#nextUntil-element-filter}
      */
     nextUntil(obj?: JQuery, filter?: string): JQuery;
 
@@ -3098,29 +3595,34 @@ interface JQuery {
      * Remove elements from the set of matched elements.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/not/#not-selector}
      */
     not(selector: string): JQuery;
     /**
      * Remove elements from the set of matched elements.
      *
      * @param func A function used as a test for each element in the set. this is the current DOM element.
+     * @see {@link https://api.jquery.com/not/#not-function}
      */
     not(func: (index: number, element: Element) => boolean): JQuery;
     /**
      * Remove elements from the set of matched elements.
      *
      * @param elements One or more DOM elements to remove from the matched set.
+     * @see {@link https://api.jquery.com/not/#not-selection}
      */
     not(elements: Element|Element[]): JQuery;
     /**
      * Remove elements from the set of matched elements.
      *
      * @param obj An existing jQuery object to match the current set of elements against.
+     * @see {@link https://api.jquery.com/not/#not-selection}
      */
     not(obj: JQuery): JQuery;
 
     /**
      * Get the closest ancestor element that is positioned.
+     * @see {@link https://api.jquery.com/offsetParent/}
      */
     offsetParent(): JQuery;
 
@@ -3128,6 +3630,7 @@ interface JQuery {
      * Get the parent of each element in the current set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/parent/}
      */
     parent(selector?: string): JQuery;
 
@@ -3135,6 +3638,7 @@ interface JQuery {
      * Get the ancestors of each element in the current set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/parents/}
      */
     parents(selector?: string): JQuery;
 
@@ -3143,6 +3647,7 @@ interface JQuery {
      *
      * @param selector A string containing a selector expression to indicate where to stop matching ancestor elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/parentsUntil/#parentsUntil-selector-filter}
      */
     parentsUntil(selector?: string, filter?: string): JQuery;
     /**
@@ -3150,6 +3655,7 @@ interface JQuery {
      *
      * @param element A DOM node or jQuery object indicating where to stop matching ancestor elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/parentsUntil/#parentsUntil-element-filter}
      */
     parentsUntil(element?: Element, filter?: string): JQuery;
     /**
@@ -3157,6 +3663,7 @@ interface JQuery {
      *
      * @param obj A DOM node or jQuery object indicating where to stop matching ancestor elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/parentsUntil/#parentsUntil-element-filter}
      */
     parentsUntil(obj?: JQuery, filter?: string): JQuery;
 
@@ -3164,6 +3671,7 @@ interface JQuery {
      * Get the immediately preceding sibling of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/prev/}
      */
     prev(selector?: string): JQuery;
 
@@ -3171,6 +3679,7 @@ interface JQuery {
      * Get all preceding siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/prevAll/}
      */
     prevAll(selector?: string): JQuery;
 
@@ -3179,6 +3688,7 @@ interface JQuery {
      *
      * @param selector A string containing a selector expression to indicate where to stop matching preceding sibling elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/prevUntil/#prevUntil-selector-filter}
      */
     prevUntil(selector?: string, filter?: string): JQuery;
     /**
@@ -3186,6 +3696,7 @@ interface JQuery {
      *
      * @param element A DOM node or jQuery object indicating where to stop matching preceding sibling elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/prevUntil/#prevUntil-element-filter}
      */
     prevUntil(element?: Element, filter?: string): JQuery;
     /**
@@ -3193,6 +3704,7 @@ interface JQuery {
      *
      * @param obj A DOM node or jQuery object indicating where to stop matching preceding sibling elements.
      * @param filter A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/prevUntil/#prevUntil-element-filter}
      */
     prevUntil(obj?: JQuery, filter?: string): JQuery;
 
@@ -3200,6 +3712,7 @@ interface JQuery {
      * Get the siblings of each element in the set of matched elements, optionally filtered by a selector.
      *
      * @param selector A string containing a selector expression to match elements against.
+     * @see {@link https://api.jquery.com/siblings/}
      */
     siblings(selector?: string): JQuery;
 
@@ -3208,6 +3721,7 @@ interface JQuery {
      *
      * @param start An integer indicating the 0-based position at which the elements begin to be selected. If negative, it indicates an offset from the end of the set.
      * @param end An integer indicating the 0-based position at which the elements stop being selected. If negative, it indicates an offset from the end of the set. If omitted, the range continues until the end of the set.
+     * @see {@link https://api.jquery.com/slice/}
      */
     slice(start: number, end?: number): JQuery;
 
@@ -3215,18 +3729,21 @@ interface JQuery {
      * Show the queue of functions to be executed on the matched elements.
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
+     * @see {@link https://api.jquery.com/queue/#queue-queueName}
      */
     queue(queueName?: string): any[];
     /**
      * Manipulate the queue of functions to be executed, once for each matched element.
      *
      * @param newQueue An array of functions to replace the current queue contents.
+     * @see {@link https://api.jquery.com/queue/#queue-queueName-newQueue}
      */
     queue(newQueue: Function[]): JQuery;
     /**
      * Manipulate the queue of functions to be executed, once for each matched element.
      *
      * @param callback The new function to add to the queue, with a function to call that will dequeue the next item.
+     * @see {@link https://api.jquery.com/queue/#queue-queueName-callback}
      */
     queue(callback: Function): JQuery;
     /**
@@ -3234,6 +3751,7 @@ interface JQuery {
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param newQueue An array of functions to replace the current queue contents.
+     * @see {@link https://api.jquery.com/queue/#queue-queueName-newQueue}
      */
     queue(queueName: string, newQueue: Function[]): JQuery;
     /**
@@ -3241,6 +3759,7 @@ interface JQuery {
      *
      * @param queueName A string containing the name of the queue. Defaults to fx, the standard effects queue.
      * @param callback The new function to add to the queue, with a function to call that will dequeue the next item.
+     * @see {@link https://api.jquery.com/queue/#queue-queueName-callback}
      */
     queue(queueName: string, callback: Function): JQuery;
 }


### PR DESCRIPTION
As stated in the title, I added **documentation links for official jQuery API** via [JSDoc `@see` tags](http://usejsdoc.org/tags-see.html).

I'm not sure if VisualStudio/VSCode supports these tags yet, but other IDEs like IntelliJ/PhpStorm/WebStorm do.

This pull-request also fixes some JSDoc comments, where `@param` was not written correctly.

I also added myself to the "Definitions by" list, since i spent about 4 hours on this. ;-)