### PR TITLE
Update query-string to version 4.3

### DIFF
--- a/query-string/index.d.ts
+++ b/query-string/index.d.ts
@@ -1,26 +1,34 @@
-// Type definitions for query-string v3.0.0
+// Type definitions for query-string 4.3
 // Project: https://github.com/sindresorhus/query-string
-// Definitions by: Sam Verschueren <https://github.com/SamVerschueren>
+// Definitions by: Sam Verschueren <https://github.com/SamVerschueren>, Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 declare module "query-string" {
 
-                
-    interface StringifyOptions { strict?: boolean; encode?: boolean; }
+    interface ParseOptions {
+        arrayFormat?: 'bracket' | 'index' | 'none';
+    }
 
     /**
      * Parse a query string into an object.
      * Leading ? or # are ignored, so you can pass location.search or location.hash directly.
      * @param str
      */
-    export function parse(str: string): { [key: string]: string | string[] | null };
+    export function parse(str: string, options?: ParseOptions): any;
+
+    interface StringifyOptions {
+        strict?: boolean;
+        encode?: boolean;
+        arrayFormat?: 'bracket' | 'index' | 'none';
+    }
 
     /**
      * Stringify an object into a query string, sorting the keys.
      *
      * @param obj
      */
-    export function stringify(obj: any, options?: StringifyOptions): string;
+    export function stringify(obj: object, options?: StringifyOptions): string;
 
     /**
      * Extract a query string from a URL that can be passed into .parse().

--- a/query-string/query-string-tests.ts
+++ b/query-string/query-string-tests.ts
@@ -1,34 +1,34 @@
-
-import qs = require('query-string');
-
+import * as queryString from 'query-string';
 
 namespace stringify_tests {
     let result: string;
     // test obj
-    result = qs.stringify({
+    result = queryString.stringify({
         str: 'bar',
         strArray: ['baz'],
         num: 123,
         numArray: [456],
         bool: true,
-        boolArray: [false],
+        boolArray: [false]
     });
 
     // test options
-    result = qs.stringify({ foo: 'bar' }, { strict: false })
-    result = qs.stringify({ foo: 'bar' }, { encode: false })
-    result = qs.stringify({ foo: 'bar' }, { strict: false, encode: false })
+    result = queryString.stringify({ foo: 'bar' }, { strict: false });
+    result = queryString.stringify({ foo: 'bar' }, { encode: false });
+    result = queryString.stringify({ foo: 'bar' }, { strict: false, encode: false });
 }
 
 namespace parse_tests {
-    let result: { [key: string]: string | string[] | null };
-    result = qs.parse('?foo=bar');
-    result = qs.parse('#foo=bar');
-    result = qs.parse('&foo=bar&foo=baz');
+    let fooBar: { foo: 'bar' };
+    fooBar = queryString.parse('?foo=bar');
+    fooBar = queryString.parse('#foo=bar');
+
+    let fooBarBaz: { foo: ['bar', 'baz'] };
+    fooBarBaz = queryString.parse('&foo=bar&foo=baz');
 }
 
 namespace extract_tests {
     let result: string;
-    result = qs.extract('http://foo.bar/?abc=def&hij=klm');
-    result = qs.extract('http://foo.bar/?foo=bar');
+    result = queryString.extract('http://foo.bar/?abc=def&hij=klm');
+    result = queryString.extract('http://foo.bar/?foo=bar');
 }

--- a/query-string/tslint.json
+++ b/query-string/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tslint.json",
+  "rules": {
+    "no-single-declare-module": false
+  }
+}


### PR DESCRIPTION
Update query-string to version 4.3

Also a huge difference is the return type of `parse`. It should be `any` instead of `{ [key: string]: string | string[] | null }` otherwise this is not possible:

```TypeScript
const fooBar = queryString.parse('?foo=bar');
console.log(fooBar.foo); // Error Property 'foo' is missing in ...
```

This is also what [qs](https://github.com/ljharb/qs) definition does: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/qs/index.d.ts#L35

Due to the use of [`object`](https://blog.mariusschulz.com/2017/02/24/typescript-2-2-the-object-type), TypeScript 2.2 is needed.

The tests have been updated accordingly.

Tested with:
```
./node_modules/.bin/tsc -p query-string
npm run lint query-string
```


- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/query-string/blob/v4.3.2/readme.md
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
