### PR TITLE
Sequelize: Add benchmark to Options

### DIFF
--- a/sequelize/index.d.ts
+++ b/sequelize/index.d.ts
@@ -5219,6 +5219,12 @@ declare namespace sequelize {
          */
         transactionType?: string;
 
+        /**
+         * Print query execution time in milliseconds when logging SQL.
+         *
+         * Defaults to false
+         */
+        benchmark?: boolean;
     }
 
     /**

--- a/sequelize/v3/index.d.ts
+++ b/sequelize/v3/index.d.ts
@@ -5183,6 +5183,12 @@ declare namespace sequelize {
          */
         transactionType?: string;
 
+        /**
+         * Print query execution time in milliseconds when logging SQL.
+         *
+         * Defaults to false
+         */
+        benchmark?: boolean;
     }
 
     /**


### PR DESCRIPTION
In response to issue https://github.com/sequelize/sequelize/issues/2494
benchmarking feature was added with
version [3.21.0](https://github.com/sequelize/sequelize/blob/master/changelog.md#3210).
Options to Sequelize constructor was missing the `benchmark` field.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [ ] ~~Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).~~
- [x] Run `tsc` without errors.
- [ ] ~~Run `npm run lint package-name` if a `tslint.json` is present.~~

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [docs](http://docs.sequelizejs.com/en/v3/api/sequelize/), [source code change PR](https://github.com/sequelize/sequelize/pull/5282/files#diff-24f8b5cb05b7e92726ca732f7d16d5baR74)
- [ ] Increase the version number in the header if appropriate.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.~~
