### PR TITLE
Move CSSTransitionGroupProps to react module

### DIFF
--- a/react-addons-css-transition-group/index.d.ts
+++ b/react-addons-css-transition-group/index.d.ts
@@ -4,13 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import 'react-addons-transition-group';
-import { ComponentClass, TransitionGroupProps } from 'react';
+import { ComponentClass, TransitionGroupProps, CSSTransitionGroupProps } from 'react';
 
-declare var CSSTransitionGroup: CSSTransitionGroup;
-type CSSTransitionGroup = ComponentClass<CSSTransitionGroup.CSSTransitionGroupProps>;
-export = CSSTransitionGroup;
-
-declare namespace CSSTransitionGroup {
+declare module 'react' {
     interface CSSTransitionGroupTransitionName {
         enter: string;
         enterActive?: string;
@@ -20,7 +16,7 @@ declare namespace CSSTransitionGroup {
         appearActive?: string;
     }
 
-    interface CSSTransitionGroupProps extends TransitionGroupProps {
+    export interface CSSTransitionGroupProps extends TransitionGroupProps {
         transitionName: string | CSSTransitionGroupTransitionName;
         transitionAppear?: boolean;
         transitionAppearTimeout?: number;
@@ -30,3 +26,8 @@ declare namespace CSSTransitionGroup {
         transitionLeaveTimeout?: number;
     }
 }
+
+declare var CSSTransitionGroup: CSSTransitionGroup;
+type CSSTransitionGroup = ComponentClass<CSSTransitionGroupProps>;
+export = CSSTransitionGroup;
+

--- a/react-addons-css-transition-group/index.d.ts
+++ b/react-addons-css-transition-group/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React (react-addons-css-transition-group) 0.14
+// Type definitions for React (react-addons-css-transition-group) 15.0
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/react-css-transition-replace/index.d.ts
+++ b/react-css-transition-replace/index.d.ts
@@ -7,7 +7,7 @@ import * as React from "react";
 import * as CSSTransitionGroup from "react-addons-css-transition-group";
 
 declare namespace CSSTransitionReplace {
-    interface Props extends CSSTransitionGroup.CSSTransitionGroupProps {
+    interface Props extends React.CSSTransitionGroupProps {
         overflowHidden?: boolean
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.


This PR moves ```CSSTransitionGroupProps``` to react module itself and align self with ```react-addons-transition-group``` definition. This shouldn't break any use of ```<CSSTransitionGroup />``` in JSX but will break component props which are extending this interface. Also increased definition version so change will get major semver.