### PR TITLE
[passport] Fix serializeUser and deserializeUser

### DIFF
--- a/passport/index.d.ts
+++ b/passport/index.d.ts
@@ -55,8 +55,8 @@ declare module 'passport' {
             authenticate(strategy: string|string[], options: AuthenticateOptions, callback?: Function): express.Handler;
             authorize(strategy: string|string[], callback?: Function): express.Handler;
             authorize(strategy: string|string[], options: any, callback?: Function): express.Handler;
-            serializeUser<TUser, TID>(fn: (user: TUser, done: (err: any, id: TID) => void) => void): void;
-            deserializeUser<TUser, TID>(fn: (id: TID, done: (err: any, user: TUser) => void) => void): void;
+            serializeUser<TUser, TID>(fn: (user: TUser, done: (err: any, id?: TID) => void) => void): void;
+            deserializeUser<TUser, TID>(fn: (id: TID, done: (err: any, user?: TUser) => void) => void): void;
             transformAuthInfo(fn: (info: any, done: (err: any, info: any) => void) => void): void;
         }
 

--- a/passport/passport-tests.ts
+++ b/passport/passport-tests.ts
@@ -25,10 +25,32 @@ const newFramework:passport.Framework = {
 };
 passport.use(new TestStrategy());
 passport.framework(newFramework);
-passport.serializeUser((user, done) => { });
-passport.serializeUser<string, number>((user, done) => { });
-passport.deserializeUser((id, done) => { });
-passport.deserializeUser<string, number>((id, done) => { });
+
+interface TestUser {
+  id: number;
+}
+passport.serializeUser((user: TestUser, done) => {
+  done(null, user.id);
+});
+passport.serializeUser<TestUser, number>((user, done) => {
+  if (user.id > 0) {
+    done(null, user.id);
+  } else {
+    done(new Error('user ID is invalid'))
+  }
+});
+passport.deserializeUser((id, done) => {
+  done(null, {id});
+});
+passport.deserializeUser<TestUser, number>((id, done) => {
+  const fetchUser = (id: number): Promise<TestUser> => {
+    return Promise.reject(new Error(`user not found: ${id}`));
+  };
+
+  fetchUser(id)
+    .then((user) => done(null, user))
+    .catch((err) => done(err));
+});
 
 passport.use(new TestStrategy())
   .unuse('test')

--- a/passport/passport-tests.ts
+++ b/passport/passport-tests.ts
@@ -36,7 +36,7 @@ passport.serializeUser<TestUser, number>((user, done) => {
   if (user.id > 0) {
     done(null, user.id);
   } else {
-    done(new Error('user ID is invalid'))
+    done(new Error('user ID is invalid'));
   }
 });
 passport.deserializeUser((id, done) => {

--- a/passport/passport-tests.ts
+++ b/passport/passport-tests.ts
@@ -29,7 +29,7 @@ passport.framework(newFramework);
 interface TestUser {
   id: number;
 }
-passport.serializeUser((user: TestUser, done) => {
+passport.serializeUser((user: TestUser, done: (err: any, id?: number) => void) => {
   done(null, user.id);
 });
 passport.serializeUser<TestUser, number>((user, done) => {


### PR DESCRIPTION
As these functions are currently typed, there's no way for the serialize or deserialize callbacks to fail and only pass an error back to Passport.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport/blob/v0.3.2/README.md#sessions
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.