### PR TITLE
Fix es6 import for blueimp-md5.

### DIFF
--- a/blueimp-md5/blueimp-md5-tests.ts
+++ b/blueimp-md5/blueimp-md5-tests.ts
@@ -1,4 +1,4 @@
-import * as md5 from "blueimp-md5";
+import md5 = require("blueimp-md5");
 
 function hash1(): string {
     return md5('hello world');

--- a/blueimp-md5/blueimp-md5-tests.ts
+++ b/blueimp-md5/blueimp-md5-tests.ts
@@ -1,6 +1,5 @@
+import * as md5 from "blueimp-md5";
 
-import blueimp = require('blueimp-md5');
-
-function hash(): boolean {
-    return blueimp.md5('hello world') === '5eb63bbbe01eeed093cb22bb8f5acdc3';
+function hash1(): string {
+    return md5('hello world');
 }

--- a/blueimp-md5/index.d.ts
+++ b/blueimp-md5/index.d.ts
@@ -1,6 +1,8 @@
-// Type definitions for blueimp-md5 v1.1.0
+// Type definitions for blueimp-md5 v2.7.0
 // Project: https://github.com/blueimp/JavaScript-MD5
-// Definitions by: Ray Martone <https://github.com/rmartone>
+// Definitions by: Ray Martone <https://github.com/rmartone>, Mikael Kohlmyr <https://github.com/mkohlmyr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export declare function md5(value: string, key?: string, raw?: boolean): string;
+declare function md5(value: string, key?: string, raw?: boolean): string;
+declare namespace md5 { }
+export = md5;

--- a/blueimp-md5/index.d.ts
+++ b/blueimp-md5/index.d.ts
@@ -4,5 +4,4 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare function md5(value: string, key?: string, raw?: boolean): string;
-declare namespace md5 { }
 export = md5;


### PR DESCRIPTION
The exsting type definition allowed importing the module using `import { md5 } from "blueimp-md5";`, which leads to effectively calling blueimp-md5.md5 (undefined) as a function (once compiled with webpack).

The new definition allows the pre-existing alternative format: `import md5 = require("blueimp-md5");` as well as `import * as md5 from "blueimp-md5";` which also works correctly.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/blueimp/JavaScript-MD5#server-side
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.