### PR TITLE
redux-logger: updated export to 'default' to work with lib version 2.10.1

### DIFF
--- a/redux-logger/index.d.ts
+++ b/redux-logger/index.d.ts
@@ -46,4 +46,4 @@ declare namespace createLogger {
   }
 }
 declare function createLogger(options?: createLogger.ReduxLoggerOptions): Redux.Middleware;
-export = createLogger;
+export default createLogger;

--- a/redux-logger/index.d.ts
+++ b/redux-logger/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for redux-logger v2.6.0
+// Type definitions for redux-logger v2.10.1
 // Project: https://github.com/fcomb/redux-logger
 // Definitions by: Alexander Rusakov <https://github.com/arusakov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
@evgenyrodionov changed export in library, this syncs the definitions to match.  I have reviewed FAQ in relation to ```default``` usage.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/evgenyrodionov/redux-logger
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.