### PR TITLE
Resolves Twilio client construction error on Typescript compilation for es6 module import

### DIFF
--- a/twilio/index.d.ts
+++ b/twilio/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for twilio
 // Project: https://github.com/twilio/twilio-node
-// Definitions by: nickiannone <https://github.com/nickiannone>
+// Definitions by: nickiannone <https://github.com/nickiannone>, Ashley Brener <https://github.com/ashleybrener>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="express" />

--- a/twilio/index.d.ts
+++ b/twilio/index.d.ts
@@ -10,6 +10,10 @@ import Express = require("express");
 import Http = require("http");
 import Q = require("q");
 
+declare interface twilio {
+  (sid?: string, tkn?: string, options?: twilio.ClientOptions): twilio.RestClient
+}
+
 declare function twilio(sid?: string, tkn?: string, options?: twilio.ClientOptions): twilio.RestClient;
 
 declare namespace twilio {

--- a/twilio/index.d.ts
+++ b/twilio/index.d.ts
@@ -10,9 +10,7 @@ import Express = require("express");
 import Http = require("http");
 import Q = require("q");
 
-declare interface twilio {
-  (sid?: string, tkn?: string, options?: twilio.ClientOptions): twilio.RestClient;
-}
+declare function twilio(sid?: string, tkn?: string, options?: twilio.ClientOptions): twilio.RestClient;
 
 declare namespace twilio {
 

--- a/twilio/twilio-tests.ts
+++ b/twilio/twilio-tests.ts
@@ -6,7 +6,7 @@ import * as Express from "express";
 var str: string;
 
 // Create a client:
-var client: twilio.RestClient = (require('twilio') as twilio)('ACCOUNT_SID', 'AUTH_TOKEN');
+var client: twilio.RestClient = twilio('ACCOUNT_SID', 'AUTH_TOKEN');
 
 //Get a list of calls made by this account
 // GET /2010-04-01/Accounts/ACCOUNT_SID/Calls


### PR DESCRIPTION
Typescript outputs an error:

`Cannot invoke an expression whose type lacks a call signature. Type 'typeof twilio' has no compatible call signatures.` 

...when compiling the following code:

```ts
import * as twilio from 'twilio';

let T: twilio.RestClient = twilio('account_sid', 'token');
```

The reason for this is that in the type definition `twilio` is declared as an interface and not as a function.

Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [SEND SMS AND MMS MESSAGES IN NODE.JS](https://www.twilio.com/docs/guides/sms/how-to-send-sms-messages-in-node-js)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
