### PR TITLE
Fix react-router-redux v3

### DIFF
--- a/react-router-redux/v3/index.d.ts
+++ b/react-router-redux/v3/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/rackt/react-router-redux
 // Definitions by: Isman Usoh <http://github.com/isman-usoh>, Noah Shipley <https://github.com/noah79>, Dimitri Rosenberg <https://github.com/rosendi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 import * as Redux from "redux";
 import * as History from "history";

--- a/react-router-redux/v3/package.json
+++ b/react-router-redux/v3/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "redux": "^3.6.0"
+  }
+}


### PR DESCRIPTION
It seems we have a semantic merge conflict. My change to react worked fine isolated and the introduction of react-router-redux v3 was fine, but together all the builds are failing.