### PR TITLE
[react-router] Update LinkProps to current typings

### DIFF
--- a/react-router/lib/Link.d.ts
+++ b/react-router/lib/Link.d.ts
@@ -7,7 +7,7 @@ type Link = Link.Link;
 export default Link;
 
 declare namespace Link {
-    interface LinkProps extends React.HTMLAttributes<Link>, React.Props<Link> {
+    interface LinkProps extends React.HTMLAttributes<Link> {
         activeStyle?: React.CSSProperties;
         activeClassName?: string;
         onlyActiveOnIndex?: boolean;

--- a/react-router/react-router-tests.tsx
+++ b/react-router/react-router-tests.tsx
@@ -2,7 +2,11 @@ import * as React from "react"
 import * as ReactDOM from "react-dom"
 import {renderToString} from "react-dom/server";
 
-import { applyRouterMiddleware, browserHistory, hashHistory, match, createMemoryHistory, withRouter, routerShape, Router, Route, IndexRoute, InjectedRouter, Link, RouterOnContext, RouterContext} from "react-router";
+import { applyRouterMiddleware, browserHistory, hashHistory, match, createMemoryHistory, withRouter, routerShape, Router, Route, IndexRoute, InjectedRouter, Link, RouterOnContext, RouterContext, LinkProps} from "react-router";
+
+const NavLink = (props: LinkProps) => (
+	<Link {...props} activeClassName="active" />
+)
 
 interface MasterContext {
 	router: RouterOnContext;
@@ -28,7 +32,7 @@ class Master extends React.Component<React.Props<{}>, {}> {
 	render() {
 		return <div>
 			<h1>Master</h1>
-			<Link to="/">Dashboard</Link> <Link to="/users">Users</Link>
+			<Link to="/">Dashboard</Link> <NavLink to="/users">Users</NavLink>
 			<p>{this.props.children}</p>
 		</div>
 	}
@@ -105,7 +109,6 @@ const routes = (
 match({history, routes, location: "baseurl"}, (error, redirectLocation, renderProps) => {
 	renderToString(<RouterContext {...renderProps} />);
 });
-
 
 ReactDOM.render((
 	<Router


### PR DESCRIPTION
This allows use of Link in stateless higher order components.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Stack Overflow issue](http://stackoverflow.com/questions/41431433/typescript-issues-with-props-of-higher-order-stateless-component-in-react/41436539#41436539)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
