### PR TITLE
React-native: Add missing onMomentum* properties to ScrollView.

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -5634,6 +5634,16 @@ declare module "react" {
          * Fires when a user has finished scrolling.
          */
         onScrollEndDrag?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
+	
+	/**
+         * Fires when scroll view has finished moving
+         */
+        onMomentumScrollEnd?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
+
+        /**
+         * Fires when scroll view has begun moving
+         */
+        onMomentumScrollBegin?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
 
         /**
          * When true the scroll view stops on multiples of the scroll view's size


### PR DESCRIPTION
Added missing definitions for onMomentumScrollBegin & onMomentumScrollEnd.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/react-native/blob/779508c0ba9de62c6d8c858eef6f0d9777a95621/React/Views/RCTScrollViewManager.m#L82>>
- [ ] Increase the version number in the header if appropriate.