### PR TITLE
Add two missing properties to React.Widgets

### DIFF
--- a/react-widgets/lib/DateTimePicker.d.ts
+++ b/react-widgets/lib/DateTimePicker.d.ts
@@ -34,7 +34,7 @@ interface DateTimePickerProps extends React.Props<DateTimePickerClass> {
 	/*
      * Default value for current date. Usefull for suggesting a date when the caldenar opens without keep forcing it once 'value' is set. 
      */
-    defaultCurrentDate?: Date
+    defaultCurrentDate?: Date;
     /**
      * Change event Handler that is called when the currentDate is changed. The handler is
      * called with the currentDate object.
@@ -97,11 +97,16 @@ interface DateTimePickerProps extends React.Props<DateTimePickerClass> {
     onSelect?: (date?: Date) => void;
     /**
      * Whether or not the DateTimePicker is open. When unset (undefined) the DateTimePicker will
-     * handle the opening and closing internally. The defaultOpen prop can be used to set an
-     * initialization value for uncontrolled widgets.
+     * handle the opening and closing internally. 
      * @enum false "calendar" "time"
      */
     open?: boolean | "calendar" | "time";
+    /**
+     * The defaultOpen prop can be used to set an
+     * initialization value for uncontrolled widgets.
+     * @enum false "calendar" "time"
+     */
+    defaultOpen?: boolean | "calendar" | "time";
     /**
      * Called when the DateTimePicker is about to open or close. onToggle should be used when
      * the open prop is set otherwise the widget will never open or close.

--- a/react-widgets/lib/DateTimePicker.d.ts
+++ b/react-widgets/lib/DateTimePicker.d.ts
@@ -32,7 +32,7 @@ interface DateTimePickerProps extends React.Props<DateTimePickerClass> {
      */
     currentDate?: Date;
     /*
-     * Default value for current date. Usefull for suggesting a date when the caldenar opens without keep forcing it once 'value' is set. 
+     * Default value for current date. Useful for suggesting a date when the caldenar opens without keep forcing it once 'value' is set. 
      */
     defaultCurrentDate?: Date;
     /**

--- a/react-widgets/lib/DateTimePicker.d.ts
+++ b/react-widgets/lib/DateTimePicker.d.ts
@@ -31,6 +31,10 @@ interface DateTimePickerProps extends React.Props<DateTimePickerClass> {
      * @default Date()
      */
     currentDate?: Date;
+	/*
+     * Default value for current date. Usefull for suggesting a date when the caldenar opens without keep forcing it once 'value' is set. 
+     */
+    defaultCurrentDate?: Date
     /**
      * Change event Handler that is called when the currentDate is changed. The handler is
      * called with the currentDate object.

--- a/react-widgets/lib/DateTimePicker.d.ts
+++ b/react-widgets/lib/DateTimePicker.d.ts
@@ -31,7 +31,7 @@ interface DateTimePickerProps extends React.Props<DateTimePickerClass> {
      * @default Date()
      */
     currentDate?: Date;
-	/*
+    /*
      * Default value for current date. Usefull for suggesting a date when the caldenar opens without keep forcing it once 'value' is set. 
      */
     defaultCurrentDate?: Date;

--- a/react-widgets/lib/DropdownList.d.ts
+++ b/react-widgets/lib/DropdownList.d.ts
@@ -90,11 +90,11 @@ interface DropdownListProps extends React.Props<DropdownListClass> {
      * handle the opening and closing internally. 
      */
     open?: boolean;
-	/**
+    /**
      * The defaultOpen prop can be used to set an
      * initialization value for uncontrolled widgets.
      */
-	defaultOpen?: boolean;
+    defaultOpen?: boolean;
     /**
      * Called when the DropdownList is about to open or close. onToggle should be used when the
      * open prop is set otherwise the widget open buttons won't work.

--- a/react-widgets/lib/DropdownList.d.ts
+++ b/react-widgets/lib/DropdownList.d.ts
@@ -87,10 +87,14 @@ interface DropdownListProps extends React.Props<DropdownListClass> {
     onSearch?: (searchTerm: string) => void;
     /**
      * Whether or not the DropdownList is open. When unset (undefined) the DropdownList will
-     * handle the opening and closing internally. The defaultOpen prop can be used to set an
-     * initialization value for uncontrolled widgets.
+     * handle the opening and closing internally. 
      */
     open?: boolean;
+	/**
+     * The defaultOpen prop can be used to set an
+     * initialization value for uncontrolled widgets.
+     */
+	defaultOpen?: boolean;
     /**
      * Called when the DropdownList is about to open or close. onToggle should be used when the
      * open prop is set otherwise the widget open buttons won't work.


### PR DESCRIPTION
Just adding three missing properties: 

* DropdownList defaultOpen (x2): Is not in the examples but is referenced in `open` documentation.
* DateTimePicker defaultCurrentDate: Is not in the examples but is consistent with the other Uncontrollable properties. Of course works and is quite usefull.