### PR TITLE
[chrome] Fixed type of webNavigation.onBeforeNavigate.addListener

### DIFF
--- a/chrome/index.d.ts
+++ b/chrome/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Chrome extension development
 // Project: http://developer.chrome.com/extensions/
-// Definitions by: Matthew Kimber <https://github.com/matthewkimber>, otiai10 <https://github.com/otiai10>, couven92 <https://github.com/couven92>, RReverser <https://github.com/rreverser>
+// Definitions by: Matthew Kimber <https://github.com/matthewkimber>, otiai10 <https://github.com/otiai10>, couven92 <https://github.com/couven92>, RReverser <https://github.com/rreverser>, sreimer15 <https://github.com/sreimer15>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="filesystem" />
@@ -7062,13 +7062,12 @@ declare namespace chrome.webNavigation {
         transitionQualifiers: string[];
     }
 
-    interface WebNavigationEventFilter {
-        /** Conditions that the URL being navigated to must satisfy. The 'schemes' and 'ports' fields of UrlFilter are ignored for this event. */
-        url: chrome.events.UrlFilter[];
+    interface WebNavigationRequestFilter extends chrome.webRequest.RequestFilter {
+        /** fulfills the webRequest.RequestFilter interface even though it is under web navigation **/
     }
 
     interface WebNavigationEvent<T extends WebNavigationCallbackDetails> extends chrome.events.Event<(details: T) => void> {
-        addListener(callback: (details: T) => void, filters?: WebNavigationEventFilter): void;
+        addListener(callback: (details: T) => void, filters?: WebNavigationRequestFilter): void;
     }
 
     interface WebNavigationFramedEvent extends WebNavigationEvent<WebNavigationFramedCallbackDetails> {}
@@ -7178,7 +7177,8 @@ declare namespace chrome.webRequest {
          */
         types?: string[];
         /** A list of URLs or URL patterns. Requests that cannot match any of the URLs will be filtered out. */
-        urls: string[];
+        urls: string[] | RegExp[] | "<all_urls>";
+ 
         /** Optional. */
         windowId?: number;
     }

--- a/chrome/test/index.ts
+++ b/chrome/test/index.ts
@@ -171,6 +171,29 @@ function catBlock () {
         ["blocking"]);
 }
 
+// webNavigation.onBeforeNavigate.addListener example similar api to onBeforeRequest but without extra spec
+function beforeRedditNavigation() {
+    chrome.webNavigation.onBeforeNavigate.addListener(function (requestDetails) {
+        console.log("URL we want to redirect to: " + requestDetails.url);
+        // NOTE: This will search for top level frames with the value -1.
+        if (requestDetails.parentFrameId != -1) {
+            return;
+        }
+
+        let url = new URL(requestDetails.url);
+        let splitUrl = url.hostname.split('.');
+        //` Note: Does not cover the XX.co.uk type edge case
+        let host = (splitUrl[(splitUrl.length -1) - 1]);
+
+        if (host === null) {
+            return;
+        } else if (host === "reddit") {
+            alert("Were you trying to go on reddit, during working hours? :(")
+            return;
+        }
+    },{urls: ["http://*/*"], types: ["image"]});
+}
+
 // contrived settings example
 function proxySettings() {
     chrome.proxy.settings.get({ incognito: true }, (details) => {


### PR DESCRIPTION
Please fill in this template.

- [x ] Make your PR against the `master` branch.
- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x ] Run `tsc` without errors.
- [x ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14330>>

(I added a test, the documentation is very vague on the chrome extension website. In summary, the onBeforeNavigate.addEventListener errors with a url property making it impossible to satisfy without configuration. This PR adds an interface on the WebNavigation namespace which extends the webRequest.RequestFilter because they fulfill the same contract and take same parameters).