### PR TITLE
jasmine: added keyof validation to spyOn

### DIFF
--- a/jasmine-es6-promise-matchers/index.d.ts
+++ b/jasmine-es6-promise-matchers/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/bvaughn/jasmine-es6-promise-matchers
 // Definitions by: Stephen Lautier <https://github.com/stephenlautier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="jasmine" />
 

--- a/jasmine-expect/index.d.ts
+++ b/jasmine-expect/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/JamieMason/Jasmine-Matchers
 // Definitions by: UserPixel <https://github.com/UserPixel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="jasmine" />
 

--- a/jasmine-jquery/index.d.ts
+++ b/jasmine-jquery/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/velesin/jasmine-jquery
 // Definitions by: Gregor Stamac <https://github.com/gstamac/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="jasmine"/>
 /// <reference types="jquery"/>

--- a/jasmine-matchers/index.d.ts
+++ b/jasmine-matchers/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/uxebu/jasmine-matchers
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /*
 Typings 2013 Bart van der Schoor

--- a/jasmine-node/index.d.ts
+++ b/jasmine-node/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/mhevery/jasmine-node
 // Definitions by: Sven Reglitzki <https://github.com/svi3c/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 ///<reference types="jasmine"/>
 

--- a/jasmine-promise-matchers/index.d.ts
+++ b/jasmine-promise-matchers/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/bvaughn/jasmine-promise-matchers
 // Definitions by: Matthew Hill <https://github.com/matthewjh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="jasmine" />
 

--- a/jasmine/index.d.ts
+++ b/jasmine/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://jasmine.github.io/
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb>, David Pärsson <https://github.com/davidparsson/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 
 // For ddescribe / iit use : https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/karma-jasmine/karma-jasmine.d.ts
@@ -35,7 +36,7 @@ interface DoneFn extends Function {
     fail: (message?: Error|string) => void;
 }
 
-declare function spyOn(object: any, method: string): jasmine.Spy;
+declare function spyOn<T>(object: T, method: keyof T): jasmine.Spy;
 
 declare function runs(asyncMethod: Function): void;
 declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;

--- a/jasminewd2/index.d.ts
+++ b/jasminewd2/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/angular/jasminewd
 // Definitions by: Sammy Jelin <https://github.com/sjelin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="jasmine" />
 

--- a/karma-jasmine/index.d.ts
+++ b/karma-jasmine/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/karma-runner/karma-jasmine
 // Definitions by: Michel Salib <https://github.com/michelsalib>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="jasmine" />
 


### PR DESCRIPTION
- [x] Make your PR against the `master` branch.
> Done
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
> Done
- [x] Test the change in your own code. (Compile and run.)
> This is potentially a breaking change, but it should compile in regular projects: OK for `any` (`keyof any` is `string`) and for correctly defined types.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
> This should not compile with 2.0.x, only 2.1.x and higher. Is this a problem?
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
> I changed only one line. Generic type usage is justifiable here.
- [x] Run `tsc` without errors.
> Done.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
> tslint.json is not present in the folder.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
> Look here, anyway we should be checking for method existence, so why not to check it in compile phase: https://github.com/jasmine/jasmine/blob/5a76e59d5b66a8c8b501553d243e8214cca53357/spec/core/SpyRegistrySpec.js#L19
- [x] Increase the version number in the header if appropriate.
> Not appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
> It is a quite small change, practically, one liner... if not to count TS 2.1+ prerequisite in the definitions dependent on `jasmine` and in `jasmine` definition itself I've added to make Travis pass. Hope that makes sense.
- [x] pass the Travis CI test