### PR TITLE
Fix Yeoman Generator Exports

### DIFF
--- a/yeoman-generator/index.d.ts
+++ b/yeoman-generator/index.d.ts
@@ -8,77 +8,79 @@ import { Questions, Answers } from 'inquirer';
 
 declare type Callback = (err: any) => void;
 
-declare namespace Base {
-    class Storage {
-        constructor(name: string, fs: MemFsEditor, configPath: string);
+export class Storage {
+    constructor(name: string, fs: MemFsEditor, configPath: string);
 
-        defaults(defaults: {}): {};
-        delete(key: string): void;
-        get(key: string): any;
-        getAll(): { [key: string]: any };
-        save(): void;
-        set(key: string, value: any): any;
-    }
-    interface InstallOptions {
-        npm?: boolean;
-        bower?: boolean;
-        yarn?: boolean;
-        skipMessage?: boolean;
-        callback?: Callback;
-    }
-    interface ArgumentConfig {
-        description?: string;
-        required?: boolean;
-        optional?: boolean;
-        type?: typeof String|typeof Number|typeof Array|typeof Object;
-        default?: any;
-    }
-    interface OptionConfig {
-        alias?: string;
-        default?: any;
-        description?: string;
-        hide?: boolean;
-        type?: typeof Boolean|typeof String|typeof Number;
-    }
-    interface MemFsEditor {
-        read(filepath: string, options?: {}): string;
-        readJSON(filepath: string, defaults?: {}): any;
-        write(filepath: string, contents: string): void;
-        writeJSON(filepath: string, contents: {}, replacer?: (key: string, value: any) => any, space?: number): void;
-        extendJSON(filepath: string, contents: {}, replacer?: (key: string, value: any) => any, space?: number): void;
-        delete(filepath: string, options?: {}): void;
-        copy(from: string, to: string, options?: {}): void;
-        copyTpl(from: string, to: string, context: {}, templateOptions?: {}, copyOptions?: {}): void;
-        move(from: string, to: string, options?: {}): void;
-        exists(filepath: string): boolean;
-        commit(callback: Callback): void;
-        commit(filters: any[], callback: Callback): void;
-    }
+    defaults(defaults: {}): {};
+    delete(key: string): void;
+    get(key: string): any;
+    getAll(): { [key: string]: any };
+    save(): void;
+    set(key: string, value: any): any;
 }
 
-declare class Base extends EventEmitter {
+export interface InstallOptions {
+    npm?: boolean;
+    bower?: boolean;
+    yarn?: boolean;
+    skipMessage?: boolean;
+    callback?: Callback;
+}
+
+export interface ArgumentConfig {
+    description?: string;
+    required?: boolean;
+    optional?: boolean;
+    type?: typeof String | typeof Number | typeof Array | typeof Object;
+    default?: any;
+}
+
+export interface OptionConfig {
+    alias?: string;
+    default?: any;
+    description?: string;
+    hide?: boolean;
+    type?: typeof Boolean | typeof String | typeof Number;
+}
+
+export interface MemFsEditor {
+    read(filepath: string, options?: {}): string;
+    readJSON(filepath: string, defaults?: {}): any;
+    write(filepath: string, contents: string): void;
+    writeJSON(filepath: string, contents: {}, replacer?: (key: string, value: any) => any, space?: number): void;
+    extendJSON(filepath: string, contents: {}, replacer?: (key: string, value: any) => any, space?: number): void;
+    delete(filepath: string, options?: {}): void;
+    copy(from: string, to: string, options?: {}): void;
+    copyTpl(from: string, to: string, context: {}, templateOptions?: {}, copyOptions?: {}): void;
+    move(from: string, to: string, options?: {}): void;
+    exists(filepath: string): boolean;
+    commit(callback: Callback): void;
+    commit(filters: any[], callback: Callback): void;
+}
+
+export class Base {
     static extend(protoProps?: any, staticProps?: any): Base;
 
-    constructor(args: string|string[], options: {});
+    constructor(args: string | string[], options: {});
 
     env: {};
     args: {};
     resolved: string;
     description: string;
     appname: string;
-    config: Base.Storage;
-    fs: Base.MemFsEditor;
+    config: Storage;
+    fs: MemFsEditor;
     options: {};
     log(message?: string, context?: any): void;
 
-    argument(name: string, config: Base.ArgumentConfig): this;
-    composeWith(namespace: string, options: { [name: string]: any }, settings?: { local: string, link: 'weak'|'strong' }): this;
+    argument(name: string, config: ArgumentConfig): this;
+    composeWith(namespace: string, options: { [name: string]: any }, settings?: { local: string, link: 'weak' | 'strong' }): this;
     destinationPath(...path: string[]): string;
     destinationRoot(rootPath?: string): string;
     determineAppname(): string;
-    option(name: string, config: Base.OptionConfig): this;
+    option(name: string, config: OptionConfig): this;
     prompt(questions: Questions): Promise<Answers>;
-    registerTransformStream(stream: {}|Array<{}>): this;
+    registerTransformStream(stream: {} | Array<{}>): this;
     rootGeneratorName(): string;
     rootGeneratorVersion(): string;
     run(cb?: Callback): this;
@@ -97,11 +99,11 @@ declare class Base extends EventEmitter {
     spawnCommandSync(command: string, args: string[], opt?: {}): any;
 
     // actions/install mixin
-    bowerInstall(component?: string|string[], options?: {}, cb?: Callback, spawnOptions?: {}): this;
-    installDependencies(options?: Base.InstallOptions): this;
-    npmInstall(pkgs?: string|string[], options?: {}, cb?: Callback, spawnOptions?: {}): this;
-    runInstall(installer: string, paths?: string|string[], options?: {}, cb?: Callback, spawnOptions?: {}): this;
-    yarnInstall(pkgs?: string|string[], options?: {}, cb?: Callback, spawnOptions?: {}): this;
+    bowerInstall(component?: string | string[], options?: {}, cb?: Callback, spawnOptions?: {}): this;
+    installDependencies(options?: InstallOptions): this;
+    npmInstall(pkgs?: string | string[], options?: {}, cb?: Callback, spawnOptions?: {}): this;
+    runInstall(installer: string, paths?: string | string[], options?: {}, cb?: Callback, spawnOptions?: {}): this;
+    yarnInstall(pkgs?: string | string[], options?: {}, cb?: Callback, spawnOptions?: {}): this;
 
     // actions/user mixin
     readonly user: {
@@ -114,4 +116,3 @@ declare class Base extends EventEmitter {
         }
     };
 }
-export = Base;

--- a/yeoman-generator/yeoman-generator-tests.ts
+++ b/yeoman-generator/yeoman-generator-tests.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:no-empty */
 import yeoman = require('yeoman-generator');
 import { Questions, Answers } from 'inquirer';
 import { EventEmitter } from 'events';

--- a/yeoman-generator/yeoman-generator-tests.ts
+++ b/yeoman-generator/yeoman-generator-tests.ts
@@ -1,25 +1,24 @@
-import Base = require('yeoman-generator');
+import yeoman = require('yeoman-generator');
 import { Questions, Answers } from 'inquirer';
 import { EventEmitter } from 'events';
 
-class MyES2015Generator extends Base {}
+class MyES2015Generator extends yeoman.Base {}
 
-const MyGenerator = Base.extend({
-  writing(this: Base): void {
+const MyGenerator = yeoman.Base.extend({
+  writing(this: yeoman.Base): void {
     this.fs.write('var foo = 1;', this.destinationPath('index.js'));
   }
 });
 
 const generator = new MyES2015Generator(['arg1', 'arg2'], { opt1: 'foo', opt2: 3, opt3: false });
-const eventEmitter: EventEmitter = generator;
 
 const env: {} = generator.env;
 const args: {} = generator.args;
 const resolved: string = generator.resolved;
 const description: string = generator.description;
 const appname: string = generator.appname;
-const config: Base.Storage = generator.config;
-const fs: Base.MemFsEditor = generator.fs;
+const config: yeoman.Storage = generator.config;
+const fs: yeoman.MemFsEditor = generator.fs;
 generator.log('my message');
 
 generator.argument('arg1', {});
@@ -86,8 +85,8 @@ generator.runInstall('installer', 'pkg', { 'custom-option': 3 }, () => {});
 generator.runInstall('installer', 'pkg', {}, () => {}, {});
 
 
-const composed1: Base = generator.composeWith('bootstrap', { sass: true });
-const composed2: Base = generator.composeWith(require.resolve('generator-bootstrap/app/main.js'), { sass: true });
+const composed1: yeoman.Base = generator.composeWith('bootstrap', { sass: true });
+const composed2: yeoman.Base = generator.composeWith(require.resolve('generator-bootstrap/app/main.js'), { sass: true });
 
 generator.desc('new description');
 


### PR DESCRIPTION
The existing typedefintion exported the wrong thing, it would not work as is. This fixes the issues, working example linked below  

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Swellaby Generator (if not on master yet its in the typescript branch)](https://github.com/swellaby/generator-swell/) contains a working example using the typedefinition file I am submitting
- [x] Increase the version number in the header if appropriate. - Not needed
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`. - Already there