### PR TITLE
Fixed ES6 import error.

### DIFF
--- a/file-type/index.d.ts
+++ b/file-type/index.d.ts
@@ -5,11 +5,13 @@
 
 /// <reference types="node" />
 
-interface FileTypeResult {
-    ext: string
-    mime: string
+export = FileType;
+
+declare function FileType(buf: Buffer): FileType.FileTypeResult;
+
+declare namespace FileType {
+    export interface FileTypeResult {
+        ext: string;
+        mime: string;
+    }
 }
-
-declare function FileType(buf: Buffer): FileTypeResult
-
-export = FileType


### PR DESCRIPTION
```js
import * as fileType from 'file-type';
```
Fixed error message "resolves to a non-module entity and cannot be imported using this construct."
