### PR TITLE
Update React-Native typings for NavigationCardStack

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -7659,6 +7659,10 @@ declare module "react" {
          * Custom style applied to the card.
          */
         cardStyle?: ViewStyle
+	/**
+	 * Custom style interpolator for the card.
+	 */
+	cardStyleInterpolator?: (props: NavigationSceneRendererProps) => ViewStyle;
         /**
          * Direction of the cards movement. Value could be `horizontal` or
          * `vertical`. Default value is `horizontal`.


### PR DESCRIPTION
The NavigationCardStack recently got a cardStyleInterpolator prop:

https://github.com/facebook/react-native/pull/11082

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

This reflects a change made in https://github.com/facebook/react-native/pull/11082. It's not yet reflected in any RN documentation but is in RN as of 0.41.0