### PR TITLE
concatAll incorrectly returns Observable<T> instead of T

### DIFF
--- a/rx-lite/index.d.ts
+++ b/rx-lite/index.d.ts
@@ -232,7 +232,7 @@ declare namespace Rx {
         withLatestFrom<TOther, TResult>(souces: (Observable<TOther> | IPromise<TOther>)[], resultSelector: (firstValue: T, ...otherValues: TOther[]) => TResult): Observable<TResult>;
         concat(...sources: (Observable<T> | IPromise<T>)[]): Observable<T>;
         concat(sources: (Observable<T> | IPromise<T>)[]): Observable<T>;
-        concatAll(): Observable<T>;
+        concatAll(): T;
         concatObservable(): Observable<T>;    // alias for concatAll
         concatMap<T2, R>(selector: (value: T, index: number) => Observable<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;    // alias for selectConcat
         concatMap<T2, R>(selector: (value: T, index: number) => IPromise<T2>, resultSelector: (value1: T, value2: T2, index: number) => R): Observable<R>;    // alias for selectConcat


### PR DESCRIPTION
The method should return T since typescript doesn't allow for another solution. See [this issue](https://github.com/Microsoft/TypeScript/issues/1290)

If the instance type is `Observable<Observable<T>>` the method return type should be `Observable<T>`

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](http://reactivex.io/documentation/operators/concat.html)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
