### PR TITLE
Fix Headers.get of isomorphic-fetch

### DIFF
--- a/backlog-js/index.d.ts
+++ b/backlog-js/index.d.ts
@@ -23,9 +23,9 @@ declare class Request {
         method: string;
         path: string;
         params?: Params | FormData;
-    }): Promise<IResponse>;
-    checkStatus(response: IResponse): Promise<IResponse>;
-    parseJSON<T>(response: IResponse): Promise<T>;
+    }): Promise<ResponseInterface>;
+    checkStatus(response: ResponseInterface): Promise<ResponseInterface>;
+    parseJSON<T>(response: ResponseInterface): Promise<T>;
     private toFormData(params);
     private toQueryString(params);
     webAppBaseURL: string;
@@ -49,7 +49,7 @@ export class Backlog extends Request {
   putSpaceNotification(params: Option.Space.PutSpaceNotificationParams): Promise<any>;
   getSpaceDiskUsage(): Promise<any>;
   getSpaceIcon(): Promise<Entity.File.FileData>;
-  postSpaceAttachment(form: FormData): Promise<IResponse>;
+  postSpaceAttachment(form: FormData): Promise<ResponseInterface>;
   getUsers(): Promise<any>;
   getUser(userId: number): Promise<any>;
   postUser(params: Option.User.PostUserParams): Promise<any>;
@@ -656,7 +656,7 @@ export namespace Error {
     private _status;
     private _body;
     private _response;
-    constructor(name: BacklogErrorNameType, response: IResponse, body?: {
+    constructor(name: BacklogErrorNameType, response: ResponseInterface, body?: {
       errors: BacklogErrorMessage[];
     });
     name: BacklogErrorNameType;
@@ -665,20 +665,20 @@ export namespace Error {
     body: {
       errors: BacklogErrorMessage[];
     };
-    response: IResponse;
+    response: ResponseInterface;
   }
   export class BacklogApiError extends BacklogError {
-    constructor(response: IResponse, body?: {
+    constructor(response: ResponseInterface, body?: {
       errors: BacklogErrorMessage[];
     });
   }
   export class BacklogAuthError extends BacklogError {
-    constructor(response: IResponse, body?: {
+    constructor(response: ResponseInterface, body?: {
       errors: BacklogErrorMessage[];
     });
   }
   export class UnexpectedError extends BacklogError {
-    constructor(response: IResponse);
+    constructor(response: ResponseInterface);
   }
   export interface BacklogErrorMessage {
     message: string;

--- a/isomorphic-fetch/index.d.ts
+++ b/isomorphic-fetch/index.d.ts
@@ -3,10 +3,10 @@
 // Definitions by: Todd Lucas <https://github.com/toddlucas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type RequestType = "" | "audio" | "font" | "image" | "script" | "style" | 
+type RequestType = "" | "audio" | "font" | "image" | "script" | "style" |
     "track" | "video";
-type RequestDestination = "" | "document" | "embed" | "font" | "image" | 
-    "manifest" | "media" | "object" | "report" | "script" | "serviceworker" | 
+type RequestDestination = "" | "document" | "embed" | "font" | "image" |
+    "manifest" | "media" | "object" | "report" | "script" | "serviceworker" |
     "sharedworker" | "style" | "worker" | "xslt";
 type RequestMode = "navigate" | "same-origin" | "no-cors" | "cors";
 type RequestCredentials = "omit" | "same-origin" | "include";
@@ -15,11 +15,11 @@ type RequestCache =
     "only-if-cached";
 type RequestRedirect = "follow" | "error" | "manual";
 
-type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | 
+type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" |
     "opaqueredirect";
 
-type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | 
-    "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | 
+type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" |
+    "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" |
     "strict-origin-when-cross-origin" | "unsafe-url";
 
 interface IHeaders {

--- a/isomorphic-fetch/index.d.ts
+++ b/isomorphic-fetch/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for isomorphic-fetch
+// Type definitions for isomorphic-fetch 0.0
 // Project: https://github.com/matthew-andrews/isomorphic-fetch
 // Definitions by: Todd Lucas <https://github.com/toddlucas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -22,37 +22,37 @@ type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" |
     "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" |
     "strict-origin-when-cross-origin" | "unsafe-url";
 
-interface IHeaders {
+interface HeadersInterface {
     append(name: string, value: string): void;
     delete(name: string): void;
     get(name: string): string | null;
-    getAll(name: string): Array<string>;
+    getAll(name: string): string[];
     has(name: string): boolean;
     set(name: string, value: string): void;
 
     // TODO: iterable<string, string>;
-    forEach(callback: (value: string, index: number, headers: IHeaders) => void, thisArg?: any): void;
+    forEach(callback: (value: string, index: number, headers: HeadersInterface) => void, thisArg?: any): void;
     // NOTE: The following are supported by whatwg-fetch but not node-fetch.
     // entries(): IterableIterator<[string, string]>;
     // keys(): IterableIterator<string>;
-    // values(): IterableIterator<string>;    
+    // values(): IterableIterator<string>;
 }
 
-type HeadersInit = Headers | Array<string> | { [index: string]: string };
+type HeadersInit = Headers | string[] | { [index: string]: string };
 
-declare class Headers implements IHeaders {
+declare class Headers implements HeadersInterface {
     constructor(init?: HeadersInit);
     append(name: string, value: string): void;
     delete(name: string): void;
     get(name: string): string | null;
-    getAll(name: string): Array<string>;
+    getAll(name: string): string[];
     has(name: string): boolean;
     set(name: string, value: string): void;
 
-    forEach(callback: (value: string, index: number, headers: IHeaders) => void, thisArg?: any): void;
+    forEach(callback: (value: string, index: number, headers: HeadersInterface) => void, thisArg?: any): void;
 }
 
-interface IBody {
+interface BodyInterface {
     bodyUsed: boolean;
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
@@ -62,7 +62,7 @@ interface IBody {
     text(): Promise<string>;
 }
 
-declare class Body implements IBody {
+declare class Body implements BodyInterface {
     bodyUsed: boolean;
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
@@ -72,22 +72,22 @@ declare class Body implements IBody {
     text(): Promise<string>;
 }
 
-interface IRequest extends IBody {
+interface RequestInterface extends BodyInterface {
     method: string;
     url: string;
-    headers: IHeaders;
+    headers: HeadersInterface;
 
     type: RequestType;
     destination: RequestDestination;
     referrer?: string;
-    referrerPolicy?: ReferrerPolicy;    
+    referrerPolicy?: ReferrerPolicy;
     mode: RequestMode;
     credentials: RequestCredentials;
     cache: RequestCache;
     redirect?: RequestRedirect;
     integrity?: string;
-    
-    clone(): IRequest;
+
+    clone(): RequestInterface;
 }
 
 type BodyInit = Blob | ArrayBufferView | ArrayBuffer | FormData /* | URLSearchParams */ | string;
@@ -97,7 +97,7 @@ interface RequestInit {
     headers?: HeadersInit;
     body?: BodyInit;
     referrer?: string;
-    referrerPolicy?: ReferrerPolicy;    
+    referrerPolicy?: ReferrerPolicy;
     mode?: RequestMode;
     credentials?: RequestCredentials;
     cache?: RequestCache;
@@ -106,29 +106,29 @@ interface RequestInit {
     window?: any; // can only be set to null
 }
 
-type RequestInfo = IRequest | string;
+type RequestInfo = RequestInterface | string;
 
-declare class Request extends Body implements IRequest {
+declare class Request extends Body implements RequestInterface {
     constructor(input: RequestInfo, init?: RequestInit);
-    
+
     method: string;
     url: string;
-    headers: IHeaders;
+    headers: HeadersInterface;
 
-    type: RequestType
+    type: RequestType;
     destination: RequestDestination;
     referrer: string;
-    referrerPolicy: ReferrerPolicy;    
+    referrerPolicy: ReferrerPolicy;
     mode: RequestMode;
     credentials: RequestCredentials;
     cache: RequestCache;
     redirect: RequestRedirect;
     integrity: string;
 
-    clone(): IRequest;
+    clone(): RequestInterface;
 }
 
-interface IResponse extends IBody {
+interface ResponseInterface extends BodyInterface {
     type: ResponseType;
 
     url: string;
@@ -136,13 +136,13 @@ interface IResponse extends IBody {
     status: number;
     statusText: string;
     ok: boolean;
-    headers: IHeaders;
+    headers: HeadersInterface;
     // size: number;
     // timeout: number;
     body: any;
-    trailer: Promise<IHeaders>;
+    trailer: Promise<HeadersInterface>;
 
-    clone(): IResponse;
+    clone(): ResponseInterface;
 }
 
 type ResponseBodyInit = BodyInit;
@@ -153,28 +153,28 @@ interface ResponseInit {
     headers?: HeadersInit;
 }
 
-declare class Response extends Body implements IResponse {
+declare class Response extends Body implements ResponseInterface {
     constructor(body?: ResponseBodyInit, init?: ResponseInit);
 
-    static redirect(url: string, status?: number): IResponse;
-    static error(): IResponse;
+    static redirect(url: string, status?: number): ResponseInterface;
+    static error(): ResponseInterface;
 
-    type: ResponseType
+    type: ResponseType;
 
     url: string;
     redirected: boolean;
     status: number;
     statusText: string;
     ok: boolean;
-    headers: IHeaders;
+    headers: HeadersInterface;
     body: any;
-    trailer: Promise<IHeaders>;
+    trailer: Promise<HeadersInterface>;
 
-    clone(): IResponse;
+    clone(): ResponseInterface;
 }
 
 interface Window {
-    fetch(url: RequestInfo, init?: RequestInit): Promise<IResponse>;
+    fetch(url: RequestInfo, init?: RequestInit): Promise<ResponseInterface>;
 }
 
 declare var fetch: typeof window.fetch;

--- a/isomorphic-fetch/index.d.ts
+++ b/isomorphic-fetch/index.d.ts
@@ -25,7 +25,7 @@ type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" |
 interface IHeaders {
     append(name: string, value: string): void;
     delete(name: string): void;
-    get(name: string): string;
+    get(name: string): string | null;
     getAll(name: string): Array<string>;
     has(name: string): boolean;
     set(name: string, value: string): void;
@@ -44,7 +44,7 @@ declare class Headers implements IHeaders {
     constructor(init?: HeadersInit);
     append(name: string, value: string): void;
     delete(name: string): void;
-    get(name: string): string;
+    get(name: string): string | null;
     getAll(name: string): Array<string>;
     has(name: string): boolean;
     set(name: string, value: string): void;

--- a/isomorphic-fetch/isomorphic-fetch-tests.ts
+++ b/isomorphic-fetch/isomorphic-fetch-tests.ts
@@ -4,9 +4,9 @@ import * as fetchImportedViaES6Module from 'isomorphic-fetch';
 
 function test_isomorphicFetchTestCases_ambient() {
     expectSuccess(fetch('http://localhost:3000/good'), 'Good response');
-    
+
     fetch('http://localhost:3000/bad')
-        .then((response: IResponse) => {
+        .then((response: ResponseInterface) => {
             return response.text();
         })
         .catch((err) => {
@@ -15,9 +15,9 @@ function test_isomorphicFetchTestCases_ambient() {
 
 function test_isomorphicFetchTestCases_commonjs() {
     expectSuccess(fetchImportedViaCommonJS('http://localhost:3000/good'), 'Good response');
-    
+
     fetchImportedViaCommonJS('http://localhost:3000/bad')
-        .then((response: IResponse) => {
+        .then((response: ResponseInterface) => {
             return response.text();
         })
         .catch((err) => {
@@ -26,9 +26,9 @@ function test_isomorphicFetchTestCases_commonjs() {
 
 function test_isomorphicFetchTestCases_es6() {
     expectSuccess(fetchImportedViaES6Module('http://localhost:3000/good'), 'Good response');
-    
+
     fetchImportedViaES6Module('http://localhost:3000/bad')
-        .then((response: IResponse) => {
+        .then((response: ResponseInterface) => {
             return response.text();
         })
         .catch((err) => {
@@ -48,16 +48,16 @@ function test_whatwgTestCases_ambient() {
     };
 
     expectSuccess(fetch('http://localhost:3000/poster', requestOptions), 'Post response:');
-    
+
     var requestOptions: RequestInit = {
         method: "POST",
         headers: {
             'Content-Type': 'application/json'
         }
     };
-    
+
     expectSuccess(fetch('http://localhost:3000/poster', requestOptions), 'Post response:');
-    
+
     var requestOptions: RequestInit = {
         method: "POST",
         headers: {
@@ -68,7 +68,7 @@ function test_whatwgTestCases_ambient() {
 
     expectSuccess(fetch(request), 'Post response:');
 }
-    
+
 function test_whatwgTestCases_commonjs() {
     var headers = new Headers();
     headers.append("Content-Type", "application/json");
@@ -81,16 +81,16 @@ function test_whatwgTestCases_commonjs() {
     };
 
     expectSuccess(fetchImportedViaCommonJS('http://localhost:3000/poster', requestOptions), 'Post response:');
-    
+
     var requestOptions: RequestInit = {
         method: "POST",
         headers: {
             'Content-Type': 'application/json'
         }
     };
-    
+
     expectSuccess(fetchImportedViaCommonJS('http://localhost:3000/poster', requestOptions), 'Post response:');
-    
+
     var requestOptions: RequestInit = {
         method: "POST",
         headers: {
@@ -114,16 +114,16 @@ function test_whatwgTestCases_es6() {
     };
 
     expectSuccess(fetchImportedViaES6Module('http://localhost:3000/poster', requestOptions), 'Post response:');
-    
+
     var requestOptions: RequestInit = {
         method: "POST",
         headers: {
             'Content-Type': 'application/json'
         }
     };
-    
+
     expectSuccess(fetchImportedViaES6Module('http://localhost:3000/poster', requestOptions), 'Post response:');
-    
+
     var requestOptions: RequestInit = {
         method: "POST",
         headers: {
@@ -134,9 +134,9 @@ function test_whatwgTestCases_es6() {
 
     expectSuccess(fetchImportedViaES6Module(request), 'Post response:');
 }
-    
-function expectSuccess(promise: Promise<IResponse>, responseText: string) {
-    promise.then((response: IResponse) => {
+
+function expectSuccess(promise: Promise<ResponseInterface>, responseText: string) {
+    promise.then((response: ResponseInterface) => {
         return response.text();
     })
     .then((text: string) => {


### PR DESCRIPTION
According to the specification, `Headers.get` can return `null`, so this should be explicit, since TS 2.0 (strictNullChecks).

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Fetch Specification: Headers.get](https://fetch.spec.whatwg.org/#dom-headers-get)
- [x] Increase the version number in the header if appropriate. (I set it, it was nonexistent)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`. (it already exists, but doesnt contain this key)

I have fixed all lint errors bar one: `no-single-declare-module  File has only 1 module declaration — write it as an external module.` since I am not sure how to.

