### PR TITLE
shelljs: update exec for after v0.6.0

### DIFF
--- a/shelljs/index.d.ts
+++ b/shelljs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ShellJS v0.3.0
+// Type definitions for ShellJS v0.6.0
 // Project: http://shelljs.org
 // Definitions by: Niklas Mollenhauer <https://github.com/nikeee>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -463,7 +463,7 @@ export declare function exec(command: string, options: ExecOptions, callback: Ex
 export declare function exec(command: string, callback: ExecCallback): child.ChildProcess;
 
 export interface ExecCallback {
-    (code: number, output: string, error?: string): any;
+    (code: number, stdout: string, stderr: string): any;
 }
 
 export interface ExecOptions {
@@ -473,7 +473,8 @@ export interface ExecOptions {
 
 export interface ExecOutputReturnValue {
     code: number;
-    output: string;
+    stdout: string;
+    stderr: string;
 }
 
 /**

--- a/shelljs/shelljs-tests.ts
+++ b/shelljs/shelljs-tests.ts
@@ -86,22 +86,22 @@ var testPath = shell.env["path"];
 
 import child = require("child_process");
 
-var version = shell.exec("node --version").output;
+var version = shell.exec("node --version").stdout;
 
 var version2 = <shell.ExecOutputReturnValue>shell.exec("node --version", { async: false });
-var output = version2.output;
+var output = version2.stdout;
 
 var asyncVersion3 = <child.ChildProcess>shell.exec("node --version", { async: true });
 var pid = asyncVersion3.pid;
 
-shell.exec("node --version", { silent: true }, function (code, output) {
-    var version = output;
+shell.exec("node --version", { silent: true }, function (code, stdout, stderr) {
+    var version = stdout;
 });
-shell.exec("node --version", { silent: true, async: true }, function (code, output) {
-    var version = output;
+shell.exec("node --version", { silent: true, async: true }, function (code, stdout, stderr) {
+    var version = stdout;
 });
-shell.exec("node --version", function (code, output) {
-    var version = output;
+shell.exec("node --version", function (code, stdout, stderr) {
+    var version = stdout;
 });
 shell.exec("node --version", function (code: number) {
     var num: number = code;


### PR DESCRIPTION
exec.output was changed to exec.stdout, and missing exec.stderr.
and ExecCallback has always stderr.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: add exec.stderr: https://github.com/shelljs/shelljs/commit/74f1ff8748ab8261ad20062dfee40d39103e0a98
change to exec.output to exec.stdout: https://github.com/shelljs/shelljs/commit/8a7f7ceec4d3a77a9309d935755675ac368b1eda
callback:  https://github.com/shelljs/shelljs/blob/master/src/exec.js#L197
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
