### PR TITLE
[backbone] Backbone.Collection.reset() should accept object literals

### DIFF
--- a/backbone/index.d.ts
+++ b/backbone/index.d.ts
@@ -234,7 +234,7 @@ declare namespace Backbone {
         pop(options?: Silenceable): TModel;
         remove(model: {}|TModel, options?: Silenceable): TModel;
         remove(models: ({}|TModel)[], options?: Silenceable): TModel[];
-        reset(models?: TModel[], options?: Silenceable): TModel[];
+        reset(models?: ({}|TModel)[], options?: Silenceable): TModel[];
         set(models?: TModel[], options?: Silenceable): TModel[];
         shift(options?: Silenceable): TModel;
         sort(options?: Silenceable): Collection<TModel>;


### PR DESCRIPTION
As stated [in backbonejs documentation](http://backbonejs.org/#Collection-reset), we may provide *attribute hashes* as parameter to `Backbone.Collection.reset()` function :

```
Use reset to replace a collection with a new list of models *(or attribute hashes)*, triggering a single "reset" event on completion, and without triggering any add or remove events on any models.
```