### PR TITLE
[react-relay] Propagate component props to container.

### DIFF
--- a/react-relay/index.d.ts
+++ b/react-relay/index.d.ts
@@ -57,7 +57,7 @@ declare module "react-relay" {
         supports(...options: string[]): boolean
     }
 
-    function createContainer<T>(component: React.ComponentClass<T> | React.StatelessComponent<T>, params?: CreateContainerOpts): RelayContainerClass<any>
+    function createContainer<T>(component: React.ComponentClass<T> | React.StatelessComponent<T>, params?: CreateContainerOpts): RelayContainerClass<T>
     function injectNetworkLayer(networkLayer: RelayNetworkLayer): any
     function isContainer(component: React.ComponentClass<any>): boolean
     function QL(...args: any[]): string

--- a/react-relay/react-relay-tests.tsx
+++ b/react-relay/react-relay-tests.tsx
@@ -41,3 +41,31 @@ export default class AddTweetMutation extends Relay.Mutation<Props, Response> {
         return this.props
     }
 }
+
+interface ArtworkProps {
+    artwork: {
+        title: string
+    }
+}
+
+class Artwork extends React.Component<ArtworkProps, null> {
+    render() {
+        return <p>{this.props.artwork.title}</p>
+    }
+}
+
+const ArtworkContainer = Relay.createContainer(Artwork, {
+    fragments: {
+        artwork: () => Relay.QL`
+            fragment on Artwork {
+                title
+            }
+        `
+    }
+})
+
+class StubbedArtwork extends React.Component<null, null> {
+    render() {
+        return <ArtworkContainer artwork={{ title: "CHAMPAGNE FORMICA FLAG" }} />
+    }
+}

--- a/react-relay/react-relay-tests.tsx
+++ b/react-relay/react-relay-tests.tsx
@@ -45,12 +45,17 @@ export default class AddTweetMutation extends Relay.Mutation<Props, Response> {
 interface ArtworkProps {
     artwork: {
         title: string
-    }
+    },
+    relay: Relay.RelayProp,
 }
 
 class Artwork extends React.Component<ArtworkProps, null> {
     render() {
-        return <p>{this.props.artwork.title}</p>
+        return (
+            <a href={`/artworks/${this.props.relay.variables.artworkID}`}>
+                {this.props.artwork.title}
+            </a>
+        )
     }
 }
 
@@ -66,6 +71,15 @@ const ArtworkContainer = Relay.createContainer(Artwork, {
 
 class StubbedArtwork extends React.Component<null, null> {
     render() {
-        return <ArtworkContainer artwork={{ title: "CHAMPAGNE FORMICA FLAG" }} />
+        const props = {
+            artwork: { title: "CHAMPAGNE FORMICA FLAG" },
+            relay: {
+                variables: {
+                    artworkID: "champagne-formica-flag",
+                },
+                setVariables: () => {},
+            }
+        }
+        return <ArtworkContainer {...props} />
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- ~~Run `npm run lint package-name` if a `tslint.json` is present.~~ Trying to install the required npm packages to be able to lint this is leading to issues with compiling nodegit’s dependencies. It was taking a considerable amount of time to debug.

This PR makes it so that the higher-order component returned from `Relay.createContainer` has the same props as the actual component. This is helpful when manually inserting stub data in tests vs having Relay insert data at runtime.

### Before

<img width="569" alt="screen shot 2017-02-08 at 13 20 19" src="https://cloud.githubusercontent.com/assets/2320/22737004/7a0a2114-ee01-11e6-831b-c7a8f1fab216.png">

### After

<img width="569" alt="screen shot 2017-02-08 at 13 20 46" src="https://cloud.githubusercontent.com/assets/2320/22737015/872116aa-ee01-11e6-9193-319ec7e04def.png">
