### PR TITLE
[ng-file-upload] Add missing file resize options fields

### DIFF
--- a/ng-file-upload/index.d.ts
+++ b/ng-file-upload/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for Angular File Upload 11.1.1
+// Type definitions for Angular File Upload 12.2
 // Project: https://github.com/danialfarid/ng-file-upload
-// Definitions by: John Reilly <https://github.com/johnnyreilly>
+// Definitions by: John Reilly <https://github.com/johnnyreilly>,
+//   Eduardo Garcia <https://github.com/thewarpaint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="angular" />
@@ -103,10 +104,12 @@ declare module 'angular' {
         interface FileResizeOptions {
             centerCrop?: boolean;
             height?: number;
-            ratio?: number;
+            pattern?: string;
+            ratio?: number | string;
             resizeIf?: ResizeIfFunction;
             restoreExif?: boolean;
             quality?: number;
+            type?: string;
             width?: number;
         }
 

--- a/ng-file-upload/ng-file-upload-tests.ts
+++ b/ng-file-upload/ng-file-upload-tests.ts
@@ -85,9 +85,11 @@ class UploadController {
 				ratio: 0.9,
 				centerCrop: true,
 				restoreExif: true,
-                                resizeIf: (width: number, height: number) => {
+				resizeIf: (width: number, height: number) => {
 					return true;
-				}
+				},
+				pattern: '.jpg',
+				type: 'image/jpeg'
 			})
 			.then((resizedFile) => {
 				console.log(resizedFile);


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/danialfarid/ng-file-upload/blob/master/src/resize.js
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

I will add tslint.json and update the interfaces in a separate PR.
