### PR TITLE
fix web-bluetooth typings

### DIFF
--- a/web-bluetooth/index.d.ts
+++ b/web-bluetooth/index.d.ts
@@ -17,7 +17,7 @@ interface BluetoothRequestDeviceFilter {
 
 interface RequestDeviceOptions {
 	filters: BluetoothRequestDeviceFilter[];
-	optionalServices?: number[];
+	optionalServices?: BluetoothServiceUUID[];
 	acceptAllDevices?: boolean;
 }
 


### PR DESCRIPTION
fix the type of `optionalServices` in `RequestDeviceOptions`

Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:  https://webbluetoothcg.github.io/web-bluetooth/#device-discovery
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
