### PR TITLE
redux-immutable: improve typings

### DIFF
--- a/redux-immutable/index.d.ts
+++ b/redux-immutable/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for redux-immutable v3.0.5
+// Type definitions for redux-immutable v3.0.10
 // Project: https://github.com/gajus/redux-immutable
-// Definitions by: Pedro Pereira <https://github.com/oizie>
+// Definitions by: Sebastian Sebald <https://github.com/sebald>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as Redux from 'redux';
 
-export declare function combineReducers(reducers: Object): Redux.Reducer<any>;
+export declare function combineReducers<S>(reducers: Redux.ReducersMapObject): Redux.Reducer<S>;

--- a/redux-immutable/index.d.ts
+++ b/redux-immutable/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for redux-immutable v3.0.10
 // Project: https://github.com/gajus/redux-immutable
-// Definitions by: Pedro Pereira <https://github.com/oizie>
+// Definitions by: Pedro Pereira <https://github.com/oizie>, Sebastian Sebald <https://github.com/sebald/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as Redux from 'redux';

--- a/redux-immutable/index.d.ts
+++ b/redux-immutable/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for redux-immutable v3.0.10
 // Project: https://github.com/gajus/redux-immutable
-// Definitions by: Sebastian Sebald <https://github.com/sebald>
+// Definitions by: Pedro Pereira <https://github.com/oizie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as Redux from 'redux';


### PR DESCRIPTION
Current available typings for `redux-immutable` do only allow to have a `Reducer<any>` and allow to be pass an arbitrary object to `combineReducers`. This patch updates the typings and brings them in-sync with the official `redux` typings.

See: https://github.com/reactjs/redux/blob/master/index.d.ts#L73

---

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`redux-immutable`](https://github.com/gajus/redux-immutable)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
