### PR TITLE
Improve declaration of FunctionColumnData in jquery.datatables

### DIFF
--- a/jquery.datatables/index.d.ts
+++ b/jquery.datatables/index.d.ts
@@ -1587,7 +1587,8 @@ declare namespace DataTables {
     }
 
     interface FunctionColumnData {
-        (row: any, t: string, s: any, meta: CellMetaSettings): void;
+        (row: any, t: 'set', s: any, meta: CellMetaSettings): void;
+        (row: any, t: 'display' | 'sort' | 'filter' | 'type', s: undefined, meta: CellMetaSettings): any;
     }
 
     interface ObjectColumnData {

--- a/jquery.datatables/jquery.datatables-tests.ts
+++ b/jquery.datatables/jquery.datatables-tests.ts
@@ -43,10 +43,17 @@ $(document).ready(function () {
         sort: "asc"
     };
 
-    var colDataFunc: DataTables.FunctionColumnData = function (row, type, set, meta) {
+    var colDataFunc: DataTables.FunctionColumnData = (row: any, type: 'set' | 'display' | 'sort' | 'filter' | 'type', set: any, meta: DataTables.CellMetaSettings) => {
         meta.col;
         meta.row;
         meta.settings;
+        switch (type) {
+            case 'set':
+                row.value = set;
+                return;
+            default:
+                return row.value;
+        }
     };
 
     var colRenderObject: DataTables.ObjectColumnRender = {
@@ -276,7 +283,7 @@ $(document).ready(function () {
         bScrollbarLeft: true,
         bScrollOversize: true
     }
-    
+
     //#endregion
 
     //#region "Init"


### PR DESCRIPTION
Resolves #12686 

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatables.net/reference/option/columns.data
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.