### PR TITLE
Add type definition for `hapi-auth-jwt2`

### DIFF
--- a/hapi-auth-jwt2/hapi-auth-jwt2-tests.ts
+++ b/hapi-auth-jwt2/hapi-auth-jwt2-tests.ts
@@ -1,0 +1,41 @@
+import Hapi = require('hapi');
+import hapiAuthJwt2 = require('hapi-auth-jwt2');
+
+var server = new Hapi.Server();
+server.connection({port: 8000});
+
+interface User {
+  id: number;
+  name: string;
+}
+
+interface Users {
+  [id: number]: User
+}
+
+var users:Users = {
+  1: {
+    id: 1,
+    name: 'Test User'
+  }
+};
+
+var validate = function(decoded: User, request: Hapi.Request, callback: hapiAuthJwt2.ValidateCallback) {
+  if (!users[decoded.id]) {
+    return callback(null, false);
+  }
+
+  return callback(null, true);
+}
+
+server.register(hapiAuthJwt2, function(err) {
+  server.auth.strategy('jwt', 'jwt', <hapiAuthJwt2.Options>{
+    key: 'NeverShareYourSecret',
+    validateFunc: validate,
+    verifyOptions: {
+      algorithms: ['HS256']
+    }
+  });
+});
+
+server.start();

--- a/hapi-auth-jwt2/index.d.ts
+++ b/hapi-auth-jwt2/index.d.ts
@@ -1,0 +1,126 @@
+// Type definitions for hapi-auth-jwt2 7.0
+// Project: http://github.com/dwyl/hapi-auth-jwt2
+// Definitions by: Warren Seymour <http://github.com/warrenseymour>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import {Request, Response} from 'hapi';
+
+/**
+ * A key lookup function
+ *
+ * @param decoded the *decoded* but *unverified* JWT received from client
+ * @param callback the key lookup callback
+ */
+type KeyLookup = (decoded: any, callback: KeyLookupCallback) => void;
+
+/**
+ * Called when key lookup function has completed
+ *
+ * @param err an internal error
+ * @param key the secret key
+ * @param extraInfo any additional information that you would like
+ * to use in `validateFunc` which can be accessed via
+ * `request.plugins['hapi-auth-jwt2'].extraInfo`
+ */
+type KeyLookupCallback = (err: any, key: string, extraInfo?: any) => void;
+
+/**
+ * Called when Validation has completed
+ *
+ * @param err an internal error
+ * @param valid `true` if the JWT was valid, otherwise `false`
+ * @param credentials alternative credentials to be set instead of `decoded`
+ */
+type ValidateCallback = (err: any, valid: boolean, credentials?: any) => void;
+
+/**
+  * Options passed to `hapi.auth.strategy` when this plugin is used
+  */
+export interface Options {
+  /**
+    * The secret key used to check the signature of the token *or* a *key lookup function*
+    */
+  key?: string | KeyLookup;
+
+  /**
+    * The function which is run once the Token has been decoded
+    *
+    * @param decoded the *decoded* and *verified* JWT received from the client in *request.headers.authorization*
+    * @param request the original *request* received from the client
+    * @param callback the validation callback
+    */
+  validateFunc(decoded: {}, request: Request, callback: ValidateCallback): void;
+
+  /**
+    * Settings to define how tokens are verified by the jsonwebtoken library
+    */
+  verifyOptions?: {
+    /**
+      * Ignore expired tokens
+      */
+    ignoreExpiration?: boolean;
+
+    /**
+      * Do not enforce token audience
+      */
+    audience?: boolean;
+
+    /**
+      * Do not require the issuer to be valid
+      */
+    issuer?: boolean;
+
+    /**
+      * List of allowed algorithms
+      */
+    algorithms?: string[];
+  };
+
+  /**
+    * function called to decorate the response with authentication headers
+    * before the response headers or payload is written
+    *
+    * @param request the Request object
+    * @param reply is called if an error occurred
+    */
+  responseFunc?(request: Request, reply: (err: any, response: Response) => void): void;
+
+  /**
+    * If you prefer to pass your token via url, simply add a token url
+    * parameter to your request or use a custom parameter by setting `urlKey.
+    * To disable the url parameter set urlKey to `false` or ''.
+    * @default 'token'
+    */
+  urlKey?: string | boolean;
+
+  /**
+    * If you prefer to set your own cookie key or your project has a cookie
+    * called 'token' for another purpose, you can set a custom key for your
+    * cookie by setting `options.cookieKey='yourkeyhere'`. To disable cookies
+    * set cookieKey to `false` or ''.
+    * @default 'token'
+    */
+  cookieKey?: string | boolean;
+
+  /**
+    * If you want to set a custom key for your header token use the
+    * `headerKey` option. To disable header token set headerKey to `false` or
+    * ''.
+    * @default 'authorization'
+    */
+  headerKey?: string | boolean;
+
+  /**
+    * Allow custom token type, e.g. `Authorization: <tokenType> 12345678`
+    */
+  tokenType?: string;
+
+  /**
+    * Set to `true` to receive the complete token (`decoded.header`,
+    * `decoded.payload` and `decoded.signature`) as decoded argument to key
+    * lookup and `verifyFunc` callbacks (*not `validateFunc`*)
+    * @default false
+    */
+  complete?: boolean;
+}
+
+export default function hapiAuthJwt2(): void;

--- a/hapi-auth-jwt2/tsconfig.json
+++ b/hapi-auth-jwt2/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "hapi-auth-jwt2-tests.ts"
+    ]
+}

--- a/hapi-auth-jwt2/tslint.json
+++ b/hapi-auth-jwt2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `npm run new-package package-name`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.