### PR TITLE
http-errors: Add missing constructor

### DIFF
--- a/http-errors/http-errors-tests.ts
+++ b/http-errors/http-errors-tests.ts
@@ -83,3 +83,4 @@ var err = new createError.MisdirectedRequest();
 var err = new createError.MisdirectedRequest('Where should this go?');
 
 let error: createError.HttpError;
+console.log(error instanceof createError.HttpError);

--- a/http-errors/index.d.ts
+++ b/http-errors/index.d.ts
@@ -23,6 +23,8 @@ declare module 'http-errors' {
             [code: string]: new (msg?: string) => HttpError;
 
             (...args: Array<Error | string | number | Object>): HttpError;
+            
+            HttpError: HttpErrorConstructor;
 
             Continue: HttpErrorConstructor;
             SwitchingProtocols: HttpErrorConstructor;


### PR DESCRIPTION
Allows the following to work:
```typescript
import { HttpError } from "http-errors";

//let error: HttpError;
console.log(error instanceof HttpError);
```

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
