### PR TITLE
Add csprng

### DIFF
--- a/csprng/csprng-tests.ts
+++ b/csprng/csprng-tests.ts
@@ -1,0 +1,5 @@
+import csprng = require("csprng");
+
+let rngStr: string;
+
+rngStr = csprng(32, 16);

--- a/csprng/index.d.ts
+++ b/csprng/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for csprng 0.1
+// Project: https://github.com/jcoglan/node-csprng
+// Definitions by: Wink Saville <https://github.com/winksaville>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+export = csprng;
+
+declare function csprng(bits: number, radix: number): string;

--- a/csprng/tsconfig.json
+++ b/csprng/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "csprng-tests.ts"
+    ]
+}

--- a/csprng/tslint.json
+++ b/csprng/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tslint.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [ y] Make your PR against the `master` branch.
- [ y] Use a meaningful title for the pull request. Include the name of the package modified.
- [ y] Test the change in your own code. (Compile and run.)
- [ y] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ y] Run `tsc` without errors.
- [ y] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If adding a new definition:
- [ y] The package does not provide its own types, and you can not add them.
- [ y] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ n] Create it with `npm run new-package package-name`, not by basing it on an existing project.
I tried but got an error:
```
$ npm run new-package csprng

> definitely-typed@0.0.1 new-package /home/wink/foss/DefinitelyTyped.my-fork
> dts-gen --dt "csprng"

Unexpected crash! Please log a bug with the commandline you specified.
/home/wink/foss/DefinitelyTyped.my-fork/node_modules/dts-gen/bin/lib/run.js:109
        throw e;
        ^

Error
    at new ArgsError (/home/wink/foss/DefinitelyTyped.my-fork/node_modules/dts-gen/bin/lib/run.js:25:28)
    at Object.<anonymous> (/home/wink/foss/DefinitelyTyped.my-fork/node_modules/dts-gen/bin/lib/run.js:39:15)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:425:7)
    at startup (bootstrap_node.js:146:9)
```
- [ y] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
