### PR TITLE
FullCalendar: Added two missing function definitions for renderEvents and updateEvents

### DIFF
--- a/fullcalendar/index.d.ts
+++ b/fullcalendar/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for FullCalendar 2.7.2
 // Project: http://fullcalendar.io/
-// Definitions by: Neil Stalker <https://github.com/nestalk>, Marcelo Camargo <https://github.com/hasellcamargo>
+// Definitions by: Neil Stalker <https://github.com/nestalk>, Marcelo Camargo <https://github.com/hasellcamargo>, Patrick Niemann <https://github.com/panic175>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="jquery"/>
@@ -364,6 +364,11 @@ declare global {
         fullCalendar(method: 'updateEvent', event: EventObject): void;
 
         /**
+         * Reports changes for multiple events and renders them on the calendar.
+         */
+        fullCalendar(method: 'updateEvents', events: Array<EventObject>): void;
+
+        /**
          * Retrieves events that FullCalendar has in memory.
          */
         fullCalendar(method: 'clientEvents', idOrfilter?: any): Array<EventObject>;
@@ -402,6 +407,11 @@ declare global {
          * Renders a new event on the calendar.
          */
         fullCalendar(method: 'renderEvent', event: EventObject, stick?: boolean): void;
+        
+        /**
+         * Renders new events on the calendar.
+         */
+        fullCalendar(method: 'renderEvents', events: Array<EventObject>, stick?: boolean): void;
 
         /**
          * Rerenders all events on the calendar.


### PR DESCRIPTION


Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://fullcalendar.io/docs/event_rendering/renderEvents/
https://fullcalendar.io/docs/event_data/updateEvents/
- [x] Increase the version number in the header if appropriate.
It's not
