### PR TITLE
ng-file-upload: make "method" optional for IFileUploadConfigFile

### DIFF
--- a/types/ng-file-upload/index.d.ts
+++ b/types/ng-file-upload/index.d.ts
@@ -253,6 +253,12 @@ declare module 'angular' {
              */
             url: string;
             /**
+             * HTTP method (e.g. 'GET', 'POST', etc)
+             * defaults to POST if ommited.
+             * @type {string}
+             */
+            method?: string;
+            /**
              * This is to accommodate server implementations expecting nested data object keys in .key or [key] format.
              * Example: data: {rec: {name: 'N', pic: file}} sent as: rec[name] -> N, rec[pic] -> file
              * data: {rec: {name: 'N', pic: file}, objectKey: '.k'} sent as: rec.name -> N, rec.pic -> file


### PR DESCRIPTION
ng-file-upload defines POST to be the default for the property "method".

resolves #10819