### PR TITLE
Fixed Icon type hierarchy

### DIFF
--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -1405,8 +1405,8 @@ declare namespace L {
      */
     export function map(element: string | HTMLElement, options?: MapOptions): Map;
 
-    export interface IconOptions extends LayerOptions {
-        iconUrl: string;
+    interface BaseIconOptions extends LayerOptions {
+        iconUrl?: string;
         iconRetinaUrl?: string;
         iconSize?: PointExpression;
         iconAnchor?: PointExpression;
@@ -1418,25 +1418,38 @@ declare namespace L {
         className?: string;
     }
 
-    class InternalIcon extends Layer {
-        constructor(options: IconOptions);
-        createIcon(oldIcon?: HTMLElement): HTMLElement;
+    export interface IconOptions extends BaseIconOptions {
+        iconUrl: string;
     }
 
-    export class Icon extends InternalIcon {
+    // This class does not exist in reality, it's just a way to provide
+    // options of more specific types in the sub classes
+    class BaseIcon extends Layer {
+        createIcon(oldIcon?: HTMLElement): HTMLElement;
         createShadow(oldIcon?: HTMLElement): HTMLElement;
+        options: BaseIconOptions;
+    }
+
+    export class Icon extends BaseIcon {
+        constructor(options: IconOptions);
         options: IconOptions;
     }
 
     export namespace Icon {
-        export class Default extends InternalIcon {
-            imagePath: string;
+        export interface DefaultIconOptions extends BaseIconOptions {
+            imagePath?: string;
+        }
+
+        export class Default extends BaseIcon {
+            static imagePath?: string;
+            constructor(options?: DefaultIconOptions);
+            options: DefaultIconOptions;
         }
     }
 
     export function icon(options: IconOptions): Icon;
 
-    export interface DivIconOptions extends LayerOptions {
+    export interface DivIconOptions extends BaseIconOptions {
         html?: string;
         bgPos?: PointExpression;
         iconSize?: PointExpression;
@@ -1445,7 +1458,7 @@ declare namespace L {
         className?: string;
     }
 
-    export class DivIcon extends InternalIcon {
+    export class DivIcon extends BaseIcon {
         constructor(options?: DivIconOptions);
         options: DivIconOptions;
     }
@@ -1463,8 +1476,6 @@ declare namespace L {
         opacity?: number;
         riseOnHover?: boolean;
         riseOffset?: number;
-
-        options?: DivIconOptions;
     }
 
     export class Marker extends Layer {

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -404,21 +404,28 @@ class MyMarker extends L.Marker {
 		super([12, 13]);
 	}
 }
+
 class MyLayer extends L.Layer {
 	constructor() {
 		super();
 	}
 }
+
 class MyIcon extends L.Icon {
 	constructor() {
 		super({iconUrl: 'icon.png'});
 	}
 }
+
 class MyDivIcon extends L.DivIcon {
 	constructor() {
 		super();
 	}
 }
+
+const divIcon = L.divIcon({html: ''});
+let defaultIcon = new L.Icon.Default();
+defaultIcon = new L.Icon.Default({imagePath: 'apath'});
 
 let myControlClass = L.Control.extend({});
 let myControl = new myControlClass();


### PR DESCRIPTION
Addresses issues reported in #14614 #14509 #14510 

This fixes issues with `Icon` type hierarchy. It was initially declared using interfaces but, at some point, classes were introduced. The transition was not completed, though. In the last few days, issues have been encountered because of the remaining interfaces that were still mixed into `Icon`'s type hierarchy. Unfortunately, I had to introduce the `BaseIcon` class, which doesn't exist in Leaflet's source, so that every `Icon` sub class could have an `options` property with the correct type (e.g. `DivIconOptions` for `DivIcon`, `DefaultIconOptions` for `Icon.Default`). On the bright side, `BaseIcon` remains un-exported and, as a result, hidden from the outside. If there's a better way of accomplishing what I described without introducing a fake base class, I would love to hear it.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://leafletjs.com/reference-1.0.3.html#icon
