### PR TITLE
react-modal - Change to export default

### DIFF
--- a/react-modal/index.d.ts
+++ b/react-modal/index.d.ts
@@ -27,5 +27,5 @@ declare module "react-modal" {
         contentLabel?: string
     }
     let ReactModal: React.ClassicComponentClass<ReactModal>;
-    export = ReactModal;
+    export default ReactModal;
 }

--- a/react-modal/index.d.ts
+++ b/react-modal/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-modal v1.6.1
+// Type definitions for react-modal v1.6.5
 // Project: https://github.com/reactjs/react-modal
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/react-modal/react-modal-tests.tsx
+++ b/react-modal/react-modal-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as ReactModal from 'react-modal';
+import ReactModal from 'react-modal';
 
 class ExampleOfUsingReactModal extends React.Component<{}, {}> {
   render() {


### PR DESCRIPTION
This now matches a recent change to react-modal which changed it to `export default` causing this issue https://github.com/reactjs/react-modal/issues/309

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-modal/blob/master/lib/index.js now says `export default`
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.