### PR TITLE
[js-quantities] fix export

### DIFF
--- a/js-quantities/index.d.ts
+++ b/js-quantities/index.d.ts
@@ -70,4 +70,4 @@ declare namespace Qty {
     type UnitSource = Qty | string;
 }
 
-export default Qty;
+export = Qty;

--- a/js-quantities/js-quantities-tests.ts
+++ b/js-quantities/js-quantities-tests.ts
@@ -1,5 +1,5 @@
 /// <reference types="jasmine" />
-import Qty from "js-quantities";
+import * as Qty from "js-quantities";
 
 // From project readme
 


### PR DESCRIPTION
js-quantities builds a UMD module that [does not include a `default` export](https://github.com/gentooboontoo/js-quantities#node).  This fixes the typings for folk that aren't using `allowSyntheticDefaultExports`