### PR TITLE
[whatwg-fetch] add fetch.polyfill

### DIFF
--- a/whatwg-fetch/index.d.ts
+++ b/whatwg-fetch/index.d.ts
@@ -8,7 +8,8 @@
 interface Window {
     fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 }
-declare let fetch: typeof window.fetch;
+                                         // See https://github.com/github/fetch/blob/v2.0.2/fetch.js#L457
+declare let fetch: typeof window.fetch & { polyfill?: true };
 
 declare type HeadersInit = Headers | string[][] | { [key: string]: string };
 declare class Headers {

--- a/whatwg-fetch/whatwg-fetch-tests.ts
+++ b/whatwg-fetch/whatwg-fetch-tests.ts
@@ -108,3 +108,8 @@ function test_Body_json() {
 			//console.log(fooBar.bar);
 		});
 }
+
+// See https://github.com/github/fetch/blob/v2.0.2/fetch.js#L457
+function test_fetch_polyfill() {
+	console.log(fetch.polyfill);
+}


### PR DESCRIPTION
whatwg-fetch defines a boolean named `polyfill`, see https://github.com/github/fetch/blob/v2.0.2/fetch.js#L457

Example:
```TypeScript
// prints true if whatwg-fetch is used, undefined if native fetch implementation
console.log(fetch.polyfill);
```