### PR TITLE
[react-native] - StyleSheet.create parameter constraint so react-native init example can compile

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4558,10 +4558,14 @@ export namespace StyleSheet {
 
     type Style = ViewStyle | TextStyle | ImageStyle
 
+    type NamedStyles<T> = {
+        [P in keyof T]: Style;
+    }
+
     /**
      * Creates a StyleSheet style reference from the given object.
      */
-    export function create<T>( styles: T ): T;
+    export function create<T extends NamedStyles<T>>( styles: T ): T;
 
     /**
      * Flattens an array of style objects, into one aggregated style object.

--- a/types/react-native/test/init-example.tsx
+++ b/types/react-native/test/init-example.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import {
+  AppRegistry,
+  StyleSheet,
+  Text,
+  View
+} from 'react-native';
+
+export default class AwesomeProject extends React.Component<{}, {}> {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.welcome}>
+          Welcome to React Native!
+        </Text>
+        <Text style={styles.instructions}>
+          To get started, edit index.ios.js
+        </Text>
+        <Text style={styles.instructions}>
+          Press Cmd+R to reload,{'\n'}
+          Cmd+D or shake for dev menu
+        </Text>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+});

--- a/types/react-native/tsconfig.json
+++ b/types/react-native/tsconfig.json
@@ -20,6 +20,7 @@
     "files": [
         "index.d.ts",
         "test/index.tsx",
-        "test/animated.tsx"
+        "test/animated.tsx",
+        "test/init-example.tsx"
     ]
 }


### PR DESCRIPTION
Running `react-native init AwesomeProject`, installing `@types/react @types/react-native` and renaming `index.ios.js` to `index.ios.tsx`, there are type errors right away.

The problem is that `StyleSheet.create` takes an unconstrained `T`, and when the example says:

```ts
alignItems: 'center'
```

This is typed as `string`, causing the error where the style is used:

    Type 'string' is not assignable to type '"center" | "auto" | "left" | "right" | undefined'.

Also this means that there is no type checking where styles are declared, because anything can be passed, e.g. `alignItems: 'whatever'` does not produce a type error at the call to `StyleSheet.create`.

I've amended the `create` function as follows (this requires TS 2.1 minimum):

```ts
type NamedStyles<T> = {
    [P in keyof T]: Style;
}

export function create<T extends NamedStyles>( styles: T ): T;
```

Now the example is okay. Also mistakes like `alignItems: 'whatever'` are caught early.

BTW, the simpler (old school) alternative:

```ts
interface NamedStyles {
    [name: string]: Style;
}
```

is problematic because it requires an indexer on anything other than a literal, so it fails the tests (see `LocalStyles`).