### PR TITLE
React-native: enable JS intellisense for StyleSheet.create method

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -4569,7 +4569,6 @@ declare module "react" {
         // This is for backward compatibility with previous
         // implementation where T could be an arbitrary type
         export function create<T>(styles: T): T;
-        export function create<T extends Styles>(styles: T): T;
 
         /**
          * Flattens an array of style objects, into one aggregated style object.

--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -4554,12 +4554,22 @@ declare module "react" {
     // @see https://github.com/facebook/react-native/blob/0.34-stable\Libraries\StyleSheet\StyleSheetTypes.js
     export namespace StyleSheet {
 
+        interface Styles {
+            [style: string]: Style
+        }
+
         type Style = ViewStyle | TextStyle | ImageStyle
 
         /**
          * Creates a StyleSheet style reference from the given object.
          */
-        export function create<T>( styles: T ): T;
+        // Non-generic override is required to provide intellisense
+        // for JavaScript and non-generic method invocations
+        export function create(styles: Styles): any;
+        // This is for backward compatibility with previous
+        // implementation where T could be an arbitrary type
+        export function create<T>(styles: T): T;
+        export function create<T extends Styles>(styles: T): T;
 
         /**
          * Flattens an array of style objects, into one aggregated style object.
@@ -5634,7 +5644,7 @@ declare module "react" {
          * Fires when a user has finished scrolling.
          */
         onScrollEndDrag?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
-	
+
 	/**
          * Fires when scroll view has finished moving
          */

--- a/react-native/test/index.tsx
+++ b/react-native/test/index.tsx
@@ -78,6 +78,28 @@ var styles = StyleSheet.create<LocalStyles>(
     }
 )
 
+var styles2 = StyleSheet.create({
+    container: {
+        flex:            1,
+        justifyContent:  'center',
+        alignItems:      'center',
+        backgroundColor: '#F5FCFF',
+    }
+})
+
+interface TestStyles extends React.StyleSheet.Styles {
+    container: React.ViewStyle
+}
+
+var styles3 = StyleSheet.create<TestStyles>({
+    container: {
+        flex:            1,
+        justifyContent:  'center',
+        alignItems:      'center',
+        backgroundColor: '#F5FCFF',
+    }
+})
+
 //alternative declaration of styles (inline typings)
 const stylesAlt = StyleSheet.create(
     {


### PR DESCRIPTION
Add a non-generic overload for 'create' to enable intellisense in Javascript. See microsoft/vscode-react-native#306

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/vscode-react-native/issues/306