### PR TITLE
google-protobuf - Map fixes, undefined messages and formatting

### DIFF
--- a/types/google-protobuf/google/protobuf/api_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/api_pb.d.ts
@@ -21,8 +21,8 @@ export class Api extends jspb.Message {
 
   hasSourceContext(): boolean;
   clearSourceContext(): void;
-  getSourceContext(): google_protobuf_source_context_pb.SourceContext;
-  setSourceContext(value: google_protobuf_source_context_pb.SourceContext): void;
+  getSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
+  setSourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
 
   clearMixinsList(): void;
   getMixinsList(): Array<Mixin>;
@@ -48,7 +48,7 @@ export namespace Api {
     methodsList: Array<Method.AsObject>,
     optionsList: Array<google_protobuf_type_pb.Option.AsObject>,
     version: string,
-    sourceContext: google_protobuf_source_context_pb.SourceContext.AsObject,
+    sourceContext?: google_protobuf_source_context_pb.SourceContext.AsObject,
     mixinsList: Array<Mixin.AsObject>,
     syntax: google_protobuf_type_pb.Syntax,
   }

--- a/types/google-protobuf/google/protobuf/compiler/plugin_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/compiler/plugin_pb.d.ts
@@ -34,10 +34,10 @@ export class Version extends jspb.Message {
 
 export namespace Version {
   export type AsObject = {
-    major: number,
-    minor: number,
-    patch: number,
-    suffix: string,
+    major?: number,
+    minor?: number,
+    patch?: number,
+    suffix?: string,
   }
 }
 
@@ -60,7 +60,7 @@ export class CodeGeneratorRequest extends jspb.Message {
   hasCompilerVersion(): boolean;
   clearCompilerVersion(): void;
   getCompilerVersion(): Version;
-  setCompilerVersion(value: Version): void;
+  setCompilerVersion(value?: Version): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): CodeGeneratorRequest.AsObject;
@@ -75,7 +75,7 @@ export class CodeGeneratorRequest extends jspb.Message {
 export namespace CodeGeneratorRequest {
   export type AsObject = {
     fileToGenerateList: Array<string>,
-    parameter: string,
+    parameter?: string,
     protoFileList: Array<google_protobuf_descriptor_pb.FileDescriptorProto.AsObject>,
     compilerVersion: Version.AsObject,
   }
@@ -104,7 +104,7 @@ export class CodeGeneratorResponse extends jspb.Message {
 
 export namespace CodeGeneratorResponse {
   export type AsObject = {
-    error: string,
+    error?: string,
     fileList: Array<CodeGeneratorResponse.File.AsObject>,
   }
 
@@ -136,9 +136,9 @@ export namespace CodeGeneratorResponse {
 
   export namespace File {
     export type AsObject = {
-      name: string,
-      insertionPoint: string,
-      content: string,
+      name?: string,
+      insertionPoint?: string,
+      content?: string,
     }
   }
 }

--- a/types/google-protobuf/google/protobuf/descriptor_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/descriptor_pb.d.ts
@@ -71,12 +71,12 @@ export class FileDescriptorProto extends jspb.Message {
   hasOptions(): boolean;
   clearOptions(): void;
   getOptions(): FileOptions;
-  setOptions(value: FileOptions): void;
+  setOptions(value?: FileOptions): void;
 
   hasSourceCodeInfo(): boolean;
   clearSourceCodeInfo(): void;
   getSourceCodeInfo(): SourceCodeInfo;
-  setSourceCodeInfo(value: SourceCodeInfo): void;
+  setSourceCodeInfo(value?: SourceCodeInfo): void;
 
   hasSyntax(): boolean;
   clearSyntax(): void;
@@ -95,8 +95,8 @@ export class FileDescriptorProto extends jspb.Message {
 
 export namespace FileDescriptorProto {
   export type AsObject = {
-    name: string,
-    package: string,
+    name?: string,
+    package?: string,
     dependencyList: Array<string>,
     publicDependencyList: Array<number>,
     weakDependencyList: Array<number>,
@@ -106,7 +106,7 @@ export namespace FileDescriptorProto {
     extensionList: Array<FieldDescriptorProto.AsObject>,
     options: FileOptions.AsObject,
     sourceCodeInfo: SourceCodeInfo.AsObject,
-    syntax: string,
+    syntax?: string,
   }
 }
 
@@ -149,7 +149,7 @@ export class DescriptorProto extends jspb.Message {
   hasOptions(): boolean;
   clearOptions(): void;
   getOptions(): MessageOptions;
-  setOptions(value: MessageOptions): void;
+  setOptions(value?: MessageOptions): void;
 
   clearReservedRangeList(): void;
   getReservedRangeList(): Array<DescriptorProto.ReservedRange>;
@@ -173,7 +173,7 @@ export class DescriptorProto extends jspb.Message {
 
 export namespace DescriptorProto {
   export type AsObject = {
-    name: string,
+    name?: string,
     fieldList: Array<FieldDescriptorProto.AsObject>,
     extensionList: Array<FieldDescriptorProto.AsObject>,
     nestedTypeList: Array<DescriptorProto.AsObject>,
@@ -208,8 +208,8 @@ export namespace DescriptorProto {
 
   export namespace ExtensionRange {
     export type AsObject = {
-      start: number,
-      end: number,
+      start?: number,
+      end?: number,
     }
   }
 
@@ -236,8 +236,8 @@ export namespace DescriptorProto {
 
   export namespace ReservedRange {
     export type AsObject = {
-      start: number,
-      end: number,
+      start?: number,
+      end?: number,
     }
   }
 }
@@ -291,7 +291,7 @@ export class FieldDescriptorProto extends jspb.Message {
   hasOptions(): boolean;
   clearOptions(): void;
   getOptions(): FieldOptions;
-  setOptions(value: FieldOptions): void;
+  setOptions(value?: FieldOptions): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): FieldDescriptorProto.AsObject;
@@ -305,15 +305,15 @@ export class FieldDescriptorProto extends jspb.Message {
 
 export namespace FieldDescriptorProto {
   export type AsObject = {
-    name: string,
-    number: number,
-    label: FieldDescriptorProto.Label,
-    type: FieldDescriptorProto.Type,
-    typeName: string,
-    extendee: string,
-    defaultValue: string,
-    oneofIndex: number,
-    jsonName: string,
+    name?: string,
+    number?: number,
+    label?: FieldDescriptorProto.Label,
+    type?: FieldDescriptorProto.Type,
+    typeName?: string,
+    extendee?: string,
+    defaultValue?: string,
+    oneofIndex?: number,
+    jsonName?: string,
     options: FieldOptions.AsObject,
   }
 
@@ -337,6 +337,7 @@ export namespace FieldDescriptorProto {
     TYPE_SINT32 = 17,
     TYPE_SINT64 = 18,
   }
+
   export enum Label {
     LABEL_OPTIONAL = 1,
     LABEL_REQUIRED = 2,
@@ -353,7 +354,7 @@ export class OneofDescriptorProto extends jspb.Message {
   hasOptions(): boolean;
   clearOptions(): void;
   getOptions(): OneofOptions;
-  setOptions(value: OneofOptions): void;
+  setOptions(value?: OneofOptions): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OneofDescriptorProto.AsObject;
@@ -367,7 +368,7 @@ export class OneofDescriptorProto extends jspb.Message {
 
 export namespace OneofDescriptorProto {
   export type AsObject = {
-    name: string,
+    name?: string,
     options: OneofOptions.AsObject,
   }
 }
@@ -386,7 +387,7 @@ export class EnumDescriptorProto extends jspb.Message {
   hasOptions(): boolean;
   clearOptions(): void;
   getOptions(): EnumOptions;
-  setOptions(value: EnumOptions): void;
+  setOptions(value?: EnumOptions): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): EnumDescriptorProto.AsObject;
@@ -400,7 +401,7 @@ export class EnumDescriptorProto extends jspb.Message {
 
 export namespace EnumDescriptorProto {
   export type AsObject = {
-    name: string,
+    name?: string,
     valueList: Array<EnumValueDescriptorProto.AsObject>,
     options: EnumOptions.AsObject,
   }
@@ -420,7 +421,7 @@ export class EnumValueDescriptorProto extends jspb.Message {
   hasOptions(): boolean;
   clearOptions(): void;
   getOptions(): EnumValueOptions;
-  setOptions(value: EnumValueOptions): void;
+  setOptions(value?: EnumValueOptions): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): EnumValueDescriptorProto.AsObject;
@@ -434,8 +435,8 @@ export class EnumValueDescriptorProto extends jspb.Message {
 
 export namespace EnumValueDescriptorProto {
   export type AsObject = {
-    name: string,
-    number: number,
+    name?: string,
+    number?: number,
     options: EnumValueOptions.AsObject,
   }
 }
@@ -454,7 +455,7 @@ export class ServiceDescriptorProto extends jspb.Message {
   hasOptions(): boolean;
   clearOptions(): void;
   getOptions(): ServiceOptions;
-  setOptions(value: ServiceOptions): void;
+  setOptions(value?: ServiceOptions): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ServiceDescriptorProto.AsObject;
@@ -468,7 +469,7 @@ export class ServiceDescriptorProto extends jspb.Message {
 
 export namespace ServiceDescriptorProto {
   export type AsObject = {
-    name: string,
+    name?: string,
     methodList: Array<MethodDescriptorProto.AsObject>,
     options: ServiceOptions.AsObject,
   }
@@ -493,7 +494,7 @@ export class MethodDescriptorProto extends jspb.Message {
   hasOptions(): boolean;
   clearOptions(): void;
   getOptions(): MethodOptions;
-  setOptions(value: MethodOptions): void;
+  setOptions(value?: MethodOptions): void;
 
   hasClientStreaming(): boolean;
   clearClientStreaming(): void;
@@ -517,12 +518,12 @@ export class MethodDescriptorProto extends jspb.Message {
 
 export namespace MethodDescriptorProto {
   export type AsObject = {
-    name: string,
-    inputType: string,
-    outputType: string,
+    name?: string,
+    inputType?: string,
+    outputType?: string,
     options: MethodOptions.AsObject,
-    clientStreaming: boolean,
-    serverStreaming: boolean,
+    clientStreaming?: boolean,
+    serverStreaming?: boolean,
   }
 }
 
@@ -619,21 +620,21 @@ export class FileOptions extends jspb.Message {
 
 export namespace FileOptions {
   export type AsObject = {
-    javaPackage: string,
-    javaOuterClassname: string,
-    javaMultipleFiles: boolean,
-    javaGenerateEqualsAndHash: boolean,
-    javaStringCheckUtf8: boolean,
-    optimizeFor: FileOptions.OptimizeMode,
-    goPackage: string,
-    ccGenericServices: boolean,
-    javaGenericServices: boolean,
-    pyGenericServices: boolean,
-    deprecated: boolean,
-    ccEnableArenas: boolean,
-    objcClassPrefix: string,
-    csharpNamespace: string,
-    swiftPrefix: string,
+    javaPackage?: string,
+    javaOuterClassname?: string,
+    javaMultipleFiles?: boolean,
+    javaGenerateEqualsAndHash?: boolean,
+    javaStringCheckUtf8?: boolean,
+    optimizeFor?: FileOptions.OptimizeMode,
+    goPackage?: string,
+    ccGenericServices?: boolean,
+    javaGenericServices?: boolean,
+    pyGenericServices?: boolean,
+    deprecated?: boolean,
+    ccEnableArenas?: boolean,
+    objcClassPrefix?: string,
+    csharpNamespace?: string,
+    swiftPrefix?: string,
     uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
   }
 
@@ -682,10 +683,10 @@ export class MessageOptions extends jspb.Message {
 
 export namespace MessageOptions {
   export type AsObject = {
-    messageSetWireFormat: boolean,
-    noStandardDescriptorAccessor: boolean,
-    deprecated: boolean,
-    mapEntry: boolean,
+    messageSetWireFormat?: boolean,
+    noStandardDescriptorAccessor?: boolean,
+    deprecated?: boolean,
+    mapEntry?: boolean,
     uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
   }
 }
@@ -738,12 +739,12 @@ export class FieldOptions extends jspb.Message {
 
 export namespace FieldOptions {
   export type AsObject = {
-    ctype: FieldOptions.CType,
-    packed: boolean,
-    jstype: FieldOptions.JSType,
-    lazy: boolean,
-    deprecated: boolean,
-    weak: boolean,
+    ctype?: FieldOptions.CType,
+    packed?: boolean,
+    jstype?: FieldOptions.JSType,
+    lazy?: boolean,
+    deprecated?: boolean,
+    weak?: boolean,
     uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
   }
 
@@ -752,6 +753,7 @@ export namespace FieldOptions {
     CORD = 1,
     STRING_PIECE = 2,
   }
+
   export enum JSType {
     JS_NORMAL = 0,
     JS_STRING = 1,
@@ -809,8 +811,8 @@ export class EnumOptions extends jspb.Message {
 
 export namespace EnumOptions {
   export type AsObject = {
-    allowAlias: boolean,
-    deprecated: boolean,
+    allowAlias?: boolean,
+    deprecated?: boolean,
     uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
   }
 }
@@ -838,7 +840,7 @@ export class EnumValueOptions extends jspb.Message {
 
 export namespace EnumValueOptions {
   export type AsObject = {
-    deprecated: boolean,
+    deprecated?: boolean,
     uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
   }
 }
@@ -866,7 +868,7 @@ export class ServiceOptions extends jspb.Message {
 
 export namespace ServiceOptions {
   export type AsObject = {
-    deprecated: boolean,
+    deprecated?: boolean,
     uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
   }
 }
@@ -899,8 +901,8 @@ export class MethodOptions extends jspb.Message {
 
 export namespace MethodOptions {
   export type AsObject = {
-    deprecated: boolean,
-    idempotencyLevel: MethodOptions.IdempotencyLevel,
+    deprecated?: boolean,
+    idempotencyLevel?: MethodOptions.IdempotencyLevel,
     uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
   }
 
@@ -962,12 +964,12 @@ export class UninterpretedOption extends jspb.Message {
 export namespace UninterpretedOption {
   export type AsObject = {
     nameList: Array<UninterpretedOption.NamePart.AsObject>,
-    identifierValue: string,
-    positiveIntValue: number,
-    negativeIntValue: number,
-    doubleValue: number,
+    identifierValue?: string,
+    positiveIntValue?: number,
+    negativeIntValue?: number,
+    doubleValue?: number,
     stringValue: Uint8Array | string,
-    aggregateValue: string,
+    aggregateValue?: string,
   }
 
   export class NamePart extends jspb.Message {
@@ -993,8 +995,8 @@ export namespace UninterpretedOption {
 
   export namespace NamePart {
     export type AsObject = {
-      namePart: string,
-      isExtension: boolean,
+      namePart?: string,
+      isExtension?: boolean,
     }
   }
 }
@@ -1060,8 +1062,8 @@ export namespace SourceCodeInfo {
     export type AsObject = {
       pathList: Array<number>,
       spanList: Array<number>,
-      leadingComments: string,
-      trailingComments: string,
+      leadingComments?: string,
+      trailingComments?: string,
       leadingDetachedCommentsList: Array<string>,
     }
   }
@@ -1122,9 +1124,9 @@ export namespace GeneratedCodeInfo {
   export namespace Annotation {
     export type AsObject = {
       pathList: Array<number>,
-      sourceFile: string,
-      begin: number,
-      end: number,
+      sourceFile?: string,
+      begin?: number,
+      end?: number,
     }
   }
 }

--- a/types/google-protobuf/google/protobuf/struct_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/struct_pb.d.ts
@@ -46,13 +46,13 @@ export class Value extends jspb.Message {
 
   hasStructValue(): boolean;
   clearStructValue(): void;
-  getStructValue(): Struct;
-  setStructValue(value: Struct): void;
+  getStructValue(): Struct | undefined;
+  setStructValue(value?: Struct): void;
 
   hasListValue(): boolean;
   clearListValue(): void;
-  getListValue(): ListValue;
-  setListValue(value: ListValue): void;
+  getListValue(): ListValue | undefined;
+  setListValue(value?: ListValue): void;
 
   getKindCase(): Value.KindCase;
 
@@ -75,8 +75,8 @@ export namespace Value {
     numberValue: number,
     stringValue: string,
     boolValue: boolean,
-    structValue: Struct.AsObject,
-    listValue: ListValue.AsObject,
+    structValue?: Struct.AsObject,
+    listValue?: ListValue.AsObject,
   }
 
   export enum KindCase {

--- a/types/google-protobuf/google/protobuf/type_pb.d.ts
+++ b/types/google-protobuf/google/protobuf/type_pb.d.ts
@@ -23,8 +23,8 @@ export class Type extends jspb.Message {
 
   hasSourceContext(): boolean;
   clearSourceContext(): void;
-  getSourceContext(): google_protobuf_source_context_pb.SourceContext;
-  setSourceContext(value: google_protobuf_source_context_pb.SourceContext): void;
+  getSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
+  setSourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
 
   getSyntax(): Syntax;
   setSyntax(value: Syntax): void;
@@ -45,7 +45,7 @@ export namespace Type {
     fieldsList: Array<Field.AsObject>,
     oneofsList: Array<string>,
     optionsList: Array<Option.AsObject>,
-    sourceContext: google_protobuf_source_context_pb.SourceContext.AsObject,
+    sourceContext?: google_protobuf_source_context_pb.SourceContext.AsObject,
     syntax: Syntax,
   }
 }
@@ -128,6 +128,7 @@ export namespace Field {
     TYPE_SINT32 = 17,
     TYPE_SINT64 = 18,
   }
+
   export enum Cardinality {
     CARDINALITY_UNKNOWN = 0,
     CARDINALITY_OPTIONAL = 1,
@@ -152,8 +153,8 @@ export class Enum extends jspb.Message {
 
   hasSourceContext(): boolean;
   clearSourceContext(): void;
-  getSourceContext(): google_protobuf_source_context_pb.SourceContext;
-  setSourceContext(value: google_protobuf_source_context_pb.SourceContext): void;
+  getSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
+  setSourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
 
   getSyntax(): Syntax;
   setSyntax(value: Syntax): void;
@@ -173,7 +174,7 @@ export namespace Enum {
     name: string,
     enumvalueList: Array<EnumValue.AsObject>,
     optionsList: Array<Option.AsObject>,
-    sourceContext: google_protobuf_source_context_pb.SourceContext.AsObject,
+    sourceContext?: google_protobuf_source_context_pb.SourceContext.AsObject,
     syntax: Syntax,
   }
 }
@@ -214,8 +215,8 @@ export class Option extends jspb.Message {
 
   hasValue(): boolean;
   clearValue(): void;
-  getValue(): google_protobuf_any_pb.Any;
-  setValue(value: google_protobuf_any_pb.Any): void;
+  getValue(): google_protobuf_any_pb.Any | undefined;
+  setValue(value?: google_protobuf_any_pb.Any): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): Option.AsObject;
@@ -230,7 +231,7 @@ export class Option extends jspb.Message {
 export namespace Option {
   export type AsObject = {
     name: string,
-    value: google_protobuf_any_pb.Any.AsObject,
+    value?: google_protobuf_any_pb.Any.AsObject,
   }
 }
 

--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -170,13 +170,14 @@ export class Map<K, V> {
     arr: Array<[K, V]>,
     valueCtor?: {new(init: any): V});
   toArray(): Array<[K, V]>;
-  toObject(
+  toObject(includeInstance?: boolean): Array<[K, V]>;
+  toObject<VO>(
     includeInstance: boolean,
-    valueToObject: (includeInstance: boolean) => any): Array<[K, V]>;
-  static fromObject<K, V>(
-    entries: Array<[K, V]>,
+    valueToObject: (includeInstance: boolean, valueWrapper: V) => VO): Array<[K, VO]>;
+  static fromObject<TK, TV>(
+    entries: Array<[TK, TV]>,
     valueCtor: any,
-    valueFromObject: any): Map<K, V>;
+    valueFromObject: any): Map<TK, TV>;
   getLength(): number;
   clear(): void;
   del(key: K): boolean;
@@ -186,7 +187,7 @@ export class Map<K, V> {
   forEach(
     callback: (entry: V, key: K) => void,
     thisArg?: {}): void;
-  set(key: K, value: V): void;
+  set(key: K, value: V): this;
   get(key: K): (V | undefined);
   has(key: K): boolean;
 }


### PR DESCRIPTION
This PR fixes a few issues with `google-protobuf`:

* the Map class' `toObject` function takes an optional `valueToObject` function that affects the return type, so I've overloaded it to reflect these two different behaviours.
* the Map class' `set` function returns the instance
* the getters for message fields of proto3-syntax files return `undefined`, whilst proto2-syntax files return an empty message
* the `toObject` function of message call out that properties can be undefined where appropriate

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: - not applicable
- [x] Increase the version number in the header if appropriate. - not applicable
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`. - not applicable