### PR TITLE
[react-select] onChange can be called with null

### DIFF
--- a/react-select/index.d.ts
+++ b/react-select/index.d.ts
@@ -238,7 +238,7 @@ declare namespace ReactSelectClass {
         /**
          * onChange handler: function (newValue) {}
          */
-        onChange?: (newValue: Option | Option[]) => void;
+        onChange?: (newValue: Option | Option[] | null) => void;
         /**
          * fires when the menu is closed
          */


### PR DESCRIPTION
This occurs when the selection is cleared.