### PR TITLE
Added option comparator parameter to IFilterOrderBy

### DIFF
--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -661,14 +661,14 @@ declare namespace angular {
         (actual: T, expected: T): boolean;
     }
     
-    interface IFilterOrderByItem<T> {
-        value: T,
+    interface IFilterOrderByItem {
+        value: any,
         type: string,
         index: any
     }
 
-    interface IFilterOrderByComparatorFunc<T> {
-        (left: IFilterOrderByItem<T>, right: IFilterOrderByItem<T>): -1 | 0 | 1;
+    interface IFilterOrderByComparatorFunc {
+        (left: IFilterOrderByItem, right: IFilterOrderByItem): -1 | 0 | 1;
     }
 
     interface IFilterCurrency {
@@ -756,7 +756,7 @@ declare namespace angular {
          * @param comparator Function used to determine the relative order of value pairs.
          * @return An array containing the items from the specified collection, ordered by a comparator function based on the values computed using the expression predicate.
          */
-        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc<T>): T[];
+        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc): T[];
     }
 
     /**

--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -661,14 +661,14 @@ declare namespace angular {
         (actual: T, expected: T): boolean;
     }
     
-    interface IFilterOrderByItem {
-        value: any,
+    interface IFilterOrderByItem<T> {
+        value: T,
         type: string,
         index: any
     }
 
-    interface IFilterOrderByComparatorFunc {
-        (left: IFilterOrderByItem, right: IFilterOrderByItem): [-1, 0, 1];
+    interface IFilterOrderByComparatorFunc<T> {
+        (left: IFilterOrderByItem<T>, right: IFilterOrderByItem<T>): -1 | 0 | 1;
     }
 
     interface IFilterCurrency {
@@ -756,7 +756,7 @@ declare namespace angular {
          * @param comparator Function used to determine the relative order of value pairs.
          * @return An array containing the items from the specified collection, ordered by a comparator function based on the values computed using the expression predicate.
          */
-        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc): T[];
+        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc<T>): T[];
     }
 
     /**

--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -660,7 +660,11 @@ declare namespace angular {
     interface IFilterFilterComparatorFunc<T> {
         (actual: T, expected: T): boolean;
     }
-
+    
+    interface IFilterOrderByComparatorFunc<T> {
+        (left: T, right: T): boolean;
+    }
+    
     interface IFilterCurrency {
         /**
          * Formats a number as a currency (ie $1,234.56). When no currency symbol is provided, default symbol for current locale is used.
@@ -743,9 +747,10 @@ declare namespace angular {
          * @param array The array to sort.
          * @param expression A predicate to be used by the comparator to determine the order of elements.
          * @param reverse Reverse the order of the array.
+         * @param comparator Function used to determine the relative order of value pairs.
          * @return Reverse the order of the array.
          */
-        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean): T[];
+        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc<T>): T[];
     }
 
     /**

--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -661,10 +661,16 @@ declare namespace angular {
         (actual: T, expected: T): boolean;
     }
     
-    interface IFilterOrderByComparatorFunc<T> {
-        (left: T, right: T): boolean;
+    interface IFilterOrderByItem {
+        value: any,
+        type: string,
+        index: any
     }
-    
+
+    interface IFilterOrderByComparatorFunc {
+        (left: IFilterOrderByItem, right: IFilterOrderByItem): [-1, 0, 1];
+    }
+
     interface IFilterCurrency {
         /**
          * Formats a number as a currency (ie $1,234.56). When no currency symbol is provided, default symbol for current locale is used.
@@ -748,9 +754,9 @@ declare namespace angular {
          * @param expression A predicate to be used by the comparator to determine the order of elements.
          * @param reverse Reverse the order of the array.
          * @param comparator Function used to determine the relative order of value pairs.
-         * @return Reverse the order of the array.
+         * @return An array containing the items from the specified collection, ordered by a comparator function based on the values computed using the expression predicate.
          */
-        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc<T>): T[];
+        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc): T[];
     }
 
     /**


### PR DESCRIPTION
As per title.

The order by filter has an option comparator function which is not defined:
https://docs.angularjs.org/api/ng/filter/orderBy

