### PR TITLE
Lodash compact should remove undefineds

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Lo-Dash 4.14
 // Project: http://lodash.com/
-// Definitions by: Brian Zengel <https://github.com/bczengel>, Ilya Mochalov <https://github.com/chrootsu>, Stepan Mikhaylyuk <https://github.com/stepancar>
+// Definitions by: Brian Zengel <https://github.com/bczengel>, Ilya Mochalov <https://github.com/chrootsu>, Stepan Mikhaylyuk <https://github.com/stepancar>, Eric L Anderson <https://github.com/ericanderson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -468,7 +468,7 @@ declare namespace _ {
          * @param array The array to compact.
          * @return (Array) Returns the new array of filtered values.
          */
-        compact<T>(array?: List<T>): T[];
+        compact<T>(array?: List<T | undefined>): T[];
     }
 
     interface LoDashImplicitArrayWrapper<T> {


### PR DESCRIPTION
```ts
const orig = [0, 1, 2];
const modified = _.compact(orig.map((d) => d % 2 === 0 ? d : undefined);
```

Before, `modified` was `(number | undefined)[]` ... now its `number[]`;
