### PR TITLE
fix(express-serve-static-core): Add missing route methods

### DIFF
--- a/express-serve-static-core/index.d.ts
+++ b/express-serve-static-core/index.d.ts
@@ -96,6 +96,7 @@ interface IRouter extends RequestHandler {
     head: IRouterMatcher<this>;
 
     checkout: IRouterMatcher<this>;
+    connect: IRouterMatcher<this>;
     copy: IRouterMatcher<this>;
     lock: IRouterMatcher<this>;
     merge: IRouterMatcher<this>;
@@ -104,6 +105,8 @@ interface IRouter extends RequestHandler {
     move: IRouterMatcher<this>;
     "m-search": IRouterMatcher<this>;
     notify: IRouterMatcher<this>;
+    propfind: IRouterMatcher<this>;
+    proppatch: IRouterMatcher<this>;
     purge: IRouterMatcher<this>;
     report: IRouterMatcher<this>;
     search: IRouterMatcher<this>;


### PR DESCRIPTION
According to [Express routing guide](http://expressjs.com/en/guide/routing.html):
> Express supports the following routing methods that correspond to HTTP methods: `get`,`post`,`put`,`head`,`delete`,`options`,`trace`,`copy`,`lock`,`mkcol`,`move`,`purge`,`propfind`,`proppatch`,`unlock`,`report`,`mkactivity`,`checkout`,`merge`,`m-search`,`notify`,`subscribe`,`unsubscribe`,`patch`,`search` and `connect`.

This PR just adds definitions for missing `connect`, `propfind` and `proppatch` methods.