### PR TITLE
In pdfkit/index.d.ts fixing bufferedPageRange

### DIFF
--- a/pdfkit/index.d.ts
+++ b/pdfkit/index.d.ts
@@ -269,7 +269,7 @@ declare namespace PDFKit {
         new (options?: PDFDocumentOptions): PDFDocument;
 
         addPage(options?: PDFDocumentOptions): PDFDocument;
-        bufferedPageRanges(): { start: number; count: number };
+        bufferedPageRange(): { start: number; count: number };
         switchToPage(n?: number): PDFPage;
         flushPages(): void;
         ref(data: {}): PDFKitReference;


### PR DESCRIPTION
PdfKit document has method bufferedPageRange() instead of bufferedPageRanges(). 
@see https://github.com/devongovett/pdfkit/blob/v0.8.0/docs/guide.pdf Page 5
@see https://github.com/devongovett/pdfkit/blob/63d6e5020f0b3efa3005286476a29905f8d5e843/lib/document.coffee#L107

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/devongovett/pdfkit/blob/63d6e5020f0b3efa3005286476a29905f8d5e843/lib/document.coffee#L107
https://github.com/devongovett/pdfkit/blob/v0.8.0/docs/guide.pdf Page 5
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.