### PR TITLE
Fix the type of setState using Partial

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -165,8 +165,8 @@ declare namespace React {
     class Component<P, S> implements ComponentLifecycle<P, S> {
         constructor(props?: P, context?: any);
         constructor(...args: any[]);
-        setState(f: (prevState: S, props: P) => S, callback?: () => any): void;
-        setState(state: S, callback?: () => any): void;
+        setState(f: (prevState: S, props: P) => Partial<S>, callback?: () => any): void;
+        setState(state: Partial<S>, callback?: () => any): void;
         forceUpdate(callBack?: () => any): void;
         render(): JSX.Element | null;
 


### PR DESCRIPTION
The README states that,

> ### **The type of `setState` is incorrect.**
> The `setState(state)` method on `React.Component<P, S>` takes an object with a subset of the properties on `S`, but there's no way to express this in TypeScript currently. The workaround is simple: make all properties on `S` optional. There are a number of [proposals](https://github.com/Microsoft/TypeScript/issues/2710) on [ways](https://github.com/Microsoft/TypeScript/issues/4889) to [solve](https://github.com/Microsoft/TypeScript/issues/7355) this problem, but nothing seems to have been approved yet.

but it seems like there _is_ a way to express the appropriate type as of TS 2.1, via `Partial<S>`, which makes all properties of `S` optional.