### PR TITLE
Fix Electron's MenuItem click signatures

### DIFF
--- a/electron/index.d.ts
+++ b/electron/index.d.ts
@@ -2456,7 +2456,7 @@ declare namespace Electron {
 		constructor(options: MenuItemOptions);
 
 		/**
-		 * A Function that is fired when the MenuItem recieves a click event
+		 * A function that is fired when the MenuItem receives a click event
 		 */
 		click: (event: Event, browserWindow: BrowserWindow, webContents: WebContents) => void;
 

--- a/electron/index.d.ts
+++ b/electron/index.d.ts
@@ -2492,7 +2492,7 @@ declare namespace Electron {
 		/**
 		 * Callback when the menu item is clicked.
 		 */
-		click?: (menuItem: MenuItem, browserWindow: BrowserWindow) => void;
+		click?: (menuItem: MenuItem, browserWindow: BrowserWindow, event: Event) => void;
 		/**
 		 * Can be normal, separator, submenu, checkbox or radio.
 		 */

--- a/electron/index.d.ts
+++ b/electron/index.d.ts
@@ -2455,7 +2455,11 @@ declare namespace Electron {
 		 */
 		constructor(options: MenuItemOptions);
 
-		click: (menuItem: MenuItem, browserWindow: BrowserWindow, event: Event) => void;
+		/**
+		 * A Function that is fired when the MenuItem recieves a click event
+		 */
+		click: (event: Event, browserWindow: BrowserWindow, webContents: WebContents) => void;
+
 		/**
 		 * Read-only property.
 		 */

--- a/electron/index.d.ts
+++ b/electron/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Electron v1.4.8
 // Project: http://electron.atom.io/
-// Definitions by: jedmao <https://github.com/jedmao/>, rhysd <https://rhysd.github.io>, Milan Burda <https://github.com/miniak/>, aliib <https://github.com/aliib>, Daniel Perez Alvarez <https://github.com/unindented>
+// Definitions by: jedmao <https://github.com/jedmao/>, rhysd <https://rhysd.github.io>, Milan Burda <https://github.com/miniak/>, aliib <https://github.com/aliib>, Daniel Perez Alvarez <https://github.com/unindented>, Markus Olsson <https://github.com/niik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/electron/test/main.ts
+++ b/electron/test/main.ts
@@ -531,12 +531,19 @@ var winWindows = new BrowserWindow({
 // menu-item
 // https://github.com/atom/electron/blob/master/docs/api/menu-item.md
 
-var menuItem = new MenuItem({});
+var menuItem = new MenuItem({
+	click: (menuItem: Electron.MenuItem, browserWindow: Electron.BrowserWindow, event: Electron.Event) => {
+		console.log('click', menuItem, browserWindow, event);
+	}
+});
+
+const fakeEvent: Electron.Event = {
+	preventDefault: () => { },
+	sender: winWindows.webContents,
+}
 
 menuItem.label = 'Hello World!';
-menuItem.click = (menuItem, browserWindow) => {
-	console.log('click', menuItem, browserWindow);
-};
+menuItem.click(fakeEvent, winWindows, winWindows.webContents)
 
 // menu
 // https://github.com/atom/electron/blob/master/docs/api/menu.md


### PR DESCRIPTION
Electron's [MenuItem](https://github.com/electron/electron/blob/master/docs/api/menu-item.md) class has two different signatures for its click-related functions. The first is the `MenuItem#click` instance method which is called by electron when a menu item is clicked and the second is the event handler which consumers provide which is invoked [via the click instance method](https://github.com/electron/electron/blob/master/lib/browser/api/menu-item.js#L52).

The [instance method](https://github.com/electron/electron/blob/master/lib/browser/api/menu-item.js#L44) takes an `Event` instance, a `BrowserWindow` instance and a `WebContents` instance while the click callback takes a `MenuItem` instance (the item just clicked), a `BrowserWindow` instance and an `Event` instance.

This PR updates both signatures such that they conform to the current state of affairs in Electron.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] ~~~Run `npm run lint package-name` if a `tslint.json` is present.~~~

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/electron/electron/blob/master/docs/api/menu-item.md
- [ ] ~~~Increase the version number in the header if appropriate.~~~
- [ ] ~~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.~~~