### PR TITLE
angularjs - Fix ITimeoutService interface ($timeout signature)

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -602,7 +602,7 @@ declare namespace angular {
     ///////////////////////////////////////////////////////////////////////////
     interface ITimeoutService {
         (delay?: number, invokeApply?: boolean): IPromise<void>;
-        <T>(fn: (...args: any[]) => T, delay?: number, invokeApply?: boolean, ...args: any[]): IPromise<T>;
+        <T>(fn: (...args: any[]) => T | IPromise<T>, delay?: number, invokeApply?: boolean, ...args: any[]): IPromise<T>;
         cancel(promise?: IPromise<any>): boolean;
     }
 


### PR DESCRIPTION
$timeout is not correctly described by ITimeoutService, causing compile time errors like: 'TS2322:Type 'IPromise<IPromise>' is not assignable to type 'IPromise'...'

More information [here](http://stackoverflow.com/questions/41838982/in-typescript-how-to-define-a-recursive-function-that-return-a-promise/42982365#42982365).