### PR TITLE
Ensure boom.BoomError can be cast to Error

### DIFF
--- a/boom/boom-tests.ts
+++ b/boom/boom-tests.ts
@@ -5,3 +5,4 @@ import Boom = require('boom');
 Boom.create(500, 'Internal server error', { timestamp: Date.now() });
 Boom.wrap(new Error('test'), 400);
 Boom.badRequest('Invalid cookies');
+Boom.unauthorized() as Error;

--- a/boom/index.d.ts
+++ b/boom/index.d.ts
@@ -16,6 +16,7 @@ declare namespace Boom {
         isServer: boolean;
         message: string;
         output: Output;
+        name: string;
     }
 
     export interface Output {


### PR DESCRIPTION
`BoomError` lacked `name`, preventing it being upcast to `Error` despite:

* It's an `Error`
* It's documented as an instance of `Error`
* It does have a `name` property (the default `"Error"` except for `wrap`, in which case it's the original error's `name`)

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] ~~Run `npm run lint package-name` if a `tslint.json` is present.~~ (not present)

Also:

- [x] Run `npm test`, which isn't in the template for some reason

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/boom#boom
  > **boom** provides a set of utilities for returning HTTP errors. Each utility returns a `Boom` error response object (instance of `Error`)…
- [x] ~~Increase the version number in the header if appropriate.~~ (no version number in header)
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.~~ (not substantial)

