### PR TITLE
react-router: Improve typing of withRouter

### DIFF
--- a/react-router/lib/withRouter.d.ts
+++ b/react-router/lib/withRouter.d.ts
@@ -6,7 +6,7 @@ interface Options {
 
 type ComponentConstructor<P> = ComponentClass<P> | StatelessComponent<P>;
 
-declare function withRouter<P>(component: ComponentConstructor<P>, options?: Options): ComponentClass<P>;
 declare function withRouter<P, S>(component: ComponentConstructor<P> & S, options?: Options): ComponentClass<P> & S;
+declare function withRouter<P>(component: ComponentConstructor<P>, options?: Options): ComponentClass<P>;
 
 export default withRouter;

--- a/react-router/lib/withRouter.d.ts
+++ b/react-router/lib/withRouter.d.ts
@@ -6,4 +6,7 @@ interface Options {
 
 type ComponentConstructor<P> = ComponentClass<P> | StatelessComponent<P>;
 
-export default function withRouter<P>(component: ComponentConstructor<P>, options?: Options): ComponentClass<P>;
+declare function withRouter<P>(component: ComponentConstructor<P>, options?: Options): ComponentClass<P>;
+declare function withRouter<P, S>(component: ComponentConstructor<P> & S, options?: Options): ComponentClass<P> & S;
+
+export default withRouter;

--- a/react-router/react-router-tests.tsx
+++ b/react-router/react-router-tests.tsx
@@ -81,6 +81,7 @@ interface DashboardProps {
 }
 
 class Dashboard extends React.Component<DashboardProps, {}> {
+    static staticMethodToBeHoisted(): void {}
 
 	navigate() {
 		var router = this.props.router;
@@ -101,6 +102,8 @@ class Dashboard extends React.Component<DashboardProps, {}> {
 }
 
 const DashboardWithRouter = withRouter(Dashboard);
+
+DashboardWithRouter.staticMethodToBeHoisted();
 
 class NotFound extends React.Component<{}, {}> {
 


### PR DESCRIPTION
React-Router (v3) uses `hoist-non-react-statics` which is used for HoC to hoist static methods from wrapped component.
But the HoC returned from `withRouter` doesn't have types of hoisted static methods.

```ts
import * as React from 'react';
import {withRouter} from 'react-router';

class SampleComponent extends React.Component<{}, {}> {
    public static someStaticMethod(): any {}
}

SampleComponent.someStaticMethod;  // OK

const HoC = withRouter(SampleComponent);
HoC.someStaticMethod;  // error TS2339: Property 'someStaticMethod' does not exist on type 'ComponentClass<{}>'.
```

---

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/v3/modules/withRouter.js#L50
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.