### PR TITLE
Adding missing bsClass to React-Bootstrap Button

### DIFF
--- a/react-bootstrap/index.d.ts
+++ b/react-bootstrap/index.d.ts
@@ -74,6 +74,7 @@ declare namespace ReactBootstrap {
 
     // <Button />
     interface ButtonProps extends React.HTMLProps<Button> {
+        bsClass?: string;
         active?: boolean;
         block?: boolean;
         bsStyle?: string;


### PR DESCRIPTION
Per the docs, there's a bsClass on Button.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-bootstrap.github.io/components.html#buttons-props
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

