### PR TITLE
html-to-text: wordwrap option can be false/null

### DIFF
--- a/html-to-text/index.d.ts
+++ b/html-to-text/index.d.ts
@@ -39,7 +39,7 @@ interface HtmlToTextOptions {
      * Defines after how many chars a line break should follow in p elements.
      * Set to null or false to disable word-wrapping. Default: 80
      */
-    wordwrap?: number;
+    wordwrap?: number | false | null;
 
     /**
      *  Allows to select certain tables by the class or id attribute from the HTML


### PR DESCRIPTION
According to documentation, the "wordwrap" option can be either a number, false, or null.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/werk85/node-html-to-text#options>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
