### PR TITLE
Fixes #13756 - Fixes a typo in DocumentDb definition

### DIFF
--- a/documentdb/index.d.ts
+++ b/documentdb/index.d.ts
@@ -231,7 +231,7 @@ interface IndexingPolicy {
     indexingMode: string;
 
     /** An array of {@link IndexingPath} represents The paths to be incuded for indexing. */
-    IncludedPath: IndexingPath[];
+    IncludedPaths: IndexingPath[];
 
     /** An array of strings representing the paths to be excluded from indexing. */
     ExcludedPaths: string[];


### PR DESCRIPTION
- [x ] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
As far as I can see there is a typo in IndexingPolicy.IncludedPath property definition. According to official documentation, the property is called IndexingPolicy.IncludedPaths: http://azure.github.io/azure-documentdb-node/global.html#IndexingPolicy