### PR TITLE
Fix fetch-mock whatwg-fetch dependency

### DIFF
--- a/fetch-mock/index.d.ts
+++ b/fetch-mock/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/wheresrhys/fetch-mock
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Tamir Duberstein <https://github.com/tamird>, Risto Keravuori <https://github.com/merrywhether>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-/// <reference types="whatwg-fetch" />
 
 type MockRequest = Request | RequestInit;
 

--- a/fetch-mock/tsconfig.json
+++ b/fetch-mock/tsconfig.json
@@ -9,7 +9,9 @@
         "typeRoots": [
             "../"
         ],
-        "types": [],
+        "types": [
+          "whatwg-fetch"
+        ],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

`Request`, `RequestInit`, etc can come from `whatwg-fetch`, but they can also come from the `isomorphic-fetch` library. If people are using `isomorphic-fetch`, hard-coding the `whatwg-fetch` dependency in the definition file will force them to need the `whatwg-fetch` definition, which can then cause duplicate identifiers if they've made the `isomorphic-fetch` definition available globally via tsconfig's `types` array. Additionally, the situation will become more complex once `fetch` is part of browsers and thus part of TS's own definitions.

Pulling the type reference into the tsconfig file allows local dev on DT to work without causing problems for downstream consumers.