### PR TITLE
Do not use `Node` and `NodeList` in rx-lite defintions

### DIFF
--- a/rx-lite/index.d.ts
+++ b/rx-lite/index.d.ts
@@ -654,21 +654,19 @@ declare namespace Rx {
         fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (arguments: any[]) => T): Observable<T>;
     }
 
-    type NodeEventTarget = {
+    interface NodeEventTarget {
         addListener: (name: string, cb: (e: any) => any) => void;
-    };
+    }
 
-    type NativeEventTarget = {
+    interface NativeEventTarget {
         on: (name: string, cb: (e: any) => any) => void;
         off: (name: string, cb: (e: any) => any) => void;
     }
 
-    type DOMEventTarget = {
+    interface DOMEventTarget {
         addEventListener(type: string, listener: (e: any) => any, useCapture: boolean): void;
         removeEventListener(type: string, listener: (e: any) => any, useCapture: boolean): void;
     }
-
-    type DOMEventTargetList = ArrayLike<DOMEventTarget>;
 }
 
 

--- a/rx-lite/index.d.ts
+++ b/rx-lite/index.d.ts
@@ -649,12 +649,28 @@ declare namespace Rx {
             <T>(func: Function, context?: any): (...args: any[]) => Observable<T>;
         };
 
-        fromEvent<T>(element: NodeList, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
-        fromEvent<T>(element: Node, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
-        fromEvent<T>(element: { on: (name: string, cb: (e: any) => any) => void; off: (name: string, cb: (e: any) => any) => void }, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        fromEvent<T>(element: ArrayLike<DOMEventTarget> | DOMEventTarget | NodeEventTarget| NativeEventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+
         fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (arguments: any[]) => T): Observable<T>;
     }
+
+    type NodeEventTarget = {
+        addListener: (name: string, cb: (e: any) => any) => void;
+    };
+
+    type NativeEventTarget = {
+        on: (name: string, cb: (e: any) => any) => void;
+        off: (name: string, cb: (e: any) => any) => void;
+    }
+
+    type DOMEventTarget = {
+        addEventListener(type: string, listener: (e: any) => any, useCapture: boolean): void;
+        removeEventListener(type: string, listener: (e: any) => any, useCapture: boolean): void;
+    }
+
+    type DOMEventTargetList = ArrayLike<DOMEventTarget>;
 }
+
 
 // time
 

--- a/rx-lite/index.d.ts
+++ b/rx-lite/index.d.ts
@@ -651,7 +651,7 @@ declare namespace Rx {
 
         fromEvent<T>(element: ArrayLike<DOMEventTarget> | DOMEventTarget | NodeEventTarget| NativeEventTarget, eventName: string, selector?: (...args: any[]) => T): Observable<T>;
 
-        fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (arguments: any[]) => T): Observable<T>;
+        fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (...args: any[]) => T): Observable<T>;
     }
 
     interface NodeEventTarget {

--- a/rx-lite/index.d.ts
+++ b/rx-lite/index.d.ts
@@ -649,7 +649,7 @@ declare namespace Rx {
             <T>(func: Function, context?: any): (...args: any[]) => Observable<T>;
         };
 
-        fromEvent<T>(element: ArrayLike<DOMEventTarget> | DOMEventTarget | NodeEventTarget| NativeEventTarget, eventName: string, selector?: (arguments: any[]) => T): Observable<T>;
+        fromEvent<T>(element: ArrayLike<DOMEventTarget> | DOMEventTarget | NodeEventTarget| NativeEventTarget, eventName: string, selector?: (...args: any[]) => T): Observable<T>;
 
         fromEventPattern<T>(addHandler: (handler: Function) => void, removeHandler: (handler: Function) => void, selector?: (arguments: any[]) => T): Observable<T>;
     }


### PR DESCRIPTION
- Do not use the DOM types `Node` and `NodeList` and instead define `DOMEventTarget`
- Also adds NodeEventTarget support
- Coalesce all overloads in one using union types

Please see https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/fromevent.js for implementation details. 

Fixes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/13733
