### PR TITLE
[material-ui] Fixed muiThemeable on decorator usage #9843

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -452,7 +452,10 @@ declare namespace __MaterialUI {
         var lightBaseTheme: RawTheme;
         var darkBaseTheme: RawTheme;
 
-        export function muiThemeable<TComponent extends React.Component<P, S>, P, S>(): (component: TComponent) => TComponent;
+        export function muiThemeable(): <
+            TComponent extends React.ComponentClass<P> | React.StatelessComponent<P>,
+            P extends {muiTheme?: MuiTheme}
+        >(component: TComponent) => TComponent;
 
         interface MuiThemeProviderProps {
             muiTheme?: Styles.MuiTheme;

--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import {Component, PropTypes} from 'react';
 import * as ReactDOM from 'react-dom';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import {muiThemeable} from 'material-ui/styles/muiThemeable';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import darkBaseTheme from 'material-ui/styles/baseThemes/darkBaseTheme';
 import {MuiTheme} from 'material-ui/styles';
@@ -319,6 +320,35 @@ class DeepDownTheTree extends React.Component<{} & {muiTheme: MuiTheme}, {}> {
     );
   }
 }
+
+
+const MuiThemeableFunction = muiThemeable()((props: {label: string, muiTheme?: MuiTheme}) => {
+  return (
+      <span style={{color: props.muiTheme.palette.textColor}}>
+        Applied the Theme to functional component: {props.label}.
+      </span>
+  );
+});
+
+@muiThemeable()
+class MuiThemeableClass extends React.Component<{label: string} & {muiTheme?: MuiTheme}, {}> {
+  render() {
+    return (
+      <span style={{color: this.props.muiTheme.palette.textColor}}>
+        Applied the Theme to class component decorated: {this.props.label}.
+      </span>
+    );
+  }
+}
+
+const MuiThemeableContainer = (props: {}) => (
+  <MuiThemeProvider muiTheme={getMuiTheme()}>
+    <div>
+      <MuiThemeableFunction label='Hello'/>
+      <MuiThemeableClass label='Hello'/>
+    </div>
+  </MuiThemeProvider>
+);
 
 
 // "http://www.material-ui.com/#/customization/inline-styles"


### PR DESCRIPTION
Fixed #9843.

We should make `muiTheme` optional property of the return type while require one of the input type.  Could anyone?

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/9843
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
