### PR TITLE
cucumber: Added HookOptions as a 1st arg to Before/After hooks

### DIFF
--- a/cucumber/cucumber-tests.ts
+++ b/cucumber/cucumber-tests.ts
@@ -3,7 +3,7 @@ import cucumber = require("cucumber");
 
 function StepSample() {
 	type Callback = cucumber.CallbackStepDefinition;
-  	type Table = cucumber.TableDefinition;
+	type Table = cucumber.TableDefinition;
 	type HookScenario = cucumber.HookScenario;
 	type Hooks = cucumber.Hooks;
 	var step = <cucumber.StepDefinitions>this;
@@ -17,6 +17,14 @@ function StepSample() {
 
 	hook.Before(function(scenario: HookScenario, callback: Callback){
 		scenario.isFailed() && callback.pending();
+	});
+
+	hook.Before({ timeout: 1000 }, function(scenario: HookScenario, callback: Callback) {
+		callback();
+	});
+
+	hook.After({ timeout: 1000 }, function(scenario: HookScenario, callback: Callback) {
+		callback();
 	});
 
 	hook.Around(function(scenario: HookScenario, runScenario: (error:string, callback?:Function)=>void)  {

--- a/cucumber/index.d.ts
+++ b/cucumber/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for cucumber-js
 // Project: https://github.com/cucumber/cucumber-js
-// Definitions by: Abraão Alves <https://github.com/abraaoalves>, Jan Molak <https://github.com/jan-molak>
+// Definitions by: Abraão Alves <https://github.com/abraaoalves>, Jan Molak <https://github.com/jan-molak>, Isaiah Soung <https://github.com/isoung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = cucumber;

--- a/cucumber/index.d.ts
+++ b/cucumber/index.d.ts
@@ -70,9 +70,15 @@ declare namespace cucumber {
 		typeName: string;
 	}
 
+	interface HookOptions{
+		timeout?: number;
+	}
+
 	export interface Hooks {
 		Before(code: HookCode): void;
+		Before(options: HookOptions, code: HookCode): void;
 		After(code: HookCode): void;
+		After(options: HookOptions, code: HookCode): void;
 		Around(code: AroundCode):void;
 		setDefaultTimeout(time:number): void;
 		setWorldConstructor(world: () => void): void;


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md#timeouts
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.


* Cucumber supports the use of a timeout arg as the 1st argument in the Before/After hooks. 
https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/timeouts.md#timeouts
