### PR TITLE
lodash - _.filter(): predicate can be a RegExp

### DIFF
--- a/lodash/index.d.ts
+++ b/lodash/index.d.ts
@@ -6707,7 +6707,7 @@ declare namespace _ {
          */
         filter<T>(
             collection: List<T>|Dictionary<T>,
-            predicate: string
+            predicate: string|RegExp
         ): T[];
 
         /**
@@ -6740,7 +6740,7 @@ declare namespace _ {
          * @see _.filter
          */
         filter(
-            predicate: string
+            predicate: string|RegExp
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -6761,7 +6761,7 @@ declare namespace _ {
          * @see _.filter
          */
         filter<T>(
-            predicate: string
+            predicate: string|RegExp
         ): LoDashImplicitArrayWrapper<T>;
 
         /**
@@ -6791,7 +6791,7 @@ declare namespace _ {
          * @see _.filter
          */
         filter(
-            predicate: string
+            predicate: string|RegExp
         ): LoDashExplicitArrayWrapper<T>;
 
         /**
@@ -6812,7 +6812,7 @@ declare namespace _ {
          * @see _.filter
          */
         filter<T>(
-            predicate: string
+            predicate: string|RegExp
         ): LoDashExplicitArrayWrapper<T>;
 
         /**

--- a/lodash/lodash-tests.ts
+++ b/lodash/lodash-tests.ts
@@ -3625,14 +3625,17 @@ namespace TestFilter {
 
         result = _.filter<TResult>(array, listIterator);
         result = _.filter<TResult>(array, '');
+        result = _.filter<TResult>(array, /./);
         result = _.filter<TResult>(array, {a: 42});
 
         result = _.filter<TResult>(list, listIterator);
         result = _.filter<TResult>(list, '');
+        result = _.filter<TResult>(list, /./);
         result = _.filter<TResult>(list, {a: 42});
 
         result = _.filter<TResult>(dictionary, dictionaryIterator);
         result = _.filter<TResult>(dictionary, '');
+        result = _.filter<TResult>(dictionary, /./);
         result = _.filter<TResult>(dictionary, {a: 42});
     }
 
@@ -3647,14 +3650,17 @@ namespace TestFilter {
 
         result = _(array).filter(listIterator);
         result = _(array).filter('');
+        result = _(array).filter(/./);
         result = _(array).filter({a: 42});
 
         result = _(list).filter<TResult>(listIterator);
         result = _(list).filter<TResult>('');
+        result = _(list).filter<TResult>(/./);
         result = _(list).filter<TResult>({a: 42});
 
         result = _(dictionary).filter<TResult>(dictionaryIterator);
         result = _(dictionary).filter<TResult>('');
+        result = _(dictionary).filter<TResult>(/./);
         result = _(dictionary).filter<TResult>({a: 42});
     }
 
@@ -3669,14 +3675,17 @@ namespace TestFilter {
 
         result = _(array).chain().filter(listIterator);
         result = _(array).chain().filter('');
+        result = _(array).chain().filter(/./);
         result = _(array).chain().filter({a: 42});
 
         result = _(list).chain().filter<TResult>(listIterator);
         result = _(list).chain().filter<TResult>('');
+        result = _(list).chain().filter<TResult>(/./);
         result = _(list).chain().filter<TResult>({a: 42});
 
         result = _(dictionary).chain().filter<TResult>(dictionaryIterator);
         result = _(dictionary).chain().filter<TResult>('');
+        result = _(dictionary).chain().filter<TResult>(/./);
         result = _(dictionary).chain().filter<TResult>({a: 42});
     }
 }


### PR DESCRIPTION
As seen in the example of https://lodash.com/docs/4.17.4#iteratee `_.filter()` supports a `RegExp` predicate:

    _.filter(['abc', 'def'], /ef/);
    // => ['def']

----

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.4#iteratee - example
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
