### PR TITLE
Add 'matb33:collection-hooks' type definitions

### DIFF
--- a/meteor-collection-hooks/README.md
+++ b/meteor-collection-hooks/README.md
@@ -1,0 +1,4 @@
+# Meteor Collection Hooks Definitions
+
+Type definitions for Meteor package `matb33:collection-hooks`.
+Be sure to reference any sort of basic Meteor type definitions file before use.

--- a/meteor-collection-hooks/index.d.ts
+++ b/meteor-collection-hooks/index.d.ts
@@ -1,0 +1,184 @@
+// Type definitions for Meteor package matb33:collection-hooks
+// Project: https://github.com/matb33/meteor-collection-hooks
+// Definitions by: Trygve Wastvedt <https://github.com/twastvedt>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'meteor/mongo' {
+  namespace Mongo {
+    interface Selector {}
+    interface Modifier {}
+    interface ObjectID {}
+    interface SortSpecifier {}
+    interface FieldSpecifier {}
+    interface Cursor<T> {}
+
+    interface Collection<T> {
+      before: {
+        find(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+        findOne(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+        insert(hook: {(userId: string, doc: T): void}): void;
+        remove(hook: {(userId: string, doc: T): void}): void;
+        update(hook: {(userId: string, doc: T, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+        upsert(hook: {(userId: string, doc: T, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+      };
+      after: {
+        find(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, cursor: Mongo.Cursor<T>): void}): void;
+        findOne(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, doc: T): void}): void;
+        insert(hook: {(userId: string, doc: T): void}): void;
+        remove(hook: {(userId: string, doc: T): void}): void;
+        update(hook: {(userId: string, doc: T, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}, options?: HookOptions): void;
+        upsert(hook: {(userId: string, doc: T, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+      };
+      direct: {
+        find(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
+          sort?: Mongo.SortSpecifier;
+          skip?: number;
+          limit?: number;
+          fields?: Mongo.FieldSpecifier;
+          reactive?: boolean;
+          transform?: Function;
+        }): Mongo.Cursor<T>;
+        findOne(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
+          sort?: Mongo.SortSpecifier;
+          skip?: number;
+          fields?: Mongo.FieldSpecifier;
+          reactive?: boolean;
+          transform?: Function;
+        }): T;
+        insert(doc: T, callback?: Function): string;
+        remove(selector: Mongo.Selector | Mongo.ObjectID | string, callback?: Function): number;
+        update(selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
+          multi?: boolean;
+          upsert?: boolean;
+        }, callback?: Function): number;
+        upsert(selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
+          multi?: boolean;
+        }, callback?: Function): {numberAffected?: number; insertedId?: string;};
+      };
+      hookOptions: CollectionOptions;
+    }
+  }
+
+  interface HookOptions {
+    fetchPrevious?: boolean;
+  }
+
+  interface CollectionOptions {
+    before?: {
+      all?: HookOptions;
+      find?: HookOptions;
+      findOne?: HookOptions;
+      insert?: HookOptions;
+      remove?: HookOptions;
+      update?: HookOptions;
+      upsert?: HookOptions;
+    };
+    after?: {
+      all?: HookOptions;
+      find?: HookOptions;
+      findOne?: HookOptions;
+      insert?: HookOptions;
+      remove?: HookOptions;
+      update?: HookOptions;
+      upsert?: HookOptions;
+    };
+    all?: {
+      all?: HookOptions;
+      find?: HookOptions;
+      findOne?: HookOptions;
+      insert?: HookOptions;
+      remove?: HookOptions;
+      update?: HookOptions;
+      upsert?: HookOptions;
+    };
+  }
+}
+
+declare namespace Mongo {
+  interface Selector {}
+  interface Modifier {}
+  interface ObjectID {}
+  interface SortSpecifier {}
+  interface FieldSpecifier {}
+  interface Cursor<T> {}
+
+  interface Collection<T> {
+    before: {
+      find(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+      findOne(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+      insert(hook: {(userId: string, doc: T): void}): void;
+      remove(hook: {(userId: string, doc: T): void}): void;
+      update(hook: {(userId: string, doc: T, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+      upsert(hook: {(userId: string, doc: T, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+    };
+    after: {
+      find(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, cursor: Mongo.Cursor<T>): void}): void;
+      findOne(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, doc: T): void}): void;
+      insert(hook: {(userId: string, doc: T): void}): void;
+      remove(hook: {(userId: string, doc: T): void}): void;
+      update(hook: {(userId: string, doc: T, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}, options?: HookOptions): void;
+      upsert(hook: {(userId: string, doc: T, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+    };
+    direct: {
+      find(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
+        sort?: Mongo.SortSpecifier;
+        skip?: number;
+        limit?: number;
+        fields?: Mongo.FieldSpecifier;
+        reactive?: boolean;
+        transform?: Function;
+      }): Mongo.Cursor<T>;
+      findOne(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
+        sort?: Mongo.SortSpecifier;
+        skip?: number;
+        fields?: Mongo.FieldSpecifier;
+        reactive?: boolean;
+        transform?: Function;
+      }): T;
+      insert(doc: T, callback?: Function): string;
+      remove(selector: Mongo.Selector | Mongo.ObjectID | string, callback?: Function): number;
+      update(selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
+        multi?: boolean;
+        upsert?: boolean;
+      }, callback?: Function): number;
+      upsert(selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
+        multi?: boolean;
+      }, callback?: Function): {numberAffected?: number; insertedId?: string;};
+    };
+    hookOptions: CollectionOptions;
+  }
+}
+
+declare interface HookOptions {
+  fetchPrevious?: boolean;
+}
+
+declare interface CollectionOptions {
+  before?: {
+    all?: HookOptions;
+    find?: HookOptions;
+    findOne?: HookOptions;
+    insert?: HookOptions;
+    remove?: HookOptions;
+    update?: HookOptions;
+    upsert?: HookOptions;
+  };
+  after?: {
+    all?: HookOptions;
+    find?: HookOptions;
+    findOne?: HookOptions;
+    insert?: HookOptions;
+    remove?: HookOptions;
+    update?: HookOptions;
+    upsert?: HookOptions;
+  };
+  all?: {
+    all?: HookOptions;
+    find?: HookOptions;
+    findOne?: HookOptions;
+    insert?: HookOptions;
+    remove?: HookOptions;
+    update?: HookOptions;
+    upsert?: HookOptions;
+  };
+}

--- a/meteor-collection-hooks/index.d.ts
+++ b/meteor-collection-hooks/index.d.ts
@@ -1,123 +1,94 @@
-// Type definitions for Meteor package matb33:collection-hooks
+// Type definitions for Meteor package matb33:collection-hooks 0.8
 // Project: https://github.com/matb33/meteor-collection-hooks
 // Definitions by: Trygve Wastvedt <https://github.com/twastvedt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module 'meteor/mongo' {
-  namespace Mongo {
-    interface Selector {}
-    interface Modifier {}
-    interface ObjectID {}
-    interface SortSpecifier {}
-    interface FieldSpecifier {}
-    interface Cursor<T> {}
-
-    interface Collection<T> {
-      before: {
-        find(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void}): void;
-        findOne(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void}): void;
-        insert(hook: {(userId: string, doc: T): void}): void;
-        remove(hook: {(userId: string, doc: T): void}): void;
-        update(hook: {(userId: string, doc: T, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
-        upsert(hook: {(userId: string, doc: T, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
-      };
-      after: {
-        find(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, cursor: Mongo.Cursor<T>): void}): void;
-        findOne(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, doc: T): void}): void;
-        insert(hook: {(userId: string, doc: T): void}): void;
-        remove(hook: {(userId: string, doc: T): void}): void;
-        update(hook: {(userId: string, doc: T, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}, options?: HookOptions): void;
-        upsert(hook: {(userId: string, doc: T, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
-      };
-      direct: {
-        find(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
-          sort?: Mongo.SortSpecifier;
-          skip?: number;
-          limit?: number;
-          fields?: Mongo.FieldSpecifier;
-          reactive?: boolean;
-          transform?: Function;
-        }): Mongo.Cursor<T>;
-        findOne(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
-          sort?: Mongo.SortSpecifier;
-          skip?: number;
-          fields?: Mongo.FieldSpecifier;
-          reactive?: boolean;
-          transform?: Function;
-        }): T;
-        insert(doc: T, callback?: Function): string;
-        remove(selector: Mongo.Selector | Mongo.ObjectID | string, callback?: Function): number;
-        update(selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
-          multi?: boolean;
-          upsert?: boolean;
-        }, callback?: Function): number;
-        upsert(selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
-          multi?: boolean;
-        }, callback?: Function): {numberAffected?: number; insertedId?: string;};
-      };
-      hookOptions: CollectionOptions;
-    }
-  }
-
-  interface HookOptions {
-    fetchPrevious?: boolean;
-  }
-
-  interface CollectionOptions {
-    before?: {
-      all?: HookOptions;
-      find?: HookOptions;
-      findOne?: HookOptions;
-      insert?: HookOptions;
-      remove?: HookOptions;
-      update?: HookOptions;
-      upsert?: HookOptions;
-    };
-    after?: {
-      all?: HookOptions;
-      find?: HookOptions;
-      findOne?: HookOptions;
-      insert?: HookOptions;
-      remove?: HookOptions;
-      update?: HookOptions;
-      upsert?: HookOptions;
-    };
-    all?: {
-      all?: HookOptions;
-      find?: HookOptions;
-      findOne?: HookOptions;
-      insert?: HookOptions;
-      remove?: HookOptions;
-      update?: HookOptions;
-      upsert?: HookOptions;
-    };
-  }
-}
+/// <reference path="meteor-mongo.d.ts" />
 
 declare namespace Mongo {
-  interface Selector {}
-  interface Modifier {}
-  interface ObjectID {}
-  interface SortSpecifier {}
-  interface FieldSpecifier {}
-  interface Cursor<T> {}
-
   interface Collection<T> {
     before: {
-      find(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void}): void;
-      findOne(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void}): void;
-      insert(hook: {(userId: string, doc: T): void}): void;
-      remove(hook: {(userId: string, doc: T): void}): void;
-      update(hook: {(userId: string, doc: T, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
-      upsert(hook: {(userId: string, doc: T, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+      find(hook: (
+          userId: string,
+          selector: Mongo.Selector,
+          options: CollectionHooks.ModifierOptions
+        ) => void
+      ): void;
+      findOne(hook: (
+          userId: string,
+          selector: Mongo.Selector,
+          options: CollectionHooks.ModifierOptions
+        ) => void
+      ): void;
+      insert(hook: (
+          userId: string,
+          doc: T
+        ) => void
+      ): void;
+      remove(hook: (
+          userId: string,
+          doc: T
+        ) => void
+      ): void;
+      update(hook: (
+          userId: string,
+          doc: T,
+          fieldNames: string[],
+          modifier: Mongo.Modifier,
+          options: CollectionHooks.ModifierOptions
+        ) => void
+      ): void;
+      upsert(hook: (
+          userId: string,
+          doc: T,
+          selector: Mongo.Selector,
+          modifier: Mongo.Modifier,
+          options: CollectionHooks.ModifierOptions
+        ) => void
+      ): void;
     };
     after: {
-      find(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, cursor: Mongo.Cursor<T>): void}): void;
-      findOne(hook: {(userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, doc: T): void}): void;
-      insert(hook: {(userId: string, doc: T): void}): void;
-      remove(hook: {(userId: string, doc: T): void}): void;
-      update(hook: {(userId: string, doc: T, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}, options?: HookOptions): void;
-      upsert(hook: {(userId: string, doc: T, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void}): void;
+      find(hook: (
+          userId: string,
+          selector: Mongo.Selector,
+          options: CollectionHooks.ModifierOptions,
+          cursor: Mongo.Cursor<T>
+        ) => void
+      ): void;
+      findOne(hook: (
+          userId: string,
+          selector: Mongo.Selector,
+          options: CollectionHooks.ModifierOptions,
+          doc: T
+        ) => void
+      ): void;
+      insert(hook: (
+          userId: string,
+          doc: T
+        ) => void
+      ): void;
+      remove(hook: (
+          userId: string,
+          doc: T
+        ) => void
+      ): void;
+      update(hook: (
+          userId: string,
+          doc: T,
+          fieldNames: string[],
+          modifier: Mongo.Modifier,
+          options: CollectionHooks.ModifierOptions
+        ) => void,
+        options?: CollectionHooks.HookOptionValue
+      ): void;
+      upsert(hook: (
+          userId: string,
+          doc: T,
+          selector: Mongo.Selector,
+          modifier: Mongo.Modifier,
+          options: CollectionHooks.ModifierOptions
+        ) => void
+      ): void;
     };
     direct: {
       find(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
@@ -126,59 +97,63 @@ declare namespace Mongo {
         limit?: number;
         fields?: Mongo.FieldSpecifier;
         reactive?: boolean;
-        transform?: Function;
+        transform?: (doc: any) => void;
       }): Mongo.Cursor<T>;
       findOne(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
         sort?: Mongo.SortSpecifier;
         skip?: number;
         fields?: Mongo.FieldSpecifier;
         reactive?: boolean;
-        transform?: Function;
+        transform?: (doc: any) => void;
       }): T;
-      insert(doc: T, callback?: Function): string;
-      remove(selector: Mongo.Selector | Mongo.ObjectID | string, callback?: Function): number;
-      update(selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
-        multi?: boolean;
-        upsert?: boolean;
-      }, callback?: Function): number;
-      upsert(selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
-        multi?: boolean;
-      }, callback?: Function): {numberAffected?: number; insertedId?: string;};
+      insert(
+        doc: T,
+        callback?: () => void
+      ): string;
+      remove(
+        selector: Mongo.Selector | Mongo.ObjectID | string, callback?: () => void
+      ): number;
+      update(
+        selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
+          multi?: boolean;
+          upsert?: boolean;
+        },
+        callback?: () => void
+      ): number;
+      upsert(
+        selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
+          multi?: boolean;
+        },
+        callback?: () => void
+      ): { numberAffected?: number; insertedId?: string; };
     };
-    hookOptions: CollectionOptions;
+    hookOptions: CollectionHooks.GlobalHookOptions;
   }
 }
 
-declare interface HookOptions {
-  fetchPrevious?: boolean;
-}
+declare namespace CollectionHooks {
+  interface ModifierOptions {
+    multi?: boolean;
+    upsert?: boolean;
+  }
 
-declare interface CollectionOptions {
-  before?: {
-    all?: HookOptions;
-    find?: HookOptions;
-    findOne?: HookOptions;
-    insert?: HookOptions;
-    remove?: HookOptions;
-    update?: HookOptions;
-    upsert?: HookOptions;
-  };
-  after?: {
-    all?: HookOptions;
-    find?: HookOptions;
-    findOne?: HookOptions;
-    insert?: HookOptions;
-    remove?: HookOptions;
-    update?: HookOptions;
-    upsert?: HookOptions;
-  };
-  all?: {
-    all?: HookOptions;
-    find?: HookOptions;
-    findOne?: HookOptions;
-    insert?: HookOptions;
-    remove?: HookOptions;
-    update?: HookOptions;
-    upsert?: HookOptions;
-  };
+  interface HookOptionValue {
+    fetchPrevious?: boolean;
+  }
+
+  interface LocalHookOptions {
+    all?: HookOptionValue;
+    find?: HookOptionValue;
+    findOne?: HookOptionValue;
+    insert?: HookOptionValue;
+    remove?: HookOptionValue;
+    update?: HookOptionValue;
+    upsert?: HookOptionValue;
+  }
+
+  interface GlobalHookOptions {
+    before?: LocalHookOptions;
+    after?: LocalHookOptions;
+    all?: LocalHookOptions;
+  }
 }

--- a/meteor-collection-hooks/meteor-collection-hooks-tests.ts
+++ b/meteor-collection-hooks/meteor-collection-hooks-tests.ts
@@ -1,0 +1,79 @@
+/// <reference types="meteor-typings" />
+
+interface Model {
+  _id: string;
+  value: number;
+}
+
+const Collection = new Mongo.Collection<Model>("test_collection");
+let cursor: Mongo.Cursor<Model>;
+let doc: Model;
+
+const selector = {
+  sort: { createdAt: -1 },
+  skip: 5,
+  limit: 5,
+  fields: { createdAt: 1 },
+  reacrive: true,
+  transform: function () {}
+};
+
+Collection.before.find(function (userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void {});
+Collection.before.findOne(function (userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }): void {});
+Collection.before.insert(function (userId: string, doc: Model): void {});
+Collection.before.remove(function (userId: string, doc: Model): void {});
+Collection.before.update(function (userId: string, doc: Model, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void {});
+Collection.before.upsert(function (userId: string, doc: Model, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void {});
+
+Collection.after.find(function (userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, cursor: Mongo.Cursor<Model>): void {});
+Collection.after.findOne(function (userId: string, selector: Mongo.Selector, options: { multi?: boolean; upsert?: boolean; }, doc: Model): void {});
+Collection.after.insert(function (userId: string, doc: Model): void {});
+Collection.after.remove(function (userId: string, doc: Model): void {});
+Collection.after.update(function (userId: string, doc: Model, fieldNames: string[], modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void {}, { fetchPrevious: true });
+Collection.after.upsert(function (userId: string, doc: Model, selector: Mongo.Selector, modifier: Mongo.Modifier, options: { multi?: boolean; upsert?: boolean; }): void {});
+
+cursor = Collection.direct.find({ _id: doc._id }, { sort: { createdAt: -1 }, skip: 5, limit: 5, fields: { createdAt: 1 }, reactive: true, transform: function () {} });
+cursor = Collection.direct.find(doc._id, { sort: { createdAt: -1 }, skip: 5, limit: 5, fields: { createdAt: 1 }, reactive: true, transform: function () {} });
+
+doc = Collection.direct.findOne({ _id: doc._id }, { sort: { createdAt: -1 }, skip: 5, fields: { createdAt: 1 }, reactive: true, transform: function () {} });
+doc = Collection.direct.findOne(doc._id, { sort: { createdAt: -1 }, skip: 5, fields: { createdAt: 1 }, reactive: true, transform: function () {} });
+
+doc._id = Collection.direct.insert(doc, function () {});
+
+doc.value = Collection.direct.remove({ _id: doc._id }, function () {});
+doc.value = Collection.direct.remove(doc._id, function () {});
+
+doc.value = Collection.direct.update({ _id: doc._id }, { $inc: { votes: 2 } }, { multi: true, upsert: true }, function () {});
+doc.value = Collection.direct.update(doc._id, { $inc: { votes: 2 } }, { multi: true, upsert: true }, function () {});
+
+let { numberAffected, insertedId }: { numberAffected?: number; insertedId?: string; } = Collection.direct.upsert(doc._id, { $inc: { votes: 2 } }, { multi: true }, function () {});
+
+Collection.hookOptions = {
+  before: {
+    all: { fetchPrevious: true },
+    find: { fetchPrevious: true },
+    findOne: { fetchPrevious: true },
+    insert: { fetchPrevious: true },
+    remove: { fetchPrevious: true },
+    update: { fetchPrevious: true },
+    upsert: { fetchPrevious: true }
+  },
+  after: {
+    all: { fetchPrevious: true },
+    find: { fetchPrevious: true },
+    findOne: { fetchPrevious: true },
+    insert: { fetchPrevious: true },
+    remove: { fetchPrevious: true },
+    update: { fetchPrevious: true },
+    upsert: { fetchPrevious: true }
+  },
+  all: {
+    all: { fetchPrevious: true },
+    find: { fetchPrevious: true },
+    findOne: { fetchPrevious: true },
+    insert: { fetchPrevious: true },
+    remove: { fetchPrevious: true },
+    update: { fetchPrevious: true },
+    upsert: { fetchPrevious: true }
+  }
+};

--- a/meteor-collection-hooks/meteor-mongo.d.ts
+++ b/meteor-collection-hooks/meteor-mongo.d.ts
@@ -1,0 +1,154 @@
+declare module 'meteor/mongo' {
+  namespace Mongo {
+    interface Collection<T> {
+      before: {
+        find(hook: (
+            userId: string,
+            selector: Mongo.Selector,
+            options: CollectionHooks.ModifierOptions
+          ) => void
+        ): void;
+        findOne(hook: (
+            userId: string,
+            selector: Mongo.Selector,
+            options: CollectionHooks.ModifierOptions
+          ) => void
+        ): void;
+        insert(hook: (
+            userId: string,
+            doc: T
+          ) => void
+        ): void;
+        remove(hook: (
+            userId: string,
+            doc: T
+          ) => void
+        ): void;
+        update(hook: (
+            userId: string,
+            doc: T,
+            fieldNames: string[],
+            modifier: Mongo.Modifier,
+            options: CollectionHooks.ModifierOptions
+          ) => void
+        ): void;
+        upsert(hook: (
+            userId: string,
+            doc: T,
+            selector: Mongo.Selector,
+            modifier: Mongo.Modifier,
+            options: CollectionHooks.ModifierOptions
+          ) => void
+        ): void;
+      };
+      after: {
+        find(hook: (
+            userId: string,
+            selector: Mongo.Selector,
+            options: CollectionHooks.ModifierOptions,
+            cursor: Mongo.Cursor<T>
+          ) => void
+        ): void;
+        findOne(hook: (
+            userId: string,
+            selector: Mongo.Selector,
+            options: CollectionHooks.ModifierOptions,
+            doc: T
+          ) => void
+        ): void;
+        insert(hook: (
+            userId: string,
+            doc: T
+          ) => void
+        ): void;
+        remove(hook: (
+            userId: string,
+            doc: T
+          ) => void
+        ): void;
+        update(hook: (
+            userId: string,
+            doc: T,
+            fieldNames: string[],
+            modifier: Mongo.Modifier,
+            options: CollectionHooks.ModifierOptions
+          ) => void,
+          options?: CollectionHooks.HookOptionValue
+        ): void;
+        upsert(hook: (
+            userId: string,
+            doc: T,
+            selector: Mongo.Selector,
+            modifier: Mongo.Modifier,
+            options: CollectionHooks.ModifierOptions
+          ) => void
+        ): void;
+      };
+      direct: {
+        find(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
+          sort?: Mongo.SortSpecifier;
+          skip?: number;
+          limit?: number;
+          fields?: Mongo.FieldSpecifier;
+          reactive?: boolean;
+          transform?: (doc: any) => void;
+        }): Mongo.Cursor<T>;
+        findOne(selector?: Mongo.Selector | Mongo.ObjectID | string, options?: {
+          sort?: Mongo.SortSpecifier;
+          skip?: number;
+          fields?: Mongo.FieldSpecifier;
+          reactive?: boolean;
+          transform?: (doc: any) => void;
+        }): T;
+        insert(
+          doc: T,
+          callback?: () => void
+        ): string;
+        remove(
+          selector: Mongo.Selector | Mongo.ObjectID | string, callback?: () => void
+        ): number;
+        update(
+          selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
+            multi?: boolean;
+            upsert?: boolean;
+          },
+          callback?: () => void
+        ): number;
+        upsert(
+          selector: Mongo.Selector | Mongo.ObjectID | string, modifier: Mongo.Modifier, options?: {
+            multi?: boolean;
+          },
+          callback?: () => void
+        ): { numberAffected?: number; insertedId?: string; };
+      };
+      hookOptions: CollectionHooks.GlobalHookOptions;
+    }
+  }
+
+  namespace CollectionHooks {
+    interface ModifierOptions {
+      multi?: boolean;
+      upsert?: boolean;
+    }
+
+    interface HookOptionValue {
+      fetchPrevious?: boolean;
+    }
+
+    interface LocalHookOptions {
+      all?: HookOptionValue;
+      find?: HookOptionValue;
+      findOne?: HookOptionValue;
+      insert?: HookOptionValue;
+      remove?: HookOptionValue;
+      update?: HookOptionValue;
+      upsert?: HookOptionValue;
+    }
+
+    interface GlobalHookOptions {
+      before?: LocalHookOptions;
+      after?: LocalHookOptions;
+      all?: LocalHookOptions;
+    }
+  }
+}

--- a/meteor-collection-hooks/package.json
+++ b/meteor-collection-hooks/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "meteor-typings": "^1.3.1"
+  }
+}

--- a/meteor-collection-hooks/tsconfig.json
+++ b/meteor-collection-hooks/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": false,
+    "strictNullChecks": false,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "meteor-collection-hooks-tests.ts"
+  ]
+}

--- a/meteor-collection-hooks/tslint.json
+++ b/meteor-collection-hooks/tslint.json
@@ -1,0 +1,6 @@
+{
+   "extends": "../tslint.json",
+   "rules": {
+     "no-single-declare-module": false
+   }
+}


### PR DESCRIPTION
# Meteor Collection Hooks Definitions

Type definitions for Meteor package `matb33:collection-hooks`.
Be sure to reference any sort of basic Meteor type definitions file before use.