### PR TITLE
Add Visual Studio IDE support files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ node_modules
 .sublimets
 .settings/launch.json
 
+.vs
 .vscode
 yarn.lock


### PR DESCRIPTION
With Visual Studio 2017 we actually get an additional *reasonable* TypeScript and JavaScript editor.

In case someone edit the DefinitelyTyped repo in Visual Studio, it would be nice if git ignored the `.vs` folder.