### PR TITLE
@Types/ramda: incorrect definitions for path-related functions

### DIFF
--- a/ramda/index.d.ts
+++ b/ramda/index.d.ts
@@ -8,7 +8,7 @@ declare var R: R.Static;
 declare namespace R {
     type Ord = number | string | boolean;
 
-    type Path = number | string;
+    type Path = (number | string)[];
 
     interface ListIterator<T, TResult> {
         (value: T, index: number, list: T[]): TResult;
@@ -223,9 +223,9 @@ declare namespace R {
          * Makes a shallow clone of an object, setting or overriding the nodes required to create the given path, and
          * placing the specific value at the tail end of that path.
          */
-        assocPath<T,U>(path: Path[], val: T, obj: U): U;
-        assocPath<T,U>(path: Path[], val: T): (obj: U) => U;
-        assocPath<T,U>(path: Path[]): CurriedFunction2<T, U, U>;
+        assocPath<T,U>(path: Path, val: T, obj: U): U;
+        assocPath<T,U>(path: Path, val: T): (obj: U) => U;
+        assocPath<T,U>(path: Path): CurriedFunction2<T, U, U>;
 
         /**
          * Wraps a function of any arity (including nullary) in a function that accepts exactly 2
@@ -441,8 +441,8 @@ declare namespace R {
         /**
          * Makes a shallow clone of an object, omitting the property at the given path.
          */
-        dissocPath<T>(path: Path[], obj: any): T;
-        dissocPath<T>(path: Path[]): (obj: any) => T;
+        dissocPath<T>(path: Path, obj: any): T;
+        dissocPath<T>(path: Path): (obj: any) => T;
 
         /**
          * Divides two numbers. Equivalent to a / b.
@@ -840,7 +840,7 @@ declare namespace R {
          * Returns a lens whose focus is the specified path.
          * See also view, set, over.
          */
-        lensPath(path: Path[]): Lens;
+        lensPath(path: Path): Lens;
 
         /**
          * lensProp creates a lens that will focus on property k of the source object.
@@ -1131,24 +1131,24 @@ declare namespace R {
         /**
          * Retrieve the value at a given path.
          */
-        path<T>(path: Path[], obj: any): T;
-        path<T>(path: Path[]): (obj: any) => T;
+        path<T>(path: Path, obj: any): T;
+        path<T>(path: Path): (obj: any) => T;
 
         /**
         * Determines whether a nested path on an object has a specific value,
         * in `R.equals` terms. Most likely used to filter a list.
         */
-        pathEq(path: Path[], val: any, obj: any): boolean;
-        pathEq(path: Path[], val: any): (obj: any) => boolean;
-        pathEq(path: Path[]): CurriedFunction2<any, any, boolean>;
+        pathEq(path: Path, val: any, obj: any): boolean;
+        pathEq(path: Path, val: any): (obj: any) => boolean;
+        pathEq(path: Path): CurriedFunction2<any, any, boolean>;
 
         /**
          * If the given, non-null object has a value at the given path, returns the value at that path.
          * Otherwise returns the provided default value.
          */
-        pathOr<T>(d: T, p: Path[], obj: any): T|any;
-        pathOr<T>(d: T, p: Path[]): (obj: any) => T|any;
-        pathOr<T>(d: T): CurriedFunction2<Path[], any, T|any>;
+        pathOr<T>(d: T, p: Path, obj: any): T|any;
+        pathOr<T>(d: T, p: Path): (obj: any) => T|any;
+        pathOr<T>(d: T): CurriedFunction2<Path, any, T|any>;
 
         /**
          * Returns a partial copy of an object containing only the keys specified.  If the key does not exist, the

--- a/ramda/index.d.ts
+++ b/ramda/index.d.ts
@@ -8,6 +8,8 @@ declare var R: R.Static;
 declare namespace R {
     type Ord = number | string | boolean;
 
+    type Path = number | string;
+
     interface ListIterator<T, TResult> {
         (value: T, index: number, list: T[]): TResult;
     }
@@ -221,9 +223,9 @@ declare namespace R {
          * Makes a shallow clone of an object, setting or overriding the nodes required to create the given path, and
          * placing the specific value at the tail end of that path.
          */
-        assocPath<T,U>(path: string[], val: T, obj: U): U;
-        assocPath(path: string[]): <T,U>(val: T, obj: U) => U;
-        assocPath<T>(path: string[], val: T): <U>(obj: U) => U;
+        assocPath<T,U>(path: Path[], val: T, obj: U): U;
+        assocPath<T,U>(path: Path[], val: T): (obj: U) => U;
+        assocPath<T,U>(path: Path[]): CurriedFunction2<T, U, U>;
 
         /**
          * Wraps a function of any arity (including nullary) in a function that accepts exactly 2
@@ -439,8 +441,8 @@ declare namespace R {
         /**
          * Makes a shallow clone of an object, omitting the property at the given path.
          */
-        dissocPath<T>(path: string[], obj: any): T;
-        dissocPath(path: string[]): <T>(obj: any) => T;
+        dissocPath<T>(path: Path[], obj: any): T;
+        dissocPath<T>(path: Path[]): (obj: any) => T;
 
         /**
          * Divides two numbers. Equivalent to a / b.
@@ -838,7 +840,7 @@ declare namespace R {
          * Returns a lens whose focus is the specified path.
          * See also view, set, over.
          */
-        lensPath(path: string[]): Lens;
+        lensPath(path: Path[]): Lens;
 
         /**
          * lensProp creates a lens that will focus on property k of the source object.
@@ -1129,26 +1131,24 @@ declare namespace R {
         /**
          * Retrieve the value at a given path.
          */
-        path<T>(path: string[], obj: any): T;
-        path(path: string[]): <T>(obj: any) => T;
+        path<T>(path: Path[], obj: any): T;
+        path<T>(path: Path[]): (obj: any) => T;
 
         /**
         * Determines whether a nested path on an object has a specific value,
         * in `R.equals` terms. Most likely used to filter a list.
         */
-        pathEq(path: string[], val: any, obj: any): boolean;
-        pathEq(path: string[], val: any): (obj: any) => boolean;
-        pathEq(path: string[]): (val: any, obj: any) => boolean;
-        pathEq(path: string[]): (val: any) => (obj: any) => boolean;
+        pathEq(path: Path[], val: any, obj: any): boolean;
+        pathEq(path: Path[], val: any): (obj: any) => boolean;
+        pathEq(path: Path[]): CurriedFunction2<any, any, boolean>;
 
         /**
          * If the given, non-null object has a value at the given path, returns the value at that path.
          * Otherwise returns the provided default value.
          */
-        pathOr<T>(d: T, p: string[], obj: any): T|any;
-        pathOr<T>(d: T, p: string[]): (obj: any) => T|any;
-        pathOr<T>(d: T): (p: string[], obj: any) => T|any;
-
+        pathOr<T>(d: T, p: Path[], obj: any): T|any;
+        pathOr<T>(d: T, p: Path[]): (obj: any) => T|any;
+        pathOr<T>(d: T): CurriedFunction2<Path[], any, T|any>;
 
         /**
          * Returns a partial copy of an object containing only the keys specified.  If the key does not exist, the

--- a/ramda/ramda-tests.ts
+++ b/ramda/ramda-tests.ts
@@ -491,6 +491,14 @@ R.times(i, 5);
     R.findLastIndex((x: number) => x === 1, [1, 2, 3]);
 }
 () => {
+    const testPath = ['x', 0, 'y'];
+    const testObj = {x: [{y: 2, z: 3}, {y: 4, z: 5}]};
+
+    R.pathEq(testPath, 2, testObj); // => true
+    R.pathEq(testPath, 2)(testObj); // => true
+    R.pathEq(testPath)(2)(testObj); // => true
+    R.pathEq(testPath)(2, testObj); // => true
+
     var user1 = { address: { zipCode: 90210 } };
     var user2 = { address: { zipCode: 55555 } };
     var user3 = { name: 'Bob' };
@@ -1028,9 +1036,13 @@ type Pair = KeyValuePair<string, number>
 }
 
 () => {
-    const a = R.assocPath(['a', 'b', 'c'], 42, {a: {b: {c: 0}}}); //=> {a: {b: {c: 42}}}
-    const b = R.assocPath(['a', 'b', 'c'])(42, {a: {b: {c: 0}}}); //=> {a: {b: {c: 42}}}
-    const c = R.assocPath(['a', 'b', 'c'], 42)({a: {b: {c: 0}}}); //=> {a: {b: {c: 42}}}
+    const testPath = ['x', 0, 'y'];
+    const testObj = {x: [{y: 2, z: 3}, {y: 4, z: 5}]};
+
+    R.assocPath(testPath, 42, testObj); //=> {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+    R.assocPath(testPath, 42)(testObj); //=> {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+    R.assocPath(testPath)(42)(testObj); //=> {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
+    R.assocPath(testPath)(42, testObj); //=> {x: [{y: 42, z: 3}, {y: 4, z: 5}]}
 }
 
 () => {
@@ -1038,6 +1050,12 @@ type Pair = KeyValuePair<string, number>
     // optionally specify return type
     const a2 = R.dissocPath<{a :{ b: number}}>(['a', 'b', 'c'], {a: {b: {c: 42}}}); //=> {a: {b: {}}}
     const a3 = R.dissocPath(['a', 'b', 'c'])({a: {b: {c: 42}}}); //=> {a: {b: {}}}
+
+    const testPath = ['x', 0, 'y'];
+    const testObj = {x: [{y: 2, z: 3}, {y: 4, z: 5}]};
+
+    R.dissocPath(testPath, testObj); //=> {x: [{z: 3}, {y: 4, z: 5}]}
+    R.dissocPath(testPath)(testObj); //=> {x: [{z: 3}, {y: 4, z: 5}]}
 }
 
 () => {
@@ -1163,11 +1181,12 @@ class Rectangle {
 }
 
 () => {
-  const xyLens = R.lensPath(['x', 'y']);
+  const xyLens = R.lensPath(['x', 0, 'y']);
+  const testObj = {x: [{y: 2, z: 3}, {y: 4, z: 5}]};
 
-  R.view(xyLens, {x: {y: 2, z: 3}});            //=> 2
-  R.set(xyLens, 4, {x: {y: 2, z: 3}});          //=> {x: {y: 4, z: 3}}
-  R.over(xyLens, R.negate, {x: {y: 2, z: 3}});  //=> {x: {y: -2, z: 3}}
+  R.view(xyLens, testObj);            //=> 2
+  R.set(xyLens, 4, testObj);          //=> {x: [{y: 4, z: 3}, {y: 4, z: 5}]}
+  R.over(xyLens, R.negate, testObj);  //=> {x: [{y: -2, z: 3}, {y: 4, z: 5}]}
 }
 
 () => {
@@ -1242,10 +1261,15 @@ class Rectangle {
 }
 
 () => {
-    const a1 = R.pathOr('N/A', ['a', 'b'], {a: {b: 2}}); //=> 2
-    const a2 = R.pathOr('N/A', ['a', 'b'])({a: {b: 2}}); //=> 2
-    const a3 = R.pathOr('N/A', ['a', 'b'], {c: {b: 2}}); //=> "N/A"
-    const a4 = R.pathOr({c:2})(['a', 'b'], {c: {b: 2}}); //=> "N/A"
+    const orValue = 'N/A';
+    const testPath = ['x', 0, 'y'];
+    const testObj = {x: [{y: 2, z: 3}, {y: 4, z: 5}]};
+
+    R.pathOr(orValue, testPath, testObj); //=> 2
+    R.pathOr(orValue, testPath)(testObj); //=> 2
+    R.pathOr(orValue)(testPath)(testObj); //=> 2
+    R.pathOr(orValue)(testPath, testObj); //=> 2
+    R.pathOr(orValue, testPath, {c: {b: 2}}); //=> "N/A"
 }
 
 () => {
@@ -1586,8 +1610,11 @@ matchPhrases(['foo', 'bar', 'baz']);
 }
 
 () => {
-    R.path(['a', 'b'], {a: {b: 2}}); //=> 2
-    R.path(['a', 'b'])({a: {b: 2}}); //=> 2
+    const testPath = ['x', 0, 'y'];
+    const testObj = {x: [{y: 2, z: 3}, {y: 4, z: 5}]};
+
+    R.path(testPath, testObj); //=> 2
+    R.path(testPath)(testObj); //=> 2
 }
 
 () => {


### PR DESCRIPTION
- path should be (string | number)[]
- some currying problems with path related functions

fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14480

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://ramdajs.com/docs/>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

