### PR TITLE
Fixed a method-name and signature in the node-validator typings

### DIFF
--- a/node-validator/index.d.ts
+++ b/node-validator/index.d.ts
@@ -32,7 +32,7 @@ declare namespace Validator {
     interface IsObjectValidator extends Validatable {
         withRequired: (name: String, validator: Validatable) => IsObjectValidator,
         withOptional: (name: String, validator: Validatable) => IsObjectValidator,
-        custom: (customValidator: Validatable) => IsObjectValidator,
+        withCustom: (customValidator: ValidateFn) => IsObjectValidator,
         validate: ValidateFn
     }
 


### PR DESCRIPTION
The correct method-name has always been `withCustom()` instead of `custom()`. Also, the method-signature is (sadly) inconsistent with the other `withX()`-methods: it expects the `ValidateFn` directly instead of wrapped in a `Validatable` (but it does wraps it into a `Validatable` internally...)

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [`withCustom` definition](https://bitbucket.org/gregbacchus/node-validator/src/48c7656bc2b427026decb1c59e5e070d694b8930/lib/validator.js?at=master&fileviewer=file-view-default#validator.js-178)
  - [Internal wrapping of the `ValidateFn` in the `withCustom`-method](https://bitbucket.org/gregbacchus/node-validator/src/48c7656bc2b427026decb1c59e5e070d694b8930/lib/validator.js?at=master&fileviewer=file-view-default#validator.js-198)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.