### PR TITLE
FilterOrderBy allows `null` and `undefined`

### DIFF
--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -756,7 +756,7 @@ declare namespace angular {
          * @param comparator Function used to determine the relative order of value pairs.
          * @return An array containing the items from the specified collection, ordered by a comparator function based on the values computed using the expression predicate.
          */
-        <T>(array: T[], expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc): T[];
+        <T, A extends T[]|null|undefined>(array: A, expression: string|((value: T) => any)|(((value: T) => any)|string)[], reverse?: boolean, comparator?: IFilterOrderByComparatorFunc): A;
     }
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  Please see [my SO question](http://stackoverflow.com/q/41604348/1836506). The problem I am addressing: using `strictNullChecks` the current definition does not allow passing in `null` or `undefined`, but Angular does handle it by returning `null` or `undefined`, respectively. There are a few ways to adjust the definition to allow it, each with a drawback as discussed in the SO question, and the comments on the answer. Which is most appropriate?
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
