### PR TITLE
[node] AsyncCompleter for readline

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -1546,22 +1546,20 @@ declare module "readline" {
         prependOnceListener(event: "SIGTSTP", listener: () => void): this;
     }
 
-    export interface Completer {
-        (line: string): CompleterResult;
-        (line: string, callback: (err: any, result: CompleterResult) => void): any;
-    }
+    type Completer = (line: string) => CompleterResult;
+    type AsyncCompleter = (line: string, callback: (err: any, result: CompleterResult) => void) => any;
 
     export type CompleterResult = [string[], string];
 
     export interface ReadLineOptions {
         input: NodeJS.ReadableStream;
         output?: NodeJS.WritableStream;
-        completer?: Completer;
+        completer?: Completer | AsyncCompleter;
         terminal?: boolean;
         historySize?: number;
     }
 
-    export function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer, terminal?: boolean): ReadLine;
+    export function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): ReadLine;
     export function createInterface(options: ReadLineOptions): ReadLine;
 
     export function cursorTo(stream: NodeJS.WritableStream, x: number, y: number): void;

--- a/node/node-tests.ts
+++ b/node/node-tests.ts
@@ -1265,6 +1265,12 @@ namespace readline_tests {
                 return [['test'], 'test'];
             }
         });
+        result = readline.createInterface({
+            input: input,
+            completer: function(str: string, callback: (err: any, result: readline.CompleterResult) => void): any {
+                callback(null, [['test'], 'test']);
+            }
+        });
     }
 
     {


### PR DESCRIPTION
Previous Completer interface required implementation
of BOTH types (sync and async). Sync type could
be assigned to async type, but not vice versa, forcing
implementers to always implement the sync interface.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [N/A] Run `npm run lint package-name` if a `tslint.json` is present.

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/readline.html#readline_use_of_the_completer_function
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
