### PR TITLE
Jest: Fix mocked type

### DIFF
--- a/jest/index.d.ts
+++ b/jest/index.d.ts
@@ -109,7 +109,7 @@ declare namespace jest {
     interface It {
         /**
          * Creates a test closure.
-         * 
+         *
          * @param {string} name The name of your test
          * @param {fn?} ProvidesCallback The function for your test
          */
@@ -152,9 +152,9 @@ declare namespace jest {
 
     /** The `expect` function is used every time you want to test a value. You will rarely call `expect` by itself. */
     interface Expect {
-        /** 
-         * The `expect` function is used every time you want to test a value. You will rarely call `expect` by itself. 
-         * 
+        /**
+         * The `expect` function is used every time you want to test a value. You will rarely call `expect` by itself.
+         *
          * @param {any} actual The value to apply matchers against.
         */
         (actual: any): Matchers;
@@ -255,8 +255,8 @@ declare namespace jest {
      *  myApi.myApiMethod.mockImplementation(() => "test");
      */
     type Mocked<T> = {
-        [P in keyof T]: T[P] & MockInstance<T>;
-    };
+        [P in keyof T]: T[P] & MockInstance<T[P]>;
+    } & T;
 
     interface MockInstance<T> {
         mock: MockContext<T>;

--- a/jest/jest-tests.ts
+++ b/jest/jest-tests.ts
@@ -433,6 +433,7 @@ describe('strictNullChecks', function () {
 class TestApi {
     constructor() { };
     testProp: boolean;
+    private anotherProp: string;
     testMethod(a: number): string { return ""; }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<Not applicable>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.


Update Mocked type in Jest.
Added intersection with T since ```P in keyof T``` will drop private properties and methods thus final type won't be assignable to original non-mocked type.
