### PR TITLE
[passport-facebook] Add req to verify function

### DIFF
--- a/passport-facebook/index.d.ts
+++ b/passport-facebook/index.d.ts
@@ -36,7 +36,7 @@ interface IStrategyOption {
 
 declare class Strategy implements passport.Strategy {
     constructor(options: IStrategyOption,
-        verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void);
+        verify: (req?: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void);
     name: string;
     authenticate: (req: express.Request, options?: Object) => void;
 }

--- a/passport-facebook/index.d.ts
+++ b/passport-facebook/index.d.ts
@@ -45,11 +45,11 @@ interface IStrategyOptionWithRequest {
 }
 
 interface VerifyFunction {
-    (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void): void;
+    (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void): void;
 }
 
 interface VerifyFunctionWithRequest {
-    (req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void): void;
+    (req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void): void;
 }
 
 declare class Strategy implements passport.Strategy {

--- a/passport-facebook/index.d.ts
+++ b/passport-facebook/index.d.ts
@@ -31,12 +31,31 @@ interface IStrategyOption {
     scopeSeparator?: string;
     enableProof?: boolean;
     profileFields?: string[];
-    passReqToCallback?: boolean;
+}
+
+interface IStrategyOptionWithRequest {
+	clientID: string;
+	clientSecret: string;
+	callbackURL: string;
+				
+	scopeSeparator?: string;
+	enableProof?: boolean;
+	profileFields?: string[];
+	passReqToCallback: boolean;
+}
+
+interface VerifyFunction {
+	(accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void): void;
+}
+
+interface VerifyFunctionWithRequest {
+	(req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void): void;
 }
 
 declare class Strategy implements passport.Strategy {
-    constructor(options: IStrategyOption,
-        verify: (req?: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void);
-    name: string;
+    constructor(options: IStrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
+	constructor(options: IStrategyOption, verify: VerifyFunction);
+    
+	name: string;
     authenticate: (req: express.Request, options?: Object) => void;
 }

--- a/passport-facebook/index.d.ts
+++ b/passport-facebook/index.d.ts
@@ -34,28 +34,28 @@ interface IStrategyOption {
 }
 
 interface IStrategyOptionWithRequest {
-	clientID: string;
-	clientSecret: string;
-	callbackURL: string;
-				
-	scopeSeparator?: string;
-	enableProof?: boolean;
-	profileFields?: string[];
-	passReqToCallback: boolean;
+    clientID: string;
+    clientSecret: string;
+    callbackURL: string;
+
+    scopeSeparator?: string;
+    enableProof?: boolean;
+    profileFields?: string[];
+    passReqToCallback: boolean;
 }
 
 interface VerifyFunction {
-	(accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void): void;
+    (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void): void;
 }
 
 interface VerifyFunctionWithRequest {
-	(req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void): void;
+    (req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any, info?: any) => void) => void): void;
 }
 
 declare class Strategy implements passport.Strategy {
     constructor(options: IStrategyOptionWithRequest, verify: VerifyFunctionWithRequest);
-	constructor(options: IStrategyOption, verify: VerifyFunction);
+    constructor(options: IStrategyOption, verify: VerifyFunction);
     
-	name: string;
+    name: string;
     authenticate: (req: express.Request, options?: Object) => void;
 }


### PR DESCRIPTION
I saw some change in passport-facebook that add `passReqToCallback` to options but I don't see `req` in the verify function. So maybe we need to add `req` to verify as well. And I suggest to seperate constructor between withRequest and withoutRequest in same way as [passport-local](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4869992bc079b88280b9ff91213528904109e8ae/passport-local/index.d.ts) dose.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: reference code style from [@types/passport-local](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4869992bc079b88280b9ff91213528904109e8ae/passport-local/index.d.ts)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
