### PR TITLE
Fix deep-equal argument restrictions

### DIFF
--- a/deep-equal/deep-equal-tests.ts
+++ b/deep-equal/deep-equal-tests.ts
@@ -1,8 +1,11 @@
 
-import * as deepEqual from "deep-equal";
+import deepEqual = require("deep-equal");
 
 let isDeepEqual1: boolean = deepEqual({}, {});
 let isDeepEqual2: boolean = deepEqual({}, {}, { strict: true });
 let isDeepEqual3: boolean = deepEqual({}, {}, { strict: false });
+let isDeepEqual4: boolean = deepEqual(undefined, undefined);
+let isDeepEqual5: boolean = deepEqual(3, false);
+let isDeepEqual6: boolean = deepEqual("a-string", null);
 
-console.log(isDeepEqual1, isDeepEqual2, isDeepEqual3);
+console.log(isDeepEqual1, isDeepEqual2, isDeepEqual3, isDeepEqual4, isDeepEqual5, isDeepEqual6);

--- a/deep-equal/deep-equal-tests.ts
+++ b/deep-equal/deep-equal-tests.ts
@@ -1,11 +1,11 @@
 
 import deepEqual = require("deep-equal");
 
-let isDeepEqual1: boolean = deepEqual({}, {});
-let isDeepEqual2: boolean = deepEqual({}, {}, { strict: true });
-let isDeepEqual3: boolean = deepEqual({}, {}, { strict: false });
-let isDeepEqual4: boolean = deepEqual(undefined, undefined);
-let isDeepEqual5: boolean = deepEqual(3, false);
-let isDeepEqual6: boolean = deepEqual("a-string", null);
+const isDeepEqual1: boolean = deepEqual({}, {});
+const isDeepEqual2: boolean = deepEqual({}, {}, { strict: true });
+const isDeepEqual3: boolean = deepEqual({}, {}, { strict: false });
+const isDeepEqual4: boolean = deepEqual(undefined, undefined);
+const isDeepEqual5: boolean = deepEqual(3, false);
+const isDeepEqual6: boolean = deepEqual("a-string", null);
 
 console.log(isDeepEqual1, isDeepEqual2, isDeepEqual3, isDeepEqual4, isDeepEqual5, isDeepEqual6);

--- a/deep-equal/index.d.ts
+++ b/deep-equal/index.d.ts
@@ -1,17 +1,15 @@
-// Type definitions for deep-equal
+// Type definitions for deep-equal 1.0
 // Project: https://github.com/substack/node-deep-equal
 // Definitions by: remojansen <https://github.com/remojansen>, Jay Anslow <http://github.com/janslow>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-
 
 interface DeepEqualOptions {
     strict: boolean;
 }
 
-declare let deepEqual: (
+declare function deepEqual(
     actual: any,
     expected: any,
-    opts?: DeepEqualOptions) => boolean;
+    opts?: DeepEqualOptions): boolean;
 
 export = deepEqual;

--- a/deep-equal/index.d.ts
+++ b/deep-equal/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for deep-equal
 // Project: https://github.com/substack/node-deep-equal
-// Definitions by: remojansen <https://github.com/remojansen>
+// Definitions by: remojansen <https://github.com/remojansen>, Jay Anslow <http://github.com/janslow>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
@@ -10,8 +10,8 @@ interface DeepEqualOptions {
 }
 
 declare let deepEqual: (
-    actual: Object,
-    expected: Object,
+    actual: any,
+    expected: any,
     opts?: DeepEqualOptions) => boolean;
 
 export = deepEqual;

--- a/deep-equal/tsconfig.json
+++ b/deep-equal/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/deep-equal/tslint.json
+++ b/deep-equal/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../tslint.json"
+}


### PR DESCRIPTION
Previously only accepted defined objects, whereas it actually accepts all types.

Also updated the types to enable strictNullChecks and add linting.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Rule 7.3 in source code](https://github.com/substack/node-deep-equal/blob/master/index.js#L14)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.