### PR TITLE
[leaflet-markercluster] Allow DivIcon in leaflet MarkerClusterGroupOptions.iconCreateFunction

### DIFF
--- a/leaflet-markercluster/index.d.ts
+++ b/leaflet-markercluster/index.d.ts
@@ -105,7 +105,7 @@ declare namespace L {
         /*
         * Function used to create the cluster icon
         */
-        iconCreateFunction?: ((cluster: L.MarkerCluster) => L.Icon);
+        iconCreateFunction?: ((cluster: L.MarkerCluster) => L.BaseIcon);
 
         /*
         * Boolean to split the addLayers processing in to small intervals so that the page does not freeze.

--- a/leaflet-markercluster/index.d.ts
+++ b/leaflet-markercluster/index.d.ts
@@ -105,7 +105,7 @@ declare namespace L {
         /*
         * Function used to create the cluster icon
         */
-        iconCreateFunction?: ((cluster: L.MarkerCluster) => L.BaseIcon);
+        iconCreateFunction?: ((cluster: L.MarkerCluster) => L.Icon | L.DivIcon);
 
         /*
         * Boolean to split the addLayers processing in to small intervals so that the page does not freeze.

--- a/leaflet-markercluster/leaflet-markercluster-tests.ts
+++ b/leaflet-markercluster/leaflet-markercluster-tests.ts
@@ -28,6 +28,10 @@ markerClusterGroupOptions = {
     chunkDelay: 100
 }
 
+markerClusterGroupOptions.iconCreateFunction = (cluster: L.MarkerCluster) => {
+    return L.divIcon();
+};
+
 let markerClusterGroup: L.MarkerClusterGroup;
 markerClusterGroup = L.markerClusterGroup();
 markerClusterGroup = L.markerClusterGroup(markerClusterGroupOptions);


### PR DESCRIPTION
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leaflet/Leaflet.markercluster/blob/master/src/MarkerClusterGroup.js#L816
It should be able to accept any icon. The default `iconCreateFunction` in the library happens to use `L.divIcon` and would be invalid according to the old definition.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
