### PR TITLE
allow void return on es6-promise.all

### DIFF
--- a/es6-promise/index.d.ts
+++ b/es6-promise/index.d.ts
@@ -66,7 +66,8 @@ declare namespace Promise {
     function all<T1, T2, T3, T4>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable <T4>]): Promise<[T1, T2, T3, T4]>;
     function all<T1, T2, T3>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>]): Promise<[T1, T2, T3]>;
     function all<T1, T2>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>]): Promise<[T1, T2]>;
-    function all<T>(values: (T | Thenable<T>)[]): Promise<T[]>;
+	function all<T extends Object>(values: (T | Thenable<T>)[]): Promise<T[]>;
+	function all<T extends void>(values: any[]): Promise<void>;
 
 	/**
 	 * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.

--- a/es6-promise/index.d.ts
+++ b/es6-promise/index.d.ts
@@ -66,8 +66,8 @@ declare namespace Promise {
     function all<T1, T2, T3, T4>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable <T4>]): Promise<[T1, T2, T3, T4]>;
     function all<T1, T2, T3>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>]): Promise<[T1, T2, T3]>;
     function all<T1, T2>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>]): Promise<[T1, T2]>;
-	function all<T extends Object>(values: (T | Thenable<T>)[]): Promise<T[]>;
-	function all<T extends void>(values: any[]): Promise<void>;
+    function all<T extends Object>(values: (T | Thenable<T>)[]): Promise<T[]>;
+    function all<T extends void>(values: any[]): Promise<void>;
 
 	/**
 	 * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.


### PR DESCRIPTION
Allows this scenario:
```javascript
function F() : Promise<void> {
    return Promise.all<void>([p1, p2, p3]);
}
```
actually the return type is void[] or T[] (inferred from p1..n), hence you have to write:
```javascript
function F() : Promise<void> {
    return <Promise<void>>Promise.all([p1, p2, p3]);
}
```

In the definition I used `values: any[]` with any instead of `(any | Thenable<any>)[]` because _any_ swallows - of course - any other type.
