### PR TITLE
Material-UI: Add overlayStyle prop to RaisedButtonProps.

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -688,6 +688,7 @@ declare namespace __MaterialUI {
         onMouseUp?: React.MouseEventHandler<{}>;
         onTouchEnd?: React.TouchEventHandler<{}>;
         onTouchStart?: React.TouchEventHandler<{}>;
+        overlayStyle?: React.CSSProperties;
         primary?: boolean;
         rippleStyle?: React.CSSProperties;
         secondary?: boolean;


### PR DESCRIPTION
This is available per Material-UI docs to allow for styling the raised button's overlay.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://www.material-ui.com/#/components/raised-button>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
