### PR TITLE
[estree] Use null for optional fields in estree

### DIFF
--- a/types/acorn/index.d.ts
+++ b/types/acorn/index.d.ts
@@ -63,7 +63,7 @@ declare namespace acorn {
     class SourceLocation implements ESTree.SourceLocation {
         start: Position;
         end: Position;
-        source?: string;
+        source?: string | null;
 
         constructor(p: Parser, start: Position, end: Position);
     }

--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -123,7 +123,7 @@ expression = expressionStatement.expression;
 var ifStatement: ESTree.IfStatement;
 expression = ifStatement.test;
 statement = ifStatement.consequent;
-var statementOrNull: ESTree.Statement | undefined = ifStatement.alternate;
+var statementOrNull: ESTree.Statement | null | undefined = ifStatement.alternate;
 
 // LabeledStatement
 var labeledStatement: ESTree.LabeledStatement;
@@ -141,18 +141,18 @@ switchCase = switchStatement.cases[0];
 
 // ReturnStatement
 var returnStatement: ESTree.ReturnStatement;
-var expressionMaybe: ESTree.Expression | undefined = returnStatement.argument;
+var expressionMaybe: ESTree.Expression | null | undefined = returnStatement.argument;
 
 // TryStatement
 var tryStatement: ESTree.TryStatement;
 blockStatement = tryStatement.block;
-var catchClauseMaybe: ESTree.CatchClause | undefined = tryStatement.handler;
-var blockStatementMaybe: ESTree.BlockStatement | undefined = tryStatement.finalizer;
+var catchClauseMaybe: ESTree.CatchClause | null | undefined = tryStatement.handler;
+var blockStatementMaybe: ESTree.BlockStatement | null | undefined = tryStatement.finalizer;
 
 // ForStatement
 var forStatement: ESTree.ForStatement;
-var variableDeclaratorOrExpressionMaybe: typeof variableDeclaratorOrExpression | undefined = forStatement.init;
-var expressionMaybe: ESTree.Expression | undefined = forStatement.update;
+var variableDeclaratorOrExpressionMaybe: typeof variableDeclaratorOrExpression | null | undefined = forStatement.init;
+var expressionMaybe: ESTree.Expression | null | undefined = forStatement.update;
 
 // ForInStatement
 var forInStatement: ESTree.ForInStatement;
@@ -176,7 +176,7 @@ string = property.kind;
 
 // FunctionExpression
 var functionExpression: ESTree.FunctionExpression;
-var identifierMaybe: ESTree.Identifier | undefined = functionExpression.id;
+var identifierMaybe: ESTree.Identifier | null | undefined = functionExpression.id;
 pattern = functionExpression.params[0];
 pattern = assignmentPattern.left;
 expression = assignmentPattern.right;

--- a/types/estree/flow.d.ts
+++ b/types/estree/flow.d.ts
@@ -26,20 +26,20 @@ declare namespace ESTree {
 
   interface ClassImplements extends Node {
     id: Identifier;
-    typeParameters?: TypeParameterInstantiation;
+    typeParameters?: TypeParameterInstantiation | null;
   }
 
   interface ClassProperty {
     key: Expression;
-    value?: Expression;
-    typeAnnotation?: TypeAnnotation;
+    value?: Expression | null;
+    typeAnnotation?: TypeAnnotation | null;
     computed: boolean;
     static: boolean;
   }
 
   interface DeclareClass extends FlowDeclaration {
     id: Identifier;
-    typeParameters?: TypeParameterDeclaration;
+    typeParameters?: TypeParameterDeclaration | null;
     body: ObjectTypeAnnotation;
     extends: Array<InterfaceExtends>;
   }
@@ -60,8 +60,8 @@ declare namespace ESTree {
   interface FunctionTypeAnnotation extends FlowTypeAnnotation {
     params: Array<FunctionTypeParam>;
     returnType: FlowTypeAnnotation;
-    rest?: FunctionTypeParam;
-    typeParameters?: TypeParameterDeclaration;
+    rest?: FunctionTypeParam | null;
+    typeParameters?: TypeParameterDeclaration | null;
   }
 
   interface FunctionTypeParam {
@@ -72,17 +72,17 @@ declare namespace ESTree {
 
   interface GenericTypeAnnotation extends FlowTypeAnnotation {
     id: Identifier | QualifiedTypeIdentifier;
-    typeParameters?: TypeParameterInstantiation;
+    typeParameters?: TypeParameterInstantiation | null;
   }
 
   interface InterfaceExtends extends Node {
     id: Identifier | QualifiedTypeIdentifier;
-    typeParameters?: TypeParameterInstantiation;
+    typeParameters?: TypeParameterInstantiation | null;
   }
 
   interface InterfaceDeclaration extends FlowDeclaration {
     id: Identifier;
-    typeParameters?: TypeParameterDeclaration;
+    typeParameters?: TypeParameterDeclaration | null;
     extends: Array<InterfaceExtends>;
     body: ObjectTypeAnnotation;
   }
@@ -115,7 +115,7 @@ declare namespace ESTree {
 
   interface TypeAlias extends FlowDeclaration {
     id: Identifier;
-    typeParameters?: TypeParameterDeclaration;
+    typeParameters?: TypeParameterDeclaration | null;
     right: FlowTypeAnnotation;
   }
 

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -28,7 +28,7 @@ interface BaseNode {
 
   leadingComments?: Array<Comment>;
   trailingComments?: Array<Comment>;
-  loc?: SourceLocation;
+  loc?: SourceLocation | null;
   range?: [number, number];
 }
 export type Node =
@@ -42,7 +42,7 @@ export interface Comment {
 }
 
 interface SourceLocation {
-  source?: string;
+  source?: string | null;
   start: Position;
   end: Position;
 }
@@ -100,7 +100,7 @@ export interface IfStatement extends BaseStatement {
   type: "IfStatement";
   test: Expression;
   consequent: Statement;
-  alternate?: Statement;
+  alternate?: Statement | null;
 }
 
 export interface LabeledStatement extends BaseStatement {
@@ -111,12 +111,12 @@ export interface LabeledStatement extends BaseStatement {
 
 export interface BreakStatement extends BaseStatement {
   type: "BreakStatement";
-  label?: Identifier;
+  label?: Identifier | null;
 }
 
 export interface ContinueStatement extends BaseStatement {
   type: "ContinueStatement";
-  label?: Identifier;
+  label?: Identifier | null;
 }
 
 export interface WithStatement extends BaseStatement {
@@ -133,7 +133,7 @@ export interface SwitchStatement extends BaseStatement {
 
 export interface ReturnStatement extends BaseStatement {
   type: "ReturnStatement";
-  argument?: Expression;
+  argument?: Expression | null;
 }
 
 export interface ThrowStatement extends BaseStatement {
@@ -144,8 +144,8 @@ export interface ThrowStatement extends BaseStatement {
 export interface TryStatement extends BaseStatement {
   type: "TryStatement";
   block: BlockStatement;
-  handler?: CatchClause;
-  finalizer?: BlockStatement;
+  handler?: CatchClause | null;
+  finalizer?: BlockStatement | null;
 }
 
 export interface WhileStatement extends BaseStatement {
@@ -162,9 +162,9 @@ export interface DoWhileStatement extends BaseStatement {
 
 export interface ForStatement extends BaseStatement {
   type: "ForStatement";
-  init?: VariableDeclaration | Expression;
-  test?: Expression;
-  update?: Expression;
+  init?: VariableDeclaration | Expression | null;
+  test?: Expression | null;
+  update?: Expression | null;
   body: Statement;
 }
 
@@ -201,7 +201,7 @@ export interface VariableDeclaration extends BaseDeclaration {
 export interface VariableDeclarator extends BaseNode {
   type: "VariableDeclarator";
   id: Pattern;
-  init?: Expression;
+  init?: Expression | null;
 }
 
 type Expression =
@@ -239,7 +239,7 @@ export interface Property extends BaseNode {
 }
 
 export interface FunctionExpression extends BaseFunction, BaseExpression {
-  id?: Identifier;
+  id?: Identifier | null;
   type: "FunctionExpression";
   body: BlockStatement;
 }
@@ -319,7 +319,7 @@ interface BasePattern extends BaseNode { }
 
 export interface SwitchCase extends BaseNode {
   type: "SwitchCase";
-  test?: Expression;
+  test?: Expression | null;
   consequent: Array<Statement>;
 }
 
@@ -389,7 +389,7 @@ export interface ArrowFunctionExpression extends BaseExpression, BaseFunction {
 
 export interface YieldExpression extends BaseExpression {
   type: "YieldExpression";
-  argument?: Expression;
+  argument?: Expression | null;
   delegate: boolean;
 }
 
@@ -443,7 +443,7 @@ export interface AssignmentPattern extends BasePattern {
 
 export type Class = ClassDeclaration | ClassExpression;
 interface BaseClass extends BaseNode {
-  superClass?: Expression;
+  superClass?: Expression | null;
   body: ClassBody;
 }
 
@@ -468,7 +468,7 @@ export interface ClassDeclaration extends BaseClass, BaseDeclaration {
 
 export interface ClassExpression extends BaseClass, BaseExpression {
   type: "ClassExpression";
-  id?: Identifier;
+  id?: Identifier | null;
 }
 
 export interface MetaProperty extends BaseExpression {
@@ -510,9 +510,9 @@ export interface ImportNamespaceSpecifier extends BaseModuleSpecifier {
 
 export interface ExportNamedDeclaration extends BaseModuleDeclaration {
   type: "ExportNamedDeclaration";
-  declaration?: Declaration;
+  declaration?: Declaration | null;
   specifiers: Array<ExportSpecifier>;
-  source?: Literal;
+  source?: Literal | null;
 }
 
 export interface ExportSpecifier extends BaseModuleSpecifier {


### PR DESCRIPTION
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/estree/estree/blob/master/es5.md
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

Optional fields are currently marked with `?`, meaning that the field may be `undefined`, but not `null`. Though the specification at [https://github.com/estree/estree/blob/master/es5.md#node-objects](estree/estree) uses `| null` for optional fields (and they really mean `null`, not `null | undefined`). This PR fixes this.

One exception: `async` and `generator` are marked optional and I kept it that way, since they are optional since they were added in a language extension. So these properties can be absent when using a tool that works with ES5.

@RReverser Do you agree?