### PR TITLE
added react-copy-to-clipboard typedefinition

### DIFF
--- a/react-copy-to-clipboard/index.d.ts
+++ b/react-copy-to-clipboard/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for react-copy-to-clipboard 4.2
+// Project: https://github.com/nkbt/react-copy-to-clipboard
+// Definitions by: Meno Abels <https://github.com/mabels>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+import * as React from "react";
+
+export as namespace CopyToClipboard;
+
+export = CopyToClipboard;
+
+declare namespace CopyToClipboard {
+
+  export interface Options {
+    debug: boolean;
+    message: string;
+  }
+
+  export interface Props {
+    text: string;
+    options?: Options;
+  }
+
+}
+
+declare class CopyToClipboard extends React.Component<CopyToClipboard.Props, {}> {
+}
+

--- a/react-copy-to-clipboard/index.d.ts
+++ b/react-copy-to-clipboard/index.d.ts
@@ -19,6 +19,7 @@ declare namespace CopyToClipboard {
 
   export interface Props {
     text: string;
+    onCopy: (a: string) => void,
     options?: Options;
   }
 

--- a/react-copy-to-clipboard/index.d.ts
+++ b/react-copy-to-clipboard/index.d.ts
@@ -19,7 +19,7 @@ declare namespace CopyToClipboard {
 
   export interface Props {
     text: string;
-    onCopy: (a: string) => void,
+    onCopy?: (a: string) => void,
     options?: Options;
   }
 

--- a/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
+++ b/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
@@ -1,12 +1,12 @@
 
 import * as React from "react";
-import CopyToClipboard from "react-copy-to-clipboard";
+import * as CopyToClipboard from "react-copy-to-clipboard";
 
 export class Test extends React.Component<any, any> {
     render() {
         return (
           <CopyToClipboard text={"Hello World"}
-            onCopy={() => this.setState({copied: true})}>
+            onCopy={() => {}}>
             <span>Copy to clipboard with span</span>
           </CopyToClipboard>
         );

--- a/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
+++ b/react-copy-to-clipboard/react-copy-to-clipboard-tests.tsx
@@ -1,0 +1,14 @@
+
+import * as React from "react";
+import CopyToClipboard from "react-copy-to-clipboard";
+
+export class Test extends React.Component<any, any> {
+    render() {
+        return (
+          <CopyToClipboard text={"Hello World"}
+            onCopy={() => this.setState({copied: true})}>
+            <span>Copy to clipboard with span</span>
+          </CopyToClipboard>
+        );
+    }
+}

--- a/react-copy-to-clipboard/tsconfig.json
+++ b/react-copy-to-clipboard/tsconfig.json
@@ -9,13 +9,13 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "baseUrl": "../",
+        "jsx": "react",
         "typeRoots": [
             "../"
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "jsx": "react"
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/react-copy-to-clipboard/tsconfig.json
+++ b/react-copy-to-clipboard/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-copy-to-clipboard-tests.tsx"
+    ]
+}

--- a/react-copy-to-clipboard/tslint.json
+++ b/react-copy-to-clipboard/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If adding a new definition:
- [n] The package does not provide its own types, and you can not add them.
- [y] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [n] Create it with `npm run new-package package-name`, not by basing it on an existing project.
- [y] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
