### PR TITLE
Update type definitions for bablyon.

### DIFF
--- a/babylon/index.d.ts
+++ b/babylon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for babylon v6.7
+// Type definitions for babylon v6.16.1
 // Project: https://github.com/babel/babylon
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -41,7 +41,17 @@ export interface BabylonOptions {
     plugins?: PluginName[];
 }
 
-export type PluginName = 'jsx' | 'flow' | 'asyncFunctions' | 'classConstructorCall' | 'doExpressions'
-    | 'trailingFunctionCommas' | 'objectRestSpread' | 'decorators' | 'classProperties' | 'exportExtensions'
-    | 'exponentiationOperator' | 'asyncGenerators' | 'functionBind' | 'functionSent' | '*';
-
+export type PluginName =
+    'estree' |
+    'jsx' |
+    'flow' |
+    'classConstructorCall' |
+    'doExpressions' |
+    'objectRestSpread' |
+    'decorators' |
+    'classProperties' |
+    'exportExtensions' |
+    'asyncGenerators' |
+    'functionBind' |
+    'functionSent' |
+    'dynamicImport';


### PR DESCRIPTION
The list of available plugins changed, with `estree` and `dynamicImport` being added and `asyncFunctions`, `exponentiationOperator`, and `trailingFunctionCommas` being removed.

- [v6.16.0](https://github.com/babel/babylon/blob/v6.16.1/CHANGELOG.md#6160-2017-02-23): `estree` added
- [v6.12.0](https://github.com/babel/babylon/blob/v6.16.1/CHANGELOG.md#v6120-2016-10-14): `dynamicImport` added
- [v6.9.1](https://github.com/babel/babylon/blob/v6.16.1/CHANGELOG.md#691-2016-08-23): `asyncFunctions`, `exponentiationOperator`, `trailingFunctionCommas` removed

Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babylon/blob/v6.16.1/CHANGELOG.md
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.