### PR TITLE
lodash - change weakmap declaration to work with TS 2.2

### DIFF
--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -12701,7 +12701,7 @@ declare namespace _ {
          * @param value The value to check.
          * @returns Returns true if value is correctly classified, else false.
          */
-        isWeakMap<K, V>(value?: any): value is WeakMap<K, V>;
+        isWeakMap<K, V>(value?: any): value is WeakMapLike<K, V>;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {
@@ -19446,5 +19446,5 @@ declare global {
     interface Set<T> { }
     interface Map<K, V> { }
     interface WeakSet<T> { }
-    interface WeakMap<K, V> { }
+    interface WeakMapLike<K, V> { }
 }

--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -12701,7 +12701,7 @@ declare namespace _ {
          * @param value The value to check.
          * @returns Returns true if value is correctly classified, else false.
          */
-        isWeakMap<K, V>(value?: any): value is WeakMapLike<K, V>;
+        isWeakMap<K, V>(value?: any): boolean;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {
@@ -19446,5 +19446,4 @@ declare global {
     interface Set<T> { }
     interface Map<K, V> { }
     interface WeakSet<T> { }
-    interface WeakMapLike<K, V> { }
 }

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -7446,17 +7446,6 @@ namespace TestIsUndefined {
 // _.isWeakMap
 namespace TestIsWeakMap {
     {
-        let value: number|WeakMapLike<string, number>;
-
-        if (_.isWeakMap<string, number>(value)) {
-            let result: WeakMapLike<string, number> = value;
-        }
-        else {
-            let result: number = value;
-        }
-    }
-
-    {
         let result: boolean;
 
         result = _.isWeakMap(any);

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -7446,10 +7446,10 @@ namespace TestIsUndefined {
 // _.isWeakMap
 namespace TestIsWeakMap {
     {
-        let value: number|WeakMap<string, number>;
+        let value: number|WeakMapLike<string, number>;
 
         if (_.isWeakMap<string, number>(value)) {
-            let result: WeakMap<string, number> = value;
+            let result: WeakMapLike<string, number> = value;
         }
         else {
             let result: number = value;


### PR DESCRIPTION
In TS 2.2 WeakMap interface for ES6 has been changed from WeakMap<K, V> to WeakMap<K extends object, V>. This changes makes @types/lodash not working with new ES6 introduced in TS2.2.

To keep the backward compatibility with ES5, I think it is safe to rename the WeakMap declaration.

I know TS 2.2 is still in RC version now, but many people using it, including me :). So if you think this is too early and also bad idea then feel free to close this PR without merging it.

If this get merged then it's should close #14324.

This pull request is clean version of pull request #14502

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/pull/13350
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.