### PR TITLE
Explain how to use custom matchers in jasmine

### DIFF
--- a/jasmine/jasmine-tests.ts
+++ b/jasmine/jasmine-tests.ts
@@ -872,6 +872,14 @@ var customMatchers: jasmine.CustomMatcherFactories = {
     }
 };
 // add the custom matchers to interface jasmine.Matchers via TypeScript declaration merging
+// if your test files import or export anything, you'll want to use:
+// declare global {
+//     namespace jasmine {
+//         interface Matchers {
+//             ...
+//         }
+//     }
+// }
 declare namespace jasmine {
     interface Matchers {
         toBeGoofy(expected?: any): boolean;


### PR DESCRIPTION
The test only compile because `jasmine-tests.ts` doesn't import or export
anything, and so the typescript compiler thinks it is a global definition file.
I've added a note explaining how normal users would declare their custom
matchers.

This is an issue I ran into while writing [my own tests](https://github.com/angular/jasminewd/pull/79) with custom matchers in jasmine, and having a note like this in these tests would have saved me a lot of time

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors. ***(there were errors but they were pre-existing)***
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sjelin/jasminewd/blob/types/spec/common.ts#L129
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.