### PR TITLE
findNodeHandle also accepts base react-native components

### DIFF
--- a/react-native/index.d.ts
+++ b/react-native/index.d.ts
@@ -8417,7 +8417,7 @@ export function requireNativeComponent<P>(
     extraConfig?: {nativeOnly?: any}
 ): React.ComponentClass<P>;
 
-export function findNodeHandle(componentOrHandle: null | number | React.Component<any, any>): null | number;
+export function findNodeHandle(componentOrHandle: null | number | React.Component<any, any> | React.ComponentClass<any>): null | number;
 
 export function processColor(color: any): number;
 


### PR DESCRIPTION
We're also able to pass in base react-native components that don't expose .setState() (like View, TextView, etc.) to findNodeHandle.

https://github.com/facebook/react-native/blob/master/Libraries/Renderer/src/renderers/native/findNodeHandle.js#L103

^ Not a great reference to go off of, but if you look at the source it only checks for the existence of a render function, not a setState function.