### PR TITLE
Fix elastic.js typings. Adding module and namespace exports.

### DIFF
--- a/elastic.js/elastic.js-tests.ts
+++ b/elastic.js/elastic.js-tests.ts
@@ -1,3 +1,5 @@
+import * as elasticjs from 'elastic.js';
+
 let body = new elasticjs.Request({})
   .query(new elasticjs.MatchQuery('title_field', 'testQuery'))
   .facet(new elasticjs.TermsFacet('tags').field('tags'))

--- a/elastic.js/index.d.ts
+++ b/elastic.js/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Oleksii Trekhleb <https://ua.linkedin.com/in/trekhleb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module elasticjs {
+declare module 'elastic.js' {
 
   export interface Facet {}
   export interface Geo {}

--- a/elastic.js/index.d.ts
+++ b/elastic.js/index.d.ts
@@ -3,7 +3,11 @@
 // Definitions by: Oleksii Trekhleb <https://ua.linkedin.com/in/trekhleb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'elastic.js' {
+export = elasticjs;
+
+export as namespace elasticjs;
+
+declare module elasticjs {
 
   export interface Facet {}
   export interface Geo {}


### PR DESCRIPTION
This will allow using 'import' statement against elastic.js like so:
import * as elasticjs from 'elastic.js';

This also makes using this typings to be TSlint "no-var-require" rule compliant.