### PR TITLE
add missing ObjectId methods to bson type definition

### DIFF
--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -68,6 +68,8 @@ export class ObjectId {
     static isValid(id: number | string | ObjectId): boolean;
 
     constructor(id?: number | string | ObjectId);
+    toHexString(): string;
+    getTimestamp(): Date;
 }
 export type ObjectID = ObjectId;
 export class BSONRegExp {


### PR DESCRIPTION
Please fill in this template.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mongodb/js-bson/blob/9e4b56b/lib/bson/objectid.js#L83  
https://github.com/mongodb/js-bson/blob/9e4b56b/lib/bson/objectid.js#L230
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.