### PR TITLE
Correct spelling on "ApplicationRequestHandler"

### DIFF
--- a/express-serve-static-core/index.d.ts
+++ b/express-serve-static-core/index.d.ts
@@ -858,7 +858,7 @@ interface RequestParamHandler {
     (req: Request, res: Response, next: NextFunction, value: any, name: string): any;
 }
 
-type ApplicaitonRequestHandler<T> =  IRouterHandler<T> & IRouterMatcher<T> & {
+type ApplicationRequestHandler<T> =  IRouterHandler<T> & IRouterMatcher<T> & {
   (...handlers: RequestHandlerParams[]): T;
 };
 


### PR DESCRIPTION
I didn't test or anything, I figured it was a quick fix.