### PR TITLE
Add route-parser type declarations

### DIFF
--- a/route-parser/index.d.ts
+++ b/route-parser/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for route-parser 0.0
+// Project: https://github.com/rcs/route-parser
+// Definitions by: Ian Ker-Seymer <https://github.com/ianks>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare class Route {
+    /**
+     * Represents a route
+     * @example
+     * var route = new Route('/:foo/:bar');
+     * @example
+     * var route = new Route('/:foo/:bar');
+     */
+    constructor(spec: string);
+
+    /**
+     * Match a path against this route, returning the matched parameters if
+     * it matches, false if not.
+     * @example
+     * var route = new Route('/this/is/my/route')
+     * route.match('/this/is/my/route') // -> {}
+     * @example
+     * var route = new Route('/:one/:two')
+     * route.match('/foo/bar/') // -> {one: 'foo', two: 'bar'}
+     */
+    match(pathname: string): { [i: string]: string } | boolean;
+
+    /**
+     * Reverse a route specification to a path, returning false if it can't be
+     * fulfilled
+     * @example
+     * var route = new Route('/:one/:two')
+     * route.reverse({one: 'foo', two: 'bar'}) -> '/foo/bar'
+     */
+    reverse(params: { [i: string]: any } ): string | boolean;
+}
+
+declare namespace Route {}
+export = Route;

--- a/route-parser/route-parser-tests.ts
+++ b/route-parser/route-parser-tests.ts
@@ -1,0 +1,5 @@
+import * as Route from 'route-parser';
+
+const route = new Route('/users/:id');
+const matched = route.match('/users/42'); // => { id: '42' }
+const reversed = route.reverse({ id: 42 });

--- a/route-parser/tsconfig.json
+++ b/route-parser/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "files": [
+        "index.d.ts",
+        "route-parser-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/route-parser/tslint.json
+++ b/route-parser/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../tslint.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `npm run new-package package-name`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.


Currently, everything is ready to go except I am getting this error from tslint that I need help with:

```
index.d.ts[6, 1]: File has only 1 module declaration — write it as an external module.
```

I am confused since this is an external module. What should I do to fix this?

Cheers!