### PR TITLE
vinyl-fs: add undocumented allowEmpty option flag

### DIFF
--- a/vinyl-fs/.editorconfig
+++ b/vinyl-fs/.editorconfig
@@ -1,0 +1,3 @@
+[*.ts]
+indent_style = space
+indent_size = 3

--- a/vinyl-fs/index.d.ts
+++ b/vinyl-fs/index.d.ts
@@ -1,25 +1,26 @@
-// Type definitions for vinyl-fs
+// Type definitions for vinyl-fs 2.4
 // Project: https://github.com/wearefractal/vinyl-fs
 // Definitions by: vvakame <https://github.com/vvakame/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-/// <reference types="vinyl" />
-/// <reference types="glob-stream" />
 
 declare global {
    namespace NodeJS {
       interface WritableStream {
-         write(buffer: any/* Vinyl.File */, cb?: Function): boolean;
+         write(buffer: any/* Vinyl.File */, cb?: (err?: Error) => void): boolean;
       }
    }
 }
 
-import _events = require("events");
-import File = require("vinyl");
-import globStream = require("glob-stream");
+import * as _events from 'events';
+import * as File from 'vinyl';
+import * as globStream from 'glob-stream';
 
-interface ISrcOptions extends globStream.Options {
+interface SrcOptions extends globStream.Options {
+   /** Prevents stream from emitting an error when file not found. */
+   allowEmpty?: boolean;
+
    /** Specifies the working directory the folder is relative to */
    cwd?: string;
 
@@ -62,7 +63,7 @@ interface ISrcOptions extends globStream.Options {
 * fs.src(['!b*.js', '*.js']) would not exclude any files, but this would: fs.src(['*.js', '!b*.js'])
 * @param opt Options Vinyl source options, changes the way the files are read, found, or stored in the vinyl stream
 */
-declare function src(globs: string|string[], opt?: ISrcOptions): NodeJS.ReadWriteStream;
+declare function src(globs: string|string[], opt?: SrcOptions): NodeJS.ReadWriteStream;
 
 /**
 * This is just a glob-watcher
@@ -80,7 +81,7 @@ declare function watch(globs: string|string[], cb?: (outEvt: { type: any; path: 
 * Globs are executed in order, so negations should follow positive globs
 * fs.src(['!b*.js', '*.js']) would not exclude any files, but this would: fs.src(['*.js', '!b*.js'])
 */
-declare function watch(globs: string|string[], opt?: { interval?: number; debounceDelay?: number; cwd?: string; maxListeners?: Function; }, cb?: (outEvt: { type: any; path: any; old: any; }) => void): _events.EventEmitter;
+declare function watch(globs: string|string[], opt?: { interval?: number; debounceDelay?: number; cwd?: string; maxListeners?: () => number; }, cb?: (outEvt: { type: any; path: any; old: any; }) => void): _events.EventEmitter;
 
 /**
 * On write the stream will save the vinyl File to disk at the folder/cwd specified.

--- a/vinyl-fs/tsconfig.json
+++ b/vinyl-fs/tsconfig.json
@@ -1,22 +1,22 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
-        "noImplicitAny": true,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "vinyl-fs-tests.ts"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "strictNullChecks": false,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "vinyl-fs-tests.ts"
+  ]
 }

--- a/vinyl-fs/tslint.json
+++ b/vinyl-fs/tslint.json
@@ -1,0 +1,3 @@
+{
+   "extends": "../tslint.json"
+}

--- a/vinyl-fs/vinyl-fs-tests.ts
+++ b/vinyl-fs/vinyl-fs-tests.ts
@@ -3,10 +3,10 @@
 
 // from src
 
-import vfs = require('vinyl-fs');
+import * as vfs from 'vinyl-fs';
 
-import path = require('path');
-import fs = require('fs'); // require('graceful-fs');
+import * as path from 'path';
+import * as fs from 'fs'; // require('graceful-fs');
 
 // import bufEqual = require('buffer-equal');
 declare var bufEqual: any;
@@ -16,8 +16,8 @@ import File = require('vinyl');
 // var spies = require('./spy');
 declare var spies: any;
 
-import should = require('should');
-require('mocha');
+import * as should from 'should';
+import 'mocha';
 
 declare var gulp: any;
 declare var bufferStream: any;
@@ -210,7 +210,7 @@ import rimraf = require('rimraf');
 // var File = require('vinyl');
 
 // var should = require('should');
-require('mocha');
+// require('mocha');
 
 var wipeOut = function (cb: any) {
    rimraf(path.join(__dirname, "./out-fixtures/"), cb);
@@ -374,7 +374,7 @@ describe('dest stream', function () {
          cwd: __dirname,
          path: inputPath,
          contents: expectedContents,
-         stat: <fs.Stats>{
+         stat: <fs.Stats> {
             mode: expectedMode
          }
       });
@@ -415,7 +415,7 @@ describe('dest stream', function () {
          cwd: __dirname,
          path: inputPath,
          contents: contentStream,
-         stat: <fs.Stats>{
+         stat: <fs.Stats> {
             mode: expectedMode
          }
       });
@@ -458,10 +458,8 @@ describe('dest stream', function () {
          cwd: __dirname,
          path: inputPath,
          contents: null,
-         stat: <fs.Stats>{
-            isDirectory: function () {
-               return true;
-            },
+         stat: <fs.Stats> {
+            isDirectory: () => true,
             mode: expectedMode
          }
       });
@@ -503,7 +501,7 @@ describe('dest stream', function () {
 
       stream1.on('data', function (file: any) {
          file.path.should.equal(inputPath1);
-      })
+      });
 
       stream1.pipe(rename).pipe(stream2);
       stream2.on('data', function (file: any) {
@@ -519,11 +517,11 @@ describe('dest stream', function () {
          path: inputPath1,
          cwd: __dirname,
          contents: content
-      })
+      });
 
       stream1.write(file);
       stream1.end();
-   })
+   });
 
 });
 
@@ -708,7 +706,7 @@ describe('symlink stream', function () {
          cwd: __dirname,
          path: inputPath,
          contents: expectedContents,
-         stat: <fs.Stats>{
+         stat: <fs.Stats> {
             mode: expectedMode
          }
       });
@@ -749,7 +747,7 @@ describe('symlink stream', function () {
          cwd: __dirname,
          path: inputPath,
          contents: contentStream,
-         stat: <fs.Stats>{
+         stat: <fs.Stats> {
             mode: expectedMode
          }
       });
@@ -792,10 +790,8 @@ describe('symlink stream', function () {
          cwd: __dirname,
          path: inputPath,
          contents: null,
-         stat: <fs.Stats>{
-            isDirectory: function () {
-               return true;
-            },
+         stat: <fs.Stats> {
+            isDirectory: () => true,
             mode: expectedMode
          }
       });
@@ -869,7 +865,7 @@ describe('symlink stream', function () {
          cwd: __dirname,
          path: inputPath,
          contents: expectedContents,
-         stat: <fs.Stats>{
+         stat: <fs.Stats> {
             mode: expectedMode
          }
       });
@@ -878,7 +874,7 @@ describe('symlink stream', function () {
       fs.chmodSync(expectedBase, 0);
 
       var stream = vfs.symlink('./out-fixtures/', { cwd: __dirname });
-      stream.on('error', function (err:any) {
+      stream.on('error', function (err: any) {
          err.code.should.equal('EACCES');
          done();
       });
@@ -914,5 +910,5 @@ describe('symlink stream', function () {
       var file = new File(options);
       File.isVinyl(file).should.equal(true);
       File.isVinyl(options).should.equal(false);
-   })
+   });
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
- [x] Run `tsc` without errors.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/gulpjs/vinyl-fs/issues/217#issuecomment-267120498>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
