### PR TITLE
fix type `Axis` in  react-sortable-hoc

### DIFF
--- a/react-sortable-hoc/index.d.ts
+++ b/react-sortable-hoc/index.d.ts
@@ -7,7 +7,7 @@
 declare module 'react-sortable-hoc' {
     import React = require('react');
 
-    export type Axis = 'x' | 'y';
+    export type Axis = 'x' | 'y' | 'xy';
 
     export type Offset = number | string;
 

--- a/react-sortable-hoc/react-sortable-hoc-tests.tsx
+++ b/react-sortable-hoc/react-sortable-hoc-tests.tsx
@@ -8,6 +8,7 @@ interface SortableItemProps {
 
 interface SortableListProps {
     items: Array<string>;
+    axis: 'x' | 'y' | 'xy'
 }
 
 type SortableComponentState = SortableListProps;
@@ -40,12 +41,15 @@ class SortableComponent extends React.Component<void, SortableComponentState> {
 
     public constructor() {
         super();
-        this.state = { items: ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5', 'Item 6'] };
+        this.state = {
+            items: ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5', 'Item 6'],
+            axis: 'x'
+        };
         this._onSortEnd = this._handleSotEnd.bind(this);
     }
 
     public render(): JSX.Element {
-        return <SortableList items={this.state.items} onSortEnd={this._onSortEnd} />;
+        return <SortableList items={this.state.items} axis={this.state.axis} onSortEnd={this._onSortEnd} />;
     }
 }
 


### PR DESCRIPTION
Now `SortableContainer` allow to receive Axis with 'xy', Please see https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableContainer/index.js#L53.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `npm run new-package package-name`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
