### PR TITLE
vis - add property "group" to interface "Node"

### DIFF
--- a/vis/index.d.ts
+++ b/vis/index.d.ts
@@ -1497,6 +1497,7 @@ export interface Data {
 }
 
 export interface Node {
+  group?: string;
   id?: IdType;
   label?: string;
   x?: number;


### PR DESCRIPTION
There are several options for a node which are not implemented in the definitions, as you can see under http://visjs.org/docs/network/nodes.html#. One of the most common property is the "group" option.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://visjs.org/docs/network/nodes.html#
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
