### PR TITLE
lodash - fix tslint warrnings in v3 tests

### DIFF
--- a/lodash/v3/lodash-tests.ts
+++ b/lodash/v3/lodash-tests.ts
@@ -80,7 +80,7 @@ var keys: IKey[] = [
 class Dog {
     constructor(public name: string) { }
 
-    public bark() {
+    bark() {
         console.log('Woof, woof!');
     }
 }
@@ -4064,21 +4064,15 @@ namespace TestFind {
     result = _(dictionary).find<{a: number}, TResult>({a: 42});
 }
 
-result = <number>_.findWhere([1, 2, 3, 4], function (num) {
-    return num % 2 == 0;
-});
+result = <number>_.findWhere([1, 2, 3, 4], num => num % 2 == 0);
 result = <IFoodCombined>_.findWhere(foodsCombined, { 'type': 'vegetable' });
 result = <IFoodCombined>_.findWhere(foodsCombined, 'organic');
 
-result = <number>_.findLast([1, 2, 3, 4], function (num) {
-    return num % 2 == 0;
-});
+result = <number>_.findLast([1, 2, 3, 4], num => num % 2 == 0);
 result = <IFoodCombined>_.findLast(foodsCombined, { 'type': 'vegetable' });
 result = <IFoodCombined>_.findLast(foodsCombined, 'organic');
 
-result = <number>_([1, 2, 3, 4]).findLast(function (num) {
-    return num % 2 == 0;
-});
+result = <number>_([1, 2, 3, 4]).findLast(num => num % 2 == 0);
 result = <IFoodCombined>_(foodsCombined).findLast({ 'type': 'vegetable' });
 result = <IFoodCombined>_(foodsCombined).findLast('organic');
 
@@ -4850,56 +4844,44 @@ interface ABC {
     c: number;
 }
 
-result = <number>_.reduce<number, number>([1, 2, 3], function (sum: number, num: number) {
-    return sum + num;
-});
-result = <ABC>_.reduce({ 'a': 1, 'b': 2, 'c': 3 }, function (r: ABC, num: number, key: string) {
+result = <number>_.reduce<number, number>([1, 2, 3], (sum: number, num: number) => sum + num);
+result = <ABC>_.reduce({ 'a': 1, 'b': 2, 'c': 3 }, (r: ABC, num: number, key: string) => {
     r[key] = num * 3;
     return r;
 }, {});
 
-result = <number>_.foldl([1, 2, 3], function (sum: number, num: number) {
-    return sum + num;
-});
-result = <ABC>_.foldl({ 'a': 1, 'b': 2, 'c': 3 }, function (r: ABC, num: number, key: string) {
+result = <number>_.foldl([1, 2, 3], (sum: number, num: number) => sum + num);
+result = <ABC>_.foldl({ 'a': 1, 'b': 2, 'c': 3 }, (r: ABC, num: number, key: string) => {
     r[key] = num * 3;
     return r;
 }, {});
 
-result = <number>_.inject([1, 2, 3], function (sum: number, num: number) {
-    return sum + num;
-});
-result = <ABC>_.inject({ 'a': 1, 'b': 2, 'c': 3 }, function (r: ABC, num: number, key: string) {
+result = <number>_.inject([1, 2, 3], (sum: number, num: number) => sum + num);
+result = <ABC>_.inject({ 'a': 1, 'b': 2, 'c': 3 },  (r: ABC, num: number, key: string) => {
     r[key] = num * 3;
     return r;
 }, {});
 
-result = <number>_([1, 2, 3]).reduce<number>(function (sum: number, num: number) {
-    return sum + num;
-});
-result = <ABC>_({ 'a': 1, 'b': 2, 'c': 3 }).reduce<number, ABC>(function (r: ABC, num: number, key: string) {
+result = <number>_([1, 2, 3]).reduce<number>((sum: number, num: number) => sum + num);
+result = <ABC>_({ 'a': 1, 'b': 2, 'c': 3 }).reduce<number, ABC>((r: ABC, num: number, key: string) => {
     r[key] = num * 3;
     return r;
 }, {});
 
-result = <number>_([1, 2, 3]).foldl<number>(function (sum: number, num: number) {
-    return sum + num;
-});
-result = <ABC>_({ 'a': 1, 'b': 2, 'c': 3 }).foldl<number, ABC>(function (r: ABC, num: number, key: string) {
+result = <number>_([1, 2, 3]).foldl<number>((sum: number, num: number) => sum + num);
+result = <ABC>_({ 'a': 1, 'b': 2, 'c': 3 }).foldl<number, ABC>((r: ABC, num: number, key: string) => {
     r[key] = num * 3;
     return r;
 }, {});
 
-result = <number>_([1, 2, 3]).inject<number>(function (sum: number, num: number) {
-    return sum + num;
-});
-result = <ABC>_({ 'a': 1, 'b': 2, 'c': 3 }).inject<number, ABC>(function (r: ABC, num: number, key: string) {
+result = <number>_([1, 2, 3]).inject<number>((sum: number, num: number) => sum + num);
+result = <ABC>_({ 'a': 1, 'b': 2, 'c': 3 }).inject<number, ABC>((r: ABC, num: number, key: string) => {
     r[key] = num * 3;
     return r;
 }, {});
 
-result = <number[]>_.reduceRight([[0, 1], [2, 3], [4, 5]], function (a: number[], b: number[]) { return a.concat(b); }, <number[]>[]);
-result = <number[]>_.foldr([[0, 1], [2, 3], [4, 5]], function (a: number[], b: number[]) { return a.concat(b); }, <number[]>[]);
+result = <number[]>_.reduceRight([[0, 1], [2, 3], [4, 5]], (a: number[], b: number[]) => a.concat(b), <number[]>[]);
+result = <number[]>_.foldr([[0, 1], [2, 3], [4, 5]], (a: number[], b: number[]) => a.concat(b), <number[]>[]);
 
 // _.reject
 namespace TestReject {
@@ -5455,9 +5437,9 @@ namespace TestSortBy {
     }
 }
 
-result = <IStoogesAge[]>_.sortByAll(stoogesAges, function(stooge) { return Math.sin(stooge.age); }, function(stooge) { return stooge.name.slice(1); });
+result = <IStoogesAge[]>_.sortByAll(stoogesAges, (stooge) => Math.sin(stooge.age), (stooge) => stooge.name.slice(1));
 result = <IStoogesAge[]>_.sortByAll(stoogesAges, ['name', 'age']);
-result = <IStoogesAge[]>_.sortByAll(stoogesAges, 'name', function(stooge) { return Math.sin(stooge.age); });
+result = <IStoogesAge[]>_.sortByAll(stoogesAges, 'name', (stooge) => Math.sin(stooge.age));
 
 result = <IFoodOrganic[]>_(foodsOrganic).sortByAll('organic', (food) => food.name, { organic: true }).value();
 
@@ -6317,7 +6299,7 @@ namespace TestOnce {
     }
 }
 
-var greetPartial = function (greeting: string, name: string) { return greeting + ' ' + name; };
+var greetPartial = (greeting: string, name: string) => greeting + ' ' + name;
 var hi = _.partial(greetPartial, 'hi');
 hi('moe');
 
@@ -10384,7 +10366,7 @@ namespace TestNoConflict {
 // _.noop
 namespace TestNoop {
     {
-        let result: void;
+        let result: void; // tslint:disable-line:void-return
 
         result = _.noop();
         result = _.noop(1);


### PR DESCRIPTION
Reduce the number of tslint warrning when running `npm run lint lodash`.
Before:
```
v3/index.d.ts
1:1       dt-header                 Header should only be in `index.d.ts`, not in v3/index.d.ts
15892:1   no-single-declare-module  File has only 1 module declaration — write it as an external module.

v3/lodash-tests.ts
83:5      no-public                 No need to write `public`; this is implicit.
10387:21  void-return               Use the `void` type for return types only. Otherwise, use `undefined`.
4067:44   only-arrow-functions-2    non-arrow functions are forbidden
4073:43   only-arrow-functions-2    non-arrow functions are forbidden
4079:43   only-arrow-functions-2    non-arrow functions are forbidden
4853:54   only-arrow-functions-2    non-arrow functions are forbidden
4856:52   only-arrow-functions-2    non-arrow functions are forbidden
4861:37   only-arrow-functions-2    non-arrow functions are forbidden
4864:51   only-arrow-functions-2    non-arrow functions are forbidden
4869:38   only-arrow-functions-2    non-arrow functions are forbidden
4872:52   only-arrow-functions-2    non-arrow functions are forbidden
4877:46   only-arrow-functions-2    non-arrow functions are forbidden
4880:65   only-arrow-functions-2    non-arrow functions are forbidden
4885:45   only-arrow-functions-2    non-arrow functions are forbidden
4888:64   only-arrow-functions-2    non-arrow functions are forbidden
4893:46   only-arrow-functions-2    non-arrow functions are forbidden
4896:65   only-arrow-functions-2    non-arrow functions are forbidden
4901:60   only-arrow-functions-2    non-arrow functions are forbidden
4902:54   only-arrow-functions-2    non-arrow functions are forbidden
5458:50   only-arrow-functions-2    non-arrow functions are forbidden
5458:101  only-arrow-functions-2    non-arrow functions are forbidden
5460:58   only-arrow-functions-2    non-arrow functions are forbidden
6320:20   only-arrow-functions-2    non-arrow functions are forbidden
```
After:
```
v3/index.d.ts
1:1      dt-header                 Header should only be in `index.d.ts`, not in v3/index.d.ts
15892:1  no-single-declare-module  File has only 1 module declaration — write it as an external module.
```

Not sure what to do with warnings in `v3/index.d.ts`. They are quite valid points. 
Is the `v3` directory actually still needed?


----

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.