### PR TITLE
Fix z-schema module definition and add SchemaErrorDetail

### DIFF
--- a/z-schema/index.d.ts
+++ b/z-schema/index.d.ts
@@ -3,10 +3,7 @@
 // Definitions by: Adam Meadows <https://github.com/job13er>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = ZSchema.Validator;
-export as namespace ZSchema;
-
-declare namespace ZSchema {
+declare module ZSchema {
 
     export interface Options {
         asyncTimeout?: number;
@@ -93,4 +90,8 @@ declare namespace ZSchema {
         getLastError(): SchemaError;
         getLastErrors(): SchemaError[];
     }
+}
+
+declare module "z-schema" {
+  export = ZSchema.Validator;
 }

--- a/z-schema/index.d.ts
+++ b/z-schema/index.d.ts
@@ -3,8 +3,7 @@
 // Definitions by: pgonzal <https://github.com/pgonzal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module ZSchema {
-
+declare namespace Validator {
     export interface Options {
         asyncTimeout?: number;
         forceAdditional?: boolean;
@@ -80,71 +79,68 @@ declare module ZSchema {
          */
         inner: SchemaErrorDetail[];
     }
-
-    export class Validator {
-
-        /**
-         * Register a custom format.
-         *
-         * @param name - name of the custom format
-         * @param validatorFunction - custom format validator function.
-         *   Returns `true` if `value` matches the custom format.
-         */
-        public static registerFormat(formatName: string, validatorFunction: (value: any) => boolean): void;
-
-        /**
-         * Unregister a format.
-         *
-         * @param name - name of the custom format
-         */
-        public static unregisterFormat(name: string): void;
-
-        /**
-         * Get the list of all registered formats.
-         *
-         * Both the names of the burned-in formats and the custom format names are
-         * returned by this function.
-         *
-         * @returns {string[]} the list of all registered format names.
-         */
-        public static getRegisteredFormats(): string[];
-
-        public static getDefaultOptions(): Options;
-
-        constructor(options: Options);
-
-        /**
-         * @param schema - JSON object representing schema
-         * @returns {boolean} true if schema is valid.
-         */
-        validateSchema(schema: any): boolean;
-
-        /**
-         * @param json - either a JSON string or a parsed JSON object
-         * @param schema - the JSON object representing the schema
-         * @returns true if json matches schema
-         */
-        validate(json: any, schema: any): boolean;
-
-        /**
-         * @param json - either a JSON string or a parsed JSON object
-         * @param schema - the JSON object representing the schema
-         */
-        validate(json: any, schema: any, callback: (err: any, valid: boolean) => void): void;
-
-        /**
-         * Returns an Error object for the most recent failed validation, or null if the validation was successful.
-         */
-        getLastError(): SchemaError;
-
-        /**
-         * Returns the error details for the most recent validation, or undefined if the validation was successful.
-         * This is the same list as the SchemaError.details property.
-         */
-        getLastErrors(): SchemaErrorDetail[];
-    }
 }
 
-declare module "z-schema" {
-  export = ZSchema.Validator;
+declare class Validator {
+    /**
+     * Register a custom format.
+     *
+     * @param name - name of the custom format
+     * @param validatorFunction - custom format validator function.
+     *   Returns `true` if `value` matches the custom format.
+     */
+    public static registerFormat(formatName: string, validatorFunction: (value: any) => boolean): void;
+
+    /**
+     * Unregister a format.
+     *
+     * @param name - name of the custom format
+     */
+    public static unregisterFormat(name: string): void;
+
+    /**
+     * Get the list of all registered formats.
+     *
+     * Both the names of the burned-in formats and the custom format names are
+     * returned by this function.
+     *
+     * @returns {string[]} the list of all registered format names.
+     */
+    public static getRegisteredFormats(): string[];
+
+    public static getDefaultOptions(): Validator.Options;
+
+    constructor(options: Validator.Options);
+
+    /**
+     * @param schema - JSON object representing schema
+     * @returns {boolean} true if schema is valid.
+     */
+    validateSchema(schema: any): boolean;
+
+    /**
+     * @param json - either a JSON string or a parsed JSON object
+     * @param schema - the JSON object representing the schema
+     * @returns true if json matches schema
+     */
+    validate(json: any, schema: any): boolean;
+
+    /**
+     * @param json - either a JSON string or a parsed JSON object
+     * @param schema - the JSON object representing the schema
+     */
+    validate(json: any, schema: any, callback: (err: any, valid: boolean) => void): void;
+
+    /**
+     * Returns an Error object for the most recent failed validation, or null if the validation was successful.
+     */
+    getLastError(): Validator.SchemaError;
+
+    /**
+     * Returns the error details for the most recent validation, or undefined if the validation was successful.
+     * This is the same list as the SchemaError.details property.
+     */
+    getLastErrors(): Validator.SchemaErrorDetail[];
 }
+
+export = Validator;

--- a/z-schema/index.d.ts
+++ b/z-schema/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for z-schema v3.16.0
 // Project: https://github.com/zaggino/z-schema
-// Definitions by: Adam Meadows <https://github.com/job13er>
+// Definitions by: pgonzal <https://github.com/pgonzal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module ZSchema {

--- a/z-schema/index.d.ts
+++ b/z-schema/index.d.ts
@@ -28,16 +28,61 @@ declare module ZSchema {
         ignoreUnknownFormats?: boolean;
     }
 
-    export interface SchemaError {
-        code: string;
-        description: string;
+    export interface SchemaError extends Error {
+        /**
+         * Implements the Error.name contract.  The value is always "z-schema validation error".
+         */
+        name: string;
+
+        /**
+         * An identifier indicating the type of error.
+         * Example: "JSON_OBJECT_VALIDATION_FAILED"
+         */
         message: string;
-        params: string[];
+
+        /**
+         * Returns details for each error that occurred during validation.
+         * See Options.breakOnFirstError.
+         */
+        details: SchemaErrorDetail[];
+    }
+
+    export interface SchemaErrorDetail {
+        /**
+         * Example: "Expected type string but found type array"
+         */
+        message: string;
+        /**
+         * An error identifier that can be used to format a custom error message.
+         * Example: "INVALID_TYPE"
+         */
+        code: string;
+        /**
+         * Format parameters that can be used to format a custom error message.
+         * Example: ["string","array"]
+         */
+        params: Array<string>;
+        /**
+         * A JSON path indicating the location of the error.
+         * Example: "#/projects/1"
+         */
         path: string;
+        /**
+         * The schema rule description, which is included for certain errors where
+         * this information is useful (e.g. to describe a constraint).
+         */
+        description: string;
+
+        /**
+         * Returns details for sub-schemas that failed to match.  For example, if the schema
+         * uses the "oneOf" constraint to accept several alternative possibilities, each
+         * alternative will have its own inner detail object explaining why it failed to match.
+         */
+        inner: SchemaErrorDetail[];
     }
 
     export class Validator {
-    
+
         /**
          * Register a custom format.
          *
@@ -53,7 +98,7 @@ declare module ZSchema {
          * @param name - name of the custom format
          */
         public static unregisterFormat(name: string): void;
-        
+
         /**
          * Get the list of all registered formats.
          *
@@ -63,9 +108,9 @@ declare module ZSchema {
          * @returns {string[]} the list of all registered format names.
          */
         public static getRegisteredFormats(): string[];
-        
+
         public static getDefaultOptions(): Options;
-    
+
         constructor(options: Options);
 
         /**
@@ -87,8 +132,16 @@ declare module ZSchema {
          */
         validate(json: any, schema: any, callback: (err: any, valid: boolean) => void): void;
 
+        /**
+         * Returns an Error object for the most recent failed validation, or null if the validation was successful.
+         */
         getLastError(): SchemaError;
-        getLastErrors(): SchemaError[];
+
+        /**
+         * Returns the error details for the most recent validation, or undefined if the validation was successful.
+         * This is the same list as the SchemaError.details property.
+         */
+        getLastErrors(): SchemaErrorDetail[];
     }
 }
 

--- a/z-schema/z-schema-tests.ts
+++ b/z-schema/z-schema-tests.ts
@@ -1,7 +1,7 @@
 
 import Validator = require('z-schema');
 
-var options: ZSchema.Options = {
+var options: Validator.Options = {
   noTypeless: true,
   forceItems: true,
 };
@@ -30,5 +30,5 @@ validator.validate(json, schema, function (err: any, valid: boolean) {
     }
 });
 
-var error: ZSchema.SchemaError = validator.getLastError();
-var errors: ZSchema.SchemaErrorDetail[] = validator.getLastErrors();
+var error: Validator.SchemaError = validator.getLastError();
+var errors: Validator.SchemaErrorDetail[] = validator.getLastErrors();

--- a/z-schema/z-schema-tests.ts
+++ b/z-schema/z-schema-tests.ts
@@ -1,13 +1,12 @@
 
+import Validator = require('z-schema');
 
-import ZSchema = require('z-schema');
-
-var options = {
+var options: ZSchema.Options = {
   noTypeless: true,
   forceItems: true,
 };
 
-var validator = new ZSchema(options);
+var validator: Validator = new Validator(options);
 var json: any = {
     foo: 'bar',
 };
@@ -31,5 +30,5 @@ validator.validate(json, schema, function (err: any, valid: boolean) {
     }
 });
 
-var error = validator.getLastError();
-var errors = validator.getLastErrors();
+var error: ZSchema.SchemaError = validator.getLastError();
+var errors: ZSchema.SchemaErrorDetail[] = validator.getLastErrors();


### PR DESCRIPTION
Changes made in this PR:
- Removed "export as namespace ZSchema" because there is no global variable
- Replaced the "export = ZSchema.Validator" with a module declaration so that we can access the other types such as ZSchema.Options
- Fixed a problem where ZSchema.SchemaError was including properties that are actually from a completely different data structure, which I named SchemaErrorDetail
- Added support for SchemaError.details and SchemaErrorDetail.inner, which is needed for rich error reporting
- Added JSDoc explanations for these structures
- The unit test file now actually uses these types, rather than relying on implicit types

Please fill in this template.
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zaggino/z-schema
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

