### PR TITLE
added redis.client.end(flush) parameter

### DIFF
--- a/redis/index.d.ts
+++ b/redis/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for redis 0.12.1
+// Type definitions for redis 0.12.2
 // Project: https://github.com/mranney/node_redis
 // Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>, Peter Harris <https://github.com/CodeAnimal>, TANAKA Koichi <https://github.com/MugeSo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -91,7 +91,12 @@ export interface RedisClient extends NodeJS.EventEmitter {
     offline_queue: any[];
     server_info: ServerInfo;
 
-    end(): void;
+    /**
+     * Forcibly close the connection to the Redis server. Note that this does not wait until all replies have been parsed. If you want to exit cleanly, call client.quit()
+     *
+     * @param {boolean} flush You should set flush to true, if you are not absolutely sure you do not care about any other commands. If you set flush to false all still running commands will silently fail.
+     */
+    end(flush: boolean): void;
     unref(): void;
 
     /**
@@ -274,8 +279,8 @@ export interface RedisClient extends NodeJS.EventEmitter {
     hmget(...args: any[]): boolean;
     hincrby(args: any[], callback?: ResCallbackT<any>): boolean;
     hincrby(...args: any[]): boolean;
-    hincrbyfloat(args:any[], callback?:ResCallbackT<any>): boolean;
-    hincrbyfloat(...args:any[]): boolean;
+    hincrbyfloat(args: any[], callback?: ResCallbackT<any>): boolean;
+    hincrbyfloat(...args: any[]): boolean;
     hdel(args: any[], callback?: ResCallbackT<any>): boolean;
     hdel(...args: any[]): boolean;
     hlen(args: any[], callback?: ResCallbackT<any>): boolean;
@@ -408,7 +413,7 @@ export interface RedisClient extends NodeJS.EventEmitter {
     zscan(args: any[], callback?: ResCallbackT<any>): boolean;
 
     // Extras
-    duplicate(options?:any[], callback?:ResCallbackT<any>): RedisClient;
+    duplicate(options?: any[], callback?: ResCallbackT<any>): RedisClient;
 }
 
 export interface Multi {

--- a/redis/redis-tests.ts
+++ b/redis/redis-tests.ts
@@ -31,10 +31,10 @@ client = redis.createClient(num, str, options);
 function retryStrategyNumber(options: redis.RetryStrategyOptions): number {
   // Ensure that the properties of RetryStrategyOptions are resilient to breaking change.
   // If the properties of the interface changes, the variables below will also need to be adapted.
-  var error:            Error  = options.error;
+  var error: Error = options.error;
   var total_retry_time: number = options.total_retry_time;
-  var times_connected:  number = options.times_connected;
-  var attempt:          number = options.attempt;
+  var times_connected: number = options.times_connected;
+  var attempt: number = options.attempt;
   return 5000;
 }
 function retryStrategyError(options: redis.RetryStrategyOptions): Error {
@@ -57,7 +57,7 @@ info = client.server_info;
 
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
-client.end();
+client.end(true);
 
 // Connection (http://redis.io/commands#connection)
 client.auth(str, resCallback);
@@ -98,11 +98,11 @@ client.subscribe(str);
 
 // Multi
 client.multi()
-    .scard(str)
-    .smembers(str)
-    .keys('*', resCallback)
-    .dbsize()
-    .exec(resCallback);
+  .scard(str)
+  .smembers(str)
+  .keys('*', resCallback)
+  .dbsize()
+  .exec(resCallback);
 
 client.multi(commandArr).exec();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
-  ~~Run `npm run lint package-name` if a `tslint.json` is present~~ -> ~280 pre-existing linting issues. outside of scope of this pr

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NodeRedis/node_redis#clientendflush
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.