### PR TITLE
[knex] allow numbers as the right hand side of a join equality

### DIFF
--- a/knex/index.d.ts
+++ b/knex/index.d.ts
@@ -165,7 +165,7 @@ declare namespace Knex {
 
     interface Join {
         (raw: Raw): QueryBuilder;
-        (tableName: string, columns: { [key: string]: string | Raw }): QueryBuilder;
+        (tableName: string, columns: { [key: string]: string | number | Raw }): QueryBuilder;
         (tableName: string, callback: Function): QueryBuilder;
         (tableName: TableName, raw: Raw): QueryBuilder;
         (tableName: TableName, column1: string, column2: string): QueryBuilder;

--- a/knex/knex-tests.ts
+++ b/knex/knex-tests.ts
@@ -189,6 +189,10 @@ knex('users')
   .select('users.id', 'contacts.phone');
 
 knex('users')
+  .join('contacts', { 'users.id': 12355 })
+  .select('users.id', 'contacts.phone');
+
+knex('users')
   .join('contacts', 'users.id', 'contacts.user_id')
   .select('users.id', 'contacts.phone');
 


### PR DESCRIPTION
Knex allows for raw numbers to be put as the right hand side of the object-based join syntax, like so:

```javascript
knex.select('*')
.from('Foo')
.join('Bar', { 'Bar.a' : 123,
               'Bar.b' : 'Foo.id' });
```

This PR opens up the right hand side of a join to allow for this.

I've tested this against my own code and seen that the number syntax does in fact generate an equals query, not a column name reference.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.

