### PR TITLE
Fabric: Fixed the return-type of the IIntersectionStatic constructor

### DIFF
--- a/fabric/index.d.ts
+++ b/fabric/index.d.ts
@@ -635,7 +635,7 @@ declare namespace fabric {
     /**
      * Intersection class
      */
-    new (status?: string): void;
+    new (status?: string): IIntersection;
     /**
      * Checks if polygon intersects another polygon
      */


### PR DESCRIPTION
Having a constructor return "void" never makes sense, since a function called with "new" will always return something different from void.

Please fill in this template.
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.