### PR TITLE
Ensure the HelloSign object can be imported

### DIFF
--- a/hellosign-embedded/hellosign-embedded-tests.ts
+++ b/hellosign-embedded/hellosign-embedded-tests.ts
@@ -1,4 +1,4 @@
-import HelloSign = require('hellosign-embedded');
+import { HelloSign } from 'hellosign-embedded';
 
 HelloSign.init('abc123');
 

--- a/hellosign-embedded/hellosign-embedded-tests.ts
+++ b/hellosign-embedded/hellosign-embedded-tests.ts
@@ -1,4 +1,4 @@
-import HelloSign from 'hellosign-embedded';
+import HelloSign = require('hellosign-embedded');
 
 HelloSign.init('abc123');
 

--- a/hellosign-embedded/hellosign-embedded-tests.ts
+++ b/hellosign-embedded/hellosign-embedded-tests.ts
@@ -1,3 +1,5 @@
+import HelloSign from 'hellosign-embedded';
+
 HelloSign.init('abc123');
 
 // some options

--- a/hellosign-embedded/index.d.ts
+++ b/hellosign-embedded/index.d.ts
@@ -269,4 +269,4 @@ declare module HelloSign {
 
 declare var HelloSign: HelloSign.HelloSignStatic;
 
-export = HelloSign;
+export default HelloSign;

--- a/hellosign-embedded/index.d.ts
+++ b/hellosign-embedded/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/HelloFax/hellosign-embedded
 // Definitions by: Brian Surowiec <https://github.com/xt0rted/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-declare module HelloSign {
+export declare module HelloSign {
     interface SignedMessageEvent {
         event: 'signature_request_signed';
         signature_id: string;
@@ -269,4 +269,4 @@ declare module HelloSign {
 
 declare var HelloSign: HelloSign.HelloSignStatic;
 
-export = HelloSign;
+export as namespace HelloSign;

--- a/hellosign-embedded/index.d.ts
+++ b/hellosign-embedded/index.d.ts
@@ -268,3 +268,5 @@ declare module HelloSign {
 }
 
 declare var HelloSign: HelloSign.HelloSignStatic;
+
+export = HelloSign;

--- a/hellosign-embedded/index.d.ts
+++ b/hellosign-embedded/index.d.ts
@@ -269,4 +269,4 @@ declare module HelloSign {
 
 declare var HelloSign: HelloSign.HelloSignStatic;
 
-export default HelloSign;
+export = HelloSign;


### PR DESCRIPTION
In the current form, the ``hellosign-embedded`` library could not be imported. The type declaration expects a global variable, but [the library](https://github.com/HelloFax/hellosign-embedded/blob/master/src/embedded.js) does not define any.