### PR TITLE
highcharts: Add missing dataLabels option for series @damianog @baltie

### DIFF
--- a/highcharts/index.d.ts
+++ b/highcharts/index.d.ts
@@ -5050,6 +5050,10 @@ declare namespace Highcharts {
          * Define the visual z index of the series.
          */
         zIndex?: number;
+        /**
+         * Individual data label for each point. The options are the same as the ones for plotOptions.series.dataLabels
+         */
+        dataLabels?: DataLabels;
     }
 
     interface SeriesOptions extends IndividualSeriesOptions, SeriesChart { }


### PR DESCRIPTION
To be sync with http://api.highcharts.com/highcharts/plotOptions.series.dataLabels

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://api.highcharts.com/highcharts/plotOptions.series.dataLabels

**sample chart** with the missing label type definition:
http://www.highcharts.com/demo/column-rotated-labels/grid-light
