### PR TITLE
js-beautify - updated incorrect method name

### DIFF
--- a/types/js-beautify/index.d.ts
+++ b/types/js-beautify/index.d.ts
@@ -57,7 +57,7 @@ interface CSSBeautifyOptions {
 interface jsb{
   (js_source_text: string, options?: JsBeautifyOptions) : string ;
   js:(js_source_text: string, options?: JsBeautifyOptions) => string ;
-  beautify_js:(js_source_text: string, options?: JsBeautifyOptions) => string ;
+  js_beautify:(js_source_text: string, options?: JsBeautifyOptions) => string ;
 
   css:(js_source_text: string, options?: CSSBeautifyOptions) => string ;
   css_beautify:(js_source_text: string, options?: CSSBeautifyOptions) => string ;


### PR DESCRIPTION
Changed beautify_js to js_beautify.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/beautify-web/js-beautify
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.