### PR TITLE
fix enzyme CommonWrapper.reduce function to return R instead of R[]

### DIFF
--- a/enzyme/enzyme-tests.tsx
+++ b/enzyme/enzyme-tests.tsx
@@ -277,14 +277,14 @@ namespace ShallowWrapperTest {
     }
 
     function test_reduce() {
-        const total: number[] =
+        const total: number =
             shallowWrapper.reduce(
                 (amount: number, n: ShallowWrapper<MyComponentProps, MyComponentState>) => amount + n.props().numberProp
             );
     }
 
     function test_reduceRight() {
-        const total: number[] =
+        const total: number =
             shallowWrapper.reduceRight<number>(
                 (amount: number, n: ShallowWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
             );
@@ -557,14 +557,14 @@ namespace ReactWrapperTest {
     }
 
     function test_reduce() {
-        const total: number[] =
+        const total: number =
             reactWrapper.reduce<number>(
                 (amount: number, n: ReactWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
             );
     }
 
     function test_reduceRight() {
-        const total: number[] =
+        const total: number =
             reactWrapper.reduceRight<number>(
                 (amount: number, n: ReactWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
             );
@@ -799,14 +799,14 @@ namespace CheerioWrapperTest {
     }
 
     function test_reduce() {
-        const total: number[] =
+        const total: number =
             cheerioWrapper.reduce<number>(
                 (amount: number, n: CheerioWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
             );
     }
 
     function test_reduceRight() {
-        const total: number[] =
+        const total: number =
             cheerioWrapper.reduceRight<number>(
                 (amount: number, n: CheerioWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
             );

--- a/enzyme/index.d.ts
+++ b/enzyme/index.d.ts
@@ -346,7 +346,7 @@ interface CommonWrapper<P, S> {
      * @param fn
      * @param initialValue
      */
-    reduce<R>(fn: (prevVal: R, wrapper: this, index: number) => R, initialValue?: R): R[];
+    reduce<R>(fn: (prevVal: R, wrapper: this, index: number) => R, initialValue?: R): R;
 
     /**
      * Applies the provided reducing function to every node in the wrapper to reduce to a single value.
@@ -354,7 +354,7 @@ interface CommonWrapper<P, S> {
      * @param fn
      * @param initialValue
      */
-    reduceRight<R>(fn: (prevVal: R, wrapper: this, index: number) => R, initialValue?: R): R[];
+    reduceRight<R>(fn: (prevVal: R, wrapper: this, index: number) => R, initialValue?: R): R;
 
     /**
      * Returns whether or not any of the nodes in the wrapper match the provided selector.


### PR DESCRIPTION

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/airbnb/enzyme/blob/64ac7441d23157732d38b62a29003646cc92bcd2/src/ShallowWrapper.js#L799-L804>> 
- [ ] Increase the version number in the header if appropriate.  - I didn't increase the version - should I?
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`. - not substantial (bug fix)

CC: @NoHomey 