### PR TITLE
google-protobuf - abstract Message

### DIFF
--- a/google-protobuf/google-protobuf-tests.ts
+++ b/google-protobuf/google-protobuf-tests.ts
@@ -24,12 +24,12 @@ class MySimple extends jspb.Message {
 
   static repeatedFields_ = [3];
 
-  toObject(opt_includeInstance: boolean) {
+  toObject(opt_includeInstance: boolean): {} {
     return MySimple.toObject(opt_includeInstance, this);
   };
 
-  static toObject(includeInstance: boolean, msg: MySimple) {
-    const obj = {
+  static toObject(includeInstance: boolean, msg: MySimple): {} {
+    const obj: {} = {
       myString: jspb.Message.getFieldWithDefault(msg, 1, ""),
       myBool: jspb.Message.getFieldWithDefault(msg, 2, false),
       someLabelsList: jspb.Message.getField(msg, 3),

--- a/google-protobuf/index.d.ts
+++ b/google-protobuf/index.d.ts
@@ -9,7 +9,7 @@ type RepeatedFieldType = ScalarFieldType[] | Uint8Array[];
 type AnyFieldType = ScalarFieldType | RepeatedFieldType | Uint8Array;
 type FieldValue = (string|number|boolean|Uint8Array|any/*This should be Array<FieldValue>, but that isn't allowed*/|undefined)
 
-export class Message {
+export abstract class Message {
   getJsPbMessageId(): (string | undefined);
   static initialize(msg: Message,
                     data: Message.MessageArray,
@@ -112,6 +112,18 @@ export class Message {
                   toMessage: Message): void;
   static registerMessageType(id: number,
                              constructor: typeof Message): void;
+
+  abstract serializeBinary(): Uint8Array;
+  abstract toObject(includeInstance?: boolean): Object;
+
+  // These are `abstract static`, but that isn't allowed. Subclasses of Message will have these methods and properties
+  // and not having them on Message makes using this class for its intended purpose quite difficult.
+  static deserializeBinary(bytes: Uint8Array): Message;
+  static deserializeBinaryFromReader(message: Message, reader: BinaryReader): Message;
+  static serializeBinaryToWriter(message: Message, writer: BinaryWriter): void;
+  static toObject(includeInstance: boolean, msg: Message): Object;
+  static extensions: {[key: number]: ExtensionFieldInfo<Message>};
+  static extensionsBinary: {[key: number]: ExtensionFieldBinaryInfo<Message>};
 }
 
 export namespace Message {

--- a/google-protobuf/index.d.ts
+++ b/google-protobuf/index.d.ts
@@ -114,14 +114,14 @@ export abstract class Message {
                              constructor: typeof Message): void;
 
   abstract serializeBinary(): Uint8Array;
-  abstract toObject(includeInstance?: boolean): Object;
+  abstract toObject(includeInstance?: boolean): {};
 
   // These are `abstract static`, but that isn't allowed. Subclasses of Message will have these methods and properties
   // and not having them on Message makes using this class for its intended purpose quite difficult.
   static deserializeBinary(bytes: Uint8Array): Message;
   static deserializeBinaryFromReader(message: Message, reader: BinaryReader): Message;
   static serializeBinaryToWriter(message: Message, writer: BinaryWriter): void;
-  static toObject(includeInstance: boolean, msg: Message): Object;
+  static toObject(includeInstance: boolean, msg: Message): {};
   static extensions: {[key: number]: ExtensionFieldInfo<Message>};
   static extensionsBinary: {[key: number]: ExtensionFieldBinaryInfo<Message>};
 }


### PR DESCRIPTION
This is a fix/addition to the `google-protobuf` type declarations. 

In normal usage of the library the `Message` class is extended by generated classes produced by the protobuf compiler. These generated classes all have `static` methods (e.g. `deserializeBinary`). These methods are effectively `abstract static` methods on the `Message` class as any subclass of `Message` should have these methods.

Whilst it's technically incorrect to declare these methods as simply `static` on the `Message` class, the lack of `abstract static` support in TypeScript as of writing makes this the most pragmatic approach IMO.

To this end I have made the `Message` class `abstract`.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate. - not appropriate; these are fixes
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.