### PR TITLE
Angular: Remove dictionary declaration from RootScope

### DIFF
--- a/angular/index.d.ts
+++ b/angular/index.d.ts
@@ -449,8 +449,6 @@ declare namespace angular {
      * see https://docs.angularjs.org/api/ng/type/$rootScope.Scope and https://docs.angularjs.org/api/ng/service/$rootScope
      */
     interface IRootScopeService {
-        [index: string]: any;
-
         $apply(): any;
         $apply(exp: string): any;
         $apply(exp: (scope: IScope) => any): any;


### PR DESCRIPTION
This declaratin break the typings system. This interface
should extends a custome one and not be extendable by default.

Error Case:
var newScope  = scope,$new());
newscope.a = {};      //no error
newscope.b = 'temp';  // no error

//some function that need an object {a: any}
foo(newscope as {a: any}); // error cannot convert ng.IScope to {a: any}



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.angularjs.org/api/ng/type/$rootScope.Scope>> (here u can see that there only 3 properties)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
