### PR TITLE
jquery.dataTables: mark optional properties as such

### DIFF
--- a/jquery.datatables/index.d.ts
+++ b/jquery.datatables/index.d.ts
@@ -908,7 +908,7 @@ declare namespace DataTables {
         * @param d Data to use for the row.
         */
         data(d: any[] | Object): DataTable;
-        
+
         /**
 
         * Get the id of the selected row. Since: 1.10.8
@@ -1456,9 +1456,9 @@ declare namespace DataTables {
     }
 
     export interface AjaxData {
-        draw: number;
-        recordsTotal: number;
-        recordsFiltered: number;
+        draw?: number;
+        recordsTotal?: number;
+        recordsFiltered?: number;
         data: any;
         error?: string;
     }


### PR DESCRIPTION
This change converts a handful of interface properties to optional properties because the DataTables plugin does not always require them.

Interface name: `AjaxData`.

Only one property is almost always required: `AjaxData.data`. (Not required/ignored for delete operations)
https://editor.datatables.net/manual/server#Server-to-client

All other properties of the `AjaxData` interface are optional unless server-side processing is enabled (default: disabled).
https://datatables.net/manual/server-side#Returned-data
