### PR TITLE
react: Use type parameter for animation events

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -371,13 +371,13 @@ declare namespace React {
         deltaZ: number;
     }
 
-    interface AnimationEvent extends SyntheticEvent<{}> {
+    interface AnimationEvent<T> extends SyntheticEvent<T> {
         animationName: string;
         pseudoElement: string;
         elapsedTime: number;
     }
 
-    interface TransitionEvent extends SyntheticEvent<{}> {
+    interface TransitionEvent<T> extends SyntheticEvent<T> {
         propertyName: string;
         pseudoElement: string;
         elapsedTime: number;
@@ -404,8 +404,8 @@ declare namespace React {
     type TouchEventHandler<T> = EventHandler<TouchEvent<T>>;
     type UIEventHandler<T> = EventHandler<UIEvent<T>>;
     type WheelEventHandler<T> = EventHandler<WheelEvent<T>>;
-    type AnimationEventHandler = EventHandler<AnimationEvent>;
-    type TransitionEventHandler = EventHandler<TransitionEvent>;
+    type AnimationEventHandler<T> = EventHandler<AnimationEvent<T>>;
+    type TransitionEventHandler<T> = EventHandler<TransitionEvent<T>>;
 
     //
     // Props / DOM Attributes
@@ -597,16 +597,16 @@ declare namespace React {
         onWheelCapture?: WheelEventHandler<T>;
 
         // Animation Events
-        onAnimationStart?: AnimationEventHandler;
-        onAnimationStartCapture?: AnimationEventHandler;
-        onAnimationEnd?: AnimationEventHandler;
-        onAnimationEndCapture?: AnimationEventHandler;
-        onAnimationIteration?: AnimationEventHandler;
-        onAnimationIterationCapture?: AnimationEventHandler;
+        onAnimationStart?: AnimationEventHandler<T>;
+        onAnimationStartCapture?: AnimationEventHandler<T>;
+        onAnimationEnd?: AnimationEventHandler<T>;
+        onAnimationEndCapture?: AnimationEventHandler<T>;
+        onAnimationIteration?: AnimationEventHandler<T>;
+        onAnimationIterationCapture?: AnimationEventHandler<T>;
 
         // Transition Events
-        onTransitionEnd?: TransitionEventHandler;
-        onTransitionEndCapture?: TransitionEventHandler;
+        onTransitionEnd?: TransitionEventHandler<T>;
+        onTransitionEndCapture?: TransitionEventHandler<T>;
     }
 
     // See CSS 3 CSS-wide keywords https://www.w3.org/TR/css3-values/#common-keywords

--- a/react/test/index.ts
+++ b/react/test/index.ts
@@ -325,6 +325,9 @@ var htmlAttr: React.HTMLProps<HTMLElement> = {
         event.preventDefault();
         event.stopPropagation();
     },
+    onAnimationStart: event => {
+        console.log(event.currentTarget.className);
+    },
     dangerouslySetInnerHTML: {
         __html: "<strong>STRONG</strong>"
     }


### PR DESCRIPTION
Generics was added to event classes in #9939, but #9443 which adds animation and transition events was created before #9939 was merged, so currently they does not have type parameters. This PR fixes it..!

----

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #9939, #9443
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.