### PR TITLE
add HeapInfo interface to v8 module

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -3962,6 +3962,11 @@ declare module "v8" {
         physical_space_size: number;
     }
 
+    const enum DoesZapCodeSpaceFlag {
+        Disabled = 0,
+        Enabled = 1
+    }
+
     interface HeapInfo { 
         total_heap_size: number;
         total_heap_size_executable: number;
@@ -3971,7 +3976,7 @@ declare module "v8" {
         heap_size_limit: number;
         malloced_memory: number;
         peak_malloced_memory: number;
-        does_zap_garbage: 0|1;
+        does_zap_garbage: DoesZapCodeSpaceFlag;
     }
 
     export function getHeapStatistics(): HeapInfo;

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -3971,7 +3971,7 @@ declare module "v8" {
         heap_size_limit: number;
         malloced_memory: number;
         peak_malloced_memory: number;
-        does_zap_garbage: number;
+        does_zap_garbage: 0|1;
     }
 
     export function getHeapStatistics(): HeapInfo;

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -3961,7 +3961,20 @@ declare module "v8" {
         space_available_size: number;
         physical_space_size: number;
     }
-    export function getHeapStatistics(): { total_heap_size: number, total_heap_size_executable: number, total_physical_size: number, total_avaialble_size: number, used_heap_size: number, heap_size_limit: number };
+
+    interface HeapInfo { 
+        total_heap_size: number;
+        total_heap_size_executable: number;
+        total_physical_size: number;
+        total_available_size: number;
+        used_heap_size: number;
+        heap_size_limit: number;
+        malloced_memory: number;
+        peak_malloced_memory: number;
+        does_zap_garbage: number;
+    }
+
+    export function getHeapStatistics(): HeapInfo;
     export function getHeapSpaceStatistics(): HeapSpaceInfo[];
     export function setFlagsFromString(flags: string): void;
 }


### PR DESCRIPTION
Documentation:
https://nodejs.org/dist/latest-v7.x/docs/api/v8.html#v8_v8_getheapstatistics

Changes:
- add HeapInfo interface to the v8 module, add missing properties: malloced_memory, peak_malloced_memory, does_zap_garbage
- change return type for the method: v8.getHeapStatistics()

