### PR TITLE
[lodash] change weakmap declaration to work with TS 2.2

### DIFF
--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -12701,7 +12701,7 @@ declare namespace _ {
          * @param value The value to check.
          * @returns Returns true if value is correctly classified, else false.
          */
-        isWeakMap<K, V>(value?: any): value is WeakMap<K, V>;
+        isWeakMap<K, V>(value?: any): value is WeakMapES5<K, V>;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {
@@ -19446,5 +19446,5 @@ declare global {
     interface Set<T> { }
     interface Map<K, V> { }
     interface WeakSet<T> { }
-    interface WeakMap<K, V> { }
+    interface WeakMapES5<K, V> { }
 }

--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -19446,5 +19446,5 @@ declare global {
     interface Set<T> { }
     interface Map<K, V> { }
     interface WeakSet<T> { }
-    interface WeakMap<K, V> { }
+    interface WeakMap<K extends object, V> { }
 }

--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -19446,5 +19446,5 @@ declare global {
     interface Set<T> { }
     interface Map<K, V> { }
     interface WeakSet<T> { }
-    interface WeakMap<K extends object, V> { }
+    interface WeakMap<K, V> { }
 }

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -7446,10 +7446,10 @@ namespace TestIsUndefined {
 // _.isWeakMap
 namespace TestIsWeakMap {
     {
-        let value: number|WeakMap<string, number>;
+        let value: number|WeakMapES5<string, number>;
 
         if (_.isWeakMap<string, number>(value)) {
-            let result: WeakMap<string, number> = value;
+            let result: WeakMapES5<string, number> = value;
         }
         else {
             let result: number = value;


### PR DESCRIPTION
In TS 2.2 `WeakMap` interface for ES6 has been changed from `WeakMap<K, V>` to `WeakMap<K extends object, V>`. This changes makes `@types/lodash` not working with new ES6 introduced in TS2.2.

To keep the backward compatibility with ES5, I think it is safe to rename the `WeakMap` declaration.

I know TS 2.2 is still in RC version now, but many people using it, including me :). So if you think this is too early and also bad idea then feel free to close this PR without merging it.

If this get merged then it's should close #14324.