### PR TITLE
react-virtualized: add missing style and key param to rowRender methods

### DIFF
--- a/react-virtualized/index.d.ts
+++ b/react-virtualized/index.d.ts
@@ -61,7 +61,7 @@ declare module "react-virtualized" {
         onScroll?: (info: { clientHeight: number, scrollHeight: number, scrollTop: number }) => void;
         overscanRowCount?: number;
         rowHeight: number | ((info: { index: number }) => number);
-        rowRenderer: (info: { index: number, isScrolling: boolean }) => React.ReactNode;
+        rowRenderer: (info: { index: number, key: string, style: Object, isScrolling: boolean }) => React.ReactNode;
         rowCount: number;
         scrollToAlignment?: string;
         scrollToIndex?: number;
@@ -120,7 +120,7 @@ declare module "react-virtualized" {
         rowCount: number;
         rowGetter?: (info: { index: number }) => any;
         rowHeight: number | ((info: { index: number }) => number);
-        rowRenderer?: (info: { index: number, isScrolling: boolean }) => React.ReactNode;
+        rowRenderer?: (info: { index: number, isScrolling: boolean, style: Object }) => React.ReactNode;
         rowStyle?: React.CSSProperties | ((info: { index: number }) => React.CSSProperties);
         scrollToAlignment?: string;
         scrollToIndex?: number;

--- a/react-virtualized/react-virtualized-tests.tsx
+++ b/react-virtualized/react-virtualized-tests.tsx
@@ -124,7 +124,7 @@ function ListTest() {
             height={300}
             rowHeight={30}
             rowCount={list.length}
-            rowRenderer={({ index, isScrolling }) => list[index]}
+            rowRenderer={({ index, isScrolling, key, style }) => list[index]}
             />,
         document.getElementById('example')
     );


### PR DESCRIPTION
I did not add all the possible parameters, as I don't have the context to know which are optional. Style was the important one though, because this param is critical for correct scroll positions. Without, you see this issue: http://stackoverflow.com/questions/40980012/react-virtualized-list-skips-rows-when-scrolling

Relevant documentation:
- Table.rowRenderer - https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md#rowrenderer
- List.rowRenderer - https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md
