### PR TITLE
[react-bootstrap-table] Add customEditor property

### DIFF
--- a/react-bootstrap-table/index.d.ts
+++ b/react-bootstrap-table/index.d.ts
@@ -475,6 +475,13 @@ export interface TableHeaderColumnProps extends Props<TableHeaderColumn> {
 	This function taking one arguments: order which present the sort order currently.
 	*/
     caretRender?: Function;
+        /**
+ 	Give an Object like following to able to customize your own editing component.
+ 	This Object should contain these two property:
+    	    getElement(REQUIRED): Accept a callback function and take two arguments: onUpdate and props.
+    	    customEditorParameters: Another extra data for custom cell edit component.
+	 */
+    customEditor?: {getElement: (onUpdate: any, props: any) => ReactElement<any>, customEditorParameters?: Object} ;	
 	/**
 	To customize the column. This callback function should return a String or a React Component.
 	In addition, this function taking two argument: cell and row.


### PR DESCRIPTION
Hi!

I was having this issue while using the library:

```
ERROR in [at-loader] frontend/src/components/modals/Upload.tsx:538:40
    TS2339: Property 'customEditor' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<TableHeaderColumnProps, ComponentState>>...'.
```

It seems it is missing from the Definition file, so I just added it :).

Hope it helps!

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://allenfang.github.io/react-bootstrap-table/docs.html#customEditor
