### PR TITLE
Fix of React SyntheticEvent.timeStamp property type

### DIFF
--- a/react/index.d.ts
+++ b/react/index.d.ts
@@ -289,7 +289,7 @@ declare namespace React {
         persist(): void;
         // If you thought this should be `EventTarget & T`, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12239
         target: EventTarget;
-        timeStamp: Date;
+        timeStamp: number;
         type: string;
     }
 


### PR DESCRIPTION
Minor change: The `timeStamp` property of events is a numeric value in milliseconds, not a `Date`.

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp
