### PR TITLE
Fix 'patname' typo introduced in 69a9f6d671 in react-router-redux typings

### DIFF
--- a/react-router/lib/Router.d.ts
+++ b/react-router/lib/Router.d.ts
@@ -37,7 +37,7 @@ export type ChangeHook = (prevState: RouterState, nextState: RouterState, replac
 export type RouteHook = (nextLocation?: Location) => any;
 
 export interface Location {
-    patname: Pathname;
+    pathname: Pathname;
     search: Search;
     query: Query;
     state: LocationState;


### PR DESCRIPTION
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

It's just trivially typo'd.