### PR TITLE
Renamed 'XHRLoader' to 'FileLoader' class, Texture class fix

### DIFF
--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -1989,18 +1989,20 @@ declare namespace THREE {
         get(file: string): Loader;
     }
 
-    export class XHRLoader {
+    export class FileLoader {
         constructor(manager?: LoadingManager);
 
         manager: LoadingManager;
+        mimeType: MimeType;
         path: string;
         responseType: string;
-        withCredentials: boolean;
+        withCredentials: string        
 
-        load(url: string, onLoad?: (responseText: string) => void, onProgress?: (event: any) => void, onError?: (event: any) => void): any;
-        setPath(path: string): XHRLoader;
-        setResponseType(responseType: string): XHRLoader;
-        setWithCredentials(withCredentials: boolean): XHRLoader;
+        load(url: string, onLoad?: (response: any) => void, onProgress?: (request: XMLHttpRequest) => void, onError?:(event: any) => void): any;
+        setMimeType(mimeType: MimeType): FileLoader;
+        setPath(path: string) : FileLoader;
+        setResponseType(responseType: string) : FileLoader;
+        setWithCredentials(value: string): FileLoader;
     }
 
     export class FontLoader {
@@ -5606,7 +5608,7 @@ declare namespace THREE {
 
     export class Texture extends EventDispatcher {
         constructor(
-            image: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
+            image?: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
             mapping?: Mapping,
             wrapS?: Wrapping,
             wrapT?: Wrapping,


### PR DESCRIPTION
+ ~~Added FileLoader class~~
I just saw that FileLoader is a rename of the XHRLoader . Changed for r.83.0. 

* Changed the image parameter to optional for the Texture class constructor
see: [this code line](https://github.com/mrdoob/three.js/blob/master/src/textures/Texture.js#L23)

