### PR TITLE
[winston] fix LoggerOptions with correct type for rewritters and filters

### DIFF
--- a/winston-dynamodb/index.d.ts
+++ b/winston-dynamodb/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: nickiannone <http://github.com/nickiannone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="winston" />
-
 import * as winston from 'winston';
 import { TransportInstance } from 'winston';
 export interface DynamoDBTransportOptions {

--- a/winston-dynamodb/winston-dynamodb-tests.ts
+++ b/winston-dynamodb/winston-dynamodb-tests.ts
@@ -13,7 +13,11 @@ var queryOptions: winston.QueryOptions;
 var transportOptions: winston.TransportOptions;
 var loggerOptions: winston.LoggerOptions = {
   transports: [new (winston.Transport)()],
-  rewriters: [new (winston.Transport)()],
+  rewriters: [
+    (level: string, msg: string, meta: any): any => {
+      return meta;
+    }
+  ],
   exceptionHandlers: [new (winston.Transport)()],
   handleExceptions: false
 };
@@ -101,7 +105,7 @@ logger = winston.remove(transport);
 logger = winston.add(transport, {filename: 'path/to/file.log'});
 
 winston.clear();
-logger = winston.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any):void => {
+logger = winston.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any): void => {
 
 });
 logger = winston.profile(str);
@@ -114,7 +118,7 @@ winston.unhandleExceptions(transport);
 
 readableStream = winston.stream(options);
 
-readableStream.on('log', function (log:any):void {
+readableStream.on('log', (log: any): void => {
   console.log(log);
 });
 
@@ -155,7 +159,7 @@ logger = logger.add(transport, {filename: 'path/to/file.log'});
 logger.clear();
 logger = logger.remove(transport);
 profiler = logger.startTimer();
-logger = logger.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any):void => {
+logger = logger.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any): void => {
 
 });
 value = logger.setLevels(value);
@@ -167,7 +171,7 @@ logger = profiler.logger;
 profiler.start = new Date();
 
 let testRewriter : winston.MetadataRewriter;
-testRewriter = function(level: string, msg: string, meta: any) {
+testRewriter = (level: string, msg: string, meta: any): any => {
     return meta;
 };
 

--- a/winston/index.d.ts
+++ b/winston/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for winston v2.2.0
+// Type definitions for winston 2.3
 // Project: https://github.com/flatiron/winston
 // Definitions by: bonnici <https://github.com/bonnici>, Peter Harris <https://github.com/codeanimal>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -123,8 +123,7 @@ declare namespace winston {
         unhandleExceptions(...transports: winston.TransportInstance[]): void;
         add(transport: winston.TransportInstance, options?: winston.TransportOptions, created?: boolean): winston.LoggerInstance;
         clear(): void;
-        remove(transport: string): winston.LoggerInstance;
-        remove(transport: winston.TransportInstance): winston.LoggerInstance;
+        remove(transport: string | winston.TransportInstance): winston.LoggerInstance;
         startTimer(): winston.ProfileHandler;
         profile(id: string, msg?: string, meta?: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): winston.LoggerInstance;
         addColors(target: AbstractConfigColors): any;
@@ -232,13 +231,14 @@ declare namespace winston {
         configure(options: LoggerOptions): void;
         setLevels(target: AbstractConfigLevels): any;
         cli(): LoggerInstance;
-        
+
         level: string;
     }
 
     export interface LoggerOptions {
         transports?: TransportInstance[];
-        rewriters?: TransportInstance[];
+        rewriters?: MetadataRewriter[];
+        filters?: MetadataFilter[];
         exceptionHandlers?: TransportInstance[];
         handleExceptions?: boolean;
         level?: string;
@@ -285,7 +285,7 @@ declare namespace winston {
         logstash: boolean;
         depth: string|null;
         align: boolean;
-        stderrLevels: {[key: string]: LeveledLogMethod;}
+        stderrLevels: { [key: string]: LeveledLogMethod; }
         eol: string;
         stringify?: (obj: Object) => string;
 

--- a/winston/winston-tests.ts
+++ b/winston/winston-tests.ts
@@ -13,7 +13,11 @@ var queryOptions: winston.QueryOptions;
 var transportOptions: winston.TransportOptions;
 var loggerOptions: winston.LoggerOptions = {
   transports: [new (winston.Transport)()],
-  rewriters: [new (winston.Transport)()],
+  rewriters: [
+    (level: string, msg: string, meta: any): any => {
+      return meta;
+    }
+  ],
   exceptionHandlers: [new (winston.Transport)()],
   handleExceptions: false
 };
@@ -107,7 +111,7 @@ logger = winston.remove(transport);
 logger = winston.add(transport, {filename: 'path/to/file.log'});
 
 winston.clear();
-logger = winston.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any):void => {
+logger = winston.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any): void => {
 
 });
 logger = winston.profile(str);
@@ -120,7 +124,7 @@ winston.unhandleExceptions(transport);
 
 readableStream = winston.stream(options);
 
-readableStream.on('log', function (log:any):void {
+readableStream.on('log', (log: any): void => {
   console.log(log);
 });
 
@@ -161,7 +165,7 @@ logger = logger.add(transport, {filename: 'path/to/file.log'});
 logger.clear();
 logger = logger.remove(transport);
 profiler = logger.startTimer();
-logger = logger.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any):void => {
+logger = logger.profile(str, str, metadata, (err: Error, level: string, msg: string, meta: any): void => {
 
 });
 value = logger.setLevels(value);
@@ -173,7 +177,7 @@ logger = profiler.logger;
 profiler.start = new Date();
 
 let testRewriter : winston.MetadataRewriter;
-testRewriter = function(level: string, msg: string, meta: any) {
+testRewriter = (level: string, msg: string, meta: any): any => {
     return meta;
 };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/winstonjs/winston/tree/2.3.0#filters-and-rewriters
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
