### PR TITLE
Update auth0-lock to v10.9.1

### DIFF
--- a/auth0-lock/auth0-lock-tests.ts
+++ b/auth0-lock/auth0-lock-tests.ts
@@ -1,5 +1,5 @@
 /// <reference types="auth0-js" />
-
+/// <reference path="index.d.ts" />
 
 const CLIENT_ID = "YOUR_AUTH0_APP_CLIENTID";
 const DOMAIN = "YOUR_DOMAIN_AT.auth0.com";
@@ -9,6 +9,30 @@ var lock: Auth0LockStatic = new Auth0Lock(CLIENT_ID, DOMAIN);
 lock.show();
 lock.hide();
 lock.logout(() => {});
+
+// Show supports UI arguments
+
+var showOptions : Auth0LockShowOptions = {
+  allowedConnections: [ "twitter", "facebook" ],
+  autoclose: false,
+  autofocus: true,
+  closable: true,
+  container: "somediv",
+  flashMessage: {
+    type: "error",
+    text: "an error has occurred"
+  },
+  language: "en",
+  popupOptions: {
+    width: 100,
+    height: 400,
+    left: 200,
+    top: 200
+  },
+  rememberLastLogin: false
+};
+
+lock.show(showOptions);
 
 // The examples below are lifted from auth0-lock documentation on Github
 

--- a/auth0-lock/auth0-lock-tests.ts
+++ b/auth0-lock/auth0-lock-tests.ts
@@ -14,20 +14,19 @@ lock.logout(() => {});
 
 var showOptions : Auth0LockShowOptions = {
   allowedConnections: [ "twitter", "facebook" ],
-  autoclose: false,
-  autofocus: true,
-  closable: true,
-  container: "somediv",
+  allowSignUp: true,
+  allowForgotPassword: false,
+  auth: {
+    params: { state: "foo" },
+    redirect: true,
+    redirectUrl: "some url",
+    responseType: "token",
+    sso: true
+  },
+  initialScreen: "login",
   flashMessage: {
     type: "error",
     text: "an error has occurred"
-  },
-  language: "en",
-  popupOptions: {
-    width: 100,
-    height: 400,
-    left: 200,
-    top: 200
   },
   rememberLastLogin: false
 };

--- a/auth0-lock/index.d.ts
+++ b/auth0-lock/index.d.ts
@@ -110,15 +110,11 @@ interface Auth0LockFlashMessageOptions {
 
 interface Auth0LockShowOptions {
     allowedConnections?: string[];
-    autoclose?: boolean;
-    autofocus?: boolean;
-    avatar?: Auth0LockAvatarOptions;
-    closable?: boolean;
-    container?: string;
+    allowSignUp?: boolean;
+    allowForgotPassword?: boolean;
+    auth?: Auth0LockAuthOptions;
+    initialScreen?: "login" | "signUp" | "forgotPassword";
     flashMessage?: Auth0LockFlashMessageOptions;
-    language?: string;
-    languageDictionary?: any;
-    popupOptions?: Auth0LockPopupOptions;
     rememberLastLogin?: boolean;
 }
 

--- a/auth0-lock/index.d.ts
+++ b/auth0-lock/index.d.ts
@@ -110,8 +110,9 @@ interface Auth0LockFlashMessageOptions {
 
 interface Auth0LockShowOptions {
     allowedConnections?: string[];
-    allowSignUp?: boolean;
     allowForgotPassword?: boolean;
+    allowLogin?: boolean;
+    allowSignUp?: boolean;
     auth?: Auth0LockAuthOptions;
     initialScreen?: "login" | "signUp" | "forgotPassword";
     flashMessage?: Auth0LockFlashMessageOptions;

--- a/auth0-lock/index.d.ts
+++ b/auth0-lock/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for auth0-lock v10.0.1
+// Type definitions for auth0-lock v10.9.1
 // Project: http://auth0.com
 // Definitions by: Brian Caruso <https://github.com/carusology>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -103,13 +103,33 @@ interface Auth0LockConstructorOptions {
     usernameStyle?: string;
 }
 
+interface Auth0LockFlashMessageOptions {
+    type: "success" | "error",
+    text: string;
+}
+
+interface Auth0LockShowOptions {
+    allowedConnections?: string[];
+    autoclose?: boolean;
+    autofocus?: boolean;
+    avatar?: Auth0LockAvatarOptions;
+    closable?: boolean;
+    container?: string;
+    flashMessage?: Auth0LockFlashMessageOptions;
+    language?: string;
+    languageDictionary?: any;
+    popupOptions?: Auth0LockPopupOptions;
+    rememberLastLogin?: boolean;
+}
+
 interface Auth0LockStatic {
     new (clientId: string, domain: string, options?: Auth0LockConstructorOptions): Auth0LockStatic;
-    getProfile(token: string, callback: (error: Auth0Error, profile: Auth0UserProfile) => void) : void;
 
+    // deprecated
+    getProfile(token: string, callback: (error: Auth0Error, profile: Auth0UserProfile) => void) : void;
     getUserInfo(token: string, callback: (error: Auth0Error, profile: Auth0UserProfile) => void) : void;
 
-    show(): void;
+    show(options?: Auth0LockShowOptions): void;
     hide(): void;
     logout(query: any): void;
 

--- a/auth0-lock/index.d.ts
+++ b/auth0-lock/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for auth0-lock v10.9.1
+// Type definitions for auth0-lock 10.9
 // Project: http://auth0.com
 // Definitions by: Brian Caruso <https://github.com/carusology>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -104,7 +104,7 @@ interface Auth0LockConstructorOptions {
 }
 
 interface Auth0LockFlashMessageOptions {
-    type: "success" | "error",
+    type: "success" | "error";
     text: string;
 }
 
@@ -126,19 +126,17 @@ interface Auth0LockStatic {
     new (clientId: string, domain: string, options?: Auth0LockConstructorOptions): Auth0LockStatic;
 
     // deprecated
-    getProfile(token: string, callback: (error: Auth0Error, profile: Auth0UserProfile) => void) : void;
-    getUserInfo(token: string, callback: (error: Auth0Error, profile: Auth0UserProfile) => void) : void;
+    getProfile(token: string, callback: (error: Auth0Error, profile: Auth0UserProfile) => void): void;
+    getUserInfo(token: string, callback: (error: Auth0Error, profile: Auth0UserProfile) => void): void;
 
     show(options?: Auth0LockShowOptions): void;
     hide(): void;
     logout(query: any): void;
 
-    on(event: "show", callback: () => void) : void;
-    on(event: "hide", callback: () => void) : void;
-    on(event: "unrecoverable_error", callback: (error: Auth0Error) => void) : void;
-    on(event: "authorization_error", callback: (error: Auth0Error) => void) : void;
-    on(event: "authenticated", callback: (authResult: any) => void) : void;
-    on(event: string, callback: (...args: any[]) => void) : void;
+    on(event: "show" | "hide", callback: () => void): void;
+    on(event: "unrecoverable_error" | "authorization_error", callback: (error: Auth0Error) => void): void;
+    on(event: "authenticated", callback: (authResult: any) => void): void;
+    on(event: string, callback: (...args: any[]) => void): void;
 }
 
 declare var Auth0Lock: Auth0LockStatic;


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present. **NOTE: One `no-single-declare-module` tslint issue still exists that is unrelated to these changes**

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/lock#showoptions
- [X] Increase the version number in the header if appropriate.

**Notes**
I had to reference the `auth0-js`dependency manually when running `tsc`. The `<reference types="auth0-js" />` declaration doesn't seem to get picked up correctly when running as defined in [the contributing guide](http://definitelytyped.org/guides/contributing.html). When I swapped to `<reference path="../auth0-js/index.d.ts" />` it worked fine, but then the DefinitivelyTyped linter complained when I ran the tests.

Here's the output I got from running tsc.

This straight up failed:
```
DefinitelyTyped$ tsc --noImplicitAny auth0-lock/auth0-lock-tests.ts 
auth0-lock/auth0-lock-tests.ts(1,1): error TS2688: Cannot find type definition file for 'auth0-js'.
auth0-lock/index.d.ts(6,1): error TS2688: Cannot find type definition file for 'auth0-js'.
auth0-lock/index.d.ts(14,13): error TS2304: Cannot find name 'Auth0Error'.
auth0-lock/index.d.ts(20,13): error TS2304: Cannot find name 'Auth0Error'.
auth0-lock/index.d.ts(35,43): error TS2304: Cannot find name 'Auth0Error'.
auth0-lock/index.d.ts(36,51): error TS2304: Cannot find name 'Auth0Error'.
auth0-lock/index.d.ts(129,49): error TS2304: Cannot find name 'Auth0Error'.
auth0-lock/index.d.ts(129,70): error TS2304: Cannot find name 'Auth0UserProfile'.
auth0-lock/index.d.ts(130,50): error TS2304: Cannot find name 'Auth0Error'.
auth0-lock/index.d.ts(130,71): error TS2304: Cannot find name 'Auth0UserProfile'.
auth0-lock/index.d.ts(138,56): error TS2304: Cannot find name 'Auth0Error'.
auth0-lock/index.d.ts(139,56): error TS2304: Cannot find name 'Auth0Error'.
```

This kinda worked:

```
DefinitelyTyped$ tsc --noImplicitAny auth0-lock/auth0-lock-tests.ts auth0-js/index.d.ts 
auth0-lock/auth0-lock-tests.ts(1,1): error TS2688: Cannot find type definition file for 'auth0-js'.
auth0-lock/index.d.ts(6,1): error TS2688: Cannot find type definition file for 'auth0-js'.
```

In any event, I was able to swap out the old version of this type definition file and it worked fine in my project that depends on the `auth0-lock` npm modules.