### PR TITLE
Make iconUrl and createShadow optional in leaflet

### DIFF
--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -1406,7 +1406,7 @@ declare namespace L {
     export function map(element: string | HTMLElement, options?: MapOptions): Map;
 
     export interface IconOptions extends LayerOptions {
-        iconUrl: string;
+        iconUrl?: string;
         iconRetinaUrl?: string;
         iconSize?: PointExpression;
         iconAnchor?: PointExpression;
@@ -1424,7 +1424,7 @@ declare namespace L {
     }
 
     export class Icon extends InternalIcon {
-        createShadow(oldIcon?: HTMLElement): HTMLElement;
+        createShadow?(oldIcon?: HTMLElement): HTMLElement;
         options: IconOptions;
     }
 


### PR DESCRIPTION
This allows extending `DivIcon` class without having to implement `iconUrl` and `createShadow`
