### PR TITLE
[request] Support jsonReviver and jsonReplacer options

### DIFF
--- a/request/index.d.ts
+++ b/request/index.d.ts
@@ -91,6 +91,8 @@ declare namespace request {
         qsStringifyOptions?: any;
         qsParseOptions?: any;
         json?: any;
+        jsonReviver?: (key: string, value: any) => any;
+        jsonReplacer?: (key: string, value: any) => any;
         multipart?: RequestPart[] | Multipart;
         agent?: http.Agent | https.Agent;
         agentOptions?: any;

--- a/request/request-tests.ts
+++ b/request/request-tests.ts
@@ -91,6 +91,12 @@ var options: request.Options = {
 	aws: aws,
 	qs: obj,
 	json: value,
+	jsonReviver: (key: string, value: any) => {
+
+	},
+	jsonReplacer: (key: string, value: any) => {
+
+	},
 	multipart: value,
 	agent: new http.Agent(),
 	agentOptions: value,


### PR DESCRIPTION
Add support for `jsonReviver` and `jsonReplacer` options.

Documentation:
https://github.com/request/request#requestoptions-callback

> - `jsonReviver` - a [reviver function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) that will be passed to `JSON.parse()` when parsing a JSON response body.
> - `jsonReplacer` - a [replacer function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) that will be passed to `JSON.stringify()` when stringifying a JSON request body.