### PR TITLE
react-intl: Add properties used in tests.

### DIFF
--- a/react-intl/index.d.ts
+++ b/react-intl/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-intl 2.2.1
 // Project: http://formatjs.io/react/
-// Definitions by: Bruno Grieder <https://github.com/bgrieder>, Christian Droulers <https://github.com/cdroulers>, Fedor Nezhivoi <https://github.com/gyzerok>, Till Wolff <https://github.com/tillwolff> 
+// Definitions by: Bruno Grieder <https://github.com/bgrieder>, Christian Droulers <https://github.com/cdroulers>, Fedor Nezhivoi <https://github.com/gyzerok>, Till Wolff <https://github.com/tillwolff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -14,7 +14,8 @@ declare namespace ReactIntl {
         pluralRuleFunction?: (n: number, ord: boolean) => string;
     }
 
-    function injectIntl<T>(component: React.ComponentClass<InjectedIntlProps & T> | React.StatelessComponent<InjectedIntlProps & T>): React.ComponentClass<T>;
+    function injectIntl<T>(component: React.ComponentClass<InjectedIntlProps & T> | React.StatelessComponent<InjectedIntlProps & T>):
+        React.ComponentClass<T> & { WrappedComponent: React.ComponentClass<InjectedIntlProps & T> | React.StatelessComponent<InjectedIntlProps & T> };
 
     function addLocaleData(data: Locale[] | Locale): void;
 
@@ -227,7 +228,11 @@ declare namespace ReactIntl {
             defaultFormats?: Object;
         }
     }
-    class IntlProvider extends React.Component<IntlProvider.Props, any> { }
+    class IntlProvider extends React.Component<IntlProvider.Props, any> {
+        getChildContext(): {
+            intl: InjectedIntl;
+        }
+    }
 
     class LocaleData extends Array<Locale> {
     }

--- a/react-intl/react-intl-tests.tsx
+++ b/react-intl/react-intl-tests.tsx
@@ -168,7 +168,7 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
     }
 }
 
-const SomeComponentWithIntl: React.ComponentClass<SomeComponentProps> = injectIntl(SomeComponent);
+const SomeComponentWithIntl = injectIntl(SomeComponent);
 
 class TestApp extends React.Component<{}, {}> {
     public render(): React.ReactElement<{}> {
@@ -190,6 +190,10 @@ class TestApp extends React.Component<{}, {}> {
         );
     }
 }
+
+const intlProvider = new IntlProvider({ locale: 'en' }, {});
+const { intl } = intlProvider.getChildContext();
+const wrappedComponent = <SomeComponentWithIntl.WrappedComponent className="test" intl={intl}/>
 
 export default {
     TestApp,


### PR DESCRIPTION
### Context
`react-intl` provides an `injectIntl` higher order component which wraps a React component and provides some extra props to it. It also [exposes the original component](https://github.com/yahoo/react-intl/blob/master/src/inject.js) as `WrappedComponent` and this is [useful for testing](https://github.com/yahoo/react-intl/wiki/Testing-with-React-Intl#relativedate-advanced-uses-injectintl).

In order to get the data necessary to pass to such a component, the `IntlProvider` component exposes a [`getChildContext()` method](https://github.com/yahoo/react-intl/blob/master/src/components/provider.js#L147).

### Questions
- Is there a way to say that the type of `WrappedComponent` is the same as that of the `component` parameter, but still assert that this is a react component with the given props? The solution presented here works but feels inelegant.
