### PR TITLE
use PromiseLike instead of PromisesAPlus.Thenable

### DIFF
--- a/chai-as-promised/chai-as-promised-tests.ts
+++ b/chai-as-promised/chai-as-promised-tests.ts
@@ -1,5 +1,3 @@
-
-/// <reference types="promises-a-plus" />
 /// <reference types="q" />
 
 import chai = require('chai');
@@ -12,7 +10,7 @@ class TestClass {}
 
 // ReSharper disable WrongExpressionStatement
 // BDD API (expect)
-var thenableNum: PromisesAPlus.Thenable<number>;
+var thenableNum: PromiseLike<number>;
 thenableNum = chai.expect(thenableNum).to.eventually.equal(3);
 thenableNum = chai.expect(thenableNum).to.eventually.have.property('foo');
 thenableNum = chai.expect(thenableNum).to.become(3);
@@ -56,7 +54,7 @@ Q.all([
 ]).should.notify(() => console.log('done'));
 
 // Assert API
-var thenableVoid: PromisesAPlus.Thenable<void>;
+var thenableVoid: PromiseLike<void>;
 thenableVoid = chai.assert.eventually.equal(thenableNum, 4, 'Message');
 thenableVoid = chai.assert.isFulfilled(thenableNum, "optional message");
 thenableVoid = chai.assert.becomes(thenableNum, "foo", "optional message");

--- a/chai-as-promised/index.d.ts
+++ b/chai-as-promised/index.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="chai" />
-/// <reference types="promises-a-plus" />
 
 declare module 'chai-as-promised' {
     function chaiAsPromised(chai: any, utils: any): void;
@@ -27,7 +26,7 @@ declare namespace Chai {
     // Eventually does not have .then(), but PromisedAssertion have.
     interface Eventually extends PromisedLanguageChains, PromisedNumericComparison, PromisedTypeComparison {
         // From chai-as-promised
-        become(expected: PromisesAPlus.Thenable<any>): PromisedAssertion;
+        become(expected: PromiseLike<any>): PromisedAssertion;
         fulfilled: PromisedAssertion;
         rejected: PromisedAssertion;
         rejectedWith(expected: any, message?: string | RegExp): PromisedAssertion;
@@ -74,7 +73,7 @@ declare namespace Chai {
         members: PromisedMembers;
     }
 
-    interface PromisedAssertion extends Eventually, PromisesAPlus.Thenable<any> {
+    interface PromisedAssertion extends Eventually, PromiseLike<any> {
     }
 
     interface PromisedLanguageChains {
@@ -181,111 +180,111 @@ declare namespace Chai {
     // For Assert API
     interface Assert {
         eventually: PromisedAssert;
-        isFulfilled(promise: PromisesAPlus.Thenable<any>, message?: string): PromisesAPlus.Thenable<void>;
-        becomes(promise: PromisesAPlus.Thenable<any>, expected: any, message?: string): PromisesAPlus.Thenable<void>;
-        doesNotBecome(promise: PromisesAPlus.Thenable<any>, expected: any, message?: string): PromisesAPlus.Thenable<void>;
-        isRejected(promise: PromisesAPlus.Thenable<any>, message?: string): PromisesAPlus.Thenable<void>;
-        isRejected(promise: PromisesAPlus.Thenable<any>, expected: any, message?: string): PromisesAPlus.Thenable<void>;
-        isRejected(promise: PromisesAPlus.Thenable<any>, match: RegExp, message?: string): PromisesAPlus.Thenable<void>;
-        notify(fn: Function): PromisesAPlus.Thenable<void>;
+        isFulfilled(promise: PromiseLike<any>, message?: string): PromiseLike<void>;
+        becomes(promise: PromiseLike<any>, expected: any, message?: string): PromiseLike<void>;
+        doesNotBecome(promise: PromiseLike<any>, expected: any, message?: string): PromiseLike<void>;
+        isRejected(promise: PromiseLike<any>, message?: string): PromiseLike<void>;
+        isRejected(promise: PromiseLike<any>, expected: any, message?: string): PromiseLike<void>;
+        isRejected(promise: PromiseLike<any>, match: RegExp, message?: string): PromiseLike<void>;
+        notify(fn: Function): PromiseLike<void>;
     }
 
     export interface PromisedAssert {
-        fail(actual?: any, expected?: any, msg?: string, operator?: string): PromisesAPlus.Thenable<void>;
+        fail(actual?: any, expected?: any, msg?: string, operator?: string): PromiseLike<void>;
 
-        ok(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        notOk(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        ok(val: any, msg?: string): PromiseLike<void>;
+        notOk(val: any, msg?: string): PromiseLike<void>;
 
-        equal(act: any, exp: any, msg?: string): PromisesAPlus.Thenable<void>;
-        notEqual(act: any, exp: any, msg?: string): PromisesAPlus.Thenable<void>;
+        equal(act: any, exp: any, msg?: string): PromiseLike<void>;
+        notEqual(act: any, exp: any, msg?: string): PromiseLike<void>;
 
-        strictEqual(act: any, exp: any, msg?: string): PromisesAPlus.Thenable<void>;
-        notStrictEqual(act: any, exp: any, msg?: string): PromisesAPlus.Thenable<void>;
+        strictEqual(act: any, exp: any, msg?: string): PromiseLike<void>;
+        notStrictEqual(act: any, exp: any, msg?: string): PromiseLike<void>;
 
-        deepEqual(act: any, exp: any, msg?: string): PromisesAPlus.Thenable<void>;
-        notDeepEqual(act: any, exp: any, msg?: string): PromisesAPlus.Thenable<void>;
+        deepEqual(act: any, exp: any, msg?: string): PromiseLike<void>;
+        notDeepEqual(act: any, exp: any, msg?: string): PromiseLike<void>;
 
-        isTrue(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isFalse(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isTrue(val: any, msg?: string): PromiseLike<void>;
+        isFalse(val: any, msg?: string): PromiseLike<void>;
 
-        isNull(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isNotNull(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isNull(val: any, msg?: string): PromiseLike<void>;
+        isNotNull(val: any, msg?: string): PromiseLike<void>;
 
-        isUndefined(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isDefined(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isUndefined(val: any, msg?: string): PromiseLike<void>;
+        isDefined(val: any, msg?: string): PromiseLike<void>;
 
-        isFunction(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isNotFunction(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isFunction(val: any, msg?: string): PromiseLike<void>;
+        isNotFunction(val: any, msg?: string): PromiseLike<void>;
 
-        isObject(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isNotObject(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isObject(val: any, msg?: string): PromiseLike<void>;
+        isNotObject(val: any, msg?: string): PromiseLike<void>;
 
-        isArray(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isNotArray(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isArray(val: any, msg?: string): PromiseLike<void>;
+        isNotArray(val: any, msg?: string): PromiseLike<void>;
 
-        isString(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isNotString(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isString(val: any, msg?: string): PromiseLike<void>;
+        isNotString(val: any, msg?: string): PromiseLike<void>;
 
-        isNumber(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isNotNumber(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isNumber(val: any, msg?: string): PromiseLike<void>;
+        isNotNumber(val: any, msg?: string): PromiseLike<void>;
 
-        isBoolean(val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        isNotBoolean(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        isBoolean(val: any, msg?: string): PromiseLike<void>;
+        isNotBoolean(val: any, msg?: string): PromiseLike<void>;
 
-        typeOf(val: any, type: string, msg?: string): PromisesAPlus.Thenable<void>;
-        notTypeOf(val: any, type: string, msg?: string): PromisesAPlus.Thenable<void>;
+        typeOf(val: any, type: string, msg?: string): PromiseLike<void>;
+        notTypeOf(val: any, type: string, msg?: string): PromiseLike<void>;
 
-        instanceOf(val: any, type: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        notInstanceOf(val: any, type: Function, msg?: string): PromisesAPlus.Thenable<void>;
+        instanceOf(val: any, type: Function, msg?: string): PromiseLike<void>;
+        notInstanceOf(val: any, type: Function, msg?: string): PromiseLike<void>;
 
-        include(exp: string, inc: any, msg?: string): PromisesAPlus.Thenable<void>;
-        include(exp: any[], inc: any, msg?: string): PromisesAPlus.Thenable<void>;
+        include(exp: string, inc: any, msg?: string): PromiseLike<void>;
+        include(exp: any[], inc: any, msg?: string): PromiseLike<void>;
 
-        notInclude(exp: string, inc: any, msg?: string): PromisesAPlus.Thenable<void>;
-        notInclude(exp: any[], inc: any, msg?: string): PromisesAPlus.Thenable<void>;
+        notInclude(exp: string, inc: any, msg?: string): PromiseLike<void>;
+        notInclude(exp: any[], inc: any, msg?: string): PromiseLike<void>;
 
-        match(exp: any, re: RegExp, msg?: string): PromisesAPlus.Thenable<void>;
-        notMatch(exp: any, re: RegExp, msg?: string): PromisesAPlus.Thenable<void>;
+        match(exp: any, re: RegExp, msg?: string): PromiseLike<void>;
+        notMatch(exp: any, re: RegExp, msg?: string): PromiseLike<void>;
 
-        property(obj: Object, prop: string, msg?: string): PromisesAPlus.Thenable<void>;
-        notProperty(obj: Object, prop: string, msg?: string): PromisesAPlus.Thenable<void>;
-        deepProperty(obj: Object, prop: string, msg?: string): PromisesAPlus.Thenable<void>;
-        notDeepProperty(obj: Object, prop: string, msg?: string): PromisesAPlus.Thenable<void>;
+        property(obj: Object, prop: string, msg?: string): PromiseLike<void>;
+        notProperty(obj: Object, prop: string, msg?: string): PromiseLike<void>;
+        deepProperty(obj: Object, prop: string, msg?: string): PromiseLike<void>;
+        notDeepProperty(obj: Object, prop: string, msg?: string): PromiseLike<void>;
 
-        propertyVal(obj: Object, prop: string, val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        propertyNotVal(obj: Object, prop: string, val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        propertyVal(obj: Object, prop: string, val: any, msg?: string): PromiseLike<void>;
+        propertyNotVal(obj: Object, prop: string, val: any, msg?: string): PromiseLike<void>;
 
-        deepPropertyVal(obj: Object, prop: string, val: any, msg?: string): PromisesAPlus.Thenable<void>;
-        deepPropertyNotVal(obj: Object, prop: string, val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        deepPropertyVal(obj: Object, prop: string, val: any, msg?: string): PromiseLike<void>;
+        deepPropertyNotVal(obj: Object, prop: string, val: any, msg?: string): PromiseLike<void>;
 
-        lengthOf(exp: any, len: number, msg?: string): PromisesAPlus.Thenable<void>;
+        lengthOf(exp: any, len: number, msg?: string): PromiseLike<void>;
         //alias frenzy
-        throw(fn: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        throw(fn: Function, regExp: RegExp): PromisesAPlus.Thenable<void>;
-        throw(fn: Function, errType: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        throw(fn: Function, errType: Function, regExp: RegExp): PromisesAPlus.Thenable<void>;
+        throw(fn: Function, msg?: string): PromiseLike<void>;
+        throw(fn: Function, regExp: RegExp): PromiseLike<void>;
+        throw(fn: Function, errType: Function, msg?: string): PromiseLike<void>;
+        throw(fn: Function, errType: Function, regExp: RegExp): PromiseLike<void>;
 
-        throws(fn: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        throws(fn: Function, regExp: RegExp): PromisesAPlus.Thenable<void>;
-        throws(fn: Function, errType: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        throws(fn: Function, errType: Function, regExp: RegExp): PromisesAPlus.Thenable<void>;
+        throws(fn: Function, msg?: string): PromiseLike<void>;
+        throws(fn: Function, regExp: RegExp): PromiseLike<void>;
+        throws(fn: Function, errType: Function, msg?: string): PromiseLike<void>;
+        throws(fn: Function, errType: Function, regExp: RegExp): PromiseLike<void>;
 
-        Throw(fn: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        Throw(fn: Function, regExp: RegExp): PromisesAPlus.Thenable<void>;
-        Throw(fn: Function, errType: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        Throw(fn: Function, errType: Function, regExp: RegExp): PromisesAPlus.Thenable<void>;
+        Throw(fn: Function, msg?: string): PromiseLike<void>;
+        Throw(fn: Function, regExp: RegExp): PromiseLike<void>;
+        Throw(fn: Function, errType: Function, msg?: string): PromiseLike<void>;
+        Throw(fn: Function, errType: Function, regExp: RegExp): PromiseLike<void>;
 
-        doesNotThrow(fn: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        doesNotThrow(fn: Function, regExp: RegExp): PromisesAPlus.Thenable<void>;
-        doesNotThrow(fn: Function, errType: Function, msg?: string): PromisesAPlus.Thenable<void>;
-        doesNotThrow(fn: Function, errType: Function, regExp: RegExp): PromisesAPlus.Thenable<void>;
+        doesNotThrow(fn: Function, msg?: string): PromiseLike<void>;
+        doesNotThrow(fn: Function, regExp: RegExp): PromiseLike<void>;
+        doesNotThrow(fn: Function, errType: Function, msg?: string): PromiseLike<void>;
+        doesNotThrow(fn: Function, errType: Function, regExp: RegExp): PromiseLike<void>;
 
-        operator(val: any, operator: string, val2: any, msg?: string): PromisesAPlus.Thenable<void>;
-        closeTo(act: number, exp: number, delta: number, msg?: string): PromisesAPlus.Thenable<void>;
+        operator(val: any, operator: string, val2: any, msg?: string): PromiseLike<void>;
+        closeTo(act: number, exp: number, delta: number, msg?: string): PromiseLike<void>;
 
-        sameMembers(set1: any[], set2: any[], msg?: string): PromisesAPlus.Thenable<void>;
-        includeMembers(set1: any[], set2: any[], msg?: string): PromisesAPlus.Thenable<void>;
+        sameMembers(set1: any[], set2: any[], msg?: string): PromiseLike<void>;
+        includeMembers(set1: any[], set2: any[], msg?: string): PromiseLike<void>;
 
-        ifError(val: any, msg?: string): PromisesAPlus.Thenable<void>;
+        ifError(val: any, msg?: string): PromiseLike<void>;
     }
 }


### PR DESCRIPTION
`PromisesAPlus.Thenable` is not compatible with TypeScript 2.2 `await` (though it should also been updated), but as there are already a bunch of declarations using `PromiseLike`...

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

