### PR TITLE
Refer .md file directly to reduce heavy load

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,8 @@ Please fill in this template.
 - [ ] Make your PR against the `master` branch.
 - [ ] Use a meaningful title for the pull request. Include the name of the package modified.
 - [ ] Test the change in your own code. (Compile and run.)
-- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
-- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
+- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
+- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
 - [ ] Run `tsc` without errors.
 - [ ] Run `npm run lint package-name` if a `tslint.json` is present.
 


### PR DESCRIPTION
The main page of DefinitlyTyped is heavy because of the long list of types. Linking directly to the .md files can help.