### PR TITLE
fetch-mock : remove explicit reference to whatwg-fetch. Prevents errors when targeting ES6.

### DIFF
--- a/fetch-mock/index.d.ts
+++ b/fetch-mock/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/wheresrhys/fetch-mock
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Tamir Duberstein <https://github.com/tamird>, Risto Keravuori <https://github.com/merrywhether>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-/// <reference types="whatwg-fetch" />
 
 type MockRequest = Request | RequestInit;
 


### PR DESCRIPTION
It causes "Duplicate identifier" collisions with typescript/lib/lib.es6.d.ts when targeting es6 as of Typescript 2.2.

Please fill in this template.

- [x ] Make your PR against the `master` branch.
- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `tsc` without errors.
- [ x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wheresrhys/fetch-mock/blob/master/docs/installation.md#polyfilling-fetch
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

