### PR TITLE
Add type of context for react-router and react-router-dom

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -17,7 +17,8 @@ declare module 'react-router-dom' {
     Switch,
     match,
     matchPath,
-    withRouter
+    withRouter,
+    RouterChildContext
   } from 'react-router';
   import * as React from 'react';
   import * as H from 'history';
@@ -74,6 +75,7 @@ declare module 'react-router-dom' {
     Switch,
     match, // TypeScript specific, not from React Router itself
     matchPath,
-    withRouter
+    withRouter,
+    RouterChildContext
   }
 }

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for React Router 4.0
 // Project: https://github.com/ReactTraining/react-router
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
+//                 Huy Nguyen <https://github.com/huy-nguyen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -17,7 +17,17 @@ declare module 'react-router' {
   import * as React from 'react';
   import * as H from 'history';
 
-
+	// This is the type of the context object that will be passed down to all children of
+	// a `Router` component:
+	interface RouterChildContext<P> {
+		router: {
+			history: H.History
+			route: {
+				location: H.Location,
+				match: match<P>
+			}
+		}
+	}
   interface MemoryRouterProps {
     initialEntries?: H.Location[];
     initialIndex?: number;
@@ -105,6 +115,7 @@ declare module 'react-router' {
     Switch,
     match, // TypeScript specific, not from React Router itself
     matchPath,
-    withRouter
+		withRouter,
+		RouterChildContext
   }
 }

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -10,6 +10,7 @@
 //                 Karol Janyst <https://github.com/LKay>
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 //                 Tanguy Krotoff <https://github.com/tkrotoff>
+//                 Huy Nguyen <https://github.com/huy-nguyen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/react-router/test/NavigateWithContext.tsx
+++ b/types/react-router/test/NavigateWithContext.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+	RouterChildContext,
+	RouteComponentProps
+} from 'react-router';
+import {
+	BrowserRouter as Router,
+	Route,
+} from 'react-router-dom'
+
+interface Params {
+	id?: string
+}
+type Props = RouteComponentProps<Params>
+
+class ComponentThatUsesContext extends React.Component<Props, {}> {
+	static contextTypes = {
+		router: React.PropTypes.object.isRequired
+	}
+	context: RouterChildContext<Params>
+	private onClick = () => {
+		const {
+			history,
+			route: {
+				location,
+				match
+			}
+		} = this.context.router;
+		history.push('/some/url');
+	}
+	render() {
+		return <div/>
+	}
+}
+
+const Test = () => (
+	<Router>
+		<Route path='/' exact component={ComponentThatUsesContext}/>
+	</Router>
+);
+
+export default Test;

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -20,6 +20,7 @@
     "test/Basic.tsx",
     "test/CustomLink.tsx",
     "test/ModalGallery.tsx",
+    "test/NavigateWithContext.tsx",
     "test/NoMatch.tsx",
     "test/Params.tsx",
     "test/PreventingTransitions.tsx",


### PR DESCRIPTION
The `Router` component passes a context object down to children.  This
commit adds the type definition for this context object for children of
`Router` to use.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/ReactTraining/react-router/blob/master/packages/react-router/modules/Router.js#L22-L33>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.