### PR TITLE
query-string: support strictNullChecks

### DIFF
--- a/query-string/index.d.ts
+++ b/query-string/index.d.ts
@@ -13,7 +13,7 @@ declare module "query-string" {
      * Leading ? or # are ignored, so you can pass location.search or location.hash directly.
      * @param str
      */
-    export function parse(str: string): { [key: string]: string | string[] };
+    export function parse(str: string): { [key: string]: string | string[] | null };
 
     /**
      * Stringify an object into a query string, sorting the keys.

--- a/query-string/query-string-tests.ts
+++ b/query-string/query-string-tests.ts
@@ -21,7 +21,7 @@ namespace stringify_tests {
 }
 
 namespace parse_tests {
-    let result: { [key: string]: string | string[] };
+    let result: { [key: string]: string | string[] | null };
     result = qs.parse('?foo=bar');
     result = qs.parse('#foo=bar');
     result = qs.parse('&foo=bar&foo=baz');

--- a/query-string/tsconfig.json
+++ b/query-string/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
better reflect the documented and implemented API