### PR TITLE
Update msgpack-lite definitions

### DIFF
--- a/msgpack-lite/index.d.ts
+++ b/msgpack-lite/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for msgpack-lite v0.1.26
+// Type definitions for msgpack-lite 0.1
 // Project: https://github.com/kawanet/msgpack-lite
 // Definitions by: Endel Dreyer <https://github.com/endel/>, Edmund Fokschaner <https://github.com/efokschaner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -16,7 +16,7 @@ declare module 'msgpack-lite' {
     /**
      * decode from MessagePack to JS Object
      */
-    function decode(input: Buffer | Uint8Array | Array<number>, options?: DecoderOptions): any;
+    function decode(input: Buffer | Uint8Array | number[], options?: DecoderOptions): any;
 
     /**
      * create a stream that encodes from JS Object to MessagePack
@@ -147,11 +147,11 @@ declare module 'msgpack-lite' {
     }
 
     interface EncoderOptions {
-      codec?: Codec
+      codec?: Codec;
     }
 
     interface DecoderOptions {
-      codec?: Codec
+      codec?: Codec;
     }
   }
 

--- a/msgpack-lite/index.d.ts
+++ b/msgpack-lite/index.d.ts
@@ -4,156 +4,150 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-declare module 'msgpack-lite' {
-  import * as stream from 'stream';
+import * as stream from 'stream';
 
-  namespace MsgpackLite {
-    /**
-     * encode from JS Object to MessagePack
-     */
-    function encode(input: any, options?: EncoderOptions): Buffer;
+/**
+ * encode from JS Object to MessagePack
+ */
+export function encode(input: any, options?: EncoderOptions): Buffer;
 
-    /**
-     * decode from MessagePack to JS Object
-     */
-    function decode(input: Buffer | Uint8Array | number[], options?: DecoderOptions): any;
+/**
+ * decode from MessagePack to JS Object
+ */
+export function decode(input: Buffer | Uint8Array | number[], options?: DecoderOptions): any;
 
-    /**
-     * create a stream that encodes from JS Object to MessagePack
-     */
-    function createEncodeStream(options?: EncoderOptions & stream.TransformOptions ): EncodeStream;
+/**
+ * create a stream that encodes from JS Object to MessagePack
+ */
+export function createEncodeStream(options?: EncoderOptions & stream.TransformOptions ): EncodeStream;
 
-    /**
-     * create a stream that decodes from MessagePack (Buffer) to JS Object
-     */
-    function createDecodeStream(options?: DecoderOptions & stream.TransformOptions): DecodeStream;
+/**
+ * create a stream that decodes from MessagePack (Buffer) to JS Object
+ */
+export function createDecodeStream(options?: DecoderOptions & stream.TransformOptions): DecodeStream;
 
-    /**
-     * Codecs allow for Custom Extension Types
-     * Register a custom extension type number to serialize/deserialize your own class instances.
-     * https://github.com/kawanet/msgpack-lite#custom-extension-types-codecs
-     * If you wish to modify the default built-in codec, you can access it at msgpack.codec.preset
-     */
-    function createCodec(options?: CodecOptions): Codec;
+/**
+ * Codecs allow for Custom Extension Types
+ * Register a custom extension type number to serialize/deserialize your own class instances.
+ * https://github.com/kawanet/msgpack-lite#custom-extension-types-codecs
+ * If you wish to modify the default built-in codec, you can access it at msgpack.codec.preset
+ */
+export function createCodec(options?: CodecOptions): Codec;
 
-    /**
-     * The default built-in codec
-     */
-    var codec: {
-      /**
-       * The default built-in codec
-       */
-      preset: Codec;
-    };
+/**
+ * The default built-in codec
+ */
+export var codec: {
+  /**
+   * The default built-in codec
+   */
+  preset: Codec;
+};
 
-    interface Codec {
-      /**
-       * Register a custom extension to serialize your own class instances
-       *
-       * @param etype an integer within the range of 0 and 127 (0x0 and 0x7F)
-       * @param Class the constructor of the type you wish to serialize
-       * @param packer a function that converts an instance of T to bytes
-       */
-      addExtPacker<T>(
-        etype: number,
-        Class: new(...args: any[]) => T,
-        packer: (t: T) => Buffer | Uint8Array): void;
+export interface Codec {
+  /**
+   * Register a custom extension to serialize your own class instances
+   *
+   * @param etype an integer within the range of 0 and 127 (0x0 and 0x7F)
+   * @param Class the constructor of the type you wish to serialize
+   * @param packer a function that converts an instance of T to bytes
+   */
+  addExtPacker<T>(
+    etype: number,
+    Class: new(...args: any[]) => T,
+    packer: (t: T) => Buffer | Uint8Array): void;
 
-      /**
-       * Register a custom extension to deserialize your own class instances
-       *
-       * @param etype an integer within the range of 0 and 127 (0x0 and 0x7F)
-       * @param unpacker a function that converts bytes to an instance of T
-       */
-      addExtUnpacker<T>(etype: number, unpacker: (data: Buffer | Uint8Array) => T): void;
-    }
+  /**
+   * Register a custom extension to deserialize your own class instances
+   *
+   * @param etype an integer within the range of 0 and 127 (0x0 and 0x7F)
+   * @param unpacker a function that converts bytes to an instance of T
+   */
+  addExtUnpacker<T>(etype: number, unpacker: (data: Buffer | Uint8Array) => T): void;
+}
 
-    interface Encoder {
-      bufferish: any;
-      maxBufferSize: number;
-      minBufferSize: number;
-      offset: number;
-      start: number;
-      write: (chunk: any) => void;
-      fetch: () => void;
-      flush: () => void;
-      push: (chunk: any) => void;
-      pull: () => number;
-      read: () => number;
-      reserve: (length: number) => number;
-      send: (buffer: Buffer) => void;
-      encode: (chunk: any) => void;
-      end: (chunk: any) => void;
-    }
+export interface Encoder {
+  bufferish: any;
+  maxBufferSize: number;
+  minBufferSize: number;
+  offset: number;
+  start: number;
+  write: (chunk: any) => void;
+  fetch: () => void;
+  flush: () => void;
+  push: (chunk: any) => void;
+  pull: () => number;
+  read: () => number;
+  reserve: (length: number) => number;
+  send: (buffer: Buffer) => void;
+  encode: (chunk: any) => void;
+  end: (chunk: any) => void;
+}
 
-    interface Decoder {
-      bufferish: any;
-      offset: number;
-      fetch: () => void;
-      flush: () => void;
-      pull: () => number;
-      read: () => number;
-      write: (chunk: any) => void;
-      reserve: (length: number) => number;
-      decode: (chunk: any) => void;
-      push: (chunk: any) => void;
-      end: (chunk: any) => void;
-    }
+export interface Decoder {
+  bufferish: any;
+  offset: number;
+  fetch: () => void;
+  flush: () => void;
+  pull: () => number;
+  read: () => number;
+  write: (chunk: any) => void;
+  reserve: (length: number) => number;
+  decode: (chunk: any) => void;
+  push: (chunk: any) => void;
+  end: (chunk: any) => void;
+}
 
-    interface EncodeStream extends stream.Transform {
-      encoder: Encoder;
-    }
+export interface EncodeStream extends stream.Transform {
+  encoder: Encoder;
+}
 
-    interface DecodeStream extends stream.Transform {
-      decoder: Decoder;
-    }
+export interface DecodeStream extends stream.Transform {
+  decoder: Decoder;
+}
 
-    interface CodecOptions {
-      /**
-       * It includes the preset extensions for JavaScript native objects.
-       * @see https://github.com/kawanet/msgpack-lite#extension-types
-       * @default false
-       */
-      preset?: boolean;
-      /**
-       * It runs a validation of the value before writing it into buffer.
-       * This is the default behavior for some old browsers which do not support ArrayBuffer object.
-       * @default varies
-       */
-      safe?: boolean;
-      /**
-       * It uses raw formats instead of bin and str.
-       * Set true for compatibility with msgpack's old spec.
-       * @see https://github.com/kawanet/msgpack-lite#compatibility-mode
-       * @default false
-       */
-      raw?: boolean;
-      /**
-       * It decodes msgpack's int64/uint64 formats with int64-buffer object.
-       * int64-buffer is a cutom integer type with 64 bits of precision instead
-       * of the built-in IEEE-754 53 bits. See https://github.com/kawanet/int64-buffer
-       * @default false
-       */
-      int64?: boolean;
-      /**
-       * It ties msgpack's bin format with ArrayBuffer object, instead of Buffer object.
-       * @default false
-       */
-      binarraybuffer?: boolean;
-      /**
-       * It returns Uint8Array object when encoding, instead of Buffer object.
-       */
-      uint8array?: boolean;
-    }
+export interface CodecOptions {
+  /**
+   * It includes the preset extensions for JavaScript native objects.
+   * @see https://github.com/kawanet/msgpack-lite#extension-types
+   * @default false
+   */
+  preset?: boolean;
+  /**
+   * It runs a validation of the value before writing it into buffer.
+   * This is the default behavior for some old browsers which do not support ArrayBuffer object.
+   * @default varies
+   */
+  safe?: boolean;
+  /**
+   * It uses raw formats instead of bin and str.
+   * Set true for compatibility with msgpack's old spec.
+   * @see https://github.com/kawanet/msgpack-lite#compatibility-mode
+   * @default false
+   */
+  raw?: boolean;
+  /**
+   * It decodes msgpack's int64/uint64 formats with int64-buffer object.
+   * int64-buffer is a cutom integer type with 64 bits of precision instead
+   * of the built-in IEEE-754 53 bits. See https://github.com/kawanet/int64-buffer
+   * @default false
+   */
+  int64?: boolean;
+  /**
+   * It ties msgpack's bin format with ArrayBuffer object, instead of Buffer object.
+   * @default false
+   */
+  binarraybuffer?: boolean;
+  /**
+   * It returns Uint8Array object when encoding, instead of Buffer object.
+   */
+  uint8array?: boolean;
+}
 
-    interface EncoderOptions {
-      codec?: Codec;
-    }
+export interface EncoderOptions {
+  codec?: Codec;
+}
 
-    interface DecoderOptions {
-      codec?: Codec;
-    }
-  }
-
-  export = MsgpackLite;
+export interface DecoderOptions {
+  codec?: Codec;
 }

--- a/msgpack-lite/msgpack-lite-tests.ts
+++ b/msgpack-lite/msgpack-lite-tests.ts
@@ -28,7 +28,6 @@ function writingToStream() {
 // https://github.com/kawanet/msgpack-lite#reading-from-messagepack-stream
 function readingFromStream() {
   var fs = require("fs");
-  var msgpack = require("msgpack-lite");
 
   var readStream = fs.createReadStream("test.msp");
   var decodeStream = msgpack.createDecodeStream();

--- a/msgpack-lite/msgpack-lite-tests.ts
+++ b/msgpack-lite/msgpack-lite-tests.ts
@@ -1,5 +1,75 @@
+import * as msgpack from 'msgpack-lite';
 
-import * as msgpack from "msgpack-lite";
+// https://github.com/kawanet/msgpack-lite#encoding-and-decoding-messagepack
+function encodingAndDecoding() {
+  // encode from JS Object to MessagePack (Buffer)
+  var buffer = msgpack.encode({"foo": "bar"});
 
-var encoded = msgpack.encode("");
-msgpack.decode(encoded);
+  // decode from MessagePack (Buffer) to JS Object
+  var data = msgpack.decode(buffer); // => {"foo": "bar"}
+}
+
+// https://github.com/kawanet/msgpack-lite#writing-to-messagepack-stream
+function writingToStream() {
+  var fs = require("fs");
+
+  var writeStream = fs.createWriteStream("test.msp");
+  var encodeStream = msgpack.createEncodeStream();
+  encodeStream.pipe(writeStream);
+
+  // send multiple objects to stream
+  encodeStream.write({foo: "bar"});
+  encodeStream.write({baz: "qux"});
+
+  // call this once you're done writing to the stream.
+  encodeStream.end();
+}
+
+// https://github.com/kawanet/msgpack-lite#reading-from-messagepack-stream
+function readingFromStream() {
+  var fs = require("fs");
+  var msgpack = require("msgpack-lite");
+
+  var readStream = fs.createReadStream("test.msp");
+  var decodeStream = msgpack.createDecodeStream();
+
+  // show multiple objects decoded from stream
+  readStream.pipe(decodeStream).on("data", console.warn);
+}
+
+// https://github.com/kawanet/msgpack-lite#decoding-messagepack-bytes-array
+function decodingBytesArray() {
+  // decode() accepts Buffer instance per default
+  msgpack.decode(new Buffer([0x81, 0xA3, 0x66, 0x6F, 0x6F, 0xA3, 0x62, 0x61, 0x72]));
+
+  // decode() also accepts Array instance
+  msgpack.decode([0x81, 0xA3, 0x66, 0x6F, 0x6F, 0xA3, 0x62, 0x61, 0x72]);
+
+  // decode() accepts raw Uint8Array instance as well
+  msgpack.decode(new Uint8Array([0x81, 0xA3, 0x66, 0x6F, 0x6F, 0xA3, 0x62, 0x61, 0x72]));
+}
+
+// https://github.com/kawanet/msgpack-lite#custom-extension-types-codecs
+function customExtensionTypes() {
+  var codec = msgpack.createCodec();
+  codec.addExtPacker(0x3F, MyVector, myVectorPacker);
+  codec.addExtUnpacker(0x3F, myVectorUnpacker);
+
+  var data = new MyVector(1, 2);
+  var encoded = msgpack.encode(data, {codec: codec});
+  var decoded = msgpack.decode(encoded, {codec: codec});
+
+  class MyVector {
+    constructor(public x: number, public y: number) {}
+  }
+
+  function myVectorPacker(vector: MyVector) {
+    var array = [vector.x, vector.y];
+    return msgpack.encode(array); // return Buffer serialized
+  }
+
+  function myVectorUnpacker(buffer: Buffer | Uint8Array): MyVector {
+    var array = msgpack.decode(buffer);
+    return new MyVector(array[0], array[1]); // return Object deserialized
+  }
+}

--- a/msgpack-lite/tsconfig.json
+++ b/msgpack-lite/tsconfig.json
@@ -4,7 +4,7 @@
         "target": "es6",
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/msgpack-lite/tslint.json
+++ b/msgpack-lite/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
@endel we'll probably need to discuss my changes to the Codec interface. I've removed anything that wasn't documented. If those changes break anything for you we should check with @kawanet whether he intended to expose and support members other than `addExtPacker` and `addExtUnpacker`. If that doesn't turn out to be the case then you can still augment the Codec interface in your local source.

DefinitelyTyped Checklist:
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kawanet/msgpack-lite
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.