### PR TITLE
findNodeHandle also accepts base react-native components

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8417,7 +8417,7 @@ export function requireNativeComponent<P>(
     extraConfig?: {nativeOnly?: any}
 ): React.ComponentClass<P>;
 
-export function findNodeHandle(componentOrHandle: null | number | React.Component<any, any>): null | number;
+export function findNodeHandle(componentOrHandle: null | number | React.Component<any, any> | React.ComponentClass<any>): null | number;
 
 export function processColor(color: any): number;
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -97,13 +97,13 @@ const stylesAlt = StyleSheet.create(
 )
 
 class CustomView extends React.Component<{}, {}> {
-    
+
     render() {
         return (
             <Text>Custom View</Text>
         );
     }
-    
+
 }
 
 class Welcome extends React.Component<any, any> {
@@ -121,11 +121,11 @@ class Welcome extends React.Component<any, any> {
 
         rootView.measure((x: number, y: number, width: number, height: number) => {
         });
-        
+
     }
-    
+
     testFindNodeHandle() {
-        
+
         const { rootView, customView } = this.refs;
         
         let nativeComponentHandle = findNodeHandle(rootView);

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -127,13 +127,13 @@ class Welcome extends React.Component<any, any> {
     testFindNodeHandle() {
 
         const { rootView, customView } = this.refs;
-        
+
         let nativeComponentHandle = findNodeHandle(rootView);
-        
+
         let customComponentHandle = findNodeHandle(customView);
-        
+
         let fromHandle = findNodeHandle(customComponentHandle);
-        
+
     }
 
     render() {

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -25,6 +25,7 @@ import {
     View,
     ViewStyle,
     ViewPagerAndroid,
+    findNodeHandle
 } from 'react-native';
 
 function testDimensions() {
@@ -95,21 +96,44 @@ const stylesAlt = StyleSheet.create(
     }
 )
 
+class CustomView extends React.Component<{}, {}> {
+    
+    render() {
+        return (
+            <Text>Custom View</Text>
+        );
+    }
+    
+}
 
 class Welcome extends React.Component<any, any> {
 
     refs: {
-      [key: string]: any
-      rootView: View
+        [key: string]: any
+        rootView: View
+        customView: CustomView
     }
 
     testNativeMethods() {
-      // this.setNativeProps({});
+        // this.setNativeProps({});
 
-      const { rootView } = this.refs;
+        const { rootView } = this.refs;
 
-      rootView.measure((x: number, y: number, width: number, height: number) => {
-      });
+        rootView.measure((x: number, y: number, width: number, height: number) => {
+        });
+        
+    }
+    
+    testFindNodeHandle() {
+        
+        const { rootView, customView } = this.refs;
+        
+        let nativeComponentHandle = findNodeHandle(rootView);
+        
+        let customComponentHandle = findNodeHandle(customView);
+        
+        let fromHandle = findNodeHandle(customComponentHandle);
+        
     }
 
     render() {
@@ -126,6 +150,7 @@ class Welcome extends React.Component<any, any> {
                     Press Cmd+R to reload,{'\n'}
                     Cmd+D or shake for dev menu
                 </Text>
+                <CustomView ref="customView" />
             </View>
         )
     }


### PR DESCRIPTION
We're also able to pass in base react-native components that don't expose .setState() (like View, TextView, etc.) to findNodeHandle.

https://github.com/facebook/react-native/blob/master/Libraries/Renderer/src/renderers/native/findNodeHandle.js#L103

^ Not a great reference to go off of, but if you look at the source it only checks for the existence of a render function, not a setState function.

** Migrated PR from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15366