### PR TITLE
babel-traverse: add "module" as one of possible values for Binding.kind

### DIFF
--- a/babel-traverse/babel-traverse-tests.ts
+++ b/babel-traverse/babel-traverse-tests.ts
@@ -109,3 +109,16 @@ const v1: Visitor = {
         path.scope.rename("n");
     }
 };
+
+// Binding.kind
+const BindingKindTest: Visitor  = {
+    Identifier(path) {
+        const kind = path.scope.getBinding("str").kind;
+        kind === 'module';
+        kind === 'const';
+        kind === 'let';
+        kind === 'var';
+        // The following should fail when uncommented
+        // kind === 'anythingElse';
+    },
+};

--- a/babel-traverse/index.d.ts
+++ b/babel-traverse/index.d.ts
@@ -126,7 +126,7 @@ export class Binding {
     identifier: t.Identifier;
     scope: Scope;
     path: NodePath<Node>;
-    kind: 'var' | 'let' | 'const';
+    kind: 'var' | 'let' | 'const' | 'module';
     referenced: boolean;
     references: number;
     referencePaths: NodePath<Node>[];


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
   - Unfortunately `babel-traverse` has a lot of lint errors that I don't have time to fix

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes <<https://github.com/babel/babel/blob/672adba9a14aa3b4d4676ef6b8699616d2062a55/packages/babel-traverse/src/path/introspection.js>>