### PR TITLE
react: use more narrow constructor definition

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -163,8 +163,8 @@ declare namespace React {
 
     // Base component for plain JS classes
     class Component<P, S> implements ComponentLifecycle<P, S> {
-        constructor(...args: any[]);
         constructor(props?: P, context?: any);
+        constructor(...args: any[]);
         setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
         setState(state: S, callback?: () => any): void;
         forceUpdate(callBack?: () => any): void;


### PR DESCRIPTION
This has almost no sense for typescript, but very useful for ide.
At least webstorm uses first constructor definition with `Generate constructor action`.
And, I think it is good to define more narrow method definition earlier that more general.