### PR TITLE
NodeJS v4 typings should not depend on `dom` lib.

### DIFF
--- a/node/v4/index.d.ts
+++ b/node/v4/index.d.ts
@@ -9,6 +9,25 @@
 *                                               *
 ************************************************/
 
+// This needs to be global to avoid TS2403 in case lib.dom.d.ts is present in the same build
+interface Console {
+    Console: {
+        prototype: Console,
+        new(stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream): Console;
+    };
+    assert(value: any, message?: string, ...optionalParams: any[]): void;
+    dir(obj: any, options?: {showHidden?: boolean, depth?: number, colors?: boolean}): void;
+    error(message?: any, ...optionalParams: any[]): void;
+    info(message?: any, ...optionalParams: any[]): void;
+    log(message?: any, ...optionalParams: any[]): void;
+    time(label: string): void;
+    timeEnd(label: string): void;
+    trace(message?: any, ...optionalParams: any[]): void;
+    warn(message?: any, ...optionalParams: any[]): void;
+}
+
+declare var console: Console;
+
 interface Error {
     stack?: string;
 }

--- a/node/v4/tsconfig.json
+++ b/node/v4/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present. No new lint warnings added.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v4.x/docs/api/console.html
- [x] Increase the version number in the header if appropriate. (not appropriate)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`. (not substantial change)

Node projects should not need to depend on the `dom` lib. Currently if they do not, they get errors because these typings reference `console` from the `dom` lib. This change copies over the typings for Console from the node/v6 directory of DefinitelyTyped.