### PR TITLE
Fix "Discover JCB" -> "Discover" | "JCB", refine StripeStatic.cardType

### DIFF
--- a/stripe/index.d.ts
+++ b/stripe/index.d.ts
@@ -11,7 +11,7 @@ interface StripeStatic {
     validateCardNumber(cardNumber: string): boolean;
     validateExpiry(month: string, year: string): boolean;
     validateCVC(cardCVC: string): boolean;
-    cardType(cardNumber: string): string;
+    cardType(cardNumber: string): StripeCardDataBrand;
     getToken(token: string, responseHandler: (status: number, response: StripeTokenResponse) => void): void;
     card: StripeCardData;
     createToken(data: StripeTokenData, responseHandler: (status: number, response: StripeTokenResponse) => void): void;
@@ -51,7 +51,7 @@ interface StripeError {
     param?: string;
 }
 
-type StripeCardDataBrand = 'Visa' | 'American Express' | 'MasterCard' | 'Discover JCB' | 'Diners Club' | 'Unknown';
+type StripeCardDataBrand = 'Visa' | 'American Express' | 'MasterCard' | 'Discover' | 'JCB' | 'Diners Club' | 'Unknown';
 
 interface StripeCardData {
     object: string;


### PR DESCRIPTION
Fixes "Discover JCB" -> "Discover" | "JCB".
https://stripe.com/docs/api#card_object
This PR also refines the type of `StripeStatic.cardType` to return a `StripeCardDataBrand` string.

Please fill in this template.

- [ ] Make your PR against the `master` branch.
- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.