### PR TITLE
Context passed to EventEmitter.addListener() should be optional.

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -149,7 +149,7 @@ interface EventEmitterListener {
      * @param {*} context - Optional context object to use when invoking the
      *   listener
      */
-    addListener(eventType: string, listener: (...args: any[]) => any, context: any): EmitterSubscription
+    addListener(eventType: string, listener: (...args: any[]) => any, context?: any): EmitterSubscription
 }
 
 interface EventEmitter extends EventEmitterListener {


### PR DESCRIPTION
As suggested in the already existing comments above the declaration.

And as specified in the react-native source: 

https://github.com/facebook/react-native/blob/master/Libraries/EventEmitter/EventEmitter.js#L60-L64
