### PR TITLE
[knockout] Update KnockoutComponentTypes.Loader.getConfig signature

### DIFF
--- a/knockout/index.d.ts
+++ b/knockout/index.d.ts
@@ -658,7 +658,7 @@ declare namespace KnockoutComponentTypes {
     }
 
     interface Loader {
-        getConfig? (componentName: string, callback: (result: ComponentConfig) => void): void;
+        getConfig? (componentName: string, callback: (result: ComponentConfig | null) => void): void;
         loadComponent? (componentName: string, config: ComponentConfig, callback: (result: Definition) => void): void;
         loadTemplate? (componentName: string, templateConfig: any, callback: (result: Node[]) => void): void;
         loadViewModel? (componentName: string, viewModelConfig: any, callback: (result: any) => void): void;

--- a/knockout/test/templatingBehaviors.ts
+++ b/knockout/test/templatingBehaviors.ts
@@ -1,5 +1,7 @@
-/// <reference types="jasmine" />
 /// <reference types="knockout.mapping" />
+
+declare function describe(desc: string, f: () => void): void;
+declare function it(desc: string, f: () => void): void;
 
 declare namespace jasmine {
   interface Matchers {

--- a/knockout/test/templatingBehaviors.ts
+++ b/knockout/test/templatingBehaviors.ts
@@ -1,17 +1,30 @@
 /// <reference types="knockout.mapping" />
 
+// Jasmine definitions
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
 declare function beforeEach(action: (done: DoneFn) => void, timeout?: number): void;
 declare function expect(spy: Function): jasmine.Matchers;
 declare function expect(actual: any): jasmine.Matchers;
 
+interface DoneFn extends Function {
+    (): void;
+
+    /** fails the spec and indicates that it has completed. If the message is an Error, Error.message is used */
+    fail: (message?: Error|string) => void;
+}
+
 declare namespace jasmine {
   interface Matchers {
+    toEqual(expected: any, expectationFailOutput?: any): boolean;
+    toBeDefined(expectationFailOutput?: any): boolean;
     toContainHtml(expected: string): boolean;
     toContainText(expected: string): boolean;
+    not: Matchers;
   }
 }
+//End Jasmine definitions
+
 
 var dummyTemplateEngine = function (templates?) {
     var inMemoryTemplates = templates || {};

--- a/knockout/test/templatingBehaviors.ts
+++ b/knockout/test/templatingBehaviors.ts
@@ -18,6 +18,7 @@ declare namespace jasmine {
   interface Matchers {
     toEqual(expected: any, expectationFailOutput?: any): boolean;
     toBeDefined(expectationFailOutput?: any): boolean;
+    toBeNull(expectationFailOutput?: any): boolean;
     toContainHtml(expected: string): boolean;
     toContainText(expected: string): boolean;
     not: Matchers;

--- a/knockout/test/templatingBehaviors.ts
+++ b/knockout/test/templatingBehaviors.ts
@@ -2,6 +2,9 @@
 
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
+declare function beforeEach(action: (done: DoneFn) => void, timeout?: number): void;
+declare function expect(spy: Function): jasmine.Matchers;
+declare function expect(actual: any): jasmine.Matchers;
 
 declare namespace jasmine {
   interface Matchers {


### PR DESCRIPTION
Callback in method signature is missing a null type, so when trying to call the callback with null (which is a valid scenario, if you want to skip current loader), compilation with strict null check on fails.
See: http://knockoutjs.com/documentation/component-loaders.html#getconfigname-callback