### PR TITLE
Type Error Classes missing from json-patch

### DIFF
--- a/types/json-patch/index.d.ts
+++ b/types/json-patch/index.d.ts
@@ -4,36 +4,42 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace jsonpatch {
-    type OpPatch = AddPath | RemovePath | ReplacePath | MovePath | CopyPath | TestPath;
+    type OpPatch = AddPatch | RemovePatch | ReplacePatch | MovePatch | CopyPatch | TestPatch;
     interface Patch {
-        op: string;
-    }
-    interface AddPath extends Patch {
         path: string;
+    }
+    interface AddPatch extends Patch {
+        op: 'add';
         value: any;
     }
-    interface RemovePath extends Patch {
-        path: string;
+    interface RemovePatch extends Patch {
+        op: 'remove';
     }
-    interface ReplacePath extends Patch {
-        path: string;
+    interface ReplacePatch extends Patch {
+        op: 'replace';
         value: any;
     }
-    interface MovePath extends Patch {
+    interface MovePatch extends Patch {
+        op: 'move';
         from: string;
-        path: string;
     }
-    interface CopyPath extends Patch {
+    interface CopyPatch extends Patch {
+        op: 'copy';
         from: string;
-        path: string;
     }
-    interface TestPath extends Patch {
-        path: string;
+    interface TestPatch extends Patch {
+        op: 'test';
         value: any;
     }
 
     function apply(document: any, patches: OpPatch[]): any;
     function compile(patches: OpPatch[]): (document: any) => any;
+
+    class JSONPatchError extends Error { }
+    class InvalidPointerError extends Error { }
+    class InvalidPatchError extends JSONPatchError { }
+    class PatchConflictError extends JSONPatchError { }
+    class PatchTestFailed extends Error { }
 }
 
 export = jsonpatch;

--- a/types/json-patch/json-patch-tests.ts
+++ b/types/json-patch/json-patch-tests.ts
@@ -32,3 +32,22 @@ jsonpatch.apply({ foo: 'bar' }, [{ op: 'test', path: '/foo', value: 'bar' }]);
 jsonpatch.compile([{ op: 'test', path: '/foo', value: 'bar' }])({ foo: 'bar' });
 
 jp.apply({}, [{ op: 'add', path: '/foo', value: 'bar' }]);
+
+function patchShouldFail(document: any, patches: jsonpatch.OpPatch[]): string {
+    try {
+        jsonpatch.apply(document, patches);
+        throw new Error('Patch did not fail...');
+    } catch (err) {
+        if (err instanceof jsonpatch.PatchTestFailed) {
+            return 'Test failed';
+        } else if (err instanceof jsonpatch.InvalidPointerError) {
+            return 'Invalid Pointer';
+        } else if (err instanceof jsonpatch.InvalidPatchError) {
+            return 'Invalid Patch';
+        } else if (err instanceof jsonpatch.PatchConflictError) {
+            return 'Patch Conflict';
+        } else {
+            return 'Failed with unknown error';
+        }
+    }
+}


### PR DESCRIPTION
Also, Enforce stricter typings.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `npm run new-package package-name`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bruth/jsonpatch-js#error-types>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
