### PR TITLE
[swagger-schema-official] declare array properties as arrays, not tuples

### DIFF
--- a/swagger-schema-official/index.d.ts
+++ b/swagger-schema-official/index.d.ts
@@ -96,13 +96,13 @@ export interface Operation {
   description?: string;
   externalDocs?: ExternalDocs;
   operationId?: string;
-  produces?: [string];
-  consumes?: [string];
-  parameters?: [Parameter];
-  schemes?: [string];
+  produces?: string[];
+  consumes?: string[];
+  parameters?: Parameter[];
+  schemes?: string[];
   deprecated?: boolean;
-  security?: [Secuirty];
-  tags?: [string];
+  security?: Security[];
+  tags?: string[];
 }
 
 // ----------------------------- Response ------------------------------------
@@ -132,14 +132,14 @@ interface BaseSchema {
   uniqueItems?: boolean;
   maxProperties?: number;
   minProperties?: number;
-  enum?: [string|boolean|number|{}];
+  enum?: (string|boolean|number|{})[];
   type?: string;
-  items?: Schema|[Schema];
+  items?: Schema|Schema[];
 }
 
 export interface Schema extends BaseSchema {
   $ref?: string;
-  allOf?: [Schema];
+  allOf?: Schema[];
   additionalProperties?: boolean;
   properties?: {[propertyName: string]: Schema};
   discriminator?: string;
@@ -147,7 +147,7 @@ export interface Schema extends BaseSchema {
   xml?: XML;
   externalDocs?: ExternalDocs;
   example?: {[exampleName: string]: {}};
-  required?: [string];
+  required?: string[];
 }
 
 export interface XML {
@@ -184,25 +184,25 @@ export interface OAuth2ImplicitSecurity extends BaseOAuthSecuirty {
 
 export interface OAuth2PasswordSecurity extends BaseOAuthSecuirty {
   tokenUrl: string;
-  scopes?: [OAuthScope];
+  scopes?: OAuthScope[];
 }
 
 export interface OAuth2ApplicationSecurity extends BaseOAuthSecuirty {
   tokenUrl: string;
-  scopes?: [OAuthScope];
+  scopes?: OAuthScope[];
 }
 
 export interface OAuth2AccessCodeSecurity extends BaseOAuthSecuirty {
   tokenUrl: string;
   authorizationUrl: string;
-  scopes?: [OAuthScope];
+  scopes?: OAuthScope[];
 }
 
 export interface OAuthScope {
   [scopeName: string]: string;
 }
 
-type Secuirty =
+type Security =
   BasicAuthenticationSecurity |
   OAuth2AccessCodeSecurity |
   OAuth2ApplicationSecurity |
@@ -217,14 +217,14 @@ export interface Spec {
   externalDocs?: ExternalDocs;
   host?: string;
   basePath?: string;
-  schemes?: [string];
-  consumes?: [string];
-  produces?: [string];
+  schemes?: string[];
+  consumes?: string[];
+  produces?: string[];
   paths: {[pathName: string]: Path};
   definitions?: {[definitionsName: string]: Schema };
   parameters?: {[parameterName: string]: BodyParameter|QueryParameter};
   responses?: {[responseName: string]: Response };
-  security?: [Secuirty];
-  securityDefinitions?: { [securityDefinitionName: string]: Secuirty};
-  tags?: [Tag];
+  security?: Security[];
+  securityDefinitions?: { [securityDefinitionName: string]: Security};
+  tags?: Tag[];
 }


### PR DESCRIPTION
The swagger specification does not use tuple types (`[string]` in TypeScript),
it uses only arrays, but it describes arrays as `[string]`; see http://swagger.io/specification/ .

The use of [string] etc. in the type definitions means that code like 

    function getRequiredFields(): string[] { ... }

    let fields = getRequiredFields()
    schema.required = fields;

generates an error at compile time because the declared type expects a tuple of length 1, not an array that may be of length 0. 

No error is reported when a swagger definition is consumed using these type definitions because TypeScript tolerates access to elements outside the declared tuple.

The problem can be worked around with a cast

     schema.required = fields as [string];

but this defeats the purpose of the type definitions.

See https://github.com/Microsoft/TypeScript/issues/3428 for an explanation of the difference in syntax. 

This PR also fixes a typo in "Security" (was Secuirty).

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
