### PR TITLE
redis: Added the parameter flush for RedisClient.end() method.

### DIFF
--- a/redis/index.d.ts
+++ b/redis/index.d.ts
@@ -91,7 +91,11 @@ export interface RedisClient extends NodeJS.EventEmitter {
     offline_queue: any[];
     server_info: ServerInfo;
 
-    end(): void;
+    /**
+     * client.end() without the flush parameter set to true should
+     * NOT be used in production!
+     */
+    end(flush?: boolean): void;
     unref(): void;
 
     /**


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/redis#clientendflush
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

The `RedisClient.end` method cannot work without `flush` argument under production environment.