### PR TITLE
react-input-mask, react-native-scrollable-tab-view: fix linter issues

### DIFF
--- a/react-input-mask/index.d.ts
+++ b/react-input-mask/index.d.ts
@@ -13,7 +13,7 @@ declare namespace reactInputMask {
          * * `9`: `0-9`
          * * `a`: `A-Z, a-z`
          * * `\*`: `A-Z, a-z, 0-9`
-         * 
+         *
          * Any character can be escaped with backslash, which usually will appear as double backslash in JS strings. For example, German phone mask with unremoveable prefix +49 will look like `mask="+4\\9 99 999 99"` or `mask={"+4\\\\9 99 999 99"}`
          */
         mask: string;

--- a/react-native-scrollable-tab-view/index.d.ts
+++ b/react-native-scrollable-tab-view/index.d.ts
@@ -37,9 +37,9 @@ export interface renderTabBarProperties {
 interface ScrollableTabViewProperties extends React.Props<ScrollableTabView> {
 
   /**
-   * tabBarPosition (String) Defaults to "top". 
+   * tabBarPosition (String) Defaults to "top".
    * "bottom" to position the tab bar below content.
-   * "overlayTop" or "overlayBottom" for a semitransparent tab bar that overlays content. Custom 
+   * "overlayTop" or "overlayBottom" for a semitransparent tab bar that overlays content. Custom
    * tab bars must consume a style prop on their outer element to support this feature: style={this.props.style}.
    */
   tabBarPosition?: 'top' | 'bottom' | 'overlayTop' | 'overlayBottom';
@@ -50,27 +50,27 @@ interface ScrollableTabViewProperties extends React.Props<ScrollableTabView> {
   initialPage?: number;
 
   /**
-   * (Integer) - set selected tab(can be buggy see 
+   * (Integer) - set selected tab(can be buggy see
    * https://github.com/skv-headless/react-native-scrollable-tab-view/issues/126
    */
   page?: number;
 
   /**
-   * onChangeTab (Function) - function to call when tab changes, should accept 1 argument which is 
-   * an Object containing two keys: i: the index of the tab that is selected, ref: the ref of the 
+   * onChangeTab (Function) - function to call when tab changes, should accept 1 argument which is
+   * an Object containing two keys: i: the index of the tab that is selected, ref: the ref of the
    * tab that is selected
    */
   onChangeTab?: (value: onChangeTabProperties) => void;
 
   /**
-   * onScroll (Function) - function to call when the pages are sliding, 
+   * onScroll (Function) - function to call when the pages are sliding,
    * should accept 1 argument which is an Float number representing the page position in the slide frame.
    */
   onScroll?: (value: number) => void;
 
   /**
    * renderTabBar (Function:ReactComponent) - accept 1 argument props and should return a component
-   * to use as the tab bar. The component has goToPage, tabs, activeTab and ref added to the props, 
+   * to use as the tab bar. The component has goToPage, tabs, activeTab and ref added to the props,
    * and should implement setAnimationValue to be able to animate itself along with the tab content.
    * You can manually pass the props to the TabBar component.
    */
@@ -82,7 +82,7 @@ interface ScrollableTabViewProperties extends React.Props<ScrollableTabView> {
   style?: ViewStyle;
 
   /**
-   * contentProps (Object) - props that are applied to root ScrollView/ViewPagerAndroid. 
+   * contentProps (Object) - props that are applied to root ScrollView/ViewPagerAndroid.
    * Note that overriding defaults set by the library may break functionality; see the source for details.
    */
   contentProps?: React.ScrollViewProperties;
@@ -98,7 +98,7 @@ interface ScrollableTabViewProperties extends React.Props<ScrollableTabView> {
   locked?: boolean;
 
   /**
-   * prerenderingSiblingsNumber (Integer) - pre-render nearby # sibling, Infinity === render all 
+   * prerenderingSiblingsNumber (Integer) - pre-render nearby # sibling, Infinity === render all
    * the siblings, default to 0 === render current page.
    */
   prerenderingSiblingsNumber?: number;


### PR DESCRIPTION
Fixes #14272.

This PR just removes the trailing whitespace in `react-input-mask` and `react-native-scrollable-tab-view` that is breaking the `master` build.

----

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://travis-ci.org/DefinitelyTyped/DefinitelyTyped/builds/195607434
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
