### PR TITLE
Fix getLocation return type

### DIFF
--- a/webdriverio/index.d.ts
+++ b/webdriverio/index.d.ts
@@ -352,36 +352,37 @@ declare namespace WebdriverIO {
         ): Client<P>;
         getHTML<P>(includeSelectorTag: boolean): Client<P>;
 
-        getLocation(selector?: string): Size;
-        getLocation(selector: string, axis: string): number;
-        getLocation(axis: string): number;
+        getLocation(selector?: string): Location;
+        getLocation(selector: string, axis: Axis): number;
+        getLocation(axis: Axis): number;
         getLocation<P>(selector?: string): Client<P>;
         getLocation<P>(
             selector: string,
-            axis: string
+            axis: Axis
         ): Client<P>;
-        getLocation<P>(axis: string): Client<P>;
+        getLocation<P>(axis: Axis): Client<P>;
 
-        getLocationInView(selector: string): Size;
-        getLocationInView(selector: string): Size[];
-        getLocationInView(): Size;
-        getLocationInView(): Size[];
+        getLocationInView(selector: string): Location;
+        getLocationInView(selector: string): Location[];
+        getLocationInView(): Location;
+        getLocationInView(): Location[];
         getLocationInView(
             selector: string,
-            axis: string
+            axis: Axis
         ): number;
         getLocationInView(
             selector: string,
-            axis: string
+            axis: Axis
         ): number[];
-        getLocationInView(axis: string): number;
-        getLocationInView(axis: string): number[];
+        getLocationInView(axis: Axis): number;
+        getLocationInView(axis: Axis): number[];
         getLocationInView<P>(selector?: string): Client<P>;
         getLocationInView<P>(
             selector: string,
-            axis: string
+            axis: Axis
         ): Client<P>;
-        getLocationInView<P>(axis: string): Client<P>;
+        getLocationInView<P>(axis: Axis): Client<P>;
+
 
         getSource(): Client<string>;
         getSource<P>(): Client<P>;
@@ -428,7 +429,7 @@ declare namespace WebdriverIO {
         value: any;
     }
 
-    export interface Location {
+    export interface GeoLocation {
         latitude: number;
         longitude: number;
         altitude: number;
@@ -982,6 +983,8 @@ declare namespace WebdriverIO {
         switchTab(windowHandle?: string): Client<void>;
         switchTab<P>(windowHandle?: string): Client<P>;
     }
+
+    export type Axis = "x" | "y";
 
     export interface Options {
         protocol: string;

--- a/webdriverio/index.d.ts
+++ b/webdriverio/index.d.ts
@@ -352,37 +352,22 @@ declare namespace WebdriverIO {
         ): Client<P>;
         getHTML<P>(includeSelectorTag: boolean): Client<P>;
 
-        getLocation(selector?: string): Location;
-        getLocation(selector: string, axis: Axis): number;
         getLocation(axis: Axis): number;
-        getLocation<P>(selector?: string): Client<P>;
-        getLocation<P>(
-            selector: string,
-            axis: Axis
-        ): Client<P>;
         getLocation<P>(axis: Axis): Client<P>;
+        getLocation(selector?: string): Location;
+        getLocation<P>(selector?: string): Client<P>;
+        getLocation(selector: string, axis: Axis): number;
+        getLocation<P>(selector: string, axis: Axis): Client<P>;
 
-        getLocationInView(selector: string): Location;
-        getLocationInView(selector: string): Location[];
-        getLocationInView(): Location;
-        getLocationInView(): Location[];
-        getLocationInView(
-            selector: string,
-            axis: Axis
-        ): number;
-        getLocationInView(
-            selector: string,
-            axis: Axis
-        ): number[];
         getLocationInView(axis: Axis): number;
         getLocationInView(axis: Axis): number[];
-        getLocationInView<P>(selector?: string): Client<P>;
-        getLocationInView<P>(
-            selector: string,
-            axis: Axis
-        ): Client<P>;
         getLocationInView<P>(axis: Axis): Client<P>;
-
+        getLocationInView(selector?: string): Location;
+        getLocationInView(selector?: string): Location[];
+        getLocationInView<P>(selector?: string): Client<P>;
+        getLocationInView(selector: string, axis: Axis): number;
+        getLocationInView(selector: string, axis: Axis): number[];
+        getLocationInView<P>(selector: string, axis: Axis): Client<P>;
 
         getSource(): Client<string>;
         getSource<P>(): Client<P>;


### PR DESCRIPTION
Please fill in this template.

- [x] Prefer to make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint -- package-name` if a `tslint.json` is present.
  _no lint_

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  http://webdriver.io/api/property/getLocation.html
- [x] Increase the version number in the header if appropriate.
  _no need_

This is a correction of the getLocation and getLocationInView return types.
In the types is Size but it's supposed to be Location according to documentation and use.
Also renamed GeoLocation type because it was being incorrectly merged with Location type.

This is a new PR for what was already merged in #12994 but then mistakenly reverted in #13229.