### PR TITLE
angular: Removed success and error methods of IHttpPromise

### DIFF
--- a/angular-ui-router/angular-ui-router-tests.ts
+++ b/angular-ui-router/angular-ui-router-tests.ts
@@ -143,7 +143,7 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
         private $state: ng.ui.IStateService
     ) {
         $rootScope.$on("$locationChangeSuccess", (event: ng.IAngularEvent) => this.onLocationChangeSuccess(event));
-        $rootScope.$on('$stateNotFound', (event: ng.IAngularEvent, unfoundState: ng.ui.IUnfoundState, fromState: ng.ui.IState, fromParams: {}) => 
+        $rootScope.$on('$stateNotFound', (event: ng.IAngularEvent, unfoundState: ng.ui.IUnfoundState, fromState: ng.ui.IState, fromParams: {}) =>
                                               this.onStateNotFound(event, unfoundState, fromState, fromParams));
     }
 
@@ -157,8 +157,8 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
 
             // Note that we do not concern ourselves with what to do if this request fails,
             // because if it fails, the web page will be redirected away to the login screen.
-            this.$http({ url: "/api/me", method: "GET" }).success((user: any) => {
-                this.currentUser = user;
+            this.$http({ url: "/api/me", method: "GET" }).then((response: ng.IHttpPromiseCallbackArg<any>) => {
+                this.currentUser = response.data;
 
                 // sync the ui-state with the location in the browser, which effectively
                 // restarts the state change that was stopped previously
@@ -166,14 +166,14 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
             });
         }
     }
-    
+
      private onStateNotFound(event: ng.IAngularEvent,
                              unfoundState: ng.ui.IUnfoundState,
                              fromState: ng.ui.IState,
                              fromParams: {}) {
         var unfoundTo: string = unfoundState.to;
         var unfoundToParams: {} = unfoundState.toParams;
-        var unfoundOptions: ng.ui.IStateOptions = unfoundState.options 
+        var unfoundOptions: ng.ui.IStateOptions = unfoundState.options
     }
 
     private stateServiceTest() {

--- a/angular/angular-tests.ts
+++ b/angular/angular-tests.ts
@@ -109,11 +109,6 @@ namespace HttpAndRegularPromiseTests {
 
     function someController($scope: SomeControllerScope, $http: ng.IHttpService, $q: ng.IQService) {
         $http.get<ExpectedResponse>('http://somewhere/some/resource')
-            .success((data: ExpectedResponse) => {
-                $scope.person = data;
-            });
-
-        $http.get<ExpectedResponse>('http://somewhere/some/resource')
             .then((response: ng.IHttpPromiseCallbackArg<ExpectedResponse>) => {
                 // typing lost, so something like
                 // var i: number = response.data
@@ -156,21 +151,6 @@ namespace HttpAndRegularPromiseTests {
             $scope.nothing = 'really nothing';
         });
     }
-
-    // Test that we can pass around a type-checked success/error Promise Callback
-    function anotherController($scope: SomeControllerScope, $http: ng.IHttpService, $q: ng.IQService) {
-        function buildFooData(): ng.IRequestShortcutConfig {
-            return {};
-        }
-
-        function doFoo(callback: ng.IHttpPromiseCallback<ExpectedResponse>) {
-            $http
-                .get<ExpectedResponse>('/foo', buildFooData())
-                .success(callback);
-        };
-
-        doFoo((data: any) => console.log(data));
-    };
 }
 
 // Test for AngularJS Syntax
@@ -441,10 +421,10 @@ httpFoo.then((x) => {
     x.toFixed();
 });
 
-httpFoo.success((data, status, headers, config) => {
-    const h = headers('test');
+httpFoo.then((response: ng.IHttpPromiseCallbackArg<any>) => {
+    const h = response.headers('test');
     h.charAt(0);
-    const hs = headers();
+    const hs = response.headers();
     hs['content-type'].charAt(1);
 });
 

--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -1505,18 +1505,6 @@ declare namespace angular {
     }
 
     interface IHttpPromise<T> extends IPromise<IHttpPromiseCallbackArg<T>> {
-        /**
-         * The $http legacy promise methods success and error have been deprecated. Use the standard then method instead.
-         * If $httpProvider.useLegacyPromiseExtensions is set to false then these methods will throw $http/legacy error.
-         * @deprecated
-         */
-        success?(callback: IHttpPromiseCallback<T>): IHttpPromise<T>;
-        /**
-         * The $http legacy promise methods success and error have been deprecated. Use the standard then method instead.
-         * If $httpProvider.useLegacyPromiseExtensions is set to false then these methods will throw $http/legacy error.
-         * @deprecated
-         */
-        error?(callback: IHttpPromiseCallback<any>): IHttpPromise<T>;
     }
 
     // See the jsdoc for transformData() at https://github.com/angular/angular.js/blob/master/src/ng/http.js#L228

--- a/ng-file-upload/ng-file-upload-tests.ts
+++ b/ng-file-upload/ng-file-upload-tests.ts
@@ -26,7 +26,7 @@ class UploadController {
 			ngfValidateForce: true
 		});
 	}
-	
+
 	onFileSelect(files: Array<File>) {
 
 		this.Upload
@@ -44,11 +44,11 @@ class UploadController {
 			}).progress((evt: angular.angularFileUpload.IFileProgressEvent) => {
 				let percent = parseInt((100.0 * evt.loaded / evt.total).toString(), 10);
 				console.log("upload progress: " + percent + "% for " + evt.config.data.media[0]);
-			}).error((data: any, status: number, response: any, headers: any) => {
-				console.error(data, status, response, headers);
-			}).success((data: any, status: number, headers: any, config: angular.angularFileUpload.IFileUploadConfigFile) => {
+			}).catch((response: ng.IHttpPromiseCallbackArg<any>) => {
+				console.error(response.data, response.status, response.statusText, response.headers);
+			}).then((response: ng.IHttpPromiseCallbackArg<any>) => {
 				// file is uploaded successfully
-				console.log("Success!", data, status, headers, config);
+				console.log("Success!", response.data, response.status, response.headers, response.config);
 			});
 
 		this.Upload
@@ -72,16 +72,16 @@ class UploadController {
 		this.Upload.isResizeSupported();
 		this.Upload.isResumeSupported();
 		this.Upload.isUploadInProgress();
-		
+
 		let json = this.Upload.json({ test: true }),
 			jsonBlob = this.Upload.jsonBlob({ test: true }),
 			fileWithNewName = this.Upload.rename(files[0], "newName.jpg");
 
 		this.Upload
-			.resize(files[0], { 
+			.resize(files[0], {
 				height: 1024,
 				width: 1024,
-				quality: 0.7, 
+				quality: 0.7,
 				ratio: 0.9,
 				centerCrop: true,
 				restoreExif: true,


### PR DESCRIPTION
 - they are removed in angular 1.6

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$http
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
