### PR TITLE
[react-intl] injectIntl Props injection typings

### DIFF
--- a/react-intl/index.d.ts
+++ b/react-intl/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-intl 2.2.0
+// Type definitions for react-intl 2.2.1
 // Project: http://formatjs.io/react/
 // Definitions by: Bruno Grieder <https://github.com/bgrieder>, Christian Droulers <https://github.com/cdroulers>, Fedor Nezhivoi <https://github.com/gyzerok>, Till Wolff <https://github.com/tillwolff> 
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/react-intl/index.d.ts
+++ b/react-intl/index.d.ts
@@ -14,7 +14,7 @@ declare namespace ReactIntl {
         pluralRuleFunction?: (n: number, ord: boolean) => string;
     }
 
-    function injectIntl<T extends React.ComponentClass<InjectedIntlProps> | React.StatelessComponent<InjectedIntlProps>>(component: T): T;
+    function injectIntl<T>(component: React.ComponentClass<InjectedIntlProps & T> | React.StatelessComponent<InjectedIntlProps & T>): React.ComponentClass<T> | React.StatelessComponent<T>;
 
     function addLocaleData(data: Locale[] | Locale): void;
 
@@ -47,7 +47,7 @@ declare namespace ReactIntl {
     }
 
     interface InjectedIntlProps {
-        intl?: InjectedIntl
+        intl: InjectedIntl
     }
 
     namespace IntlComponent {

--- a/react-intl/index.d.ts
+++ b/react-intl/index.d.ts
@@ -14,7 +14,7 @@ declare namespace ReactIntl {
         pluralRuleFunction?: (n: number, ord: boolean) => string;
     }
 
-    function injectIntl<T>(component: React.ComponentClass<InjectedIntlProps & T> | React.StatelessComponent<InjectedIntlProps & T>): React.ComponentClass<T> | React.StatelessComponent<T>;
+    function injectIntl<T>(component: React.ComponentClass<InjectedIntlProps & T> | React.StatelessComponent<InjectedIntlProps & T>): React.ComponentClass<T>;
 
     function addLocaleData(data: Locale[] | Locale): void;
 

--- a/react-intl/react-intl-tests.tsx
+++ b/react-intl/react-intl-tests.tsx
@@ -11,6 +11,7 @@ import * as reactMixin from "react-mixin"
 import {
     IntlProvider,
     InjectedIntl,
+    InjectedIntlProps,
     addLocaleData,
     hasLocaleData,
     injectIntl,
@@ -31,11 +32,35 @@ addLocaleData(reactIntlEn);
 console.log(hasLocaleData("en"));
 
 interface SomeComponentProps {
-    className: string,
-    intl?: InjectedIntl
+    className: string
 }
 
-class SomeComponent extends React.Component<SomeComponentProps, void> {
+const SomeFunctionalComponentWithIntl = injectIntl<SomeComponentProps>(({
+    intl: {
+        formatDate,
+        formatHTMLMessage,
+        formatNumber,
+        formatMessage,
+        formatPlural,
+        formatRelative,
+        formatTime
+    },
+    className
+}) => {
+    const formattedDate = formatDate(new Date(), { format: "short" });
+    const formattedTime = formatTime(new Date(), { format: "short" });
+    const formattedRelative = formatRelative(new Date().getTime(), { format: "short" });
+    const formattedNumber = formatNumber(123, { format: "short" });
+    const formattedPlural = formatPlural(1, { one: "hai!" });
+    const formattedMessage = formatMessage({ id: "hello", defaultMessage: "Hello {name}!" }, { name: "Roger" });
+    const formattedHTMLMessage = formatHTMLMessage({ id: "hello", defaultMessage: "Hello <strong>{name}</strong>!" }, { name: "Roger" });
+    return (
+        <div className={className}>
+        </div>
+    );
+});
+
+class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlProps, void> {
     static propTypes: React.ValidationMap<any> = {
         intl: intlShape.isRequired
     };
@@ -145,7 +170,7 @@ class SomeComponent extends React.Component<SomeComponentProps, void> {
     }
 }
 
-const SomeComponentWithIntl = injectIntl(SomeComponent);
+const SomeComponentWithIntl: React.ComponentClass<SomeComponentProps> = injectIntl(SomeComponent);
 
 class TestApp extends React.Component<{}, {}> {
     public render(): React.ReactElement<{}> {
@@ -162,6 +187,7 @@ class TestApp extends React.Component<{}, {}> {
         return (
             <IntlProvider locale="en" formats={{}} messages={messages} defaultLocale="en" defaultFormats={messages}>
                 <SomeComponentWithIntl className="just-for-test" />
+                <SomeFunctionalComponentWithIntl className="another-one" />
             </IntlProvider>
         );
     }


### PR DESCRIPTION
## Summary
given : decorated = decorator(target)

- decorated has no intl props <T>
- target has them <InjectedIntlProps & T>
- intl is always injected in target props and is not optional, nor is it present in decorated component

### Guidelines
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] <strike> Run npm run lint package-name if a tslint.json is present. </strike>

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/yahoo/react-intl/blob/master/src/inject.js#L53>>
- [x] Increase the version number in the header if appropriate.
