### PR TITLE
React router3

### DIFF
--- a/react-router/lib/Router.d.ts
+++ b/react-router/lib/Router.d.ts
@@ -86,11 +86,11 @@ export interface InjectedRouter {
 }
 
 export interface RouteComponentProps<P, R> {
-    location?: Location;
-    params?: P & R;
-    route?: PlainRoute;
-    router?: InjectedRouter;
-    routeParams?: R;
+    location: Location;
+    params: P & R;
+    route: PlainRoute;
+    router: InjectedRouter;
+    routeParams: R;
 }
 
 export interface RouterProps extends ClassAttributes<any> {


### PR DESCRIPTION
This pull requests does a few things: 

In react-router:
* Make `RouteComponentProps` props non-optional. This facilitates consumption from the inside of the component when `stringNullChecks` is enabled, otherwise you need to `!` every property access for properties that react router is always going to populate. 
* Update to history v3 that is the current dependency https://github.com/ReactTraining/react-router/blob/master/package.json 

In history: 
* Bump the 'legacy' version from `v2` to `v3` since is the one that react-router needs now and rename the folder acordingly. 
* Change export of `createBrowserHistory` to `createHistory` as this is how is exported now https://github.com/mjackson/history/blob/v3.x/modules/index.js.
* Add an indexer to `Query` to facilitate consumption (otherwise casting to any is needed all the time).