### PR TITLE
Add spyOnProperty to jasmine

### DIFF
--- a/jasmine/index.d.ts
+++ b/jasmine/index.d.ts
@@ -38,6 +38,8 @@ interface DoneFn extends Function {
 
 declare function spyOn<T>(object: T, method: keyof T): jasmine.Spy;
 
+declare function spyOnProperty<T>(object: T, property: keyof T, accessType: string): jasmine.Spy;
+
 declare function runs(asyncMethod: Function): void;
 declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;
 declare function waits(timeout?: number): void;
@@ -455,6 +457,7 @@ declare namespace jasmine {
         addBeforesAndAftersToQueue(): void;
         explodes(): void;
         spyOn(obj: any, methodName: string, ignoreMethodDoesntExist: boolean): Spy;
+        spyOnProperty(object: any, property: string, accessType: string): Spy;
         removeAllSpies(): void;
         throwOnExpectationFailure: boolean;
     }

--- a/jasmine/index.d.ts
+++ b/jasmine/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jasmine 2.5
+// Type definitions for Jasmine 2.5.2
 // Project: http://jasmine.github.io/
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb>, David Pärsson <https://github.com/davidparsson/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
While spyOnProperty does not have an official release tag for jasmine it is in the master branch. I'm not sure this should be added at this point but since I need to use that method I figured I'd create the PR.

Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/jasmine/jasmine/pull/1203>>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.