### PR TITLE
[three] Added non-legacy BufferAttribute types + JSDoc deprecation

### DIFF
--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -665,8 +665,8 @@ declare namespace THREE {
         toJSON(meta?: any): any;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         setLens(focalLength: number, frameHeight?: number): void;
     }
 
@@ -722,70 +722,70 @@ declare namespace THREE {
         setXYZ(index: number, x: number, y: number, z: number): BufferAttribute;
         setXYZW(index: number, x: number, y: number, z: number, w: number): BufferAttribute;
         /**
-		 * @deprecated Use count instead.
-		 */
+         * @deprecated Use count instead.
+         */
         length: number;
     }
 
-	/**
-	 * @deprecated THREE.Int8Attribute has been removed. Use new THREE.Int8BufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Int8Attribute has been removed. Use new THREE.Int8BufferAttribute() instead.
+     */
     export class Int8Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
-	/**
-	 * @deprecated THREE.Uint8Attribute has been removed. Use new THREE.Uint8BufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Uint8Attribute has been removed. Use new THREE.Uint8BufferAttribute() instead.
+     */
     export class Uint8Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
-	/**
-	 * @deprecated THREE.Uint8ClampedAttribute has been removed. Use new THREE.Uint8ClampedBufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Uint8ClampedAttribute has been removed. Use new THREE.Uint8ClampedBufferAttribute() instead.
+     */
     export class Uint8ClampedAttribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
-	/**
-	 * @deprecated THREE.Int16Attribute has been removed. Use new THREE.Int16BufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Int16Attribute has been removed. Use new THREE.Int16BufferAttribute() instead.
+     */
     export class Int16Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
-	/**
-	 * @deprecated THREE.Uint16Attribute has been removed. Use new THREE.Uint16BufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Uint16Attribute has been removed. Use new THREE.Uint16BufferAttribute() instead.
+     */
     export class Uint16Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
-	/**
-	 * @deprecated THREE.Int32Attribute has been removed. Use new THREE.Int32BufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Int32Attribute has been removed. Use new THREE.Int32BufferAttribute() instead.
+     */
     export class Int32Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
-	/**
-	 * @deprecated THREE.Uint32Attribute has been removed. Use new THREE.Uint32BufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Uint32Attribute has been removed. Use new THREE.Uint32BufferAttribute() instead.
+     */
     export class Uint32Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
-	/**
-	 * @deprecated THREE.Float32Attribute has been removed. Use new THREE.Float32BufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Float32Attribute has been removed. Use new THREE.Float32BufferAttribute() instead.
+     */
     export class Float32Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
-	/**
-	 * @deprecated THREE.Float64Attribute has been removed. Use new THREE.Float64BufferAttribute() instead.
-	 */
+    /**
+     * @deprecated THREE.Float64Attribute has been removed. Use new THREE.Float64BufferAttribute() instead.
+     */
     export class Float64Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
@@ -827,8 +827,8 @@ declare namespace THREE {
     }
 
     /**
-	 * @deprecated, use new THREE.BufferAttribute().setDynamic( true ).
-	 */ 
+     * @deprecated, use new THREE.BufferAttribute().setDynamic( true ).
+     */ 
     export class DynamicBufferAttribute extends BufferAttribute {}
 
     /**
@@ -928,8 +928,8 @@ declare namespace THREE {
         dispose(): void;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         drawcalls: any;
         offsets: any;
 
@@ -1173,9 +1173,9 @@ declare namespace THREE {
         copy(source: this): this;
     }
 
-	/**
-	 * @deprecated Use Face3 instead.
-	 */
+    /**
+     * @deprecated Use Face3 instead.
+     */
     export class Face4 extends Face3 {}
 
     export interface MorphTarget {
@@ -1422,17 +1422,17 @@ declare namespace THREE {
         dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
     }
 
-	/**
-	 * @deprecated
-	 */
+    /**
+     * @deprecated
+     */
     export namespace GeometryUtils {
-		/**
-		 * @deprecated Use geometry.merge( geometry2, matrix, materialIndexOffset ).
-		 */
+        /**
+         * @deprecated Use geometry.merge( geometry2, matrix, materialIndexOffset ).
+         */
         export function merge(geometry1: any, geometry2: any, materialIndexOffset?: any): any;
-		/**
-		 * @deprecated Use geometry.center().
-		 */
+        /**
+         * @deprecated Use geometry.center().
+         */
         export function center(geometry: any): any;
     }
 
@@ -1514,9 +1514,9 @@ declare namespace THREE {
         setXY(index: number, x: number, y: number): InterleavedBufferAttribute;
         setXYZ(index: number, x: number, y: number, z: number): InterleavedBufferAttribute;
         setXYZW(index: number, x: number, y: number, z: number, w: number): InterleavedBufferAttribute;
-		/**
-		 * @deprecated Use count instead.
-		 */
+        /**
+         * @deprecated Use count instead.
+         */
         length: number;
     }
 
@@ -1790,8 +1790,8 @@ declare namespace THREE {
         copy(source: this, recursive?: boolean): this;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         eulerOrder: string;
         getChildByName(name: string): Object3D;
         translate(distance: number, axis: Vector3): Object3D;
@@ -1863,45 +1863,45 @@ declare namespace THREE {
         intensity: number;
         receiveShadow: boolean;
         shadow: LightShadow;
-		/**
-		 * @deprecated Use shadow.camera.fov instead.
-		 */
+        /**
+         * @deprecated Use shadow.camera.fov instead.
+         */
         shadowCameraFov: any;
-		/**
-		 * @deprecated Use shadow.camera.left instead.
-		 */
+        /**
+         * @deprecated Use shadow.camera.left instead.
+         */
         shadowCameraLeft: any;
-		/**
-		 * @deprecated Use shadow.camera.right instead.
-		 */
+        /**
+         * @deprecated Use shadow.camera.right instead.
+         */
         shadowCameraRight: any;
-		/**
-		 * @deprecated Use shadow.camera.top instead.
-		 */
+        /**
+         * @deprecated Use shadow.camera.top instead.
+         */
         shadowCameraTop: any;
-		/**
-		 * @deprecated Use shadow.camera.bottom instead.
-		 */
+        /**
+         * @deprecated Use shadow.camera.bottom instead.
+         */
         shadowCameraBottom: any;
-		/**
-		 * @deprecated Use shadow.camera.near instead.
-		 */
+        /**
+         * @deprecated Use shadow.camera.near instead.
+         */
         shadowCameraNear: any;
-		/**
-		 * @deprecated Use shadow.camera.far instead.
-		 */
+        /**
+         * @deprecated Use shadow.camera.far instead.
+         */
         shadowCameraFar: any;
-		/**
-		 * @deprecated Use shadow.bias instead.
-		 */
+        /**
+         * @deprecated Use shadow.bias instead.
+         */
         shadowBias: any;
-		/**
-		 * @deprecated Use shadow.mapSize.width instead.
-		 */
+        /**
+         * @deprecated Use shadow.mapSize.width instead.
+         */
         shadowMapWidth: any;
-		/**
-		 * @deprecated Use shadow.mapSize.height instead.
-		 */
+        /**
+         * @deprecated Use shadow.mapSize.height instead.
+         */
         shadowMapHeight: any;
     }
 
@@ -2479,8 +2479,8 @@ declare namespace THREE {
         dispose(): void;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         warpRGB: Color;
     }
 
@@ -2795,9 +2795,9 @@ declare namespace THREE {
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
-		/**
-		 * @deprecated
-		 */
+        /**
+         * @deprecated
+         */
         metal: boolean;
 
         setValues(parameters: MeshPhongMaterialParameters): void;
@@ -2828,9 +2828,9 @@ declare namespace THREE {
         toJSON(meta: any): any;
     }
 
-	/**
-	 * @deprecated Use MultiMaterial instead.
-	 */
+    /**
+     * @deprecated Use MultiMaterial instead.
+     */
     export class MeshFaceMaterial extends MultiMaterial {}
 
     export interface PointsMaterialParameters extends MaterialParameters {
@@ -2851,17 +2851,17 @@ declare namespace THREE {
         setValues(parameters: PointsMaterialParameters): void;
     }
 
-	/**
-	 * @deprecated
-	 */
+    /**
+     * @deprecated
+     */
     export class PointCloudMaterial extends PointsMaterial {}
-	/**
-	 * @deprecated
-	 */
+    /**
+     * @deprecated
+     */
     export class ParticleBasicMaterial extends PointsMaterial {}
-	/**
-	 * @deprecated
-	 */
+    /**
+     * @deprecated
+     */
     export class ParticleSystemMaterial extends PointsMaterial {}
 
     export interface ShaderMaterialParameters extends MaterialParameters {
@@ -2894,9 +2894,9 @@ declare namespace THREE {
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
-		/**
-		 * @deprecated Use extensions.derivatives instead.
-		 */
+        /**
+         * @deprecated Use extensions.derivatives instead.
+         */
         derivatives: any;
         extensions: { derivatives: boolean; fragDepth: boolean; drawBuffers: boolean; shaderTextureLOD: boolean };
         defaultAttributeValues: any;
@@ -2960,13 +2960,13 @@ declare namespace THREE {
         union(box: Box2): Box2;
         translate(offset: Vector2): Box2;
         equals(box: Box2): boolean;
-		/**
-		 * @deprecated Use isEmpty() instead.
-		 */
+        /**
+         * @deprecated Use isEmpty() instead.
+         */
         empty(): any;
-		/**
-		 * @deprecated Use intersectsBox() instead.
-		 */
+        /**
+         * @deprecated Use intersectsBox() instead.
+         */
         isIntersectionBox(b: any): any;
     }
 
@@ -3005,17 +3005,17 @@ declare namespace THREE {
         applyMatrix4(matrix: Matrix4): Box3;
         translate(offset: Vector3): Box3;
         equals(box: Box3): boolean;
-		/**
-		 * @deprecated Use isEmpty() instead.
-		 */
+        /**
+         * @deprecated Use isEmpty() instead.
+         */
         empty(): any;
-		/**
-		 * @deprecated Use intersectsBox() instead.
-		 */
+        /**
+         * @deprecated Use intersectsBox() instead.
+         */
         isIntersectionBox(b: any): any;
-		/**
-		 * @deprecated Use intersectsSphere() instead.
-		 */
+        /**
+         * @deprecated Use intersectsSphere() instead.
+         */
         isIntersectionSphere(s: any): any;
     }
 
@@ -3405,7 +3405,7 @@ declare namespace THREE {
         /**
          * Random float from 0 to 1 with 16 bits of randomness.
          * Standard Math.random() creates repetitive patterns when applied over larger space.
-		 * @deprecated Use Math.random()
+         * @deprecated Use Math.random()
          */
         export function random16(): number;
 
@@ -3515,8 +3515,8 @@ declare namespace THREE {
         toArray(): number[];
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         multiplyVector3(vector: Vector3): any;
         multiplyVector3Array(a: any): any;
         getInverse(matrix: Matrix4, throwOnDegenerate?: boolean): Matrix3;
@@ -3699,8 +3699,8 @@ declare namespace THREE {
         toArray(): number[];
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         extractPosition(m: Matrix4): Matrix4;
         setRotationFromQuaternion(q: Quaternion): Matrix4;
         multiplyVector3(v: any): any;
@@ -3738,8 +3738,8 @@ declare namespace THREE {
         equals(plane: Plane): boolean;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         isIntersectionLine(l: any): any;
     }
 
@@ -3863,8 +3863,8 @@ declare namespace THREE {
         static slerpFlat(dst: number[], dstOffset: number, src0: number[], srcOffset: number, src1: number[], stcOffset1: number, t: number): Quaternion;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         multiplyVector3(v: any): any;
     }
 
@@ -3896,8 +3896,8 @@ declare namespace THREE {
         equals(ray: Ray): boolean;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         isIntersectionBox(b: any): any;
         isIntersectionPlane(p: any): any;
         isIntersectionSphere(s: any): any;
@@ -4416,16 +4416,16 @@ declare namespace THREE {
         fromBufferAttribute( attribute: BufferAttribute, index: number, offset?: number): Vector3;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         getPositionFromMatrix(m: Matrix4): Vector3;
         getScaleFromMatrix(m: Matrix4): Vector3;
         getColumnFromMatrix(index: number, matrix: Matrix4): Vector3;
     }
 
-	/**
-	 * @deprecated use THREE.Vector3 instead.
-	 */
+    /**
+     * @deprecated use THREE.Vector3 instead.
+     */
     export class Vertex extends Vector3 {}
 
     /**
@@ -4646,8 +4646,8 @@ declare namespace THREE {
         toJSON(meta: any): any;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         objects: any[];
     }
 
@@ -4690,13 +4690,13 @@ declare namespace THREE {
         raycast(raycaster: Raycaster, intersects: any): void;
     }
 
-	/**
-	 * @deprecated
-	 */
+    /**
+     * @deprecated
+     */
     export const LineStrip: number;
-	/**
-	 * @deprecated
-	 */
+    /**
+     * @deprecated
+     */
     export const LinePieces: number;
 
     export class LineSegments extends Line {
@@ -4752,13 +4752,13 @@ declare namespace THREE {
         raycast(raycaster: Raycaster, intersects: any): void;
     }
 
-	/**
-	 * @deprecated
-	 */
+    /**
+     * @deprecated
+     */
     export class PointCloud extends Points {}
-	/**
-	 * @deprecated
-	 */
+    /**
+     * @deprecated
+     */
     export class ParticleSystem extends Points {}
 
     export class Skeleton {
@@ -4808,9 +4808,9 @@ declare namespace THREE {
         raycast(raycaster: Raycaster, intersects: any): void;
     }
 
-	/**
-	 * @deprecated Use Sprite instead.
-	 */
+    /**
+     * @deprecated Use Sprite instead.
+     */
     export class Particle extends Sprite {}
 
 
@@ -5077,9 +5077,9 @@ declare namespace THREE {
          * @param frontFace "ccw" or "cw
          */
         setFaceCulling(cullFace?: CullFace, frontFace?: FrontFaceDirection): void;
-		/**
-		 * @deprecated
-		 */
+        /**
+         * @deprecated
+         */
         setTexture(texture: Texture, slot: number): void;
         setTexture2D(texture: Texture, slot: number): void;
         setTextureCube(texture: Texture, slot: number): void;
@@ -5088,8 +5088,8 @@ declare namespace THREE {
         readRenderTargetPixels( renderTarget: RenderTarget, x: number, y: number, width: number, height: number, buffer: any ): void;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         gammaFactor: number;
         shadowMapEnabled: boolean;
         shadowMapType: ShadowMapType;
@@ -5133,45 +5133,45 @@ declare namespace THREE {
         depthBuffer: boolean;
         stencilBuffer: boolean;
         depthTexture: Texture;
-		/**
-		 * @deprecated Use texture.wrapS instead.
-		 */
+        /**
+         * @deprecated Use texture.wrapS instead.
+         */
         wrapS: any;
-		/**
-		 * @deprecated Use texture.wrapT instead.
-		 */
+        /**
+         * @deprecated Use texture.wrapT instead.
+         */
         wrapT: any;
-		/**
-		 * @deprecated Use texture.magFilter instead.
-		 */
+        /**
+         * @deprecated Use texture.magFilter instead.
+         */
         magFilter: any;
-		/**
-		 * @deprecated Use texture.minFilter instead.
-		 */
+        /**
+         * @deprecated Use texture.minFilter instead.
+         */
         minFilter: any;
-		/**
-		 * @deprecated Use texture.anisotropy instead.
-		 */
+        /**
+         * @deprecated Use texture.anisotropy instead.
+         */
         anisotropy: any;
-		/**
-		 * @deprecated Use texture.offset instead.
-		 */
+        /**
+         * @deprecated Use texture.offset instead.
+         */
         offset: any;
-		/**
-		 * @deprecated Use texture.repeat instead.
-		 */
+        /**
+         * @deprecated Use texture.repeat instead.
+         */
         repeat: any;
-		/**
-		 * @deprecated Use texture.format instead.
-		 */
+        /**
+         * @deprecated Use texture.format instead.
+         */
         format: any;
-		/**
-		 * @deprecated Use texture.type instead.
-		 */
+        /**
+         * @deprecated Use texture.type instead.
+         */
         type: any;
-		/**
-		 * @deprecated Use texture.generateMipmaps instead.
-		 */
+        /**
+         * @deprecated Use texture.generateMipmaps instead.
+         */
         generateMipmaps: any;
 
         setSize(width: number, height: number): void;
@@ -5443,13 +5443,13 @@ declare namespace THREE {
 
     export class Uniform {
         constructor(value: any);
-		/**
-		 *  @deprecated
-		 */
+        /**
+         *  @deprecated
+         */
         constructor(type: string, value: any);
-		/**
-		 *  @deprecated
-		 */
+        /**
+         *  @deprecated
+         */
         type: string;
         value: any;
         dynamic: boolean;
@@ -5547,13 +5547,13 @@ declare namespace THREE {
         program: any;
         vertexShader: WebGLShader;
         fragmentShader: WebGLShader;
-		/**
-		 *  @deprecated Use getUniforms() instead.
-		 */
+        /**
+         *  @deprecated Use getUniforms() instead.
+         */
         uniforms: any;
-		/**
-		 *  @deprecated Use getAttributes() instead.
-		 */
+        /**
+         *  @deprecated Use getAttributes() instead.
+         */
         attributes: any;
 
         getUniforms(): WebGLUniforms;
@@ -5622,8 +5622,8 @@ declare namespace THREE {
         render(scene: Scene, camera: Camera): void;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         cullFace: any;
     }
 
@@ -5945,9 +5945,9 @@ declare namespace THREE {
 
     // Extras /////////////////////////////////////////////////////////////////////
 
-	/**
-	 * @deprecated Use TextureLoader instead.
-	 */
+    /**
+     * @deprecated Use TextureLoader instead.
+     */
     export namespace ImageUtils {
         export let crossOrigin: string;
 
@@ -6004,9 +6004,9 @@ declare namespace THREE {
         setLoop(value: boolean): void;
         getVolume(): number;
         setVolume(value: number): Audio;
-		/**
-		 * @deprecated Use AudioLoader instead.
-		 */
+        /**
+         * @deprecated Use AudioLoader instead.
+         */
         load(file: string): Audio;
     }
 
@@ -6020,8 +6020,8 @@ declare namespace THREE {
         getAverageFrequency(): number;
 
         /**
-		 * @deprecated
-		 */
+         * @deprecated
+         */
         getData(file: any): any;
     }
 
@@ -6355,9 +6355,9 @@ declare namespace THREE {
         };
     }
 
-	/**
-	 * @deprecated Use BoxGeometry instead.
-	 */
+    /**
+     * @deprecated Use BoxGeometry instead.
+     */
     export class CubeGeometry extends BoxGeometry {}
 
     export class CircleBufferGeometry extends BufferGeometry {
@@ -6789,9 +6789,9 @@ declare namespace THREE {
 
     export class GridHelper extends LineSegments {
         constructor(size: number, divisions: number, color1?: Color|number, color2?: Color|number);
-		/**
-		 * @deprecated
-		 */
+        /**
+         * @deprecated
+         */
         setColors(color1?: Color|number, color2?: Color|number): void;
     }
 

--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -723,40 +723,103 @@ declare namespace THREE {
         length: number; // deprecated, use count
     }
 
+	/**
+	 * @deprecated THREE.Int8Attribute has been removed. Use new THREE.Int8BufferAttribute() instead.
+	 */
     export class Int8Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
+	/**
+	 * @deprecated THREE.Uint8Attribute has been removed. Use new THREE.Uint8BufferAttribute() instead.
+	 */
     export class Uint8Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
+	/**
+	 * @deprecated THREE.Uint8ClampedAttribute has been removed. Use new THREE.Uint8ClampedBufferAttribute() instead.
+	 */
     export class Uint8ClampedAttribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
+	/**
+	 * @deprecated THREE.Int16Attribute has been removed. Use new THREE.Int16BufferAttribute() instead.
+	 */
     export class Int16Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
+	/**
+	 * @deprecated THREE.Uint16Attribute has been removed. Use new THREE.Uint16BufferAttribute() instead.
+	 */
     export class Uint16Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
+	/**
+	 * @deprecated THREE.Int32Attribute has been removed. Use new THREE.Int32BufferAttribute() instead.
+	 */
     export class Int32Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
+	/**
+	 * @deprecated THREE.Uint32Attribute has been removed. Use new THREE.Uint32BufferAttribute() instead.
+	 */
     export class Uint32Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
+	/**
+	 * @deprecated THREE.Float32Attribute has been removed. Use new THREE.Float32BufferAttribute() instead.
+	 */
     export class Float32Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
     }
 
+	/**
+	 * @deprecated THREE.Float64Attribute has been removed. Use new THREE.Float64BufferAttribute() instead.
+	 */
     export class Float64Attribute extends BufferAttribute {
         constructor(array: any, itemSize: number);
+    }
+
+    export class Int8BufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
+    }
+
+    export class Uint8BufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
+    }
+
+    export class Uint8ClampedBufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
+    }
+
+    export class Int16BufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
+    }
+
+    export class Uint16BufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
+    }
+
+    export class Int32BufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
+    }
+
+    export class Uint32BufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
+    }
+
+    export class Float32BufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
+    }
+
+    export class Float64BufferAttribute extends BufferAttribute {
+        constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
     }
 
     // deprecated, use new THREE.BufferAttribute().setDynamic( true )

--- a/three/index.d.ts
+++ b/three/index.d.ts
@@ -664,7 +664,9 @@ declare namespace THREE {
         updateProjectionMatrix(): void;
         toJSON(meta?: any): any;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         setLens(focalLength: number, frameHeight?: number): void;
     }
 
@@ -719,8 +721,10 @@ declare namespace THREE {
         setXY(index: number, x: number, y: number): BufferAttribute;
         setXYZ(index: number, x: number, y: number, z: number): BufferAttribute;
         setXYZW(index: number, x: number, y: number, z: number, w: number): BufferAttribute;
-
-        length: number; // deprecated, use count
+        /**
+		 * @deprecated Use count instead.
+		 */
+        length: number;
     }
 
 	/**
@@ -822,7 +826,9 @@ declare namespace THREE {
         constructor(array: Iterable<number> | ArrayLike<number> | ArrayBuffer, itemSize: number);
     }
 
-    // deprecated, use new THREE.BufferAttribute().setDynamic( true )
+    /**
+	 * @deprecated, use new THREE.BufferAttribute().setDynamic( true ).
+	 */ 
     export class DynamicBufferAttribute extends BufferAttribute {}
 
     /**
@@ -921,7 +927,9 @@ declare namespace THREE {
          */
         dispose(): void;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         drawcalls: any;
         offsets: any;
 
@@ -1165,7 +1173,10 @@ declare namespace THREE {
         copy(source: this): this;
     }
 
-    export class Face4 extends Face3 {} // deprecated, use Face3
+	/**
+	 * @deprecated Use Face3 instead.
+	 */
+    export class Face4 extends Face3 {}
 
     export interface MorphTarget {
         name: string;
@@ -1411,9 +1422,18 @@ declare namespace THREE {
         dispatchEvent(event: { type: string; [attachment: string]: any; }): void;
     }
 
-    export namespace GeometryUtils { // deprecated
-        export function merge(geometry1: any, geometry2: any, materialIndexOffset?: any): any; // deprecated, use geometry.merge( geometry2, matrix, materialIndexOffset )
-        export function center(geometry: any): any; // deprecated, use geometry.center()
+	/**
+	 * @deprecated
+	 */
+    export namespace GeometryUtils {
+		/**
+		 * @deprecated Use geometry.merge( geometry2, matrix, materialIndexOffset ).
+		 */
+        export function merge(geometry1: any, geometry2: any, materialIndexOffset?: any): any;
+		/**
+		 * @deprecated Use geometry.center().
+		 */
+        export function center(geometry: any): any;
     }
 
     /**
@@ -1494,8 +1514,10 @@ declare namespace THREE {
         setXY(index: number, x: number, y: number): InterleavedBufferAttribute;
         setXYZ(index: number, x: number, y: number, z: number): InterleavedBufferAttribute;
         setXYZW(index: number, x: number, y: number, z: number, w: number): InterleavedBufferAttribute;
-
-        length: number; // deprecated, use count instead
+		/**
+		 * @deprecated Use count instead.
+		 */
+        length: number;
     }
 
     export let Object3DIdCount: number;
@@ -1767,7 +1789,9 @@ declare namespace THREE {
          */
         copy(source: this, recursive?: boolean): this;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         eulerOrder: string;
         getChildByName(name: string): Object3D;
         translate(distance: number, axis: Vector3): Object3D;
@@ -1839,16 +1863,46 @@ declare namespace THREE {
         intensity: number;
         receiveShadow: boolean;
         shadow: LightShadow;
-        shadowCameraFov: any; // deprecated, use shadow.camera.fov
-        shadowCameraLeft: any; // deprecated, use shadow.camera.left
-        shadowCameraRight: any; // deprecated, use shadow.camera.right
-        shadowCameraTop: any; // deprecated, use shadow.camera.top
-        shadowCameraBottom: any; // deprecated, use shadow.camera.bottom
-        shadowCameraNear: any; // deprecated, use shadow.camera.near
-        shadowCameraFar: any; // deprecated, use shadow.camera.far
-        shadowBias: any; // deprecated, use shadow.bias
-        shadowMapWidth: any; // deprecated, use shadow.mapSize.width
-        shadowMapHeight: any; // deprecated, use shadow.mapSize.height
+		/**
+		 * @deprecated Use shadow.camera.fov instead.
+		 */
+        shadowCameraFov: any;
+		/**
+		 * @deprecated Use shadow.camera.left instead.
+		 */
+        shadowCameraLeft: any;
+		/**
+		 * @deprecated Use shadow.camera.right instead.
+		 */
+        shadowCameraRight: any;
+		/**
+		 * @deprecated Use shadow.camera.top instead.
+		 */
+        shadowCameraTop: any;
+		/**
+		 * @deprecated Use shadow.camera.bottom instead.
+		 */
+        shadowCameraBottom: any;
+		/**
+		 * @deprecated Use shadow.camera.near instead.
+		 */
+        shadowCameraNear: any;
+		/**
+		 * @deprecated Use shadow.camera.far instead.
+		 */
+        shadowCameraFar: any;
+		/**
+		 * @deprecated Use shadow.bias instead.
+		 */
+        shadowBias: any;
+		/**
+		 * @deprecated Use shadow.mapSize.width instead.
+		 */
+        shadowMapWidth: any;
+		/**
+		 * @deprecated Use shadow.mapSize.height instead.
+		 */
+        shadowMapHeight: any;
     }
 
     export class LightShadow {
@@ -2424,7 +2478,9 @@ declare namespace THREE {
         update(): void;
         dispose(): void;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         warpRGB: Color;
     }
 
@@ -2739,7 +2795,10 @@ declare namespace THREE {
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
-        metal: boolean; // deprecated
+		/**
+		 * @deprecated
+		 */
+        metal: boolean;
 
         setValues(parameters: MeshPhongMaterialParameters): void;
     }
@@ -2769,7 +2828,10 @@ declare namespace THREE {
         toJSON(meta: any): any;
     }
 
-    export class MeshFaceMaterial extends MultiMaterial {} // deprecated, use MultiMaterial
+	/**
+	 * @deprecated Use MultiMaterial instead.
+	 */
+    export class MeshFaceMaterial extends MultiMaterial {}
 
     export interface PointsMaterialParameters extends MaterialParameters {
         color?: number|string;
@@ -2789,9 +2851,18 @@ declare namespace THREE {
         setValues(parameters: PointsMaterialParameters): void;
     }
 
-    export class PointCloudMaterial extends PointsMaterial {} // deprecated
-    export class ParticleBasicMaterial extends PointsMaterial {} // deprecated
-    export class ParticleSystemMaterial extends PointsMaterial {} // deprecated
+	/**
+	 * @deprecated
+	 */
+    export class PointCloudMaterial extends PointsMaterial {}
+	/**
+	 * @deprecated
+	 */
+    export class ParticleBasicMaterial extends PointsMaterial {}
+	/**
+	 * @deprecated
+	 */
+    export class ParticleSystemMaterial extends PointsMaterial {}
 
     export interface ShaderMaterialParameters extends MaterialParameters {
         defines?: any;
@@ -2823,7 +2894,10 @@ declare namespace THREE {
         skinning: boolean;
         morphTargets: boolean;
         morphNormals: boolean;
-        derivatives: any; // deprecated, use extensions.derivatives
+		/**
+		 * @deprecated Use extensions.derivatives instead.
+		 */
+        derivatives: any;
         extensions: { derivatives: boolean; fragDepth: boolean; drawBuffers: boolean; shaderTextureLOD: boolean };
         defaultAttributeValues: any;
         index0AttributeName: string;
@@ -2886,9 +2960,14 @@ declare namespace THREE {
         union(box: Box2): Box2;
         translate(offset: Vector2): Box2;
         equals(box: Box2): boolean;
-
-        empty(): any; // deprecated, use isEmpty()
-        isIntersectionBox(b: any): any; // deprecated, use intersectsBox()
+		/**
+		 * @deprecated Use isEmpty() instead.
+		 */
+        empty(): any;
+		/**
+		 * @deprecated Use intersectsBox() instead.
+		 */
+        isIntersectionBox(b: any): any;
     }
 
     export class Box3 {
@@ -2926,10 +3005,18 @@ declare namespace THREE {
         applyMatrix4(matrix: Matrix4): Box3;
         translate(offset: Vector3): Box3;
         equals(box: Box3): boolean;
-
-        empty(): any; // deprecated, use isEmpty()
-        isIntersectionBox(b: any): any; // deprecated, use intersectsBox()
-        isIntersectionSphere(s: any): any; // deprecated, use intersectsSphere()
+		/**
+		 * @deprecated Use isEmpty() instead.
+		 */
+        empty(): any;
+		/**
+		 * @deprecated Use intersectsBox() instead.
+		 */
+        isIntersectionBox(b: any): any;
+		/**
+		 * @deprecated Use intersectsSphere() instead.
+		 */
+        isIntersectionSphere(s: any): any;
     }
 
     export interface HSL {
@@ -3318,8 +3405,9 @@ declare namespace THREE {
         /**
          * Random float from 0 to 1 with 16 bits of randomness.
          * Standard Math.random() creates repetitive patterns when applied over larger space.
+		 * @deprecated Use Math.random()
          */
-        export function random16(): number; // deprecated, use Math.random()
+        export function random16(): number;
 
         /**
          * Random integer from low to high interval.
@@ -3426,7 +3514,9 @@ declare namespace THREE {
         fromArray(array: number[], offset?: number): Matrix3;
         toArray(): number[];
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         multiplyVector3(vector: Vector3): any;
         multiplyVector3Array(a: any): any;
         getInverse(matrix: Matrix4, throwOnDegenerate?: boolean): Matrix3;
@@ -3608,7 +3698,9 @@ declare namespace THREE {
         fromArray(array: number[], offset?: number): Matrix4;
         toArray(): number[];
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         extractPosition(m: Matrix4): Matrix4;
         setRotationFromQuaternion(q: Quaternion): Matrix4;
         multiplyVector3(v: any): any;
@@ -3645,7 +3737,9 @@ declare namespace THREE {
         translate(offset: Vector3): Plane;
         equals(plane: Plane): boolean;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         isIntersectionLine(l: any): any;
     }
 
@@ -3768,7 +3862,9 @@ declare namespace THREE {
 
         static slerpFlat(dst: number[], dstOffset: number, src0: number[], srcOffset: number, src1: number[], stcOffset1: number, t: number): Quaternion;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         multiplyVector3(v: any): any;
     }
 
@@ -3799,7 +3895,9 @@ declare namespace THREE {
         applyMatrix4(matrix4: Matrix4): Ray;
         equals(ray: Ray): boolean;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         isIntersectionBox(b: any): any;
         isIntersectionPlane(p: any): any;
         isIntersectionSphere(s: any): any;
@@ -4317,13 +4415,18 @@ declare namespace THREE {
         toArray(xyz?: number[], offset?: number): number[];
         fromBufferAttribute( attribute: BufferAttribute, index: number, offset?: number): Vector3;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         getPositionFromMatrix(m: Matrix4): Vector3;
         getScaleFromMatrix(m: Matrix4): Vector3;
         getColumnFromMatrix(index: number, matrix: Matrix4): Vector3;
     }
 
-    export class Vertex extends Vector3 {} // deprecated
+	/**
+	 * @deprecated use THREE.Vector3 instead.
+	 */
+    export class Vertex extends Vector3 {}
 
     /**
      * 4D vector.
@@ -4542,7 +4645,9 @@ declare namespace THREE {
         update(camera: Camera): void;
         toJSON(meta: any): any;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         objects: any[];
     }
 
@@ -4585,8 +4690,14 @@ declare namespace THREE {
         raycast(raycaster: Raycaster, intersects: any): void;
     }
 
-    export const LineStrip: number; // deprecated
-    export const LinePieces: number; // deprecated
+	/**
+	 * @deprecated
+	 */
+    export const LineStrip: number;
+	/**
+	 * @deprecated
+	 */
+    export const LinePieces: number;
 
     export class LineSegments extends Line {
         constructor(
@@ -4641,8 +4752,14 @@ declare namespace THREE {
         raycast(raycaster: Raycaster, intersects: any): void;
     }
 
-    export class PointCloud extends Points {} // deprecated
-    export class ParticleSystem extends Points {} // deprecated
+	/**
+	 * @deprecated
+	 */
+    export class PointCloud extends Points {}
+	/**
+	 * @deprecated
+	 */
+    export class ParticleSystem extends Points {}
 
     export class Skeleton {
         constructor(bones: Bone[], boneInverses?: Matrix4[], useVertexTexture?: boolean);
@@ -4691,7 +4808,10 @@ declare namespace THREE {
         raycast(raycaster: Raycaster, intersects: any): void;
     }
 
-    export class Particle extends Sprite {} // deprecated
+	/**
+	 * @deprecated Use Sprite instead.
+	 */
+    export class Particle extends Sprite {}
 
 
     // Renderers //////////////////////////////////////////////////////////////////////////////////
@@ -4957,14 +5077,19 @@ declare namespace THREE {
          * @param frontFace "ccw" or "cw
          */
         setFaceCulling(cullFace?: CullFace, frontFace?: FrontFaceDirection): void;
-        setTexture(texture: Texture, slot: number): void; // deprecated
+		/**
+		 * @deprecated
+		 */
+        setTexture(texture: Texture, slot: number): void;
         setTexture2D(texture: Texture, slot: number): void;
         setTextureCube(texture: Texture, slot: number): void;
         getCurrentRenderTarget(): RenderTarget;
         setRenderTarget(renderTarget: RenderTarget): void;
         readRenderTargetPixels( renderTarget: RenderTarget, x: number, y: number, width: number, height: number, buffer: any ): void;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         gammaFactor: number;
         shadowMapEnabled: boolean;
         shadowMapType: ShadowMapType;
@@ -5008,16 +5133,46 @@ declare namespace THREE {
         depthBuffer: boolean;
         stencilBuffer: boolean;
         depthTexture: Texture;
-        wrapS: any; // deprecated, use texture.wrapS
-        wrapT: any; // deprecated, use texture.wrapT
-        magFilter: any; // deprecated, use texture.magFilter
-        minFilter: any; // deprecated, use texture.minFilter
-        anisotropy: any; // deprecated, use texture.anisotropy
-        offset: any; // deprecated, use texture.offset
-        repeat: any; // deprecated, use texture.repeat
-        format: any; // deprecated, use texture.format
-        type: any; // deprecated, use texture.type
-        generateMipmaps: any; // deprecated, use texture.generateMipmaps
+		/**
+		 * @deprecated Use texture.wrapS instead.
+		 */
+        wrapS: any;
+		/**
+		 * @deprecated Use texture.wrapT instead.
+		 */
+        wrapT: any;
+		/**
+		 * @deprecated Use texture.magFilter instead.
+		 */
+        magFilter: any;
+		/**
+		 * @deprecated Use texture.minFilter instead.
+		 */
+        minFilter: any;
+		/**
+		 * @deprecated Use texture.anisotropy instead.
+		 */
+        anisotropy: any;
+		/**
+		 * @deprecated Use texture.offset instead.
+		 */
+        offset: any;
+		/**
+		 * @deprecated Use texture.repeat instead.
+		 */
+        repeat: any;
+		/**
+		 * @deprecated Use texture.format instead.
+		 */
+        format: any;
+		/**
+		 * @deprecated Use texture.type instead.
+		 */
+        type: any;
+		/**
+		 * @deprecated Use texture.generateMipmaps instead.
+		 */
+        generateMipmaps: any;
 
         setSize(width: number, height: number): void;
         clone(): this;
@@ -5288,9 +5443,14 @@ declare namespace THREE {
 
     export class Uniform {
         constructor(value: any);
-        constructor(type: string, value: any); // deprecated
-
-        type: string; // deprecated
+		/**
+		 *  @deprecated
+		 */
+        constructor(type: string, value: any);
+		/**
+		 *  @deprecated
+		 */
+        type: string;
         value: any;
         dynamic: boolean;
         onUpdateCallback: Function;
@@ -5387,8 +5547,14 @@ declare namespace THREE {
         program: any;
         vertexShader: WebGLShader;
         fragmentShader: WebGLShader;
-        uniforms: any; // deprecated, use getUniforms()
-        attributes: any; // deprecated, use getAttributes()
+		/**
+		 *  @deprecated Use getUniforms() instead.
+		 */
+        uniforms: any;
+		/**
+		 *  @deprecated Use getAttributes() instead.
+		 */
+        attributes: any;
 
         getUniforms(): WebGLUniforms;
         getAttributes(): any;
@@ -5455,7 +5621,9 @@ declare namespace THREE {
 
         render(scene: Scene, camera: Camera): void;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         cullFace: any;
     }
 
@@ -5777,7 +5945,10 @@ declare namespace THREE {
 
     // Extras /////////////////////////////////////////////////////////////////////
 
-    export namespace ImageUtils { // deprecated
+	/**
+	 * @deprecated Use TextureLoader instead.
+	 */
+    export namespace ImageUtils {
         export let crossOrigin: string;
 
         export function loadTexture(url: string, mapping?: Mapping, onLoad?: (texture: Texture) => void, onError?: (message: string) => void): Texture;
@@ -5833,7 +6004,10 @@ declare namespace THREE {
         setLoop(value: boolean): void;
         getVolume(): number;
         setVolume(value: number): Audio;
-        load(file: string): Audio; // deprecated, use the AudioLoader class
+		/**
+		 * @deprecated Use AudioLoader instead.
+		 */
+        load(file: string): Audio;
     }
 
     export class AudioAnalyser {
@@ -5845,7 +6019,9 @@ declare namespace THREE {
         getFrequencyData(): Uint8Array;
         getAverageFrequency(): number;
 
-        // deprecated
+        /**
+		 * @deprecated
+		 */
         getData(file: any): any;
     }
 
@@ -6179,7 +6355,10 @@ declare namespace THREE {
         };
     }
 
-    export class CubeGeometry extends BoxGeometry {} // deprecated, use BoxGeometry
+	/**
+	 * @deprecated Use BoxGeometry instead.
+	 */
+    export class CubeGeometry extends BoxGeometry {}
 
     export class CircleBufferGeometry extends BufferGeometry {
         constructor(radius?: number, segments?: number, thetaStart?: number, thetaLength?: number);
@@ -6610,8 +6789,10 @@ declare namespace THREE {
 
     export class GridHelper extends LineSegments {
         constructor(size: number, divisions: number, color1?: Color|number, color2?: Color|number);
-
-        setColors(color1?: Color|number, color2?: Color|number): void; // deprecated
+		/**
+		 * @deprecated
+		 */
+        setColors(color1?: Color|number, color2?: Color|number): void;
     }
 
     export class HemisphereLightHelper extends Object3D {


### PR DESCRIPTION
Derived BufferAttribute classes were renamed in earlier versions.
 - Added new definitions
 - Deprecated the old ones

The file was full of "deprecated" comments instead of useful JSDoc.
 - Replaced all deprecation comments with an equal or more helpful JSDoc deprecation annotation.
____________________________________________________
- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mrdoob/three.js/blob/dev/src/core/BufferAttribute.js#L344
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
