### PR TITLE
ExtensionMessageEvent has return type of boolean

### DIFF
--- a/chrome/index.d.ts
+++ b/chrome/index.d.ts
@@ -4972,7 +4972,7 @@ declare namespace chrome.runtime {
 
     interface PortMessageEvent extends chrome.events.Event<(message: Object, port: Port) => void> {}
 
-    interface ExtensionMessageEvent extends chrome.events.Event<(message: any, sender: MessageSender, sendResponse: (response: any) => void) => void> {}
+    interface ExtensionMessageEvent extends chrome.events.Event<(message: any, sender: MessageSender, sendResponse: (response: any) => void) => boolean> {}
 
     interface ExtensionConnectEvent extends chrome.events.Event<(port: Port) => void> {}
 


### PR DESCRIPTION
According to documentation function may return boolean.
https://developer.chrome.com/extensions/runtime#event-onMessage

```
This function becomes invalid when the event listener returns, unless you return **true** from the event listener to indicate you wish to send a response asynchronously (this will keep the message channel open to the other end until sendResponse is called). 
```

Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/extensions/runtime#event-onMessage
- [X] Increase the version number in the header if appropriate.