### PR TITLE
doT: make index.d.ts export doT ot be imported in Typescript 2 and fix linter complaints

### DIFF
--- a/dot/index.d.ts
+++ b/dot/index.d.ts
@@ -6,6 +6,9 @@
 declare var doT: doT.doTStatic;
 
 declare namespace doT {
+	interface renderFunction {
+		(...args: {}[]): string;
+	}
 
 	interface doTStatic {
 		/**
@@ -20,12 +23,12 @@ declare namespace doT {
 		/**
 	* Compile template
 	*/
-		template(tmpl: string, c?: TemplateSettings, def?: {}): () => string;
+		template(tmpl: string, c?: TemplateSettings, def?: {}): renderFunction;
 
 		/**
 	* For express
 	*/
-		compile(tmpl: string, def?: {}): () => string;
+		compile(tmpl: string, def?: {}): renderFunction;
 	}
 
 	interface TemplateSettings {
@@ -49,4 +52,6 @@ interface String {
 	encodeHTML(): string;
 }
 
-export = doT;
+declare module "doT" {
+  export = doT;
+}

--- a/dot/index.d.ts
+++ b/dot/index.d.ts
@@ -48,3 +48,5 @@ declare namespace doT {
 interface String {
 	encodeHTML(): string;
 }
+
+export = doT;

--- a/dot/index.d.ts
+++ b/dot/index.d.ts
@@ -3,12 +3,8 @@
 // Definitions by: ZombieHunter <https://github.com/ZombieHunter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare var doT: doT.doTStatic;
-
 declare namespace doT {
-	interface renderFunction {
-		(...args: {}[]): string;
-	}
+	type RenderFunction = (...args: Array<{}>) => string;
 
 	interface doTStatic {
 		/**
@@ -23,12 +19,12 @@ declare namespace doT {
 		/**
 	* Compile template
 	*/
-		template(tmpl: string, c?: TemplateSettings, def?: {}): renderFunction;
+		template(tmpl: string, c?: TemplateSettings, def?: {}): RenderFunction;
 
 		/**
 	* For express
 	*/
-		compile(tmpl: string, def?: {}): renderFunction;
+		compile(tmpl: string, def?: {}): RenderFunction;
 	}
 
 	interface TemplateSettings {
@@ -50,8 +46,4 @@ declare namespace doT {
 
 interface String {
 	encodeHTML(): string;
-}
-
-declare module "doT" {
-  export = doT;
 }

--- a/dot/index.d.ts
+++ b/dot/index.d.ts
@@ -3,8 +3,12 @@
 // Definitions by: ZombieHunter <https://github.com/ZombieHunter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+declare var doT: doT.doTStatic;
+
 declare namespace doT {
-	type RenderFunction = (...args: Array<{}>) => string;
+	interface renderFunction {
+		(...args: {}[]): string;
+	}
 
 	interface doTStatic {
 		/**
@@ -19,12 +23,12 @@ declare namespace doT {
 		/**
 	* Compile template
 	*/
-		template(tmpl: string, c?: TemplateSettings, def?: {}): RenderFunction;
+		template(tmpl: string, c?: TemplateSettings, def?: {}): renderFunction;
 
 		/**
 	* For express
 	*/
-		compile(tmpl: string, def?: {}): RenderFunction;
+		compile(tmpl: string, def?: {}): renderFunction;
 	}
 
 	interface TemplateSettings {
@@ -46,4 +50,8 @@ declare namespace doT {
 
 interface String {
 	encodeHTML(): string;
+}
+
+declare module "doT" {
+  export = doT;
 }

--- a/dot/index.d.ts
+++ b/dot/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for doT v1.0.1
+// Type definitions for doT 1.1
 // Project: https://github.com/olado/doT
 // Definitions by: ZombieHunter <https://github.com/ZombieHunter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -20,12 +20,12 @@ declare namespace doT {
 		/**
 	* Compile template
 	*/
-		template(tmpl: string, c?: TemplateSettings, def?: Object): Function;
+		template(tmpl: string, c?: TemplateSettings, def?: {}): () => string;
 
 		/**
 	* For express
 	*/
-		compile(tmpl: string, def?: Object): Function;
+		compile(tmpl: string, def?: {}): () => string;
 	}
 
 	interface TemplateSettings {

--- a/dot/index.d.ts
+++ b/dot/index.d.ts
@@ -6,9 +6,7 @@
 declare var doT: doT.doTStatic;
 
 declare namespace doT {
-	interface renderFunction {
-		(...args: {}[]): string;
-	}
+	type IRenderFunction = (...args: Array<{}>) => string;
 
 	interface doTStatic {
 		/**
@@ -23,12 +21,12 @@ declare namespace doT {
 		/**
 	* Compile template
 	*/
-		template(tmpl: string, c?: TemplateSettings, def?: {}): renderFunction;
+		template(tmpl: string, c?: TemplateSettings, def?: {}): IRenderFunction;
 
 		/**
 	* For express
 	*/
-		compile(tmpl: string, def?: {}): renderFunction;
+		compile(tmpl: string, def?: {}): IRenderFunction;
 	}
 
 	interface TemplateSettings {
@@ -50,8 +48,4 @@ declare namespace doT {
 
 interface String {
 	encodeHTML(): string;
-}
-
-declare module "doT" {
-  export = doT;
 }

--- a/dot/tslint.json
+++ b/dot/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../tslint.json"
-}

--- a/dot/tslint.json
+++ b/dot/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tslint.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
- [x] pass the Travis CI test?

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  simply install doT to your node project and try to import it into typescript
- [x] Increase the version number in the header if appropriate.
  it's 1.1 now
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
  The default tslint.json did the job pretty well