### PR TITLE
[webfontloader] Fix typescript configuration options

### DIFF
--- a/webfontloader/index.d.ts
+++ b/webfontloader/index.d.ts
@@ -42,7 +42,7 @@ declare namespace WebFont {
 		text?: string;
 	}
 	export interface Typekit {
-		id?:Array<string>;
+		id?:string;
 	}
 	export interface Custom {
 		families?:Array<string>;


### PR DESCRIPTION
The typescript configuration field expects a single string id, not an array

* [Documentation](https://github.com/typekit/webfontloader#typekit)
* [Source](https://github.com/typekit/webfontloader/blob/33bec9da7ca4b0a46b1efbaca705c2ae5029840b/src/modules/typekit.js#L30)