### PR TITLE
Update PDFKit to support `font(buffer)`

### DIFF
--- a/pdfkit/index.d.ts
+++ b/pdfkit/index.d.ts
@@ -69,6 +69,7 @@ declare namespace PDFKit.Mixins {
     }
 
     interface PDFFont<TDocument> {
+        font(buffer: Buffer): TDocument;
         font(src: string, family?: string, size?: number): TDocument;
         fontSize(size: number): TDocument;
         currentLineHeight(includeGap?: boolean): number;


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Add `font(buffer: Buffer)` overload.

UPDATE link: http://pdfkit.org/docs/text.html#fonts

> To change the font used to render text, just call the font method. If you are using a standard PDF font, just pass the name to the font method. Otherwise, pass the path to the font file, **or a Buffer containing the font data**