### PR TITLE
angular-file-saver extending angular module

### DIFF
--- a/angular-file-saver/index.d.ts
+++ b/angular-file-saver/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Donald Nairn <https://github.com/deenairn/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="angular" />
 import * as angular from 'angular';
 declare module 'angular' {
     /**

--- a/angular-file-saver/index.d.ts
+++ b/angular-file-saver/index.d.ts
@@ -4,12 +4,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="angular" />
-
-declare namespace angular {
+import * as angular from 'angular';
+declare module 'angular' {
     /**
      * A core Angular factory proving FileSaver functionality.
      */
-    interface FileSaver {
+    export interface FileSaver {
         /**
          * Immediately starts saving a file
          * @param data: a Blob instance;


### PR DESCRIPTION
Updating to reflect the new way to extend the angular module. See angular-ui-router or ng-file-upload for supporting examples.

I checked these changes with tsc.

Hopefully it's okay that I did this through the web-editor. If not, I can do the PR from my fork. Just let me know.