### PR TITLE
fix: [node-lorem-ipsum] make loremIpsum the default export

### DIFF
--- a/lorem-ipsum/index.d.ts
+++ b/lorem-ipsum/index.d.ts
@@ -62,4 +62,4 @@ declare namespace loremIpsum {}
  */
 declare function loremIpsum(options?: LoremIpsumOptions): string;
 
-export = loremIpsum;
+export default loremIpsum;


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:

When doing:
```ts
import loremIpsum from 'lorem-ipsum';
```
you get a 
```
src/ui/caption/stories/caption.stories.tsx(4,8): error TS1192: Module '"/Users/joscha/dev/canva/web-ui/node_modules/@types/lorem-ipsum/index"' has no default export.
```

This can be fixed by switching on `allowSyntheticDefaultImports` or the fix in this PR.
