### PR TITLE
Mongoose: add “names” selector version of Document#populate

### DIFF
--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://mongoosejs.com/
 // Definitions by: simonxca <https://github.com/simonxca/>, horiuchi <https://github.com/horiuchi/>, sindrenm <https://github.com/sindrenm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="mongodb" />
 /// <reference types="node" />

--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Mongoose 4.7.0
 // Project: http://mongoosejs.com/
-// Definitions by: simonxca <https://github.com/simonxca/>, horiuchi <https://github.com/horiuchi/>
+// Definitions by: simonxca <https://github.com/simonxca/>, horiuchi <https://github.com/horiuchi/>, sindrenm <https://github.com/sindrenm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="mongodb" />
@@ -994,10 +994,12 @@ declare module "mongoose" {
      * call execPopulate(). Passing the same path a second time will overwrite
      * the previous path options. See Model.populate() for explaination of options.
      * @param path The path to populate or an options object
+     * @param names The properties to fetch from the populated document
      * @param callback When passed, population is invoked
      */
     populate(callback: (err: any, res: this) => void): this;
     populate(path: string, callback?: (err: any, res: this) => void): this;
+    populate(path: string, names: string, callback?: (err: any, res: this) => void): this;
     populate(options: ModelPopulateOptions | ModelPopulateOptions[], callback?: (err: any, res: this) => void): this;
 
     /** Gets _id(s) used during population of the given path. If the path was not populated, undefined is returned. */


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
  - Not present.

**Changing an existing definition**

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongoosejs.com/docs/populate.html
- [ ] Increase the version number in the header if appropriate.
  - Not sure if this is appropriate. I looked at the chanelog from 4.7.0 through 4.7.3,
    where I know it's present, and didn't find it included there.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
  - Not a substantial change.