### PR TITLE
[passport-facebook] Add missing optional param in verify callback

### DIFF
--- a/passport-facebook/index.d.ts
+++ b/passport-facebook/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for passport-facebook 1.0.3
+// Type definitions for passport-facebook 2.1.1
 // Project: https://github.com/jaredhanson/passport-facebook
-// Definitions by: James Roland Cabresos <https://github.com/staticfunction>
+// Definitions by: James Roland Cabresos <https://github.com/staticfunction>, Lucas Acosta <https://github.com/lucasmacosta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="passport"/>
@@ -31,7 +31,7 @@ interface IStrategyOption {
 
 declare class Strategy implements passport.Strategy {
     constructor(options: IStrategyOption,
-        verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any) => void) => void);
+        verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void);
     name: string;
     authenticate: (req: express.Request, options?: Object) => void;
 }

--- a/passport-facebook/passport-facebook-tests.ts
+++ b/passport-facebook/passport-facebook-tests.ts
@@ -24,3 +24,13 @@ passport.use(new facebook.Strategy({
          });
     })
 );
+
+passport.use(new facebook.Strategy({
+            clientID: process.env.PASSPORT_FACEBOOK_CLIENT_ID,
+            clientSecret: process.env.PASSPORT_FACEBOOK_CLIENT_SECRET,
+            callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL
+    },
+    function(accessToken:string, refreshToken:string, profile:facebook.Profile, done:(error:any, user?:any, info?:any) => void) {
+         done(null, false, { message: 'Some error.' });
+    })
+);


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: According to the [passport documentation page about configuration](http://passportjs.org/docs/configure) the strategies should use a `done` verify callback that can use an optional third parameter with context info about the error
- [X] Increase the version number in the header if appropriate.
