### PR TITLE
Add missing parameter.

### DIFF
--- a/riot/index.d.ts
+++ b/riot/index.d.ts
@@ -205,8 +205,9 @@ declare namespace riot {
      * Register a shared mixin, globally available to be used in any tag using `TagInstance.mixin(mixinName)`
      * @param mixinName Name of the mixin
      * @param mixinObject Mixin object
+     * @param isGlobal Is global mixin?
      */
-    function mixin(mixinName: string, mixinObject: TagMixin): void;
+    function mixin(mixinName: string, mixinObject: TagMixin, isGlobal?: boolean): void;
 
     /**
      * Create a new custom tag “manually” without the compiler. Returns name of the tag.


### PR DESCRIPTION
Updating mixin function with the missing parameter according to the riot documentation:

```
riot.mixin('globalMixinOne', mixinObjectOne, true)
console.log(riot.mixin('globalMixinOne') === mixinObjectOne) // true
```

> Sometimes you may need to retrieve the mixin object so alternatively you may set your global mixin object by name. In this case the third boolean parameter indicates this mixin is not a shared but a global mixin.

source: http://riotjs.com/v2/guide/#mixins