### PR TITLE
material-ui: Add missing MuiTheme.button.textTransform property

### DIFF
--- a/material-ui/index.d.ts
+++ b/material-ui/index.d.ts
@@ -174,6 +174,7 @@ declare namespace __MaterialUI {
                 height?: number;
                 minWidth?: number;
                 iconButtonSize?: number;
+                textTransform?: string;
             };
             card?: {
                 titleColor?: string;

--- a/material-ui/material-ui-tests.tsx
+++ b/material-ui/material-ui-tests.tsx
@@ -285,6 +285,9 @@ const lightBaseTheme = {
     desktopSubheaderHeight: 48,
     desktopToolbarHeight: 56,
   },
+  button: {
+    textTransform: "lowercase"
+  },
   fontFamily: 'Roboto, sans-serif',
   palette: {
     primary1Color: cyan500,


### PR DESCRIPTION
Please fill in this template.

- [√] Make your PR against the `master` branch.
- [√] Use a meaningful title for the pull request. Include the name of the package modified.
- [√] Test the change in your own code. (Compile and run.)
- [√] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [√] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [√] Run `tsc` without errors.
- [existing warnings in output, but none caused by my changes] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [√] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/callemall/material-ui/blob/master/src/RaisedButton/RaisedButton.js#L84
- [covers existing version of material-ui] Increase the version number in the header if appropriate.
- [not substantial] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
