### PR TITLE
unit_tab property was missing in SchedulerLocaleLabels

### DIFF
--- a/types/dhtmlxscheduler/index.d.ts
+++ b/types/dhtmlxscheduler/index.d.ts
@@ -1044,6 +1044,7 @@ interface SchedulerLocaleLabels {
 	confirm_deleting: string;
 	section_description: string;
 	section_time: string;
+	unit_tab: string;
 }
 
 interface SchedulerLocale {


### PR DESCRIPTION
More information regarding this missing property:
https://docs.dhtmlx.com/scheduler/units_view.html