### PR TITLE
d3-selection: Correct parent element/datum types for sub-selections

### DIFF
--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -461,20 +461,6 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     html(value: ValueFn<GElement, Datum, string | null>): this;
 
     /**
-     * Appends a new element of the specified type (tag name) as the last child of each selected element.
-     *
-     * This method returns a new selection containing the appended elements.
-     * Each new element inherits the data of the current elements, if any.
-     *
-     * The generic refers to the type of the child element to be appended.
-     *
-     * @param type A string representing the tag name. The specified name may have a namespace prefix, such as svg:text
-     * to specify a text attribute in the SVG namespace. If no namespace is specified, the namespace will be inherited
-     * from the parent element; or, if the name is one of the known prefixes, the corresponding namespace will be used
-     * (for example, svg implies svg:svg)
-     */
-    append<ChildElement extends BaseType>(type: string): Selection<ChildElement, Datum, GElement, Datum>;
-    /**
      * Appends a new element of the specified type (tag name) as the next following sibling in the update selection.
      * (This allows you to insert elements into the DOM in an order consistent with bound data;
      * however, the slower selection.order may still be required if updating elements change order.)
@@ -491,19 +477,22 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      */
     append<ChildElement extends BaseType>(this: Selection<EnterElement, Datum, PElement, PDatum>, type: string)
         : Selection<ChildElement, Datum, PElement, PDatum>
+
     /**
-     * Appends a new element of the type provided by the element creator function as the last child of each selected element.
+     * Appends a new element of the specified type (tag name) as the last child of each selected element.
      *
      * This method returns a new selection containing the appended elements.
      * Each new element inherits the data of the current elements, if any.
      *
      * The generic refers to the type of the child element to be appended.
      *
-     * @param type A creator function which is evaluated for each selected element, in order, being passed the current datum (d),
-     * the current index (i), and the current group (nodes), with this as the current DOM element. This function should return
-     * an element to be appended. (The function typically creates a new element, but it may instead return an existing element.)
+     * @param type A string representing the tag name. The specified name may have a namespace prefix, such as svg:text
+     * to specify a text attribute in the SVG namespace. If no namespace is specified, the namespace will be inherited
+     * from the parent element; or, if the name is one of the known prefixes, the corresponding namespace will be used
+     * (for example, svg implies svg:svg)
      */
-    append<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>): Selection<ChildElement, Datum, GElement, Datum>;
+    append<ChildElement extends BaseType>(type: string): Selection<ChildElement, Datum, GElement, Datum>;
+
     /**
      * Appends a new element of the type provided by the element creator function as the next following sibling in the update selection.
      * (This allows you to insert elements into the DOM in an order consistent with bound data;
@@ -520,6 +509,21 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      */
     append<ChildElement extends BaseType>(this: Selection<EnterElement, Datum, PElement, PDatum>,type: ValueFn<GElement, Datum, ChildElement>)
         : Selection<ChildElement, Datum, PElement, PDatum>;
+
+    /**
+     * Appends a new element of the type provided by the element creator function as the last child of each selected element.
+     *
+     * This method returns a new selection containing the appended elements.
+     * Each new element inherits the data of the current elements, if any.
+     *
+     * The generic refers to the type of the child element to be appended.
+     *
+     * @param type A creator function which is evaluated for each selected element, in order, being passed the current datum (d),
+     * the current index (i), and the current group (nodes), with this as the current DOM element. This function should return
+     * an element to be appended. (The function typically creates a new element, but it may instead return an existing element.)
+     */
+    append<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>): Selection<ChildElement, Datum, GElement, Datum>;
+
     /**
      * Inserts a new element of the specified type (tag name) before the element matching the specified "before"
      * selector string for each selected element.

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -461,10 +461,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     html(value: ValueFn<GElement, Datum, string | null>): this;
 
     /**
-     * Appends a new element of the specified type (tag name) as the last child of each selected element, or the next
-     * following sibling in the update selection if this is an enter selection.
-     * (The enter behavior allows you to insert elements into the DOM in an order consistent with bound data;
-     * however, the slower selection.order may still be required if updating elements change order.)
+     * Appends a new element of the specified type (tag name) as the last child of each selected element.
      *
      * This method returns a new selection containing the appended elements.
      * Each new element inherits the data of the current elements, if any.
@@ -478,10 +475,24 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      */
     append<ChildElement extends BaseType>(type: string): Selection<ChildElement, Datum, GElement, Datum>;
     /**
-     * Appends a new element of the type provided by the element creator function as the last child of each selected element,
-     * or the next following sibling in the update selection if this is an enter selection.
-     * (The enter behavior allows you to insert elements into the DOM in an order consistent with bound data;
+     * Appends a new element of the specified type (tag name) as the next following sibling in the update selection.
+     * (This allows you to insert elements into the DOM in an order consistent with bound data;
      * however, the slower selection.order may still be required if updating elements change order.)
+     *
+     * This method returns a new selection containing the appended elements.
+     * Each new element inherits the data of the current elements, if any.
+     *
+     * The generic refers to the type of the child element to be appended.
+     *
+     * @param type A string representing the tag name. The specified name may have a namespace prefix, such as svg:text
+     * to specify a text attribute in the SVG namespace. If no namespace is specified, the namespace will be inherited
+     * from the parent element; or, if the name is one of the known prefixes, the corresponding namespace will be used
+     * (for example, svg implies svg:svg)
+     */
+    append<ChildElement extends BaseType>(this: Selection<EnterElement, Datum, PElement, PDatum>, type: string)
+        : Selection<ChildElement, Datum, PElement, PDatum>
+    /**
+     * Appends a new element of the type provided by the element creator function as the last child of each selected element.
      *
      * This method returns a new selection containing the appended elements.
      * Each new element inherits the data of the current elements, if any.
@@ -493,7 +504,22 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * an element to be appended. (The function typically creates a new element, but it may instead return an existing element.)
      */
     append<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>): Selection<ChildElement, Datum, GElement, Datum>;
-
+    /**
+     * Appends a new element of the type provided by the element creator function as the next following sibling in the update selection.
+     * (This allows you to insert elements into the DOM in an order consistent with bound data;
+     * however, the slower selection.order may still be required if updating elements change order.)
+     *
+     * This method returns a new selection containing the appended elements.
+     * Each new element inherits the data of the current elements, if any.
+     *
+     * The generic refers to the type of the child element to be appended.
+     *
+     * @param type A creator function which is evaluated for each selected element, in order, being passed the current datum (d),
+     * the current index (i), and the current group (nodes), with this as the current DOM element. This function should return
+     * an element to be appended. (The function typically creates a new element, but it may instead return an existing element.)
+     */
+    append<ChildElement extends BaseType>(this: Selection<EnterElement, Datum, PElement, PDatum>,type: ValueFn<GElement, Datum, ChildElement>)
+        : Selection<ChildElement, Datum, PElement, PDatum>;
     /**
      * Inserts a new element of the specified type (tag name) before the element matching the specified "before"
      * selector string for each selected element.

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -475,8 +475,8 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * from the parent element; or, if the name is one of the known prefixes, the corresponding namespace will be used
      * (for example, svg implies svg:svg)
      */
-    append<ChildElement extends BaseType>(this: Selection<EnterElement, Datum, PElement, PDatum>, type: string)
-        : Selection<ChildElement, Datum, PElement, PDatum>
+    append<ChildElement extends BaseType>(this: Selection<EnterElement, Datum, PElement, PDatum>,
+        type: string): Selection<ChildElement, Datum, PElement, PDatum>;
 
     /**
      * Appends a new element of the specified type (tag name) as the last child of each selected element.
@@ -507,8 +507,8 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * the current index (i), and the current group (nodes), with this as the current DOM element. This function should return
      * an element to be appended. (The function typically creates a new element, but it may instead return an existing element.)
      */
-    append<ChildElement extends BaseType>(this: Selection<EnterElement, Datum, PElement, PDatum>,type: ValueFn<GElement, Datum, ChildElement>)
-        : Selection<ChildElement, Datum, PElement, PDatum>;
+    append<ChildElement extends BaseType>(this: Selection<EnterElement, Datum, PElement, PDatum>,
+        type: ValueFn<GElement, Datum, ChildElement>): Selection<ChildElement, Datum, PElement, PDatum>;
 
     /**
      * Appends a new element of the type provided by the element creator function as the last child of each selected element.

--- a/d3-selection/index.d.ts
+++ b/d3-selection/index.d.ts
@@ -476,7 +476,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * from the parent element; or, if the name is one of the known prefixes, the corresponding namespace will be used
      * (for example, svg implies svg:svg)
      */
-    append<ChildElement extends BaseType>(type: string): Selection<ChildElement, Datum, PElement, PDatum>;
+    append<ChildElement extends BaseType>(type: string): Selection<ChildElement, Datum, GElement, Datum>;
     /**
      * Appends a new element of the type provided by the element creator function as the last child of each selected element,
      * or the next following sibling in the update selection if this is an enter selection.
@@ -492,7 +492,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * the current index (i), and the current group (nodes), with this as the current DOM element. This function should return
      * an element to be appended. (The function typically creates a new element, but it may instead return an existing element.)
      */
-    append<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>): Selection<ChildElement, Datum, PElement, PDatum>;
+    append<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>): Selection<ChildElement, Datum, GElement, Datum>;
 
     /**
      * Inserts a new element of the specified type (tag name) before the element matching the specified "before"
@@ -520,7 +520,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     insert<ChildElement extends BaseType>(
         type: string | ValueFn<GElement, Datum, ChildElement>,
         before?: string | ValueFn<GElement, Datum, BaseType>
-        ): Selection<ChildElement, Datum, PElement, PDatum>;
+        ): Selection<ChildElement, Datum, GElement, Datum>;
 
     /**
      * Removes the selected elements from the document.

--- a/d3-zoom/d3-zoom-tests.ts
+++ b/d3-zoom/d3-zoom-tests.ts
@@ -229,7 +229,7 @@ canvas.call(canvasZoom);
 // SVG Example --------------------------------------------------------------
 
 // attach the zoom behavior to an overlay svg rectangle
-const svgOverlay: Selection<SVGRectElement, SVGDatum, HTMLElement, any> = svg.append<SVGRectElement>('rect')
+const svgOverlay: Selection<SVGRectElement, SVGDatum, SVGSVGElement, any> = svg.append<SVGRectElement>('rect')
     .attr('width', d => d.width)
     .attr('height', d => d.height)
     .style('fill', 'none')


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [N/A] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
--------------

`append` creates a new selection of elements that have the current selection as parents, so the parent element and data types should be set accordingly. The same applies to `insert`.

edit: also added overloads to handle the `enter` selection case, where having the old parent types is the correct behaviour