### PR TITLE
Acorn: Bump the header version for npm publication

### DIFF
--- a/acorn/index.d.ts
+++ b/acorn/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Acorn v4.0.3
+// Type definitions for Acorn v4.0.4
 // Project: https://github.com/marijnh/acorn
 // Definitions by: RReverser <https://github.com/RReverser>, e-cloud <https://github.com/e-cloud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Not realizing how npm publication worked for this project, I failed to bump the header version in the file in #15018 . This just adds a minor version bump to force publication.