### PR TITLE
[consul] Add key option to consul.watch

### DIFF
--- a/consul/index.d.ts
+++ b/consul/index.d.ts
@@ -951,10 +951,14 @@ declare namespace Consul {
     }
 
     namespace Watch {
+        
+        interface WatchOptions {
+            key?: string;
+        }
 
         interface Options {
             method: Function;
-            options?: CommonOptions;
+            options?: CommonOptions & WatchOptions;
         }
     }
 


### PR DESCRIPTION
Add `key` option to `consul.watch options` parameter.

See: https://github.com/silas/node-consul#watch

```js
// make this working
consul.watch({
  method: consul.kv.get,
  options: {
    key: 'something',
  },
});
```