### PR TITLE
pg - Add Field interface definition

### DIFF
--- a/pg/index.d.ts
+++ b/pg/index.d.ts
@@ -50,11 +50,22 @@ export interface QueryConfig {
     values?: any[];
 }
 
+export interface Field {
+    columnID?: number;
+    dataTypeID?: number;
+    dataTypeModifier?: number;
+    dataTypeSize?: number;
+    format?: string;
+    name?: string;
+    tableID?: number;
+}
+
 export interface QueryResult {
     command: string;
     rowCount: number;
     oid: number;
     rows: any[];
+    fields: Field[];
 }
 
 export interface ResultBuilder extends QueryResult {

--- a/pg/index.d.ts
+++ b/pg/index.d.ts
@@ -51,13 +51,13 @@ export interface QueryConfig {
 }
 
 export interface Field {
-    columnID?: number;
-    dataTypeID?: number;
-    dataTypeModifier?: number;
-    dataTypeSize?: number;
-    format?: string;
-    name?: string;
-    tableID?: number;
+    columnID: number;
+    dataTypeID: number;
+    dataTypeModifier: number;
+    dataTypeSize: number;
+    format: string;
+    name: string;
+    tableID: number;
 }
 
 export interface QueryResult {


### PR DESCRIPTION
The `QueryResult` definition currently does not define the `fields` array as a part of `QueryResult` and there is no definition for `Field` as an interface.