### PR TITLE
make Query and LocationState in history of type 'any' instead of 'Object' to avoid casting

### DIFF
--- a/history/v2/index.d.ts
+++ b/history/v2/index.d.ts
@@ -75,10 +75,10 @@ export namespace History {
     export type LocationDescriptor = LocationDescriptorObject | Path;
     export type LocationKey = string;
     export type LocationListener = (location: Location) => void;
-    export type LocationState = Object;
+    export type LocationState = any;
     export type Path = string // Pathname + QueryString;
     export type Pathname = string;
-    export type Query = Object;
+    export type Query = any;
     export type QueryString = string;
     export type Search = string;
     export type TransitionHook = (location: Location, callback: (result: any) => void) => any


### PR DESCRIPTION
Since this two properties are dynamically typed anyway, there is no reason for needing a cast on every usage. 