### PR TITLE
Fix Bookshelf transaction callback return type

### DIFF
--- a/bookshelf/index.d.ts
+++ b/bookshelf/index.d.ts
@@ -17,7 +17,7 @@ interface Bookshelf extends Bookshelf.Events<any> {
 	Collection: typeof Bookshelf.Collection;
 
 	plugin(name: string | string[] | Function, options?: any): Bookshelf;
-	transaction<T>(callback: (transaction: knex.Transaction) => T): BlueBird<T>;
+	transaction<T>(callback: (transaction: knex.Transaction) => BlueBird<T>): BlueBird<T>;
 }
 
 declare function Bookshelf(knex: knex): Bookshelf;


### PR DESCRIPTION
return `BlueBird<T>` instead of `T`
see [transaction](http://bookshelfjs.org/index.html#Bookshelf-instance-transaction)