### PR TITLE
Made bunyan typing conform to the way the module was written

### DIFF
--- a/browser-bunyan/index.d.ts
+++ b/browser-bunyan/index.d.ts
@@ -3,6 +3,10 @@
 // Definitions by: Paul Lockwood <https://github.com/PaulLockwood>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export * from "bunyan";
+import bunyan = require("bunyan");
 
-export function ConsoleFormattedStream(): void;
+declare module "bunyan" {
+    export function ConsoleFormattedStream(): void;
+}
+
+export = bunyan;

--- a/bunyan-logentries/bunyan-logentries-tests.ts
+++ b/bunyan-logentries/bunyan-logentries-tests.ts
@@ -1,7 +1,7 @@
-import bunyan = require("bunyan");
+import Logger = require("bunyan");
 import bunyanLogentries = require("bunyan-logentries");
 
-var logger: bunyan.Logger = bunyan.createLogger({
+var logger: Logger = Logger.createLogger({
   name: "foobar",
   streams: [{
     level: "info",

--- a/bunyan/bunyan-tests.ts
+++ b/bunyan/bunyan-tests.ts
@@ -1,83 +1,83 @@
 
-import * as bunyan from 'bunyan';
+import Logger = require('bunyan');
 
-var ringBufferOptions:bunyan.RingBufferOptions = {
+var ringBufferOptions: Logger.RingBufferOptions = {
     limit: 100
 };
-var ringBuffer:bunyan.RingBuffer = new bunyan.RingBuffer(ringBufferOptions);
+var ringBuffer: Logger.RingBuffer = new Logger.RingBuffer(ringBufferOptions);
 ringBuffer.write("hello");
 ringBuffer.end();
 ringBuffer.destroy();
 ringBuffer.destroySoon();
 
-var level:number;
-level = bunyan.resolveLevel("trace");
-level = bunyan.resolveLevel("debug");
-level = bunyan.resolveLevel("info");
-level = bunyan.resolveLevel("warn");
-level = bunyan.resolveLevel("error");
-level = bunyan.resolveLevel("fatal");
-level = bunyan.resolveLevel(bunyan.TRACE);
-level = bunyan.resolveLevel(bunyan.DEBUG);
-level = bunyan.resolveLevel(bunyan.INFO);
-level = bunyan.resolveLevel(bunyan.WARN);
-level = bunyan.resolveLevel(bunyan.ERROR);
-level = bunyan.resolveLevel(bunyan.FATAL);
+var level: number;
+level = Logger.resolveLevel("trace");
+level = Logger.resolveLevel("debug");
+level = Logger.resolveLevel("info");
+level = Logger.resolveLevel("warn");
+level = Logger.resolveLevel("error");
+level = Logger.resolveLevel("fatal");
+level = Logger.resolveLevel(Logger.TRACE);
+level = Logger.resolveLevel(Logger.DEBUG);
+level = Logger.resolveLevel(Logger.INFO);
+level = Logger.resolveLevel(Logger.WARN);
+level = Logger.resolveLevel(Logger.ERROR);
+level = Logger.resolveLevel(Logger.FATAL);
 
-var options:bunyan.LoggerOptions = {
+var options: Logger.LoggerOptions = {
     name: 'test-logger',
-    serializers: bunyan.stdSerializers,
+    serializers: Logger.stdSerializers,
     streams: [{
         type: 'stream',
         stream: process.stdout,
-        level: bunyan.TRACE
+        level: Logger.TRACE
     }, {
         type: 'file',
         path: '/tmp/test.log',
-        level: bunyan.DEBUG,
+        level: Logger.DEBUG,
         closeOnExit: true
     }, {
         type: 'rotating-file',
         path: '/tmp/test2.log',
-        level: bunyan.INFO,
+        level: Logger.INFO,
         closeOnExit: false,
         period: '1d',
         count: 3
     }, {
         type: 'raw',
         stream: process.stderr,
-        level: bunyan.WARN
+        level: Logger.WARN
     }, {
         type: 'raw',
         stream: ringBuffer,
-        level: bunyan.ERROR
+        level: Logger.ERROR
     }]
 };
 
-var log = bunyan.createLogger(options);
+var log = Logger.createLogger(options);
 
 var customSerializer = function(anything: any) {
     return { obj: anything};
 };
 
 log.addSerializers({anything: customSerializer});
-log.addSerializers(bunyan.stdSerializers);
+log.addSerializers(Logger.stdSerializers);
 log.addSerializers(
     {
-        err: bunyan.stdSerializers.err,
-        req: bunyan.stdSerializers.req,
-        res: bunyan.stdSerializers.res
+        err: Logger.stdSerializers.err,
+        req: Logger.stdSerializers.req,
+        res: Logger.stdSerializers.res
     }
 );
 
 var child = log.child({name: 'child'});
 child.reopenFileStreams();
 log.addStream({path: '/dev/null'});
-child.level(bunyan.DEBUG);
+child.level(Logger.DEBUG);
 child.level('debug');
-child.levels(0, bunyan.ERROR);
+child.levels(0, Logger.ERROR);
 child.levels(0, 'error');
-child.levels('stream1', bunyan.FATAL);
+child.levels('stream1', Logger.FATAL);
 child.levels('stream1', 'fatal');
 
 var buffer = new Buffer(0);
@@ -118,4 +118,10 @@ var recursive: any = {
     }
 }
 
-JSON.stringify(recursive, bunyan.safeCycles());
+JSON.stringify(recursive, Logger.safeCycles());
+
+class MyLogger extends Logger {
+    constructor() {
+        super(options);
+    }
+}

--- a/bunyan/index.d.ts
+++ b/bunyan/index.d.ts
@@ -5,14 +5,13 @@
 
 /// <reference types="node" />
 
-
 import { EventEmitter } from 'events';
 
 declare class Logger extends EventEmitter {
-    constructor(options: LoggerOptions);
-    addStream(stream: Stream): void;
-    addSerializers(serializers:Serializers | StdSerializers):void;
-    child(options: LoggerOptions, simple?: boolean): Logger;
+    constructor(options: Logger.LoggerOptions);
+    addStream(stream: Logger.Stream): void;
+    addSerializers(serializers: Logger.Serializers | Logger.StdSerializers): void;
+    child(options: Logger.LoggerOptions, simple?: boolean): Logger;
     child(obj: Object, simple?: boolean): Logger;
     reopenFileStreams(): void;
 
@@ -21,7 +20,7 @@ declare class Logger extends EventEmitter {
     levels(name: number | string, value: number | string): void;
 
     fields: any;
-        src:boolean;
+    src: boolean;
 
     trace(error: Error, format?: any, ...params: any[]): void;
     trace(buffer: Buffer, format?: any, ...params: any[]): void;
@@ -49,31 +48,23 @@ declare class Logger extends EventEmitter {
     fatal(format: string, ...params: any[]): void;
 }
 
-interface LoggerOptions {
-    name: string;
-    streams?: Stream[];
-    level?: string | number;
-    stream?: NodeJS.WritableStream;
-    serializers?: Serializers | StdSerializers;
-    src?: boolean;
-    [custom: string]: any;
-}
+declare namespace Logger {
+  const TRACE: number;
+  const DEBUG: number;
+  const INFO: number;
+  const WARN: number;
+  const ERROR: number;
+  const FATAL: number;
 
-interface Serializer {
-    (input:any): any;
-}
+  const stdSerializers: StdSerializers;
 
-interface Serializers {
-    [key: string]: Serializer
-}
+  function createLogger(options: LoggerOptions): Logger;
 
-interface StdSerializers {
-    err: Serializer;
-    res: Serializer;
-    req: Serializer;
-}
+  function safeCycles(): (key: string, value: any) => any;
 
-interface Stream {
+  function resolveLevel(value: number | string): number;
+
+  interface Stream {
     type?: string;
     level?: number | string;
     path?: string;
@@ -81,22 +72,37 @@ interface Stream {
     closeOnExit?: boolean;
     period?: string;
     count?: number;
-}
+  }
 
-export declare var stdSerializers: StdSerializers;
+  interface LoggerOptions {
+    name: string;
+    streams?: Stream[];
+    level?: string | number;
+    stream?: NodeJS.WritableStream;
+    serializers?: Serializers | StdSerializers;
+    src?: boolean;
+    [custom: string]: any;
+  }
 
-export declare var TRACE: number;
-export declare var DEBUG: number;
-export declare var INFO: number;
-export declare var WARN: number;
-export declare var ERROR: number;
-export declare var FATAL: number;
+  interface Serializer {
+    (input:any): any;
+  }
 
-export declare function resolveLevel(value: number | string): number;
+  interface Serializers {
+    [key: string]: Serializer
+  }
 
-export declare function createLogger(options: LoggerOptions): Logger;
+  interface StdSerializers {
+    err: Serializer;
+    res: Serializer;
+    req: Serializer;
+  }
 
-declare class RingBuffer extends EventEmitter {
+  interface RingBufferOptions {
+    limit?: number;
+  }
+
+  class RingBuffer extends EventEmitter {
     constructor(options: RingBufferOptions);
 
     writable: boolean;
@@ -106,10 +112,7 @@ declare class RingBuffer extends EventEmitter {
     end(record?: any): void;
     destroy(): void;
     destroySoon(): void;
+  }
 }
 
-interface RingBufferOptions {
-    limit?: number;
-}
-
-export declare function safeCycles(): (key: string, value: any) => any;
+export = Logger;

--- a/easy-api-request/index.d.ts
+++ b/easy-api-request/index.d.ts
@@ -9,7 +9,7 @@
 import stream = require('stream');
 import http = require('http');
 import request = require('request');
-import bunyan = require('bunyan');
+import Logger = require('bunyan');
 import express = require('express');
 import Q = require('q');
 
@@ -35,7 +35,7 @@ interface Result {
 declare class BaseRequest {
     protected base: request.Request;
     protected req: express.Request;
-    protected log: bunyan.Logger;
+    protected log: Logger;
     protected replyCookies: string[];
     protected jSend: boolean;
     constructor(opts: any);

--- a/easy-xapi/index.d.ts
+++ b/easy-xapi/index.d.ts
@@ -18,7 +18,7 @@ declare namespace Express {
 declare module "easy-xapi" {
     import express = require('express');
     import http = require('http');
-    import bunyan = require('bunyan');
+    import Logger = require('bunyan');
 
     interface InitConfig {
         jSend?: {partial: boolean};
@@ -40,7 +40,7 @@ declare module "easy-xapi" {
         express: any;
         app: express.Application;
         server: http.Server;
-        log: bunyan.Logger;
+        log: Logger;
         listen: () => void;
     }
 

--- a/restify-plugins/index.d.ts
+++ b/restify-plugins/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import {RequestHandler, Server, Request, Response, Route} from 'restify';
-import * as bunyan from 'bunyan';
+import Logger = require('bunyan');
 
 //*************** This module includes the follow pre plugins, which are intended to be used prior to the routing of a request:
 
@@ -15,7 +15,7 @@ export namespace pre {
   function context(): RequestHandler;
 
   /**
-   * 
+   *
    */
   function dedupeSlashes(): RequestHandler;
 
@@ -56,7 +56,7 @@ interface AuditLoggerOptions {
   /**
    * Bunyan logger
    */
-  log: bunyan.Logger;
+  log: Logger;
 
   /**
    * Restify server. If passed in, causes server to emit 'auditlog' event after audit logs are flushed
@@ -74,7 +74,7 @@ interface AuditLoggerOptions {
   printLog?: boolean;
 
   /**
-   * 
+   *
    */
   body?: boolean;
 }
@@ -165,12 +165,12 @@ interface BodyParserOptions {
   rejectUnknown?: boolean;
 
   /**
-   * 
+   *
    */
   reviver?: any;
 
   /**
-   * 
+   *
    */
   maxFieldsSize?: number;
 }
@@ -192,7 +192,7 @@ interface UrlEncodedBodyParser {
 
 /**
  * Parse the HTTP request body IFF the contentType is application/x-www-form-urlencoded.
- * 
+ *
  * If req.params already contains a given key, that key is skipped and an
  * error is logged.
  */
@@ -287,7 +287,7 @@ interface RequestLogger {
 
 /**
  * Adds timers for each handler in your request chain
- * 
+ *
  * `options.properties` properties to pass to bunyan's `log.child()` method
  */
 export function requestLogger(options?: RequestLogger): RequestHandler;
@@ -341,7 +341,7 @@ interface MetricsCallback {
   err: Error;
 
   /**
-   * 
+   *
    */
   metrics: MetricsCallbackOptions;
 
@@ -380,7 +380,7 @@ interface MetricsCallbackOptions {
 
   /**
    * If this value is set, err will be a corresponding `RequestCloseError` or `RequestAbortedError`.
-   * 
+   *
    * If connectionState is either 'close' or 'aborted', then the statusCode is not applicable since the connection was severed before a response was written.
    */
   connectionState: TMetricsCallback;
@@ -395,7 +395,7 @@ interface MetricsReturns {
 
 /**
  * Listens to the server's after event and emits information about that request (5.x compatible only).
- * 
+ *
  * ```
  * server.on('after', plugins.metrics( (err, metrics) =>
  * {
@@ -407,7 +407,7 @@ export function metrics(opts: {server: Server}, callback: (options: MetricsCallb
 
 /**
  * Parse the client's request for an OAUTH2 access tokensTable
- * 
+ *
  * Subsequent handlers will see `req.oauth2`, which looks like:
  * ```
  * {
@@ -441,7 +441,7 @@ interface RequestExpiryOptions {
 
 /**
  * A request expiry will use headers to tell if the incoming request has expired or not.
- * 
+ *
  * There are two options for this plugin:
  *   1. Absolute Time
  *     * Time in Milliseconds since the Epoch when this request should be considered expired

--- a/restify/index.d.ts
+++ b/restify/index.d.ts
@@ -6,7 +6,7 @@
 /// <reference types="node" />
 
 import http = require('http');
-import bunyan = require('bunyan');
+import Logger = require('bunyan');
 import url = require('url');
 
 
@@ -196,7 +196,7 @@ interface Request extends http.IncomingMessage {
      */
     href: () => string;
 
-    log: bunyan.Logger;
+    log: Logger;
     /**
      * retrieves the request uuid. was created when the request was setup.
      * @public
@@ -486,7 +486,7 @@ interface HttpClient extends Client {
     patch: (opts?: string | { path?: string; [name: string]: any }, callback?: Function) => any;
     del: (opts?: string | { path?: string; [name: string]: any }, callback?: Function) => any;
 }
- 
+
 interface ThrottleOptions {
     burst?: number;
     rate?: number;


### PR DESCRIPTION
When I tried to extend the `Logger` class, I got runtime errors saying something on the lines of `unable to extend undefined`. I checked `bunyan`'s source code and noticed that `module.exports` was being used and that, therefore, the definition needed no be updated to account for that fact. After these changes, extending `Logger` becomes possible.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js
