### PR TITLE
	fix react-native-scrollable-tab-view props missing

### DIFF
--- a/react-native-scrollable-tab-view/index.d.ts
+++ b/react-native-scrollable-tab-view/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/brentvatne/react-native-scrollable-tab-view#readme
 // Definitions by: CaiHuan <https://github.com/CaiHuan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 import * as React from 'react';
 import {
@@ -101,6 +102,29 @@ interface ScrollableTabViewProperties extends React.Props<ScrollableTabView> {
    * the siblings, default to 0 === render current page.
    */
   prerenderingSiblingsNumber?: number;
+
+  /**
+   * style of the default tab bar's underline
+   */
+
+  tabBarUnderlineStyle?: React.ViewStyle;
+
+  /**
+   * Additional styles to the tab bar's text. Example: {fontFamily: 'Roboto', fontSize: 15}
+   */
+  tabBarTextStyle?: React.TextStyle;
+
+  /**
+   * color of the default tab bar's text when active, defaults to navy
+   */
+
+  tabBarActiveTextColor?: string;
+
+  /**
+   * color of the default tab bar's text when inactive, defaults to black
+   */
+
+  tabBarInactiveTextColor?: string;
 }
 
 export default class ScrollableTabView extends React.Component<ScrollableTabViewProperties, {}> {

--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -1894,7 +1894,12 @@ declare module "react" {
          * Used on Android only, controls whether DOM Storage is enabled
          * or not android
          */
-        domStorageEnabled?: boolean
+        domStorageEnabled?: boolean,
+
+        /**
+         * Sets the user-agent for the WebView.
+         */
+        userAgent?: string
     }
 
     export interface WebViewIOSLoadRequestEvent {
@@ -2044,7 +2049,7 @@ declare module "react" {
         /**
          * Invoked when window.postMessage is called from WebView.
          */
-	onMessage?: ( event: NativeSyntheticEvent<WebViewMessageEventData> ) => void
+	    onMessage?: ( event: NativeSyntheticEvent<WebViewMessageEventData> ) => void
 
         /**
          * Function that is invoked when the `WebView` loading starts or ends.


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/skv-headless/react-native-scrollable-tab-view#props>>
