### PR TITLE
fix FindOrInitializeOptions and FindCreateFindOptions

### DIFF
--- a/sequelize/index.d.ts
+++ b/sequelize/index.d.ts
@@ -3319,38 +3319,25 @@ declare namespace sequelize {
     /**
      * Options for Model.findOrInitialize method
      */
-    interface FindOrInitializeOptions<TAttributes> extends LoggingOptions {
-
-        /**
-         * A hash of search attributes.
-         */
-        where: string | WhereOptions;
+    interface FindOrInitializeOptions<TAttributes> extends FindOptions {
 
         /**
          * Default values to use if building a new instance
          */
         defaults?: TAttributes;
 
-        /**
-         * Transaction to run query under
-         */
-        transaction?: Transaction;
     }
 
     /**
-         * Options for Model.findOrInitialize method
+     * Options for Model.findOrInitialize method
      */
-    interface FindCreateFindOptions<TAttributes> {
+    interface FindCreateFindOptions<TAttributes> extends FindOptions {
 
         /**
-             * A hash of search attributes.
-         */
-        where: string | WhereOptions;
-
-        /**
-             * Default values to use if building a new instance
+         * Default values to use if building a new instance
          */
         defaults?: TAttributes;
+
     }
 
     /**

--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -977,6 +977,7 @@ let findOrRetVal: Promise<[AnyInstance, boolean]>;
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' } } );
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, transaction : t } );
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, defaults : { foo : 'asd' }, transaction : t } );
+findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, defaults : { foo : 'asd' }, paranoid : false } );
 
 findOrRetVal = User.findOrCreate( { where : { a : 'b' }, defaults : { json : { a : { b : 'c' }, d : [1, 2, 3] } } } );
 findOrRetVal = User.findOrCreate( { where : { a : 'b' }, defaults : { json : 'a', data : 'b' } } );
@@ -989,7 +990,6 @@ findOrRetVal = User.findOrCreate( { where : { objectId : 'asdasdasd' }, defaults
 findOrRetVal = User.findOrCreate( { where : { id : undefined }, defaults : { name : Math.random().toString() } } );
 findOrRetVal = User.findOrCreate( { where : { email : 'unique.email.@d.com', companyId : Math.floor( Math.random() * 5 ) } } );
 findOrRetVal = User.findOrCreate( { where : { objectId : 1 }, defaults : { bool : false } } );
-findOrRetVal = User.findOrCreate( { where : 'c', defaults : {} } );
 
 User.upsert( { id : 42, username : 'doe', foo : s.fn( 'upper', 'mixedCase2' ) } );
 


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

both `findOrCreate` and `findCreateFind` delegate options to `findOne` method which uses `FindOptions` interface, so these methods should extend this interface, implementation details are here:
https://github.com/sequelize/sequelize/blob/e22ce18db2bd52a7e60ee52865bfa5a994e8ab7a/lib/model.js#L2008-L2034
https://github.com/sequelize/sequelize/blob/e22ce18db2bd52a7e60ee52865bfa5a994e8ab7a/lib/model.js#L2101-L2114

this is important so we can pass stuff like `paranoid : false` into these where it makes sense (for models that have `paranoid: true` defined)

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
