### PR TITLE
Add socket_id to pusher-js ConnectionManager interface

### DIFF
--- a/pusher-js/index.d.ts
+++ b/pusher-js/index.d.ts
@@ -145,6 +145,7 @@ declare namespace pusher {
         key: string;
         options: any; //TODO: Timeline.js
         state: string;
+        socket_id: string;
         connection: any; //TODO: Type this
         encrypted: boolean;
         timeline: any; //TODO: Type this


### PR DESCRIPTION
Adds missing socker_id attribute to ConnectionManager interface

```js
var pusher = new Pusher('APP_KEY');
var socketId = null;
pusher.connection.bind('connected', function() {
  socketId = pusher.connection.socket_id;
});
```