### PR TITLE
[mongoose] Adds missing retainKeyOrder option

### DIFF
--- a/mongoose/index.d.ts
+++ b/mongoose/index.d.ts
@@ -720,6 +720,8 @@ declare module "mongoose" {
     validateBeforeSave?: boolean;
     /** defaults to "__v" */
     versionKey?: string|boolean;
+    /** defaults to false */
+    retainKeyOrder?: boolean;
     /**
      * skipVersioning allows excluding paths from
      * versioning (the internal revision will not be


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongoosejs.com/docs/guide.html#retainKeyOrder
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.