### PR TITLE
webgl-ext: fix OESVertexArrayObject to confom spec

### DIFF
--- a/webgl-ext/index.d.ts
+++ b/webgl-ext/index.d.ts
@@ -118,10 +118,10 @@ interface WebGLVertexArrayObjectOES extends WebGLObject {
 interface OESVertexArrayObject {
 	VERTEX_ARRAY_BINDING_OES: number;
 
-	createVertexArrayOES(): WebGLVertexArrayObjectOES;
-	deleteVertexArrayOES(arrayObject: WebGLVertexArrayObjectOES): void;
-	isVertexArrayOES(arrayObject: WebGLVertexArrayObjectOES): boolean;
-	bindVertexArrayOES(arrayObject: WebGLVertexArrayObjectOES): void;
+	createVertexArrayOES(): WebGLVertexArrayObjectOES | null;
+	deleteVertexArrayOES(arrayObject: WebGLVertexArrayObjectOES | null): void;
+	isVertexArrayOES(arrayObject: WebGLVertexArrayObjectOES | null): boolean;
+	bindVertexArrayOES(arrayObject: WebGLVertexArrayObjectOES | null): void;
 }
 
 interface WebGLColorBufferFloat {


### PR DESCRIPTION
According to the [spec](https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/), everywhere `WebGLVertexArrayObjectOES` is used, it has to be nullable (not optional, however).