### PR TITLE
Easeljs SpriteSheets The parameter in getNumFrames can be ommited

### DIFF
--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -549,7 +549,6 @@ declare module createjs {
         getAnimations(): string[];
         getFrame(frameIndex: number): Object;
         getFrameBounds(frameIndex: number): Rectangle;
-        getNumFrames(animation: string): number;
         toString(): string;
 
         // events

--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -549,6 +549,7 @@ declare module createjs {
         getAnimations(): string[];
         getFrame(frameIndex: number): Object;
         getFrameBounds(frameIndex: number): Rectangle;
+        getNumFrames(animation?: string ): number;
         toString(): string;
 
         // events


### PR DESCRIPTION
The parameter in getNumFrames can be null.
Reference:
http://www.createjs.com/docs/easeljs/classes/SpriteSheet.html#method_getFrame