### PR TITLE
Historyjs: added missed methods, arguments and fields

### DIFF
--- a/history.js/index.d.ts
+++ b/history.js/index.d.ts
@@ -20,8 +20,8 @@ interface Historyjs {
 
     enabled: boolean;
 
-    pushState(data: any, title: string, url: string, queue?: boolean);
-    replaceState(data: any, title: string, url: string, queue?: boolean);
+    pushState(data: any, title: string, url: string, queue?: boolean): boolean;
+    replaceState(data: any, title: string, url: string, queue?: boolean): boolean;
     getState(friendly?: boolean, create?: boolean): HistoryState;
     getStateId (passedState: HistoryState): string;
     getStateById (id: string): HistoryState;
@@ -47,13 +47,13 @@ interface Historyjs {
      * @return {Boolean}
      */
     setTitle (newState: HistoryState): boolean
-    clearQueue();
-    clearAllIntervals();
+    clearQueue(): Historyjs;
+    clearAllIntervals(): void;
     getRootUrl(): string;
 
     emulated: {
-        hashChange?;
-        pushState?;
+        hashChange?: any;
+        pushState?: any;
     }
 }
 

--- a/history.js/index.d.ts
+++ b/history.js/index.d.ts
@@ -20,9 +20,11 @@ interface Historyjs {
 
     enabled: boolean;
 
-    pushState(data: any, title: string, url: string): void;
-    replaceState(data: any, title: string, url: string): void;
-    getState(): HistoryState;
+    pushState(data: any, title: string, url: string, queue?: boolean);
+    replaceState(data: any, title: string, url: string, queue?: boolean);
+    getState(friendly?: boolean, create?: boolean): HistoryState;
+    getStateId (passedState: HistoryState): string;
+    getStateById (id: string): HistoryState;
     getStateByIndex(index: number): HistoryState;
     getCurrentIndex(): number;
     getHash(): string;
@@ -37,12 +39,30 @@ interface Historyjs {
     debug(...messages: any[]): void;
 
     options: HistoryOptions;
+
+    /**
+     * History.setTitle(title)
+     * Applies the title to the document
+     * @param {HistoryState} newState
+     * @return {Boolean}
+     */
+    setTitle (newState: HistoryState): boolean
+    clearQueue();
+    clearAllIntervals();
+    getRootUrl(): string;
+
+    emulated: {
+        hashChange?;
+        pushState?;
+    }
 }
 
 interface HistoryState {
     data?: any;
     title?: string;
     url: string;
+    hashedUrl?: string;
+    cleanUrl?: string;
 }
 
 interface HistoryOptions {
@@ -56,6 +76,4 @@ interface HistoryOptions {
     initialTitle?: string;
     html4Mode?: boolean;
     delayInit?: number;
-
-
 }


### PR DESCRIPTION
# Historyjs interface
## changed
* `pushState`: added `queue` arg (optional), return type
* `replaceState`: added `queue` arg (optional), return type
* `getState`: added `friendly`, `create` args (optional)

## added
* method `getStateId`
* method `getStateById`
* method `setTitle`
* method `clearQueue`
* method `clearAllIntervals`
* method `getRootUrl`
* field `emulated`

# HistroyState interface
## added
* field `hashedUrl`
* field `cleanUrl`
