### PR TITLE
Three.js: Fix typo in TrianglesDrawModes enum

### DIFF
--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -217,7 +217,7 @@ declare namespace THREE {
 
     // Triangle Draw modes
     export enum TrianglesDrawModes { }
-    export const TrianglesDrawModesMode: TrianglesDrawModes;
+    export const TrianglesDrawMode: TrianglesDrawModes;
     export const TriangleStripDrawMode: TrianglesDrawModes;
     export const TriangleFanDrawMode: TrianglesDrawModes;
 


### PR DESCRIPTION
https://threejs.org/docs/index.html#Reference/Constants/DrawModes

Fix for `TrianglesDrawMode` being erroneously exposed as `TrianglesDrawModesMode`.