### PR TITLE
bugfix: WebResponseHeadersDetails missing method

### DIFF
--- a/chrome/index.d.ts
+++ b/chrome/index.d.ts
@@ -7267,6 +7267,7 @@ declare namespace chrome.webRequest {
     interface WebResponseHeadersDetails extends WebResponseDetails {
         /** Optional. The HTTP response headers that have been received with this response. */
         responseHeaders?: HttpHeader[];
+        method: string; /** standard HTTP method i.e. GET, POST, PUT, etc. */
     }
 
     interface WebResponseCacheDetails extends WebResponseHeadersDetails {


### PR DESCRIPTION
WebResponseHeadersDetails interface missing the method field defined in the documentation.
https://developer.chrome.com/extensions/webRequest#event-onHeadersReceived

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [n/a] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/extensions/webRequest#event-onHeadersReceived
- [n/a] Increase the version number in the header if appropriate.
- [n/a ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.