### PR TITLE
Fix webappsec-credential-management definitions to be compatible with TS 2.2

### DIFF
--- a/webappsec-credential-management/index.d.ts
+++ b/webappsec-credential-management/index.d.ts
@@ -1,10 +1,150 @@
-// Type definitions for W3C (WebAppSec) Credential Management API, Level 1, 0.0
+// Type definitions for W3C (WebAppSec) Credential Management API Level 1, 0.1
 // Project: https://github.com/w3c/webappsec-credential-management
 // Definitions by: Iain McGinniss <https://github.com/iainmcgin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 // Spec: http://www.w3.org/TR/2016/WD-credential-management-1-20160425/
 
-/// <reference types="whatwg-fetch" />
+/* ************************ FETCH API DEFINITIONS ******************************
+ * TS 2.2 introduced definitions for the fetch API in the dom library, but
+ * prior to that it was necessary to use the types defined in
+ * @types/whatwg-fetch. In order to support all versions of TS 2.x, the
+ * definitions for fetch from TS 2.2 dom are duplicated here. As long as these
+ * remain identical to the definitions in dom 2.2+, they cause no issues.
+ *
+ * One caveat to "identical" here is that type definitions cannot be duplicated,
+ * and so the "RequestInfo" type has been substituted for its expansion in
+ * the below definitions:
+ *
+ * type RequestInfo = Request|string;
+ * ************************************************************************** */
+
+interface Request extends Object, Body {
+    readonly cache: string;
+    readonly credentials: string;
+    readonly destination: string;
+    readonly headers: Headers;
+    readonly integrity: string;
+    readonly keepalive: boolean;
+    readonly method: string;
+    readonly mode: string;
+    readonly redirect: string;
+    readonly referrer: string;
+    readonly referrerPolicy: string;
+    readonly type: string;
+    readonly url: string;
+    clone(): Request;
+}
+
+declare var Request: {
+    prototype: Request;
+    new(input: Request | string, init?: RequestInit): Request;
+};
+
+interface Headers {
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    forEach(callback: ForEachCallback): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+}
+
+declare var Headers: {
+    prototype: Headers;
+    new(init?: any): Headers;
+};
+
+interface Response extends Object, Body {
+    readonly body: ReadableStream | null;
+    readonly headers: Headers;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly type: string;
+    readonly url: string;
+    clone(): Response;
+}
+
+declare var Response: {
+    prototype: Response;
+    new(body?: any, init?: ResponseInit): Response;
+};
+
+interface ResponseInit {
+    status?: number;
+    statusText?: string;
+    headers?: any;
+}
+
+interface ReadableStream {
+    readonly locked: boolean;
+    cancel(): Promise<void>;
+    getReader(): ReadableStreamReader;
+}
+
+declare var ReadableStream: {
+    prototype: ReadableStream;
+    new(): ReadableStream;
+};
+
+interface ReadableStreamReader {
+    cancel(): Promise<void>;
+    read(): Promise<any>;
+    releaseLock(): void;
+}
+
+declare var ReadableStreamReader: {
+    prototype: ReadableStreamReader;
+    new(): ReadableStreamReader;
+};
+
+interface Body {
+    readonly bodyUsed: boolean;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    json(): Promise<any>;
+    text(): Promise<string>;
+}
+
+interface URLSearchParams {
+    /**
+      * Appends a specified key/value pair as a new search parameter.
+      */
+    append(name: string, value: string): void;
+    /**
+      * Deletes the given search parameter, and its associated value, from the list of all search parameters.
+      */
+    delete(name: string): void;
+    /**
+      * Returns the first value associated to the given search parameter.
+      */
+    get(name: string): string | null;
+    /**
+      * Returns all the values association with a given search parameter.
+      */
+    getAll(name: string): string[];
+    /**
+      * Returns a Boolean indicating if such a search parameter exists.
+      */
+    has(name: string): boolean;
+    /**
+      * Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
+      */
+    set(name: string, value: string): void;
+}
+
+declare var URLSearchParams: {
+    prototype: URLSearchParams;
+    /**
+      * Constructor returning a URLSearchParams object.
+      */
+    new (init?: string | URLSearchParams): URLSearchParams;
+};
+
+interface GlobalFetch {
+    fetch(input: Request|string, init?: RequestInit): Promise<Response>;
+}
 
 /* ************************* FETCH MODIFICATIONS *******************************
  * The credential management spec modifies fetch(), by adding a new
@@ -16,38 +156,33 @@
  * See: https://www.w3.org/TR/credential-management-1/#monkey-patching
  * ************************************************************************** */
 
-interface Window {
-    fetch(url: CMRequestInfo, init?: CMRequestInit): Promise<Response>;
-}
+declare function fetch(
+    input: Request|string,
+    init?: RequestInit|CMRequestInit):
+    Promise<Response>;
 
-type CMRequestInfo = CMRequest|string;
+interface GlobalFetch {
+    // variant for navigator.credentials monkey patching
+    fetch(url: Request|string, init?: CMRequestInit): Promise<Response>;
+}
 
 /**
- * Variant of {@link Request} that permits a {@code 'password'} value in the
- * {@code credentials} property.
+ * Original definition from TS 2.2 dom.
  */
-interface CMRequest extends Body {
-    // the only modified property from RequestCredentials:
-    credentials: CMRequestCredentials;
-
-    method: string;
-    url: string;
-    headers: Headers;
-
-    type: RequestType;
-    destination: RequestDestination;
-    referrer: string;
-    referrerPolicy: ReferrerPolicy;
-    mode: RequestMode;
-
-    cache: RequestCache;
-    redirect: RequestRedirect;
-    integrity: string;
-
-    clone(): Request;
+interface RequestInit {
+    method?: string;
+    headers?: any;
+    body?: any;
+    referrer?: string;
+    referrerPolicy?: string;
+    mode?: string;
+    credentials?: string;
+    cache?: string;
+    redirect?: string;
+    integrity?: string;
+    keepalive?: boolean;
+    window?: any;
 }
-
-type CMRequestCredentials = RequestCredentials|'password';
 
 /**
  * Variant of {@link RequestInit} that permits a {@link PasswordCredential} to
@@ -55,37 +190,18 @@ type CMRequestCredentials = RequestCredentials|'password';
  * identical to {@link RequestInit}.
  */
 interface CMRequestInit {
-    credentials?: PasswordCredential|CMRequestCredentials;
-
     method?: string;
-    headers?: HeadersInit;
-    body?: BodyInit;
+    headers?: any;
+    body?: any;
     referrer?: string;
-    referrerPolicy?: ReferrerPolicy;
-    mode?: RequestMode;
-
-    cache?: RequestCache;
-    redirect?: RequestRedirect;
+    referrerPolicy?: string;
+    mode?: string;
+    credentials?: PasswordCredential|string;
+    cache?: string;
+    redirect?: string;
     integrity?: string;
+    keepalive?: boolean;
     window?: any;
-}
-
-/**
- * URLSearchParams is not yet included in the core lib.d.ts declarations, so we
- * include it here.
- * The official definition should be included in TypeScript 2.2, at which point
- * this can be removed.
- *
- * @see {@link https://github.com/Microsoft/TypeScript/issues/12517}
- */
-declare class URLSearchParams {
-    constructor(init?: string|URLSearchParams);
-    append(name: string, value: string): void;
-    delete(name: string): void;
-    get(name: string): string|null;
-    getAll(name: string): string[];
-    has(name: string): boolean;
-    set(name: string, value: string): void;
 }
 
 /* ***************** CREDENTIAL MANAGEMENT API DEFINITONS ******************* */


### PR DESCRIPTION
TS 2.2 provides definitions for the fetch API directly in the dom library, and those definitions are slightly different from those that were provided in @types/whatwg-fetch. This change updates the webappsec-credential-management definitions to be compatible with TS 2.2, and drops the dependency on @types/whatwg-fetch.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [TS 2.2 breaking changes - Changes to DOM APIs](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#changes-to-dom-apis-in-the-standard-library)
- [x] Increase the version number in the header if appropriate.
- (not applicable) If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
