### PR TITLE
Allow empty LatLngBounds and make iconUrl optional

### DIFF
--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -146,6 +146,7 @@ declare namespace L {
     export class LatLngBounds {
         constructor(southWest: LatLngExpression, northEast: LatLngExpression);
         constructor(latlngs: LatLngBoundsLiteral);
+        constructor();
         extend(latlngOrBounds: LatLngExpression | LatLngBoundsExpression): this;
         pad(bufferRatio: number): LatLngBounds; // does this modify the current instance or does it return a new one?
         getCenter(): LatLng;
@@ -1419,7 +1420,7 @@ declare namespace L {
     }
 
     export interface IconOptions extends BaseIconOptions {
-        iconUrl: string;
+        iconUrl?: string;
     }
 
     // This class does not exist in reality, it's just a way to provide

--- a/leaflet/index.d.ts
+++ b/leaflet/index.d.ts
@@ -145,8 +145,7 @@ declare namespace L {
 
     export class LatLngBounds {
         constructor(southWest: LatLngExpression, northEast: LatLngExpression);
-        constructor(latlngs: LatLngBoundsLiteral);
-        constructor();
+        constructor(latlngs?: LatLngBoundsLiteral);
         extend(latlngOrBounds: LatLngExpression | LatLngBoundsExpression): this;
         pad(bufferRatio: number): LatLngBounds; // does this modify the current instance or does it return a new one?
         getCenter(): LatLng;


### PR DESCRIPTION
This is to fix typing for our existing working code:


```ts
let b = new L.LatLngBounds();
```

and 

```ts
class AnIcon extends L.DivIcon {
  public createIcon() { return document.createElement('div'); }
}

class AMarker extends L.Marker {
  constructor(latLng: L.LatLng) {
    super(L.latLng(latLng), { icon: new AnIcon() });
  }
}

```