### PR TITLE
fleshing out the relayProp

### DIFF
--- a/react-relay/index.d.ts
+++ b/react-relay/index.d.ts
@@ -151,7 +151,7 @@ declare module "react-relay" {
         pendingVariables?: any;
         setVariables(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
         forceFetch(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
-        hasOptimisticUpdate(record: any): boolean;
-        getPendingTransactions(record: any): RelayMutationTransaction[];
+        hasOptimisticUpdate(record?: any): boolean;
+        getPendingTransactions(record?: any): RelayMutationTransaction[];
     }
 }

--- a/react-relay/index.d.ts
+++ b/react-relay/index.d.ts
@@ -153,5 +153,6 @@ declare module "react-relay" {
         forceFetch(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
         hasOptimisticUpdate(record?: any): boolean;
         getPendingTransactions(record?: any): RelayMutationTransaction[];
+        commitUpdate?: (mutation: Mutation<any,any>, callbacks?: StoreUpdateCallbacks<any>) => any;
     }
 }

--- a/react-relay/index.d.ts
+++ b/react-relay/index.d.ts
@@ -31,6 +31,24 @@ declare module "react-relay" {
         response: any
     }
 
+    type RelayMutationStatus =
+      'UNCOMMITTED' | // Transaction hasn't yet been sent to the server. Transaction can be committed or rolled back.
+      'COMMIT_QUEUED' | // Transaction was committed but another transaction with the same collision key is pending, so the transaction has been queued to send to the server.
+      'COLLISION_COMMIT_FAILED' | //Transaction was queued for commit but another transaction with the same collision key failed. All transactions in the collision queue, including this one, have been failed. Transaction can be recommitted or rolled back.
+      'COMMITTING' | // Transaction is waiting for the server to respond.
+      'COMMIT_FAILED';
+
+    class RelayMutationTransaction {
+      applyOptimistic(): RelayMutationTransaction;
+      commit(): RelayMutationTransaction;
+      recommit(): void;
+      rollback(): void;
+      getError(): Error;
+      getStatus(): RelayMutationStatus;
+      getHash(): string;
+      getID(): string;
+    }
+
     interface RelayMutationRequest {
         getQueryString(): string
         getVariables(): RelayVariables
@@ -104,7 +122,7 @@ declare module "react-relay" {
         renderFailure?(error: Error, retry: Function): JSX.Element
     }
 
-    type ReadyStateEvent = 
+    type ReadyStateEvent =
         'ABORT' |
         'CACHE_RESTORED_REQUIRED' |
         'CACHE_RESTORE_FAILED' |
@@ -128,7 +146,12 @@ declare module "react-relay" {
     }
 
     interface RelayProp {
-        variables: any
-        setVariables(variables: Object, onReadyStateChange?: OnReadyStateChange): void
+        route: { name: string; }; // incomplete, also has params and queries
+        variables: any;
+        pendingVariables?: any;
+        setVariables(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
+        forceFetch(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
+        hasOptimisticUpdate(record: any): boolean;
+        getPendingTransactions(record: any): RelayMutationTransaction[];
     }
 }

--- a/react-relay/index.d.ts
+++ b/react-relay/index.d.ts
@@ -15,7 +15,7 @@ declare module "react-relay" {
     }
 
     interface CreateContainerOpts {
-        initialVariables?: Object
+        initialVariables?: any
         fragments: Fragments
         prepareVariables?(prevVariables: RelayVariables): RelayVariables
     }
@@ -148,13 +148,13 @@ declare module "react-relay" {
     }
 
     interface RelayProp {
-        route: { name: string; }; // incomplete, also has params and queries
-        variables: Object;
-        pendingVariables?: Object | null;
-        setVariables(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
-        forceFetch(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
-        hasOptimisticUpdate(record: Object): boolean;
-        getPendingTransactions(record: Object): RelayMutationTransaction[];
+        readonly route: { name: string; }; // incomplete, also has params and queries
+        readonly variables: any;
+        readonly pendingVariables?: any | null;
+        setVariables(variables: any, onReadyStateChange?: OnReadyStateChange): void;
+        forceFetch(variables: any, onReadyStateChange?: OnReadyStateChange): void;
+        hasOptimisticUpdate(record: any): boolean;
+        getPendingTransactions(record: any): RelayMutationTransaction[];
         commitUpdate: (mutation: Mutation<any,any>, callbacks?: StoreUpdateCallbacks<any>) => any;
     }
 }

--- a/react-relay/index.d.ts
+++ b/react-relay/index.d.ts
@@ -7,6 +7,8 @@
 declare module "react-relay" {
     import * as React from "react";
 
+    type ClientMutationID = string;
+
     /** Fragments are a hash of functions */
     interface Fragments {
         [query: string]: ((variables?: RelayVariables) => string)
@@ -40,13 +42,13 @@ declare module "react-relay" {
 
     class RelayMutationTransaction {
       applyOptimistic(): RelayMutationTransaction;
-      commit(): RelayMutationTransaction;
+      commit(): RelayMutationTransaction | null;
       recommit(): void;
       rollback(): void;
       getError(): Error;
       getStatus(): RelayMutationStatus;
       getHash(): string;
-      getID(): string;
+      getID(): ClientMutationID;
     }
 
     interface RelayMutationRequest {
@@ -147,12 +149,12 @@ declare module "react-relay" {
 
     interface RelayProp {
         route: { name: string; }; // incomplete, also has params and queries
-        variables: any;
-        pendingVariables?: any;
+        variables: Object;
+        pendingVariables?: Object | null;
         setVariables(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
         forceFetch(variables: Object, onReadyStateChange?: OnReadyStateChange): void;
-        hasOptimisticUpdate(record?: any): boolean;
-        getPendingTransactions(record?: any): RelayMutationTransaction[];
-        commitUpdate?: (mutation: Mutation<any,any>, callbacks?: StoreUpdateCallbacks<any>) => any;
+        hasOptimisticUpdate(record: Object): boolean;
+        getPendingTransactions(record: Object): RelayMutationTransaction[];
+        commitUpdate: (mutation: Mutation<any,any>, callbacks?: StoreUpdateCallbacks<any>) => any;
     }
 }

--- a/react-relay/react-relay-tests.tsx
+++ b/react-relay/react-relay-tests.tsx
@@ -74,10 +74,16 @@ class StubbedArtwork extends React.Component<null, null> {
         const props = {
             artwork: { title: "CHAMPAGNE FORMICA FLAG" },
             relay: {
+                route: {
+                    name: "champagne"
+                },
                 variables: {
                     artworkID: "champagne-formica-flag",
                 },
                 setVariables: () => {},
+                forceFetch: () => {},
+                hasOptimisticUpdate: () => false,
+                getPendingTransactions: (): Relay.RelayMutationTransaction[] => undefined,
             }
         }
         return <ArtworkContainer {...props} />

--- a/react-relay/react-relay-tests.tsx
+++ b/react-relay/react-relay-tests.tsx
@@ -84,6 +84,7 @@ class StubbedArtwork extends React.Component<null, null> {
                 forceFetch: () => {},
                 hasOptimisticUpdate: () => false,
                 getPendingTransactions: (): Relay.RelayMutationTransaction[] => undefined,
+                commitUpdate: () => {},
             }
         }
         return <ArtworkContainer {...props} />


### PR DESCRIPTION
A variety of methods were missing from RelayProp, which is a bit painful since it's often the primary interface for Relay.

Everything I've added is documented here: https://facebook.github.io/relay/docs/api-reference-relay-container.html

------------------

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/relay/docs/api-reference-relay-container.html
- [x] Increase the version number in the header if appropriate.
