### PR TITLE
xml2js - Prevent error when using Parser's event emitter

### DIFF
--- a/xml2js/index.d.ts
+++ b/xml2js/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for node-xml2js
 // Project: https://github.com/Leonidas-from-XIV/node-xml2js
-// Definitions by: Michel Salib <https://github.com/michelsalib>, Jason McNeil <https://github.com/jasonrm>, Christopher Currens <https://github.com/ccurrens>
+// Definitions by: Michel Salib <https://github.com/michelsalib>, Jason McNeil <https://github.com/jasonrm>, Christopher Currens <https://github.com/ccurrens>, Edward Hinkle <https://github.com/edwardhinkle>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="./processors.d.ts" />

--- a/xml2js/index.d.ts
+++ b/xml2js/index.d.ts
@@ -7,6 +7,8 @@
 
 export = xml2js;
 
+import * as events from 'events'
+
 declare namespace xml2js {
     function parseString(xml: convertableToString, callback: (err: any, result: any) => void): void;
     function parseString(xml: convertableToString, options: OptionsV2, callback: (err: any, result: any) => void): void;
@@ -21,7 +23,7 @@ declare namespace xml2js {
         buildObject(rootObj: any): string;
     }
 
-    class Parser {
+    class Parser extends events.EventEmitter {
         constructor(options?: OptionsV2);
         parseString(str: convertableToString, cb?: Function): void;
         reset(): void;

--- a/xml2js/xml2js-tests.ts
+++ b/xml2js/xml2js-tests.ts
@@ -69,6 +69,11 @@ var outString = builder.buildObject({
 
 var parser = new xml2js.Parser();
 
+parser.on('end', (result: any) => {
+    console.log("Parser Finished");
+    return;
+});
+
 var v1Defaults = xml2js.defaults['0.1'];
 v1Defaults.async = true;
 


### PR DESCRIPTION
xml2js.Parser .emits event.eventEmitters, but this is not part of the TypeScript definitions. That means when you try to use parser.on, you receive a TypeScript error. This pull request fixes that small error.