### PR TITLE
rsvp: RSVP.hash should take object literal, not array

### DIFF
--- a/rsvp/index.d.ts
+++ b/rsvp/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for RSVP 3.0.9
-// Project: github.com/tildeio/rsvp.js 3.0.9
-// Definitions by: Taylor Brown <https://github.com/Taytay>
+// Type definitions for RSVP 3.3.3
+// Project: github.com/tildeio/rsvp.js 3.3.3
+// Definitions by: Taylor Brown <https://github.com/Taytay>, Mikael Kohlmyr <https://github.com/mkohlmyr>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 // Some of this file was taken from the type definitions for es6-promise https://github.com/borisyankov/DefinitelyTyped/blob/master/es6-promise/es6-promise.d.ts
@@ -220,8 +220,8 @@ declare module RSVP {
      * having to remember the initial order like you would with all().
      *
      */
-    export function hash<T>(promises: Thenable<T>[]): Promise<T[]>;
-    export function hash<T>(promises: any[]): Promise<T[]>;
+    export function hash<T>(promises: { [key: string]: Thenable<T> }): Promise<{ [key: string]: T }>;
+    export function hash<T>(promises: { [key: string]: any }): Promise<{ [key: string]: T }>;
 
     /**
      `RSVP.map` is similar to JavaScript's native `map` method, except that it

--- a/rsvp/index.d.ts
+++ b/rsvp/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for RSVP 3.3.3
-// Project: github.com/tildeio/rsvp.js 3.3.3
+// Project: https://github.com/tildeio/rsvp.js
 // Definitions by: Taylor Brown <https://github.com/Taytay>, Mikael Kohlmyr <https://github.com/mkohlmyr>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 


### PR DESCRIPTION
* fixed interface for RSVP.hash to accept object literal instead of array
* added self to definitions by header
* changed version header to most recently published (3.3.3)

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tildeio/rsvp.js/blob/master/lib/rsvp/hash.js#L17
- [x] Increase the version number in the header if appropriate. 
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
