### PR TITLE
14622 Allow for mapStateToProps to be undefined.

### DIFF
--- a/react-redux/index.d.ts
+++ b/react-redux/index.d.ts
@@ -49,14 +49,9 @@ export interface InferableComponentDecorator {
 export declare function connect(): InferableComponentDecorator;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: FuncOrSelf<MapStateToProps<TStateProps, TOwnProps>>,
-    mapDispatchToProps?: FuncOrSelf<MapDispatchToPropsFunction<TDispatchProps, TOwnProps> | MapDispatchToPropsObject>
-): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
-
-export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: FuncOrSelf<MapStateToProps<TStateProps, TOwnProps>>,
-    mapDispatchToProps: FuncOrSelf<MapDispatchToPropsFunction<TDispatchProps, TOwnProps> | MapDispatchToPropsObject>,
-    mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
+    mapStateToProps?: FuncOrSelf<MapStateToProps<TStateProps, TOwnProps>>,
+    mapDispatchToProps?: FuncOrSelf<MapDispatchToPropsFunction<TDispatchProps, TOwnProps> | MapDispatchToPropsObject>,
+    mergeProps?: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
     options?: Options
 ): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 

--- a/react-redux/react-redux-tests.tsx
+++ b/react-redux/react-redux-tests.tsx
@@ -258,8 +258,9 @@ function mergeProps(stateProps: TodoState, dispatchProps: DispatchProps, ownProp
 connect(mapStateToProps2, actionCreators, mergeProps)(TodoApp);
 
 
-
-
+//https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14622#issuecomment-279820358
+//Allow for undefined mapStateToProps
+connect(undefined, mapDispatchToProps6)(TodoApp);
 
 interface TestProp {
     property1: number;


### PR DESCRIPTION
[Issue number 14622](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14622)