### PR TITLE
leaflet: Update marker classes to accept both Icon and DivIcon

### DIFF
--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -1466,7 +1466,7 @@ declare namespace L {
     export function divIcon(options?: DivIconOptions): DivIcon;
 
     export interface MarkerOptions extends InteractiveLayerOptions {
-        icon?: Icon;
+        icon?: Icon | DivIcon;
         clickable?: boolean;
         draggable?: boolean;
         keyboard?: boolean;
@@ -1483,7 +1483,7 @@ declare namespace L {
         getLatLng(): LatLng;
         setLatLng(latlng: LatLngExpression): this;
         setZIndexOffset(offset: number): this;
-        setIcon(icon: Icon): this;
+        setIcon(icon: Icon | DivIcon): this;
         setOpacity(opacity: number): this;
         getElement(): HTMLElement;
 

--- a/leaflet/leaflet-tests.ts
+++ b/leaflet/leaflet-tests.ts
@@ -447,3 +447,13 @@ L.marker([1, 2], {
 		iconUrl: 'my-icon.png'
 	})
 }).bindPopup('<p>Hi</p>');
+
+L.marker([1, 2], {
+	icon: L.divIcon({
+		className: 'my-icon-class'
+	})
+}).setIcon(L.icon({
+	iconUrl: 'my-icon.png'
+})).setIcon(L.divIcon({
+	className: 'my-div-icon'
+}));;


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
 **`leaflet/v0/index.d.ts` had errors, but it looks like linting isn't maintained on that file. No errors in `leaflet/index.d.ts`**

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://leafletjs.com/reference-1.0.3.html#divicon
Since `DivIcon` inherits from `Icon`, it should be usable in any API taking a type `Icon`. In the definition file, `DivIcon` doesn't inherit from `Icon` so this adds explicit support for other `Icon` classes in the `Marker` APIs.
- **N/A** Increase the version number in the header if appropriate.
- **N/A** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.