### PR TITLE
stripe: Fix "Discover JCB" -> "Discover" | "JCB", refine StripeStatic.cardType

### DIFF
--- a/stripe/index.d.ts
+++ b/stripe/index.d.ts
@@ -11,7 +11,7 @@ interface StripeStatic {
     validateCardNumber(cardNumber: string): boolean;
     validateExpiry(month: string, year: string): boolean;
     validateCVC(cardCVC: string): boolean;
-    cardType(cardNumber: string): string;
+    cardType(cardNumber: string): StripeCardDataBrand;
     getToken(token: string, responseHandler: (status: number, response: StripeTokenResponse) => void): void;
     card: StripeCardData;
     createToken(data: StripeTokenData, responseHandler: (status: number, response: StripeTokenResponse) => void): void;
@@ -51,7 +51,7 @@ interface StripeError {
     param?: string;
 }
 
-type StripeCardDataBrand = 'Visa' | 'American Express' | 'MasterCard' | 'Discover JCB' | 'Diners Club' | 'Unknown';
+type StripeCardDataBrand = 'Visa' | 'American Express' | 'MasterCard' | 'Discover' | 'JCB' | 'Diners Club' | 'Unknown';
 
 interface StripeCardData {
     object: string;


### PR DESCRIPTION
Fixed bug previously introduced due to misread documentation.
Source: https://stripe.com/docs/api#account_card_object

Refined the return type of `StripeStatic.cardType`, `string` => `StripeCardDataBrand`.
Source: not documented but is behavior (verified by perusing source)

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.