### PR TITLE
Fix transform argument type, and add deprecated method documentation.

### DIFF
--- a/typeahead/index.d.ts
+++ b/typeahead/index.d.ts
@@ -1015,7 +1015,7 @@ declare namespace Bloodhound {
          * @param response Prefetch response.
          * @returns Transform response.
          */
-        transform?: (response: T[]) => T[];
+        transform?: (response: T) => T;
     }
 
     /**
@@ -1069,7 +1069,13 @@ declare namespace Bloodhound {
          * @param response Prefetch response.
          * @returns Transform response.
          */
-        transform?: (response: T[]) => T[];
+        transform?: (response: T) => T;
+
+        /**
+         * DEPRECATED: transform the remote response before the Bloodhound instance operates on it.
+         * */
+        filter?: (response: T) => T;
+
     }
 
     /**
@@ -1200,6 +1206,11 @@ declare class Bloodhound<T> {
      * clearRemoteCache offers a way to programmatically clear said cache.
      */
     public clearRemoteCache(): Bloodhound<T>;
+
+    /*
+     * DEPRECATED: wraps the suggestion engine in an adapter that is compatible with the typeahead jQuery plugin
+     */
+    public ttAdapter(): any;
 }
 
 declare module "bloodhound" {

--- a/typeahead/typeahead-tests.ts
+++ b/typeahead/typeahead-tests.ts
@@ -374,7 +374,7 @@ function test_bloodhout() {
         }
 
         function test_bloodhout_prefetch_options_transform() {
-            var options: Bloodhound.PrefetchOptions<string> = {
+            var options: Bloodhound.PrefetchOptions<string[]> = {
                 url: 'url',
                 transform: (response: string[]) => { return new Array<string>(); }
             };
@@ -383,7 +383,7 @@ function test_bloodhout() {
         function test_bloodhout_prefetch_options_all() {
             var ajaxSettings: JQueryAjaxSettings = { url: 'url' };
 
-            var options: Bloodhound.PrefetchOptions<string> = {
+            var options: Bloodhound.PrefetchOptions<string[]> = {
                 url: 'url',
                 cache: true,
                 ttl: 86400000,
@@ -433,7 +433,7 @@ function test_bloodhout() {
         }
 
         function test_bloodhout_remote_options_transform() {
-            var options: Bloodhound.RemoteOptions<string> = {
+            var options: Bloodhound.RemoteOptions<string[]> = {
                 url: 'url',
                 transform: (response: string[]) => { return new Array<string>(); }
             };
@@ -442,7 +442,7 @@ function test_bloodhout() {
         function test_bloodhout_remote_options_all() {
             var ajaxSettings: JQueryAjaxSettings = { url: 'url' };
 
-            var options: Bloodhound.RemoteOptions<string> = {
+            var options: Bloodhound.RemoteOptions<string[]> = {
                 url: 'url',
                 prepare: (query: string, settings: JQueryAjaxSettings) => { return ajaxSettings; },
                 wildcard: '%QUERY',


### PR DESCRIPTION
- `transform` API is just an identity function, no need for it to only accept arrays.
- Deprecation notice for [`filter`](https://github.com/twitter/typeahead.js/blob/588440f66559714280628a4f9799f0c4eb880a4a/src/bloodhound/options_parser.js#L64) and [`ttAdapter`](https://github.com/twitter/typeahead.js/blob/588440f66559714280628a4f9799f0c4eb880a4a/src/bloodhound/bloodhound.js#L185) in the source seems to suggest `v1.0`, since the package is not there yet, and there does not seem to be a simple way to transition away from `ttAdapter`, no reason to break valid code.

