### PR TITLE
[cucumber] Define addTransform method in hooks and combine SupportCodeConsumer argument types

### DIFF
--- a/cucumber/cucumber-tests.ts
+++ b/cucumber/cucumber-tests.ts
@@ -105,6 +105,16 @@ function StepSample() {
 		});
 	});
 
+	cucumber.defineSupportCode(function({After, Given}) {
+		Given( /^a variable set to (\d+)$/, (x:string) => {
+			console.log("the number is: " + x);
+		});
+		After((scenario: HookScenario, callback?: Callback) => {
+			console.log("After");
+			callback();
+		});
+	});
+
 	let fns : cucumber.SupportCodeConsumer[] = cucumber.getSupportCodeFns()
 
 	cucumber.clearSupportCodeFns();

--- a/cucumber/cucumber-tests.ts
+++ b/cucumber/cucumber-tests.ts
@@ -97,6 +97,14 @@ function StepSample() {
 		} )
 	});
 
+	cucumber.defineSupportCode(function(hook: cucumber.Hooks){
+		hook.addTransform({
+			captureGroupRegexps: ['red|blue|green'],
+			transformer: (arg: string) => arg,
+			typeName: 'color'
+		});
+	});
+
 	let fns : cucumber.SupportCodeConsumer[] = cucumber.getSupportCodeFns()
 
 	cucumber.clearSupportCodeFns();

--- a/cucumber/index.d.ts
+++ b/cucumber/index.d.ts
@@ -64,6 +64,12 @@ declare namespace cucumber {
 		(scenario: HookScenario, runScenario?: (error:string, callback?:Function)=>void): void;
 	}
 
+	interface Transform {
+		captureGroupRegexps: Array<RegExp | string>;
+		transformer: (arg: string) => any;
+		typeName: string;
+	}
+
 	export interface Hooks {
 		Before(code: HookCode): void;
 		After(code: HookCode): void;
@@ -72,6 +78,7 @@ declare namespace cucumber {
 		setWorldConstructor(world: () => void): void;
 		registerHandler(handlerOption:string, code:(event:any, callback:CallbackStepDefinition) =>void): void;
 		registerListener(listener: EventListener): void;
+		addTransform(transform: Transform): void;
 	}
 
 	export class EventListener {

--- a/cucumber/index.d.ts
+++ b/cucumber/index.d.ts
@@ -215,7 +215,7 @@ declare namespace cucumber {
 	}
 
 	export interface SupportCodeConsumer {
-		(stepDefinitions:StepDefinitions | Hooks):void;
+		(stepDefinitions:StepDefinitions & Hooks):void;
 	}
 
 	export function defineSupportCode(consumer:SupportCodeConsumer): void;


### PR DESCRIPTION
Define a method to add custom argument transformations, added in cucumber v2.0.0-rc.0:
https://github.com/cucumber/cucumber-js/blob/master/CHANGELOG.md#new-features-3

Combine `SupportCodeConsumer` argument types to expose all support methods,
as specified in https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md#api-reference

It also enables [destructuring](http://exploringjs.com/es6/ch_destructuring.html) the argument passed to the function, e.g.:
```typescript
defineSupportCode(({After, Given, Then}) => {
    // After('etc'...);
});
```


Please fill in this template.

- [x] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md#addtransformcapturegroupregexps-typename-transformer
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
