### PR TITLE
[fs-extra] 2.0.0 obsoletes walk and walkSync

### DIFF
--- a/fs-extra/fs-extra-tests.ts
+++ b/fs-extra/fs-extra-tests.ts
@@ -102,35 +102,3 @@ fs.ensureSymlink(path, errorCallback);
 fs.ensureSymlinkSync(path);
 fs.emptyDir(path, errorCallback);
 fs.emptyDirSync(path);
-
-var items: string[];
-fs.walk("my-path")
-  .on('data', function (item) {
-    items.push(item.path);
-  })
-  .on('end', function () {
-    console.dir(items);
-  });
-
-const ignoreHiddenFiles = (item: string): boolean => {
-  const basename = Path.basename(item)
-  return basename === '.' || basename[0] !== '.'
-}
-
-const sortPaths = (left: string, right: string) => left.localeCompare(right);
-
-const options = {
-  filter: ignoreHiddenFiles,
-  pathSorter: sortPaths
-}
-
-fs.walk(path, options)
-  .on('readable', function (this: fs.PathEntryStream) {
-    let item: fs.PathEntry | undefined
-    while ((item = this.read())) {
-      items.push(item.path)
-    }
-  })
-  .on('end', function () {
-
-  })

--- a/fs-extra/fs-extra-tests.ts
+++ b/fs-extra/fs-extra-tests.ts
@@ -2,7 +2,7 @@
 /// <reference types="node" />
 
 import fs = require('fs-extra');
-import * as Path from 'path'
+import * as Path from 'path';
 
 var src: string;
 var dest: string;
@@ -22,7 +22,7 @@ fs.copy(src, dest,
 	{
 		clobber: true,
 		preserveTimestamps: true,
-		filter: (src: string) => {return false}
+		filter: (src: string) => { return false; }
 	},
 	errorCallback
 );
@@ -43,7 +43,7 @@ fs.copySync(src, dest,
 	{
 		clobber: true,
 		preserveTimestamps: true,
-		filter: (src: string) => {return false}
+		filter: (src: string) => { return false; }
 	}
 );
 fs.copySync(src, dest,

--- a/fs-extra/index.d.ts
+++ b/fs-extra/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for fs-extra v2.0.0
 // Project: https://github.com/jprichardson/node-fs-extra
-// Definitions by: midknight41 <https://github.com/midknight41>
+// Definitions by: midknight41 <https://github.com/midknight41>, Brendan Forster <https://github.com/shiftkey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/fs-extra.d.ts

--- a/fs-extra/index.d.ts
+++ b/fs-extra/index.d.ts
@@ -120,9 +120,6 @@ export type PathEntryStream = {
   read(): PathEntry | null
 }
 
-export function walk(path: string, options?: WalkOptions): WalkEventEmitter;
-export function walkSync(path: string): ReadonlyArray<string>;
-
 export interface CopyFilterFunction {
     (src: string): boolean
 }

--- a/fs-extra/index.d.ts
+++ b/fs-extra/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for fs-extra
+// Type definitions for fs-extra v2.0.0
 // Project: https://github.com/jprichardson/node-fs-extra
 // Definitions by: midknight41 <https://github.com/midknight41>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- ~~[ ] Run `npm run lint package-name` if a `tslint.json` is present.~~ 

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes

This is mentioned in [the NPM package](https://www.npmjs.com/package/fs-extra#what-happened-to-walk-and-walksync-) but here's the PR where it was obsoleted https://github.com/jprichardson/node-fs-extra/pull/339.

<img width="720" alt="screen shot 2017-03-06 at 2 44 29 pm" src="https://cloud.githubusercontent.com/assets/359239/23596081/71630876-027b-11e7-8ad1-270efc110601.png">

I'll follow up with subsequent PRs to ensure the type declarations exist for those packages.

- [x] Increase the version number in the header if appropriate.
- ~~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.~~


