### PR TITLE
googlemaps fixe Place Details query params

### DIFF
--- a/googlemaps/index.d.ts
+++ b/googlemaps/index.d.ts
@@ -2258,7 +2258,7 @@ declare namespace google.maps {
         }
 
         export interface PlaceDetailsRequest  {
-            placeId: string;
+            placeid: string;
         }
 
         export interface PlaceGeometry {


### PR DESCRIPTION
The parameter `placeid` is documented as lower-case. I am using TypeScript with my project but the 3rd party Places library I'm using is not and it is duck-type checking against `placeid` (matching Google's documentation). When I attempt to type my function with `PlaceDetailsRequest` TS is getting upset I didn't camel case the variable. 

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/places/web-service/details
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
