### PR TITLE
Sequelize: Changing `scope` definition

### DIFF
--- a/sequelize/index.d.ts
+++ b/sequelize/index.d.ts
@@ -3671,7 +3671,7 @@ declare namespace sequelize {
  * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
  *     model will clear the previous scope.
  */
-        scope(options?: string | string[] | ScopeOptions | WhereOptions): this;
+        scope(options?: string | ScopeOptions | WhereOptions | Array<string | ScopeOptions | WhereOptions>): this;
 
         /**
          * Search for multiple instances.

--- a/sequelize/sequelize-tests.ts
+++ b/sequelize/sequelize-tests.ts
@@ -853,11 +853,14 @@ User.schema( 'special' ).create( { age : 3 }, { logging : function(  ) {} } );
 User.getTableName();
 
 User.addScope('lowAccess', { where : { parent_id : 2 } });
-User.addScope('lowAccess', function() { } );
 User.addScope('lowAccess', { where : { parent_id : 2 } }, { override: true });
+User.addScope('lowAccessWithParam', function(id: number) {
+  return { where : { parent_id : id } }
+} );
 
 User.scope( 'lowAccess' ).count();
 User.scope( { where : { parent_id : 2 } } );
+User.scope( [ 'lowAccess', { method: ['lowAccessWithParam', 2] }, { where : { parent_id : 2 } } ] )
 
 User.findAll();
 User.findAll( { where : { data : { employment : null } } } );

--- a/sequelize/v3/index.d.ts
+++ b/sequelize/v3/index.d.ts
@@ -3648,7 +3648,7 @@ declare namespace sequelize {
  * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
  *     model will clear the previous scope.
  */
-        scope(options?: string | string[] | ScopeOptions | WhereOptions): this;
+        scope(options?: string | ScopeOptions | WhereOptions | Array<string | ScopeOptions | WhereOptions>): this;
 
         /**
          * Search for multiple instances.

--- a/sequelize/v3/sequelize-tests.ts
+++ b/sequelize/v3/sequelize-tests.ts
@@ -840,11 +840,14 @@ User.schema( 'special' ).create( { age : 3 }, { logging : function(  ) {} } );
 User.getTableName();
 
 User.addScope('lowAccess', { where : { parent_id : 2 } });
-User.addScope('lowAccess', function() { } );
 User.addScope('lowAccess', { where : { parent_id : 2 } }, { override: true });
+User.addScope('lowAccessWithParam', function(id: number) {
+  return { where : { parent_id : id } }
+} );
 
 User.scope( 'lowAccess' ).count();
 User.scope( { where : { parent_id : 2 } } );
+User.scope( [ 'lowAccess', { method: ['lowAccessWithParam', 2] }, { where : { parent_id : 2 } } ] )
 
 User.findAll();
 User.findAll( { where : { data : { employment : null } } } );


### PR DESCRIPTION
current definition
```ts
scope(options?: string | string[] | ScopeOptions | WhereOptions): this;
```
doesn't allow all valid calls. example from [documentation](http://docs.sequelizejs.com/en/latest/docs/scopes/):
```ts
Project.scope('random', { method: ['accessLevel', 19]}).findAll();
```
changing it to
```ts
scope(options?: string | ScopeOptions | WhereOptions | Array<string | ScopeOptions | WhereOptions>): this;
```
should fix the issue since, according to the docs
```ts
// These two are equivalent
Project.scope('deleted', 'activeUsers').findAll();
Project.scope(['deleted', 'activeUsers']).findAll();
```

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
