### PR TITLE
Updating rx-dom typings to be module style instead of ambient style

### DIFF
--- a/rx-dom/index.d.ts
+++ b/rx-dom/index.d.ts
@@ -3,140 +3,140 @@
 // Definitions by: oliver Weichhold <https://github.com/oliverw>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference types="rx" />
+import * as Rx from 'rx';
 
-declare module Rx.DOM {
-    export interface AjaxSettings {
-        async?: boolean;
-        body?: string;
-        // This options does not seem to be used in the code yet
-        // contentType?: string;
-        crossDomain?: boolean;
-        headers?: any;
-        method?: string;
-        password?: string;
-        progressObserver?: Rx.Observer<any>;
-        responseType?: string;
-        url?: string;
-        user?: string;
+declare module 'rx' {
+  namespace DOM {
+    interface AjaxSettings {
+      async?: boolean;
+      body?: string;
+      // This options does not seem to be used in the code yet
+      // contentType?: string;
+      crossDomain?: boolean;
+      headers?: any;
+      method?: string;
+      password?: string;
+      progressObserver?: Rx.Observer<any>;
+      responseType?: string;
+      url?: string;
+      user?: string;
     }
 
-    export interface AjaxSuccessResponse {
-        response: any;
-        status: number;
-        responseType: string;
-        xhr: XMLHttpRequest;
-        originalEvent: Event;
+    interface AjaxSuccessResponse {
+      response: any;
+      status: number;
+      responseType: string;
+      xhr: XMLHttpRequest;
+      originalEvent: Event;
     }
 
-    export interface AjaxErrorResponse {
-        type: string;
-        status: number;
-        xhr: XMLHttpRequest;
-        originalEvent: Event;
+    interface AjaxErrorResponse {
+      type: string;
+      status: number;
+      xhr: XMLHttpRequest;
+      originalEvent: Event;
     }
 
-    export interface JsonpSettings {
-        async?: boolean;
-        jsonp?: string;
-        jsonpCallback?: string;
-        url?: string;
+    interface JsonpSettings {
+      async?: boolean;
+      jsonp?: string;
+      jsonpCallback?: string;
+      url?: string;
     }
 
-    export interface JsonpSuccessResponse {
-        response: any;
-        status: number;
-        responseType: string;
-        originalEvent: Event;
+    interface JsonpSuccessResponse {
+      response: any;
+      status: number;
+      responseType: string;
+      originalEvent: Event;
     }
 
-    export interface JsonpErrorResponse {
-        type: string;
-        status: number;
-        originalEvent: Event;
+    interface JsonpErrorResponse {
+      type: string;
+      status: number;
+      originalEvent: Event;
     }
 
-    export interface GeolocationOptions {
-        enableHighAccuracy?: boolean;
-        timeout?: number;
-        maximumAge?: number;
+    interface GeolocationOptions {
+      enableHighAccuracy?: boolean;
+      timeout?: number;
+      maximumAge?: number;
     }
 
     // Events
-    function fromEvent<T>(element:any, eventName:string, selector?:Function, useCapture?:boolean):Rx.Observable<T>;
+    function fromEvent<T>(element: any, eventName: string, selector?: Function, useCapture?: boolean): Rx.Observable<T>;
 
-    function ready():Rx.Observable<any>;
+    function ready(): Rx.Observable<any>;
 
     // Event Shortcuts
-    function blur(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<FocusEvent>;
-    function change(element: Element, selector?:Function):Rx.Observable<Event>;
-    function click(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function contextmenu(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function dblclick(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function error(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<Event>;
-    function focus(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<FocusEvent>;
-    function focusin(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function focusout(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function keydown(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<KeyboardEvent>;
-    function keypress(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<KeyboardEvent>;
-    function keyup(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<KeyboardEvent>;
-    function load(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<UIEvent>;
-    function mousedown(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function mouseenter(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function mouseleave(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function mousemove(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function mouseout(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function mouseover(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function mouseup(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<MouseEvent>;
-    function resize(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<UIEvent>;
-    function scroll(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<UIEvent>;
-    function select(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<Event>;
-    function submit(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<Event>;
-    function unload(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<Event>;
+    function blur(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<FocusEvent>;
+    function change(element: Element, selector?: Function): Rx.Observable<Event>;
+    function click(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function contextmenu(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function dblclick(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function error(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<Event>;
+    function focus(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<FocusEvent>;
+    function focusin(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function focusout(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function keydown(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<KeyboardEvent>;
+    function keypress(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<KeyboardEvent>;
+    function keyup(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<KeyboardEvent>;
+    function load(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<UIEvent>;
+    function mousedown(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function mouseenter(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function mouseleave(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function mousemove(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function mouseout(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function mouseover(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function mouseup(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<MouseEvent>;
+    function resize(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<UIEvent>;
+    function scroll(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<UIEvent>;
+    function select(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<Event>;
+    function submit(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<Event>;
+    function unload(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<Event>;
 
     // Pointer Events
-    function pointerdown(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<PointerEvent>;
-    function pointerenter(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<PointerEvent>;
-    function pointerleave(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<PointerEvent>;
-    function pointermove(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<PointerEvent>;
-    function pointerout(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<PointerEvent>;
-    function pointerover(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<PointerEvent>;
-    function pointerup(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<PointerEvent>;
+    function pointerdown(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<PointerEvent>;
+    function pointerenter(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<PointerEvent>;
+    function pointerleave(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<PointerEvent>;
+    function pointermove(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<PointerEvent>;
+    function pointerout(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<PointerEvent>;
+    function pointerover(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<PointerEvent>;
+    function pointerup(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<PointerEvent>;
 
     // Touch Events
-    function touchcancel(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<TouchEvent>;
-    function touchend(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<TouchEvent>;
-    function touchmove(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<TouchEvent>;
-    function touchstart(element: Element, selector?:Function, useCapture?:boolean):Rx.Observable<TouchEvent>;
+    function touchcancel(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<TouchEvent>;
+    function touchend(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<TouchEvent>;
+    function touchmove(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<TouchEvent>;
+    function touchstart(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<TouchEvent>;
 
     // Ajax
-    function ajax(url:string):Rx.Observable<AjaxSuccessResponse>;
-    function ajax(settings:AjaxSettings):Rx.Observable<AjaxSuccessResponse>;
-    function get(url:string):Rx.Observable<AjaxSuccessResponse>;
-    function getJSON(url:string):Rx.Observable<string>;
-    function post(url:string, body:any):Rx.Observable<AjaxSuccessResponse>;
-    function jsonpRequest(url:string):Rx.Observable<string>;
-    function jsonpRequest(settings:JsonpSettings):Rx.Observable<JsonpSuccessResponse>;
+    function ajax(url: string): Rx.Observable<AjaxSuccessResponse>;
+    function ajax(settings: AjaxSettings): Rx.Observable<AjaxSuccessResponse>;
+    function get(url: string): Rx.Observable<AjaxSuccessResponse>;
+    function getJSON(url: string): Rx.Observable<string>;
+    function post(url: string, body: any): Rx.Observable<AjaxSuccessResponse>;
+    function jsonpRequest(url: string): Rx.Observable<string>;
+    function jsonpRequest(settings: JsonpSettings): Rx.Observable<JsonpSuccessResponse>;
 
     // Server-Sent Events
-    function fromEventSource<T>(url:string, openObservable?:Rx.Observer<T>):Rx.Observable<T>;
+    function fromEventSource<T>(url: string, openObservable?: Rx.Observer<T>): Rx.Observable<T>;
 
     // Web Sockets
-    function fromWebSocket(url:string, protocol:string, openObserver?:Rx.Observer<Event>, closingObserver?:Rx.Observer<CloseEvent>):Rx.Subject<MessageEvent>;
+    function fromWebSocket(url: string, protocol: string, openObserver?: Rx.Observer<Event>, closingObserver?: Rx.Observer<CloseEvent>): Rx.Subject<MessageEvent>;
 
     // Web Workers
-    function fromWebWorker(url:string):Rx.Subject<string>;
+    function fromWebWorker(url: string): Rx.Subject<string>;
 
     // Mutation Observers
-    function fromMutationObserver(target:Node, options:MutationObserverInit):Rx.Observable<MutationEvent>;
+    function fromMutationObserver(target: Node, options: MutationObserverInit): Rx.Observable<MutationEvent>;
 
     // Geolocation
-    export module geolocation {
-        function getCurrentPosition(geolocationOptions?:GeolocationOptions):Rx.Observable<Position>;
-        function watchPosition(geolocationOptions?:GeolocationOptions):Rx.Observable<Position>;
+    namespace geolocation {
+      function getCurrentPosition(geolocationOptions?: GeolocationOptions): Rx.Observable<Position>;
+      function watchPosition(geolocationOptions?: GeolocationOptions): Rx.Observable<Position>;
     }
+  }
 }
 
-declare module "rx-dom" {
-    export default Rx.DOM;
-}
+export = Rx;

--- a/rx-dom/index.d.ts
+++ b/rx-dom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for RxJS v2.5.3
+// Type definitions for RxJS 7.0
 // Project: https://github.com/Reactive-Extensions/RxJS-DOM
 // Definitions by: oliver Weichhold <https://github.com/oliverw>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/rx-dom/index.d.ts
+++ b/rx-dom/index.d.ts
@@ -111,8 +111,7 @@ declare module 'rx' {
     function touchstart(element: Element, selector?: Function, useCapture?: boolean): Rx.Observable<TouchEvent>;
 
     // Ajax
-    function ajax(url: string): Rx.Observable<AjaxSuccessResponse>;
-    function ajax(settings: AjaxSettings): Rx.Observable<AjaxSuccessResponse>;
+    function ajax(settingsOrUrl: AjaxSettings | string): Rx.Observable<AjaxSuccessResponse>;
     function get(url: string): Rx.Observable<AjaxSuccessResponse>;
     function getJSON(url: string): Rx.Observable<string>;
     function post(url: string, body: any): Rx.Observable<AjaxSuccessResponse>;

--- a/rx-dom/rx-dom-tests.ts
+++ b/rx-dom/rx-dom-tests.ts
@@ -1,2 +1,9 @@
 import * as Rx from 'rx';
 import * as DOM from 'rx-dom';
+
+// Rx and DOM should both be the same reference
+// before rx-dom import, Rx will not contain the DOM namespace
+// after rx-dom import, Rx will contain the DOM namespace
+
+// this is the standard approach for importing rx + rx-dom
+import { Observable, Subject, DOM as rxdom } from 'rx-dom';

--- a/rx-dom/tslint.json
+++ b/rx-dom/tslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tslint.json",
+  "rules": {
+    // this package augments Rx with namespace level functions
+    // it would be particualrly strange to type these functions differently 
+    "forbidden-types": false
+  }
+}


### PR DESCRIPTION
ambient style typings are outdated and can be troublesome to deal with. module style typings work much better with typescript 2. This module is particularly troublesome due to its dependency on `rx` typings, which are not required since `rx` provides its own module typings, resulting in duplicate type definitions. Switching to module style typings allows us to import existing typings from the workspace, rather than explicitly depending on another typings module.

Added a lint config, applied minor adjustments for the linter warnings, and bumped version to match rx-dom.

I'm not sure if these changes will impact the existing 'rx' typings, but some of them could probably also be converted to module style typings (or removed entirely for those already provided by the `rx` module).

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
