### PR TITLE
async Make timeout info param optional + add support for error, result callback with timeout and queue

### DIFF
--- a/async/index.d.ts
+++ b/async/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Async 2.0.1
 // Project: https://github.com/caolan/async
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Arseniy Maximov <https://github.com/kern0>, Joe Herman <https://github.com/Penryn>, Angus Fenying <https://github.com/fenying>
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Arseniy Maximov <https://github.com/kern0>, Joe Herman <https://github.com/Penryn>, Angus Fenying <https://github.com/fenying>, Pascal Martin <https://github.com/pascalmartin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Dictionary<T> { [key: string]: T; }
@@ -29,6 +29,7 @@ interface AsyncQueue<T> {
     idle(): boolean;
     concurrency: number;
     push<E>(task: T, callback?: ErrorCallback<E>): void;
+    push<E>(task: T, callback?: AsyncResultCallback<T, E>): void;
     push<E>(task: T[], callback?: ErrorCallback<E>): void;
     unshift<E>(task: T, callback?: ErrorCallback<E>): void;
     unshift<E>(task: T[], callback?: ErrorCallback<E>): void;
@@ -180,6 +181,7 @@ interface Async {
     applyEach(fns: Function[], argsAndCallback: any[]): void;           // applyEach(fns, args..., callback). TS does not support ... for a middle argument. Callback is optional.
     applyEachSeries(fns: Function[], argsAndCallback: any[]): void;     // applyEachSeries(fns, args..., callback). TS does not support ... for a middle argument. Callback is optional.
     queue<T, E>(worker: AsyncWorker<T, E>, concurrency?: number): AsyncQueue<T>;
+    queue<T, R, E>(worker: AsyncResultIterator<T, R, E>, concurrency?: number): AsyncQueue<T>;
     priorityQueue<T, E>(worker: AsyncWorker<T, E>, concurrency: number): AsyncPriorityQueue<T>;
     cargo<E>(worker : (tasks: any[], callback : ErrorCallback<E>) => void, payload? : number) : AsyncCargo;
     auto<E>(tasks: any, concurrency?: number, callback?: AsyncResultCallback<any, E>): void;
@@ -194,7 +196,8 @@ interface Async {
     reflect<T, E>(fn: AsyncFunction<T, E>) : (callback: (err: void, result: {error?: Error, value?: T}) => void) => void;
     reflectAll<T, E>(tasks: AsyncFunction<T, E>[]): ((callback: (err: void, result: {error?: Error, value?: T}) => void) => void)[];
 
-    timeout<T, E>(fn: AsyncFunction<T, E>, milliseconds: number, info: any): AsyncFunction<T, E>;
+    timeout<T, E>(fn: AsyncFunction<T, E>, milliseconds: number, info?: any): AsyncFunction<T, E>;
+    timeout<T, R, E>(fn: AsyncResultIterator<T, R, E>, milliseconds: number, info?: any): AsyncResultIterator<T, R, E>;
 
     times<T, E> (n: number, iterator: AsyncResultIterator<number, T, E>, callback: AsyncResultArrayCallback<T, E>): void;
     timesSeries<T, E>(n: number, iterator: AsyncResultIterator<number, T, E>, callback: AsyncResultArrayCallback<T, E>): void;
@@ -223,3 +226,4 @@ declare var async: Async;
 declare module "async" {
     export = async;
 }
+

--- a/async/test/index.ts
+++ b/async/test/index.ts
@@ -349,6 +349,16 @@ q2.unshift(['task3', 'task4', 'task5'], function (error) {
     console.log('Finished tasks');
 });
 
+
+var aq = async.queue<number, number, Error>(function (level: number, callback: (error : Error, newLevel: number) => void) {
+    console.log('hello ' + level);
+    callback(null, level+1);
+});
+
+aq.push(1, function (err : Error, newLevel : number) {
+    console.log('finished processing bar' + newLevel);
+});
+
 // create a cargo object with payload 2
 var cargo = async.cargo(function (tasks, callback) {
     for (var i = 0; i < tasks.length; i++) {
@@ -794,3 +804,36 @@ async.some<number, Error>({
     console.log("async.some/any: done with result", result);
 
 });
+
+// timeout
+
+function myFunction1(foo : any, callback: (err : Error, result : any) => void ) : void {
+	console.log(`async.timeout 1 ${foo}`);
+	return callback(null, foo);
+}
+var wrapped1 = async.timeout(myFunction1, 1000);
+wrapped1({ bar: 'bar' }, function(err : Error, data : any) {
+    console.log(`async.timeout 1 end ${data}`);
+});
+
+
+function myFunction2(callback: (err : Error, result : any) => void ) : void {
+	console.log(`async.timeout 2`);
+	return callback(null, { bar: 'bar' });
+}
+
+var wrapped2 = async.timeout(myFunction2, 1000);
+wrapped2( function(err : Error, data : any) {
+    console.log(`async.timeout 2 end ${data}`);
+});
+
+function myFunction3(callback: (err : Error, result : any) => void ) : void {
+	console.log(`async.timeout 3`);
+	return callback(null, { bar: 'bar' });
+}
+
+var wrapped3 = async.timeout(myFunction3, 1000, { bar: 'bar' });
+wrapped3( function(err : Error, data : any) {
+    console.log(`async.timeout 3 end ${data}`);
+});
+


### PR DESCRIPTION
Make timeout info param optional (http://caolan.github.io/async/docs.html#timeout)
Add support for timeout with AsyncResulIterator (http://caolan.github.io/async/docs.html#timeout)
Add support for queue with AsyncResullIterator  (http://caolan.github.io/async/docs.html#queue)

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://caolan.github.io/async/docs.html#timeout
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

