### PR TITLE
meta is not required in ActionMeta

### DIFF
--- a/redux-actions/index.d.ts
+++ b/redux-actions/index.d.ts
@@ -19,7 +19,7 @@ declare namespace ReduxActions {
     }
 
     export interface ActionMeta<Payload, Meta> extends Action<Payload> {
-        meta: Meta;
+        meta?: Meta;
     }
 
     interface ReducerMap<State, Payload> {


### PR DESCRIPTION
Example:
```ts
actionCreator: (foo: number, bar: string) => ActionMeta<number, string>
```
if meta is required, then
dispatch(actionCreator(foo, bar)) will throw an error because
```
interface Action {
    type: any;
}
interface Dispatch<S> {
    <A extends Action>(action: A): A;
}
dispatch: Dispatch<S>;
```
in '@types/redux/index.d.ts'