### PR TITLE
[react-mdl] Add MDLComponent class

### DIFF
--- a/react-mdl/index.d.ts
+++ b/react-mdl/index.d.ts
@@ -615,4 +615,6 @@ declare namespace __ReactMDL {
         title?: string;
     }
     class Tooltip extends __MDLComponent<TooltipProps> { }
+
+    class MDLComponent extends React.Component<{ recursive?: boolean }, {}> { }
 }

--- a/react-mdl/react-mdl-tests.tsx
+++ b/react-mdl/react-mdl-tests.tsx
@@ -22,7 +22,8 @@ import {Chip, ChipContact,
     Switch,
     Tabs, Tab,
     Textfield,
-    Tooltip} from 'react-mdl';
+    Tooltip,
+    MDLComponent} from 'react-mdl';
 
 // all tests are from the examples provided here: https://tleunen.github.io/react-mdl/
 
@@ -1069,5 +1070,16 @@ React.createClass({
                 </Tooltip>
             </div>
         );
+    }
+});
+
+// MDLComponent tests
+React.createClass({
+    render: function() {
+        return (
+            <MDLComponent recursive={false}>
+                <div />
+            </MDLComponent>
+        )
     }
 });


### PR DESCRIPTION
`MDLComponent` is necessary to define custom component which utilizes material design lite pached by react-mdl. And it is public class. So I added type definition.

Note that mdlUpgrade() method replaces render() method of passed class. This causes destructive change to source class, so not suitable for typescript.

Also note that __MDLComponent is (virtual) interface, while MDLComponent is actual class.

----

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-mdl/react-mdl/blob/v1.7.0/src/index.js#L2
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.