### PR TITLE
koa: use AppContext at Application instance

### DIFF
--- a/koa/index.d.ts
+++ b/koa/index.d.ts
@@ -555,7 +555,7 @@ declare class Application extends EventEmitter {
     middleware: Application.Middleware[];
     subdomainOffset: number;
     env: string;
-    context: BaseContext;
+    context: Application.AppContext;
     request: BaseRequest;
     response: BaseResponse;
     silent: boolean;
@@ -642,7 +642,11 @@ declare namespace Application {
         request: Request;
     }
 
-    interface Context extends BaseContext {
+    interface AppContext extends BaseContext {
+        // this interface supposed to be augmented from userland code
+    }
+
+    interface Context extends AppContext {
         app: Application;
         request: Request;
         response: Response;


### PR DESCRIPTION
In koa `app.context` is namespace, which supposed to be extended from userland code.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- x ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://koajs.com/#app-context
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
