### PR TITLE
Add type definitions for es6-weak-map

### DIFF
--- a/es6-weak-map/es6-weak-map-tests.ts
+++ b/es6-weak-map/es6-weak-map-tests.ts
@@ -1,0 +1,18 @@
+import WeakMap = require('es6-weak-map');
+
+new WeakMap<{}, string>();
+
+var tuples: [number, string][] = [ [0, 'foo'], [1, 'bar'] ];
+new WeakMap<number, string>(tuples);
+
+var map = new WeakMap<{}, string>();
+var obj = {};
+
+map.set(obj, 'foo');
+map.get(obj);
+map.has(obj);
+map.delete(obj);
+map.get(obj);
+map.has(obj);
+map.set(obj, 'bar');
+map.has(obj);

--- a/es6-weak-map/index.d.ts
+++ b/es6-weak-map/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for es6-weak-map 1.2
+// Project: https://github.com/medikoo/es6-weak-map
+// Definitions by: Pine Mizune <https://github.com/pine>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = WeakMap;
+export as namespace WeakMap;
+
+interface Iterable<T> {
+    [Symbol.iterator](): Iterator<T>;
+}
+
+declare class WeakMap<K, V> {
+    constructor();
+    constructor(iterable: Iterable<[K, V]>);
+
+    delete(key: K): boolean;
+    get(key: K): V;
+    has(key: K): boolean;
+    set(key: K, value?: V): WeakMap<K, V>;
+}

--- a/es6-weak-map/tsconfig.json
+++ b/es6-weak-map/tsconfig.json
@@ -1,0 +1,23 @@
+
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "es6-weak-map-tests.ts"
+    ]
+}

--- a/es6-weak-map/tslint.json
+++ b/es6-weak-map/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Hello.

I added type definitions for es6-weak-map.

- https://github.com/medikoo/es6-weak-map
- https://www.npmjs.com/package/es6-weak-map

Thank you.

---

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `npm run new-package package-name`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
