### PR TITLE
[tether-drop] Improve beforeClose function signature

### DIFF
--- a/tether-drop/index.d.ts
+++ b/tether-drop/index.d.ts
@@ -49,7 +49,7 @@ declare namespace Drop {
         constrainToWindow?: boolean;
         constrainToScrollParent?: boolean;
         remove?: boolean;
-        beforeClose?: () => boolean;
+        beforeClose?: (event: Event, drop: Drop) => boolean;
         openDelay?: number;
         closeDelay?: number;
         focusDelay?: number;

--- a/tether-drop/tether-drop-tests.ts
+++ b/tether-drop/tether-drop-tests.ts
@@ -13,6 +13,7 @@ var d = new Drop({
     tetherOptions: {},
     remove: true,
     target: yellowBox,
+    beforeClose: () => true,
     content: greenBox
 });
 


### PR DESCRIPTION
beforeClose function in the type definition has no parameters, yet in drop source code (DropInstance class, beforeCloseHandler method) two parameters are passed to this function.
First the JavaScript event object, that triggered the close, and then the drop instance object. The signature was updated to reflect this.