### PR TITLE
added details to Grid and Table class, fixed typing for cell-measurer cache

### DIFF
--- a/react-virtualized/react-virtualized-tests.tsx
+++ b/react-virtualized/react-virtualized-tests.tsx
@@ -203,10 +203,8 @@ function CellMeasurerTest() {
 
     ReactDOM.render(
         <CellMeasurer
-            cellRenderer={cellRenderer}
-            columnCount={columnCount}
-            height={fixedRowHeight}
-            rowCount={rowCount}
+            columnIndex={0}
+            rowIndex={0}
         >
             {({ getColumnWidth }) => (
                 <Grid


### PR DESCRIPTION
Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/bvaughn/react-virtualized/blob/master/source/CellMeasurer/CellMeasurer.js
    - https://github.com/bvaughn/react-virtualized/blob/master/source/Table/Table.js
    - https://github.com/bvaughn/react-virtualized/blob/master/source/Grid/Grid.js

The classes of Table and Grid are extended by there public methods and properties