### PR TITLE
get actionlib servers

### DIFF
--- a/roslib/index.d.ts
+++ b/roslib/index.d.ts
@@ -67,6 +67,16 @@ declare namespace ROSLIB {
 		callOnConnection(message:any):void;
 
 		/**
+		 * Retrieves list of actionlib servers in ROS as an array.
+		 *
+		 * @param callback function with params:
+		 *   * action_servers - Array of actionlib servers names
+		 * @param failedCallback - the callback function when the ros call failed (optional). Params:
+		 *   * error - the error message reported by ROS
+		 */
+    	getActionServers(callback:(action_servers:string[]) => void, failedCallback?:(error:any)=>void):void;
+
+		/**
 		 * Retrieves list of topics in ROS as an array.
 		 *
 		 * @param callback function with params:

--- a/roslib/index.d.ts
+++ b/roslib/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for roslib.js
+// Type definitions for roslib.js 1.9
 // Project: http://wiki.ros.org/roslibjs
 // Definitions by: Stefan Profanter <https://github.com/Pro/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
This update is because a pull request for the library with a new method:
https://github.com/RobotWebTools/roslibjs/pull/242