### PR TITLE
urijs: adds segmentCoded method

### DIFF
--- a/types/urijs/index.d.ts
+++ b/types/urijs/index.d.ts
@@ -104,6 +104,11 @@ declare namespace uri {
         segment(position: number): string;
         segment(position: number, level: string): URI;
         segment(segment: string): URI;
+        segmentCoded(): string[];
+        segmentCoded(segments: string[]): URI;
+        segmentCoded(position: number): string;
+        segmentCoded(position: number, level: string): URI;
+        segmentCoded(segment: string): URI;
         setQuery(key: string, value: string): URI;
         setQuery(qry: Object): URI;
         setSearch(key: string, value: string): URI;

--- a/types/urijs/urijs-tests.ts
+++ b/types/urijs/urijs-tests.ts
@@ -39,6 +39,10 @@ URI('http://example.org/foo/hello.html').segment('bar');
 URI('http://example.org/foo/hello.html').segment(0, 'bar');
 URI('http://example.org/foo/hello.html').segment(['foo', 'bar', 'foobar.html']);
 
+URI('http://example.org/foo/hello.html').segmentCoded('foo bar');
+URI('http://example.org/foo/hello.html').segmentCoded(0, 'foo bar');
+URI('http://example.org/foo/hello.html').segmentCoded(['foo bar', 'bar foo', 'foo bar.html']);
+
 var withDuplicates = URI("?bar=1&bar=1")
   .duplicateQueryParameters(true)
   .normalizeQuery()


### PR DESCRIPTION
Adds `segmentCoded` support, which shadows `segment` with transparent URI-encode/-decode.  It's been around since v1.11 of urijs, so I've left the version intact (1.15.1).

FAO previous authors, @RodneyJT and @xt0rted

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/medialize/URI.js/blob/gh-pages/CHANGELOG.md#1110-august-6th-2013>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.