### PR TITLE
fix type definition for package: apex.js

### DIFF
--- a/apex.js/apex.js-tests.ts
+++ b/apex.js/apex.js-tests.ts
@@ -1,5 +1,8 @@
-import λ from "apex.js";
+import * as λ from "apex.js";
 
-const handler = λ(event => {
-    console.log("Invoked with event " + JSON.stringify(event));
+const handler = λ((event, context) => {
+    console.log("Event: " + JSON.stringify(event));
+    console.log("Context: " + JSON.stringify(context));
+
+    return {event, context};
 });

--- a/apex.js/index.d.ts
+++ b/apex.js/index.d.ts
@@ -5,8 +5,6 @@
 
 /// <reference types="aws-lambda" />
 
-declare module "apex.js" {
-    function λ(fn: (event: any, context: AWSLambda.Context) => any): (event: any, context: AWSLambda.Context, callback: AWSLambda.Callback) => void;
-    namespace λ {}
-    export = λ;
-}
+declare function λ(fn: (event: any, context: AWSLambda.Context) => any): (event: any, context: AWSLambda.Context, callback: AWSLambda.Callback) => void;
+declare namespace λ {}
+export = λ;

--- a/apex.js/index.d.ts
+++ b/apex.js/index.d.ts
@@ -7,6 +7,6 @@
 
 declare module "apex.js" {
     function λ(fn: (event: any, context: AWSLambda.Context) => any): (event: any, context: AWSLambda.Context, callback: AWSLambda.Callback) => void;
-    module λ {}
+    namespace λ {}
     export = λ;
 }

--- a/apex.js/index.d.ts
+++ b/apex.js/index.d.ts
@@ -5,4 +5,8 @@
 
 /// <reference types="aws-lambda" />
 
-export default function λ(fn: (event: any, context: AWSLambda.Context) => any): (event: any, context: AWSLambda.Context, callback: AWSLambda.Callback) => void;
+declare module "apex.js" {
+    function λ(fn: (event: any, context: AWSLambda.Context) => any): (event: any, context: AWSLambda.Context, callback: AWSLambda.Callback) => void;
+    module λ {}
+    export = λ;
+}


### PR DESCRIPTION
After #13796 has been merged, I noticed that it has an `export default` problem similar to [this](https://github.com/Microsoft/TypeScript/issues/5565). It produces an error `apex_js_1.default is not a function`.

So I edited the definition and the test. Sorry for my poor checking before last PR.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.~~
