### PR TITLE
Optional parameters on node v6 and v7 path.ParsedPath

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -2722,23 +2722,23 @@ declare module "path" {
         /**
          * The root of the path such as '/' or 'c:\'
          */
-        root: string;
+        root?: string;
         /**
          * The full directory path such as '/home/user/dir' or 'c:\path\dir'
          */
-        dir: string;
+        dir?: string;
         /**
          * The file name including extension (if any) such as 'index.html'
          */
-        base: string;
+        base?: string;
         /**
          * The file extension (if any) such as '.html'
          */
-        ext: string;
+        ext?: string;
         /**
          * The file name without extension (if any) such as 'index'
          */
-        name: string;
+        name?: string;
     }
 
     /**

--- a/node/v6/index.d.ts
+++ b/node/v6/index.d.ts
@@ -2643,23 +2643,23 @@ declare module "path" {
         /**
          * The root of the path such as '/' or 'c:\'
          */
-        root: string;
+        root?: string;
         /**
          * The full directory path such as '/home/user/dir' or 'c:\path\dir'
          */
-        dir: string;
+        dir?: string;
         /**
          * The file name including extension (if any) such as 'index.html'
          */
-        base: string;
+        base?: string;
         /**
          * The file extension (if any) such as '.html'
          */
-        ext: string;
+        ext?: string;
         /**
          * The file name without extension (if any) such as 'index'
          */
-        name: string;
+        name?: string;
     }
 
     /**


### PR DESCRIPTION
All fields on the ParsedPath object are optional when passing into path.format. Added support for allowing only partial declaration of ParsedPath object.  https://nodejs.org/api/path.html#path_path_format_pathobject

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://nodejs.org/api/path.html#path_path_format_pathobject>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

