### PR TITLE
(validator.js) Add missing options to isInt method

### DIFF
--- a/validator/index.d.ts
+++ b/validator/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for validator.js v5.7.0
+// Type definitions for validator.js v6.2.1
 // Project: https://github.com/chriso/validator.js
 // Definitions by: tgfjt <https://github.com/tgfjt>, Ilya Mochalov <https://github.com/chrootsu>, Ayman Nedjmeddine <https://github.com/IOAyman>, Louy Alakkad <https://github.com/louy>, Kacper Polak <https://github.com/kacepe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/validator/index.d.ts
+++ b/validator/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for validator.js v5.7.0
 // Project: https://github.com/chriso/validator.js
-// Definitions by: tgfjt <https://github.com/tgfjt>, Ilya Mochalov <https://github.com/chrootsu>, Ayman Nedjmeddine <https://github.com/IOAyman>, Louy Alakkad <https://github.com/louy>
+// Definitions by: tgfjt <https://github.com/tgfjt>, Ilya Mochalov <https://github.com/chrootsu>, Ayman Nedjmeddine <https://github.com/IOAyman>, Louy Alakkad <https://github.com/louy>, Kacper Polak <https://github.com/kacepe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace ValidatorJS {
@@ -276,6 +276,9 @@ declare namespace ValidatorJS {
   interface IsIntOptions {
     min?: number;
     max?: number;
+    allow_leading_zeroes?: boolean;
+    lt?: number;
+    gt?: number;
   }
 
   // options for IsLength

--- a/validator/index.d.ts
+++ b/validator/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for validator.js v6.2.0
+// Type definitions for validator.js v6.2
 // Project: https://github.com/chriso/validator.js
 // Definitions by: tgfjt <https://github.com/tgfjt>, Ilya Mochalov <https://github.com/chrootsu>, Ayman Nedjmeddine <https://github.com/IOAyman>, Louy Alakkad <https://github.com/louy>, Kacper Polak <https://github.com/kacepe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/validator/index.d.ts
+++ b/validator/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for validator.js v6.2.1
+// Type definitions for validator.js v6.2.0
 // Project: https://github.com/chriso/validator.js
 // Definitions by: tgfjt <https://github.com/tgfjt>, Ilya Mochalov <https://github.com/chrootsu>, Ayman Nedjmeddine <https://github.com/IOAyman>, Louy Alakkad <https://github.com/louy>, Kacper Polak <https://github.com/kacepe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/validator/tslint.json
+++ b/validator/tslint.json
@@ -1,1 +1,0 @@
-{ "extends": "../tslint.json" }

--- a/validator/tslint.json
+++ b/validator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Missing options:
`allow_leading_zeroes`: https://github.com/chriso/validator.js/blob/master/src/lib/isInt.js#L13
`lt`: https://github.com/chriso/validator.js/blob/master/src/lib/isInt.js#L20
`gt`: https://github.com/chriso/validator.js/blob/master/src/lib/isInt.js#L21

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chriso/validator.js/blob/master/src/lib/isInt.js
- [x] Increase the version number in the header if appropriate.

@tgfjt @chrootsu @IOAyman @louy  