### PR TITLE
google-protobuf - added built-in proto classes

### DIFF
--- a/google-protobuf/google-protobuf-tests.ts
+++ b/google-protobuf/google-protobuf-tests.ts
@@ -1,4 +1,17 @@
-import * as jspb from "google-protobuf";
+import * as jspb from "./index";
+
+import * as google_protobuf_compiler_plugin_pb from "./google/protobuf/compiler/plugin_pb";
+import * as google_protobuf_any_pb from "./google/protobuf/any_pb";
+import * as google_protobuf_api_pb from "./google/protobuf/api_pb";
+import * as google_protobuf_descriptor_pb from "./google/protobuf/descriptor_pb";
+import * as google_protobuf_duration_pb from "./google/protobuf/duration_pb";
+import * as google_protobuf_empty_pb from "./google/protobuf/empty_pb";
+import * as google_protobuf_field_mask_pb from "./google/protobuf/field_mask_pb";
+import * as google_protobuf_source_context_pb from "./google/protobuf/source_context_pb";
+import * as google_protobuf_struct_pb from "./google/protobuf/struct_pb";
+import * as google_protobuf_timestamp_pb from "./google/protobuf/timestamp_pb";
+import * as google_protobuf_type_pb from "./google/protobuf/type_pb";
+import * as google_protobuf_wrappers_pb from "./google/protobuf/wrappers_pb";
 
 /* This is a typescript version of a simple generated class from a proto file that is shown below. In order to make
  this ES5 JS file into TypeScript there have been quite a few modifications, but the same calls are made to the library
@@ -13,6 +26,18 @@ import * as jspb from "google-protobuf";
    string my_string = 1;
    bool my_bool = 2;
    repeated string some_labels = 3;
+   google.protobuf.compiler.CodeGeneratorRequest some_code_generator_request = 4;
+   google.protobuf.Any some_any = 5;
+   google.protobuf.Method some_method = 6;
+   google.protobuf.GeneratedCodeInfo some_generated_code_info = 7;
+   google.protobuf.Duration some_duration = 8;
+   google.protobuf.Empty some_empty = 9;
+   google.protobuf.FieldMask some_field_mask = 10;
+   google.protobuf.SourceContext some_source_context = 11;
+   google.protobuf.Struct some_struct = 12;
+   google.protobuf.Timestamp some_timestamp = 13;
+   google.protobuf.Type some_type = 14;
+   google.protobuf.DoubleValue some_double_value = 15;
  }
 */
 
@@ -24,15 +49,27 @@ class MySimple extends jspb.Message {
 
   static repeatedFields_ = [3];
 
-  toObject(opt_includeInstance: boolean): {} {
-    return MySimple.toObject(opt_includeInstance, this);
+  toObject(opt_includeInstance?: boolean): {} {
+    return MySimple.toObject(opt_includeInstance || false, this);
   };
 
   static toObject(includeInstance: boolean, msg: MySimple): {} {
-    const obj: {} = {
+    var f, obj = {
       myString: jspb.Message.getFieldWithDefault(msg, 1, ""),
       myBool: jspb.Message.getFieldWithDefault(msg, 2, false),
       someLabelsList: jspb.Message.getField(msg, 3),
+      someCodeGeneratorRequest: (f = msg.getSomeCodeGeneratorRequest()) && google_protobuf_compiler_plugin_pb.CodeGeneratorRequest.toObject(includeInstance, f),
+      someAny: (f = msg.getSomeAny()) && google_protobuf_any_pb.Any.toObject(includeInstance, f),
+      someMethod: (f = msg.getSomeMethod()) && google_protobuf_api_pb.Method.toObject(includeInstance, f),
+      someGeneratedCodeInfo: (f = msg.getSomeGeneratedCodeInfo()) && google_protobuf_descriptor_pb.GeneratedCodeInfo.toObject(includeInstance, f),
+      someDuration: (f = msg.getSomeDuration()) && google_protobuf_duration_pb.Duration.toObject(includeInstance, f),
+      someEmpty: (f = msg.getSomeEmpty()) && google_protobuf_empty_pb.Empty.toObject(includeInstance, f),
+      someFieldMask: (f = msg.getSomeFieldMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f),
+      someSourceContext: (f = msg.getSomeSourceContext()) && google_protobuf_source_context_pb.SourceContext.toObject(includeInstance, f),
+      someStruct: (f = msg.getSomeStruct()) && google_protobuf_struct_pb.Struct.toObject(includeInstance, f),
+      someTimestamp: (f = msg.getSomeTimestamp()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
+      someType: (f = msg.getSomeType()) && google_protobuf_type_pb.Type.toObject(includeInstance, f),
+      someDoubleValue: (f = msg.getSomeDoubleValue()) && google_protobuf_wrappers_pb.DoubleValue.toObject(includeInstance, f)
     };
 
     if (includeInstance) {
@@ -42,30 +79,90 @@ class MySimple extends jspb.Message {
     return obj;
   };
 
-  static deserializeBinary(bytes: Uint8Array) {
-    const reader = new jspb.BinaryReader(bytes);
-    const msg = new MySimple();
+  static deserializeBinary(bytes: Uint8Array): MySimple {
+    var reader = new jspb.BinaryReader(bytes);
+    var msg = new MySimple;
     return MySimple.deserializeBinaryFromReader(msg, reader);
   };
 
-  static deserializeBinaryFromReader(msg: MySimple, reader: jspb.BinaryReader) {
+  static deserializeBinaryFromReader(msg: MySimple, reader: jspb.BinaryReader): MySimple {
     while (reader.nextField()) {
       if (reader.isEndGroup()) {
         break;
       }
-      const field = reader.getFieldNumber();
+      var field = reader.getFieldNumber();
       switch (field) {
         case 1:
-          const value1 = (reader.readString());
+          var value1 = /** @type {string} */ (reader.readString());
           msg.setMyString(value1);
           break;
         case 2:
-          const value2 = (reader.readBool());
+          var value2 = /** @type {boolean} */ (reader.readBool());
           msg.setMyBool(value2);
           break;
         case 3:
-          const value3 = (reader.readString());
+          var value3 = /** @type {string} */ (reader.readString());
           msg.addSomeLabels(value3);
+          break;
+        case 4:
+          var value4 = new google_protobuf_compiler_plugin_pb.CodeGeneratorRequest;
+          reader.readMessage(value4, google_protobuf_compiler_plugin_pb.CodeGeneratorRequest.deserializeBinaryFromReader);
+          msg.setSomeCodeGeneratorRequest(value4);
+          break;
+        case 5:
+          var value5 = new google_protobuf_any_pb.Any;
+          reader.readMessage(value5, google_protobuf_any_pb.Any.deserializeBinaryFromReader);
+          msg.setSomeAny(value5);
+          break;
+        case 6:
+          var value6 = new google_protobuf_api_pb.Method;
+          reader.readMessage(value6, google_protobuf_api_pb.Method.deserializeBinaryFromReader);
+          msg.setSomeMethod(value6);
+          break;
+        case 7:
+          var value7 = new google_protobuf_descriptor_pb.GeneratedCodeInfo;
+          reader.readMessage(value7, google_protobuf_descriptor_pb.GeneratedCodeInfo.deserializeBinaryFromReader);
+          msg.setSomeGeneratedCodeInfo(value7);
+          break;
+        case 8:
+          var value8 = new google_protobuf_duration_pb.Duration;
+          reader.readMessage(value8, google_protobuf_duration_pb.Duration.deserializeBinaryFromReader);
+          msg.setSomeDuration(value8);
+          break;
+        case 9:
+          var value9 = new google_protobuf_empty_pb.Empty;
+          reader.readMessage(value9, google_protobuf_empty_pb.Empty.deserializeBinaryFromReader);
+          msg.setSomeEmpty(value9);
+          break;
+        case 10:
+          var value10 = new google_protobuf_field_mask_pb.FieldMask;
+          reader.readMessage(value10, google_protobuf_field_mask_pb.FieldMask.deserializeBinaryFromReader);
+          msg.setSomeFieldMask(value10);
+          break;
+        case 11:
+          var value11 = new google_protobuf_source_context_pb.SourceContext;
+          reader.readMessage(value11, google_protobuf_source_context_pb.SourceContext.deserializeBinaryFromReader);
+          msg.setSomeSourceContext(value11);
+          break;
+        case 12:
+          var value12 = new google_protobuf_struct_pb.Struct;
+          reader.readMessage(value12, google_protobuf_struct_pb.Struct.deserializeBinaryFromReader);
+          msg.setSomeStruct(value12);
+          break;
+        case 13:
+          var value13 = new google_protobuf_timestamp_pb.Timestamp;
+          reader.readMessage(value13, google_protobuf_timestamp_pb.Timestamp.deserializeBinaryFromReader);
+          msg.setSomeTimestamp(value13);
+          break;
+        case 14:
+          var value14 = new google_protobuf_type_pb.Type;
+          reader.readMessage(value14, google_protobuf_type_pb.Type.deserializeBinaryFromReader);
+          msg.setSomeType(value14);
+          break;
+        case 15:
+          var value15 = new google_protobuf_wrappers_pb.DoubleValue;
+          reader.readMessage(value15, google_protobuf_wrappers_pb.DoubleValue.deserializeBinaryFromReader);
+          msg.setSomeDoubleValue(value15);
           break;
         default:
           reader.skipField();
@@ -76,64 +173,353 @@ class MySimple extends jspb.Message {
   };
 
   serializeBinary(): Uint8Array {
-    const writer = new jspb.BinaryWriter();
+    var writer = new jspb.BinaryWriter();
     MySimple.serializeBinaryToWriter(this, writer);
     return writer.getResultBuffer();
   };
 
   static serializeBinaryToWriter(message: MySimple, writer: jspb.BinaryWriter) {
-    let f1 = message.getMyString();
-    if (f1.length > 0) {
+    var f = undefined;
+    f = message.getMyString();
+    if (f.length > 0) {
       writer.writeString(
         1,
-        f1,
+        f
       );
     }
-    const f2 = message.getMyBool();
-    if (f2) {
+    f = message.getMyBool();
+    if (f) {
       writer.writeBool(
         2,
-        f2,
+        f
       );
     }
-    const f3 = message.getSomeLabelsList();
-    if (f3.length > 0) {
+    f = message.getSomeLabelsList();
+    if (f.length > 0) {
       writer.writeRepeatedString(
         3,
-        f3,
+        f
       );
     }
-  }
+    f = message.getSomeCodeGeneratorRequest();
+    if (f != null) {
+      writer.writeMessage(
+        4,
+        f,
+        google_protobuf_compiler_plugin_pb.CodeGeneratorRequest.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeAny();
+    if (f != null) {
+      writer.writeMessage(
+        5,
+        f,
+        google_protobuf_any_pb.Any.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeMethod();
+    if (f != null) {
+      writer.writeMessage(
+        6,
+        f,
+        google_protobuf_api_pb.Method.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeGeneratedCodeInfo();
+    if (f != null) {
+      writer.writeMessage(
+        7,
+        f,
+        google_protobuf_descriptor_pb.GeneratedCodeInfo.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeDuration();
+    if (f != null) {
+      writer.writeMessage(
+        8,
+        f,
+        google_protobuf_duration_pb.Duration.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeEmpty();
+    if (f != null) {
+      writer.writeMessage(
+        9,
+        f,
+        google_protobuf_empty_pb.Empty.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeFieldMask();
+    if (f != null) {
+      writer.writeMessage(
+        10,
+        f,
+        google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeSourceContext();
+    if (f != null) {
+      writer.writeMessage(
+        11,
+        f,
+        google_protobuf_source_context_pb.SourceContext.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeStruct();
+    if (f != null) {
+      writer.writeMessage(
+        12,
+        f,
+        google_protobuf_struct_pb.Struct.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeTimestamp();
+    if (f != null) {
+      writer.writeMessage(
+        13,
+        f,
+        google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeType();
+    if (f != null) {
+      writer.writeMessage(
+        14,
+        f,
+        google_protobuf_type_pb.Type.serializeBinaryToWriter
+      );
+    }
+    f = message.getSomeDoubleValue();
+    if (f != null) {
+      writer.writeMessage(
+        15,
+        f,
+        google_protobuf_wrappers_pb.DoubleValue.serializeBinaryToWriter
+      );
+    }
+  };
 
   getMyString(): string {
     return jspb.Message.getFieldWithDefault(this, 1, "");
-  }
+  };
 
   setMyString(value: string) {
     jspb.Message.setField(this, 1, value);
-  }
+  };
 
   getMyBool(): boolean {
     return jspb.Message.getFieldWithDefault(this, 2, false);
-  }
+  };
 
   setMyBool(value: boolean) {
     jspb.Message.setField(this, 2, value);
-  }
+  };
 
-  getSomeLabelsList(): string[] {
+  getSomeLabelsList(): Array<string> {
     return jspb.Message.getField(this, 3);
-  }
+  };
 
-  setSomeLabelsList(value: string[]) {
+  setSomeLabelsList(value: Array<string>) {
     jspb.Message.setField(this, 3, value || []);
-  }
+  };
 
   addSomeLabels(value: string, opt_index?: number) {
     jspb.Message.addToRepeatedField(this, 3, value, opt_index);
-  }
+  };
 
   clearSomeLabelsList() {
     this.setSomeLabelsList([]);
-  }
-}
+  };
+
+  getSomeCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_compiler_plugin_pb.CodeGeneratorRequest, 4) as google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
+  };
+
+  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest) {
+    jspb.Message.setWrapperField(this, 4, value);
+  };
+
+  clearSomeCodeGeneratorRequest() {
+    this.setSomeCodeGeneratorRequest(undefined);
+  };
+
+  hasSomeCodeGeneratorRequest(): boolean {
+    return jspb.Message.getField(this, 4) != null;
+  };
+
+  getSomeAny(): google_protobuf_any_pb.Any | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_any_pb.Any, 5) as google_protobuf_any_pb.Any | undefined;
+  };
+
+  setSomeAny(value?: google_protobuf_any_pb.Any) {
+    jspb.Message.setWrapperField(this, 5, value);
+  };
+
+  clearSomeAny() {
+    this.setSomeAny(undefined);
+  };
+
+  hasSomeAny(): boolean {
+    return jspb.Message.getField(this, 5) != null;
+  };
+
+  getSomeMethod(): google_protobuf_api_pb.Method | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_api_pb.Method, 6) as google_protobuf_api_pb.Method | undefined;
+  };
+
+  setSomeMethod(value?: google_protobuf_api_pb.Method) {
+    jspb.Message.setWrapperField(this, 6, value);
+  };
+
+  clearSomeMethod() {
+    this.setSomeMethod(undefined);
+  };
+
+  hasSomeMethod(): boolean {
+    return jspb.Message.getField(this, 6) != null;
+  };
+
+  getSomeGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo|undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_descriptor_pb.GeneratedCodeInfo, 7) as google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
+  };
+
+  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo) {
+    jspb.Message.setWrapperField(this, 7, value);
+  };
+
+  clearSomeGeneratedCodeInfo() {
+    this.setSomeGeneratedCodeInfo(undefined);
+  };
+
+  hasSomeGeneratedCodeInfo(): boolean {
+    return jspb.Message.getField(this, 7) != null;
+  };
+
+  getSomeDuration(): google_protobuf_duration_pb.Duration | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_duration_pb.Duration, 8) as google_protobuf_duration_pb.Duration | undefined;
+  };
+
+  setSomeDuration(value?: google_protobuf_duration_pb.Duration) {
+    jspb.Message.setWrapperField(this, 8, value);
+  };
+
+  clearSomeDuration() {
+    this.setSomeDuration(undefined);
+  };
+
+  hasSomeDuration(): boolean {
+    return jspb.Message.getField(this, 8) != null;
+  };
+
+  getSomeEmpty(): google_protobuf_empty_pb.Empty | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_empty_pb.Empty, 9) as google_protobuf_empty_pb.Empty | undefined;
+  };
+
+  setSomeEmpty(value?: google_protobuf_empty_pb.Empty) {
+    jspb.Message.setWrapperField(this, 9, value);
+  };
+
+  clearSomeEmpty() {
+    this.setSomeEmpty(undefined);
+  };
+
+  hasSomeEmpty(): boolean {
+    return jspb.Message.getField(this, 9) != null;
+  };
+
+  getSomeFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_field_mask_pb.FieldMask, 10) as google_protobuf_field_mask_pb.FieldMask | undefined;
+  };
+
+  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask) {
+    jspb.Message.setWrapperField(this, 10, value);
+  };
+
+  clearSomeFieldMask() {
+    this.setSomeFieldMask(undefined);
+  };
+
+  hasSomeFieldMask(): boolean {
+    return jspb.Message.getField(this, 10) != null;
+  };
+
+  getSomeSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_source_context_pb.SourceContext, 11) as google_protobuf_source_context_pb.SourceContext | undefined;
+  };
+
+  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext) {
+    jspb.Message.setWrapperField(this, 11, value);
+  };
+
+  clearSomeSourceContext() {
+    this.setSomeSourceContext(undefined);
+  };
+
+  hasSomeSourceContext(): boolean {
+    return jspb.Message.getField(this, 11) != null;
+  };
+
+  getSomeStruct(): google_protobuf_struct_pb.Struct | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Struct, 12) as google_protobuf_struct_pb.Struct | undefined;
+  };
+
+  setSomeStruct(value?: google_protobuf_struct_pb.Struct) {
+    jspb.Message.setWrapperField(this, 12, value);
+  };
+
+  clearSomeStruct() {
+    this.setSomeStruct(undefined);
+  };
+
+  hasSomeStruct(): boolean {
+    return jspb.Message.getField(this, 12) != null;
+  };
+
+  getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 13) as google_protobuf_timestamp_pb.Timestamp | undefined;
+  };
+
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp) {
+    jspb.Message.setWrapperField(this, 13, value);
+  };
+
+  clearSomeTimestamp() {
+    this.setSomeTimestamp(undefined);
+  };
+
+  hasSomeTimestamp(): boolean {
+    return jspb.Message.getField(this, 13) != null;
+  };
+
+  getSomeType(): google_protobuf_type_pb.Type | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_type_pb.Type, 14) as google_protobuf_type_pb.Type | undefined;
+  };
+
+  setSomeType(value?: google_protobuf_type_pb.Type) {
+    jspb.Message.setWrapperField(this, 14, value);
+  };
+
+  clearSomeType() {
+    this.setSomeType(undefined);
+  };
+
+  hasSomeType(): boolean {
+    return jspb.Message.getField(this, 14) != null;
+  };
+
+  getSomeDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined {
+    return jspb.Message.getWrapperField(this, google_protobuf_wrappers_pb.DoubleValue, 15) as google_protobuf_wrappers_pb.DoubleValue | undefined;
+  };
+
+  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue) {
+    jspb.Message.setWrapperField(this, 15, value);
+  };
+
+  clearSomeDoubleValue() {
+    this.setSomeDoubleValue(undefined);
+  };
+
+  hasSomeDoubleValue(): boolean {
+    return jspb.Message.getField(this, 15) != null;
+  };
+};

--- a/google-protobuf/google-protobuf-tests.ts
+++ b/google-protobuf/google-protobuf-tests.ts
@@ -54,22 +54,22 @@ class MySimple extends jspb.Message {
   };
 
   static toObject(includeInstance: boolean, msg: MySimple): {} {
-    var f, obj = {
+    const obj = {
       myString: jspb.Message.getFieldWithDefault(msg, 1, ""),
       myBool: jspb.Message.getFieldWithDefault(msg, 2, false),
       someLabelsList: jspb.Message.getField(msg, 3),
-      someCodeGeneratorRequest: (f = msg.getSomeCodeGeneratorRequest()) && google_protobuf_compiler_plugin_pb.CodeGeneratorRequest.toObject(includeInstance, f),
-      someAny: (f = msg.getSomeAny()) && google_protobuf_any_pb.Any.toObject(includeInstance, f),
-      someMethod: (f = msg.getSomeMethod()) && google_protobuf_api_pb.Method.toObject(includeInstance, f),
-      someGeneratedCodeInfo: (f = msg.getSomeGeneratedCodeInfo()) && google_protobuf_descriptor_pb.GeneratedCodeInfo.toObject(includeInstance, f),
-      someDuration: (f = msg.getSomeDuration()) && google_protobuf_duration_pb.Duration.toObject(includeInstance, f),
-      someEmpty: (f = msg.getSomeEmpty()) && google_protobuf_empty_pb.Empty.toObject(includeInstance, f),
-      someFieldMask: (f = msg.getSomeFieldMask()) && google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, f),
-      someSourceContext: (f = msg.getSomeSourceContext()) && google_protobuf_source_context_pb.SourceContext.toObject(includeInstance, f),
-      someStruct: (f = msg.getSomeStruct()) && google_protobuf_struct_pb.Struct.toObject(includeInstance, f),
-      someTimestamp: (f = msg.getSomeTimestamp()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
-      someType: (f = msg.getSomeType()) && google_protobuf_type_pb.Type.toObject(includeInstance, f),
-      someDoubleValue: (f = msg.getSomeDoubleValue()) && google_protobuf_wrappers_pb.DoubleValue.toObject(includeInstance, f)
+      someCodeGeneratorRequest: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest.toObject(includeInstance, msg.getSomeCodeGeneratorRequest()),
+      someAny: google_protobuf_any_pb.Any.toObject(includeInstance, msg.getSomeAny()),
+      someMethod: google_protobuf_api_pb.Method.toObject(includeInstance, msg.getSomeMethod()),
+      someGeneratedCodeInfo: google_protobuf_descriptor_pb.GeneratedCodeInfo.toObject(includeInstance, msg.getSomeGeneratedCodeInfo()),
+      someDuration: google_protobuf_duration_pb.Duration.toObject(includeInstance, msg.getSomeDuration()),
+      someEmpty: google_protobuf_empty_pb.Empty.toObject(includeInstance, msg.getSomeEmpty()),
+      someFieldMask: google_protobuf_field_mask_pb.FieldMask.toObject(includeInstance, msg.getSomeFieldMask()),
+      someSourceContext: google_protobuf_source_context_pb.SourceContext.toObject(includeInstance, msg.getSomeSourceContext()),
+      someStruct: google_protobuf_struct_pb.Struct.toObject(includeInstance, msg.getSomeStruct()),
+      someTimestamp: google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, msg.getSomeTimestamp()),
+      someType: google_protobuf_type_pb.Type.toObject(includeInstance, msg.getSomeType()),
+      someDoubleValue: google_protobuf_wrappers_pb.DoubleValue.toObject(includeInstance, msg.getSomeDoubleValue()),
     };
 
     if (includeInstance) {
@@ -179,121 +179,120 @@ class MySimple extends jspb.Message {
   };
 
   static serializeBinaryToWriter(message: MySimple, writer: jspb.BinaryWriter) {
-    var f = undefined;
-    f = message.getMyString();
-    if (f.length > 0) {
+    const f1 = message.getMyString();
+    if (f1.length > 0) {
       writer.writeString(
         1,
-        f
+        f1
       );
     }
-    f = message.getMyBool();
-    if (f) {
+    const f2 = message.getMyBool();
+    if (f2) {
       writer.writeBool(
         2,
-        f
+        f2
       );
     }
-    f = message.getSomeLabelsList();
-    if (f.length > 0) {
+    const f3 = message.getSomeLabelsList();
+    if (f3.length > 0) {
       writer.writeRepeatedString(
         3,
-        f
+        f3
       );
     }
-    f = message.getSomeCodeGeneratorRequest();
-    if (f != null) {
+    const f4 = message.getSomeCodeGeneratorRequest();
+    if (f4 != null) {
       writer.writeMessage(
         4,
-        f,
+        f4,
         google_protobuf_compiler_plugin_pb.CodeGeneratorRequest.serializeBinaryToWriter
       );
     }
-    f = message.getSomeAny();
-    if (f != null) {
+    const f5 = message.getSomeAny();
+    if (f5 != null) {
       writer.writeMessage(
         5,
-        f,
+        f5,
         google_protobuf_any_pb.Any.serializeBinaryToWriter
       );
     }
-    f = message.getSomeMethod();
-    if (f != null) {
+    const f6 = message.getSomeMethod();
+    if (f6 != null) {
       writer.writeMessage(
         6,
-        f,
+        f6,
         google_protobuf_api_pb.Method.serializeBinaryToWriter
       );
     }
-    f = message.getSomeGeneratedCodeInfo();
-    if (f != null) {
+    const f7 = message.getSomeGeneratedCodeInfo();
+    if (f7 != null) {
       writer.writeMessage(
         7,
-        f,
+        f7,
         google_protobuf_descriptor_pb.GeneratedCodeInfo.serializeBinaryToWriter
       );
     }
-    f = message.getSomeDuration();
-    if (f != null) {
+    const f8 = message.getSomeDuration();
+    if (f8 != null) {
       writer.writeMessage(
         8,
-        f,
+        f8,
         google_protobuf_duration_pb.Duration.serializeBinaryToWriter
       );
     }
-    f = message.getSomeEmpty();
-    if (f != null) {
+    const f9 = message.getSomeEmpty();
+    if (f9 != null) {
       writer.writeMessage(
         9,
-        f,
+        f9,
         google_protobuf_empty_pb.Empty.serializeBinaryToWriter
       );
     }
-    f = message.getSomeFieldMask();
-    if (f != null) {
+    const f10 = message.getSomeFieldMask();
+    if (f10 != null) {
       writer.writeMessage(
         10,
-        f,
+        f10,
         google_protobuf_field_mask_pb.FieldMask.serializeBinaryToWriter
       );
     }
-    f = message.getSomeSourceContext();
-    if (f != null) {
+    const f11 = message.getSomeSourceContext();
+    if (f11 != null) {
       writer.writeMessage(
         11,
-        f,
+        f11,
         google_protobuf_source_context_pb.SourceContext.serializeBinaryToWriter
       );
     }
-    f = message.getSomeStruct();
-    if (f != null) {
+    const f12 = message.getSomeStruct();
+    if (f12 != null) {
       writer.writeMessage(
         12,
-        f,
+        f12,
         google_protobuf_struct_pb.Struct.serializeBinaryToWriter
       );
     }
-    f = message.getSomeTimestamp();
-    if (f != null) {
+    const f13 = message.getSomeTimestamp();
+    if (f13 != null) {
       writer.writeMessage(
         13,
-        f,
+        f13,
         google_protobuf_timestamp_pb.Timestamp.serializeBinaryToWriter
       );
     }
-    f = message.getSomeType();
-    if (f != null) {
+    const f14 = message.getSomeType();
+    if (f14 != null) {
       writer.writeMessage(
         14,
-        f,
+        f14,
         google_protobuf_type_pb.Type.serializeBinaryToWriter
       );
     }
-    f = message.getSomeDoubleValue();
-    if (f != null) {
+    const f15 = message.getSomeDoubleValue();
+    if (f15 != null) {
       writer.writeMessage(
         15,
-        f,
+        f15,
         google_protobuf_wrappers_pb.DoubleValue.serializeBinaryToWriter
       );
     }
@@ -331,8 +330,8 @@ class MySimple extends jspb.Message {
     this.setSomeLabelsList([]);
   };
 
-  getSomeCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_compiler_plugin_pb.CodeGeneratorRequest, 4) as google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
+  getSomeCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest {
+    return jspb.Message.getWrapperField(this, google_protobuf_compiler_plugin_pb.CodeGeneratorRequest, 4) as google_protobuf_compiler_plugin_pb.CodeGeneratorRequest;
   };
 
   setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest) {
@@ -347,8 +346,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 4) != null;
   };
 
-  getSomeAny(): google_protobuf_any_pb.Any | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_any_pb.Any, 5) as google_protobuf_any_pb.Any | undefined;
+  getSomeAny(): google_protobuf_any_pb.Any {
+    return jspb.Message.getWrapperField(this, google_protobuf_any_pb.Any, 5) as google_protobuf_any_pb.Any;
   };
 
   setSomeAny(value?: google_protobuf_any_pb.Any) {
@@ -363,8 +362,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 5) != null;
   };
 
-  getSomeMethod(): google_protobuf_api_pb.Method | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_api_pb.Method, 6) as google_protobuf_api_pb.Method | undefined;
+  getSomeMethod(): google_protobuf_api_pb.Method {
+    return jspb.Message.getWrapperField(this, google_protobuf_api_pb.Method, 6) as google_protobuf_api_pb.Method;
   };
 
   setSomeMethod(value?: google_protobuf_api_pb.Method) {
@@ -379,8 +378,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 6) != null;
   };
 
-  getSomeGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo|undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_descriptor_pb.GeneratedCodeInfo, 7) as google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
+  getSomeGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo {
+    return jspb.Message.getWrapperField(this, google_protobuf_descriptor_pb.GeneratedCodeInfo, 7) as google_protobuf_descriptor_pb.GeneratedCodeInfo;
   };
 
   setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo) {
@@ -395,8 +394,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 7) != null;
   };
 
-  getSomeDuration(): google_protobuf_duration_pb.Duration | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_duration_pb.Duration, 8) as google_protobuf_duration_pb.Duration | undefined;
+  getSomeDuration(): google_protobuf_duration_pb.Duration {
+    return jspb.Message.getWrapperField(this, google_protobuf_duration_pb.Duration, 8) as google_protobuf_duration_pb.Duration;
   };
 
   setSomeDuration(value?: google_protobuf_duration_pb.Duration) {
@@ -411,8 +410,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 8) != null;
   };
 
-  getSomeEmpty(): google_protobuf_empty_pb.Empty | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_empty_pb.Empty, 9) as google_protobuf_empty_pb.Empty | undefined;
+  getSomeEmpty(): google_protobuf_empty_pb.Empty {
+    return jspb.Message.getWrapperField(this, google_protobuf_empty_pb.Empty, 9) as google_protobuf_empty_pb.Empty;
   };
 
   setSomeEmpty(value?: google_protobuf_empty_pb.Empty) {
@@ -427,8 +426,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 9) != null;
   };
 
-  getSomeFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_field_mask_pb.FieldMask, 10) as google_protobuf_field_mask_pb.FieldMask | undefined;
+  getSomeFieldMask(): google_protobuf_field_mask_pb.FieldMask {
+    return jspb.Message.getWrapperField(this, google_protobuf_field_mask_pb.FieldMask, 10) as google_protobuf_field_mask_pb.FieldMask;
   };
 
   setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask) {
@@ -443,8 +442,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 10) != null;
   };
 
-  getSomeSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_source_context_pb.SourceContext, 11) as google_protobuf_source_context_pb.SourceContext | undefined;
+  getSomeSourceContext(): google_protobuf_source_context_pb.SourceContext {
+    return jspb.Message.getWrapperField(this, google_protobuf_source_context_pb.SourceContext, 11) as google_protobuf_source_context_pb.SourceContext;
   };
 
   setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext) {
@@ -459,8 +458,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 11) != null;
   };
 
-  getSomeStruct(): google_protobuf_struct_pb.Struct | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Struct, 12) as google_protobuf_struct_pb.Struct | undefined;
+  getSomeStruct(): google_protobuf_struct_pb.Struct {
+    return jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Struct, 12) as google_protobuf_struct_pb.Struct;
   };
 
   setSomeStruct(value?: google_protobuf_struct_pb.Struct) {
@@ -475,8 +474,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 12) != null;
   };
 
-  getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 13) as google_protobuf_timestamp_pb.Timestamp | undefined;
+  getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp {
+    return jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 13) as google_protobuf_timestamp_pb.Timestamp;
   };
 
   setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp) {
@@ -491,8 +490,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 13) != null;
   };
 
-  getSomeType(): google_protobuf_type_pb.Type | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_type_pb.Type, 14) as google_protobuf_type_pb.Type | undefined;
+  getSomeType(): google_protobuf_type_pb.Type {
+    return jspb.Message.getWrapperField(this, google_protobuf_type_pb.Type, 14) as google_protobuf_type_pb.Type;
   };
 
   setSomeType(value?: google_protobuf_type_pb.Type) {
@@ -507,8 +506,8 @@ class MySimple extends jspb.Message {
     return jspb.Message.getField(this, 14) != null;
   };
 
-  getSomeDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined {
-    return jspb.Message.getWrapperField(this, google_protobuf_wrappers_pb.DoubleValue, 15) as google_protobuf_wrappers_pb.DoubleValue | undefined;
+  getSomeDoubleValue(): google_protobuf_wrappers_pb.DoubleValue {
+    return jspb.Message.getWrapperField(this, google_protobuf_wrappers_pb.DoubleValue, 15) as google_protobuf_wrappers_pb.DoubleValue;
   };
 
   setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue) {

--- a/google-protobuf/google/protobuf/any_pb.d.ts
+++ b/google-protobuf/google/protobuf/any_pb.d.ts
@@ -1,0 +1,24 @@
+import * as jspb from "../../index";
+
+export class Any extends jspb.Message {
+  getTypeUrl(): string;
+  setTypeUrl(value: string): void;
+
+  getValue(): Uint8Array | string;
+  getValue_asU8(): Uint8Array;
+  getValue_asB64(): string;
+  setValue(value: Uint8Array | string): void;
+
+  getTypeName(): string;
+  pack(serialized: Uint8Array, name: string, typeUrlPrefix?: string): void;
+  unpack<T extends jspb.Message>(deserialize: (packed: Uint8Array) => T, name: string): T | null;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Any): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Any, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Any;
+  static deserializeBinaryFromReader(message: Any, reader: jspb.BinaryReader): Any;
+}

--- a/google-protobuf/google/protobuf/any_pb.d.ts
+++ b/google-protobuf/google/protobuf/any_pb.d.ts
@@ -14,11 +14,19 @@ export class Any extends jspb.Message {
   unpack<T extends jspb.Message>(deserialize: (packed: Uint8Array) => T, name: string): T | null;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Any): {};
+  toObject(includeInstance?: boolean): Any.AsObject;
+  static toObject(includeInstance: boolean, msg: Any): Any.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Any, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Any;
   static deserializeBinaryFromReader(message: Any, reader: jspb.BinaryReader): Any;
 }
+
+export namespace Any {
+  export type AsObject = {
+    typeUrl: string,
+    value: Uint8Array | string,
+  }
+}
+

--- a/google-protobuf/google/protobuf/api_pb.d.ts
+++ b/google-protobuf/google/protobuf/api_pb.d.ts
@@ -33,13 +33,25 @@ export class Api extends jspb.Message {
   setSyntax(value: google_protobuf_type_pb.Syntax): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Api): {};
+  toObject(includeInstance?: boolean): Api.AsObject;
+  static toObject(includeInstance: boolean, msg: Api): Api.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Api, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Api;
   static deserializeBinaryFromReader(message: Api, reader: jspb.BinaryReader): Api;
+}
+
+export namespace Api {
+  export type AsObject = {
+    name: string,
+    methodsList: Array<Method.AsObject>,
+    optionsList: Array<google_protobuf_type_pb.Option.AsObject>,
+    version: string,
+    sourceContext: google_protobuf_source_context_pb.SourceContext.AsObject,
+    mixinsList: Array<Mixin.AsObject>,
+    syntax: google_protobuf_type_pb.Syntax,
+  }
 }
 
 export class Method extends jspb.Message {
@@ -67,13 +79,25 @@ export class Method extends jspb.Message {
   setSyntax(value: google_protobuf_type_pb.Syntax): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Method): {};
+  toObject(includeInstance?: boolean): Method.AsObject;
+  static toObject(includeInstance: boolean, msg: Method): Method.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Method, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Method;
   static deserializeBinaryFromReader(message: Method, reader: jspb.BinaryReader): Method;
+}
+
+export namespace Method {
+  export type AsObject = {
+    name: string,
+    requestTypeUrl: string,
+    requestStreaming: boolean,
+    responseTypeUrl: string,
+    responseStreaming: boolean,
+    optionsList: Array<google_protobuf_type_pb.Option.AsObject>,
+    syntax: google_protobuf_type_pb.Syntax,
+  }
 }
 
 export class Mixin extends jspb.Message {
@@ -84,11 +108,19 @@ export class Mixin extends jspb.Message {
   setRoot(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Mixin): {};
+  toObject(includeInstance?: boolean): Mixin.AsObject;
+  static toObject(includeInstance: boolean, msg: Mixin): Mixin.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Mixin, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Mixin;
   static deserializeBinaryFromReader(message: Mixin, reader: jspb.BinaryReader): Mixin;
 }
+
+export namespace Mixin {
+  export type AsObject = {
+    name: string,
+    root: string,
+  }
+}
+

--- a/google-protobuf/google/protobuf/api_pb.d.ts
+++ b/google-protobuf/google/protobuf/api_pb.d.ts
@@ -1,0 +1,94 @@
+import * as jspb from "../../index";
+import * as google_protobuf_source_context_pb from "./source_context_pb";
+import * as google_protobuf_type_pb from "./type_pb";
+
+export class Api extends jspb.Message {
+  getName(): string;
+  setName(value: string): void;
+
+  clearMethodsList(): void;
+  getMethodsList(): Array<Method>;
+  setMethodsList(value: Array<Method>): void;
+  addMethods(value?: Method, index?: number): void;
+
+  clearOptionsList(): void;
+  getOptionsList(): Array<google_protobuf_type_pb.Option>;
+  setOptionsList(value: Array<google_protobuf_type_pb.Option>): void;
+  addOptions(value?: google_protobuf_type_pb.Option, index?: number): void;
+
+  getVersion(): string;
+  setVersion(value: string): void;
+
+  hasSourceContext(): boolean;
+  clearSourceContext(): void;
+  getSourceContext(): google_protobuf_source_context_pb.SourceContext;
+  setSourceContext(value: google_protobuf_source_context_pb.SourceContext): void;
+
+  clearMixinsList(): void;
+  getMixinsList(): Array<Mixin>;
+  setMixinsList(value: Array<Mixin>): void;
+  addMixins(value?: Mixin, index?: number): void;
+
+  getSyntax(): google_protobuf_type_pb.Syntax;
+  setSyntax(value: google_protobuf_type_pb.Syntax): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Api): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Api, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Api;
+  static deserializeBinaryFromReader(message: Api, reader: jspb.BinaryReader): Api;
+}
+
+export class Method extends jspb.Message {
+  getName(): string;
+  setName(value: string): void;
+
+  getRequestTypeUrl(): string;
+  setRequestTypeUrl(value: string): void;
+
+  getRequestStreaming(): boolean;
+  setRequestStreaming(value: boolean): void;
+
+  getResponseTypeUrl(): string;
+  setResponseTypeUrl(value: string): void;
+
+  getResponseStreaming(): boolean;
+  setResponseStreaming(value: boolean): void;
+
+  clearOptionsList(): void;
+  getOptionsList(): Array<google_protobuf_type_pb.Option>;
+  setOptionsList(value: Array<google_protobuf_type_pb.Option>): void;
+  addOptions(value?: google_protobuf_type_pb.Option, index?: number): void;
+
+  getSyntax(): google_protobuf_type_pb.Syntax;
+  setSyntax(value: google_protobuf_type_pb.Syntax): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Method): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Method, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Method;
+  static deserializeBinaryFromReader(message: Method, reader: jspb.BinaryReader): Method;
+}
+
+export class Mixin extends jspb.Message {
+  getName(): string;
+  setName(value: string): void;
+
+  getRoot(): string;
+  setRoot(value: string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Mixin): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Mixin, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Mixin;
+  static deserializeBinaryFromReader(message: Mixin, reader: jspb.BinaryReader): Mixin;
+}

--- a/google-protobuf/google/protobuf/compiler/plugin_pb.d.ts
+++ b/google-protobuf/google/protobuf/compiler/plugin_pb.d.ts
@@ -22,14 +22,23 @@ export class Version extends jspb.Message {
   getSuffix(): string;
   setSuffix(value: string): void;
 
-  static deserializeBinary(bytes: Uint8Array): Version;
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Version): {};
+  toObject(includeInstance?: boolean): Version.AsObject;
+  static toObject(includeInstance: boolean, msg: Version): Version.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Version, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Version;
   static deserializeBinaryFromReader(message: Version, reader: jspb.BinaryReader): Version;
+}
+
+export namespace Version {
+  export type AsObject = {
+    major: number,
+    minor: number,
+    patch: number,
+    suffix: string,
+  }
 }
 
 export class CodeGeneratorRequest extends jspb.Message {
@@ -53,14 +62,23 @@ export class CodeGeneratorRequest extends jspb.Message {
   getCompilerVersion(): Version;
   setCompilerVersion(value: Version): void;
 
-  static deserializeBinary(bytes: Uint8Array): CodeGeneratorRequest;
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: CodeGeneratorRequest): {};
+  toObject(includeInstance?: boolean): CodeGeneratorRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: CodeGeneratorRequest): CodeGeneratorRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: CodeGeneratorRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CodeGeneratorRequest;
   static deserializeBinaryFromReader(message: CodeGeneratorRequest, reader: jspb.BinaryReader): CodeGeneratorRequest;
+}
+
+export namespace CodeGeneratorRequest {
+  export type AsObject = {
+    fileToGenerateList: Array<string>,
+    parameter: string,
+    protoFileList: Array<google_protobuf_descriptor_pb.FileDescriptorProto.AsObject>,
+    compilerVersion: Version.AsObject,
+  }
 }
 
 export class CodeGeneratorResponse extends jspb.Message {
@@ -74,40 +92,54 @@ export class CodeGeneratorResponse extends jspb.Message {
   setFileList(value: Array<CodeGeneratorResponse.File>): void;
   addFile(value?: CodeGeneratorResponse.File, index?: number): void;
 
-  static deserializeBinary(bytes: Uint8Array): CodeGeneratorResponse;
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: CodeGeneratorResponse): {};
+  toObject(includeInstance?: boolean): CodeGeneratorResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: CodeGeneratorResponse): CodeGeneratorResponse.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: CodeGeneratorResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CodeGeneratorResponse;
   static deserializeBinaryFromReader(message: CodeGeneratorResponse, reader: jspb.BinaryReader): CodeGeneratorResponse;
 }
 
 export namespace CodeGeneratorResponse {
+  export type AsObject = {
+    error: string,
+    fileList: Array<CodeGeneratorResponse.File.AsObject>,
+  }
+
   export class File extends jspb.Message {
-   hasName(): boolean;
-   clearName(): void;
-   getName(): string;
-   setName(value: string): void;
+    hasName(): boolean;
+    clearName(): void;
+    getName(): string;
+    setName(value: string): void;
 
-   hasInsertionPoint(): boolean;
-   clearInsertionPoint(): void;
-   getInsertionPoint(): string;
-   setInsertionPoint(value: string): void;
+    hasInsertionPoint(): boolean;
+    clearInsertionPoint(): void;
+    getInsertionPoint(): string;
+    setInsertionPoint(value: string): void;
 
-   hasContent(): boolean;
-   clearContent(): void;
-   getContent(): string;
-   setContent(value: string): void;
+    hasContent(): boolean;
+    clearContent(): void;
+    getContent(): string;
+    setContent(value: string): void;
 
-   static deserializeBinary(bytes: Uint8Array): File;
-   serializeBinary(): Uint8Array;
-   toObject(includeInstance?: boolean): {};
-   static toObject(includeInstance: boolean, msg: File): {};
-   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-   static serializeBinaryToWriter(message: File, writer: jspb.BinaryWriter): void;
-   static deserializeBinaryFromReader(message: File, reader: jspb.BinaryReader): File;
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): File.AsObject;
+    static toObject(includeInstance: boolean, msg: File): File.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: File, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): File;
+    static deserializeBinaryFromReader(message: File, reader: jspb.BinaryReader): File;
+  }
+
+  export namespace File {
+    export type AsObject = {
+      name: string,
+      insertionPoint: string,
+      content: string,
+    }
   }
 }
+

--- a/google-protobuf/google/protobuf/compiler/plugin_pb.d.ts
+++ b/google-protobuf/google/protobuf/compiler/plugin_pb.d.ts
@@ -1,0 +1,113 @@
+import * as jspb from "../../../index";
+import * as google_protobuf_descriptor_pb from "../descriptor_pb";
+
+export class Version extends jspb.Message {
+  hasMajor(): boolean;
+  clearMajor(): void;
+  getMajor(): number;
+  setMajor(value: number): void;
+
+  hasMinor(): boolean;
+  clearMinor(): void;
+  getMinor(): number;
+  setMinor(value: number): void;
+
+  hasPatch(): boolean;
+  clearPatch(): void;
+  getPatch(): number;
+  setPatch(value: number): void;
+
+  hasSuffix(): boolean;
+  clearSuffix(): void;
+  getSuffix(): string;
+  setSuffix(value: string): void;
+
+  static deserializeBinary(bytes: Uint8Array): Version;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Version): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Version, writer: jspb.BinaryWriter): void;
+  static deserializeBinaryFromReader(message: Version, reader: jspb.BinaryReader): Version;
+}
+
+export class CodeGeneratorRequest extends jspb.Message {
+  clearFileToGenerateList(): void;
+  getFileToGenerateList(): Array<string>;
+  setFileToGenerateList(value: Array<string>): void;
+  addFileToGenerate(value: string, index?: number): void;
+
+  hasParameter(): boolean;
+  clearParameter(): void;
+  getParameter(): string;
+  setParameter(value: string): void;
+
+  clearProtoFileList(): void;
+  getProtoFileList(): Array<google_protobuf_descriptor_pb.FileDescriptorProto>;
+  setProtoFileList(value: Array<google_protobuf_descriptor_pb.FileDescriptorProto>): void;
+  addProtoFile(value?: google_protobuf_descriptor_pb.FileDescriptorProto, index?: number): void;
+
+  hasCompilerVersion(): boolean;
+  clearCompilerVersion(): void;
+  getCompilerVersion(): Version;
+  setCompilerVersion(value: Version): void;
+
+  static deserializeBinary(bytes: Uint8Array): CodeGeneratorRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: CodeGeneratorRequest): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CodeGeneratorRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinaryFromReader(message: CodeGeneratorRequest, reader: jspb.BinaryReader): CodeGeneratorRequest;
+}
+
+export class CodeGeneratorResponse extends jspb.Message {
+  hasError(): boolean;
+  clearError(): void;
+  getError(): string;
+  setError(value: string): void;
+
+  clearFileList(): void;
+  getFileList(): Array<CodeGeneratorResponse.File>;
+  setFileList(value: Array<CodeGeneratorResponse.File>): void;
+  addFile(value?: CodeGeneratorResponse.File, index?: number): void;
+
+  static deserializeBinary(bytes: Uint8Array): CodeGeneratorResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: CodeGeneratorResponse): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CodeGeneratorResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinaryFromReader(message: CodeGeneratorResponse, reader: jspb.BinaryReader): CodeGeneratorResponse;
+}
+
+export namespace CodeGeneratorResponse {
+  export class File extends jspb.Message {
+   hasName(): boolean;
+   clearName(): void;
+   getName(): string;
+   setName(value: string): void;
+
+   hasInsertionPoint(): boolean;
+   clearInsertionPoint(): void;
+   getInsertionPoint(): string;
+   setInsertionPoint(value: string): void;
+
+   hasContent(): boolean;
+   clearContent(): void;
+   getContent(): string;
+   setContent(value: string): void;
+
+   static deserializeBinary(bytes: Uint8Array): File;
+   serializeBinary(): Uint8Array;
+   toObject(includeInstance?: boolean): {};
+   static toObject(includeInstance: boolean, msg: File): {};
+   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+   static serializeBinaryToWriter(message: File, writer: jspb.BinaryWriter): void;
+   static deserializeBinaryFromReader(message: File, reader: jspb.BinaryReader): File;
+  }
+}

--- a/google-protobuf/google/protobuf/descriptor_pb.d.ts
+++ b/google-protobuf/google/protobuf/descriptor_pb.d.ts
@@ -1,0 +1,908 @@
+import * as jspb from "../../index";
+
+export class FileDescriptorSet extends jspb.Message {
+  clearFileList(): void;
+  getFileList(): Array<FileDescriptorProto>;
+  setFileList(value: Array<FileDescriptorProto>): void;
+  addFile(value?: FileDescriptorProto, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: FileDescriptorSet): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileDescriptorSet, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileDescriptorSet;
+  static deserializeBinaryFromReader(message: FileDescriptorSet, reader: jspb.BinaryReader): FileDescriptorSet;
+}
+
+export class FileDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string;
+  setName(value: string): void;
+
+  hasPackage(): boolean;
+  clearPackage(): void;
+  getPackage(): string;
+  setPackage(value: string): void;
+
+  clearDependencyList(): void;
+  getDependencyList(): Array<string>;
+  setDependencyList(value: Array<string>): void;
+  addDependency(value: string, index?: number): void;
+
+  clearPublicDependencyList(): void;
+  getPublicDependencyList(): Array<number>;
+  setPublicDependencyList(value: Array<number>): void;
+  addPublicDependency(value: number, index?: number): void;
+
+  clearWeakDependencyList(): void;
+  getWeakDependencyList(): Array<number>;
+  setWeakDependencyList(value: Array<number>): void;
+  addWeakDependency(value: number, index?: number): void;
+
+  clearMessageTypeList(): void;
+  getMessageTypeList(): Array<DescriptorProto>;
+  setMessageTypeList(value: Array<DescriptorProto>): void;
+  addMessageType(value?: DescriptorProto, index?: number): void;
+
+  clearEnumTypeList(): void;
+  getEnumTypeList(): Array<EnumDescriptorProto>;
+  setEnumTypeList(value: Array<EnumDescriptorProto>): void;
+  addEnumType(value?: EnumDescriptorProto, index?: number): void;
+
+  clearServiceList(): void;
+  getServiceList(): Array<ServiceDescriptorProto>;
+  setServiceList(value: Array<ServiceDescriptorProto>): void;
+  addService(value?: ServiceDescriptorProto, index?: number): void;
+
+  clearExtensionList(): void;
+  getExtensionList(): Array<FieldDescriptorProto>;
+  setExtensionList(value: Array<FieldDescriptorProto>): void;
+  addExtension(value?: FieldDescriptorProto, index?: number): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): FileOptions;
+  setOptions(value: FileOptions): void;
+
+  hasSourceCodeInfo(): boolean;
+  clearSourceCodeInfo(): void;
+  getSourceCodeInfo(): SourceCodeInfo;
+  setSourceCodeInfo(value: SourceCodeInfo): void;
+
+  hasSyntax(): boolean;
+  clearSyntax(): void;
+  getSyntax(): string;
+  setSyntax(value: string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: FileDescriptorProto): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileDescriptorProto;
+  static deserializeBinaryFromReader(message: FileDescriptorProto, reader: jspb.BinaryReader): FileDescriptorProto;
+}
+
+export class DescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string;
+  setName(value: string): void;
+
+  clearFieldList(): void;
+  getFieldList(): Array<FieldDescriptorProto>;
+  setFieldList(value: Array<FieldDescriptorProto>): void;
+  addField(value?: FieldDescriptorProto, index?: number): void;
+
+  clearExtensionList(): void;
+  getExtensionList(): Array<FieldDescriptorProto>;
+  setExtensionList(value: Array<FieldDescriptorProto>): void;
+  addExtension(value?: FieldDescriptorProto, index?: number): void;
+
+  clearNestedTypeList(): void;
+  getNestedTypeList(): Array<DescriptorProto>;
+  setNestedTypeList(value: Array<DescriptorProto>): void;
+  addNestedType(value?: DescriptorProto, index?: number): void;
+
+  clearEnumTypeList(): void;
+  getEnumTypeList(): Array<EnumDescriptorProto>;
+  setEnumTypeList(value: Array<EnumDescriptorProto>): void;
+  addEnumType(value?: EnumDescriptorProto, index?: number): void;
+
+  clearExtensionRangeList(): void;
+  getExtensionRangeList(): Array<DescriptorProto.ExtensionRange>;
+  setExtensionRangeList(value: Array<DescriptorProto.ExtensionRange>): void;
+  addExtensionRange(value?: DescriptorProto.ExtensionRange, index?: number): void;
+
+  clearOneofDeclList(): void;
+  getOneofDeclList(): Array<OneofDescriptorProto>;
+  setOneofDeclList(value: Array<OneofDescriptorProto>): void;
+  addOneofDecl(value?: OneofDescriptorProto, index?: number): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): MessageOptions;
+  setOptions(value: MessageOptions): void;
+
+  clearReservedRangeList(): void;
+  getReservedRangeList(): Array<DescriptorProto.ReservedRange>;
+  setReservedRangeList(value: Array<DescriptorProto.ReservedRange>): void;
+  addReservedRange(value?: DescriptorProto.ReservedRange, index?: number): void;
+
+  clearReservedNameList(): void;
+  getReservedNameList(): Array<string>;
+  setReservedNameList(value: Array<string>): void;
+  addReservedName(value: string, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: DescriptorProto): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DescriptorProto;
+  static deserializeBinaryFromReader(message: DescriptorProto, reader: jspb.BinaryReader): DescriptorProto;
+}
+
+export namespace DescriptorProto {
+  export class ExtensionRange extends jspb.Message {
+    hasStart(): boolean;
+    clearStart(): void;
+    getStart(): number;
+    setStart(value: number): void;
+
+    hasEnd(): boolean;
+    clearEnd(): void;
+    getEnd(): number;
+    setEnd(value: number): void;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): {};
+    static toObject(includeInstance: boolean, msg: ExtensionRange): {};
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ExtensionRange, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ExtensionRange;
+    static deserializeBinaryFromReader(message: ExtensionRange, reader: jspb.BinaryReader): ExtensionRange;
+  }
+
+  export class ReservedRange extends jspb.Message {
+    hasStart(): boolean;
+    clearStart(): void;
+    getStart(): number;
+    setStart(value: number): void;
+
+    hasEnd(): boolean;
+    clearEnd(): void;
+    getEnd(): number;
+    setEnd(value: number): void;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): {};
+    static toObject(includeInstance: boolean, msg: ReservedRange): {};
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ReservedRange, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ReservedRange;
+    static deserializeBinaryFromReader(message: ReservedRange, reader: jspb.BinaryReader): ReservedRange;
+  }
+}
+
+export class FieldDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string;
+  setName(value: string): void;
+
+  hasNumber(): boolean;
+  clearNumber(): void;
+  getNumber(): number;
+  setNumber(value: number): void;
+
+  hasLabel(): boolean;
+  clearLabel(): void;
+  getLabel(): FieldDescriptorProto.Label;
+  setLabel(value: FieldDescriptorProto.Label): void;
+
+  hasType(): boolean;
+  clearType(): void;
+  getType(): FieldDescriptorProto.Type;
+  setType(value: FieldDescriptorProto.Type): void;
+
+  hasTypeName(): boolean;
+  clearTypeName(): void;
+  getTypeName(): string;
+  setTypeName(value: string): void;
+
+  hasExtendee(): boolean;
+  clearExtendee(): void;
+  getExtendee(): string;
+  setExtendee(value: string): void;
+
+  hasDefaultValue(): boolean;
+  clearDefaultValue(): void;
+  getDefaultValue(): string;
+  setDefaultValue(value: string): void;
+
+  hasOneofIndex(): boolean;
+  clearOneofIndex(): void;
+  getOneofIndex(): number;
+  setOneofIndex(value: number): void;
+
+  hasJsonName(): boolean;
+  clearJsonName(): void;
+  getJsonName(): string;
+  setJsonName(value: string): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): FieldOptions;
+  setOptions(value: FieldOptions): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: FieldDescriptorProto): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FieldDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FieldDescriptorProto;
+  static deserializeBinaryFromReader(message: FieldDescriptorProto, reader: jspb.BinaryReader): FieldDescriptorProto;
+}
+
+export namespace FieldDescriptorProto {
+  export enum Type {
+    TYPE_DOUBLE = 1,
+    TYPE_FLOAT = 2,
+    TYPE_INT64 = 3,
+    TYPE_UINT64 = 4,
+    TYPE_INT32 = 5,
+    TYPE_FIXED64 = 6,
+    TYPE_FIXED32 = 7,
+    TYPE_BOOL = 8,
+    TYPE_STRING = 9,
+    TYPE_GROUP = 10,
+    TYPE_MESSAGE = 11,
+    TYPE_BYTES = 12,
+    TYPE_UINT32 = 13,
+    TYPE_ENUM = 14,
+    TYPE_SFIXED32 = 15,
+    TYPE_SFIXED64 = 16,
+    TYPE_SINT32 = 17,
+    TYPE_SINT64 = 18,
+  }
+  export enum Label {
+    LABEL_OPTIONAL = 1,
+    LABEL_REQUIRED = 2,
+    LABEL_REPEATED = 3,
+  }
+}
+
+export class OneofDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string;
+  setName(value: string): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): OneofOptions;
+  setOptions(value: OneofOptions): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: OneofDescriptorProto): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OneofDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OneofDescriptorProto;
+  static deserializeBinaryFromReader(message: OneofDescriptorProto, reader: jspb.BinaryReader): OneofDescriptorProto;
+}
+
+export class EnumDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string;
+  setName(value: string): void;
+
+  clearValueList(): void;
+  getValueList(): Array<EnumValueDescriptorProto>;
+  setValueList(value: Array<EnumValueDescriptorProto>): void;
+  addValue(value?: EnumValueDescriptorProto, index?: number): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): EnumOptions;
+  setOptions(value: EnumOptions): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: EnumDescriptorProto): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumDescriptorProto;
+  static deserializeBinaryFromReader(message: EnumDescriptorProto, reader: jspb.BinaryReader): EnumDescriptorProto;
+}
+
+export class EnumValueDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string;
+  setName(value: string): void;
+
+  hasNumber(): boolean;
+  clearNumber(): void;
+  getNumber(): number;
+  setNumber(value: number): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): EnumValueOptions;
+  setOptions(value: EnumValueOptions): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: EnumValueDescriptorProto): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumValueDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumValueDescriptorProto;
+  static deserializeBinaryFromReader(message: EnumValueDescriptorProto, reader: jspb.BinaryReader): EnumValueDescriptorProto;
+}
+
+export class ServiceDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string;
+  setName(value: string): void;
+
+  clearMethodList(): void;
+  getMethodList(): Array<MethodDescriptorProto>;
+  setMethodList(value: Array<MethodDescriptorProto>): void;
+  addMethod(value?: MethodDescriptorProto, index?: number): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): ServiceOptions;
+  setOptions(value: ServiceOptions): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: ServiceDescriptorProto): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ServiceDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ServiceDescriptorProto;
+  static deserializeBinaryFromReader(message: ServiceDescriptorProto, reader: jspb.BinaryReader): ServiceDescriptorProto;
+}
+
+export class MethodDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string;
+  setName(value: string): void;
+
+  hasInputType(): boolean;
+  clearInputType(): void;
+  getInputType(): string;
+  setInputType(value: string): void;
+
+  hasOutputType(): boolean;
+  clearOutputType(): void;
+  getOutputType(): string;
+  setOutputType(value: string): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): MethodOptions;
+  setOptions(value: MethodOptions): void;
+
+  hasClientStreaming(): boolean;
+  clearClientStreaming(): void;
+  getClientStreaming(): boolean;
+  setClientStreaming(value: boolean): void;
+
+  hasServerStreaming(): boolean;
+  clearServerStreaming(): void;
+  getServerStreaming(): boolean;
+  setServerStreaming(value: boolean): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: MethodDescriptorProto): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MethodDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MethodDescriptorProto;
+  static deserializeBinaryFromReader(message: MethodDescriptorProto, reader: jspb.BinaryReader): MethodDescriptorProto;
+}
+
+export class FileOptions extends jspb.Message {
+  hasJavaPackage(): boolean;
+  clearJavaPackage(): void;
+  getJavaPackage(): string;
+  setJavaPackage(value: string): void;
+
+  hasJavaOuterClassname(): boolean;
+  clearJavaOuterClassname(): void;
+  getJavaOuterClassname(): string;
+  setJavaOuterClassname(value: string): void;
+
+  hasJavaMultipleFiles(): boolean;
+  clearJavaMultipleFiles(): void;
+  getJavaMultipleFiles(): boolean;
+  setJavaMultipleFiles(value: boolean): void;
+
+  hasJavaGenerateEqualsAndHash(): boolean;
+  clearJavaGenerateEqualsAndHash(): void;
+  getJavaGenerateEqualsAndHash(): boolean;
+  setJavaGenerateEqualsAndHash(value: boolean): void;
+
+  hasJavaStringCheckUtf8(): boolean;
+  clearJavaStringCheckUtf8(): void;
+  getJavaStringCheckUtf8(): boolean;
+  setJavaStringCheckUtf8(value: boolean): void;
+
+  hasOptimizeFor(): boolean;
+  clearOptimizeFor(): void;
+  getOptimizeFor(): FileOptions.OptimizeMode;
+  setOptimizeFor(value: FileOptions.OptimizeMode): void;
+
+  hasGoPackage(): boolean;
+  clearGoPackage(): void;
+  getGoPackage(): string;
+  setGoPackage(value: string): void;
+
+  hasCcGenericServices(): boolean;
+  clearCcGenericServices(): void;
+  getCcGenericServices(): boolean;
+  setCcGenericServices(value: boolean): void;
+
+  hasJavaGenericServices(): boolean;
+  clearJavaGenericServices(): void;
+  getJavaGenericServices(): boolean;
+  setJavaGenericServices(value: boolean): void;
+
+  hasPyGenericServices(): boolean;
+  clearPyGenericServices(): void;
+  getPyGenericServices(): boolean;
+  setPyGenericServices(value: boolean): void;
+
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean;
+  setDeprecated(value: boolean): void;
+
+  hasCcEnableArenas(): boolean;
+  clearCcEnableArenas(): void;
+  getCcEnableArenas(): boolean;
+  setCcEnableArenas(value: boolean): void;
+
+  hasObjcClassPrefix(): boolean;
+  clearObjcClassPrefix(): void;
+  getObjcClassPrefix(): string;
+  setObjcClassPrefix(value: string): void;
+
+  hasCsharpNamespace(): boolean;
+  clearCsharpNamespace(): void;
+  getCsharpNamespace(): string;
+  setCsharpNamespace(value: string): void;
+
+  hasSwiftPrefix(): boolean;
+  clearSwiftPrefix(): void;
+  getSwiftPrefix(): string;
+  setSwiftPrefix(value: string): void;
+
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: FileOptions): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileOptions;
+  static deserializeBinaryFromReader(message: FileOptions, reader: jspb.BinaryReader): FileOptions;
+}
+
+export namespace FileOptions {
+  export enum OptimizeMode {
+    SPEED = 1,
+    CODE_SIZE = 2,
+    LITE_RUNTIME = 3,
+  }
+}
+
+export class MessageOptions extends jspb.Message {
+  hasMessageSetWireFormat(): boolean;
+  clearMessageSetWireFormat(): void;
+  getMessageSetWireFormat(): boolean;
+  setMessageSetWireFormat(value: boolean): void;
+
+  hasNoStandardDescriptorAccessor(): boolean;
+  clearNoStandardDescriptorAccessor(): void;
+  getNoStandardDescriptorAccessor(): boolean;
+  setNoStandardDescriptorAccessor(value: boolean): void;
+
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean;
+  setDeprecated(value: boolean): void;
+
+  hasMapEntry(): boolean;
+  clearMapEntry(): void;
+  getMapEntry(): boolean;
+  setMapEntry(value: boolean): void;
+
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: MessageOptions): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MessageOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MessageOptions;
+  static deserializeBinaryFromReader(message: MessageOptions, reader: jspb.BinaryReader): MessageOptions;
+}
+
+export class FieldOptions extends jspb.Message {
+  hasCtype(): boolean;
+  clearCtype(): void;
+  getCtype(): FieldOptions.CType;
+  setCtype(value: FieldOptions.CType): void;
+
+  hasPacked(): boolean;
+  clearPacked(): void;
+  getPacked(): boolean;
+  setPacked(value: boolean): void;
+
+  hasJstype(): boolean;
+  clearJstype(): void;
+  getJstype(): FieldOptions.JSType;
+  setJstype(value: FieldOptions.JSType): void;
+
+  hasLazy(): boolean;
+  clearLazy(): void;
+  getLazy(): boolean;
+  setLazy(value: boolean): void;
+
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean;
+  setDeprecated(value: boolean): void;
+
+  hasWeak(): boolean;
+  clearWeak(): void;
+  getWeak(): boolean;
+  setWeak(value: boolean): void;
+
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: FieldOptions): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FieldOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FieldOptions;
+  static deserializeBinaryFromReader(message: FieldOptions, reader: jspb.BinaryReader): FieldOptions;
+}
+
+export namespace FieldOptions {
+  export enum CType {
+    STRING = 0,
+    CORD = 1,
+    STRING_PIECE = 2,
+  }
+  export enum JSType {
+    JS_NORMAL = 0,
+    JS_STRING = 1,
+    JS_NUMBER = 2,
+  }
+}
+
+export class OneofOptions extends jspb.Message {
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: OneofOptions): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OneofOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OneofOptions;
+  static deserializeBinaryFromReader(message: OneofOptions, reader: jspb.BinaryReader): OneofOptions;
+}
+
+export class EnumOptions extends jspb.Message {
+  hasAllowAlias(): boolean;
+  clearAllowAlias(): void;
+  getAllowAlias(): boolean;
+  setAllowAlias(value: boolean): void;
+
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean;
+  setDeprecated(value: boolean): void;
+
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: EnumOptions): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumOptions;
+  static deserializeBinaryFromReader(message: EnumOptions, reader: jspb.BinaryReader): EnumOptions;
+}
+
+export class EnumValueOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean;
+  setDeprecated(value: boolean): void;
+
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: EnumValueOptions): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumValueOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumValueOptions;
+  static deserializeBinaryFromReader(message: EnumValueOptions, reader: jspb.BinaryReader): EnumValueOptions;
+}
+
+export class ServiceOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean;
+  setDeprecated(value: boolean): void;
+
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: ServiceOptions): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ServiceOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ServiceOptions;
+  static deserializeBinaryFromReader(message: ServiceOptions, reader: jspb.BinaryReader): ServiceOptions;
+}
+
+export class MethodOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean;
+  setDeprecated(value: boolean): void;
+
+  hasIdempotencyLevel(): boolean;
+  clearIdempotencyLevel(): void;
+  getIdempotencyLevel(): MethodOptions.IdempotencyLevel;
+  setIdempotencyLevel(value: MethodOptions.IdempotencyLevel): void;
+
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: MethodOptions): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MethodOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MethodOptions;
+  static deserializeBinaryFromReader(message: MethodOptions, reader: jspb.BinaryReader): MethodOptions;
+}
+
+export namespace MethodOptions {
+  export enum IdempotencyLevel {
+    IDEMPOTENCY_UNKNOWN = 0,
+    NO_SIDE_EFFECTS = 1,
+    IDEMPOTENT = 2,
+  }
+}
+
+export class UninterpretedOption extends jspb.Message {
+  clearNameList(): void;
+  getNameList(): Array<UninterpretedOption.NamePart>;
+  setNameList(value: Array<UninterpretedOption.NamePart>): void;
+  addName(value?: UninterpretedOption.NamePart, index?: number): void;
+
+  hasIdentifierValue(): boolean;
+  clearIdentifierValue(): void;
+  getIdentifierValue(): string;
+  setIdentifierValue(value: string): void;
+
+  hasPositiveIntValue(): boolean;
+  clearPositiveIntValue(): void;
+  getPositiveIntValue(): number;
+  setPositiveIntValue(value: number): void;
+
+  hasNegativeIntValue(): boolean;
+  clearNegativeIntValue(): void;
+  getNegativeIntValue(): number;
+  setNegativeIntValue(value: number): void;
+
+  hasDoubleValue(): boolean;
+  clearDoubleValue(): void;
+  getDoubleValue(): number;
+  setDoubleValue(value: number): void;
+
+  hasStringValue(): boolean;
+  clearStringValue(): void;
+  getStringValue(): Uint8Array | string;
+  getStringValue_asU8(): Uint8Array;
+  getStringValue_asB64(): string;
+  setStringValue(value: Uint8Array | string): void;
+
+  hasAggregateValue(): boolean;
+  clearAggregateValue(): void;
+  getAggregateValue(): string;
+  setAggregateValue(value: string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: UninterpretedOption): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UninterpretedOption, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UninterpretedOption;
+  static deserializeBinaryFromReader(message: UninterpretedOption, reader: jspb.BinaryReader): UninterpretedOption;
+}
+
+export namespace UninterpretedOption {
+  export class NamePart extends jspb.Message {
+    hasNamePart(): boolean;
+    clearNamePart(): void;
+    getNamePart(): string;
+    setNamePart(value: string): void;
+
+    hasIsExtension(): boolean;
+    clearIsExtension(): void;
+    getIsExtension(): boolean;
+    setIsExtension(value: boolean): void;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): {};
+    static toObject(includeInstance: boolean, msg: NamePart): {};
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: NamePart, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): NamePart;
+    static deserializeBinaryFromReader(message: NamePart, reader: jspb.BinaryReader): NamePart;
+  }
+}
+
+export class SourceCodeInfo extends jspb.Message {
+  clearLocationList(): void;
+  getLocationList(): Array<SourceCodeInfo.Location>;
+  setLocationList(value: Array<SourceCodeInfo.Location>): void;
+  addLocation(value?: SourceCodeInfo.Location, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: SourceCodeInfo): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SourceCodeInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SourceCodeInfo;
+  static deserializeBinaryFromReader(message: SourceCodeInfo, reader: jspb.BinaryReader): SourceCodeInfo;
+}
+
+export namespace SourceCodeInfo {
+  export class Location extends jspb.Message {
+    clearPathList(): void;
+    getPathList(): Array<number>;
+    setPathList(value: Array<number>): void;
+    addPath(value: number, index?: number): void;
+
+    clearSpanList(): void;
+    getSpanList(): Array<number>;
+    setSpanList(value: Array<number>): void;
+    addSpan(value: number, index?: number): void;
+
+    hasLeadingComments(): boolean;
+    clearLeadingComments(): void;
+    getLeadingComments(): string;
+    setLeadingComments(value: string): void;
+
+    hasTrailingComments(): boolean;
+    clearTrailingComments(): void;
+    getTrailingComments(): string;
+    setTrailingComments(value: string): void;
+
+    clearLeadingDetachedCommentsList(): void;
+    getLeadingDetachedCommentsList(): Array<string>;
+    setLeadingDetachedCommentsList(value: Array<string>): void;
+    addLeadingDetachedComments(value: string, index?: number): void;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): {};
+    static toObject(includeInstance: boolean, msg: Location): {};
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Location, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Location;
+    static deserializeBinaryFromReader(message: Location, reader: jspb.BinaryReader): Location;
+  }
+}
+
+export class GeneratedCodeInfo extends jspb.Message {
+  clearAnnotationList(): void;
+  getAnnotationList(): Array<GeneratedCodeInfo.Annotation>;
+  setAnnotationList(value: Array<GeneratedCodeInfo.Annotation>): void;
+  addAnnotation(value?: GeneratedCodeInfo.Annotation, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: GeneratedCodeInfo): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GeneratedCodeInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GeneratedCodeInfo;
+  static deserializeBinaryFromReader(message: GeneratedCodeInfo, reader: jspb.BinaryReader): GeneratedCodeInfo;
+}
+
+export namespace GeneratedCodeInfo {
+  export class Annotation extends jspb.Message {
+    clearPathList(): void;
+    getPathList(): Array<number>;
+    setPathList(value: Array<number>): void;
+    addPath(value: number, index?: number): void;
+
+    hasSourceFile(): boolean;
+    clearSourceFile(): void;
+    getSourceFile(): string;
+    setSourceFile(value: string): void;
+
+    hasBegin(): boolean;
+    clearBegin(): void;
+    getBegin(): number;
+    setBegin(value: number): void;
+
+    hasEnd(): boolean;
+    clearEnd(): void;
+    getEnd(): number;
+    setEnd(value: number): void;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): {};
+    static toObject(includeInstance: boolean, msg: Annotation): {};
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Annotation, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Annotation;
+    static deserializeBinaryFromReader(message: Annotation, reader: jspb.BinaryReader): Annotation;
+  }
+}

--- a/google-protobuf/google/protobuf/descriptor_pb.d.ts
+++ b/google-protobuf/google/protobuf/descriptor_pb.d.ts
@@ -7,13 +7,19 @@ export class FileDescriptorSet extends jspb.Message {
   addFile(value?: FileDescriptorProto, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: FileDescriptorSet): {};
+  toObject(includeInstance?: boolean): FileDescriptorSet.AsObject;
+  static toObject(includeInstance: boolean, msg: FileDescriptorSet): FileDescriptorSet.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: FileDescriptorSet, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): FileDescriptorSet;
   static deserializeBinaryFromReader(message: FileDescriptorSet, reader: jspb.BinaryReader): FileDescriptorSet;
+}
+
+export namespace FileDescriptorSet {
+  export type AsObject = {
+    fileList: Array<FileDescriptorProto.AsObject>,
+  }
 }
 
 export class FileDescriptorProto extends jspb.Message {
@@ -78,13 +84,30 @@ export class FileDescriptorProto extends jspb.Message {
   setSyntax(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: FileDescriptorProto): {};
+  toObject(includeInstance?: boolean): FileDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: FileDescriptorProto): FileDescriptorProto.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: FileDescriptorProto, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): FileDescriptorProto;
   static deserializeBinaryFromReader(message: FileDescriptorProto, reader: jspb.BinaryReader): FileDescriptorProto;
+}
+
+export namespace FileDescriptorProto {
+  export type AsObject = {
+    name: string,
+    package: string,
+    dependencyList: Array<string>,
+    publicDependencyList: Array<number>,
+    weakDependencyList: Array<number>,
+    messageTypeList: Array<DescriptorProto.AsObject>,
+    enumTypeList: Array<EnumDescriptorProto.AsObject>,
+    serviceList: Array<ServiceDescriptorProto.AsObject>,
+    extensionList: Array<FieldDescriptorProto.AsObject>,
+    options: FileOptions.AsObject,
+    sourceCodeInfo: SourceCodeInfo.AsObject,
+    syntax: string,
+  }
 }
 
 export class DescriptorProto extends jspb.Message {
@@ -139,8 +162,8 @@ export class DescriptorProto extends jspb.Message {
   addReservedName(value: string, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: DescriptorProto): {};
+  toObject(includeInstance?: boolean): DescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: DescriptorProto): DescriptorProto.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: DescriptorProto, writer: jspb.BinaryWriter): void;
@@ -149,6 +172,19 @@ export class DescriptorProto extends jspb.Message {
 }
 
 export namespace DescriptorProto {
+  export type AsObject = {
+    name: string,
+    fieldList: Array<FieldDescriptorProto.AsObject>,
+    extensionList: Array<FieldDescriptorProto.AsObject>,
+    nestedTypeList: Array<DescriptorProto.AsObject>,
+    enumTypeList: Array<EnumDescriptorProto.AsObject>,
+    extensionRangeList: Array<DescriptorProto.ExtensionRange.AsObject>,
+    oneofDeclList: Array<OneofDescriptorProto.AsObject>,
+    options: MessageOptions.AsObject,
+    reservedRangeList: Array<DescriptorProto.ReservedRange.AsObject>,
+    reservedNameList: Array<string>,
+  }
+
   export class ExtensionRange extends jspb.Message {
     hasStart(): boolean;
     clearStart(): void;
@@ -161,13 +197,20 @@ export namespace DescriptorProto {
     setEnd(value: number): void;
 
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): {};
-    static toObject(includeInstance: boolean, msg: ExtensionRange): {};
+    toObject(includeInstance?: boolean): ExtensionRange.AsObject;
+    static toObject(includeInstance: boolean, msg: ExtensionRange): ExtensionRange.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
     static serializeBinaryToWriter(message: ExtensionRange, writer: jspb.BinaryWriter): void;
     static deserializeBinary(bytes: Uint8Array): ExtensionRange;
     static deserializeBinaryFromReader(message: ExtensionRange, reader: jspb.BinaryReader): ExtensionRange;
+  }
+
+  export namespace ExtensionRange {
+    export type AsObject = {
+      start: number,
+      end: number,
+    }
   }
 
   export class ReservedRange extends jspb.Message {
@@ -182,13 +225,20 @@ export namespace DescriptorProto {
     setEnd(value: number): void;
 
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): {};
-    static toObject(includeInstance: boolean, msg: ReservedRange): {};
+    toObject(includeInstance?: boolean): ReservedRange.AsObject;
+    static toObject(includeInstance: boolean, msg: ReservedRange): ReservedRange.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
     static serializeBinaryToWriter(message: ReservedRange, writer: jspb.BinaryWriter): void;
     static deserializeBinary(bytes: Uint8Array): ReservedRange;
     static deserializeBinaryFromReader(message: ReservedRange, reader: jspb.BinaryReader): ReservedRange;
+  }
+
+  export namespace ReservedRange {
+    export type AsObject = {
+      start: number,
+      end: number,
+    }
   }
 }
 
@@ -244,8 +294,8 @@ export class FieldDescriptorProto extends jspb.Message {
   setOptions(value: FieldOptions): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: FieldDescriptorProto): {};
+  toObject(includeInstance?: boolean): FieldDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: FieldDescriptorProto): FieldDescriptorProto.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: FieldDescriptorProto, writer: jspb.BinaryWriter): void;
@@ -254,6 +304,19 @@ export class FieldDescriptorProto extends jspb.Message {
 }
 
 export namespace FieldDescriptorProto {
+  export type AsObject = {
+    name: string,
+    number: number,
+    label: FieldDescriptorProto.Label,
+    type: FieldDescriptorProto.Type,
+    typeName: string,
+    extendee: string,
+    defaultValue: string,
+    oneofIndex: number,
+    jsonName: string,
+    options: FieldOptions.AsObject,
+  }
+
   export enum Type {
     TYPE_DOUBLE = 1,
     TYPE_FLOAT = 2,
@@ -293,13 +356,20 @@ export class OneofDescriptorProto extends jspb.Message {
   setOptions(value: OneofOptions): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: OneofDescriptorProto): {};
+  toObject(includeInstance?: boolean): OneofDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: OneofDescriptorProto): OneofDescriptorProto.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: OneofDescriptorProto, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): OneofDescriptorProto;
   static deserializeBinaryFromReader(message: OneofDescriptorProto, reader: jspb.BinaryReader): OneofDescriptorProto;
+}
+
+export namespace OneofDescriptorProto {
+  export type AsObject = {
+    name: string,
+    options: OneofOptions.AsObject,
+  }
 }
 
 export class EnumDescriptorProto extends jspb.Message {
@@ -319,13 +389,21 @@ export class EnumDescriptorProto extends jspb.Message {
   setOptions(value: EnumOptions): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: EnumDescriptorProto): {};
+  toObject(includeInstance?: boolean): EnumDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumDescriptorProto): EnumDescriptorProto.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: EnumDescriptorProto, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): EnumDescriptorProto;
   static deserializeBinaryFromReader(message: EnumDescriptorProto, reader: jspb.BinaryReader): EnumDescriptorProto;
+}
+
+export namespace EnumDescriptorProto {
+  export type AsObject = {
+    name: string,
+    valueList: Array<EnumValueDescriptorProto.AsObject>,
+    options: EnumOptions.AsObject,
+  }
 }
 
 export class EnumValueDescriptorProto extends jspb.Message {
@@ -345,13 +423,21 @@ export class EnumValueDescriptorProto extends jspb.Message {
   setOptions(value: EnumValueOptions): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: EnumValueDescriptorProto): {};
+  toObject(includeInstance?: boolean): EnumValueDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumValueDescriptorProto): EnumValueDescriptorProto.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: EnumValueDescriptorProto, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): EnumValueDescriptorProto;
   static deserializeBinaryFromReader(message: EnumValueDescriptorProto, reader: jspb.BinaryReader): EnumValueDescriptorProto;
+}
+
+export namespace EnumValueDescriptorProto {
+  export type AsObject = {
+    name: string,
+    number: number,
+    options: EnumValueOptions.AsObject,
+  }
 }
 
 export class ServiceDescriptorProto extends jspb.Message {
@@ -371,13 +457,21 @@ export class ServiceDescriptorProto extends jspb.Message {
   setOptions(value: ServiceOptions): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: ServiceDescriptorProto): {};
+  toObject(includeInstance?: boolean): ServiceDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: ServiceDescriptorProto): ServiceDescriptorProto.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: ServiceDescriptorProto, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): ServiceDescriptorProto;
   static deserializeBinaryFromReader(message: ServiceDescriptorProto, reader: jspb.BinaryReader): ServiceDescriptorProto;
+}
+
+export namespace ServiceDescriptorProto {
+  export type AsObject = {
+    name: string,
+    methodList: Array<MethodDescriptorProto.AsObject>,
+    options: ServiceOptions.AsObject,
+  }
 }
 
 export class MethodDescriptorProto extends jspb.Message {
@@ -412,13 +506,24 @@ export class MethodDescriptorProto extends jspb.Message {
   setServerStreaming(value: boolean): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: MethodDescriptorProto): {};
+  toObject(includeInstance?: boolean): MethodDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: MethodDescriptorProto): MethodDescriptorProto.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: MethodDescriptorProto, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): MethodDescriptorProto;
   static deserializeBinaryFromReader(message: MethodDescriptorProto, reader: jspb.BinaryReader): MethodDescriptorProto;
+}
+
+export namespace MethodDescriptorProto {
+  export type AsObject = {
+    name: string,
+    inputType: string,
+    outputType: string,
+    options: MethodOptions.AsObject,
+    clientStreaming: boolean,
+    serverStreaming: boolean,
+  }
 }
 
 export class FileOptions extends jspb.Message {
@@ -503,8 +608,8 @@ export class FileOptions extends jspb.Message {
   addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: FileOptions): {};
+  toObject(includeInstance?: boolean): FileOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: FileOptions): FileOptions.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: FileOptions, writer: jspb.BinaryWriter): void;
@@ -513,6 +618,25 @@ export class FileOptions extends jspb.Message {
 }
 
 export namespace FileOptions {
+  export type AsObject = {
+    javaPackage: string,
+    javaOuterClassname: string,
+    javaMultipleFiles: boolean,
+    javaGenerateEqualsAndHash: boolean,
+    javaStringCheckUtf8: boolean,
+    optimizeFor: FileOptions.OptimizeMode,
+    goPackage: string,
+    ccGenericServices: boolean,
+    javaGenericServices: boolean,
+    pyGenericServices: boolean,
+    deprecated: boolean,
+    ccEnableArenas: boolean,
+    objcClassPrefix: string,
+    csharpNamespace: string,
+    swiftPrefix: string,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
+
   export enum OptimizeMode {
     SPEED = 1,
     CODE_SIZE = 2,
@@ -547,13 +671,23 @@ export class MessageOptions extends jspb.Message {
   addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: MessageOptions): {};
+  toObject(includeInstance?: boolean): MessageOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: MessageOptions): MessageOptions.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: MessageOptions, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): MessageOptions;
   static deserializeBinaryFromReader(message: MessageOptions, reader: jspb.BinaryReader): MessageOptions;
+}
+
+export namespace MessageOptions {
+  export type AsObject = {
+    messageSetWireFormat: boolean,
+    noStandardDescriptorAccessor: boolean,
+    deprecated: boolean,
+    mapEntry: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
 export class FieldOptions extends jspb.Message {
@@ -593,8 +727,8 @@ export class FieldOptions extends jspb.Message {
   addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: FieldOptions): {};
+  toObject(includeInstance?: boolean): FieldOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: FieldOptions): FieldOptions.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: FieldOptions, writer: jspb.BinaryWriter): void;
@@ -603,6 +737,16 @@ export class FieldOptions extends jspb.Message {
 }
 
 export namespace FieldOptions {
+  export type AsObject = {
+    ctype: FieldOptions.CType,
+    packed: boolean,
+    jstype: FieldOptions.JSType,
+    lazy: boolean,
+    deprecated: boolean,
+    weak: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
+
   export enum CType {
     STRING = 0,
     CORD = 1,
@@ -622,13 +766,19 @@ export class OneofOptions extends jspb.Message {
   addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: OneofOptions): {};
+  toObject(includeInstance?: boolean): OneofOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: OneofOptions): OneofOptions.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: OneofOptions, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): OneofOptions;
   static deserializeBinaryFromReader(message: OneofOptions, reader: jspb.BinaryReader): OneofOptions;
+}
+
+export namespace OneofOptions {
+  export type AsObject = {
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
 export class EnumOptions extends jspb.Message {
@@ -648,13 +798,21 @@ export class EnumOptions extends jspb.Message {
   addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: EnumOptions): {};
+  toObject(includeInstance?: boolean): EnumOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumOptions): EnumOptions.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: EnumOptions, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): EnumOptions;
   static deserializeBinaryFromReader(message: EnumOptions, reader: jspb.BinaryReader): EnumOptions;
+}
+
+export namespace EnumOptions {
+  export type AsObject = {
+    allowAlias: boolean,
+    deprecated: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
 export class EnumValueOptions extends jspb.Message {
@@ -669,13 +827,20 @@ export class EnumValueOptions extends jspb.Message {
   addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: EnumValueOptions): {};
+  toObject(includeInstance?: boolean): EnumValueOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumValueOptions): EnumValueOptions.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: EnumValueOptions, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): EnumValueOptions;
   static deserializeBinaryFromReader(message: EnumValueOptions, reader: jspb.BinaryReader): EnumValueOptions;
+}
+
+export namespace EnumValueOptions {
+  export type AsObject = {
+    deprecated: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
 export class ServiceOptions extends jspb.Message {
@@ -690,13 +855,20 @@ export class ServiceOptions extends jspb.Message {
   addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: ServiceOptions): {};
+  toObject(includeInstance?: boolean): ServiceOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: ServiceOptions): ServiceOptions.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: ServiceOptions, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): ServiceOptions;
   static deserializeBinaryFromReader(message: ServiceOptions, reader: jspb.BinaryReader): ServiceOptions;
+}
+
+export namespace ServiceOptions {
+  export type AsObject = {
+    deprecated: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
 export class MethodOptions extends jspb.Message {
@@ -716,8 +888,8 @@ export class MethodOptions extends jspb.Message {
   addUninterpretedOption(value?: UninterpretedOption, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: MethodOptions): {};
+  toObject(includeInstance?: boolean): MethodOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: MethodOptions): MethodOptions.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: MethodOptions, writer: jspb.BinaryWriter): void;
@@ -726,6 +898,12 @@ export class MethodOptions extends jspb.Message {
 }
 
 export namespace MethodOptions {
+  export type AsObject = {
+    deprecated: boolean,
+    idempotencyLevel: MethodOptions.IdempotencyLevel,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
+
   export enum IdempotencyLevel {
     IDEMPOTENCY_UNKNOWN = 0,
     NO_SIDE_EFFECTS = 1,
@@ -772,8 +950,8 @@ export class UninterpretedOption extends jspb.Message {
   setAggregateValue(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: UninterpretedOption): {};
+  toObject(includeInstance?: boolean): UninterpretedOption.AsObject;
+  static toObject(includeInstance: boolean, msg: UninterpretedOption): UninterpretedOption.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: UninterpretedOption, writer: jspb.BinaryWriter): void;
@@ -782,6 +960,16 @@ export class UninterpretedOption extends jspb.Message {
 }
 
 export namespace UninterpretedOption {
+  export type AsObject = {
+    nameList: Array<UninterpretedOption.NamePart.AsObject>,
+    identifierValue: string,
+    positiveIntValue: number,
+    negativeIntValue: number,
+    doubleValue: number,
+    stringValue: Uint8Array | string,
+    aggregateValue: string,
+  }
+
   export class NamePart extends jspb.Message {
     hasNamePart(): boolean;
     clearNamePart(): void;
@@ -794,13 +982,20 @@ export namespace UninterpretedOption {
     setIsExtension(value: boolean): void;
 
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): {};
-    static toObject(includeInstance: boolean, msg: NamePart): {};
+    toObject(includeInstance?: boolean): NamePart.AsObject;
+    static toObject(includeInstance: boolean, msg: NamePart): NamePart.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
     static serializeBinaryToWriter(message: NamePart, writer: jspb.BinaryWriter): void;
     static deserializeBinary(bytes: Uint8Array): NamePart;
     static deserializeBinaryFromReader(message: NamePart, reader: jspb.BinaryReader): NamePart;
+  }
+
+  export namespace NamePart {
+    export type AsObject = {
+      namePart: string,
+      isExtension: boolean,
+    }
   }
 }
 
@@ -811,8 +1006,8 @@ export class SourceCodeInfo extends jspb.Message {
   addLocation(value?: SourceCodeInfo.Location, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: SourceCodeInfo): {};
+  toObject(includeInstance?: boolean): SourceCodeInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: SourceCodeInfo): SourceCodeInfo.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: SourceCodeInfo, writer: jspb.BinaryWriter): void;
@@ -821,6 +1016,10 @@ export class SourceCodeInfo extends jspb.Message {
 }
 
 export namespace SourceCodeInfo {
+  export type AsObject = {
+    locationList: Array<SourceCodeInfo.Location.AsObject>,
+  }
+
   export class Location extends jspb.Message {
     clearPathList(): void;
     getPathList(): Array<number>;
@@ -848,13 +1047,23 @@ export namespace SourceCodeInfo {
     addLeadingDetachedComments(value: string, index?: number): void;
 
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): {};
-    static toObject(includeInstance: boolean, msg: Location): {};
+    toObject(includeInstance?: boolean): Location.AsObject;
+    static toObject(includeInstance: boolean, msg: Location): Location.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
     static serializeBinaryToWriter(message: Location, writer: jspb.BinaryWriter): void;
     static deserializeBinary(bytes: Uint8Array): Location;
     static deserializeBinaryFromReader(message: Location, reader: jspb.BinaryReader): Location;
+  }
+
+  export namespace Location {
+    export type AsObject = {
+      pathList: Array<number>,
+      spanList: Array<number>,
+      leadingComments: string,
+      trailingComments: string,
+      leadingDetachedCommentsList: Array<string>,
+    }
   }
 }
 
@@ -865,8 +1074,8 @@ export class GeneratedCodeInfo extends jspb.Message {
   addAnnotation(value?: GeneratedCodeInfo.Annotation, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: GeneratedCodeInfo): {};
+  toObject(includeInstance?: boolean): GeneratedCodeInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: GeneratedCodeInfo): GeneratedCodeInfo.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: GeneratedCodeInfo, writer: jspb.BinaryWriter): void;
@@ -875,6 +1084,10 @@ export class GeneratedCodeInfo extends jspb.Message {
 }
 
 export namespace GeneratedCodeInfo {
+  export type AsObject = {
+    annotationList: Array<GeneratedCodeInfo.Annotation.AsObject>,
+  }
+
   export class Annotation extends jspb.Message {
     clearPathList(): void;
     getPathList(): Array<number>;
@@ -897,12 +1110,22 @@ export namespace GeneratedCodeInfo {
     setEnd(value: number): void;
 
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): {};
-    static toObject(includeInstance: boolean, msg: Annotation): {};
+    toObject(includeInstance?: boolean): Annotation.AsObject;
+    static toObject(includeInstance: boolean, msg: Annotation): Annotation.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
     static serializeBinaryToWriter(message: Annotation, writer: jspb.BinaryWriter): void;
     static deserializeBinary(bytes: Uint8Array): Annotation;
     static deserializeBinaryFromReader(message: Annotation, reader: jspb.BinaryReader): Annotation;
   }
+
+  export namespace Annotation {
+    export type AsObject = {
+      pathList: Array<number>,
+      sourceFile: string,
+      begin: number,
+      end: number,
+    }
+  }
 }
+

--- a/google-protobuf/google/protobuf/duration_pb.d.ts
+++ b/google-protobuf/google/protobuf/duration_pb.d.ts
@@ -1,0 +1,18 @@
+import * as jspb from "../../index";
+
+export class Duration extends jspb.Message {
+  getSeconds(): number;
+  setSeconds(value: number): void;
+
+  getNanos(): number;
+  setNanos(value: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Duration): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Duration, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Duration;
+  static deserializeBinaryFromReader(message: Duration, reader: jspb.BinaryReader): Duration;
+}

--- a/google-protobuf/google/protobuf/duration_pb.d.ts
+++ b/google-protobuf/google/protobuf/duration_pb.d.ts
@@ -8,11 +8,19 @@ export class Duration extends jspb.Message {
   setNanos(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Duration): {};
+  toObject(includeInstance?: boolean): Duration.AsObject;
+  static toObject(includeInstance: boolean, msg: Duration): Duration.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Duration, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Duration;
   static deserializeBinaryFromReader(message: Duration, reader: jspb.BinaryReader): Duration;
 }
+
+export namespace Duration {
+  export type AsObject = {
+    seconds: number,
+    nanos: number,
+  }
+}
+

--- a/google-protobuf/google/protobuf/empty_pb.d.ts
+++ b/google-protobuf/google/protobuf/empty_pb.d.ts
@@ -2,11 +2,17 @@ import * as jspb from "../../index";
 
 export class Empty extends jspb.Message {
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Empty): {};
+  toObject(includeInstance?: boolean): Empty.AsObject;
+  static toObject(includeInstance: boolean, msg: Empty): Empty.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Empty, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Empty;
   static deserializeBinaryFromReader(message: Empty, reader: jspb.BinaryReader): Empty;
 }
+
+export namespace Empty {
+  export type AsObject = {
+  }
+}
+

--- a/google-protobuf/google/protobuf/empty_pb.d.ts
+++ b/google-protobuf/google/protobuf/empty_pb.d.ts
@@ -1,0 +1,12 @@
+import * as jspb from "../../index";
+
+export class Empty extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Empty): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Empty, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Empty;
+  static deserializeBinaryFromReader(message: Empty, reader: jspb.BinaryReader): Empty;
+}

--- a/google-protobuf/google/protobuf/field_mask_pb.d.ts
+++ b/google-protobuf/google/protobuf/field_mask_pb.d.ts
@@ -1,0 +1,17 @@
+import * as jspb from "../../index";
+
+export class FieldMask extends jspb.Message {
+  clearPathsList(): void;
+  getPathsList(): Array<string>;
+  setPathsList(value: Array<string>): void;
+  addPaths(value: string, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: FieldMask): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FieldMask, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FieldMask;
+  static deserializeBinaryFromReader(message: FieldMask, reader: jspb.BinaryReader): FieldMask;
+}

--- a/google-protobuf/google/protobuf/field_mask_pb.d.ts
+++ b/google-protobuf/google/protobuf/field_mask_pb.d.ts
@@ -7,11 +7,18 @@ export class FieldMask extends jspb.Message {
   addPaths(value: string, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: FieldMask): {};
+  toObject(includeInstance?: boolean): FieldMask.AsObject;
+  static toObject(includeInstance: boolean, msg: FieldMask): FieldMask.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: FieldMask, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): FieldMask;
   static deserializeBinaryFromReader(message: FieldMask, reader: jspb.BinaryReader): FieldMask;
 }
+
+export namespace FieldMask {
+  export type AsObject = {
+    pathsList: Array<string>,
+  }
+}
+

--- a/google-protobuf/google/protobuf/source_context_pb.d.ts
+++ b/google-protobuf/google/protobuf/source_context_pb.d.ts
@@ -1,0 +1,15 @@
+import * as jspb from "../../index";
+
+export class SourceContext extends jspb.Message {
+  getFileName(): string;
+  setFileName(value: string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: SourceContext): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SourceContext, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SourceContext;
+  static deserializeBinaryFromReader(message: SourceContext, reader: jspb.BinaryReader): SourceContext;
+}

--- a/google-protobuf/google/protobuf/source_context_pb.d.ts
+++ b/google-protobuf/google/protobuf/source_context_pb.d.ts
@@ -5,11 +5,18 @@ export class SourceContext extends jspb.Message {
   setFileName(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: SourceContext): {};
+  toObject(includeInstance?: boolean): SourceContext.AsObject;
+  static toObject(includeInstance: boolean, msg: SourceContext): SourceContext.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: SourceContext, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): SourceContext;
   static deserializeBinaryFromReader(message: SourceContext, reader: jspb.BinaryReader): SourceContext;
 }
+
+export namespace SourceContext {
+  export type AsObject = {
+    fileName: string,
+  }
+}
+

--- a/google-protobuf/google/protobuf/struct_pb.d.ts
+++ b/google-protobuf/google/protobuf/struct_pb.d.ts
@@ -1,0 +1,101 @@
+import * as jspb from "../../index";
+
+export class Struct extends jspb.Message {
+  getFieldsMap(): jspb.Map<string, Value>;
+  clearFieldsMap(): void;
+
+  toJavaScript(): {[key: string]: JavaScriptValue};
+  static fromJavaScript(value: {[key: string]: JavaScriptValue}): Struct;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Struct): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Struct, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Struct;
+  static deserializeBinaryFromReader(message: Struct, reader: jspb.BinaryReader): Struct;
+}
+
+export class Value extends jspb.Message {
+  hasNullValue(): boolean;
+  clearNullValue(): void;
+  getNullValue(): NullValue;
+  setNullValue(value: NullValue): void;
+
+  hasNumberValue(): boolean;
+  clearNumberValue(): void;
+  getNumberValue(): number;
+  setNumberValue(value: number): void;
+
+  hasStringValue(): boolean;
+  clearStringValue(): void;
+  getStringValue(): string;
+  setStringValue(value: string): void;
+
+  hasBoolValue(): boolean;
+  clearBoolValue(): void;
+  getBoolValue(): boolean;
+  setBoolValue(value: boolean): void;
+
+  hasStructValue(): boolean;
+  clearStructValue(): void;
+  getStructValue(): Struct;
+  setStructValue(value: Struct): void;
+
+  hasListValue(): boolean;
+  clearListValue(): void;
+  getListValue(): ListValue;
+  setListValue(value: ListValue): void;
+
+  getKindCase(): Value.KindCase;
+
+  toJavaScript(): JavaScriptValue;
+  static fromJavaScript(value: JavaScriptValue): Value;
+
+  static deserializeBinary(bytes: Uint8Array): Value;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Value): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Value, writer: jspb.BinaryWriter): void;
+  static deserializeBinaryFromReader(message: Value, reader: jspb.BinaryReader): Value;
+}
+
+export namespace Value {
+  export enum KindCase {
+    KIND_NOT_SET = 0,
+    NULL_VALUE = 1,
+    NUMBER_VALUE = 2,
+    STRING_VALUE = 3,
+    BOOL_VALUE = 4,
+    STRUCT_VALUE = 5,
+    LIST_VALUE = 6,
+  }
+}
+
+export class ListValue extends jspb.Message {
+  clearValuesList(): void;
+  getValuesList(): Array<Value>;
+  setValuesList(value: Array<Value>): void;
+  addValues(value?: Value, index?: number): void;
+
+  toJavaScript(): Array<JavaScriptValue>;
+  static fromJavaScript(value: Array<JavaScriptValue>): ListValue;
+
+  static deserializeBinary(bytes: Uint8Array): ListValue;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: ListValue): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListValue, writer: jspb.BinaryWriter): void;
+  static deserializeBinaryFromReader(message: ListValue, reader: jspb.BinaryReader): ListValue;
+}
+
+export enum NullValue {
+  NULL_VALUE = 0,
+}
+
+export type JavaScriptValue = null | number | string | boolean | Array<any> | {};

--- a/google-protobuf/google/protobuf/struct_pb.d.ts
+++ b/google-protobuf/google/protobuf/struct_pb.d.ts
@@ -8,13 +8,19 @@ export class Struct extends jspb.Message {
   static fromJavaScript(value: {[key: string]: JavaScriptValue}): Struct;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Struct): {};
+  toObject(includeInstance?: boolean): Struct.AsObject;
+  static toObject(includeInstance: boolean, msg: Struct): Struct.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Struct, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Struct;
   static deserializeBinaryFromReader(message: Struct, reader: jspb.BinaryReader): Struct;
+}
+
+export namespace Struct {
+  export type AsObject = {
+    fieldsMap: Array<[string, Value.AsObject]>,
+  }
 }
 
 export class Value extends jspb.Message {
@@ -53,17 +59,26 @@ export class Value extends jspb.Message {
   toJavaScript(): JavaScriptValue;
   static fromJavaScript(value: JavaScriptValue): Value;
 
-  static deserializeBinary(bytes: Uint8Array): Value;
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Value): {};
+  toObject(includeInstance?: boolean): Value.AsObject;
+  static toObject(includeInstance: boolean, msg: Value): Value.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Value, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Value;
   static deserializeBinaryFromReader(message: Value, reader: jspb.BinaryReader): Value;
 }
 
 export namespace Value {
+  export type AsObject = {
+    nullValue: NullValue,
+    numberValue: number,
+    stringValue: string,
+    boolValue: boolean,
+    structValue: Struct.AsObject,
+    listValue: ListValue.AsObject,
+  }
+
   export enum KindCase {
     KIND_NOT_SET = 0,
     NULL_VALUE = 1,
@@ -84,14 +99,20 @@ export class ListValue extends jspb.Message {
   toJavaScript(): Array<JavaScriptValue>;
   static fromJavaScript(value: Array<JavaScriptValue>): ListValue;
 
-  static deserializeBinary(bytes: Uint8Array): ListValue;
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: ListValue): {};
+  toObject(includeInstance?: boolean): ListValue.AsObject;
+  static toObject(includeInstance: boolean, msg: ListValue): ListValue.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: ListValue, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListValue;
   static deserializeBinaryFromReader(message: ListValue, reader: jspb.BinaryReader): ListValue;
+}
+
+export namespace ListValue {
+  export type AsObject = {
+    valuesList: Array<Value.AsObject>,
+  }
 }
 
 export enum NullValue {

--- a/google-protobuf/google/protobuf/timestamp_pb.d.ts
+++ b/google-protobuf/google/protobuf/timestamp_pb.d.ts
@@ -11,11 +11,19 @@ export class Timestamp extends jspb.Message {
   fromDate(date: Date): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Timestamp): {};
+  toObject(includeInstance?: boolean): Timestamp.AsObject;
+  static toObject(includeInstance: boolean, msg: Timestamp): Timestamp.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Timestamp, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Timestamp;
   static deserializeBinaryFromReader(message: Timestamp, reader: jspb.BinaryReader): Timestamp;
 }
+
+export namespace Timestamp {
+  export type AsObject = {
+    seconds: number,
+    nanos: number,
+  }
+}
+

--- a/google-protobuf/google/protobuf/timestamp_pb.d.ts
+++ b/google-protobuf/google/protobuf/timestamp_pb.d.ts
@@ -1,0 +1,21 @@
+import * as jspb from "../../index";
+
+export class Timestamp extends jspb.Message {
+  getSeconds(): number;
+  setSeconds(value: number): void;
+
+  getNanos(): number;
+  setNanos(value: number): void;
+
+  toDate(): Date;
+  fromDate(date: Date): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Timestamp): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Timestamp, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Timestamp;
+  static deserializeBinaryFromReader(message: Timestamp, reader: jspb.BinaryReader): Timestamp;
+}

--- a/google-protobuf/google/protobuf/type_pb.d.ts
+++ b/google-protobuf/google/protobuf/type_pb.d.ts
@@ -30,13 +30,24 @@ export class Type extends jspb.Message {
   setSyntax(value: Syntax): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Type): {};
+  toObject(includeInstance?: boolean): Type.AsObject;
+  static toObject(includeInstance: boolean, msg: Type): Type.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Type, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Type;
   static deserializeBinaryFromReader(message: Type, reader: jspb.BinaryReader): Type;
+}
+
+export namespace Type {
+  export type AsObject = {
+    name: string,
+    fieldsList: Array<Field.AsObject>,
+    oneofsList: Array<string>,
+    optionsList: Array<Option.AsObject>,
+    sourceContext: google_protobuf_source_context_pb.SourceContext.AsObject,
+    syntax: Syntax,
+  }
 }
 
 export class Field extends jspb.Message {
@@ -73,8 +84,8 @@ export class Field extends jspb.Message {
   setDefaultValue(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Field): {};
+  toObject(includeInstance?: boolean): Field.AsObject;
+  static toObject(includeInstance: boolean, msg: Field): Field.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Field, writer: jspb.BinaryWriter): void;
@@ -83,6 +94,19 @@ export class Field extends jspb.Message {
 }
 
 export namespace Field {
+  export type AsObject = {
+    kind: Field.Kind,
+    cardinality: Field.Cardinality,
+    number: number,
+    name: string,
+    typeUrl: string,
+    oneofIndex: number,
+    packed: boolean,
+    optionsList: Array<Option.AsObject>,
+    jsonName: string,
+    defaultValue: string,
+  }
+
   export enum Kind {
     TYPE_UNKNOWN = 0,
     TYPE_DOUBLE = 1,
@@ -135,13 +159,23 @@ export class Enum extends jspb.Message {
   setSyntax(value: Syntax): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Enum): {};
+  toObject(includeInstance?: boolean): Enum.AsObject;
+  static toObject(includeInstance: boolean, msg: Enum): Enum.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Enum, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Enum;
   static deserializeBinaryFromReader(message: Enum, reader: jspb.BinaryReader): Enum;
+}
+
+export namespace Enum {
+  export type AsObject = {
+    name: string,
+    enumvalueList: Array<EnumValue.AsObject>,
+    optionsList: Array<Option.AsObject>,
+    sourceContext: google_protobuf_source_context_pb.SourceContext.AsObject,
+    syntax: Syntax,
+  }
 }
 
 export class EnumValue extends jspb.Message {
@@ -157,13 +191,21 @@ export class EnumValue extends jspb.Message {
   addOptions(value?: Option, index?: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: EnumValue): {};
+  toObject(includeInstance?: boolean): EnumValue.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumValue): EnumValue.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: EnumValue, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): EnumValue;
   static deserializeBinaryFromReader(message: EnumValue, reader: jspb.BinaryReader): EnumValue;
+}
+
+export namespace EnumValue {
+  export type AsObject = {
+    name: string,
+    number: number,
+    optionsList: Array<Option.AsObject>,
+  }
 }
 
 export class Option extends jspb.Message {
@@ -176,13 +218,20 @@ export class Option extends jspb.Message {
   setValue(value: google_protobuf_any_pb.Any): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Option): {};
+  toObject(includeInstance?: boolean): Option.AsObject;
+  static toObject(includeInstance: boolean, msg: Option): Option.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Option, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): Option;
   static deserializeBinaryFromReader(message: Option, reader: jspb.BinaryReader): Option;
+}
+
+export namespace Option {
+  export type AsObject = {
+    name: string,
+    value: google_protobuf_any_pb.Any.AsObject,
+  }
 }
 
 export enum Syntax {

--- a/google-protobuf/google/protobuf/type_pb.d.ts
+++ b/google-protobuf/google/protobuf/type_pb.d.ts
@@ -1,0 +1,191 @@
+import * as jspb from "../../index";
+import * as google_protobuf_any_pb from "./any_pb";
+import * as google_protobuf_source_context_pb from "./source_context_pb";
+
+export class Type extends jspb.Message {
+  getName(): string;
+  setName(value: string): void;
+
+  clearFieldsList(): void;
+  getFieldsList(): Array<Field>;
+  setFieldsList(value: Array<Field>): void;
+  addFields(value?: Field, index?: number): void;
+
+  clearOneofsList(): void;
+  getOneofsList(): Array<string>;
+  setOneofsList(value: Array<string>): void;
+  addOneofs(value: string, index?: number): void;
+
+  clearOptionsList(): void;
+  getOptionsList(): Array<Option>;
+  setOptionsList(value: Array<Option>): void;
+  addOptions(value?: Option, index?: number): void;
+
+  hasSourceContext(): boolean;
+  clearSourceContext(): void;
+  getSourceContext(): google_protobuf_source_context_pb.SourceContext;
+  setSourceContext(value: google_protobuf_source_context_pb.SourceContext): void;
+
+  getSyntax(): Syntax;
+  setSyntax(value: Syntax): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Type): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Type, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Type;
+  static deserializeBinaryFromReader(message: Type, reader: jspb.BinaryReader): Type;
+}
+
+export class Field extends jspb.Message {
+  getKind(): Field.Kind;
+  setKind(value: Field.Kind): void;
+
+  getCardinality(): Field.Cardinality;
+  setCardinality(value: Field.Cardinality): void;
+
+  getNumber(): number;
+  setNumber(value: number): void;
+
+  getName(): string;
+  setName(value: string): void;
+
+  getTypeUrl(): string;
+  setTypeUrl(value: string): void;
+
+  getOneofIndex(): number;
+  setOneofIndex(value: number): void;
+
+  getPacked(): boolean;
+  setPacked(value: boolean): void;
+
+  clearOptionsList(): void;
+  getOptionsList(): Array<Option>;
+  setOptionsList(value: Array<Option>): void;
+  addOptions(value?: Option, index?: number): void;
+
+  getJsonName(): string;
+  setJsonName(value: string): void;
+
+  getDefaultValue(): string;
+  setDefaultValue(value: string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Field): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Field, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Field;
+  static deserializeBinaryFromReader(message: Field, reader: jspb.BinaryReader): Field;
+}
+
+export namespace Field {
+  export enum Kind {
+    TYPE_UNKNOWN = 0,
+    TYPE_DOUBLE = 1,
+    TYPE_FLOAT = 2,
+    TYPE_INT64 = 3,
+    TYPE_UINT64 = 4,
+    TYPE_INT32 = 5,
+    TYPE_FIXED64 = 6,
+    TYPE_FIXED32 = 7,
+    TYPE_BOOL = 8,
+    TYPE_STRING = 9,
+    TYPE_GROUP = 10,
+    TYPE_MESSAGE = 11,
+    TYPE_BYTES = 12,
+    TYPE_UINT32 = 13,
+    TYPE_ENUM = 14,
+    TYPE_SFIXED32 = 15,
+    TYPE_SFIXED64 = 16,
+    TYPE_SINT32 = 17,
+    TYPE_SINT64 = 18,
+  }
+  export enum Cardinality {
+    CARDINALITY_UNKNOWN = 0,
+    CARDINALITY_OPTIONAL = 1,
+    CARDINALITY_REQUIRED = 2,
+    CARDINALITY_REPEATED = 3,
+  }
+}
+
+export class Enum extends jspb.Message {
+  getName(): string;
+  setName(value: string): void;
+
+  clearEnumvalueList(): void;
+  getEnumvalueList(): Array<EnumValue>;
+  setEnumvalueList(value: Array<EnumValue>): void;
+  addEnumvalue(value?: EnumValue, index?: number): void;
+
+  clearOptionsList(): void;
+  getOptionsList(): Array<Option>;
+  setOptionsList(value: Array<Option>): void;
+  addOptions(value?: Option, index?: number): void;
+
+  hasSourceContext(): boolean;
+  clearSourceContext(): void;
+  getSourceContext(): google_protobuf_source_context_pb.SourceContext;
+  setSourceContext(value: google_protobuf_source_context_pb.SourceContext): void;
+
+  getSyntax(): Syntax;
+  setSyntax(value: Syntax): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Enum): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Enum, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Enum;
+  static deserializeBinaryFromReader(message: Enum, reader: jspb.BinaryReader): Enum;
+}
+
+export class EnumValue extends jspb.Message {
+  getName(): string;
+  setName(value: string): void;
+
+  getNumber(): number;
+  setNumber(value: number): void;
+
+  clearOptionsList(): void;
+  getOptionsList(): Array<Option>;
+  setOptionsList(value: Array<Option>): void;
+  addOptions(value?: Option, index?: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: EnumValue): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumValue, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumValue;
+  static deserializeBinaryFromReader(message: EnumValue, reader: jspb.BinaryReader): EnumValue;
+}
+
+export class Option extends jspb.Message {
+  getName(): string;
+  setName(value: string): void;
+
+  hasValue(): boolean;
+  clearValue(): void;
+  getValue(): google_protobuf_any_pb.Any;
+  setValue(value: google_protobuf_any_pb.Any): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Option): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Option, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Option;
+  static deserializeBinaryFromReader(message: Option, reader: jspb.BinaryReader): Option;
+}
+
+export enum Syntax {
+  SYNTAX_PROTO2 = 0,
+  SYNTAX_PROTO3 = 1,
+}

--- a/google-protobuf/google/protobuf/wrappers_pb.d.ts
+++ b/google-protobuf/google/protobuf/wrappers_pb.d.ts
@@ -1,0 +1,129 @@
+import * as jspb from "../../index";
+
+export class DoubleValue extends jspb.Message {
+  getValue(): number;
+  setValue(value: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: DoubleValue): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DoubleValue, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DoubleValue;
+  static deserializeBinaryFromReader(message: DoubleValue, reader: jspb.BinaryReader): DoubleValue;
+}
+
+export class FloatValue extends jspb.Message {
+  getValue(): number;
+  setValue(value: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: FloatValue): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FloatValue, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FloatValue;
+  static deserializeBinaryFromReader(message: FloatValue, reader: jspb.BinaryReader): FloatValue;
+}
+
+export class Int64Value extends jspb.Message {
+  getValue(): number;
+  setValue(value: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Int64Value): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Int64Value, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Int64Value;
+  static deserializeBinaryFromReader(message: Int64Value, reader: jspb.BinaryReader): Int64Value;
+}
+
+export class UInt64Value extends jspb.Message {
+  getValue(): number;
+  setValue(value: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: UInt64Value): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UInt64Value, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UInt64Value;
+  static deserializeBinaryFromReader(message: UInt64Value, reader: jspb.BinaryReader): UInt64Value;
+}
+
+export class Int32Value extends jspb.Message {
+  getValue(): number;
+  setValue(value: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: Int32Value): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Int32Value, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Int32Value;
+  static deserializeBinaryFromReader(message: Int32Value, reader: jspb.BinaryReader): Int32Value;
+}
+
+export class UInt32Value extends jspb.Message {
+  getValue(): number;
+  setValue(value: number): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: UInt32Value): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UInt32Value, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UInt32Value;
+  static deserializeBinaryFromReader(message: UInt32Value, reader: jspb.BinaryReader): UInt32Value;
+}
+
+export class BoolValue extends jspb.Message {
+  getValue(): boolean;
+  setValue(value: boolean): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: BoolValue): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: BoolValue, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): BoolValue;
+  static deserializeBinaryFromReader(message: BoolValue, reader: jspb.BinaryReader): BoolValue;
+}
+
+export class StringValue extends jspb.Message {
+  getValue(): string;
+  setValue(value: string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: StringValue): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: StringValue, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): StringValue;
+  static deserializeBinaryFromReader(message: StringValue, reader: jspb.BinaryReader): StringValue;
+}
+
+export class BytesValue extends jspb.Message {
+  getValue(): Uint8Array | string;
+  getValue_asU8(): Uint8Array;
+  getValue_asB64(): string;
+  setValue(value: Uint8Array | string): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): {};
+  static toObject(includeInstance: boolean, msg: BytesValue): {};
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: BytesValue, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): BytesValue;
+  static deserializeBinaryFromReader(message: BytesValue, reader: jspb.BinaryReader): BytesValue;
+}

--- a/google-protobuf/google/protobuf/wrappers_pb.d.ts
+++ b/google-protobuf/google/protobuf/wrappers_pb.d.ts
@@ -5,8 +5,8 @@ export class DoubleValue extends jspb.Message {
   setValue(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: DoubleValue): {};
+  toObject(includeInstance?: boolean): DoubleValue.AsObject;
+  static toObject(includeInstance: boolean, msg: DoubleValue): DoubleValue.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: DoubleValue, writer: jspb.BinaryWriter): void;
@@ -14,13 +14,19 @@ export class DoubleValue extends jspb.Message {
   static deserializeBinaryFromReader(message: DoubleValue, reader: jspb.BinaryReader): DoubleValue;
 }
 
+export namespace DoubleValue {
+  export type AsObject = {
+    value: number,
+  }
+}
+
 export class FloatValue extends jspb.Message {
   getValue(): number;
   setValue(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: FloatValue): {};
+  toObject(includeInstance?: boolean): FloatValue.AsObject;
+  static toObject(includeInstance: boolean, msg: FloatValue): FloatValue.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: FloatValue, writer: jspb.BinaryWriter): void;
@@ -28,13 +34,19 @@ export class FloatValue extends jspb.Message {
   static deserializeBinaryFromReader(message: FloatValue, reader: jspb.BinaryReader): FloatValue;
 }
 
+export namespace FloatValue {
+  export type AsObject = {
+    value: number,
+  }
+}
+
 export class Int64Value extends jspb.Message {
   getValue(): number;
   setValue(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Int64Value): {};
+  toObject(includeInstance?: boolean): Int64Value.AsObject;
+  static toObject(includeInstance: boolean, msg: Int64Value): Int64Value.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Int64Value, writer: jspb.BinaryWriter): void;
@@ -42,13 +54,19 @@ export class Int64Value extends jspb.Message {
   static deserializeBinaryFromReader(message: Int64Value, reader: jspb.BinaryReader): Int64Value;
 }
 
+export namespace Int64Value {
+  export type AsObject = {
+    value: number,
+  }
+}
+
 export class UInt64Value extends jspb.Message {
   getValue(): number;
   setValue(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: UInt64Value): {};
+  toObject(includeInstance?: boolean): UInt64Value.AsObject;
+  static toObject(includeInstance: boolean, msg: UInt64Value): UInt64Value.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: UInt64Value, writer: jspb.BinaryWriter): void;
@@ -56,13 +74,19 @@ export class UInt64Value extends jspb.Message {
   static deserializeBinaryFromReader(message: UInt64Value, reader: jspb.BinaryReader): UInt64Value;
 }
 
+export namespace UInt64Value {
+  export type AsObject = {
+    value: number,
+  }
+}
+
 export class Int32Value extends jspb.Message {
   getValue(): number;
   setValue(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: Int32Value): {};
+  toObject(includeInstance?: boolean): Int32Value.AsObject;
+  static toObject(includeInstance: boolean, msg: Int32Value): Int32Value.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: Int32Value, writer: jspb.BinaryWriter): void;
@@ -70,13 +94,19 @@ export class Int32Value extends jspb.Message {
   static deserializeBinaryFromReader(message: Int32Value, reader: jspb.BinaryReader): Int32Value;
 }
 
+export namespace Int32Value {
+  export type AsObject = {
+    value: number,
+  }
+}
+
 export class UInt32Value extends jspb.Message {
   getValue(): number;
   setValue(value: number): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: UInt32Value): {};
+  toObject(includeInstance?: boolean): UInt32Value.AsObject;
+  static toObject(includeInstance: boolean, msg: UInt32Value): UInt32Value.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: UInt32Value, writer: jspb.BinaryWriter): void;
@@ -84,13 +114,19 @@ export class UInt32Value extends jspb.Message {
   static deserializeBinaryFromReader(message: UInt32Value, reader: jspb.BinaryReader): UInt32Value;
 }
 
+export namespace UInt32Value {
+  export type AsObject = {
+    value: number,
+  }
+}
+
 export class BoolValue extends jspb.Message {
   getValue(): boolean;
   setValue(value: boolean): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: BoolValue): {};
+  toObject(includeInstance?: boolean): BoolValue.AsObject;
+  static toObject(includeInstance: boolean, msg: BoolValue): BoolValue.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: BoolValue, writer: jspb.BinaryWriter): void;
@@ -98,18 +134,30 @@ export class BoolValue extends jspb.Message {
   static deserializeBinaryFromReader(message: BoolValue, reader: jspb.BinaryReader): BoolValue;
 }
 
+export namespace BoolValue {
+  export type AsObject = {
+    value: boolean,
+  }
+}
+
 export class StringValue extends jspb.Message {
   getValue(): string;
   setValue(value: string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: StringValue): {};
+  toObject(includeInstance?: boolean): StringValue.AsObject;
+  static toObject(includeInstance: boolean, msg: StringValue): StringValue.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: StringValue, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): StringValue;
   static deserializeBinaryFromReader(message: StringValue, reader: jspb.BinaryReader): StringValue;
+}
+
+export namespace StringValue {
+  export type AsObject = {
+    value: string,
+  }
 }
 
 export class BytesValue extends jspb.Message {
@@ -119,11 +167,18 @@ export class BytesValue extends jspb.Message {
   setValue(value: Uint8Array | string): void;
 
   serializeBinary(): Uint8Array;
-  toObject(includeInstance?: boolean): {};
-  static toObject(includeInstance: boolean, msg: BytesValue): {};
+  toObject(includeInstance?: boolean): BytesValue.AsObject;
+  static toObject(includeInstance: boolean, msg: BytesValue): BytesValue.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
   static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
   static serializeBinaryToWriter(message: BytesValue, writer: jspb.BinaryWriter): void;
   static deserializeBinary(bytes: Uint8Array): BytesValue;
   static deserializeBinaryFromReader(message: BytesValue, reader: jspb.BinaryReader): BytesValue;
 }
+
+export namespace BytesValue {
+  export type AsObject = {
+    value: Uint8Array | string,
+  }
+}
+

--- a/google-protobuf/tsconfig.json
+++ b/google-protobuf/tsconfig.json
@@ -17,6 +17,18 @@
   },
   "files": [
     "index.d.ts",
+    "google/protobuf/compiler/plugin_pb.d.ts",
+    "google/protobuf/any_pb.d.ts",
+    "google/protobuf/api_pb.d.ts",
+    "google/protobuf/descriptor_pb.d.ts",
+    "google/protobuf/duration_pb.d.ts",
+    "google/protobuf/empty_pb.d.ts",
+    "google/protobuf/field_mask_pb.d.ts",
+    "google/protobuf/source_context_pb.d.ts",
+    "google/protobuf/struct_pb.d.ts",
+    "google/protobuf/timestamp_pb.d.ts",
+    "google/protobuf/type_pb.d.ts",
+    "google/protobuf/wrappers_pb.d.ts",
     "google-protobuf-tests.ts"
   ]
 }


### PR DESCRIPTION
This PR adds the classes that are part of the `google-protobuf` library (e.g. `google-protobuf/google/protobuf/any_pb`) that are required by message generated by `protoc`.

These classes were generated by a `protoc` TypeScript plugin that I am working on, with a few of the classes being extended as per the `protoc` JS generator (`any` and `struct` have additional functions). 

I have checked that they match the JS classes.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: None. This is typing more of the library.
- [x] Increase the version number in the header if appropriate. - not appropriate
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.