### PR TITLE
[restify] Add field 'ca' in ServerOptions

### DIFF
--- a/restify/index.d.ts
+++ b/restify/index.d.ts
@@ -448,6 +448,7 @@ interface Server extends http.Server {
 }
 
 interface ServerOptions {
+    ca?: string;
     certificate?: string;
     key?: string;
     formatters?: Object;

--- a/restify/restify-tests.ts
+++ b/restify/restify-tests.ts
@@ -18,6 +18,7 @@ var server = restify.createServer({
 });
 
 server = restify.createServer({
+    ca: "test",
     certificate: "test",
     key: "test",
     formatters: {},
@@ -43,7 +44,7 @@ function send(req: restify.Request, res: restify.Response, next: restify.Next) {
     req.header('key') === 'val';
     req.trailer('key', 'val');
     req.trailer('key') === 'val';
-    
+
     req.accepts('test') === true;
     req.accepts(['test']) === true;
     req.acceptsEncoding('test') === true;
@@ -343,7 +344,7 @@ client2.get('/str/mcavage', function(err: any, req: any) {
         });
     });
 });
-  
+
 
 client.basicAuth('test', 'password');
 client2.basicAuth('test', 'password');


### PR DESCRIPTION
I added the 'ca' field for creating an HTTPS server. Restify has supported it since at least version 4.x, but it is [missing from docs](http://restify.com/#creating-a-server), so it was understandably forgotten in the type definition.

```js
restify.createServer({
  ca: fs.readFileSync('path/to/server/ca-bundle'), // not documented
  certificate: fs.readFileSync('path/to/server/certificate'),
  key: fs.readFileSync('path/to/server/key'),
  name: 'MyApp',
});
```

Source: https://github.com/restify/node-restify/blob/4.x/lib/server.js [line 270]


