### PR TITLE
Office-JS: Fix DialogOptions Interface

### DIFF
--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Office.js
 // Project: http://dev.office.com
-// Definitions by: OfficeDev <https://github.com/OfficeDev>
+// Definitions by: OfficeDev <https://github.com/OfficeDev>, Lance Austin <https://github.com/LanceEA>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*
@@ -111,6 +111,10 @@ declare namespace Office {
          * Optional. Determines whether the dialog is safe to display within a Web frame.
          */
         xFrameDenySafe?: boolean,
+        /**
+         * Optional. Determines whether the dialog box should be displayed within an IFrame. This setting is only applicable in Office Online clients, this setting is ignored by desktop clients. 
+         */
+        displayInIframe?: boolean
     }
     export interface OfficeTheme {
         bodyBackgroundColor: string;

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -108,10 +108,6 @@ declare namespace Office {
          */
         width?: number,
         /**
-         * Optional. Determines whether the dialog is safe to display within a Web frame.
-         */
-        xFrameDenySafe?: boolean,
-        /**
          * Optional. Determines whether the dialog box should be displayed within an IFrame. This setting is only applicable in Office Online clients, this setting is ignored by desktop clients. 
          */
         displayInIframe?: boolean

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -108,7 +108,7 @@ declare namespace Office {
          */
         width?: number,
         /**
-         * Optional. Determines whether the dialog box should be displayed within an IFrame. This setting is only applicable in Office Online clients, this setting is ignored by desktop clients. 
+         * Optional. Determines whether the dialog box should be displayed within an IFrame. This setting is only applicable in Office Online clients, and is ignored on the platforms. 
          */
         displayInIframe?: boolean
     }

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -108,7 +108,7 @@ declare namespace Office {
          */
         width?: number,
         /**
-         * Optional. Determines whether the dialog box should be displayed within an IFrame. This setting is only applicable in Office Online clients, and is ignored on the platforms. 
+         * Optional. Determines whether the dialog box should be displayed within an IFrame. This setting is only applicable in Office Online clients, and is ignored on other platforms.
          */
         displayInIframe?: boolean
     }


### PR DESCRIPTION
## Update Existing Package
Here is a link to the official documentation that shows what the interface for **DialogOptions** should look like. I have added the field **displayInIframe**.
 
https://github.com/OfficeDev/office-js-docs/blob/master/reference/shared/officeui.displaydialogasync.md

