### PR TITLE
chai-subset: add assert.containSubset method

### DIFF
--- a/chai-subset/chai-subset-tests.ts
+++ b/chai-subset/chai-subset-tests.ts
@@ -29,6 +29,8 @@ function test_containSubset() {
     });
 
     obj.should.containSubset({ a: 'b' });
+
+    assert.containSubset(obj, { a: 'b' });
 }
 
 function test_notContainSubset() {
@@ -52,6 +54,7 @@ function test_arrayContainSubset() {
 
     expect(list).to.containSubset([{a:'a',  b: 'b'}]);
     list.should.containSubset([{a:'a',  b: 'b'}]);
+    assert.containSubset(list, [{a:'a',  b: 'b'}]);
 }
 
 function test_arrayNotContainSubset() {

--- a/chai-subset/index.d.ts
+++ b/chai-subset/index.d.ts
@@ -1,17 +1,20 @@
-// Type definitions for chai-subset 1.0.0
+// Type definitions for chai-subset 1.3
 // Project: https://github.com/e-conomic/chai-subset
 // Definitions by: Sam Noedel <https://github.com/delta62/>, Andrew Brown <https://github.com/AGBrown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="chai" />
 
-declare namespace Chai {
-    interface Assertion {
-        containSubset(obj: Object): Assertion;
+declare global {
+    namespace Chai {
+        interface Assertion {
+            containSubset(expected: any): Assertion;
+        }
+        interface Assert {
+            containSubset(val: any, exp: any, msg?: string): void;
+        }
     }
 }
 
-declare module "chai-subset" {
-    function chaiSubset(chai: any, utils: any): void;
-    export = chaiSubset;
-}
+declare function chaiSubset(chai: any, utils: any): void;
+export = chaiSubset;

--- a/chai-subset/tslint.json
+++ b/chai-subset/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Also adds tslint.json and refactors to remove lint warnings.

Authors of existing definitions: @delta62 @AGBrown 

Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/debitoor/chai-subset/blob/master/README.md
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

