### PR TITLE
Lunr - Export as module

### DIFF
--- a/lunr/index.d.ts
+++ b/lunr/index.d.ts
@@ -916,3 +916,6 @@ declare namespace lunr
  * ```
  */
 declare function lunr(config:Function):lunr.Index;
+
+export = lunr;
+export as namespace lunr;


### PR DESCRIPTION
This PR exports the `lunr` namespace as a module so that it can be included with `import`.

I'm working on a project with the [`no-var-requires`](https://palantir.github.io/tslint/rules/no-var-requires/) TSLint rule and `moduleResolution: node` in our `tsconfig.json`, so things like `const lunr = require('lunr')` and `import lunr = require('lunr')` are no good. I couldn't find any import statement that both worked and satisfied linter.

FWIW, the Lunr library itself [does export itself as a module](https://github.com/olivernn/lunr.js/blob/20789e26f3732188216d7faf6dafb0a3656f4703/lunr.js#L2040).

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
    - **There are many lint errors but none in the code I have added.**

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
    - **N/A**
- [x] Increase the version number in the header if appropriate.
    - **There is no version number in the header (or, rather, the version number in the header refers to the version number of Lunr itself).**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
    - **N/A**
