### PR TITLE
three: Vector3 setFromSpherical return type corrected

### DIFF
--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -4240,7 +4240,7 @@ declare namespace THREE {
         distanceToSquared(v: Vector3): number;
         distanceToManhattan(v: Vector3): number;
 
-        setFromSpherical(s: Spherical): Matrix3;
+        setFromSpherical(s: Spherical): Vector3;
         setFromMatrixPosition(m: Matrix4): Vector3;
         setFromMatrixScale(m: Matrix4): Vector3;
         setFromMatrixColumn(matrix: Matrix4, index: number): Vector3;


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://threejs.org/docs/index.html?q=vector3#Reference/Math/Vector3>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
