### PR TITLE
react-router: Fixed missing type intersection

### DIFF
--- a/react-router/lib/withRouter.d.ts
+++ b/react-router/lib/withRouter.d.ts
@@ -1,4 +1,5 @@
 import { ComponentClass, StatelessComponent } from "react";
+import { RouterState } from "./Router";
 
 interface Options {
     withRef?: boolean;
@@ -6,4 +7,4 @@ interface Options {
 
 type ComponentConstructor<P> = ComponentClass<P> | StatelessComponent<P>;
 
-export default function withRouter<P>(component: ComponentConstructor<P>, options?: Options): ComponentClass<P>;
+export default function withRouter<P>(component: ComponentConstructor<P & {router: RouterState}>, options?: Options): ComponentClass<P>;


### PR DESCRIPTION
A prop called `router` is introduced by this HoC. By not explicitly intersecting that prop with the type arg, the result is an HoC that still has a `router` prop on output. This means that without the fix, any consumer that uses this component will have to manually provide a bogus value for `router` that is then overwritten by the HoC wrapper.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/master/docs/API.md#withroutercomponent-options