### PR TITLE
CKEditor : add shared space and editor path variable

### DIFF
--- a/ckeditor/ckeditor-tests.ts
+++ b/ckeditor/ckeditor-tests.ts
@@ -389,3 +389,21 @@ function test_htmlWriter() {
     writer.lineBreak();
     writer.setRules('img', {breakBeforeOpen: true, breakAfterOpen: true});
 }
+
+function test_sharedSpace() {
+    CKEDITOR.inline('content', {
+        removePlugins: 'maximize,resize',
+        sharedSpaces: {
+            top: 'someElementId',
+            bottom: document.getElementById('anotherId')
+        }
+    });
+
+    CKEDITOR.inline('content', {
+        sharedSpaces: { }
+    });
+}
+
+function test_specifying_editor_path() {
+    window.CKEDITOR_BASEPATH = '/ckeditor/';
+}

--- a/ckeditor/index.d.ts
+++ b/ckeditor/index.d.ts
@@ -5,6 +5,10 @@
 
 // WORK-IN-PROGRESS: Any contribution support welcomed.
 // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/1827 for more informations.
+interface Window {
+  CKEDITOR_BASEPATH: string;
+}
+
 declare namespace CKEDITOR {
 
     // Config options
@@ -784,7 +788,7 @@ declare namespace CKEDITOR {
         scayt_uiTabs?: string;
         scayt_userDictionaryName?: string;
 
-        sharedSpaces?: Object;
+        sharedSpaces?: CKEDITOR.sharedSpace;
         shiftEnterMode?: number;
         skin?: string;
         smiley_columns?: number;
@@ -831,6 +835,12 @@ declare namespace CKEDITOR {
 
     interface feature {
 
+    }
+
+
+    interface sharedSpace {
+        top?: string | HTMLElement;
+        bottom?: string | HTMLElement;
     }
 
 


### PR DESCRIPTION
Add Shared Space interface with top and bottom properties.
Add `CKEDITOR_BASEPATH` global variable.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

For CKEDITOR_BASEPATH:
* [Specifying the Editor Path](http://docs.ckeditor.com/#!/guide/dev_basepath-section-solution%3A-ckeditor_basepath)

For Shared Space:
* [Doc](http://docs.ckeditor.com/#!/guide/dev_sharedspace)
* [API](http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-sharedSpaces)
* [Demo](http://sdk.ckeditor.com/samples/sharedspace.html)

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
