### PR TITLE
react-router: add package.json with dependancy to  @types/history@2.0.45 (#13299)

### DIFF
--- a/react-router/package.json
+++ b/react-router/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@types/history": "^2.0.45"
+  }
+}


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/13299#issuecomment-272652699

history version 2 declaration was recently removed from the inside of react-router type defs. The day after, 
the global @types/history was upgraded to version 4 from version 2 which broke the react router definition files. 
This PR adds @types/history@2.0.45 as a dependency to react-router in order to fix the compilation issue. 

CC: @andy-ms 