### PR TITLE
SystemJS: refined typeof 'transpiler' option, added plugin-typescript specific …

### DIFF
--- a/systemjs/index.d.ts
+++ b/systemjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for SystemJS 0.20.5
+// Type definitions for SystemJS 0.20
 // Project: https://github.com/systemjs/systemjs
 // Definitions by: Ludovic HENIN <https://github.com/ludohenin/>, Nathan Walker <https://github.com/NathanWalker/>, Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,9 +6,13 @@
 
 declare namespace SystemJSLoader {
 
-    type ModulesList = { [bundleName: string]: Array<string> };
+    interface ModulesList {
+        [bundleName: string]: string[];
+    }
 
-    type PackageList<T> = { [packageName: string]: T };
+    interface PackageList<T> {
+        [packageName: string]: T;
+    }
 
     /**
      * The following module formats are supported:
@@ -49,7 +53,7 @@ declare namespace SystemJSLoader {
          * Dependencies to load before this module. Goes through regular paths and map normalization.
          * Only supported for the cjs, amd and global formats.
          */
-        deps?: Array<string>;
+        deps?: string[];
 
         /**
          * A map of global names to module names that should be defined only for the execution of this module.
@@ -247,7 +251,7 @@ declare namespace SystemJSLoader {
     interface SystemJSSystemFields {
         env: string;
         loaderErrorStack: boolean;
-        packageConfigPaths: Array<string>;
+        packageConfigPaths: string[];
         pluginFirst: boolean;
         version: string;
         warnings: boolean;
@@ -257,12 +261,12 @@ declare namespace SystemJSLoader {
         /**
          * For backwards-compatibility with AMD environments, set window.define = System.amdDefine.
          */
-        amdDefine: Function;
+        amdDefine: (...args: any[]) => void;
 
         /**
          * For backwards-compatibility with AMD environments, set window.require = System.amdRequire.
          */
-        amdRequire: Function;
+        amdRequire: (deps: string[], callback: (...modules: any[]) => void) => void;
 
         /**
          * SystemJS configuration helper function.
@@ -273,7 +277,7 @@ declare namespace SystemJSLoader {
         /**
          * This represents the System base class, which can be extended or reinstantiated to create a custom System instance.
          */
-        constructor: new() => System;
+        constructor: new () => System;
 
         /**
          * Deletes a module from the registry by normalized name.
@@ -289,7 +293,7 @@ declare namespace SystemJSLoader {
         /**
          * Returns a clone of the internal SystemJS configuration in use.
          */
-        getConfig(): Config
+        getConfig(): Config;
 
         /**
          * Returns whether a given module exists in the registry by normalized module name.
@@ -319,15 +323,15 @@ declare namespace SystemJSLoader {
         /**
          * Declaration function for defining modules of the System.register polyfill module format.
          */
-        register(name: string, deps: Array<string>, declare: Function): void;
-        register(deps: Array<string>, declare: Function): void;
+        register(name: string, deps: string[], declare: (...modules: any[]) => any): void;
+        register(deps: string[], declare: (...modules: any[]) => any): void;
 
         /**
          * Companion module format to System.register for non-ES6 modules.
          * Provides a <script>-injection-compatible module format that any CommonJS or Global module can be converted into for CSP compatibility.
          */
-        registerDynamic(name: string, deps: Array<string>, executingRequire: boolean, declare: Function): void;
-        registerDynamic(deps: Array<string>, executingRequire: boolean, declare: Function): void;
+        registerDynamic(name: string, deps: string[], executingRequire: boolean, declare: (...modules: any[]) => any): void;
+        registerDynamic(deps: string[], executingRequire: boolean, declare: (...modules: any[]) => any): void;
 
         /**
          * Sets a module into the registry directly and synchronously.
@@ -340,7 +344,7 @@ declare namespace SystemJSLoader {
          * loaded to ensure the correct detection paths in loaded code.
          * The CommonJS require can be recovered within these modules from System._nodeRequire.
          */
-        _nodeRequire: Function;
+        _nodeRequire: (dep: string) => any;
 
         /**
          * Modules list available only with trace=true
@@ -356,10 +360,10 @@ declare var __moduleName: string;
 /**
  * @deprecated use SystemJS https://github.com/systemjs/systemjs/releases/tag/0.19.10
  */
-declare var System: SystemJSLoader.System;
+declare const System: SystemJSLoader.System;
 
 declare module "systemjs" {
     import systemJSLoader = SystemJSLoader;
-    let system: systemJSLoader.System;
+    const system: systemJSLoader.System;
     export = system;
 }

--- a/systemjs/index.d.ts
+++ b/systemjs/index.d.ts
@@ -27,7 +27,7 @@ declare namespace SystemJSLoader {
      * Represents a module name for System.import that must resolve to either Traceur, Babel or TypeScript.
      * When set to traceur, babel or typescript, loading will be automatically configured as far as possible.
      */
-    type Transpiler = "plugin-traceur" | "plugin-babel" | "plugin-typescript" | "traceur" | "babel" | "typescript" | boolean;
+    type Transpiler = "plugin-traceur" | "plugin-babel" | "plugin-typescript" | "traceur" | "babel" | "typescript" | false;
 
     type ConfigMap = PackageList<string | PackageList<string>>;
 
@@ -225,7 +225,23 @@ declare namespace SystemJSLoader {
          * Sets the TypeScript transpiler options.
          */
         //TODO: Import Typescript.CompilerOptions
-        typescriptOptions?: any;
+        typescriptOptions?: {
+            /**
+             * A boolean flag which instructs the plugin to load configuration from "tsconfig.json".
+             * To override the location of the file set this option to the path of the configuration file,
+             * which will be resolved using normal SystemJS resolution.
+             * Note: This setting is specific to plugin-typescript.
+             */
+            tsconfig?: boolean | string,
+            /**
+             * A flag which controls whether the files are type-checked or simply transpiled.
+             * Set this option to "strict" to have the builds fail when compiler errors are encountered.
+             * Note: The strict option only affects builds and bundles via the SystemJS or JSPM Builder.
+             * Note: This setting is specific to plugin-typescript.
+             */
+            typeCheck?: boolean | "strict",
+            [key: string]: any
+        };
     }
 
     interface SystemJSSystemFields {


### PR DESCRIPTION
…flags to typescriptOptions

Refined typeof 'transpiler' option to only allow `false` as opposed to `boolean`.
Added the `typescriptOptions` properties that are specific to plugin-typescript to typescriptOptions object.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  
https://github.com/frankwallis/plugin-typescript#tsconfig
https://github.com/frankwallis/plugin-typescript/issues/139
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
