### PR TITLE
Add definitions for Google Calendar API (gapi.calendar)

### DIFF
--- a/gapi.auth2/gapi.auth2-tests.ts
+++ b/gapi.auth2/gapi.auth2-tests.ts
@@ -1,6 +1,6 @@
 
 
-function test_init(){
+function test_init() {
   var auth = gapi.auth2.init({
     client_id: 'my-id',
     cookie_policy: 'single_host_origin',
@@ -9,7 +9,7 @@ function test_init(){
   });
 }
 
-function test_getAuthInstance(){
+function test_getAuthInstance() {
   gapi.auth2.init({
     client_id: 'my-id',
     cookie_policy: 'single_host_origin',
@@ -19,14 +19,14 @@ function test_getAuthInstance(){
   var auth = gapi.auth2.getAuthInstance();
 }
 
-function test_signIn(){
+function test_signIn() {
   gapi.auth2.getAuthInstance().signIn({
     scope: 'email profile',
     prompt: 'content'
   });
 }
 
-function test_signInOptionsBuild(){
+function test_signInOptionsBuild() {
   var options = new gapi.auth2.SigninOptionsBuilder();
   options.setAppPackageName('com.example.app');
   options.setFetchBasicProfile(true);
@@ -35,13 +35,13 @@ function test_signInOptionsBuild(){
   gapi.auth2.getAuthInstance().signIn(options);
 }
 
-function test_getAuthResponse(){
+function test_getAuthResponse() {
   var user = gapi.auth2.getAuthInstance().currentUser.get();
   var authResponse = user.getAuthResponse();
   var authResponseWithAuth = user.getAuthResponse(true);
 }
 
-function test_render(){
+function test_render() {
   var success = (googleUser: gapi.auth2.GoogleUser): void => {
     console.log(googleUser);
   };

--- a/gapi.auth2/gapi.auth2-tests.ts
+++ b/gapi.auth2/gapi.auth2-tests.ts
@@ -1,4 +1,4 @@
-
+/// <reference types="gapi.people" />
 
 function test_init() {
   var auth = gapi.auth2.init({
@@ -57,5 +57,89 @@ function test_render() {
     theme: 'dark',
     onsuccess: success,
     onfailure: failure
+  });
+}
+
+/* Example taken from https://developers.google.com/identity/sign-in/web/ */
+function onSignIn(googleUser: gapi.auth2.GoogleUser) {
+  // Useful data for your client-side scripts:
+  var profile = googleUser.getBasicProfile();
+  console.log("ID: " + profile.getId()); // Don't send this directly to your server!
+  console.log('Full Name: ' + profile.getName());
+  console.log('Given Name: ' + profile.getGivenName());
+  console.log('Family Name: ' + profile.getFamilyName());
+  console.log("Image URL: " + profile.getImageUrl());
+  console.log("Email: " + profile.getEmail());
+
+  // The ID token you need to pass to your backend:
+  var id_token = googleUser.getAuthResponse().id_token;
+  console.log("ID Token: " + id_token);
+};
+
+
+/* Example taken from https://github.com/google/google-api-javascript-client/blob/master/samples/authSample.html */
+
+// Enter an API key from the Google API Console:
+//   https://console.developers.google.com/apis/credentials
+var apiKey = 'YOUR_API_KEY';
+// Enter the API Discovery Docs that describes the APIs you want to
+// access. In this example, we are accessing the People API, so we load
+// Discovery Doc found here: https://developers.google.com/people/api/rest/
+var discoveryDocs = ["https://people.googleapis.com/$discovery/rest?version=v1"];
+// Enter a client ID for a web application from the Google API Console:
+//   https://console.developers.google.com/apis/credentials?project=_
+// In your API Console project, add a JavaScript origin that corresponds
+//   to the domain where you will be running the script.
+var clientId = 'YOUR_WEB_CLIENT_ID.apps.googleusercontent.com';
+// Enter one or more authorization scopes. Refer to the documentation for
+// the API or https://developers.google.com/people/v1/how-tos/authorizing
+// for details.
+var scopes = 'profile';
+var authorizeButton = document.getElementById('authorize-button');
+var signoutButton = document.getElementById('signout-button');
+function handleClientLoad() {
+  // Load the API client and auth2 library
+  gapi.load('client:auth2', initClient);
+}
+function initClient() {
+  gapi.client.init({
+      apiKey: apiKey,
+      discoveryDocs: discoveryDocs,
+      clientId: clientId,
+      scope: scopes
+  }).then(function () {
+    // Listen for sign-in state changes.
+    gapi.auth2.getAuthInstance().isSignedIn.listen(updateSigninStatus);
+    // Handle the initial sign-in state.
+    updateSigninStatus(gapi.auth2.getAuthInstance().isSignedIn.get());
+    authorizeButton.onclick = handleAuthClick;
+    signoutButton.onclick = handleSignoutClick;
+  });
+}
+function updateSigninStatus(isSignedIn: boolean) {
+  if (isSignedIn) {
+    authorizeButton.style.display = 'none';
+    signoutButton.style.display = 'block';
+    makeApiCall();
+  } else {
+    authorizeButton.style.display = 'block';
+    signoutButton.style.display = 'none';
+  }
+}
+function handleAuthClick(event: MouseEvent) {
+  gapi.auth2.getAuthInstance().signIn();
+}
+function handleSignoutClick(event: MouseEvent) {
+  gapi.auth2.getAuthInstance().signOut();
+}
+// Load the API and make an API call.  Display the results on the screen.
+function makeApiCall() {
+  gapi.client.people.people.get({
+    resourceName: 'people/me'
+  }).then(function(resp) {
+    var p = document.createElement('p');
+    var name = resp.result.names[0].givenName;
+    p.appendChild(document.createTextNode('Hello, '+name+'!'));
+    document.getElementById('content').appendChild(p);
   });
 }

--- a/gapi.auth2/index.d.ts
+++ b/gapi.auth2/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Google Sign-In API
+// Type definitions for Google Sign-In API 0.0
 // Project: https://developers.google.com/identity/sign-in/web/
 // Definitions by: Derek Lawless <https://github.com/flawless2011>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -21,7 +21,7 @@ declare namespace gapi.auth2 {
      * Calls the onInit function when the GoogleAuth object is fully initialized, or calls the onFailure function if
      * initialization fails.
      */
-    then(onInit: () => any, onFailure: (reason: string) => any): any;
+    then(onInit: () => any, onFailure?: (reason: string) => any): any;
 
     /**
      * Signs in the user with the options specified to gapi.auth2.init().
@@ -58,7 +58,7 @@ declare namespace gapi.auth2 {
                        onsuccess: (googleUser: GoogleUser) => any, onfailure: (reason: string) => any): any;
   }
 
-  export interface IsSignedIn{
+  export interface IsSignedIn {
     /**
      * Returns whether the current user is currently signed in.
      */

--- a/gapi.calendar/gapi.calendar-tests.ts
+++ b/gapi.calendar/gapi.calendar-tests.ts
@@ -1,0 +1,152 @@
+﻿/* Example taken from Google Calendar API JavaScript Quickstart https://developers.google.com/google-apps/calendar/quickstart/js */
+
+{
+  // Your Client ID can be retrieved from your project in the Google
+  // Developer Console, https://console.developers.google.com
+  var CLIENT_ID = '<YOUR_CLIENT_ID>';
+
+  var SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"];
+
+  /**
+   * Check if current user has authorized this application.
+   */
+  function checkAuth() {
+    gapi.auth.authorize(
+      {
+        'client_id': CLIENT_ID,
+        'scope': SCOPES.join(' '),
+        'immediate': true
+      }, handleAuthResult);
+  }
+
+  /**
+   * Handle response from authorization server.
+   *
+   * @param {Object} authResult Authorization result.
+   */
+  function handleAuthResult(authResult: GoogleApiOAuth2TokenObject) {
+    var authorizeDiv = document.getElementById('authorize-div')!;
+    if (authResult && !authResult.error) {
+      // Hide auth UI, then load client library.
+      authorizeDiv.style.display = 'none';
+      loadCalendarApi();
+    } else {
+      // Show auth UI, allowing the user to initiate authorization by
+      // clicking authorize button.
+      authorizeDiv.style.display = 'inline';
+    }
+  }
+
+  /**
+   * Initiate auth flow in response to user clicking authorize button.
+   *
+   * @param {Event} event Button click event.
+   */
+  function handleAuthClick(event: MouseEvent) {
+    gapi.auth.authorize(
+      {client_id: CLIENT_ID, scope: SCOPES, immediate: false},
+      handleAuthResult);
+    return false;
+  }
+
+  /**
+   * Load Google Calendar client library. List upcoming events
+   * once client library is loaded.
+   */
+  function loadCalendarApi() {
+    gapi.client.load('calendar', 'v3', listUpcomingEvents);
+  }
+
+  /**
+   * Print the summary and start datetime/date of the next ten events in
+   * the authorized user's calendar. If no events are found an
+   * appropriate message is printed.
+   */
+  function listUpcomingEvents() {
+    var request = gapi.client.calendar.events.list({
+      'calendarId': 'primary',
+      'timeMin': (new Date()).toISOString(),
+      'showDeleted': false,
+      'singleEvents': true,
+      'maxResults': 10,
+      'orderBy': 'startTime'
+    });
+
+    request.execute(function(resp) {
+      var events = resp.items;
+      appendPre('Upcoming events:');
+
+      if (events.length > 0) {
+        for (let i = 0; i < events.length; i++) {
+          var event = events[i];
+          var when = event.start.dateTime;
+          if (!when) {
+            when = event.start.date;
+          }
+          appendPre(event.summary + ' (' + when + ')')
+        }
+      } else {
+        appendPre('No upcoming events found.');
+      }
+
+    });
+  }
+
+  /**
+   * Append a pre element to the body containing the given message
+   * as its text node.
+   *
+   * @param {string} message Text to be placed in pre element.
+   */
+  function appendPre(message: string) {
+    var pre = document.getElementById('output')!;
+    var textContent = document.createTextNode(message + '\n');
+    pre.appendChild(textContent);
+  }
+}
+
+/* Example taken from https://developers.google.com/google-apps/calendar/v3/reference/events/insert#examples */
+
+{
+  // Refer to the JavaScript quickstart on how to setup the environment:
+  // https://developers.google.com/google-apps/calendar/quickstart/js
+  // Change the scope to 'https://www.googleapis.com/auth/calendar' and delete any
+  // stored credentials.
+
+  const event = {
+    'summary': 'Google I/O 2015',
+    'location': '800 Howard St., San Francisco, CA 94103',
+    'description': 'A chance to hear more about Google\'s developer products.',
+    'start': {
+      'dateTime': '2015-05-28T09:00:00-07:00',
+      'timeZone': 'America/Los_Angeles'
+    },
+    'end': {
+      'dateTime': '2015-05-28T17:00:00-07:00',
+      'timeZone': 'America/Los_Angeles'
+    },
+    'recurrence': [
+      'RRULE:FREQ=DAILY;COUNT=2'
+    ],
+    'attendees': [
+      {'email': 'lpage@example.com'},
+      {'email': 'sbrin@example.com'}
+    ],
+    'reminders': {
+      'useDefault': false,
+      'overrides': [
+        {'method': 'email', 'minutes': 24 * 60},
+        {'method': 'popup', 'minutes': 10}
+      ]
+    }
+  };
+
+  var request = gapi.client.calendar.events.insert({
+    'calendarId': 'primary',
+    'resource': event
+  });
+
+  request.execute(function(event) {
+    appendPre('Event created: ' + event.htmlLink);
+  });
+}

--- a/gapi.calendar/index.d.ts
+++ b/gapi.calendar/index.d.ts
@@ -1,0 +1,675 @@
+// Type definitions for Google Calendar API 3.0
+// Project: https://developers.google.com/google-apps/calendar/
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="gapi" />
+
+declare namespace gapi.client.calendar {
+  export class freebusy {
+    static query(parameters: FreeBusyQueryParameters): HttpRequest<FreeBusy>;
+  }
+
+  interface FreeBusyQueryParameters {
+    timeMin: datetime;
+    timeMax: datetime;
+    timeZone?: string;
+    groupExpansionMax?: integer;
+    calendarExpansionMax?: integer;
+    items: {id: string}[];
+  }
+
+  interface FreeBusy {
+    kind: 'calendar#freeBusy';
+    timeMin: datetime;
+    timeMax: datetime;
+    groups: {
+      (key: string): {
+        errors?: {
+          domain: string;
+          reason: string;
+        }[];
+        calendars: string[];
+      }
+    };
+    calendars: {
+      (key: string): {
+        errors?: {
+          domain: string;
+          reason: string;
+        }[];
+        busy: {
+          start: datetime;
+          end: datetime;
+        }[];
+      }
+    };
+  }
+
+  export class acl {
+    static insert(parameters: AclInsertParameters): HttpRequest<Acl>;
+    static get(parameters: AclGetParameters): HttpRequest<Acl>;
+    static update(parameters: AclUpdateParameters): HttpRequest<Acl>;
+    static delete(parameters: AclDeleteParameters): HttpRequest<void>;
+  }
+
+  // The type of the scope. Possible values are:
+  type ScopeType =
+    // The public scope. This is the default value.
+    // Note: The permissions granted to the "default", or public, scope apply to any user, authenticated or not.
+    'default' |
+    // Limits the scope to a single user.
+    'user' |
+    // Limits the scope to a group.
+    'group' |
+    // Limits the scope to a domain.
+    'domain';
+
+  interface Acl {
+    kind: 'calendar#aclRule';
+    etag: etag;
+    id: string;
+    scope: {
+      type: ScopeType;
+      value: string;
+    };
+    role: AccessRole;
+  }
+
+  interface AclInsertParameters {
+    calendarId: string;
+
+    // Acl resource
+    role: AccessRole;
+    scope: {
+      type: ScopeType;
+      value?: string;
+    };
+  }
+
+  interface AclGetParameters {
+    calendarId: string;
+    ruleId: string;
+  }
+
+  interface AclUpdateParameters extends AclInsertParameters {
+    ruleId: string;
+  }
+
+  interface AclDeleteParameters extends AclGetParameters {
+  }
+
+  export class calendarList {
+    static list(parameters?: CalendarListListParameters): HttpRequest<CalendarList>;
+    static insert(parameters: CalendarListInsertParameters): HttpRequest<CalendarListEntry>;
+  }
+
+  type AccessRoleWithoutNone =
+    // The user has read access to free/busy information.
+    'freeBusyReader' |
+    // The user has read access to the calendar. Private events will appear to users with reader access, but event details will be hidden.
+    'reader' |
+    // The user has read and write access to the calendar. Private events will appear to users with writer access, and event details will be visible.
+    'writer' |
+    // The user has ownership of the calendar. This role has all of the permissions of the writer role with the additional ability to see and manipulate ACLs.
+    'owner';
+
+  // The user's access role for this calendar. Read-only. Possible values are:
+  type AccessRole =
+    // The user has no access.
+    'none' |
+    AccessRoleWithoutNone;
+
+  interface CalendarListListParameters {
+    maxResults?: integer;
+    // The minimum access role for the user in the returned entries. Optional. The default is no restriction. Acceptable values are:
+    minAccessRole?: AccessRoleWithoutNone;
+    pageToken?: string;
+    showDeleted?: boolean;
+    showHidden?: boolean;
+    syncToken?: string;
+  }
+
+  interface CalendarListInsertParameters {
+    // Parameters
+    // Optional query parameters
+    colorRgbFormat?: boolean;
+
+    // CalendarList resource
+    resource: CalendarListInput;
+  }
+
+  interface CalendarListInput {
+    // Required Properties
+    id: string;
+
+    // Optional Properties
+    backgroundColor?: string;
+    colorId?: string;
+    defaultReminders?: {
+      method: ReminderMethod;
+      minutes: integer;
+    }[];
+    foregroundColor?: string;
+    hidden?: boolean;
+    notificationSettings?: {
+      notifications: {
+        type: NotificationType;
+        method: string;
+      }[];
+    };
+    selected?: boolean;
+    summaryOverride?: string;
+  }
+
+  interface CalendarList {
+    kind: 'calendar#calendarList';
+    etag: etag;
+
+    /**
+     * Token used to access the next page of this result.
+     * Omitted if no further results are available, in which case nextSyncToken is provided.
+     */
+    nextPageToken?: string;
+
+    /**
+     * Token used at a later point in time to retrieve only the entries that have changed since this result was returned.
+     * Omitted if further results are available, in which case nextPageToken is provided.
+     */
+    nextSyncToken?: string;
+
+    items: CalendarListEntry[];
+  }
+
+  // The type of notification. Possible values are:
+  type NotificationType =
+    // Notification sent when a new event is put on the calendar.
+    'eventCreation' |
+    // Notification sent when an event is changed.
+    'eventChange' |
+    // Notification sent when an event is cancelled.
+    'eventCancellation' |
+    // Notification sent when an event is changed.
+    'eventResponse' |
+    // An agenda with the events of the day (sent out in the morning).
+    'agenda';
+
+  interface CalendarListEntry {
+    kind: 'calendar#calendarListEntry';
+    etag: etag;
+    id: string;
+    summary: string;
+    description?: string;
+    location?: string;
+    timeZone?: string;
+    summaryOverride?: string;
+    colorId?: string;
+    backgroundColor?: string;
+    foregroundColor?: string;
+    hidden?: boolean;
+    selected?: boolean;
+    // The effective access role that the authenticated user has on the calendar. Read-only.
+    accessRole: AccessRoleWithoutNone;
+    defaultReminders: {
+      method: ReminderMethod;
+      minutes: integer;
+    }[];
+    notificationSettings?: {
+      notifications: {
+        type: NotificationType;
+        method: string;
+      }[];
+    };
+    primary?: boolean;
+    deleted?: boolean;
+  }
+
+  export class calendars {
+    static insert(parameters: CalendarsInsertParameters): HttpRequest<Calendar>;
+    static update(parameters: CalendarsUpdateParameters): HttpRequest<Calendar>;
+    static delete(parameters: CalendarsDeleteParameters): HttpRequest<void>;
+  }
+
+  interface CalendarsUpdateParameters {
+    calendarId: string;
+
+    // Calendars resource
+    // Optional Properties
+    description?: string;
+    location?: string;
+    summary?: string;
+    timeZone?: string;
+  }
+
+  interface CalendarsInsertParameters {
+    // Calendars resource
+    // Required Properties
+    summary: string;
+
+    description?: string;
+    location?: string;
+    timeZone?: string;
+  }
+
+  interface CalendarsDeleteParameters {
+    calendarId: string;
+  }
+
+  interface Calendar {
+    kind: 'calendar#calendar';
+    etag: etag;
+    id: string;
+    summary: string;
+    description?: string;
+    location?: string;
+    timeZone?: string;
+  }
+
+  export class events {
+    static list(parameters: EventsListParameters): HttpRequest<Events>;
+    static insert(parameters: EventsInsertParameters): HttpRequest<Event>;
+    static update(parameters: EventsUpdateParameters): HttpRequest<Event>;
+    static get(parameters: EventsGetParameters): HttpRequest<Event>;
+  }
+
+  interface EventsGetParameters {
+    calendarId: string;
+    eventId: string;
+
+    alwaysIncludeEmail?: boolean;
+    maxAttendees?: integer;
+    timeZone?: string;
+  }
+
+  interface EventsInsertParameters {
+    calendarId: string;
+
+    maxAttendees?: integer;
+    sendNotifications?: boolean;
+    supportsAttachments?: boolean;
+
+    // Event resource
+    resource: EventInput;
+  }
+
+  interface EventsUpdateParameters {
+    calendarId: string;
+    eventId: string;
+
+    alwaysIncludeEmail?: boolean;
+    maxAttendees?: integer;
+    sendNotifications?: boolean;
+    supportsAttachments?: boolean;
+
+    // Event resource
+    resource: EventInput;
+  }
+
+  interface EventInput {
+    // Required Properties
+    attachments?: {
+      fileUrl: string;
+    }[];
+    attendees?: {
+      email: string;
+      displayName?: string;
+      optional?: boolean;
+      responseStatus?: AttendeeResponseStatus;
+      comment?: string;
+      additionalGuests?: integer;
+    }[];
+    end: {
+      date?: date;
+      dateTime?: datetime;
+      timeZone?: string
+    };
+    reminders?: {
+      overrides: {
+        method: string;
+        minutes: integer;
+      }[];
+      useDefault: boolean;
+    };
+    start: {
+      date?: date;
+      dateTime?: datetime;
+      timeZone: string;
+    };
+
+    // Optional Properties
+    anyoneCanAddSelf?: boolean;
+    colorId?: string;
+    description?: string;
+    extendedProperties?: {
+      private: {
+        (key: string): string
+      };
+      shared: {
+        (key: string): string
+      }
+    };
+    gadget?: {
+      display?: GadgetDisplayMode;
+      height: integer;
+      iconLink: string;
+      link: string;
+      preferences: {
+        (key: string): string
+      }
+      title: string;
+      type: string;
+      width: integer;
+    };
+    guestsCanInviteOthers?: boolean;
+    guestsCanSeeOtherGuests?: boolean;
+    id?: string;
+    location?: string;
+    originalStartTime?: {
+      date: date;
+      dateTime: datetime;
+      timeZone: string
+    };
+    recurrence?: string[];
+    sequence?: integer;
+    source?: {
+      url: string;
+      title: string
+    };
+    status?: EventStatus;
+    summary?: string;
+    transparency?: EventTransparency;
+    visibility?: EventVisibility;
+  }
+
+  // The order of the events returned in the result. Optional. The default is an unspecified, stable order.
+  // Acceptable values are:
+  type EventsOrder =
+    // Order by the start date/time (ascending). This is only available when querying single events (i.e. the parameter singleEvents is True)
+    'startTime' |
+    // Order by last modification time (ascending).
+    'updated';
+
+  // Token obtained from the nextSyncToken field returned on the last page of results from the previous list request.
+  // It makes the result of this list request contain only entries that have changed since then.
+  // All events deleted since the previous list request will always be in the result set and it is not allowed to set showDeleted to False.
+  // There are several query parameters that cannot be specified together with nextSyncToken to ensure consistency of the client state.
+  // These are:
+  type SyncToken =
+    'iCalUID' |
+    'orderBy' |
+    'privateExtendedProperty' |
+    'q' |
+    'sharedExtendedProperty' |
+    'timeMin' |
+    'timeMax' |
+    'updatedMin';
+
+  interface EventsListParameters {
+    calendarId: string;
+    alwaysIncludeEmail?: boolean;
+    iCalUID?: string;
+    maxAttendees?: integer;
+    maxResults?: integer;
+    orderBy?: EventsOrder;
+    pageToken?: string;
+    privateExtendedProperty?: string;
+    q?: string;
+    sharedExtendedProperty?: string;
+    showDeleted?: boolean;
+    showHiddenInvitations?: boolean;
+    singleEvents?: boolean;
+    syncToken?: SyncToken;
+    timeMax?: datetime;
+    timeMin?: datetime;
+    timeZone?: string;
+    updatedMin?: datetime;
+  }
+
+  interface Events {
+    kind: 'calendar#events';
+    etag: etag;
+    summary: string;
+    description: string;
+    updated: datetime;
+    timeZone: string;
+    // The user's access role for this calendar. Read-only. Possible values are:
+    accessRole: AccessRole;
+    defaultReminders: {
+      method: ReminderMethod;
+      minutes: integer;
+    }[];
+    nextPageToken?: string;
+    nextSyncToken?: string;
+    items: Event[];
+  }
+
+  type etag = string;
+  type datetime = string;
+  type date = string;
+  type integer = number;
+
+  // The attendee's response status. Possible values are:
+  type AttendeeResponseStatus =
+    // The attendee has not responded to the invitation.
+    'needsAction' |
+    // The attendee has declined the invitation.
+    'declined' |
+    // The attendee has tentatively accepted the invitation.
+    'tentative' |
+    // The attendee has accepted the invitation.
+    'accepted';
+
+  // The gadget's display mode. Optional. Possible values are:
+  type GadgetDisplayMode =
+    // The gadget displays next to the event's title in the calendar view.
+    'icon' |
+    // The gadget displays when the event is clicked.
+    'chip';
+
+  // The method used by this reminder. Possible values are:
+  type ReminderMethod =
+    // Reminders are sent via email.
+    'email' |
+    // Reminders are sent via SMS. These are only available for Google Apps for Work, Education, and Government customers. Requests to set SMS reminders for other account types are ignored.
+    'sms' |
+    // Reminders are sent via a UI popup.
+    'popup';
+
+  // Status of the event. Optional. Possible values are:
+  type EventStatus =
+    // The event is confirmed. This is the default status.
+    'confirmed' |
+    // The event is tentatively confirmed.
+    'tentative' |
+    // The event is cancelled.
+    'cancelled';
+
+  // Whether the event blocks time on the calendar. Optional. Possible values are:
+  type EventTransparency =
+    // The event blocks time on the calendar. This is the default value.
+    'opaque' |
+    // The event does not block time on the calendar.
+    'transparent';
+
+  // Visibility of the event. Optional. Possible values are:
+  type EventVisibility =
+    // Uses the default visibility for events on the calendar. This is the default value.
+    'default' |
+    // The event is public and event details are visible to all readers of the calendar.
+    'public' |
+    // The event is private and only event attendees may view event details.
+    'private' |
+    // The event is private. This value is provided for compatibility reasons.
+    'confidential';
+
+  class Event {
+    kind: 'calendar#event';
+    etag: etag;
+    id: string;
+    status?: EventStatus;
+    htmlLink: string;
+    created: datetime;
+    updated: datetime;
+    summary: string;
+    description: string;
+    location?: string;
+    colorId?: string;
+
+    // The creator of the event. Read-only.
+    creator: {
+      // The creator's Profile ID, if available.
+      id?: string;
+
+      // The creator's email address, if available.
+      email?: string;
+
+      // The creator's name, if available.
+      displayName?: string;
+
+      // Whether the creator corresponds to the calendar on which this copy of the event appears. Read-only. The default is False.
+      self?: boolean;
+    };
+
+    // The organizer of the event.
+    organizer: {
+      // The organizer's Profile ID, if available.
+      id?: string;
+
+      // The organizer's email address, if available.
+      email?: string;
+
+      // The organizer's name, if available.
+      displayName?: string;
+
+      // Whether the organizer corresponds to the calendar on which this copy of the event appears. Read-only. The default is False.
+      self?: boolean;
+    };
+
+    // The (inclusive) start time of the event. For a recurring event, this is the start time of the first instance.
+    start: {
+      // The date, in the format "yyyy-mm-dd", if this is an all-day event.
+      date?: date;
+
+      // The time, as a combined date-time value (formatted according to RFC3339).
+      // A time zone offset is required unless a time zone is explicitly specified in timeZone.
+      dateTime?: datetime;
+
+      // The time zone in which the time is specified. (Formatted as an IANA Time Zone Database name, e.g. "Europe/Zurich".)
+      // For recurring events this field is required and specifies the time zone in which the recurrence is expanded.
+      // For single events this field is optional and indicates a custom time zone for the event start/end.
+      timeZone?: string;
+    };
+
+    // The (exclusive) end time of the event. For a recurring event, this is the end time of the first instance.
+    end: {
+      // The date, in the format "yyyy-mm-dd", if this is an all-day event.
+      date?: date;
+
+      // The time, as a combined date-time value (formatted according to RFC3339).
+      // A time zone offset is required unless a time zone is explicitly specified in timeZone.
+      dateTime?: datetime;
+
+      // The time zone in which the time is specified. (Formatted as an IANA Time Zone Database name, e.g. "Europe/Zurich".)
+      // For recurring events this field is required and specifies the time zone in which the recurrence is expanded.
+      // For single events this field is optional and indicates a custom time zone for the event start/end.
+      timeZone?: string;
+    };
+
+    // 	Whether the end time is actually unspecified. An end time is still provided for compatibility reasons, even if this attribute is set to True.
+    // The default is False.
+    endTimeUnspecified?: boolean;
+
+    recurrence: string[];
+
+    // For an instance of a recurring event, this is the id of the recurring event to which this instance belongs. Immutable.
+    recurringEventId?: string;
+
+    // Whether the organizer corresponds to the calendar on which this copy of the event appears. Read-only. The default is False.
+    originalStartTime?: {
+      date: date;
+      dateTime: datetime;
+      timeZone?: string;
+    };
+
+    transparency?: EventTransparency;
+    visibility?: EventVisibility;
+    iCalUID: string;
+    sequence: integer;
+
+    // The attendees of the event.
+    attendees?: {
+      id: string;
+      email: string;
+      displayName?: string;
+      organizer: boolean;
+      self: boolean;
+      resource: boolean;
+      optional?: boolean;
+      responseStatus: AttendeeResponseStatus;
+      comment?: string;
+      additionalGuests?: integer;
+    }[];
+
+    attendeesOmitted?: boolean;
+
+    // Extended properties of the event.
+    extendedProperties?: {
+      private: {
+        (key: string): string;
+      };
+      shared: {
+        (key: string): string;
+      }
+    };
+
+    // An absolute link to the Google+ hangout associated with this event. Read-only.
+    hangoutLink?: string;
+
+    // A gadget that extends this event.
+    gadget?: {
+      type: string;
+      title: string;
+      link: string;
+      iconLink: string;
+      width?: integer;
+      height?: integer;
+      display?: GadgetDisplayMode;
+      preferences: {
+        (key: string): string;
+      }
+    };
+
+    anyoneCanAddSelf?: boolean;
+    guestsCanInviteOthers?: boolean;
+    guestsCanModify?: boolean;
+    guestsCanSeeOtherGuests?: boolean;
+    privateCopy?: boolean;
+
+    // Whether this is a locked event copy where no changes can be made to the main event fields "summary", "description", "location", "start", "end" or "recurrence". The default is False. Read-Only.
+    locked?: boolean;
+
+    reminders: {
+      useDefault: boolean;
+      overrides?: {
+        method: ReminderMethod;
+        minutes: integer;
+      }[];
+    };
+
+    // Source from which the event was created. For example, a web page, an email message or any document identifiable by an URL with HTTP or HTTPS scheme.
+    // Can only be seen or modified by the creator of the event.
+    source?: {
+      url: string;
+      title: string;
+    };
+
+    // File attachments for the event. Currently only Google Drive attachments are supported.
+    attachments?: {
+      fileUrl: string;
+      title: string;
+      mimeType: string;
+      iconLink: string;
+      fileId: string;
+    }[];
+  }
+}

--- a/gapi.calendar/tsconfig.json
+++ b/gapi.calendar/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../",
+    "typeRoots": ["../"],
+    "types": [],
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "files": [
+    "index.d.ts",
+    "gapi.calendar-tests.ts"
+  ]
+}

--- a/gapi.people/gapi.people-tests.ts
+++ b/gapi.people/gapi.people-tests.ts
@@ -1,0 +1,99 @@
+/* Example taken from Google People API JavaScript Quickstart https://developers.google.com/people/quickstart/js */
+
+{
+  // Your Client ID can be retrieved from your project in the Google
+  // Developer Console, https://console.developers.google.com
+  var CLIENT_ID = '<YOUR_CLIENT_ID>';
+
+  var SCOPES = ["https://www.googleapis.com/auth/contacts.readonly"];
+
+  /**
+   * Check if current user has authorized this application.
+   */
+  function checkAuth() {
+    gapi.auth.authorize(
+      {
+        'client_id': CLIENT_ID,
+        'scope': SCOPES.join(' '),
+        'immediate': true
+      }, handleAuthResult);
+  }
+
+  /**
+   * Handle response from authorization server.
+   *
+   * @param {Object} authResult Authorization result.
+   */
+  function handleAuthResult(authResult: GoogleApiOAuth2TokenObject) {
+    var authorizeDiv = document.getElementById('authorize-div')!;
+    if (authResult && !authResult.error) {
+      // Hide auth UI, then load client library.
+      authorizeDiv.style.display = 'none';
+      loadPeopleApi();
+    } else {
+      // Show auth UI, allowing the user to initiate authorization by
+      // clicking authorize button.
+      authorizeDiv.style.display = 'inline';
+    }
+  }
+
+  /**
+   * Initiate auth flow in response to user clicking authorize button.
+   *
+   * @param {Event} event Button click event.
+   */
+  function handleAuthClick(event: MouseEvent) {
+    gapi.auth.authorize(
+      {client_id: CLIENT_ID, scope: SCOPES, immediate: false},
+      handleAuthResult);
+    return false;
+  }
+
+  /**
+   * Load Google People client library. List names if available
+   * of 10 connections.
+   */
+  function loadPeopleApi() {
+    gapi.client.load('https://people.googleapis.com/$discovery/rest', 'v1', listConnectionNames);
+  }
+
+  /**
+   * Print the display name if available for 10 connections.
+   */
+  function listConnectionNames() {
+    var request = gapi.client.people.people.connections.list({
+        'resourceName': 'people/me',
+        'pageSize': 10,
+      });
+
+      request.execute(function(resp) {
+        var connections = resp.connections;
+        appendPre('Connections:');
+
+        if (connections.length > 0) {
+          for (var i = 0; i < connections.length; i++) {
+            var person = connections[i];
+            if (person.names && person.names.length > 0) {
+              appendPre(person.names[0].displayName)
+            } else {
+              appendPre("No display name found for connection.");
+            }
+          }
+        } else {
+          appendPre('No upcoming events found.');
+        }
+      });
+  }
+
+  /**
+   * Append a pre element to the body containing the given message
+   * as its text node.
+   *
+   * @param {string} message Text to be placed in pre element.
+   */
+  function appendPre(message: string) {
+    var pre = document.getElementById('output')!;
+    var textContent = document.createTextNode(message + '\n');
+    pre.appendChild(textContent);
+  }
+}

--- a/gapi.people/index.d.ts
+++ b/gapi.people/index.d.ts
@@ -1,0 +1,246 @@
+// Type definitions for Google People API 1.0
+// Project: https://developers.google.com/people/
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="gapi" />
+
+declare namespace gapi.client.people {
+  export namespace people {
+
+    interface GetParameters {
+      resourceName: string;
+
+      // Query parameters
+      requestMask?: RequestMask;
+    }
+
+    function get(parameters: GetParameters): HttpRequest<Person>;
+
+    interface GetBatchGetParameters {
+      // Query parameters
+      resourcesName?: string;
+      requestMask?: RequestMask;
+    }
+
+    function getBatchGet(parameters: GetBatchGetParameters): HttpRequest<BatchGetResponse>;
+
+    interface BatchGetResponse {
+      responses: PersonResponse[];
+    }
+
+    interface PersonResponse {
+      httpStatusCode: number;
+      person: Person;
+      requestedResourceName: string;
+    }
+
+    namespace connections {
+      function list(parameters: ListParameters): HttpRequest<Response>;
+
+      type SortOrder = 'LAST_MODIFIED_ASCENDING' | 'FIRST_NAME_ASCENDING' | 'LAST_NAME_ASCENDING';
+
+      interface ListParameters {
+        resourceName: string;
+
+        // Query parameters
+        pageToken?: string;
+        pageSize?: number;
+        sortOrder?: SortOrder;
+        syncToken?: string;
+        requestMask?: RequestMask;
+      }
+
+      interface Response {
+        connections: Person[];
+        nextPageToken: string;
+        nextSyncToken: string;
+      }
+    }
+  }
+
+  interface RequestMask {
+    includeField: string;
+  }
+
+  type SourceType = 'SOURCE_TYPE_UNSPECIFIED' | 'ACCOUNT' | 'PROFILE' | 'DOMAIN_PROFILE' | 'CONTACT';
+
+  interface Source {
+    type: SourceType;
+    id: string;
+    etag: string;
+    resourceName: string;
+  }
+
+  type ObjectType = 'OBJECT_TYPE_UNSPECIFIED' | 'PERSON' | 'PAGE';
+
+  interface PersonMetadata {
+    sources: Source[];
+    previousResourceNames: string[];
+    linkedPeopleResourceNames: string[];
+    deleted: boolean;
+    objectType: ObjectType;
+  }
+
+  interface FieldMetadata {
+    primary: boolean;
+    verified: boolean;
+    source: Source;
+  }
+
+  interface Locale {
+    metadata: FieldMetadata;
+    value: string;
+  }
+
+  interface Name {
+    metadata: FieldMetadata;
+    displayName: string;
+    displayNameLastFirst: string;
+    familyName: string;
+    givenName: string;
+    middleName: string;
+    honorificPrefix: string;
+    honorificSuffix: string;
+    phoneticFullName: string;
+    phoneticFamilyName: string;
+    phoneticGivenName: string;
+    phoneticMiddleName: string;
+    phoneticHonorificPrefix: string;
+    phoneticHonorificSuffix: string;
+  }
+
+  type NicknameType = 'DEFAULT' | 'MAIDEN_NAME' | 'INITIALS' | 'GPLUS' | 'OTHER_NAME';
+
+  interface Nickname {
+    metadata: FieldMetadata;
+    value: string;
+    type: NicknameType;
+  }
+
+  interface CoverPhoto {
+  }
+
+  interface Photo {
+  }
+
+  interface Gender {
+  }
+
+  interface AgeRange {
+  }
+
+  interface Birthday {
+  }
+
+  interface Event {
+  }
+
+  interface Address {
+    metadata: FieldMetadata;
+    formattedValue: string;
+    type: string;
+    formattedType: string;
+    poBox: string;
+    streetAddress: string;
+    extendedAddress: string;
+    city: string;
+    region: string;
+    postalCode: string;
+    country: string;
+    countryCode: string;
+  }
+
+  interface Residence {
+    metadata: FieldMetadata;
+    value: string;
+    current: boolean;
+  }
+
+  interface EmailAddress {
+    metadata: FieldMetadata;
+    value: string;
+    type: string;
+    formattedType: string;
+    displayName: string;
+  }
+
+  interface PhoneNumber {
+    metadata: FieldMetadata;
+    value: string;
+    canonicalForm: string;
+    type: string;
+    formattedType: string;
+  }
+
+  interface ImClient {
+  }
+
+  interface Tagline {
+  }
+
+  interface Biography {
+  }
+
+  interface Url {
+  }
+
+  interface Organization {
+  }
+
+  interface Occupation {
+  }
+
+  interface Interest {
+  }
+
+  interface Skill {
+  }
+
+  interface BraggingRights {
+  }
+
+  interface Relation {
+  }
+
+  interface RelationshipInterest {
+  }
+
+  interface RelationshipStatus {
+  }
+
+  interface Membership {
+  }
+
+  interface Person {
+    resourceName: string;
+    etag: string;
+    metadata: PersonMetadata;
+    locales: Locale[];
+    names: Name[];
+    nicknames?: Nickname[];
+    coverPhotos: CoverPhoto[];
+    photos?: Photo[];
+    genders?: Gender[];
+    ageRange?: AgeRange;
+    birthdays?: Birthday[];
+    events?: Event[];
+    addresses?: Address[];
+    residences?: Residence[];
+    emailAddresses?: EmailAddress[];
+    phoneNumbers?: PhoneNumber[];
+    imClients?: ImClient[];
+    taglines?: Tagline[];
+    biographies?: Biography[];
+    urls?: Url[];
+    organizations?: Organization[];
+    occupations?: Occupation[];
+    interests?: Interest[];
+    skills?: Skill[];
+    BraggingRights?: BraggingRights[];
+    relations?: Relation[];
+    relationshipInterests?: RelationshipInterest[];
+    relationshipStatuses?: RelationshipStatus[];
+    memberships?: Membership[];
+  }
+}

--- a/gapi.people/tsconfig.json
+++ b/gapi.people/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../",
+    "typeRoots": ["../"],
+    "types": [],
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "files": [
+    "index.d.ts",
+    "gapi.people-tests.ts"
+  ]
+}

--- a/gapi.plus/gapi.plus-tests.ts
+++ b/gapi.plus/gapi.plus-tests.ts
@@ -1,0 +1,10 @@
+/* Example taken from https://developers.google.com/+/web/people/ */
+
+gapi.client.load('plus','v1', function(){
+ var request = gapi.client.plus.people.get({
+   'userId': 'me'
+ });
+ request.execute(function(resp) {
+   console.log('Retrieved profile for:' + resp.displayName);
+ });
+});

--- a/gapi.plus/index.d.ts
+++ b/gapi.plus/index.d.ts
@@ -1,0 +1,111 @@
+// Type definitions for Google+ Platform API 1.0
+// Project: https://developers.google.com/+/web/people/
+// Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="gapi" />
+
+// See Google+ REST API Reference https://developers.google.com/+/web/api/rest/latest/
+declare namespace gapi.client.plus {
+  export namespace people {
+
+    interface GetParameters {
+      userId: string;
+    }
+    function get(parameters: GetParameters): HttpRequest<Person>;
+
+    interface SearchParameters {
+      query: string;
+      language?: string;
+      maxResults?: number;
+      pageToken?: string;
+    }
+    function search(parameters: SearchParameters): HttpRequest<PeopleFeed>;
+
+    // Search response
+    interface PeopleFeed {
+      kind: 'plus#peopleFeed';
+      etag: string;
+      selfLink: string;
+      title: string;
+      nextPageToken: string;
+      totalItems: number;
+      items: Person[];
+    }
+
+    interface Person {
+      kind: 'plus#person';
+      etag: string;
+      nickname: string;
+      occupation: string;
+      skills: string;
+      birthday: string;
+      gender: string;
+      emails: {
+        value: string;
+        type: string;
+      }[];
+      urls: {
+        value: string;
+        type: string;
+        label: string;
+      }[];
+      objectType: string;
+      id: string;
+      displayName: string;
+      name: {
+        formatted: string;
+        familyName: string;
+        givenName: string;
+        middleName: string;
+        honorificPrefix: string;
+        honorificSuffix: string;
+      };
+      tagline: string;
+      braggingRights: string;
+      aboutMe: string;
+      relationshipStatus: string;
+      url: string;
+      image: {
+        url: string;
+      };
+      organizations: {
+        name: string;
+        department: string;
+        title: string;
+        type: string;
+        startDate: string;
+        endDate: string;
+        location: string;
+        description: string;
+        primary: boolean;
+      }[];
+      placesLived: {
+        value: string;
+        primary: boolean;
+      }[];
+      isPlusUser: boolean;
+      language: string;
+      ageRange: {
+        min: number;
+        max: number;
+      };
+      plusOneCount: number;
+      circledByCount: number;
+      verified: boolean;
+      cover: {
+        layout: string;
+        coverPhoto: {
+          url: string;
+          height: number;
+          width: number;
+        };
+        coverInfo: {
+          topImageOffset: number;
+          leftImageOffset: number;
+        }
+      };
+      domain: string;
+    }
+  }
+}

--- a/gapi.plus/tsconfig.json
+++ b/gapi.plus/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../",
+    "typeRoots": ["../"],
+    "types": [],
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "files": [
+    "index.d.ts",
+    "gapi.plus-tests.ts"
+  ]
+}

--- a/gapi/gapi-tests.ts
+++ b/gapi/gapi-tests.ts
@@ -1,0 +1,97 @@
+﻿/// <reference types="gapi.people" />
+/// <reference types="gapi.plus" />
+
+/* Examples taken from https://developers.google.com/api-client-library/javascript/start/start-js */
+
+{
+  function start1() {
+    // 2. Initialize the JavaScript client library.
+    gapi.client.init({
+      'apiKey': 'YOUR_API_KEY',
+      'discoveryDocs': ['https://people.googleapis.com/$discovery/rest'],
+      // clientId and scope are optional if auth is not required.
+      'clientId': 'YOUR_WEB_CLIENT_ID.apps.googleusercontent.com',
+      'scope': 'profile',
+    }).then(function() {
+      // 3. Initialize and make the API request.
+      return gapi.client.people.people.get({
+        resourceName: 'people/me'
+      });
+    }).then(function(response) {
+      console.log(response.result);
+    }, function(reason) {
+      console.log('Error: ' + reason.result.error.message);
+    });
+  };
+  // 1. Load the JavaScript client library.
+  gapi.load('client', start1);
+}
+
+{
+  function start2() {
+    // 2. Initialize the JavaScript client library.
+    gapi.client.init({
+      'apiKey': 'YOUR_API_KEY',
+      // clientId and scope are optional if auth is not required.
+      'clientId': 'YOUR_WEB_CLIENT_ID.apps.googleusercontent.com',
+      'scope': 'profile',
+    }).then(function() {
+      // 3. Initialize and make the API request.
+      return gapi.client.request({
+        'path': 'https://people.googleapis.com/v1/people/me',
+      })
+    }).then(function(response) {
+      console.log(response.result);
+    }, function(reason) {
+      console.log('Error: ' + reason.result.error.message);
+    });
+  };
+  // 1. Load the JavaScript client library.
+  gapi.load('client', start2);
+}
+
+
+/* Examples taken from https://developers.google.com/api-client-library/javascript/features/promises */
+
+gapi.client.request({'path': '/plus/v1/people', 'params': {'query': 'John'}}).then(function(response) {
+  // Handle response
+}, function(reason) {
+  // Handle error
+});
+
+gapi.client.load('plus', 'v1').then(function() {
+  gapi.client.plus.people.search({'query': ''}).then(response => { });
+});
+
+var personFetcher = {
+  results: [],
+
+  // Why this: any? Check https://github.com/Microsoft/TypeScript/issues/10835
+
+  fetch: function(this: any, name: string) {
+    gapi.client.request({path: '/plus/v1/people', params:{query: name}}).then(function(this: any, response) {
+      this.results.push(response.result);
+    }, function(reason) {
+      console.error(name, 'was not fetched:', reason.result.error.message);
+    }, this);
+  }
+};
+personFetcher.fetch('John');
+
+gapi.client.request({
+  'path': 'plus/v1/people',
+  'params': {'query': name}
+}).execute(function(resp, rawResp) {
+  processResponse(resp);
+});
+
+gapi.client.request({
+  'path': 'plus/v1/people',
+  'params': {'query': name}
+}).then(function(resp) {
+  processResponse(resp.result);
+});
+
+function processResponse(response: any) {
+  // Stub
+}

--- a/gapi/index.d.ts
+++ b/gapi/index.d.ts
@@ -38,7 +38,7 @@ declare namespace gapi {
     /**
      * Pragmatically initialize gapi class member.
      */
-    export function load(object: string, fn: any): any;
+    export function load(apiName: string, callback: () => void): void;
 
 }
 

--- a/gapi/index.d.ts
+++ b/gapi/index.d.ts
@@ -38,7 +38,7 @@ declare namespace gapi {
     /**
      * Pragmatically initialize gapi class member.
      */
-    export function load(object: string, fn: any) : any;
+    export function load(object: string, fn: any): any;
 
 }
 
@@ -155,37 +155,37 @@ declare namespace gapi.client {
     }
 
     /**
-    * Loads the client library interface to a particular API. If a callback is not provided, a promise is returned.
-    * @param name The name of the API to load.
-    * @param version The version of the API to load.
-    * @return promise The promise that get's resolved after the request is finished.
-    */
-    export function load(name: string, version: string): Promise<void>
+     * Loads the client library interface to a particular API. If a callback is not provided, a promise is returned.
+     * @param name The name of the API to load.
+     * @param version The version of the API to load.
+     * @return promise The promise that get's resolved after the request is finished.
+     */
+    export function load(name: string, version: string): Promise<void>;
 
     /**
-    * Loads the client library interface to a particular API. The new API interface will be in the form gapi.client.api.collection.method.
-    * @param name The name of the API to load.
-    * @param version The version of the API to load
-    * @param callback the function that is called once the API interface is loaded
-    * @param url optional, the url of your app - if using Google's APIs, don't set it
-    */
+     * Loads the client library interface to a particular API. The new API interface will be in the form gapi.client.api.collection.method.
+     * @param name The name of the API to load.
+     * @param version The version of the API to load
+     * @param callback the function that is called once the API interface is loaded
+     * @param url optional, the url of your app - if using Google's APIs, don't set it
+     */
     export function load(name: string, version: string, callback: () => any, url?: string): void;
     /**
-    * Creates a HTTP request for making RESTful requests.
-    * An object encapsulating the various arguments for this method.
-    */
+     * Creates a HTTP request for making RESTful requests.
+     * An object encapsulating the various arguments for this method.
+     */
     export function request(args: RequestOptions): HttpRequest<any>;
     /**
-    * Creates an RPC Request directly. The method name and version identify the method to be executed and the RPC params are provided upon RPC creation.
-    * @param method The method to be executed.
-    * @param version The version of the API which defines the method to be executed. Defaults to v1
-    * @param rpcParams A key-value pair of the params to supply to this RPC
-    */
+     * Creates an RPC Request directly. The method name and version identify the method to be executed and the RPC params are provided upon RPC creation.
+     * @param method The method to be executed.
+     * @param version The version of the API which defines the method to be executed. Defaults to v1
+     * @param rpcParams A key-value pair of the params to supply to this RPC
+     */
     export function rpcRequest(method: string, version?: string, rpcParams?: any): RpcRequest;
     /**
-    * Sets the API key for the application.
-    * @param apiKey The API key to set
-    */
+     * Sets the API key for the application.
+     * @param apiKey The API key to set
+     */
     export function setApiKey(apiKey: string): void;
 
     /**
@@ -210,24 +210,24 @@ declare namespace gapi.client {
                 status: number;
                 statusText: string;
             }
-            ) => any):void;
-            /**
+            ) => any): void;
+        /**
          * HttpRequest supports promises.
          */
-        then(success:(response:{
-                result:T;
-                body:string;
+        then(success: (response: {
+                result: T;
+                body: string;
                 headers?: any[];
                 status?: number;
-                statusText?: string
-            })=>void,
-            failure:(response:{
-                result:T;
-                body:string;
+                statusText?: string;
+            }) => void,
+            failure: (response: {
+                result: T;
+                body: string;
                 headers?: any[];
                 status?: number;
-                statusText?: string
-            })=>void): void;
+                statusText?: string;
+            }) => void): void;
     }
     /**
      * Represents an HTTP Batch operation. Individual HTTP requests are added with the add method and the batch is executed using execute.
@@ -244,16 +244,16 @@ declare namespace gapi.client {
              */
             id: string;
             callback: (
-            /**
-             * is the response for this request only. Its format is defined by the API method being called.
-             */
-            individualResponse: any,
-            /**
-             * is the raw batch ID-response map as a string. It contains all responses to all requests in the batch.
-             */
-            rawBatchResponse: any
-            ) => any
-        }):void;
+                /**
+                 * is the response for this request only. Its format is defined by the API method being called.
+                 */
+                individualResponse: any,
+                /**
+                 * is the raw batch ID-response map as a string. It contains all responses to all requests in the batch.
+                 */
+                rawBatchResponse: any
+                ) => any
+        }): void;
         /**
          * Executes all requests in the batch. The supplied callback is executed on success or failure.
          * @param callback The callback to execute when the batch returns.
@@ -267,7 +267,7 @@ declare namespace gapi.client {
              * is the same response, but as an unparsed JSON-string.
              */
             rawBatchResponse: string
-            ) => any):void;
+            ) => any): void;
     }
 
     /**
@@ -288,7 +288,7 @@ declare namespace gapi.client {
              * is the same as jsonResp, except it is a raw string that has not been parsed. It is typically used when the response is not JSON.
              */
             rawResp: string
-            ) => void ):void;
+            ) => void): void;
     }
 
 }

--- a/gapi/index.d.ts
+++ b/gapi/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for Google API Client
+// Type definitions for Google API Client 0.0
 // Project: https://code.google.com/p/google-api-javascript-client/
 // Definitions by: Frank M <https://github.com/sgtfrankieboy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+// TypeScript Version: 2.1
 
 /**
  * The OAuth 2.0 token object represents the OAuth 2.0 token and any associated data.
@@ -102,7 +102,7 @@ declare namespace gapi.auth {
         /**
          * A function in the global namespace, which is called when the sign-in button is rendered and also called after a sign-in flow completes.
          */
-        callback?: Function;
+        callback?: () => void;
         /**
          * If true, all previously granted scopes remain granted in each incremental request, for incremental authorization. The default value true is correct for most use cases; use false only if employing delegated auth, where you pass the bearer token to a less-trusted component with lower programmatic authority.
          */
@@ -127,6 +127,30 @@ declare namespace gapi.auth {
 }
 
 declare namespace gapi.client {
+    /**
+     * Initializes the JavaScript client with API key, OAuth client ID, scope, and API discovery document(s).
+     * If OAuth client ID and scope are provided, this function will load the gapi.auth2 module to perform OAuth.
+     * The gapi.client.init function can be run multiple times, such as to set up more APIs, to change API key, or initialize OAuth lazily.
+     */
+    export function init(args: {
+        /**
+         * The API Key to use.
+         */
+        apiKey?: string;
+        /**
+         * An array of discovery doc URLs or discovery doc JSON objects.
+         */
+        discoveryDocs?: string[];
+        /**
+         * The app's client ID, found and created in the Google Developers Console.
+         */
+        clientId?: string;
+        /**
+         * The scopes to request, as a space-delimited string.
+         */
+        scope?: string
+    }): Promise<void>;
+
     interface RequestOptions {
         /**
          * The URL to handle the request
@@ -188,10 +212,46 @@ declare namespace gapi.client {
      */
     export function setApiKey(apiKey: string): void;
 
+    interface HttpRequestFulfilled<T> {
+        result: T;
+        body: string;
+        headers?: any[];
+        status?: number;
+        statusText?: string;
+    }
+
+    interface HttpRequestRejected {
+        result: {
+            error: {
+                message: string;
+            }
+        };
+        body: string;
+        headers?: any[];
+        status?: number;
+        statusText?: string;
+    }
+
+    /**
+     * HttpRequest supports promises.
+     * See Google API Client JavaScript Using Promises https://developers.google.com/api-client-library/javascript/features/promises
+     *
+     * TODO This should be updated when TypeScript 2.3 is released
+     * See https://github.com/Microsoft/TypeScript/issues/12409
+     * See https://github.com/Microsoft/TypeScript/blob/65da012527937a3074c62655d60ee08fee809f7f/lib/lib.es5.d.ts#L1339
+     */
+     class HttpRequestPromise<T> {
+        then<TResult>(
+             opt_onFulfilled?: ((response: HttpRequestFulfilled<T>) => void) | null,
+             opt_onRejected?: ((reason: HttpRequestRejected) => void) | null,
+             opt_context?: any
+        ): Promise<TResult>;
+    }
+
     /**
      * An object encapsulating an HTTP request. This object is not instantiated directly, rather it is returned by gapi.client.request.
      */
-    export class HttpRequest<T> {
+    export class HttpRequest<T> extends HttpRequestPromise<T> {
         /**
          * Executes the request and runs the supplied callback on response.
          * @param callback The callback function which executes when the request succeeds or fails.
@@ -211,24 +271,8 @@ declare namespace gapi.client {
                 statusText: string;
             }
             ) => any): void;
-        /**
-         * HttpRequest supports promises.
-         */
-        then(success: (response: {
-                result: T;
-                body: string;
-                headers?: any[];
-                status?: number;
-                statusText?: string;
-            }) => void,
-            failure: (response: {
-                result: T;
-                body: string;
-                headers?: any[];
-                status?: number;
-                statusText?: string;
-            }) => void): void;
     }
+
     /**
      * Represents an HTTP Batch operation. Individual HTTP requests are added with the add method and the batch is executed using execute.
      */

--- a/gapi/tsconfig.json
+++ b/gapi/tsconfig.json
@@ -2,11 +2,12 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
@@ -16,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "gapi-tests.ts"
     ]
 }


### PR DESCRIPTION
Add definitions for Google Calendar API (gapi.calendar)

Since I've added tests for gapi.calendar (examples taken from Google Calendar API documentation) I had to modify existing d.ts (gapi, gapi.auth2) and add others (gapi.plus, gapi.people) for the examples to work.

Most important commits:
-- "Better gapi.load"
-- "Add definitions for Google Calendar API (gapi.calendar)"

Google Calendar API is *huge*, not everything is implemented: I've typed the APIs that I'm using (same for gapi.plus and gapi.people)

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.

