### PR TITLE
Make awesomplete definitions a module

### DIFF
--- a/awesomplete/awesomplete-tests.ts
+++ b/awesomplete/awesomplete-tests.ts
@@ -1,3 +1,5 @@
+import * as Awesomplete from 'awesomplete';
+
 var input = document.getElementById("myinput");
 new Awesomplete(input, {list: "#mylist"});
 

--- a/awesomplete/awesomplete-tests.ts
+++ b/awesomplete/awesomplete-tests.ts
@@ -13,45 +13,48 @@ var awesomplete = new Awesomplete(input);
 awesomplete.list = ["Ada", "Java", "JavaScript", "LOLCODE", "Node.js", "Ruby on Rails"];
 
 new Awesomplete(input, {
-	list: [
-		{ label: "Belarus", value: "BY" },
-		{ label: "China", value: "CN" },
-		{ label: "United States", value: "US" }
-	]
+    list: [
+        { label: "Belarus", value: "BY" },
+        { label: "China", value: "CN" },
+        { label: "United States", value: "US" }
+    ]
 });
 
 // Same with arrays:
 new Awesomplete(input, {
-	list: [
-		[ "Belarus", "BY" ],
-		[ "China", "CN" ],
-		[ "United States", "US" ]
-	]
+    list: [
+        [ "Belarus", "BY" ],
+        [ "China", "CN" ],
+        [ "United States", "US" ]
+    ]
 });
 
 new Awesomplete('input[type="email"]', {
-	list: ["aol.com", "att.net", "comcast.net", "facebook.com", "gmail.com", "gmx.com", "googlemail.com", "google.com", "hotmail.com", "hotmail.co.uk", "mac.com", "me.com", "mail.com", "msn.com", "live.com", "sbcglobal.net", "verizon.net", "yahoo.com", "yahoo.co.uk"],
-	data: function (text: string, input: any) {
-		return input.slice(0, input.indexOf("@")) + "@" + text;
-	},
-	filter: Awesomplete.FILTER_STARTSWITH
+    list: ["aol.com", "att.net", "comcast.net", "facebook.com", "gmail.com",
+           "gmx.com", "googlemail.com", "google.com", "hotmail.com",
+           "hotmail.co.uk", "mac.com", "me.com", "mail.com", "msn.com",
+           "live.com", "sbcglobal.net", "verizon.net", "yahoo.com", "yahoo.co.uk"],
+    data: (text: string, input: string) => {
+        return input.slice(0, input.indexOf("@")) + "@" + text;
+    },
+    filter: Awesomplete.FILTER_STARTSWITH
 });
 
 new Awesomplete('input[data-multiple]', {
-	filter: function(text: string, input: any) {
-		return Awesomplete.FILTER_CONTAINS(text, input.match(/[^,]*$/)[0]);
-	},
+    filter: (text: string, input: any) => {
+        return Awesomplete.FILTER_CONTAINS(text, input.match(/[^,]*$/)[0]);
+    },
 
-	replace: function(text: string) {
-		var before = this.input.value.match(/^.+,\s*|/)[0];
-		this.input.value = before + text + ", ";
-	}
+    replace: (text: string) => {
+        var before = this.input.value.match(/^.+,\s*|/)[0];
+        this.input.value = before + text + ", ";
+    }
 });
 
 var ajax = new XMLHttpRequest();
 ajax.open("GET", "https://restcountries.eu/rest/v1/lang/fr", true);
-ajax.onload = function() {
-	var list = JSON.parse(ajax.responseText).map(function(i: any) { return i.name; });
-	new Awesomplete(document.querySelector("#ajax-example input"),{ list: list });
+ajax.onload = () => {
+    var list = JSON.parse(ajax.responseText).map((i: any) => { return i.name; });
+    new Awesomplete(document.querySelector("#ajax-example input"), { list: list });
 };
 ajax.send();

--- a/awesomplete/index.d.ts
+++ b/awesomplete/index.d.ts
@@ -1,10 +1,10 @@
 // Type definitions for Awesomplete v1.1.0
 // Project: https://leaverou.github.io/awesomplete/
-// Definitions by: webbiesdk <https://github.com/webbiesdk/>, Ben Dixon <https://github.com/bmdixon/>
+// Definitions by: webbiesdk <https://github.com/webbiesdk/>, Ben Dixon <https://github.com/bmdixon/>, Trevor Bekolay <https://github.com/tbekolay/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare class Awesomplete {
-	constructor(input: Element | HTMLElement | string, o?: AwesompleteOptions);
+	constructor(input: Element | HTMLElement | string, o?: Awesomplete.Options);
 	static all: Array<any>;
 	static $$: (expr: string | NodeSelector, con?: any) => NodeList;
 	static ITEM: (text: string, input: string) => HTMLElement;
@@ -36,14 +36,19 @@ declare class Awesomplete {
 	status: HTMLElement;
 }
 
-interface AwesompleteOptions {
-	list?: string | string[] | Element | { label: string, value: any }[] | [string, string][];
-	minChars?: Number;
-	maxItems?: Number;
-	autoFirst?: boolean;
-    data?: Function;
-	filter?: Function;
-	sort?: Function;
-	item?: Function;
-	replace?: Function;
+declare namespace Awesomplete {
+	interface Options {
+		list?: string | string[] | Element | { label: string, value: any }[] | [string, string][];
+		minChars?: Number;
+		maxItems?: Number;
+		autoFirst?: boolean;
+		data?: Function;
+		filter?: Function;
+		sort?: Function;
+		item?: Function;
+		replace?: Function;
+	}
 }
+
+export = Awesomplete;
+export as namespace Awesomplete;

--- a/awesomplete/index.d.ts
+++ b/awesomplete/index.d.ts
@@ -1,53 +1,56 @@
-// Type definitions for Awesomplete v1.1.0
+// Type definitions for Awesomplete 1.1
 // Project: https://leaverou.github.io/awesomplete/
 // Definitions by: webbiesdk <https://github.com/webbiesdk/>, Ben Dixon <https://github.com/bmdixon/>, Trevor Bekolay <https://github.com/tbekolay/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare class Awesomplete {
-	constructor(input: Element | HTMLElement | string, o?: Awesomplete.Options);
-	static all: Array<any>;
-	static $$: (expr: string | NodeSelector, con?: any) => NodeList;
-	static ITEM: (text: string, input: string) => HTMLElement;
-	static $: {
-		(expr: string|Element, con?: NodeSelector): string | Element;
-		regExpEscape: (s: { replace: (arg0: RegExp, arg1: string) => void }) => any;
-		create: (tag: string, o: any) => HTMLElement;
-		fire: (target: EventTarget, type: string, properties: any) => any;
-		siblingIndex: (el: Element) => number;
-	};
-	static FILTER_STARTSWITH: (text: string, input: string) => boolean;
-	static FILTER_CONTAINS: (text: string, input: string) => boolean;
-	static SORT_BYLENGTH: (a: number | any[], b: number | any[]) => number;
-	static REPLACE: (text: any) => void;
-	next: () => void;
-	container: HTMLElement;
-	select: (selected?: HTMLElement, originalTarget?: HTMLElement) => void;
-	previous: () => void;
-	index: number;
-	opened: number;
-	list: string | string[] | Element | { label: string, value: any }[] | [string, string][];
-	input: HTMLElement | string;
-	goto: (i: number) => void;
-	ul: HTMLElement;
-	close: () => void;
-	evaluate: () => void;
-	selected: boolean;
-	open: () => void;
-	status: HTMLElement;
+    constructor(input: Element | HTMLElement | string, o?: Awesomplete.Options);
+    static all: any[];
+    static $$: (expr: string | NodeSelector, con?: any) => NodeList;
+    static ITEM: (text: string, input: string) => HTMLElement;
+    static $: {
+        (expr: string|Element, con?: NodeSelector): string | Element;
+        regExpEscape: (s: { replace: (arg0: RegExp, arg1: string) => void }) => any;
+        create: (tag: string, o: any) => HTMLElement;
+        fire: (target: EventTarget, type: string, properties: any) => any;
+        siblingIndex: (el: Element) => number;
+    };
+    static FILTER_STARTSWITH: (text: string, input: string) => boolean;
+    static FILTER_CONTAINS: (text: string, input: string) => boolean;
+    static SORT_BYLENGTH: (left: number | any[], right: number | any[]) => number;
+    static REPLACE: (text: string) => void;
+    static DATA: (item: Awesomplete.Suggestion) => Awesomplete.Suggestion;
+    next: () => void;
+    container: HTMLElement;
+    select: (selected?: HTMLElement, originalTarget?: HTMLElement) => void;
+    previous: () => void;
+    index: number;
+    opened: number;
+    list: string | Element | Awesomplete.Suggestion[];
+    input: HTMLElement | string;
+    goto: (i: number) => void;
+    ul: HTMLElement;
+    close: () => void;
+    evaluate: () => void;
+    selected: boolean;
+    open: () => void;
+    status: HTMLElement;
 }
 
 declare namespace Awesomplete {
-	interface Options {
-		list?: string | string[] | Element | { label: string, value: any }[] | [string, string][];
-		minChars?: Number;
-		maxItems?: Number;
-		autoFirst?: boolean;
-		data?: Function;
-		filter?: Function;
-		sort?: Function;
-		item?: Function;
-		replace?: Function;
-	}
+    type Suggestion = string | {label: string | any, value: string | any} | [string, string];
+
+    interface Options {
+        list?: string | string[] | Element | { label: string, value: any }[] | [string, string][];
+        minChars?: number;
+        maxItems?: number;
+        autoFirst?: boolean;
+        data?: (item: Suggestion, input: string) => string;
+        filter?: (text: string, input: string) => boolean;
+        sort?: (left: number | any[], right: number | any[]) => number;
+        item?: (text: string, input: string) => HTMLElement;
+        replace?: (text: string) => void;
+    }
 }
 
 export = Awesomplete;

--- a/awesomplete/tslint.json
+++ b/awesomplete/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }

--- a/phonon/index.d.ts
+++ b/phonon/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kévin SERIN <https://github.com/kserin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="awesomplete"/>
+/// <reference types="awesomplete" />
 
 declare namespace Phonon {
     /*** Main object ***/
@@ -28,7 +28,7 @@ declare namespace Phonon {
         popover(id?: string): PhononPopoverComponent;
         preloader(element: string | Element): PhononPreloaderComponent;
         tab(): PhononTabComponent;
-        autocomplete(input: Element | HTMLElement | string, o?: AwesompleteOptions): Awesomplete;
+        autocomplete(input: Element | HTMLElement | string, o?: Awesomplete.Options): Awesomplete;
     }
     interface PhononDeviceObject {
         os: string;


### PR DESCRIPTION
This enables the use of import statements like

  import * as Awesomplete from "awesomplete";

It uses the hack (?) describedin https://github.com/Microsoft/TypeScript/issues/5073.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://leaverou.github.io/awesomplete/#extensibility>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.