### PR TITLE
React-native: enable JS intellisense for StyleSheet.create method

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -4509,10 +4509,15 @@ export namespace StyleSheet {
 
     type Style = ViewStyle | TextStyle | ImageStyle
 
+    interface Styles {
+        [style: string]: Style
+    }
+
     /**
      * Creates a StyleSheet style reference from the given object.
      */
-    export function create<T>( styles: T ): T;
+    export function create(styles: Styles): Styles;
+    export function create<T> (styles: T): T;
 
     /**
      * Flattens an array of style objects, into one aggregated style object.

--- a/react-native/test/index.tsx
+++ b/react-native/test/index.tsx
@@ -95,6 +95,17 @@ const stylesAlt = StyleSheet.create(
     }
 )
 
+const otherStyles = {
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#F5FCFF',
+    },
+};
+
+// test that non-generic function works with non-inlined styles
+StyleSheet.create(otherStyles);
 
 class Welcome extends React.Component<any, any> {
 


### PR DESCRIPTION
Add a non-generic overload for 'create' to enable intellisense in Javascript

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present - _not checked since running it shows a huge number of linting issues so fixing them IMO is a separate change, not related to this one_

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/StyleSheet/StyleSheet.js#L197

This is refined version of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/13988 with  comments from previous PR addressed. 

This PR adds non-generic overload to allow ts engine to provide intellisense in the following cases: 

- when function is called without providing generic type:

  ![screen shot 2017-03-23 at 17 17 30](https://cloud.githubusercontent.com/assets/3857604/24252747/6d26c3ac-0fef-11e7-86da-b60cc3106c94.png)

- in Javascript projects where it's impossible to use generics to provide information about `T` fields types 

The initial generic signature also needs to be retained to not break compilation of existing projects .