### PR TITLE
Nock: support options method

### DIFF
--- a/nock/index.d.ts
+++ b/nock/index.d.ts
@@ -48,6 +48,7 @@ declare namespace nock {
         patch: InterceptFunction;
         merge: InterceptFunction;
         delete: InterceptFunction;
+        options: InterceptFunction;
 
         intercept: (
             uri: string | RegExp | { (uri: string): boolean; },

--- a/nock/index.d.ts
+++ b/nock/index.d.ts
@@ -34,7 +34,8 @@ declare namespace nock {
     type HttpHeaders = { [key: string]: string | { (req: any, res: any, body: string): any; }; };
     type InterceptFunction = (
         uri: string | RegExp | { (uri: string): boolean; },
-        requestBody?: string | RegExp | { (body: any): boolean; } | any
+        requestBody?: string | RegExp | { (body: any): boolean; } | any,
+        interceptorOptions?: Options
     ) => Interceptor;
     export type ReplyCallback = (err: any, result: ReplyCallbackResult) => void;
     type ReplyCallbackResult = string | [number, string | any] | [number, string | any, HttpHeaders] | any;

--- a/nock/nock-tests.ts
+++ b/nock/nock-tests.ts
@@ -21,32 +21,39 @@ inst = scope.head(str);
 
 inst = scope.get(str);
 inst = scope.get(str, data);
+inst = scope.get(str, data, options);
 
 inst = scope.options(str);
 inst = scope.options(str, data);
+inst = scope.options(str, data, options);
 
 inst = scope.patch(str);
 inst = scope.patch(str, str);
 inst = scope.patch(str, obj);
+inst = scope.patch(str, obj, options);
 inst = scope.patch(str, regex);
 
 inst = scope.post(str);
 inst = scope.post(str, data);
+inst = scope.post(str, data, options);
 inst = scope.post(str, obj);
 inst = scope.post(str, regex);
 
 inst = scope.put(str);
 inst = scope.put(str, data);
+inst = scope.put(str, data, options);
 inst = scope.put(str, obj);
 inst = scope.put(str, regex);
 
 inst = scope.delete(str);
 inst = scope.delete(str, data);
+inst = scope.delete(str, data, options);
 inst = scope.delete(str, obj);
 inst = scope.delete(str, regex);
 
 inst = scope.merge(str);
 inst = scope.merge(str, data);
+inst = scope.merge(str, data, options);
 inst = scope.merge(str, obj);
 inst = scope.merge(str, regex);
 

--- a/nock/nock-tests.ts
+++ b/nock/nock-tests.ts
@@ -22,6 +22,9 @@ inst = scope.head(str);
 inst = scope.get(str);
 inst = scope.get(str, data);
 
+inst = scope.options(str);
+inst = scope.options(str, data);
+
 inst = scope.patch(str);
 inst = scope.patch(str, str);
 inst = scope.patch(str, obj);


### PR DESCRIPTION
Nock supports OPTIONS method since 8.2.0. (https://github.com/node-nock/nock/pull/668).
This method was missing in the corresponding type definition.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-nock/nock/pull/668

