### PR TITLE
Correct Jest toBeCloseTo signature

### DIFF
--- a/jest/index.d.ts
+++ b/jest/index.d.ts
@@ -117,7 +117,7 @@ declare namespace jest {
         toBe(expected: any): void;
         toBeCalled(): void;
         toBeCalledWith(...args: any[]): void;
-        toBeCloseTo(expected: number, delta: number): void;
+        toBeCloseTo(expected: number, delta?: number): void;
         toBeDefined(): void;
         toBeFalsy(): void;
         toBeGreaterThan(expected: number): void;

--- a/jest/jest-tests.ts
+++ b/jest/jest-tests.ts
@@ -147,6 +147,10 @@ describe('compartion', function () {
     it('works sanely with simple decimals', function () {
         expect(0.2 + 0.1).toBeCloseTo(0.3, 5);
     });
+
+    it('works sanely with simple decimals and the default delta', function () {
+        expect(0.2 + 0.1).toBeCloseTo(0.3);
+    });
 });
 
 describe('toThrow API', function () {


### PR DESCRIPTION
In Jest `.toBeCloseTo`'s second parameter is optional with a default of 5.

See:
https://facebook.github.io/jest/docs/api.html#tobeclosetonumber-numdigits

This updates the type definition to make this parameter optional as
well.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/jest/docs/api.html#tobeclosetonumber-numdigits
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.