### PR TITLE
chokidar: extend EventEmitter and implement fs.FSWatcher

### DIFF
--- a/chokidar/chokidar-tests.ts
+++ b/chokidar/chokidar-tests.ts
@@ -1,33 +1,44 @@
-
-
-import fs = require('fs');
+import * as fs from 'fs';
 import chokidar = require('chokidar');
 
-var watcher = chokidar.watch('file, dir, or glob', {
+const watcher = chokidar.watch('file, dir, or glob', {
     ignored: /[\/\\]\./, persistent: true
 });
 
-var log = console.log.bind(console);
-
-let str: string;
-let any: any;
-let stats: fs.Stats;
+const log = console.log.bind(console);
 
 watcher
-    .on('add', path => { str = path; })
-    .on('addDir', path => { str = path; })
-    .on('change', path => { str = path; })
-    .on('unlink', path => { str = path; })
-    .on('unlinkDir', path => { str = path; })
-    .on('error', (error) => { any = error; })
-    .on('ready', () => { })
-    .on('raw', (event, path, details) => { str = event; str = path; any = details; })
+    .on('add', (path: string) => {
+        log('File', path, 'has been added');
+    })
+    .on('addDir', (path: string) => {
+        log('Directory', path, 'has been added');
+    })
+    .on('change', (path: string) => {
+        log('File', path, 'has been changed');
+    })
+    .on('unlink', (path: string) => {
+        log('File', path, 'has been removed');
+    })
+    .on('unlinkDir', (path: string) => {
+        log('Directory', path, 'has been removed');
+    })
+    .on('error', (error: any) => {
+        log('Error happened', error);
+    })
+    .on('ready', () => {
+        log('Initial scan complete. Ready for changes.');
+    })
+    .on('raw', (event: string, path: string, details: any) => {
+        log('Raw event info:', event, path, details);
+    });
 
 // 'add', 'addDir' and 'change' events also receive stat() results as second
 // argument when available: http://nodejs.org/api/fs.html#fs_class_fs_stats
-watcher.on('change', (path, _stats) => {
-    str = path;
-    stats = _stats;
+watcher.on('change', (path: string, stats: fs.Stats) => {
+    if (stats) {
+        console.log('File', path, 'changed size to', stats.size);
+    }
 });
 
 // Watch new files.
@@ -41,7 +52,6 @@ watcher.unwatch('new-file*');
 watcher.close();
 
 // One-liner
-chokidar.watch('.', {ignored: /[\/\\]\./}).on('all', (event, path) => {
-    str = event;
-    str = path;
+chokidar.watch('.', { ignored: /[\/\\]\./ }).on('all', (event: string, path: string) => {
+    console.log(event, path);
 });

--- a/chokidar/index.d.ts
+++ b/chokidar/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for chokidar 1.6.1
 // Project: https://github.com/paulmillr/chokidar
-// Definitions by: Felix Becker <https://github.com/felixfbecker>
-// Original definitions by: Stefan Steinhart <https://github.com/reppners>
+// Definitions by: Stefan Steinhart <https://github.com/reppners/>, Felix Becker <https://github.com/felixfbecker/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/chokidar/index.d.ts
+++ b/chokidar/index.d.ts
@@ -1,49 +1,161 @@
-// Type definitions for chokidar 1.4.3
+// Type definitions for chokidar 1.6.1
 // Project: https://github.com/paulmillr/chokidar
-// Definitions by: Stefan Steinhart <https://github.com/reppners/>
+// Definitions by: Felix Becker <https://github.com/felixfbecker>
+// Original definitions by: Stefan Steinhart <https://github.com/reppners>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-declare module "chokidar"
-{
-    export class FSWatcher
-    {
-        constructor(options?: WatchOptions);
-        add(fileDirOrGlob:string):void;
-        add(filesDirsOrGlobs:Array<string>):void;
-        unwatch(fileDirOrGlob:string):void;
-        unwatch(filesDirsOrGlobs:Array<string>):void;
-        getWatched():any;
-        on(event: 'add', fn: (path: string, stats?: fs.Stats) => void): this;
-        on(event: 'change', fn: (path: string, stats?: fs.Stats) => void): this;
-        on(event: 'unlink', fn: (path: string) => void): this;
-        on(event: 'raw', fn: (event: string, path:string, details:any) => void): this;
-        on(event: 'all', fn: (event: string, path: string) => void): this;
-        on(event: string, fn: (path: string) => void): this;
-        close(): this;
-    }
+import * as fs from 'fs';
+import {EventEmitter} from 'events';
 
-    interface WatchOptions
-    {
-        persistent?:boolean;
-        ignored?:any;
-        ignoreInitial?:boolean;
-        followSymlinks?:boolean;
-        cwd?:string;
-        usePolling?:boolean;
-        useFsEvents?:boolean;
-        alwaysStat?:boolean;
-        depth?:number;
-        interval?:number;
-        binaryInterval?:number;
-        ignorePermissionErrors?:boolean;
-        atomic?:boolean;
-        awaitWriteFinish?:any;
-    }
-
-    import fs = require("fs");
-
-    export function watch(fileDirOrGlob:string, options?:WatchOptions):FSWatcher;
-    export function watch(filesDirsOrGlobs:Array<string>, options?:WatchOptions):FSWatcher;
+/**
+ * The object's keys are all the directories (using absolute paths unless the `cwd` option was
+ * used), and the values are arrays of the names of the items contained in each directory.
+ */
+export interface WatchedPaths {
+    [directory: string]: string[];
 }
+
+export class FSWatcher extends EventEmitter implements fs.FSWatcher {
+
+    /**
+     * Add files, directories, or glob patterns for tracking. Takes an array of strings or just one
+     * string.
+     */
+    add(paths: string | string[]): void;
+
+    /**
+     * Stop watching files, directories, or glob patterns. Takes an array of strings or just one
+     * string.
+     */
+    unwatch(paths: string | string[]): void;
+
+    /**
+     * Returns an object representing all the paths on the file system being watched by this
+     * `FSWatcher` instance. The object's keys are all the directories (using absolute paths unless
+     * the `cwd` option was used), and the values are arrays of the names of the items contained in
+     * each directory.
+     */
+    getWatched(): WatchedPaths;
+
+    /**
+     * Removes all listeners from watched files.
+     */
+    close(): void;
+}
+
+export interface WatchOptions {
+
+    /**
+     * Indicates whether the process should continue to run as long as files are being watched. If
+     * set to `false` when using `fsevents` to watch, no more events will be emitted after `ready`,
+     * even if the process continues to run.
+     */
+    persistent?: boolean;
+
+    /**
+     * ([anymatch](https://github.com/es128/anymatch)-compatible definition) Defines files/paths to
+     * be ignored. The whole relative or absolute path is tested, not just filename. If a function
+     * with two arguments is provided, it gets called twice per path - once with a single argument
+     * (the path), second time with two arguments (the path and the
+     * [`fs.Stats`](http://nodejs.org/api/fs.html#fs_class_fs_stats) object of that path).
+     */
+    ignored?: any;
+
+    /**
+     * If set to `false` then `add`/`addDir` events are also emitted for matching paths while
+     * instantiating the watching as chokidar discovers these file paths (before the `ready` event).
+     */
+    ignoreInitial?: boolean;
+
+    /**
+     * When `false`, only the symlinks themselves will be watched for changes instead of following
+     * the link references and bubbling events through the link's path.
+     */
+    followSymlinks?: boolean;
+
+    /**
+     * The base directory from which watch `paths` are to be derived. Paths emitted with events will
+     * be relative to this.
+     */
+    cwd?: string;
+
+    /**
+     * Whether to use fs.watchFile (backed by polling), or fs.watch. If polling leads to high CPU
+     * utilization, consider setting this to `false`. It is typically necessary to **set this to
+     * `true` to successfully watch files over a network**, and it may be necessary to successfully
+     * watch files in other non-standard situations. Setting to `true` explicitly on OS X overrides
+     * the `useFsEvents` default.
+     */
+    usePolling?: boolean;
+
+    /**
+     * Whether to use the `fsevents` watching interface if available. When set to `true` explicitly
+     * and `fsevents` is available this supercedes the `usePolling` setting. When set to `false` on
+     * OS X, `usePolling: true` becomes the default.
+     */
+    useFsEvents?: boolean;
+
+    /**
+     * If relying upon the [`fs.Stats`](http://nodejs.org/api/fs.html#fs_class_fs_stats) object that
+     * may get passed with `add`, `addDir`, and `change` events, set this to `true` to ensure it is
+     * provided even in cases where it wasn't already available from the underlying watch events.
+     */
+    alwaysStat?: boolean;
+
+    /**
+     * If set, limits how many levels of subdirectories will be traversed.
+     */
+    depth?: number;
+
+    /**
+     * Interval of file system polling.
+     */
+    interval?: number;
+
+    /**
+     * Interval of file system polling for binary files. ([see list of binary extensions](https://gi
+     * thub.com/sindresorhus/binary-extensions/blob/master/binary-extensions.json))
+     */
+    binaryInterval?: number;
+
+    /**
+     *  Indicates whether to watch files that don't have read permissions if possible. If watching
+     *  fails due to `EPERM` or `EACCES` with this set to `true`, the errors will be suppressed
+     *  silently.
+     */
+    ignorePermissionErrors?: boolean;
+
+    /**
+     * `true` if `useFsEvents` and `usePolling` are `false`). Automatically filters out artifacts
+     * that occur when using editors that use "atomic writes" instead of writing directly to the
+     * source file. If a file is re-added within 100 ms of being deleted, Chokidar emits a `change`
+     * event rather than `unlink` then `add`. If the default of 100 ms does not work well for you,
+     * you can override it by setting `atomic` to a custom value, in milliseconds.
+     */
+    atomic?: boolean | number;
+
+    /**
+     * can be set to an object in order to adjust timing params:
+     */
+    awaitWriteFinish?: AwaitWriteFinishOptions;
+}
+
+export interface AwaitWriteFinishOptions {
+
+    /**
+     * Amount of time in milliseconds for a file size to remain constant before emitting its event.
+     */
+    stabilityThreshold?: number;
+
+    /**
+     * File size polling interval.
+     */
+    pollInterval?: number;
+}
+
+/**
+ * produces an instance of `FSWatcher`.
+ */
+export function watch(paths: string | string[], options?: WatchOptions): FSWatcher;


### PR DESCRIPTION
Now properly extends EventEmitter and implements fs.FSWatcher.
Based on newer typings from: https://github.com/types/npm-chokidar
Also updated the tests.
Closes #14563 and #14595.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/paulmillr/chokidar/blob/master/index.js#L55
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.