### PR TITLE
@types/react-dates: Add `null` as valid value for FocusedInputShape

### DIFF
--- a/react-dates/index.d.ts
+++ b/react-dates/index.d.ts
@@ -18,7 +18,7 @@ declare namespace momentPropTypes{
     
 declare namespace ReactDates{
     type AnchorDirectionShape = 'left' | 'right';
-    type FocusedInputShape = 'startDate' | 'endDate';    
+    type FocusedInputShape = 'startDate' | 'endDate' | null;
     type OrientationShape = 'horizontal' | 'vertical';        
     type ScrollableOrientationShape = 'horizontal' | 'vertical' | 'verticalScrollable'; 
     


### PR DESCRIPTION
React dates accepts but more importantly returns `null` as a valid focused state.
Not having this in the typings allows unexpected errors when using `strictNulls` checking.
```typescript
if (focusedInput !== undefined) {
  // focusedInput input could be null here, but the type system does not acknowledge that. 
}
```

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/react-dates/blob/6d45150/src/components/DateRangePickerInputController.jsx#L104
- [ ] Increase the version number in the header if appropriate.
