### PR TITLE
Add type definitions for is-array

### DIFF
--- a/is-array/index.d.ts
+++ b/is-array/index.d.ts
@@ -4,4 +4,4 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = isArray;
-declare function isArray(val?: any): val is Array<any>;
+declare function isArray(val?: any): val is any[];

--- a/is-array/index.d.ts
+++ b/is-array/index.d.ts
@@ -4,4 +4,4 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = isArray;
-declare function isArray(val?: any): boolean;
+declare function isArray(val?: any): val is Array<any>;

--- a/is-array/index.d.ts
+++ b/is-array/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for is-array 1.0
+// Project: https://github.com/retrofox/is-array
+// Definitions by: Pine Mizune <https://github.com/pine>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = isArray;
+declare function isArray(val?: any): boolean;

--- a/is-array/is-array-tests.ts
+++ b/is-array/is-array-tests.ts
@@ -6,3 +6,8 @@ isArray(1);
 isArray(true);
 isArray([]);
 isArray({});
+
+var x = {}
+if (isArray(x)) {
+    x.push(0);
+}

--- a/is-array/is-array-tests.ts
+++ b/is-array/is-array-tests.ts
@@ -1,0 +1,8 @@
+import isArray = require('is-array');
+
+isArray();
+isArray(null);
+isArray(1);
+isArray(true);
+isArray([]);
+isArray({});

--- a/is-array/tsconfig.json
+++ b/is-array/tsconfig.json
@@ -1,0 +1,23 @@
+
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-array-tests.ts"
+    ]
+}

--- a/is-array/tslint.json
+++ b/is-array/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Hello. I added type definitions for is-array module.

- https://github.com/retrofox/is-array
- https://www.npmjs.com/package/is-array

Thank you.

---

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `npm run new-package package-name`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
