### PR TITLE
elastic.js Adding Filter as a type to Request.filter(filter)

### DIFF
--- a/elastic.js/elastic.js-tests.ts
+++ b/elastic.js/elastic.js-tests.ts
@@ -1,6 +1,13 @@
 import * as elasticjs from 'elastic.js';
 
-let body = new elasticjs.Request({})
+new elasticjs.Request({})
   .query(new elasticjs.MatchQuery('title_field', 'testQuery'))
   .facet(new elasticjs.TermsFacet('tags').field('tags'))
+  .toJSON();
+
+new elasticjs.Request({})
+  .query(new elasticjs.MatchAllQuery())
+  .filter(new elasticjs.BoolFilter().must([
+    new elasticjs.TermFilter('a', 'b'),
+    new elasticjs.TermFilter('c', 'd')]))
   .toJSON();

--- a/elastic.js/index.d.ts
+++ b/elastic.js/index.d.ts
@@ -6765,7 +6765,7 @@ declare module elasticjs {
     /*
      Allows you to set a specified filter on this request object.
      */
-    filter(filter: Object | Filter): Request;
+    filter(filter: Filter): Request;
 
     /*
      A search result set could be very large (think Google). Setting the

--- a/elastic.js/index.d.ts
+++ b/elastic.js/index.d.ts
@@ -6765,7 +6765,7 @@ declare module elasticjs {
     /*
      Allows you to set a specified filter on this request object.
      */
-    filter(filter: Object): Request;
+    filter(filter: Object | Filter): Request;
 
     /*
      A search result set could be very large (think Google). Setting the


### PR DESCRIPTION
Request.filter did not allow a Filter to be passed in. Amending signature to accept Object | Filter instead of just Object.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
