### PR TITLE
React:  SyntheticEvent.target.value should be generic on T

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -284,7 +284,7 @@ declare namespace React {
         stopPropagation(): void;
         isPropagationStopped(): boolean;
         persist(): void;
-        target: EventTarget;
+        target: EventTarget & T;
         timeStamp: Date;
         type: string;
     }

--- a/react/react-tests.ts
+++ b/react/react-tests.ts
@@ -672,3 +672,19 @@ class ConstructorSpreadArgsPureComponent extends React.PureComponent<{}, {}> {
         super(...args);
     }
 }
+
+//
+// The SyntheticEvent.target.value should be accessible
+// --------------------------------------------------------------------------
+class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
+  constructor(props:{}) {
+    super(props);
+    this.state = { value: 'a' };
+  }
+  render() {
+    return React.DOM.textarea({
+      value: this.state.value,
+      onChange: e => this.setState({value: e.target.value})
+    });
+  }
+}


### PR DESCRIPTION
When handling an event (e.g. `onChange`) it should be possible to access the changed value through `e.target.value`. 

The following example (adapted from [React's documentation](https://facebook.github.io/react/docs/forms.html#the-textarea-tag)) illustrates the scenario:

```jsx
class EssayForm extends React.Component<{}, { value: string }> {
  constructor(props:{}) {
    super(props);
    this.state = {
      value: 'Please write an essay about your favorite DOM element.'
    };
  }
  render() {
    return <textarea
      value={this.state.value}
      onChange={e => this.setState({value: e.target.value})}
    />;
  }
}
```

This currently fails in the `setState` line with:
> error TS2339: Property 'value' does not exist on type 'EventTarget'.

----

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react/docs/forms.html#the-textarea-tag
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
