### PR TITLE
Fix angular-breadcrumb typings

### DIFF
--- a/angular-breadcrumb/index.d.ts
+++ b/angular-breadcrumb/index.d.ts
@@ -4,76 +4,83 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="angular-ui-router" />
-declare namespace angular.ui {
-    export interface IState {
-        ncyBreadcrumb?: {
+
+import * as angular from 'angular';
+
+declare var _: string;
+export = _;
+
+declare module 'angular' {
+    namespace ui {
+        export interface IState {
+            ncyBreadcrumb?: {
+                /**
+                 * Contains the label for the step in the breadcrumb. The state name is used if not defined.
+                 **/
+                label?: string;
+                /**
+                 * Override the parent state (only for the breadcrumb)
+                 **/
+                parent?: string|Function;
+                /**
+                * When defined to true, the state is never included in the chain of states and never appears in the breadcrumb
+                **/
+                skip?: boolean;
+            };
+            ncyBreadcrumbLabel?: string;
+            ncyBreadcrumbLink?: string;
+        }
+    }
+
+    namespace ncy {
+        /**
+        * Provider that returns an instance of $breadcrumb service. It contains the global configuration of the module.
+        **/
+        export interface $breadcrumbProvider {
             /**
-             * Contains the label for the step in the breadcrumb. The state name is used if not defined.
-             **/
-            label?: string;
-            /**
-             * Override the parent state (only for the breadcrumb)
-             **/
-            parent?: string|Function;
-            /**
-            * When defined to true, the state is never included in the chain of states and never appears in the breadcrumb
+            * Setter for options defined in a module.config block
             **/
-            skip?: boolean;
-        },
-        ncyBreadcrumbLabel?: string;
-        ncyBreadcrumbLink?: string;
-    }
-}
-
-declare namespace ncy {
-	
-    /**
-    * Provider that returns an instance of $breadcrumb service. It contains the global configuration of the module.
-    **/
-    export interface $breadcrumbProvider {
-        /**
-        * Setter for options defined in a module.config block
-        **/
-        setOptions(options: breadcrumbProviderOptions): void;
-    }
-	
-    /**
-    * Global configuration options for angular-breadcrumb
-    **/
-    export interface breadcrumbProviderOptions {
-        /**
-        * An existing state's name to be the state is the first step of the breadcrumb
-        **/
-        prefixStateName?: string;
+            setOptions(options: breadcrumbProviderOptions): void;
+        }
 
         /**
-        * Contains a predefined template's name; 'bootstrap3' (default), 'bootstrap2' or HTML for a custom template. This property is ignored if templateUrl is defined.
+        * Global configuration options for angular-breadcrumb
         **/
-        template?: string;
+        export interface breadcrumbProviderOptions {
+            /**
+            * An existing state's name to be the state is the first step of the breadcrumb
+            **/
+            prefixStateName?: string;
 
-        /** 
-        * Contains the path to a template file. This property takes precedence over the template property.
-        **/
-        templateUrl?: string;
+            /**
+            * Contains a predefined template's name; 'bootstrap3' (default), 'bootstrap2' or HTML for a custom template. This property is ignored if templateUrl is defined.
+            **/
+            template?: string;
+
+            /**
+            * Contains the path to a template file. This property takes precedence over the template property.
+            **/
+            templateUrl?: string;
+
+            /**
+            * If true, abstract states are included in the breadcrumb. This option has a lower priority than the state-specific option skip
+            **/
+            includeAbstract?: boolean;
+        }
 
         /**
-        * If true, abstract states are included in the breadcrumb. This option has a lower priority than the state-specific option skip
+        * Service responsible for access to $state and for directive configuration.
         **/
-        includeAbstract?: boolean;
-    }
+        export interface $breadcrumbService {
+            /**
+            * Returns the state chain to the current state (i.e. all the steps of the breadcrumb). It's an array of state object enriched with the module-specific property ncyBreadcrumbLink (the href for the breadcrumb step).
+            **/
+            getStatesChain(): angular.ui.IState[];
 
-    /**
-    * Service responsible for access to $state and for directive configuration.
-    **/
-    export interface $breadcrumbService {
-        /**
-        * Returns the state chain to the current state (i.e. all the steps of the breadcrumb). It's an array of state object enriched with the module-specific property ncyBreadcrumbLink (the href for the breadcrumb step).
-        **/
-        getStatesChain(): angular.ui.IState[];
-
-        /**
-        * Return the last step of the breadcrumb, generally the one relative to the current state, expect if it is configured as skipped (the method returns its parent). As getStatesChain, the state object is enriched with ncyBreadcrumbLink.
-        **/
-        getLastStep(): angular.ui.IState;
+            /**
+            * Return the last step of the breadcrumb, generally the one relative to the current state, expect if it is configured as skipped (the method returns its parent). As getStatesChain, the state object is enriched with ncyBreadcrumbLink.
+            **/
+            getLastStep(): angular.ui.IState;
+        }
     }
 }


### PR DESCRIPTION
This fix follows the fixes from this PR for other angular packages: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/10170

Not sure what to do with the global `ncy` namespace, I moved it under `angular.ncy`, but perhaps there is a better way?

---

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/10170
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
