### PR TITLE
Enzyme: Restore strongly typed props for classes, misc. updates

### DIFF
--- a/chai-enzyme/index.d.ts
+++ b/chai-enzyme/index.d.ts
@@ -8,6 +8,7 @@
 /// <reference types="enzyme" />
 /// <reference types="chai" />
 /// <reference types="react" />
+/// <reference types="cheerio" />
 
 declare namespace Chai {
     type EnzymeSelector = string | React.StatelessComponent<any> | React.ComponentClass<any> | { [key: string]: any };
@@ -143,9 +144,9 @@ declare namespace Chai {
 }
 
 declare module "chai-enzyme" {
-    import { ShallowWrapper, ReactWrapper, CheerioWrapper } from "enzyme";
+    import { ShallowWrapper, ReactWrapper } from "enzyme";
 
-    type DebugWrapper = ShallowWrapper<any,any> | CheerioWrapper<any, any> | ReactWrapper<any, any>;
+    type DebugWrapper = ShallowWrapper<any,any> | Cheerio | ReactWrapper<any, any>;
     function chaiEnzyMe(wrapper?: (debugWrapper: DebugWrapper) => string): (chai: any) => void;
 
     module chaiEnzyMe {

--- a/enzyme/enzyme-tests.tsx
+++ b/enzyme/enzyme-tests.tsx
@@ -1,48 +1,44 @@
-import { shallow, mount, render, describeWithDOM, spyLifecycle } from "enzyme";
 import * as React from "react";
-import {Component, ReactElement, HTMLAttributes} from "react";
-import {ShallowWrapper, ReactWrapper, CheerioWrapper} from "enzyme";
+import {shallow, mount, render, ShallowWrapper, ReactWrapper} from "enzyme";
+import {Component, ReactElement, HTMLAttributes, ComponentClass, StatelessComponent} from "react";
 
 // Help classes/interfaces
 interface MyComponentProps {
-    propsProperty: any;
+    stringProp: string;
     numberProp?: number;
 }
 
 interface StatelessProps {
-    stateless: any;
+    stateless: string;
 }
 
 interface MyComponentState {
-    stateProperty: any;
+    stateProperty: string;
 }
 
 class MyComponent extends Component<MyComponentProps, MyComponentState> {
     setState(...args: any[]) {
+        console.log(args);
     }
 }
 
 const MyStatelessComponent = (props: StatelessProps) => <span />;
 
-// API
-namespace SpyLifecycleTest {
-    spyLifecycle(MyComponent);
-}
-
 // ShallowWrapper
 namespace ShallowWrapperTest {
     var shallowWrapper: ShallowWrapper<MyComponentProps, MyComponentState> =
-        shallow<MyComponentProps, MyComponentState>(<MyComponent propsProperty="value"/>);
+        shallow<MyComponentProps, MyComponentState>(<MyComponent stringProp="value"/>);
 
     var reactElement: ReactElement<any>,
-        objectVal: Object,
-        boolVal: Boolean,
-        stringVal: String,
+        objectVal: {},
+        boolVal: boolean,
+        stringVal: string,
         numOrStringVal: number | string,
-        elementWrapper: ShallowWrapper<HTMLAttributes<{}>, {}>
+        elementWrapper: ShallowWrapper<HTMLAttributes<{}>, {}>,
+        statelessWrapper: ShallowWrapper<StatelessProps, never>;
 
     function test_shallow_options() {
-        shallow(<MyComponent propsProperty={1}/>, {
+        shallow(<MyComponent stringProp="1"/>, {
             context: {
                 test: "a",
             },
@@ -51,11 +47,10 @@ namespace ShallowWrapperTest {
     }
 
     function test_find() {
-        elementWrapper = shallowWrapper.find('.selector');
         shallowWrapper = shallowWrapper.find(MyComponent);
-        shallowWrapper.find(MyStatelessComponent).props().stateless;
-        shallowWrapper.find(MyStatelessComponent).shallow();
-        shallowWrapper.find({ prop: 'value' });
+        statelessWrapper = shallowWrapper.find(MyStatelessComponent);
+        shallowWrapper = shallowWrapper.find({ prop: 'value' });
+        elementWrapper = shallowWrapper.find('.selector');
     }
 
     function test_findWhere() {
@@ -64,15 +59,16 @@ namespace ShallowWrapperTest {
     }
 
     function test_filter() {
+        shallowWrapper = shallowWrapper.filter(MyComponent);
+        statelessWrapper = shallowWrapper.filter(MyStatelessComponent);
+        shallowWrapper = shallowWrapper.filter({ prop: 'value' });
         elementWrapper = shallowWrapper.filter('.selector');
-        shallowWrapper = shallowWrapper.filter(MyComponent).shallow();
-        shallowWrapper.filter({ prop: 'val' });
     }
 
     function test_filterWhere() {
         shallowWrapper =
             shallowWrapper.filterWhere(wrapper => {
-                wrapper.props().propsProperty;
+                wrapper.props().stringProp;
                 return true;
             });
     }
@@ -95,11 +91,11 @@ namespace ShallowWrapperTest {
 
     function test_dive() {
         interface TmpProps {
-            foo: any
+            foo: any;
         }
 
         interface TmpState {
-            bar: any
+            bar: any;
         }
 
         const diveWrapper: ShallowWrapper<TmpProps, TmpState> = shallowWrapper.dive<TmpProps, TmpState>({ context: { foobar: 'barfoo' }});
@@ -122,11 +118,11 @@ namespace ShallowWrapperTest {
     }
 
     function test_isEmpty() {
-        boolVal = shallowWrapper.isEmpty()
+        boolVal = shallowWrapper.isEmpty();
     }
 
     function test_exists() {
-        boolVal = shallowWrapper.exists()
+        boolVal = shallowWrapper.exists();
     }
 
     function test_not() {
@@ -135,19 +131,21 @@ namespace ShallowWrapperTest {
 
     function test_children() {
         shallowWrapper = shallowWrapper.children();
-        shallowWrapper.children(MyStatelessComponent).props().stateless;
-        shallowWrapper.children({ prop: 'myprop' });
+        shallowWrapper = shallowWrapper.children(MyComponent);
+        statelessWrapper = shallowWrapper.children(MyStatelessComponent);
+        shallowWrapper = shallowWrapper.children({ prop: 'value' });
+        elementWrapper = shallowWrapper.children('.selector');
     }
 
     function test_childAt() {
         const childWrapper: ShallowWrapper<any, any> = shallowWrapper.childAt(0);
 
         interface TmpType1 {
-            foo: any
+            foo: any;
         }
 
         interface TmpType2 {
-            bar: any
+            bar: any;
         }
 
         const childWrapper2: ShallowWrapper<TmpType1, TmpType2> = shallowWrapper.childAt<TmpType1, TmpType2>(0);
@@ -155,6 +153,10 @@ namespace ShallowWrapperTest {
 
     function test_parents() {
         shallowWrapper = shallowWrapper.parents();
+        shallowWrapper = shallowWrapper.parents(MyComponent);
+        statelessWrapper = shallowWrapper.parents(MyStatelessComponent);
+        shallowWrapper = shallowWrapper.parents({ prop: 'myprop' });
+        elementWrapper = shallowWrapper.parents('.selector');
     }
 
     function test_parent() {
@@ -162,9 +164,10 @@ namespace ShallowWrapperTest {
     }
 
     function test_closest() {
-        elementWrapper = shallowWrapper.closest('.selector');
         shallowWrapper = shallowWrapper.closest(MyComponent);
+        statelessWrapper = shallowWrapper.closest(MyStatelessComponent);
         shallowWrapper = shallowWrapper.closest({ prop: 'myprop' });
+        elementWrapper = shallowWrapper.closest('.selector');
     }
 
     function test_shallow() {
@@ -175,14 +178,9 @@ namespace ShallowWrapperTest {
         shallowWrapper = shallowWrapper.unmount();
     }
 
-    function test_render() {
-        var cheerioWrapper: CheerioWrapper<MyComponentProps, MyComponentState> = shallowWrapper.render();
-    }
-
     function test_text() {
         stringVal = shallowWrapper.text();
     }
-
 
     function test_html() {
         stringVal = shallowWrapper.html();
@@ -206,23 +204,28 @@ namespace ShallowWrapperTest {
 
     function test_state() {
         const state: MyComponentState = shallowWrapper.state();
-        shallowWrapper.state('key');
-        const tmp: String = shallowWrapper.state<String>('key');
+        const prop: string = shallowWrapper.state('stateProperty');
+        const prop2: number = shallowWrapper.state<number>('key');
+        const prop3 = shallowWrapper.state('key');
     }
 
     function test_context() {
         shallowWrapper.context();
         shallowWrapper.context('key');
-        const tmp: String = shallowWrapper.context<String>('key');
+        const tmp: string = shallowWrapper.context<string>('key');
     }
 
     function test_props() {
-        objectVal = shallowWrapper.props();
+        const props: MyComponentProps = shallowWrapper.props();
+        const props2: MyComponentProps = shallowWrapper.find(MyComponent).props();
+        const props3: StatelessProps = shallowWrapper.find(MyStatelessComponent).props();
+        const props4: HTMLAttributes<any> = shallowWrapper.find('.selector').props();
     }
 
     function test_prop() {
-        shallowWrapper.prop('key');
-        const tmp: String = shallowWrapper.prop<String>('key');
+        const tmp: number = shallowWrapper.prop('numberProp');
+        const tmp2: string = shallowWrapper.prop<string>('key');
+        const tmp3 = shallowWrapper.prop('key');
     }
 
     function test_key() {
@@ -239,7 +242,7 @@ namespace ShallowWrapperTest {
     }
 
     function test_setProps() {
-        shallowWrapper = shallowWrapper.setProps({ propsProperty: 'foo' }, () => console.log('props updated'));
+        shallowWrapper = shallowWrapper.setProps({ stringProp: 'foo' });
     }
 
     function test_setContext() {
@@ -259,20 +262,20 @@ namespace ShallowWrapperTest {
     }
 
     function test_type() {
-        var stringOrFunction: String | Function = shallowWrapper.type();
+        const type: string | StatelessComponent<MyComponentProps> | ComponentClass<MyComponentProps> = shallowWrapper.type();
     }
 
     function test_name() {
-        var str: String = shallowWrapper.name();
+        stringVal = shallowWrapper.name();
     }
 
     function test_forEach() {
         shallowWrapper =
-            shallowWrapper.forEach(wrapper => wrapper.shallow().props().propsProperty);
+            shallowWrapper.forEach(wrapper => wrapper.shallow().props().stringProp);
     }
 
     function test_map() {
-        var arrayNumbers: Array<Number> =
+        var arrayNumbers: number[] =
             shallowWrapper.map(wrapper => wrapper.props().numberProp);
     }
 
@@ -286,13 +289,15 @@ namespace ShallowWrapperTest {
     function test_reduceRight() {
         const total: number =
             shallowWrapper.reduceRight<number>(
-                (amount: number, n: ShallowWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
+                (amount: number, n: ShallowWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('numberProp')
             );
     }
 
     function test_some() {
-        boolVal = shallowWrapper.some('.selector');
         boolVal = shallowWrapper.some(MyComponent);
+        boolVal = shallowWrapper.some(MyStatelessComponent);
+        boolVal = shallowWrapper.some({ prop: 'myprop' });
+        boolVal = shallowWrapper.some('.selector');
     }
 
     function test_someWhere() {
@@ -300,8 +305,10 @@ namespace ShallowWrapperTest {
     }
 
     function test_every() {
-        boolVal = shallowWrapper.every('.selector');
         boolVal = shallowWrapper.every(MyComponent);
+        boolVal = shallowWrapper.every(MyStatelessComponent);
+        boolVal = shallowWrapper.every({ prop: 'myprop' });
+        boolVal = shallowWrapper.every('.selector');
     }
 
     function test_everyWhere() {
@@ -321,13 +328,14 @@ namespace ShallowWrapperTest {
 // ReactWrapper
 namespace ReactWrapperTest {
     var reactWrapper: ReactWrapper<MyComponentProps, MyComponentState> =
-        mount<MyComponentProps, MyComponentState>(<MyComponent propsProperty="value"/>);
+        mount<MyComponentProps, MyComponentState>(<MyComponent stringProp="value"/>);
 
     var reactElement: ReactElement<any>,
-        objectVal: Object,
-        boolVal: Boolean,
-        stringVal: String,
-        elementWrapper: ReactWrapper<HTMLAttributes<{}>, {}>
+        objectVal: {},
+        boolVal: boolean,
+        stringVal: string,
+        elementWrapper: ReactWrapper<HTMLAttributes<{}>, {}>,
+        statelessWrapper: ReactWrapper<StatelessProps, never>;
 
     function test_unmount() {
         reactWrapper = reactWrapper.unmount();
@@ -336,7 +344,7 @@ namespace ReactWrapperTest {
     function test_mount() {
         reactWrapper = reactWrapper.mount();
 
-        mount(<MyComponent propsProperty={1}/>, {
+        mount(<MyComponent stringProp='1'/>, {
             attachTo: document.getElementById('test'),
             context: {
                 a: "b"
@@ -348,11 +356,11 @@ namespace ReactWrapperTest {
         reactWrapper = reactWrapper.ref('refName');
 
         interface TmpType1 {
-            foo: string
+            foo: string;
         }
 
         interface TmpType2 {
-            bar: string
+            bar: string;
         }
 
         const tmp: ReactWrapper<TmpType1, TmpType2> = reactWrapper.ref<TmpType1, TmpType2>('refName');
@@ -365,8 +373,8 @@ namespace ReactWrapperTest {
     function test_find() {
         elementWrapper = reactWrapper.find('.selector');
         reactWrapper = reactWrapper.find(MyComponent);
-        reactWrapper.find(MyStatelessComponent).props().stateless;
-        reactWrapper.find({ prop: 'myprop' });
+        statelessWrapper = reactWrapper.find(MyStatelessComponent);
+        reactWrapper = reactWrapper.find({ prop: 'myprop' });
     }
 
     function test_findWhere() {
@@ -375,15 +383,16 @@ namespace ReactWrapperTest {
     }
 
     function test_filter() {
-        elementWrapper = reactWrapper.filter('.selector');
         reactWrapper = reactWrapper.filter(MyComponent);
+        statelessWrapper = reactWrapper.filter(MyStatelessComponent);
         reactWrapper = reactWrapper.filter({ prop: 'myprop' });
+        elementWrapper = reactWrapper.filter('.selector');
     }
 
     function test_filterWhere() {
         reactWrapper =
             reactWrapper.filterWhere(wrapper => {
-                wrapper.props().propsProperty;
+                wrapper.props().stringProp;
                 return true;
             });
     }
@@ -421,7 +430,7 @@ namespace ReactWrapperTest {
     }
 
     function test_isEmpty() {
-        boolVal = reactWrapper.isEmpty()
+        boolVal = reactWrapper.isEmpty();
     }
 
     function test_not() {
@@ -430,17 +439,21 @@ namespace ReactWrapperTest {
 
     function test_children() {
         reactWrapper = reactWrapper.children();
+        reactWrapper = reactWrapper.children(MyComponent);
+        statelessWrapper = reactWrapper.children(MyStatelessComponent);
+        reactWrapper = reactWrapper.children({ prop: 'myprop' });
+        elementWrapper = reactWrapper.children('.selector');
     }
 
     function test_childAt() {
         const childWrapper: ReactWrapper<any, any> = reactWrapper.childAt(0);
 
         interface TmpType1 {
-            foo: any
+            foo: any;
         }
 
         interface TmpType2 {
-            bar: any
+            bar: any;
         }
 
         const childWrapper2: ReactWrapper<TmpType1, TmpType2> = reactWrapper.childAt<TmpType1, TmpType2>(0);
@@ -448,6 +461,10 @@ namespace ReactWrapperTest {
 
     function test_parents() {
         reactWrapper = reactWrapper.parents();
+        reactWrapper = reactWrapper.parents(MyComponent);
+        statelessWrapper = reactWrapper.parents(MyStatelessComponent);
+        reactWrapper = reactWrapper.parents({ prop: 'myprop' });
+        elementWrapper = reactWrapper.parents('.selector');
     }
 
     function test_parent() {
@@ -455,9 +472,10 @@ namespace ReactWrapperTest {
     }
 
     function test_closest() {
-        elementWrapper = reactWrapper.closest('.selector');
         reactWrapper = reactWrapper.closest(MyComponent);
+        statelessWrapper = reactWrapper.closest(MyStatelessComponent);
         reactWrapper = reactWrapper.closest({ prop: 'myprop' });
+        elementWrapper = reactWrapper.closest('.selector');
     }
 
     function test_text() {
@@ -485,24 +503,29 @@ namespace ReactWrapperTest {
     }
 
     function test_state() {
-        reactWrapper.state();
-        reactWrapper.state('key');
-        const tmp: String = reactWrapper.state<String>('key');
+        const state: MyComponentState = reactWrapper.state();
+        const prop: string = reactWrapper.state('stateProperty');
+        const prop2: number = reactWrapper.state<number>('key');
+        const prop3 = reactWrapper.state('key');
     }
 
     function test_context() {
         reactWrapper.context();
         reactWrapper.context('key');
-        const tmp: String = reactWrapper.context<String>('key');
+        const tmp: string = reactWrapper.context<string>('key');
     }
 
     function test_props() {
-        objectVal = reactWrapper.props();
+        const props: MyComponentProps = reactWrapper.props();
+        const props2: MyComponentProps = reactWrapper.find(MyComponent).props();
+        const props3: StatelessProps = reactWrapper.find(MyStatelessComponent).props();
+        const props4: HTMLAttributes<any> = reactWrapper.find('.selector').props();
     }
 
     function test_prop() {
-        reactWrapper.prop('key');
-        const tmp: String = reactWrapper.prop<String>('key');
+        const tmp: number = reactWrapper.prop('numberProp');
+        const tmp2: string = reactWrapper.prop<string>('key');
+        const tmp3 = reactWrapper.prop('key');
     }
 
     function test_key() {
@@ -519,7 +542,7 @@ namespace ReactWrapperTest {
     }
 
     function test_setProps() {
-        reactWrapper = reactWrapper.setProps({ propsProperty: 'foo' });
+        reactWrapper = reactWrapper.setProps({ stringProp: 'foo' });
     }
 
     function test_setContext() {
@@ -539,40 +562,42 @@ namespace ReactWrapperTest {
     }
 
     function test_type() {
-        var stringOrFunction: String | Function = reactWrapper.type();
+        const type: string | StatelessComponent<MyComponentProps> | ComponentClass<MyComponentProps> = reactWrapper.type();
     }
 
     function test_name() {
-        var str: String = reactWrapper.name();
+        stringVal = reactWrapper.name();
     }
 
     function test_forEach() {
         reactWrapper =
-            reactWrapper.forEach(wrapper => wrapper.props().propsProperty);
+            reactWrapper.forEach(wrapper => wrapper.props().stringProp);
     }
 
     function test_map() {
-        var arrayNumbers: Array<Number> =
+        var arrayNumbers: number[] =
             reactWrapper.map(wrapper => wrapper.props().numberProp);
     }
 
     function test_reduce() {
         const total: number =
             reactWrapper.reduce<number>(
-                (amount: number, n: ReactWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
+                (amount: number, n: ReactWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('numberProp')
             );
     }
 
     function test_reduceRight() {
         const total: number =
             reactWrapper.reduceRight<number>(
-                (amount: number, n: ReactWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
+                (amount: number, n: ReactWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('numberProp')
             );
     }
 
     function test_some() {
-        boolVal = reactWrapper.some('.selector');
         boolVal = reactWrapper.some(MyComponent);
+        boolVal = reactWrapper.some(MyStatelessComponent);
+        boolVal = reactWrapper.some({ prop: 'myprop' });
+        boolVal = reactWrapper.some('.selector');
     }
 
     function test_someWhere() {
@@ -580,8 +605,10 @@ namespace ReactWrapperTest {
     }
 
     function test_every() {
-        boolVal = reactWrapper.every('.selector');
         boolVal = reactWrapper.every(MyComponent);
+        boolVal = reactWrapper.every(MyStatelessComponent);
+        boolVal = reactWrapper.every({ prop: 'myprop' });
+        boolVal = reactWrapper.every('.selector');
     }
 
     function test_everyWhere() {
@@ -594,239 +621,9 @@ namespace ReactWrapperTest {
 
 // CheerioWrapper
 namespace CheerioWrapperTest {
-    var cheerioWrapper: CheerioWrapper<MyComponentProps, MyComponentState> =
-        render<MyComponentProps, MyComponentState>(<MyComponent propsProperty="value"/>);
+    const wrapper: Cheerio =
+        shallow(<div />).render() ||
+        mount(<div />).render();
 
-    var reactElement: ReactElement<any>,
-        objectVal: Object,
-        boolVal: Boolean,
-        stringVal: String,
-        elementWrapper: CheerioWrapper<HTMLAttributes<{}>, {}>
-
-    function test_find() {
-        elementWrapper = cheerioWrapper.find('.selector');
-        cheerioWrapper = cheerioWrapper.find(MyComponent);
-        cheerioWrapper.find(MyStatelessComponent).props().stateless;
-        cheerioWrapper.find({ prop: 'myprop' });
-    }
-
-    function test_findWhere() {
-        cheerioWrapper =
-            cheerioWrapper.findWhere((aCheerioWrapper: CheerioWrapper<MyComponentProps, MyComponentState>) => true);
-    }
-
-    function test_filter() {
-        elementWrapper = cheerioWrapper.filter('.selector');
-        cheerioWrapper = cheerioWrapper.filter(MyComponent);
-        cheerioWrapper = cheerioWrapper.filter({ prop: 'myprop' });
-    }
-
-    function test_filterWhere() {
-        cheerioWrapper =
-            cheerioWrapper.filterWhere(wrapper => {
-                wrapper.props().propsProperty;
-                return true;
-            });
-    }
-
-    function test_contains() {
-        boolVal = cheerioWrapper.contains(<div className="foo bar"/>);
-    }
-
-    function test_containsMatchingElement() {
-        boolVal = cheerioWrapper.contains(<div className="foo bar"/>);
-    }
-
-    function test_containsAllMatchingElements() {
-        boolVal = cheerioWrapper.containsAllMatchingElements([<div className="foo bar"/>]);
-    }
-
-    function test_containsAnyMatchingElement() {
-        boolVal = cheerioWrapper.containsAnyMatchingElements([<div className="foo bar"/>]);
-    }
-
-    function test_equals() {
-        boolVal = cheerioWrapper.equals(<div className="foo bar"/>);
-    }
-
-    function test_matchesElement() {
-        boolVal = cheerioWrapper.matchesElement(<div className="foo bar"/>);
-    }
-
-    function test_hasClass() {
-        boolVal = cheerioWrapper.find('.my-button').hasClass('disabled');
-    }
-
-    function test_is() {
-        boolVal = cheerioWrapper.is('.some-class');
-    }
-
-    function test_isEmpty() {
-        boolVal = cheerioWrapper.isEmpty()
-    }
-
-    function test_not() {
-        elementWrapper = cheerioWrapper.find('.foo').not('.bar');
-    }
-
-    function test_children() {
-        cheerioWrapper = cheerioWrapper.children();
-    }
-
-    function test_childAt() {
-        const childWrapper: CheerioWrapper<any, any> = cheerioWrapper.childAt(0);
-
-        interface TmpType1 {
-            foo: any
-        }
-
-        interface TmpType2 {
-            bar: any
-        }
-
-        const childWrapper2: CheerioWrapper<TmpType1, TmpType2> = cheerioWrapper.childAt<TmpType1, TmpType2>(0);
-    }
-
-    function test_parents() {
-        cheerioWrapper = cheerioWrapper.parents();
-    }
-
-    function test_parent() {
-        cheerioWrapper = cheerioWrapper.parent();
-    }
-
-    function test_closest() {
-        elementWrapper = cheerioWrapper.closest('.selector');
-        cheerioWrapper = cheerioWrapper.closest(MyComponent);
-        cheerioWrapper = cheerioWrapper.closest({ prop: 'myprop' });
-    }
-
-    function test_text() {
-        stringVal = cheerioWrapper.text();
-    }
-
-    function test_html() {
-        stringVal = cheerioWrapper.html();
-    }
-
-    function test_get() {
-        reactElement = cheerioWrapper.get(1);
-    }
-
-    function test_at() {
-        cheerioWrapper = cheerioWrapper.at(1);
-    }
-
-    function test_first() {
-        cheerioWrapper = cheerioWrapper.first();
-    }
-
-    function test_last() {
-        cheerioWrapper = cheerioWrapper.last();
-    }
-
-    function test_state() {
-        cheerioWrapper.state();
-        cheerioWrapper.state('key');
-        const tmp: String = cheerioWrapper.state<String>('key');
-    }
-
-    function test_context() {
-        cheerioWrapper.context();
-        cheerioWrapper.context('key');
-        const tmp: String = cheerioWrapper.context<String>('key');
-    }
-
-    function test_props() {
-        objectVal = cheerioWrapper.props();
-    }
-
-    function test_prop() {
-        cheerioWrapper.prop('key');
-        const tmp: String = cheerioWrapper.prop<String>('key');
-    }
-
-    function test_key() {
-        stringVal = cheerioWrapper.key();
-    }
-
-    function test_simulate(...args: any[]) {
-        cheerioWrapper.simulate('click');
-        cheerioWrapper.simulate('click', args);
-    }
-
-    function test_setState() {
-        cheerioWrapper = cheerioWrapper.setState({ stateProperty: 'state' });
-    }
-
-    function test_setProps() {
-        cheerioWrapper = cheerioWrapper.setProps({ propsProperty: 'foo' });
-    }
-
-    function test_setContext() {
-        cheerioWrapper = cheerioWrapper.setContext({ name: 'baz' });
-    }
-
-    function test_instance() {
-        var myComponent: MyComponent = cheerioWrapper.instance();
-    }
-
-    function test_update() {
-        cheerioWrapper = cheerioWrapper.update();
-    }
-
-    function test_debug() {
-        stringVal = cheerioWrapper.debug();
-    }
-
-    function test_type() {
-        var stringOrFunction: String | Function = cheerioWrapper.type();
-    }
-
-    function test_name() {
-        var str: String = cheerioWrapper.name();
-    }
-
-    function test_forEach() {
-        cheerioWrapper =
-            cheerioWrapper.forEach((aCheerioWrapper: CheerioWrapper<MyComponentProps, MyComponentState>) => {
-            });
-    }
-
-    function test_map() {
-        var arrayNumbers: Array<Number> =
-            cheerioWrapper.map(wrapper => wrapper.props().numberProp);
-    }
-
-    function test_reduce() {
-        const total: number =
-            cheerioWrapper.reduce<number>(
-                (amount: number, n: CheerioWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
-            );
-    }
-
-    function test_reduceRight() {
-        const total: number =
-            cheerioWrapper.reduceRight<number>(
-                (amount: number, n: CheerioWrapper<MyComponentProps, MyComponentState>) => amount + n.prop('amount')
-            );
-    }
-
-    function test_some() {
-        boolVal = cheerioWrapper.some('.selector');
-        boolVal = cheerioWrapper.some(MyComponent);
-    }
-
-    function test_someWhere() {
-        boolVal = cheerioWrapper.someWhere((aCheerioWrapper: CheerioWrapper<MyComponentProps, MyComponentState>) => true);
-    }
-
-    function test_every() {
-        boolVal = cheerioWrapper.every('.selector');
-        boolVal = cheerioWrapper.every(MyComponent);
-    }
-
-    function test_everyWhere() {
-        boolVal = cheerioWrapper.everyWhere((aCheerioWrapper: CheerioWrapper<MyComponentProps, MyComponentState>) => true);
-    }
+    wrapper.toggleClass('className');
 }

--- a/enzyme/enzyme-tests.tsx
+++ b/enzyme/enzyme-tests.tsx
@@ -60,8 +60,8 @@ namespace ShallowWrapperTest {
 
     function test_filter() {
         shallowWrapper = shallowWrapper.filter(MyComponent);
-        statelessWrapper = shallowWrapper.filter(MyStatelessComponent);
-        shallowWrapper = shallowWrapper.filter({ prop: 'value' });
+        statelessWrapper = statelessWrapper.filter(MyStatelessComponent);
+        shallowWrapper = shallowWrapper.filter({ numberProp: 12 });
         elementWrapper = shallowWrapper.filter('.selector');
     }
 
@@ -384,8 +384,8 @@ namespace ReactWrapperTest {
 
     function test_filter() {
         reactWrapper = reactWrapper.filter(MyComponent);
-        statelessWrapper = reactWrapper.filter(MyStatelessComponent);
-        reactWrapper = reactWrapper.filter({ prop: 'myprop' });
+        statelessWrapper = statelessWrapper.filter(MyStatelessComponent);
+        reactWrapper = reactWrapper.filter({ numberProp: 12 });
         elementWrapper = reactWrapper.filter('.selector');
     }
 

--- a/enzyme/index.d.ts
+++ b/enzyme/index.d.ts
@@ -352,10 +352,9 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * Removes nodes in the current wrapper that do not match the provided selector.
      * @param selector The selector to match.
      */
-    filter<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
-    filter<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
-    filter(props: EnzymePropSelector): ShallowWrapper<any, any>;
-    filter(selector: string): ShallowWrapper<HTMLAttributes, any>;
+    filter<P2>(component: ComponentClass<P2> | StatelessComponent<P2>): this;
+    filter(props: Partial<P>): this;
+    filter(selector: string): this;
 
     /**
      * Finds every node in the render tree that returns true for the provided predicate function.
@@ -459,10 +458,9 @@ export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
      * Removes nodes in the current wrapper that do not match the provided selector.
      * @param selector The selector to match.
      */
-    filter<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
-    filter<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
-    filter(props: EnzymePropSelector): ReactWrapper<any, any>;
-    filter(selector: string): ReactWrapper<HTMLAttributes, any>;
+    filter<P2>(component: ComponentClass<P2> | StatelessComponent<P2>): this;
+    filter(props: Partial<P>): this;
+    filter(selector: string): this;
 
     /**
      * Returns a new wrapper with all of the children of the node(s) in the current wrapper. Optionally, a selector

--- a/enzyme/index.d.ts
+++ b/enzyme/index.d.ts
@@ -1,15 +1,26 @@
-// Type definitions for Enzyme v2.7.0
+// Type definitions for Enzyme 2.7
 // Project: https://github.com/airbnb/enzyme
-// Definitions by: Marian Palkus <https://github.com/MarianPalkus>, Cap3 <http://www.cap3.de>, Ivo Stratev <https://github.com/NoHomey>, Tom Crockett <https://github.com/pelotom>
+// Definitions by: Marian Palkus <https://github.com/MarianPalkus>, Cap3 <http://www.cap3.de>, Ivo Stratev <https://github.com/NoHomey>, Tom Crockett <https://github.com/pelotom>, jwbay <https://githb.com/jwbay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-import { ReactElement, Component, StatelessComponent, ComponentClass, HTMLAttributes as ReactHTMLAttributes, SVGAttributes as ReactSVGAttributes } from "react";
+/// <reference types="cheerio" />
+import { ReactElement, Component, HTMLAttributes as ReactHTMLAttributes, SVGAttributes as ReactSVGAttributes } from "react";
 
 type HTMLAttributes = ReactHTMLAttributes<{}> & ReactSVGAttributes<{}>;
 
 export class ElementClass extends Component<any, any> {
 }
+
+/* These are purposefully stripped down versions of React.ComponentClass and React.StatelessComponent.
+ * The optional static properties on them break overload ordering for wrapper methods if they're not
+ * all specified in the implementation. TS chooses the EnzymePropSelector overload and loses the generics
+ */
+interface ComponentClass<Props> {
+    new(props?: Props, context?: any): Component<Props, any>;
+}
+
+type StatelessComponent<Props> = (props: Props, context?: any) => JSX.Element;
 
 /**
  * Many methods in Enzyme's API accept a selector as an argument. Selectors in Enzyme can fall into one of the
@@ -21,34 +32,12 @@ export class ElementClass extends Component<any, any> {
  *  4. A React Stateless component
  *  5. A React component property map
  */
-export type EnzymeSelector = string | StatelessComponent<any> | ComponentClass<any> | { [key: string]: any };
-export type EnzymePropSelector = { [key: string]: any };
+export interface EnzymePropSelector {
+    [key: string]: any;
+}
+export type EnzymeSelector = string | StatelessComponent<any> | ComponentClass<any> | EnzymePropSelector;
 
 interface CommonWrapper<P, S> {
-    /**
-     * Find every node in the render tree that matches the provided selector.
-     * @param selector The selector to match.
-     */
-    find<P2>(component: ComponentClass<P2>): CommonWrapper<P2, any>;
-    find<P2>(statelessComponent: StatelessComponent<P2>): CommonWrapper<P2, {}>;
-    find(props: EnzymePropSelector): CommonWrapper<any, any>;
-    find(selector: string): CommonWrapper<HTMLAttributes, any>;
-
-    /**
-     * Finds every node in the render tree that returns true for the provided predicate function.
-     * @param predicate
-     */
-    findWhere(predicate: (wrapper: CommonWrapper<any, any>) => boolean): CommonWrapper<any, any>;
-
-    /**
-     * Removes nodes in the current wrapper that do not match the provided selector.
-     * @param selector The selector to match.
-     */
-    filter<P2>(component: ComponentClass<P2>): CommonWrapper<P2, any>;
-    filter<P2>(statelessComponent: StatelessComponent<P2>): CommonWrapper<P2, {}>;
-    filter(props: EnzymePropSelector): CommonWrapper<any, any>;
-    filter(selector: string): CommonWrapper<HTMLAttributes, any>;
-
     /**
      * Returns a new wrapper with only the nodes of the current wrapper that, when passed into the provided predicate function, return true.
      * @param predicate
@@ -71,13 +60,13 @@ interface CommonWrapper<P, S> {
      * Returns whether or not all the given react elements exists in the shallow render tree
      * @param nodes
      */
-    containsAllMatchingElements(nodes: ReactElement<any>[]): boolean;
+    containsAllMatchingElements(nodes: Array<ReactElement<any>>): boolean;
 
     /**
      * Returns whether or not one of the given react elements exists in the shallow render tree.
      * @param nodes
      */
-    containsAnyMatchingElements(nodes: ReactElement<any>[]): boolean;
+    containsAnyMatchingElements(nodes: Array<ReactElement<any>>): boolean;
 
     /**
      * Returns whether or not the current render tree is equal to the given node, based on the expected value.
@@ -117,54 +106,6 @@ interface CommonWrapper<P, S> {
      * @param selector
      */
     not(selector: EnzymeSelector): this;
-
-    /**
-     * Returns a new wrapper with all of the children of the node(s) in the current wrapper. Optionally, a selector
-     * can be provided and it will filter the children by this selector.
-     * @param [selector]
-     */
-    children<P2>(component: ComponentClass<P2>): CommonWrapper<P2, any>;
-    children<P2>(statelessComponent: StatelessComponent<P2>): CommonWrapper<P2, {}>;
-    children(props: EnzymePropSelector): CommonWrapper<any, any>;
-    children(selector: string): CommonWrapper<HTMLAttributes, any>;
-    children(): CommonWrapper<any, any>;
-
-    /**
-     * Returns a new wrapper with child at the specified index.
-     * @param index
-     */
-    childAt(index: number): CommonWrapper<any, any>;
-    childAt<P2, S2>(index: number): CommonWrapper<P2, S2>;
-
-    /**
-     * Returns a wrapper around all of the parents/ancestors of the wrapper. Does not include the node in the
-     * current wrapper. Optionally, a selector can be provided and it will filter the parents by this selector.
-     *
-     * Note: can only be called on a wrapper of a single node.
-     * @param [selector]
-     */
-    parents<P2>(component: ComponentClass<P2>): CommonWrapper<P2, any>;
-    parents<P2>(statelessComponent: StatelessComponent<P2>): CommonWrapper<P2, {}>;
-    parents(props: EnzymePropSelector): CommonWrapper<any, any>;
-    parents(selector: string): CommonWrapper<HTMLAttributes, any>;
-    parents(): CommonWrapper<any, any>;
-
-    /**
-     * Returns a wrapper with the direct parent of the node in the current wrapper.
-     */
-    parent(): CommonWrapper<any, any>;
-
-    /**
-     * Returns a wrapper of the first element that matches the selector by traversing up through the current node's
-     * ancestors in the tree, starting with itself.
-     *
-     * Note: can only be called on a wrapper of a single node.
-     * @param selector
-     */
-    closest<P2>(component: ComponentClass<P2>): CommonWrapper<P2, any>;
-    closest<P2>(statelessComponent: StatelessComponent<P2>): CommonWrapper<P2, {}>;
-    closest(props: EnzymePropSelector): CommonWrapper<any, any>;
-    closest(selector: string): CommonWrapper<HTMLAttributes, any>;
 
     /**
      * Returns a string of the rendered text of the current render tree. This function should be looked at with
@@ -209,14 +150,14 @@ interface CommonWrapper<P, S> {
      * @param [key]
      */
     state(): S;
-    state(key: string): any;
+    state<K extends keyof S>(key: K): S[K];
     state<T>(key: string): T;
 
     /**
      * Returns the context hash for the root node of the wrapper. Optionally pass in a prop name and it will return just that value.
      */
-    context(key?: string): any;
-    context<T>(key?: string): T;
+    context(): any;
+    context<T>(key: string): T;
 
     /**
      * Returns the props hash for the current node of the wrapper.
@@ -231,7 +172,7 @@ interface CommonWrapper<P, S> {
      * NOTE: can only be called on a wrapper of a single node.
      * @param key
      */
-    prop(key: string): any;
+    prop<K extends keyof P>(key: K): P[K];
     prop<T>(key: string): T;
 
     /**
@@ -260,7 +201,7 @@ interface CommonWrapper<P, S> {
      * @param state
          * @param [callback]
      */
-        setState(state: S, callback?: () => void): this;
+    setState<K extends keyof S>(state: Pick<S, K>, callback?: () => void): this;
 
     /**
      * A method that sets the props of the root component, and re-renders. Useful for when you are wanting to test
@@ -274,7 +215,7 @@ interface CommonWrapper<P, S> {
          * @param props
          * @param [callback]
      */
-        setProps(props: P, callback?: () => void): this;
+    setProps<K extends keyof P>(props: Pick<P, K>): this;
 
     /**
      * A method that sets the context of the root component, and re-renders. Useful for when you are wanting to
@@ -284,7 +225,7 @@ interface CommonWrapper<P, S> {
      * NOTE: can only be called on a wrapper instance that is also the root instance.
      * @param state
      */
-    setContext(context: Object): this;
+    setContext(context: any): this;
 
     /**
      * Gets the instance of the component being rendered as the root node passed into shallow().
@@ -307,14 +248,6 @@ interface CommonWrapper<P, S> {
      * tests are not passing when you expect them to.
      */
     debug(): string;
-
-    /**
-     * Returns the type of the current node of this wrapper. If it's a composite component, this will be the
-     * component constructor. If it's native DOM node, it will be a string of the tag name.
-     *
-     * Note: can only be called on a wrapper of a single node.
-     */
-    type(): string | Function;
 
     /**
      * Returns the name of the current node of the wrapper.
@@ -381,12 +314,29 @@ interface CommonWrapper<P, S> {
      */
     everyWhere(fn: (wrapper: this) => boolean): boolean;
 
+    /**
+     * Returns true if renderer returned null
+     */
+    isEmptyRender(): boolean;
+
+    /**
+     * Renders the component to static markup and returns a Cheerio wrapper around the result.
+     */
+    render(): Cheerio;
+
+    /**
+     * Returns the type of the current node of this wrapper. If it's a composite component, this will be the
+     * component constructor. If it's native DOM node, it will be a string of the tag name.
+     *
+     * Note: can only be called on a wrapper of a single node.
+     */
+    type(): string | ComponentClass<P> | StatelessComponent<P> ;
+
     length: number;
 }
 
 export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
     shallow(): ShallowWrapper<P, S>;
-    render(): CheerioWrapper<P, S>;
     unmount(): ShallowWrapper<any, any>;
 
     /**
@@ -394,7 +344,7 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * @param selector The selector to match.
      */
     find<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
-    find<P2>(statelessComponent: (props: P2) => JSX.Element): ShallowWrapper<P2, {}>;
+    find<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     find(props: EnzymePropSelector): ShallowWrapper<any, any>;
     find(selector: string): ShallowWrapper<HTMLAttributes, any>;
 
@@ -403,7 +353,7 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * @param selector The selector to match.
      */
     filter<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
-    filter<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, {}>;
+    filter<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     filter(props: EnzymePropSelector): ShallowWrapper<any, any>;
     filter(selector: string): ShallowWrapper<HTMLAttributes, any>;
 
@@ -411,7 +361,7 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * Finds every node in the render tree that returns true for the provided predicate function.
      * @param predicate
      */
-    findWhere(predicate: (wrapper: CommonWrapper<any, any>) => boolean): ShallowWrapper<any, any>;
+    findWhere(predicate: (wrapper: ShallowWrapper<any, any>) => boolean): ShallowWrapper<any, any>;
 
     /**
      * Returns a new wrapper with all of the children of the node(s) in the current wrapper. Optionally, a selector
@@ -419,10 +369,9 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * @param [selector]
      */
     children<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
-    children<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, {}>;
-    children(props: EnzymePropSelector): ShallowWrapper<any, any>;
+    children<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     children(selector: string): ShallowWrapper<HTMLAttributes, any>;
-    children(): ShallowWrapper<any, any>;
+    children(props?: EnzymePropSelector): ShallowWrapper<any, any>;
 
     /**
      * Returns a new wrapper with child at the specified index.
@@ -432,13 +381,13 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
     childAt<P2, S2>(index: number): ShallowWrapper<P2, S2>;
 
     /**
-         * Shallow render the one non-DOM child of the current wrapper, and return a wrapper around the result.
-         * NOTE: can only be called on wrapper of a single non-DOM component element node.
-         * @param [options]
-         */
-        dive<P2, S2>(options?: ShallowRendererProps): ShallowWrapper<P2, S2>;
+     * Shallow render the one non-DOM child of the current wrapper, and return a wrapper around the result.
+     * NOTE: can only be called on wrapper of a single non-DOM component element node.
+     * @param [options]
+     */
+    dive<P2, S2>(options?: ShallowRendererProps): ShallowWrapper<P2, S2>;
 
-        /**
+    /**
      * Returns a wrapper around all of the parents/ancestors of the wrapper. Does not include the node in the
      * current wrapper. Optionally, a selector can be provided and it will filter the parents by this selector.
      *
@@ -446,10 +395,9 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * @param [selector]
      */
     parents<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
-    parents<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, {}>;
-    parents(props: EnzymePropSelector): ShallowWrapper<any, any>;
+    parents<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     parents(selector: string): ShallowWrapper<HTMLAttributes, any>;
-    parents(): ShallowWrapper<any, any>;
+    parents(props?: EnzymePropSelector): ShallowWrapper<any, any>;
 
     /**
      * Returns a wrapper of the first element that matches the selector by traversing up through the current node's
@@ -459,7 +407,7 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * @param selector
      */
     closest<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
-    closest<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, {}>;
+    closest<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     closest(props: EnzymePropSelector): ShallowWrapper<any, any>;
     closest(selector: string): ShallowWrapper<HTMLAttributes, any>;
 
@@ -467,17 +415,11 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * Returns a wrapper with the direct parent of the node in the current wrapper.
      */
     parent(): ShallowWrapper<any, any>;
-
-    /**
-     * Returns true if renderer returned null
-     */
-    isEmptyRender(): boolean;
 }
 
 export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
     unmount(): ReactWrapper<any, any>;
     mount(): ReactWrapper<any, any>;
-    render(): CheerioWrapper<P, S>;
 
     /**
      * Returns a wrapper of the node that matches the provided reference name.
@@ -503,7 +445,7 @@ export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
      * @param selector The selector to match.
      */
     find<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
-    find<P2>(statelessComponent: (props: P2) => JSX.Element): ReactWrapper<P2, {}>;
+    find<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     find(props: EnzymePropSelector): ReactWrapper<any, any>;
     find(selector: string): ReactWrapper<HTMLAttributes, any>;
 
@@ -511,14 +453,14 @@ export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
      * Finds every node in the render tree that returns true for the provided predicate function.
      * @param predicate
      */
-    findWhere(predicate: (wrapper: CommonWrapper<any, any>) => boolean): ReactWrapper<any, any>;
+    findWhere(predicate: (wrapper: ReactWrapper<any, any>) => boolean): ReactWrapper<any, any>;
 
     /**
      * Removes nodes in the current wrapper that do not match the provided selector.
      * @param selector The selector to match.
      */
     filter<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
-    filter<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, {}>;
+    filter<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     filter(props: EnzymePropSelector): ReactWrapper<any, any>;
     filter(selector: string): ReactWrapper<HTMLAttributes, any>;
 
@@ -528,10 +470,9 @@ export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
      * @param [selector]
      */
     children<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
-    children<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, {}>;
-    children(props: EnzymePropSelector): ReactWrapper<any, any>;
+    children<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     children(selector: string): ReactWrapper<HTMLAttributes, any>;
-    children(): ReactWrapper<any, any>;
+    children(props?: EnzymePropSelector): ReactWrapper<any, any>;
 
     /**
      * Returns a new wrapper with child at the specified index.
@@ -548,10 +489,9 @@ export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
      * @param [selector]
      */
     parents<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
-    parents<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, {}>;
-    parents(props: EnzymePropSelector): ReactWrapper<any, any>;
+    parents<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     parents(selector: string): ReactWrapper<HTMLAttributes, any>;
-    parents(): ReactWrapper<any, any>;
+    parents(props?: EnzymePropSelector): ReactWrapper<any, any>;
 
     /**
      * Returns a wrapper of the first element that matches the selector by traversing up through the current node's
@@ -561,7 +501,7 @@ export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
      * @param selector
      */
     closest<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
-    closest<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, {}>;
+    closest<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     closest(props: EnzymePropSelector): ReactWrapper<any, any>;
     closest(selector: string): ReactWrapper<HTMLAttributes, any>;
 
@@ -569,15 +509,6 @@ export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
      * Returns a wrapper with the direct parent of the node in the current wrapper.
      */
     parent(): ReactWrapper<any, any>;
-
-    /**
-     * Returns true if renderer returned null
-     */
-    isEmptyRender(): boolean;
-}
-
-export interface CheerioWrapper<P, S> extends CommonWrapper<P, S> {
-
 }
 
 export interface ShallowRendererProps {
@@ -626,8 +557,4 @@ export function mount<P, S>(node: ReactElement<P>, options?: MountRendererProps)
  * @param node
  * @param [options]
  */
-export function render<P, S>(node: ReactElement<P>, options?: any): CheerioWrapper<P, S>;
-
-export function describeWithDOM(description: string, fn: Function): void;
-
-export function spyLifecycle(component: typeof Component): void;
+export function render<P, S>(node: ReactElement<P>, options?: any): Cheerio;

--- a/enzyme/tslint.json
+++ b/enzyme/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../tslint.json"
+}


### PR DESCRIPTION
This is mainly to fix
`wrapper.find(MyClassComponent).props().someCallbackk(); //oops, typo`
not being caught with the latest TypeScript + definitions. I am not sure where things went wrong for that, but there is a note at the top of index.d.ts around it. The first part of the fix was #14202, but it wasn't quite enough.

Additional changes:

* Add Pick typings for setState/setProps, mirrors #13155
* Fix Cheerio wrapper to reference Cheerio typings (this was incorrect from day 1 I think -- the interfaces are not the same). This let me delete tons of overloads from CommonWrapper, which should help with typecheck performance (Enzyme types have historically caused problems there)
* Remove deprecated APIs (they've been gone for about a year)
* Add tslint and fix errors
* Normalize React+Shallow wrapper tests and add some missing overload tests
* If we're filtered down to a wrapper containing stateless components, the type of wrapper.state() is never

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/enzyme/blob/master/CHANGELOG.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.