### PR TITLE
Fix whatwg-fetch definitions for workers

### DIFF
--- a/whatwg-fetch/index.d.ts
+++ b/whatwg-fetch/index.d.ts
@@ -5,10 +5,7 @@
 
 /// <reference types="whatwg-streams" />
 
-interface Window {
-    fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
-}
-declare let fetch: typeof window.fetch;
+declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 
 declare type HeadersInit = Headers | string[][] | { [key: string]: string };
 declare class Headers {

--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -24,7 +24,7 @@ function test_fetchUrlWithOptions() {
 		cache: 'default',
 		redirect: 'manual'
 	};
-	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
+	handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
 }
 
 function test_fetchUrlWithHeadersObject() {
@@ -34,11 +34,11 @@ function test_fetchUrlWithHeadersObject() {
 			'Content-Type': 'application/json'
 		}
 	};
-	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
+	handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php", requestOptions));
 }
 
 function test_fetchUrl() {
-	handlePromise(window.fetch("http://www.andlabs.net/html5/uCOR.php"));
+	handlePromise(fetch("http://www.andlabs.net/html5/uCOR.php"));
 }
 
 function test_fetchUrlWithRequestObject() {
@@ -49,7 +49,7 @@ function test_fetchUrlWithRequestObject() {
 		}
 	};
 	var request: Request = new Request("http://www.andlabs.net/html5/uCOR.php", requestOptions);
-	handlePromise(window.fetch(request));
+	handlePromise(fetch(request));
 }
 
 function test_globalFetchVar() {


### PR DESCRIPTION
It's not an ideal fix (quite frankly, it's broken :). However, since `Window` and `WorkerGlobalScope` don't have common ancestor interface, it's not clear where to add `fetch` property (https://github.com/Microsoft/TypeScript/issues/14086).

Any ideas?