### PR TITLE
enzyme: return any as state for shallow() and mount()

### DIFF
--- a/enzyme/enzyme-tests.tsx
+++ b/enzyme/enzyme-tests.tsx
@@ -37,6 +37,13 @@ namespace ShallowWrapperTest {
         elementWrapper: ShallowWrapper<HTMLAttributes<{}>, {}>,
         statelessWrapper: ShallowWrapper<StatelessProps, never>;
 
+    function test_props_state_inferring() {
+        let wrapper: ShallowWrapper<MyComponentProps, MyComponentState>;
+        wrapper = shallow(<MyComponent stringProp="value" />);
+        wrapper.state().stateProperty;
+        wrapper.props().stringProp.toUpperCase();
+    }
+
     function test_shallow_options() {
         shallow(<MyComponent stringProp="1"/>, {
             context: {
@@ -336,6 +343,13 @@ namespace ReactWrapperTest {
         stringVal: string,
         elementWrapper: ReactWrapper<HTMLAttributes<{}>, {}>,
         statelessWrapper: ReactWrapper<StatelessProps, never>;
+
+    function test_prop_state_inferring() {
+        let wrapper: ReactWrapper<MyComponentProps, MyComponentState>;
+        wrapper = mount(<MyComponent stringProp="value" />);
+        wrapper.state().stateProperty;
+        wrapper.props().stringProp.toUpperCase();
+    }
 
     function test_unmount() {
         reactWrapper = reactWrapper.unmount();

--- a/enzyme/index.d.ts
+++ b/enzyme/index.d.ts
@@ -541,14 +541,14 @@ export interface MountRendererProps {
  * @param node
  * @param [options]
  */
-export function shallow<P, S>(node: ReactElement<P>, options?: ShallowRendererProps): ShallowWrapper<P, S>;
+export function shallow<P, S>(node: ReactElement<P>, options?: ShallowRendererProps): ShallowWrapper<P, any>;
 
 /**
  * Mounts and renders a react component into the document and provides a testing wrapper around it.
  * @param node
  * @param [options]
  */
-export function mount<P, S>(node: ReactElement<P>, options?: MountRendererProps): ReactWrapper<P, S>;
+export function mount<P, S>(node: ReactElement<P>, options?: MountRendererProps): ReactWrapper<P, any>;
 
 /**
  * Render react components to static HTML and analyze the resulting HTML structure.

--- a/enzyme/index.d.ts
+++ b/enzyme/index.d.ts
@@ -541,14 +541,16 @@ export interface MountRendererProps {
  * @param node
  * @param [options]
  */
-export function shallow<P, S>(node: ReactElement<P>, options?: ShallowRendererProps): ShallowWrapper<P, any>;
+export function shallow<P>(node: ReactElement<P>, options?: ShallowRendererProps): ShallowWrapper<P, any>;
+export function shallow<P, S>(node: ReactElement<P>, options?: ShallowRendererProps): ShallowWrapper<P, S>;
 
 /**
  * Mounts and renders a react component into the document and provides a testing wrapper around it.
  * @param node
  * @param [options]
  */
-export function mount<P, S>(node: ReactElement<P>, options?: MountRendererProps): ReactWrapper<P, any>;
+export function mount<P>(node: ReactElement<P>, options?: MountRendererProps): ReactWrapper<P, any>;
+export function mount<P, S>(node: ReactElement<P>, options?: MountRendererProps): ReactWrapper<P, S>;
 
 /**
  * Render react components to static HTML and analyze the resulting HTML structure.


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

Return any since it's not possible to infer state from ReactElement. Use case
```tsx
let wrapper: ShallowWrapper<Props, State>;

it("first", () => {
  wrapper = shallow(<MyComponent />);
});

it("second", () => {
  wrapper = shallow(<MyComponent />);
});

```
without this change, it's required to pass template types explicitly to all shallow/mount calls.