### PR TITLE
chart.js: Allow string & Date for ChartPoint.x

### DIFF
--- a/chart.js/index.d.ts
+++ b/chart.js/index.d.ts
@@ -71,7 +71,7 @@ declare namespace Chart {
     }
 
     export interface ChartPoint {
-        x?: number;
+        x?: number | string | Date;
         y?: number;
     }
 


### PR DESCRIPTION
This PR adds support for `string` and `Date` in `ChartPoint.x`. These data types are supported by ChartJS for charts where the x axis has the `time` type.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.

I ran `tsc chartjs/index.d.ts` which returns no error
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

These links show that both `string` and `Date` are valid as `ChartPoint.x`:
ChartJS docs: http://www.chartjs.org/docs/#scales-time-scale
ChartJS test: https://github.com/chartjs/Chart.js/blob/58afbe428c74d3f2df2df5620f94c34dce3798d2/test/scale.time.tests.js#L128
Plunkr: https://plnkr.co/edit/cwRYpkyB7vplCCfNCpid

- [ ] Increase the version number in the header if appropriate.
In `index.d.ts` I can't find a version number
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
No substantial changes