### PR TITLE
fleshing out RelayProp interface

### DIFF
--- a/react-relay/index.d.ts
+++ b/react-relay/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-relay 0.9.2
+// Type definitions for react-relay 0.10
 // Project: https://github.com/facebook/relay
 // Definitions by: Johannes Schickling <https://github.com/graphcool>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -29,6 +29,24 @@ declare module "react-relay" {
 
     interface RelayQueryRequestResolve {
         response: any
+    }
+
+    type RelayMutationStatus = 
+      'UNCOMMITTED' | // Transaction hasn't yet been sent to the server. Transaction can be committed or rolled back.
+      'COMMIT_QUEUED' | // Transaction was committed but another transaction with the same collision key is pending, so the transaction has been queued to send to the server.
+      'COLLISION_COMMIT_FAILED' | //Transaction was queued for commit but another transaction with the same collision key failed. All transactions in the collision queue, including this one, have been failed. Transaction can be recommitted or rolled back.
+      'COMMITTING' | // Transaction is waiting for the server to respond.
+      'COMMIT_FAILED';
+
+    class RelayMutationTransaction {
+      applyOptimistic(): RelayMutationTransaction;
+      commit(): RelayMutationTransaction;
+      recommit(): void;
+      rollback(): void;
+      getError(): Error;
+      getStatus(): RelayMutationStatus;
+      getHash(): string;
+      getID(): string; 
     }
 
     interface RelayMutationRequest {
@@ -128,7 +146,12 @@ declare module "react-relay" {
     }
 
     interface RelayProp {
-        variables: any
-        setVariables(variables: Object, onReadyStateChange?: OnReadyStateChange): void
+        route: { name: string; }; // incomplete, also has params and queries
+        variables: any;
+        pendingVariables?: any;
+        setVariables(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
+        forceFetch(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
+        hasOptimisticUpdate(record: any): boolean;
+        getPendingTransactions(record: any): RelayMutationTransaction[];
     }
 }


### PR DESCRIPTION
A variety of methods were missing from RelayProp, which is a bit painful since it's often the primary interface for Relay.

Everything I've added is documented here.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  https://facebook.github.io/relay/docs/api-reference-relay-container.html
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.