### PR TITLE
Angular formly - allow fieldTransform to be an array of functions

### DIFF
--- a/types/angular-formly/angular-formly-tests.ts
+++ b/types/angular-formly/angular-formly-tests.ts
@@ -30,6 +30,7 @@ class FormConfig {
 		formlyConfig.extras.errorExistsAndShouldBeVisibleExpression = angular.noop;
 		formlyConfig.extras.explicitAsync = true;		
 		formlyConfig.extras.fieldTransform = angular.noop;
+		formlyConfig.extras.fieldTransform = [angular.noop];
 		formlyConfig.extras.getFieldId = angular.noop;
 		formlyConfig.extras.ngModelAttrsManipulatorPreferUnbound = true;
 	}

--- a/types/angular-formly/index.d.ts
+++ b/types/angular-formly/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for angular-formly 7.2.3
+// Type definitions for angular-formly 7.2.4
 // Project: https://github.com/formly-js/angular-formly
 // Definitions by: Scott Hatcher <https://github.com/scatcher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -44,7 +44,7 @@ declare namespace AngularFormly {
 		data?: {
 			[key: string]: any;
 		};
-		fieldTransform?: Function;
+		fieldTransform?: Function | Array<Function>;
 		formState?: Object;
 		removeChromeAutoComplete?: boolean;
 		resetModel?: Function;
@@ -580,7 +580,7 @@ declare namespace AngularFormly {
 		defaultHideDirective: string;
 		errorExistsAndShouldBeVisibleExpression: any;
 		getFieldId: Function;
-		fieldTransform: Function;
+		fieldTransform: Function | Array<Function>;
 		explicitAsync: boolean;
 	}
 


### PR DESCRIPTION
Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [] Run `npm run lint package-name` if a `tslint.json` is present. 
^^ I ran the linter, but there were lots of errors unrelated to my change.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://angular-formly.com/#/example/very-advanced/field-transform
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
