### PR TITLE
@types/react-router - StaticRouter has no any history props

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -66,7 +66,7 @@ declare module 'react-router' {
   class Router extends React.Component<RouterProps, void> {}
 
 
-  interface StaticRouterProps extends RouterProps {
+  interface StaticRouterProps {
     basename?: string;
     location?: string | object;
     context?: object;


### PR DESCRIPTION
Hi,
I'm not really 100% sure, but I think that I found bug. [React router](https://github.com/ReactTraining/react-router) in actual version 4 don't require `history` props on `<StaticRouter>`. See this: https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/StaticRouter.js#L64-L71.

Workaround: `<StaticRouter history={{}}>`

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/StaticRouter.js#L64-L71>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
