### PR TITLE
Added title attribute to datatables.net-buttons ButtonSettings

### DIFF
--- a/datatables.net-buttons/datatables.net-buttons-tests.ts
+++ b/datatables.net-buttons/datatables.net-buttons-tests.ts
@@ -22,6 +22,7 @@ $(document).ready(function () {
                     name: 'name',
                     namespace: 'namespace',
                     titleAttr: 'title',
+                    title: 'title'
                 }
             ],
         }

--- a/datatables.net-buttons/index.d.ts
+++ b/datatables.net-buttons/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for JQuery DataTables Buttons extension 1.1.0
 // Project: http://datatables.net/extensions/buttons/
-// Definitions by: Sam Germano <https://github.com/SammyG4Free>
+// Definitions by: Sam Germano <https://github.com/SammyG4Free>, Jim Hartford <https://github.com/jimhartford>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="jquery" />
@@ -79,6 +79,11 @@ declare namespace DataTables {
         * Button 'title' attribute text
         */
         titleAttr?: string;
+
+        /**
+         * Button 'title' text
+         */
+        title?: string;
 
         exportOptions?: ButtonExportOptions;
         autoPrint?: boolean;

--- a/datatables.net-buttons/tsconfig.json
+++ b/datatables.net-buttons/tsconfig.json
@@ -12,7 +12,7 @@
         "typeRoots": [
             "../"
         ],
-        "types": ["jquery","datatables.net"],
+        "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },

--- a/datatables.net-buttons/tsconfig.json
+++ b/datatables.net-buttons/tsconfig.json
@@ -12,7 +12,7 @@
         "typeRoots": [
             "../"
         ],
-        "types": [],
+        "types": ["jquery","datatables.net"],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://datatables.net/extensions/buttons/examples/html5/filename.html 
You can see in the example, title can be a valid attribute
