### PR TITLE
Fix typo in webpack PerformanceOptions

### DIFF
--- a/webpack/index.d.ts
+++ b/webpack/index.d.ts
@@ -1146,7 +1146,7 @@ declare namespace webpack {
         /**
          * An entrypoint represents all assets that would be utilized during initial load time for a specific entry. This option controls when webpack should emit performance hints based on the maximum entrypoint size. The default value is 250000 (bytes).
          */
-        maxEntryPointSize?: number;
+        maxEntrypointSize?: number;
         /**
          * An asset is any emitted file from webpack. This option controls when webpack emits a performance hint based on individual asset size. The default value is 250000 (bytes).
          */

--- a/webpack/webpack-tests.ts
+++ b/webpack/webpack-tests.ts
@@ -544,7 +544,7 @@ const resolve: webpack.Resolve = {
 
 const performance: webpack.PerformanceOptions = {
 	hints: 'error',
-	maxEntryPointSize: 400000,
+	maxEntrypointSize: 400000,
 	maxAssetSize: 100000,
 	assetFilter: function(assetFilename) {
 		return assetFilename.endsWith('.js');


### PR DESCRIPTION
s/maxEntryPointSize/maxEntrypointSize


Reference: https://github.com/webpack/webpack/blob/a22b00e23d44f58932a513084f02d376c75854f7/schemas/webpackOptionsSchema.json#L796