### PR TITLE
Fix pg-query-stream by adding a compatible overload to client.query() in pg

### DIFF
--- a/pg-query-stream/index.d.ts
+++ b/pg-query-stream/index.d.ts
@@ -3,6 +3,10 @@
 // Definitions by: António Marques <https://github.com/asmarques>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
+import stream = require("stream");
+
 declare namespace QueryStream {
     interface Options {
         highWaterMark?: number;
@@ -10,7 +14,7 @@ declare namespace QueryStream {
     }
 }
 
-declare class QueryStream {
+declare class QueryStream extends stream.Readable {
     batchSize: number;
     text: string;
     values?: any[];

--- a/pg-query-stream/pg-query-stream-tests.ts
+++ b/pg-query-stream/pg-query-stream-tests.ts
@@ -10,10 +10,10 @@ const query = new QueryStream('SELECT * FROM generate_series(0, $1) num', [10000
 
 pg.connect('', (err, client, done) => {
     const stream = client.query(query);
-    stream.then(() => {
+    stream.on('end', () => {
         client.end();
     });
-    stream.then((data: any) => {
+    stream.on('data', (data: any) => {
         console.log(data);
     });
 });

--- a/pg/index.d.ts
+++ b/pg/index.d.ts
@@ -89,6 +89,7 @@ export declare class Client extends events.EventEmitter {
     end(callback?: (err: Error) => void): void;
     release(): void;
 
+    query(queryStream: QueryConfig & stream.Readable): stream.Readable;
     query(queryTextOrConfig: string | QueryConfig): Promise<QueryResult>;
     query(queryText: string, values: any[]): Promise<QueryResult>;
 


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [X] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/brianc/node-pg-query-stream/blob/master/index.js#L23
https://github.com/brianc/node-postgres/blob/master/lib/client.js#L326

- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.