### PR TITLE
Android TextView now supports the native includeFontPadding property

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -734,6 +734,7 @@ declare module "react" {
 
     export interface TextStyleAndroid extends ViewStyle {
         textAlignVertical?: "auto" | "top" | "bottom" | "center"
+        includeFontPadding?: boolean
     }
 
     // @see https://facebook.github.io/react-native/docs/text.html#style


### PR DESCRIPTION
And it's exposed by react-native as a style property.

Reference: https://facebook.github.io/react-native/docs/text.html