### PR TITLE
Fix koa-compose typings (Middleware must return Promise)

### DIFF
--- a/koa-compose/index.d.ts
+++ b/koa-compose/index.d.ts
@@ -8,7 +8,7 @@ declare function compose<T>(middleware: Array<compose.Middleware<T>>): compose.C
 
 declare namespace compose {
     type Middleware<T> = (context: T, next: () => Promise<any>) => any;
-    type ComposedMiddleware<T> = (context: T, next?: Middleware<T>) => Promise<void>;
+    type ComposedMiddleware<T> = (context: T, next?: () => Promise<any>) => Promise<void>;
 }
 
 export = compose;

--- a/koa-compose/koa-compose-tests.ts
+++ b/koa-compose/koa-compose-tests.ts
@@ -1,17 +1,15 @@
 
 import compose = require('koa-compose');
 
-var fn1: compose.Middleware<any> = function(context: any, next: () => Promise<void>): Promise<any> {
-    return Promise
+var fn1: compose.Middleware<any> = (context: any, next: () => Promise<void>): Promise<any> =>
+    Promise
         .resolve(console.log('in fn1'))
         .then(() => next());
-};
 
-var fn2: compose.Middleware<any> = function(context: any, next: () => Promise<void>): Promise<any> {
-    return Promise
+var fn2: compose.Middleware<any> = (context: any, next: () => Promise<void>): Promise<any> =>
+    Promise
         .resolve(console.log('in fn2'))
         .then(() => next());
-};
 
 
 var fn = compose([fn1, fn2]);

--- a/koa-compose/tslint.json
+++ b/koa-compose/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
This changes ComposedMiddleware to match Middleware as there should be no
distinction between them.

Specifically, Middleware must return a promise, because next returns a
promise and Middleware must return the same (or wrapped) Promise,
otherwise Middleware wrapping that non-promise-returning middleware
would not work. Also, next() never takes any arguments.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/compose/blob/next/index.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
