### PR TITLE
Amend "call" route method signature to allow path/value pair based invalidation

### DIFF
--- a/falcor-router/falcor-router-tests.ts
+++ b/falcor-router/falcor-router-tests.ts
@@ -2,6 +2,7 @@
 
 import falcor = require('falcor');
 import Router = require('falcor-router');
+import falcorJsonGraph = require('falcor-json-graph');
 
 new Router([]);
 new Router([], {});
@@ -100,3 +101,76 @@ new Router([{
     }
 }]);
 
+new Router([{
+    route: 'todos.new',
+    call(callpath, args) {
+      return {path: 'json.todosById.1234.name', value: 'Buy cheese'};
+    }
+}]);
+
+new Router([{
+    route: 'todos.new',
+    call(callpath, args) {
+      return falcorJsonGraph.pathInvalidation('json.todos.length');
+    }
+}]);
+
+new Router([{
+    route: 'todos.new',
+    call(callpath, args) {
+      return [
+        falcorJsonGraph.pathInvalidation('json.todos.length'),
+        {path: 'json.todosById.1234.name', value: 'Buy cheese'}
+      ]
+    }
+}]);
+
+new Router([{
+    route: 'todos.new',
+    call(callpath, args) {
+      return new Promise((resolve, reject): void => {
+        resolve([
+          falcorJsonGraph.pathInvalidation('json.todos.length'),
+          {path: 'json.todosById.1234.name', value: 'Buy cheese'}
+        ]);
+      });
+    }
+}]);
+
+new Router([{
+    route: 'todos.new',
+    call(callpath, args) {
+      return {
+          paths: [['json', 'todosById', '1234', 'name']],
+          jsonGraph: {
+              json: {
+                  todosById: {
+                      1234: {
+                          name: 'Buy cheese'
+                      }
+                  }
+              }
+          }
+      };
+    }
+}]);
+
+new Router([{
+    route: 'todos.new',
+    call(callpath, args) {
+      return new Promise((resolve, reject): void => {
+          resolve({
+              paths: [['json', 'todosById', '1234', 'name']],
+              jsonGraph: {
+                  json: {
+                      todosById: {
+                          1234: {
+                              name: 'Buy cheese'
+                          }
+                      }
+                  }
+              }
+          });
+      });
+    }
+}]);

--- a/falcor-router/index.d.ts
+++ b/falcor-router/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for falcor-router 0.4.0
 // Project: https://github.com/Netflix/falcor-router
-// Definitions by: Quramy <https://github.com/Quramy/>
-// Definitions by: cdhgee <https://github.com/cdhgee/>
+// Definitions by: Quramy <https://github.com/Quramy/>, cdhgee <https://github.com/cdhgee/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference types="falcor" />

--- a/falcor-router/index.d.ts
+++ b/falcor-router/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for falcor-router 0.4.0
 // Project: https://github.com/Netflix/falcor-router
-// Definitions by: Quramy <https://github.com/Quramy/> and cdhgee <https://github.com/cdhgee/>
+// Definitions by: Quramy <https://github.com/Quramy/>
+// Definitions by: cdhgee <https://github.com/cdhgee/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference types="falcor" />

--- a/falcor-router/index.d.ts
+++ b/falcor-router/index.d.ts
@@ -34,7 +34,7 @@ declare namespace FalcorRouter {
     type RoutePathSet = FalcorJsonGraph.PathSet;
 
     interface CallRoute extends Route {
-        call(callPath: RoutePathSet, args: Array<any>): RouteResult | Promise<RouteResult>;
+        call(callPath: RoutePathSet, args: Array<any>): CallRouteResult | Promise<CallRouteResult>;
     }
 
     interface GetRoute extends Route {
@@ -47,6 +47,7 @@ declare namespace FalcorRouter {
 
     type RouteDefinition = GetRoute | SetRoute | CallRoute;
     type RouteResult = FalcorJsonGraph.PathValue | Array<FalcorJsonGraph.PathValue> | FalcorJsonGraph.JSONEnvelope<any>;
+    type CallRouteResult = FalcorJsonGraph.PathValue | FalcorJsonGraph.InvalidPath | Array<FalcorJsonGraph.PathValue | FalcorJsonGraph.InvalidPath> | FalcorJsonGraph.JSONGraphEnvelope;
 
     interface RouterOptions {
         debug?: boolean;

--- a/falcor-router/index.d.ts
+++ b/falcor-router/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for falcor-router 0.4.0
 // Project: https://github.com/Netflix/falcor-router
-// Definitions by: Quramy <https://github.com/Quramy/>
+// Definitions by: Quramy <https://github.com/Quramy/> and cdhgee <https://github.com/cdhgee/>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
 /// <reference types="falcor" />


### PR DESCRIPTION
The "call" method of a falcor router allows either a JSONGraphEnvelope object or one or more path-value pairs.

The current signature of the "call" method allows only one or more path value pairs or a JSONEnvelope object to be returned. It does not allow invalidated paths to be returned. 

This change corrects the signature of the "call" method definition to reflect the correct signature, allowing path invalidation via path-value pairs to compile correctly (see discussion in  https://github.com/Netflix/falcor-router/issues/192). Sample code showing this method of path invalidation can be seen at https://github.com/Netflix/falcor-router-demo/blob/master/index.js, lines 467-476.

See also https://netflix.github.io/falcor/documentation/jsongraph.html. 