### PR TITLE
[node] reverse signals and errno in os.constants

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1209,7 +1209,7 @@ declare module "os" {
     export function userInfo(options?: { encoding: string }): { username: string, uid: number, gid: number, shell: any, homedir: string }
     export var constants: {
         UV_UDP_REUSEADDR: number,
-        errno: {
+        signals: {
             SIGHUP: number;
             SIGINT: number;
             SIGQUIT: number;
@@ -1245,7 +1245,7 @@ declare module "os" {
             SIGSYS: number;
             SIGUNUSED: number;
         },
-        signals: {
+        errno: {
             E2BIG: number;
             EACCES: number;
             EADDRINUSE: number;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1597,7 +1597,38 @@ namespace os_tests {
 
         result = os.constants.signals.SIGHUP;
         result = os.constants.signals.SIGINT;
+        result = os.constants.signals.SIGQUIT;
+        result = os.constants.signals.SIGILL;
+        result = os.constants.signals.SIGTRAP;
+        result = os.constants.signals.SIGABRT;
+        result = os.constants.signals.SIGIOT;
+        result = os.constants.signals.SIGBUS;
+        result = os.constants.signals.SIGFPE;
         result = os.constants.signals.SIGKILL;
+        result = os.constants.signals.SIGUSR1;
+        result = os.constants.signals.SIGSEGV;
+        result = os.constants.signals.SIGUSR2;
+        result = os.constants.signals.SIGPIPE;
+        result = os.constants.signals.SIGALRM;
+        result = os.constants.signals.SIGTERM;
+        result = os.constants.signals.SIGCHLD;
+        result = os.constants.signals.SIGSTKFLT;
+        result = os.constants.signals.SIGCONT;
+        result = os.constants.signals.SIGSTOP;
+        result = os.constants.signals.SIGTSTP;
+        result = os.constants.signals.SIGTTIN;
+        result = os.constants.signals.SIGTTOU;
+        result = os.constants.signals.SIGURG;
+        result = os.constants.signals.SIGXCPU;
+        result = os.constants.signals.SIGXFSZ;
+        result = os.constants.signals.SIGVTALRM;
+        result = os.constants.signals.SIGPROF;
+        result = os.constants.signals.SIGWINCH;
+        result = os.constants.signals.SIGIO;
+        result = os.constants.signals.SIGPOLL;
+        result = os.constants.signals.SIGPWR;
+        result = os.constants.signals.SIGSYS;
+        result = os.constants.signals.SIGUNUSED;
     }
 
     {
@@ -1682,45 +1713,6 @@ namespace os_tests {
         result = os.constants.errno.ETXTBSY;
         result = os.constants.errno.EWOULDBLOCK;
         result = os.constants.errno.EXDEV;
-    }
-
-    {
-        let result: number;
-
-        result = os.constants.signals.SIGHUP;
-        result = os.constants.signals.SIGINT;
-        result = os.constants.signals.SIGQUIT;
-        result = os.constants.signals.SIGILL;
-        result = os.constants.signals.SIGTRAP;
-        result = os.constants.signals.SIGABRT;
-        result = os.constants.signals.SIGIOT;
-        result = os.constants.signals.SIGBUS;
-        result = os.constants.signals.SIGFPE;
-        result = os.constants.signals.SIGKILL;
-        result = os.constants.signals.SIGUSR1;
-        result = os.constants.signals.SIGSEGV;
-        result = os.constants.signals.SIGUSR2;
-        result = os.constants.signals.SIGPIPE;
-        result = os.constants.signals.SIGALRM;
-        result = os.constants.signals.SIGTERM;
-        result = os.constants.signals.SIGCHLD;
-        result = os.constants.signals.SIGSTKFLT;
-        result = os.constants.signals.SIGCONT;
-        result = os.constants.signals.SIGSTOP;
-        result = os.constants.signals.SIGTSTP;
-        result = os.constants.signals.SIGTTIN;
-        result = os.constants.signals.SIGTTOU;
-        result = os.constants.signals.SIGURG;
-        result = os.constants.signals.SIGXCPU;
-        result = os.constants.signals.SIGXFSZ;
-        result = os.constants.signals.SIGVTALRM;
-        result = os.constants.signals.SIGPROF;
-        result = os.constants.signals.SIGWINCH;
-        result = os.constants.signals.SIGIO;
-        result = os.constants.signals.SIGPOLL;
-        result = os.constants.signals.SIGPWR;
-        result = os.constants.signals.SIGSYS;
-        result = os.constants.signals.SIGUNUSED;
     }
 }
 

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1591,6 +1591,137 @@ namespace os_tests {
 
         result = os.networkInterfaces();
     }
+
+    {
+        let result: number;
+
+        result = os.constants.signals.SIGHUP;
+        result = os.constants.signals.SIGINT;
+        result = os.constants.signals.SIGKILL;
+    }
+
+    {
+        let result: number;
+
+        result = os.constants.errno.E2BIG;
+        result = os.constants.errno.EACCES;
+        result = os.constants.errno.EADDRINUSE;
+        result = os.constants.errno.EADDRNOTAVAIL;
+        result = os.constants.errno.EAFNOSUPPORT;
+        result = os.constants.errno.EAGAIN;
+        result = os.constants.errno.EALREADY;
+        result = os.constants.errno.EBADF;
+        result = os.constants.errno.EBADMSG;
+        result = os.constants.errno.EBUSY;
+        result = os.constants.errno.ECANCELED;
+        result = os.constants.errno.ECHILD;
+        result = os.constants.errno.ECONNABORTED;
+        result = os.constants.errno.ECONNREFUSED;
+        result = os.constants.errno.ECONNRESET;
+        result = os.constants.errno.EDEADLK;
+        result = os.constants.errno.EDESTADDRREQ;
+        result = os.constants.errno.EDOM;
+        result = os.constants.errno.EDQUOT;
+        result = os.constants.errno.EEXIST;
+        result = os.constants.errno.EFAULT;
+        result = os.constants.errno.EFBIG;
+        result = os.constants.errno.EHOSTUNREACH;
+        result = os.constants.errno.EIDRM;
+        result = os.constants.errno.EILSEQ;
+        result = os.constants.errno.EINPROGRESS;
+        result = os.constants.errno.EINTR;
+        result = os.constants.errno.EINVAL;
+        result = os.constants.errno.EIO;
+        result = os.constants.errno.EISCONN;
+        result = os.constants.errno.EISDIR;
+        result = os.constants.errno.ELOOP;
+        result = os.constants.errno.EMFILE;
+        result = os.constants.errno.EMLINK;
+        result = os.constants.errno.EMSGSIZE;
+        result = os.constants.errno.EMULTIHOP;
+        result = os.constants.errno.ENAMETOOLONG;
+        result = os.constants.errno.ENETDOWN;
+        result = os.constants.errno.ENETRESET;
+        result = os.constants.errno.ENETUNREACH;
+        result = os.constants.errno.ENFILE;
+        result = os.constants.errno.ENOBUFS;
+        result = os.constants.errno.ENODATA;
+        result = os.constants.errno.ENODEV;
+        result = os.constants.errno.ENOENT;
+        result = os.constants.errno.ENOEXEC;
+        result = os.constants.errno.ENOLCK;
+        result = os.constants.errno.ENOLINK;
+        result = os.constants.errno.ENOMEM;
+        result = os.constants.errno.ENOMSG;
+        result = os.constants.errno.ENOPROTOOPT;
+        result = os.constants.errno.ENOSPC;
+        result = os.constants.errno.ENOSR;
+        result = os.constants.errno.ENOSTR;
+        result = os.constants.errno.ENOSYS;
+        result = os.constants.errno.ENOTCONN;
+        result = os.constants.errno.ENOTDIR;
+        result = os.constants.errno.ENOTEMPTY;
+        result = os.constants.errno.ENOTSOCK;
+        result = os.constants.errno.ENOTSUP;
+        result = os.constants.errno.ENOTTY;
+        result = os.constants.errno.ENXIO;
+        result = os.constants.errno.EOPNOTSUPP;
+        result = os.constants.errno.EOVERFLOW;
+        result = os.constants.errno.EPERM;
+        result = os.constants.errno.EPIPE;
+        result = os.constants.errno.EPROTO;
+        result = os.constants.errno.EPROTONOSUPPORT;
+        result = os.constants.errno.EPROTOTYPE;
+        result = os.constants.errno.ERANGE;
+        result = os.constants.errno.EROFS;
+        result = os.constants.errno.ESPIPE;
+        result = os.constants.errno.ESRCH;
+        result = os.constants.errno.ESTALE;
+        result = os.constants.errno.ETIME;
+        result = os.constants.errno.ETIMEDOUT;
+        result = os.constants.errno.ETXTBSY;
+        result = os.constants.errno.EWOULDBLOCK;
+        result = os.constants.errno.EXDEV;
+    }
+
+    {
+        let result: number;
+
+        result = os.constants.signals.SIGHUP;
+        result = os.constants.signals.SIGINT;
+        result = os.constants.signals.SIGQUIT;
+        result = os.constants.signals.SIGILL;
+        result = os.constants.signals.SIGTRAP;
+        result = os.constants.signals.SIGABRT;
+        result = os.constants.signals.SIGIOT;
+        result = os.constants.signals.SIGBUS;
+        result = os.constants.signals.SIGFPE;
+        result = os.constants.signals.SIGKILL;
+        result = os.constants.signals.SIGUSR1;
+        result = os.constants.signals.SIGSEGV;
+        result = os.constants.signals.SIGUSR2;
+        result = os.constants.signals.SIGPIPE;
+        result = os.constants.signals.SIGALRM;
+        result = os.constants.signals.SIGTERM;
+        result = os.constants.signals.SIGCHLD;
+        result = os.constants.signals.SIGSTKFLT;
+        result = os.constants.signals.SIGCONT;
+        result = os.constants.signals.SIGSTOP;
+        result = os.constants.signals.SIGTSTP;
+        result = os.constants.signals.SIGTTIN;
+        result = os.constants.signals.SIGTTOU;
+        result = os.constants.signals.SIGURG;
+        result = os.constants.signals.SIGXCPU;
+        result = os.constants.signals.SIGXFSZ;
+        result = os.constants.signals.SIGVTALRM;
+        result = os.constants.signals.SIGPROF;
+        result = os.constants.signals.SIGWINCH;
+        result = os.constants.signals.SIGIO;
+        result = os.constants.signals.SIGPOLL;
+        result = os.constants.signals.SIGPWR;
+        result = os.constants.signals.SIGSYS;
+        result = os.constants.signals.SIGUNUSED;
+    }
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -1152,7 +1152,7 @@ declare module "os" {
     export function userInfo(options?: { encoding: string }): { username: string, uid: number, gid: number, shell: any, homedir: string }
     export var constants: {
         UV_UDP_REUSEADDR: number,
-        errno: {
+        signals: {
             SIGHUP: number;
             SIGINT: number;
             SIGQUIT: number;
@@ -1188,7 +1188,7 @@ declare module "os" {
             SIGSYS: number;
             SIGUNUSED: number;
         },
-        signals: {
+        errno: {
             E2BIG: number;
             EACCES: number;
             EADDRINUSE: number;

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -1508,6 +1508,129 @@ namespace os_tests {
 
         result = os.networkInterfaces();
     }
+
+    {
+        let result: number;
+
+        result = os.constants.signals.SIGHUP;
+        result = os.constants.signals.SIGINT;
+        result = os.constants.signals.SIGQUIT;
+        result = os.constants.signals.SIGILL;
+        result = os.constants.signals.SIGTRAP;
+        result = os.constants.signals.SIGABRT;
+        result = os.constants.signals.SIGIOT;
+        result = os.constants.signals.SIGBUS;
+        result = os.constants.signals.SIGFPE;
+        result = os.constants.signals.SIGKILL;
+        result = os.constants.signals.SIGUSR1;
+        result = os.constants.signals.SIGSEGV;
+        result = os.constants.signals.SIGUSR2;
+        result = os.constants.signals.SIGPIPE;
+        result = os.constants.signals.SIGALRM;
+        result = os.constants.signals.SIGTERM;
+        result = os.constants.signals.SIGCHLD;
+        result = os.constants.signals.SIGSTKFLT;
+        result = os.constants.signals.SIGCONT;
+        result = os.constants.signals.SIGSTOP;
+        result = os.constants.signals.SIGTSTP;
+        result = os.constants.signals.SIGTTIN;
+        result = os.constants.signals.SIGTTOU;
+        result = os.constants.signals.SIGURG;
+        result = os.constants.signals.SIGXCPU;
+        result = os.constants.signals.SIGXFSZ;
+        result = os.constants.signals.SIGVTALRM;
+        result = os.constants.signals.SIGPROF;
+        result = os.constants.signals.SIGWINCH;
+        result = os.constants.signals.SIGIO;
+        result = os.constants.signals.SIGPOLL;
+        result = os.constants.signals.SIGPWR;
+        result = os.constants.signals.SIGSYS;
+        result = os.constants.signals.SIGUNUSED;
+    }
+
+    {
+        let result: number;
+
+        result = os.constants.errno.E2BIG;
+        result = os.constants.errno.EACCES;
+        result = os.constants.errno.EADDRINUSE;
+        result = os.constants.errno.EADDRNOTAVAIL;
+        result = os.constants.errno.EAFNOSUPPORT;
+        result = os.constants.errno.EAGAIN;
+        result = os.constants.errno.EALREADY;
+        result = os.constants.errno.EBADF;
+        result = os.constants.errno.EBADMSG;
+        result = os.constants.errno.EBUSY;
+        result = os.constants.errno.ECANCELED;
+        result = os.constants.errno.ECHILD;
+        result = os.constants.errno.ECONNABORTED;
+        result = os.constants.errno.ECONNREFUSED;
+        result = os.constants.errno.ECONNRESET;
+        result = os.constants.errno.EDEADLK;
+        result = os.constants.errno.EDESTADDRREQ;
+        result = os.constants.errno.EDOM;
+        result = os.constants.errno.EDQUOT;
+        result = os.constants.errno.EEXIST;
+        result = os.constants.errno.EFAULT;
+        result = os.constants.errno.EFBIG;
+        result = os.constants.errno.EHOSTUNREACH;
+        result = os.constants.errno.EIDRM;
+        result = os.constants.errno.EILSEQ;
+        result = os.constants.errno.EINPROGRESS;
+        result = os.constants.errno.EINTR;
+        result = os.constants.errno.EINVAL;
+        result = os.constants.errno.EIO;
+        result = os.constants.errno.EISCONN;
+        result = os.constants.errno.EISDIR;
+        result = os.constants.errno.ELOOP;
+        result = os.constants.errno.EMFILE;
+        result = os.constants.errno.EMLINK;
+        result = os.constants.errno.EMSGSIZE;
+        result = os.constants.errno.EMULTIHOP;
+        result = os.constants.errno.ENAMETOOLONG;
+        result = os.constants.errno.ENETDOWN;
+        result = os.constants.errno.ENETRESET;
+        result = os.constants.errno.ENETUNREACH;
+        result = os.constants.errno.ENFILE;
+        result = os.constants.errno.ENOBUFS;
+        result = os.constants.errno.ENODATA;
+        result = os.constants.errno.ENODEV;
+        result = os.constants.errno.ENOENT;
+        result = os.constants.errno.ENOEXEC;
+        result = os.constants.errno.ENOLCK;
+        result = os.constants.errno.ENOLINK;
+        result = os.constants.errno.ENOMEM;
+        result = os.constants.errno.ENOMSG;
+        result = os.constants.errno.ENOPROTOOPT;
+        result = os.constants.errno.ENOSPC;
+        result = os.constants.errno.ENOSR;
+        result = os.constants.errno.ENOSTR;
+        result = os.constants.errno.ENOSYS;
+        result = os.constants.errno.ENOTCONN;
+        result = os.constants.errno.ENOTDIR;
+        result = os.constants.errno.ENOTEMPTY;
+        result = os.constants.errno.ENOTSOCK;
+        result = os.constants.errno.ENOTSUP;
+        result = os.constants.errno.ENOTTY;
+        result = os.constants.errno.ENXIO;
+        result = os.constants.errno.EOPNOTSUPP;
+        result = os.constants.errno.EOVERFLOW;
+        result = os.constants.errno.EPERM;
+        result = os.constants.errno.EPIPE;
+        result = os.constants.errno.EPROTO;
+        result = os.constants.errno.EPROTONOSUPPORT;
+        result = os.constants.errno.EPROTOTYPE;
+        result = os.constants.errno.ERANGE;
+        result = os.constants.errno.EROFS;
+        result = os.constants.errno.ESPIPE;
+        result = os.constants.errno.ESRCH;
+        result = os.constants.errno.ESTALE;
+        result = os.constants.errno.ETIME;
+        result = os.constants.errno.ETIMEDOUT;
+        result = os.constants.errno.ETXTBSY;
+        result = os.constants.errno.EWOULDBLOCK;
+        result = os.constants.errno.EXDEV;
+    }
 }
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION
# [node]
Reverse `os.constants` `errno` and `signals` type mappings, which were swapped.

# Fallout
There are various TSLint and `tsc` errors in CI exposed by node being so commonly referenced by other typings packages. I've fixed excess whitespace errors, and a few others.

## [bittorrent-protocol]
TSLint errors due to interface constructors. Looking at [bittorrent-protocol repo](https://github.com/feross/bittorrent-protocol/blob/master/index.js), `Request` and `Extension` are inaccessible from module export. I've removed these interface constructors.

## [koa-json-error]
TSLint errors `Type literal has only a call signature` are fixed.

**Remaining failure** on `tsc` with TypeScript 2.0, caused by test file dependency on `lodash`, which now uses TypeScript 2.1 `keyof`.

## [libpq]
**Remaining failure** on `tsc` with TypeScript 2.0, caused by test file dependency on `lodash`, which now uses TypeScript 2.1 `keyof`.

## [supertest-as-promised]
**Remaining failure** on `tsc` with TypeScript 2.0, caused by test file dependency on `jasmine`, which now uses TypeScript 2.1 `keyof`.

## [...]
There are many other cases of typings packages using `jasmine` or other packages that now use TypeScript 2.1 features.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v6.x/docs/api/os.html#os_os_constants_1
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.