### PR TITLE
react-router-redux: update reducer signature to match Redux.Reducer<RouterState>

### DIFF
--- a/react-router-redux/index.d.ts
+++ b/react-router-redux/index.d.ts
@@ -59,7 +59,7 @@ declare namespace ReactRouterRedux {
         locationBeforeTransitions: History.Location
     }
 
-    function routerReducer(state?: RouterState, options?: any): R.Reducer<RouterState>
+    function routerReducer(state: RouterState, action: R.Action): RouterState;
     function syncHistoryWithStore(history: History.History, store: R.Store<any>, options?: SyncHistoryWithStoreOptions): ReactRouterReduxHistory;
     function routerMiddleware(history: History.History): R.Middleware;
 }

--- a/react-router-redux/index.d.ts
+++ b/react-router-redux/index.d.ts
@@ -59,7 +59,7 @@ declare namespace ReactRouterRedux {
         locationBeforeTransitions: History.Location
     }
 
-    function routerReducer(state: RouterState, action: R.Action): RouterState;
+    function routerReducer(state?: RouterState, action?: R.Action): RouterState;
     function syncHistoryWithStore(history: History.History, store: R.Store<any>, options?: SyncHistoryWithStoreOptions): ReactRouterReduxHistory;
     function routerMiddleware(history: History.History): R.Middleware;
 }


### PR DESCRIPTION
I'm new to both TypeScript and Redux, so please review this one carefully!

After having a look at the `react-router-redux` [source code][1], it looks like the signature of `routerReducer` is wrong. This function should be a simple Redux reducer for `RouterState`. For example: `(state?: RouterState, action?: Action) => RouterState`.

The type checker doesn't complain about this when using `combineReducers` as in the test file, because combineReducers accepts an object with `Reducer<any>` values. This type is actually satisfied by `(state?: RouterState, options?: any) => Reducer<RouterState>` because both `RouterState` and `Reducer<RouterState>` satisfy `any`.

I didn't add any tests to cover this issue. If needed, something like this might suffice:

```
// Call reducer directly:
const myRouterState: RouterState = { locationBeforeTransitions: null };
const stateAfterPush: RouterState = routerReducer(myRouterState, push('/foo'));
```

Please provide some feedback. I'm worried that I'm just missing some essential TypeScript know-how here.

[1]: https://github.com/reactjs/react-router-redux/blob/master/src/reducer.js#L17