### PR TITLE
[SpeakingURL] - Rename interface Options

### DIFF
--- a/speakingurl/index.d.ts
+++ b/speakingurl/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for speakingurl 10.0
+// Type definitions for speakingurl 13.0
 // Project: http://pid.github.io/speakingurl/
 // Definitions by: Zlatko Andonovski <https://github.com/Goldsmith42/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -7,7 +7,7 @@ interface Dictionary<T> {
     [x: string]: T;
 }
 
-interface Options {
+interface SpeakingURLOptions {
     separator?: string;
     lang?: string|boolean;
     symbols?: boolean;
@@ -20,10 +20,10 @@ interface Options {
     custom?: string[]|Dictionary<string>;
 }
 
-declare function getSlug(input: string, options?: Options|string): string;
+declare function getSlug(input: string, options?: SpeakingURLOptions|string): string;
 
 declare namespace getSlug {
-    export function createSlug(options: Options): (input: string) => string;
+    export function createSlug(options: SpeakingURLOptions): (input: string) => string;
 }
 
 export = getSlug;


### PR DESCRIPTION
Rename interface `Options` to `SpeakingURLOptions` to avoid namespace conflict with other TypeScript definitions.