### PR TITLE
Typofix in howler.js types

### DIFF
--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -11,7 +11,7 @@ interface HowlerGlobal {
     unload(): void;
     usingWebAudio: boolean;
     noAudio: boolean;
-    mobileAudioEnable: boolean;
+    mobileAutoEnable: boolean;
     autoSuspend: boolean;
     ctx: AudioContext;
     masterGain: GainNode;


### PR DESCRIPTION
`mobileAudioEnable` should be `mobileAutoEnable`

Refs https://github.com/goldfire/howler.js/issues/663