### PR TITLE
detailing declaration for dgram socket.close ()

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -2124,7 +2124,7 @@ declare module "dgram" {
         send(msg: Buffer | String | any[], offset: number, length: number, port: number, address: string, callback?: (error: Error, bytes: number) => void): void;
         bind(port?: number, address?: string, callback?: () => void): void;
         bind(options: BindOptions, callback?: Function): void;
-        close(callback?: any): void;
+        close(callback?: () => void): void;
         address(): AddressInfo;
         setBroadcast(flag: boolean): void;
         setTTL(ttl: number): void;


### PR DESCRIPTION
Alignment of the declaration for socket.close () callback function in dgram module.
According to the source of nodjs dgram module (lines: 420-435):  
https://github.com/nodejs/node/blob/master/lib/dgram.js

``` JavaScript
  this._healthCheck();
  this._stopReceiving();
  this._handle.close();
  this._handle = null;
  process.nextTick(socketCloseNT, this);

  return this;
};

function socketCloseNT(self) {
  self.emit('close');
}
```