### PR TITLE
Jest: toThrow supports same signature as toThrowError

### DIFF
--- a/jest/index.d.ts
+++ b/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 18.1.0
+// Type definitions for Jest 19.2.0
 // Project: http://facebook.github.io/jest/
 // Definitions by: Asana <https://asana.com>, Ivo Stratev <https://github.com/NoHomey>, jwbay <https://github.com/jwbay>, Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -229,7 +229,7 @@ declare namespace jest {
         /** This ensures that a value matches the most recent snapshot. Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information. */
         toMatchSnapshot(snapshotName?: string): void;
         /** Used to test that a function throws when it is called. */
-        toThrow(): void;
+        toThrow(error?: string | Constructable | RegExp): void;
         /** If you want to test that a specific error is thrown inside a function. */
         toThrowError(error?: string | Constructable | RegExp): void;
         /** Used to test that a function throws a error matching the most recent snapshot when it is called. */

--- a/jest/jest-tests.ts
+++ b/jest/jest-tests.ts
@@ -160,17 +160,21 @@ describe('toThrow API', function () {
 
    it('throws', function () {
       expect(throwTypeError()).toThrow();
+      expect(throwTypeError()).toThrowError();
    });
 
    it('throws TypeError', function () {
+       expect(throwTypeError()).toThrow(TypeError);
        expect(throwTypeError()).toThrowError(TypeError);
    });
 
    it('throws \'Definition was out of date\'', function () {
+       expect(throwTypeError()).toThrow(/Definition was out of date/);
       expect(throwTypeError()).toThrowError(/Definition was out of date/);
    });
 
    it('throws \'toThorow Definition was out of date\'', function () {
+       expect(throwTypeError()).toThrow('toThrow Definition was out of date');
       expect(throwTypeError()).toThrowError('toThrow Definition was out of date');
    });
 });


### PR DESCRIPTION
I believe this has been this way for a while, but bumping to 19.0.2 as well.

Best I can tell the notable changes from 18.1.0 -> 19.0.2 were unrelated to function signatures ([changelog](https://github.com/facebook/jest/blob/master/CHANGELOG.md) but it's missing the latest [19.0.2](https://www.npmjs.com/package/jest))

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://facebook.github.io/jest/docs/expect.html#tothrowerror
- [x] Increase the version number in the header if appropriate.