### PR TITLE
recompose: Third parameter to branch() should be optional

### DIFF
--- a/recompose/index.d.ts
+++ b/recompose/index.d.ts
@@ -103,7 +103,7 @@ declare module 'recompose' {
     export function branch<TOutter>(
         test: predicate<TOutter>,
         trueEnhancer: InferableComponentEnhancer,
-        falseEnhancer: InferableComponentEnhancer
+        falseEnhancer?: InferableComponentEnhancer
     ): ComponentEnhancer<any, TOutter>;
 
     // renderComponent: https://github.com/acdlite/recompose/blob/master/docs/API.md#renderComponent

--- a/recompose/index.d.ts
+++ b/recompose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Recompose v0.20.2
+// Type definitions for Recompose v0.20.3
 // Project: https://github.com/acdlite/recompose
 // Definitions by: Iskander Sierra <https://github.com/iskandersierra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/recompose/recompose-tests.tsx
+++ b/recompose/recompose-tests.tsx
@@ -148,13 +148,19 @@ function testBranch() {
 
     const innerComponent: React.StatelessComponent<InnerProps> = (props: InnerProps) =>
       <div onClick={() => props.update()}>{props.count}</div>;
+    const innerComponent2 = () => <div>Hello</div>;
 
     const enhancer = branch(
       (props: OutterProps) => props.toggled,
       withState("count", "update", 0),
       withState("count", "update", 100)
     );
+    const enhancer2 = branch(
+      (props: OutterProps) => props.toggled,
+      renderComponent(innerComponent),
+    )
     const enhanced: React.ComponentClass<OutterProps> = enhancer(innerComponent);
+    const enhanced2: React.ComponentClass<OutterProps> = enhancer2(innerComponent);
 }
 
 function testRenderComponent() {


### PR DESCRIPTION
This is in line with the API documentation. See the example for [renderComponent()](https://github.com/acdlite/recompose/blob/master/docs/API.md#rendercomponent).

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/acdlite/recompose/blob/master/docs/API.md#rendercomponent
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
