### PR TITLE
React: Don't ignore constructor arguments in `ClassType`

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -230,8 +230,8 @@ declare namespace React {
      */
     type ClassType<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>> =
         C &
-        (new () => T) &
-        (new () => { props: P });
+        (new (props?: P, context?: any) => T) &
+        (new (props?: P, context?: any) => { props: P });
 
     //
     // Component Specs and Lifecycle


### PR DESCRIPTION
I noticed that `React.ClassType` is not assignable to class components with arguments in the constructor when I was using it to infer type parameters. Here's a simple example of the issue:

```tsx
class Foo extends React.Component<any, void> {
  constructor(props: any) {
    super();
  }
  render() {
    return <div />
  }
}

// Type 'typeof Foo' is not assignable to type 'new () => Foo'.
const Bar: React.ClassType<any, Foo, React.ComponentClass<any>> = Foo;
```

If I empty the constructor arguments or remove the constructor completely, then:

```tsx
// OK
const Bar: React.ClassType<any, Foo, React.ComponentClass<any>> = Foo;
```

This PR simply make sure that `React.ClassType` ignores any constructor arguments.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
