### PR TITLE
Revert "googlemaps fixe Place Details query params"

### DIFF
--- a/googlemaps/index.d.ts
+++ b/googlemaps/index.d.ts
@@ -2276,7 +2276,7 @@ declare namespace google.maps {
         }
 
         export interface PlaceDetailsRequest  {
-            placeid: string;
+            placeId: string;
         }
 
         export interface PlaceGeometry {


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#14868

As per the discussion at #14868, this change should never have been made. The official JS documentation for the Google Maps JS API shows the field as camel case: `placeId`.

See https://developers.google.com/maps/documentation/javascript/reference#PlaceDetailsRequest