### PR TITLE
[leaflet] Making the GeoJSON methods accessible as static methods

### DIFF
--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -844,7 +844,8 @@ declare namespace L {
         /**
          * Reverse of coordsToLatLng
          */
-        static latLngToCoords(latlng: LatLng): number[];
+        static latLngToCoords(latlng: LatLng): [number, number, number]; // A three tuple can be assigned to a two or three tuple
+
 
         /**
          * Reverse of coordsToLatLngs closed determines whether the first point should be

--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -817,6 +817,51 @@ declare namespace L {
         coordsToLatLng?: (coords: [number, number] | [number, number, number]) => LatLng; // check if LatLng has an altitude property
     }
 
+    export class GeoJSON {
+        /**
+         * Creates a Layer from a given GeoJSON feature. Can use a custom pointToLayer
+         * and/or coordsToLatLng functions if provided as options.
+         */
+        static geometryToLayer(featureData: GeoJSON.Feature<GeoJSON.GeometryObject>, options?: GeoJSONOptions): Layer;
+
+        /**
+         * Creates a LatLng object from an array of 2 numbers (longitude, latitude) or
+         * 3 numbers (longitude, latitude, altitude) used in GeoJSON for points.
+         */
+        static coordsToLatLng(coords: [number, number] | [number, number, number]): LatLng;
+
+        /**
+         * Creates a multidimensional array of LatLngs from a GeoJSON coordinates array.
+         * levelsDeep specifies the nesting level (0 is for an array of points, 1 for an array of
+         * arrays of points, etc., 0 by default).
+         * Can use a custom coordsToLatLng function.
+         */
+        static coordsToLatLngs(
+            coords: any[],
+            levelsDeep?: number,
+            coordsToLatLng?: (coords: [number, number] | [number, number, number]) => LatLng): any[]; // Using any[] to avoid artificially limiting valid calls
+
+        /**
+         * Reverse of coordsToLatLng
+         */
+        static latLngToCoords(latlng: LatLng): number[];
+
+        /**
+         * Reverse of coordsToLatLngs closed determines whether the first point should be
+         * appended to the end of the array to close the feature, only used when levelsDeep is 0.
+         * False by default.
+         */
+        static latLngsToCoords(latlngs: any[], levelsDeep?: number, closed?: boolean): any[];  // Using any[] to avoid artificially limiting valid calls
+
+        /**
+         * Normalize GeoJSON geometries/features into GeoJSON features.
+         */
+        static asFeature(geojson: GeoJSON.GeometryObject): GeoJSON.Feature<GeoJSON.GeometryObject>;
+
+        static asFeature(geojson: GeoJSON.Feature<GeoJSON.GeometryObject>): GeoJSON.Feature<GeoJSON.GeometryObject>;
+
+    }
+
     /**
      * Represents a GeoJSON object or an array of GeoJSON objects.
      * Allows you to parse GeoJSON data and display it on the map. Extends FeatureGroup.
@@ -838,46 +883,6 @@ declare namespace L {
          */
         setStyle(style: StyleFunction): this;
 
-        /**
-         * Creates a Layer from a given GeoJSON feature. Can use a custom pointToLayer
-         * and/or coordsToLatLng functions if provided as options.
-         */
-        geometryToLayer(featureData: GeoJSON.Feature<GeoJSON.GeometryObject>, options?: GeoJSONOptions): Layer;
-
-        /**
-         * Creates a LatLng object from an array of 2 numbers (longitude, latitude) or
-         * 3 numbers (longitude, latitude, altitude) used in GeoJSON for points.
-         */
-        coordsToLatLng(coords: [number, number]): LatLng;
-
-        coordsToLatLng(coords: [number, number, number]): LatLng;
-
-        /**
-         * Creates a multidimensional array of LatLngs from a GeoJSON coordinates array.
-         * levelsDeep specifies the nesting level (0 is for an array of points, 1 for an array of
-         * arrays of points, etc., 0 by default).
-         * Can use a custom coordsToLatLng function.
-         */
-        coordsToLatLngs(coords: Array<number>, levelsDeep?: number, coordsToLatLng?: (coords: [number, number] | [number, number, number]) => LatLng): LatLng[]; // Not entirely sure how to define arbitrarily nested arrays
-
-        /**
-         * Reverse of coordsToLatLng
-         */
-        latLngToCoords(latlng: LatLng): [number, number] | [number, number, number];
-
-        /**
-         * Reverse of coordsToLatLngs closed determines whether the first point should be
-         * appended to the end of the array to close the feature, only used when levelsDeep is 0.
-         * False by default.
-         */
-        latLngsToCoords(latlngs: Array<LatLng>, levelsDeep?: number, closed?: boolean): [number, number] | [number, number, number];
-
-        /**
-         * Normalize GeoJSON geometries/features into GeoJSON features.
-         */
-        asFeature(geojson: GeoJSON.GeometryObject): GeoJSON.Feature<GeoJSON.GeometryObject>;
-
-        asFeature(geojson: GeoJSON.Feature<GeoJSON.GeometryObject>): GeoJSON.Feature<GeoJSON.GeometryObject>;
     }
 
     /**

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -360,11 +360,11 @@ draggable.on('drag', () => {});
 
 let twoCoords: [number, number] = [1, 2];
 latLng = L.GeoJSON.coordsToLatLng(twoCoords);
-let coords: number[] = L.GeoJSON.latLngToCoords(latLng);
+twoCoords = L.GeoJSON.latLngToCoords(latLng);
 
 let threeCoords: [number, number, number] = [1, 2, 3];
 latLng = L.GeoJSON.coordsToLatLng(threeCoords);
-coords = L.GeoJSON.latLngToCoords(latLng);
+threeCoords = L.GeoJSON.latLngToCoords(latLng);
 
 let nestedTwoCoords = [ [12, 13], [13, 14], [14, 15] ];
 let nestedLatLngs: L.LatLng[] = L.GeoJSON.coordsToLatLngs(nestedTwoCoords, 1);

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -358,6 +358,18 @@ draggable.enable();
 draggable.disable();
 draggable.on('drag', () => {});
 
+let twoCoords: [number, number] = [1, 2];
+latLng = L.GeoJSON.coordsToLatLng(twoCoords);
+let coords: number[] = L.GeoJSON.latLngToCoords(latLng);
+
+let threeCoords: [number, number, number] = [1, 2, 3];
+latLng = L.GeoJSON.coordsToLatLng(threeCoords);
+coords = L.GeoJSON.latLngToCoords(latLng);
+
+let nestedTwoCoords = [ [12, 13], [13, 14], [14, 15] ];
+let nestedLatLngs: L.LatLng[] = L.GeoJSON.coordsToLatLngs(nestedTwoCoords, 1);
+nestedTwoCoords = L.GeoJSON.latLngsToCoords(nestedLatLngs, 1);
+
 class MyMarker extends L.Marker {
 	constructor() {
 		super([12, 13]);


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `tsc` without errors.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://leafletjs.com/reference-1.0.2.html


The primary thing I change in this PR is to move the static methods on the GeoJSON object from being declared on the GeoJSON interface to being declared as static methods on the GeoJSON class. The reason for this change is that the typing file only provides access to the GeoJSON interface through the factory methods used to create GeoJSON layers. The factory method returns an object that doesn't actually provide the static methods. So, you can currently write code that will compile against the typing file but encounter a runtime error because the static methods are undefined.

And, you can't currently compile if you try to access the static methods through the L.GeoJSON class. By adding the static methods to the L.GeoJSON class, you can now access the methods correctly and compile and they work at runtime.

Other smaller fixes had to do with the fact that two of the static methods take as parameters or return arbitrarily nested arrays. The typings were limiting these unnecessarily. While opening them up to any[] is less helpful when writing code against the API, it makes more sense than limiting their utility.