### PR TITLE
Lodash: Add missing meanBy function to LodashStatic

### DIFF
--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -13288,6 +13288,28 @@ declare namespace _ {
         ): number;
     }
 
+    //_.meanBy
+    interface LoDashStatic {
+      /**
+       * Computes the mean of the provided propties of the objects in the `array`
+       *
+       * @static
+       * @memberOf _
+       * @category Math
+       * @param {Array} array The array to iterate over.
+       * @param {Function|Object|string} [iteratee=_.identity] The iteratee invoked per element.
+       * @returns {number} Returns the mean.
+       * @example
+       *
+       * _.mean([{ 'n': 4 }, { 'n': 2 }, { 'n': 8 }, { 'n': 6 }], 'n');
+       * // => 5
+       */
+      meanBy<T>(
+        collection: List<T>,
+        iteratee?: DictionaryIterator<T, any>
+      ): number;
+    }
+
     interface LoDashImplicitArrayWrapper<T> {
         /**
          * @see _.mean


### PR DESCRIPTION
This should resolve the issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/13861

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.4#meanBy
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
