### PR TITLE
redux-logger: updated export to 'default' to work with lib version 2.10.1

### DIFF
--- a/redux-logger/index.d.ts
+++ b/redux-logger/index.d.ts
@@ -46,4 +46,4 @@ declare namespace createLogger {
   }
 }
 declare function createLogger(options?: createLogger.ReduxLoggerOptions): Redux.Middleware;
-export = createLogger;
+export default createLogger;

--- a/redux-logger/index.d.ts
+++ b/redux-logger/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for redux-logger v2.6.0
+// Type definitions for redux-logger v2.10.1
 // Project: https://github.com/fcomb/redux-logger
 // Definitions by: Alexander Rusakov <https://github.com/arusakov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/redux-logger/index.d.ts
+++ b/redux-logger/index.d.ts
@@ -3,47 +3,49 @@
 // Definitions by: Alexander Rusakov <https://github.com/arusakov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+export as namespace ReduxLogger;
+
 import * as Redux from "redux";
 
-// Trickery to get TypeScript to accept that our anonymous, non-default export is a function.
-// see https://github.com/Microsoft/TypeScript/issues/3612 for more
-declare namespace createLogger {
-  export type LoggerPredicate = (getState: () => any, action: any) => boolean;
+export const logger: Redux.Middleware;
 
-  export type StateToString = (state: any) => string;
-  export type ActionToString = (action: any) => string;
-  export type ErrorToString = (error: any, prevState: any) => string;
+export type LoggerPredicate = (getState: () => any, action: any) => boolean;
 
-  export interface ColorsObject {
-    title?: boolean | ActionToString;
-    prevState?: boolean | StateToString;
-    action?: boolean | ActionToString;
-    nextState?: boolean | StateToString;
-    error?: boolean | ErrorToString;
-  }
+export type StateToString = (state: any) => string;
+export type ActionToString = (action: any) => string;
+export type ErrorToString = (error: any, prevState: any) => string;
 
-  export interface LevelObject {
-    prevState?: string | boolean | StateToString;
-    action?: string | boolean | ActionToString;
-    nextState?: string | boolean | StateToString;
-    error?: string | boolean | ErrorToString;
-  }
-
-  export interface ReduxLoggerOptions {
-    level?: string | ActionToString | LevelObject;
-    duration?: boolean;
-    timestamp?: boolean;
-    colors?: ColorsObject;
-    logger?: any;
-    logErrors?: boolean;
-    collapsed?: boolean | LoggerPredicate;
-    predicate?: LoggerPredicate;
-    stateTransformer?: (state: any) => any;
-    actionTransformer?: (action: any) => any;
-    errorTransformer?: (error: any) => any;
-    diff?: boolean;
-    diffPredicate?: LoggerPredicate;
-  }
+export interface ColorsObject {
+  title?: boolean | ActionToString;
+  prevState?: boolean | StateToString;
+  action?: boolean | ActionToString;
+  nextState?: boolean | StateToString;
+  error?: boolean | ErrorToString;
 }
-declare function createLogger(options?: createLogger.ReduxLoggerOptions): Redux.Middleware;
+
+export interface LevelObject {
+  prevState?: string | boolean | StateToString;
+  action?: string | boolean | ActionToString;
+  nextState?: string | boolean | StateToString;
+  error?: string | boolean | ErrorToString;
+}
+
+export interface ReduxLoggerOptions {
+  level?: string | ActionToString | LevelObject;
+  duration?: boolean;
+  timestamp?: boolean;
+  colors?: ColorsObject;
+  logger?: any;
+  logErrors?: boolean;
+  collapsed?: boolean | LoggerPredicate;
+  predicate?: LoggerPredicate;
+  stateTransformer?: (state: any) => any;
+  actionTransformer?: (action: any) => any;
+  errorTransformer?: (error: any) => any;
+  diff?: boolean;
+  diffPredicate?: LoggerPredicate;
+}
+
+declare function createLogger(options?: ReduxLoggerOptions): Redux.Middleware;
+
 export default createLogger;


### PR DESCRIPTION
@evgenyrodionov changed export in library, this syncs the definitions to match.  I have reviewed FAQ in relation to ```default``` usage.  Basically re-written now to remove old typescript fixes.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/evgenyrodionov/redux-logger
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.