### PR TITLE
Make the weak map definitions compatible with ES6 for lodash

### DIFF
--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -12701,7 +12701,7 @@ declare namespace _ {
          * @param value The value to check.
          * @returns Returns true if value is correctly classified, else false.
          */
-        isWeakMap<K, V>(value?: any): value is WeakMap<K, V>;
+        isWeakMap<K extends object, V>(value?: any): value is WeakMap<K, V>;
     }
 
     interface LoDashImplicitWrapperBase<T, TWrapper> {
@@ -19446,5 +19446,5 @@ declare global {
     interface Set<T> { }
     interface Map<K, V> { }
     interface WeakSet<T> { }
-    interface WeakMap<K, V> { }
+    interface WeakMap<K extends object, V> { }
 }

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -7436,10 +7436,10 @@ namespace TestIsUndefined {
 // _.isWeakMap
 namespace TestIsWeakMap {
     {
-        let value: number|WeakMap<string, number>;
+        let value: number|WeakMap<Object, number>;
 
-        if (_.isWeakMap<string, number>(value)) {
-            let result: WeakMap<string, number> = value;
+        if (_.isWeakMap<Object, number>(value)) {
+            let result: WeakMap<Object, number> = value;
         }
         else {
             let result: number = value;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap. The first line of the Description section states: ``Keys of WeakMaps are of the type Object only. Primitive data types as keys are not allowed.`` This corresponds to how WeakMap is defined in lib.es6.d.ts of Typescript v2.2.1.

The way it is defined now yield the following error at compile time: ./node_modules/@types/lodash/index.d.ts(19449,15): error TS2428: All declarations of 'WeakMap' must have identical type parameters.

Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: ``See the explaination above``
- [n/a] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
