### PR TITLE
Fix mongoose: Change MongooseDocument.set return type

### DIFF
--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -1010,9 +1010,9 @@ declare module "mongoose" {
      * @param type optionally specify a type for "on-the-fly" attributes
      * @param options optionally specify options that modify the behavior of the set
      */
-    set(path: string, val: any, options?: Object): void;
-    set(path: string, val: any, type: any, options?: Object): void;
-    set(value: Object): void;
+    set(path: string, val: any, options?: Object): this;
+    set(path: string, val: any, type: any, options?: Object): this;
+    set(value: Object): this;
 
     /**
      * The return value of this method is used in calls to JSON.stringify(doc).

--- a/mongoose/mongoose-tests.ts
+++ b/mongoose/mongoose-tests.ts
@@ -449,10 +449,7 @@ doc.populate(function (err, doc) {
   });
 });
 doc.populated('path');
-doc.set('path', 999, {});
-doc.set({
-  path: 999
-});
+doc.set('path', 999, {}).set({ path: 999 });
 doc.toJSON({
   getters: true,
   virtuals: false


### PR DESCRIPTION
Change MongooseDocument.set return type from void to this.
The return type should be this according to the source code displayed when going to [Mongoose Document#set documentation](http://mongoosejs.com/docs/api.html#document_Document-set) and clicking "show code".

I first tested this fix by directly modifying the mongoose definition inside my dependent project (i.e. ./node_modules/@types/mongoose). This fixed the issue where I could not do: `doc.set({path: "newvalue"}).save();`

I then forked DefinitelyTyped modified the definition and the `doc.set()` example in the test file to use chaining method calls in order to test the new return type.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] No `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongoosejs.com/docs/api.html#document_Document-set
- [x] Pull request fixes inconsistency between mongoose api and definition, no version bump required.
- [x] Not making substantial changes, so no tslint necessary.