### PR TITLE
Fix ui-router-extra

### DIFF
--- a/ui-router-extras/index.d.ts
+++ b/ui-router-extras/index.d.ts
@@ -73,12 +73,12 @@ declare module 'angular' {
             get(memoName?: string): IPreviousState;
 
             /**
-             * Go to a state
+             * Go the previous state, or to the memorized memoName state
              * @param memoName Memo name
              * @param options State options
              * @return Promise
              */
-            go(memoName: string, options?: IStateOptions): angular.IPromise<any>;
+            go(memoName?: string, options?: IStateOptions): angular.IPromise<any>;
 
             /**
              * Memorize a state


### PR DESCRIPTION
$previousState.go([memoName: optional string])

$previousState.go();
The previous state is transitioned to. Transitions use $state.go(fromState, fromParams);

$previousState.go(memoName);
The state memorized as memoName is transitioned to.

Please fill in this template.

- [ ] Make your PR against the `master` branch.
- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://christopherthielen.github.io/ui-router-extras/#/previous
