### PR TITLE
Add UMD namespace declaration to 'roslib'.

### DIFF
--- a/roslib/index.d.ts
+++ b/roslib/index.d.ts
@@ -11,6 +11,7 @@
  ---------------------------------- */
 
 export = ROSLIB;
+export as namespace ROSLIB;
 
 declare namespace ROSLIB {
 	export class Ros {


### PR DESCRIPTION
Fixes #14199. This allows you to use ROSLIB without having to import it.

See [the code which documents this](https://github.com/RobotWebTools/roslibjs/blob/243860ae2678db905ff032be53120c53aad6c7b2/src/RosLib.js#L6-L13).