### PR TITLE
React: add typed target for change events

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -270,10 +270,9 @@ declare namespace React {
     //
     // Event System
     // ----------------------------------------------------------------------
-
-    interface SyntheticEvent<T> {
+    interface SyntheticEventBase<CURRENT, TARGET> {
         bubbles: boolean;
-        currentTarget: EventTarget & T;
+        currentTarget: EventTarget & CURRENT;
         cancelable: boolean;
         defaultPrevented: boolean;
         eventPhase: number;
@@ -284,10 +283,14 @@ declare namespace React {
         stopPropagation(): void;
         isPropagationStopped(): boolean;
         persist(): void;
-        // If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
-        target: EventTarget;
+        target: EventTarget & TARGET;
         timeStamp: Date;
         type: string;
+    }
+
+    interface SyntheticEvent<T> extends SyntheticEventBase<T, EventTarget> {
+      // If you thought target should be `EventTarget & T`,
+      // see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
     }
 
     interface ClipboardEvent<T> extends SyntheticEvent<T> {
@@ -307,6 +310,9 @@ declare namespace React {
     }
 
     interface FormEvent<T> extends SyntheticEvent<T> {
+    }
+
+    interface ChangeEvent<T> extends SyntheticEventBase<T, T> {
     }
 
     interface KeyboardEvent<T> extends SyntheticEvent<T> {
@@ -391,6 +397,7 @@ declare namespace React {
     type DragEventHandler<T> = EventHandler<DragEvent<T>>;
     type FocusEventHandler<T> = EventHandler<FocusEvent<T>>;
     type FormEventHandler<T> = EventHandler<FormEvent<T>>;
+    type ChangeEventHandler<T> = EventHandler<ChangeEvent<T>>;
     type KeyboardEventHandler<T> = EventHandler<KeyboardEvent<T>>;
     type MouseEventHandler<T> = EventHandler<MouseEvent<T>>;
     type TouchEventHandler<T> = EventHandler<TouchEvent<T>>;
@@ -458,7 +465,7 @@ declare namespace React {
         onBlurCapture?: FocusEventHandler<T>;
 
         // Form Events
-        onChange?: FormEventHandler<T>;
+        onChange?: ChangeEventHandler<T>;
         onChangeCapture?: FormEventHandler<T>;
         onInput?: FormEventHandler<T>;
         onInputCapture?: FormEventHandler<T>;
@@ -2142,7 +2149,7 @@ declare namespace React {
         unselectable?: boolean;
     }
 
-    // this list is "complete" in that it contains every SVG attribute 
+    // this list is "complete" in that it contains every SVG attribute
     // that React supports, but the types can be improved.
     // Full list here: https://facebook.github.io/react/docs/dom-elements.html
     //

--- a/react/test/index.ts
+++ b/react/test/index.ts
@@ -672,3 +672,19 @@ class ConstructorSpreadArgsPureComponent extends React.PureComponent<{}, {}> {
         super(...args);
     }
 }
+
+//
+// The SyntheticEvent.target.value should be accessible for onChange
+// --------------------------------------------------------------------------
+class SyntheticEventTargetValue extends React.Component<{}, { value: string }> {
+  constructor(props:{}) {
+    super(props);
+    this.state = { value: 'a' };
+  }
+  render() {
+    return React.DOM.textarea({
+      value: this.state.value,
+      onChange: e => this.setState({value: e.target.value})
+    });
+  }
+}


### PR DESCRIPTION
Note: this PR is a proper implementation of #13665 and is also related to #12239.

---

When handling an `onChange` event it should be possible to access the changed value through `e.target.value` (see [this MDN example](https://developer.mozilla.org/en-US/docs/Web/Events/change#Example_Change_event_on_a_select)).

The following example (adapted from [React's documentation](https://facebook.github.io/react/docs/forms.html#the-textarea-tag)) illustrates the scenario:

```js
class EssayForm extends React.Component<{}, { value: string }> {
  constructor(props:{}) {
    super(props);
    this.state = {
      value: 'Please write an essay about your favorite DOM element.'
    };
  }
  render() {
    return <textarea
      value={this.state.value}
      onChange={e => this.setState({value: e.target.value})}
    />;
  }
}
```

This currently fails in the setState line with:
> error TS2339: Property 'value' does not exist on type 'EventTarget'.

---

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react/docs/forms.html#the-textarea-tag
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
