### PR TITLE
Leaflet: Changed the extension methods back to methods.

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -424,11 +424,11 @@ declare namespace L {
         getTooltip(): Tooltip | undefined;
 
         // Extension methods
-        onAdd?: (map: Map) => this;
-        onRemove?: (map: Map) => this;
-        getEvents?: () => {[name: string]: (event: Event) => void};
-        getAttribution?: () => string | null;
-        beforeAdd?: (map: Map) => this;
+        onAdd?(map: Map) : this;
+        onRemove?(map: Map) : this;
+        getEvents?() : {[name: string]: (event: Event) => void};
+        getAttribution?() : string | null;
+        beforeAdd?(map: Map) : this;
     }
 
     interface GridLayerOptions {
@@ -992,8 +992,8 @@ declare namespace L {
         remove(): this;
 
         // Extension methods
-        onAdd?: (map: Map) => HTMLElement;
-        onRemove?: (map: Map) => void;
+        onAdd?(map: Map) : HTMLElement;
+        onRemove?(map: Map) : void;
 
         options: ControlOptions;
     }
@@ -1175,8 +1175,8 @@ declare namespace L {
         enabled(): boolean;
 
         // Extension methods
-        addHooks?: () => void;
-        removeHooks?: () => void;
+        addHooks?() : void;
+        removeHooks?() : void;
     }
 
     interface Event {

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -424,8 +424,8 @@ declare namespace L {
         getTooltip(): Tooltip | undefined;
 
         // Extension methods
-        onAdd?(map: Map): this;
-        onRemove?(map: Map): this;
+        onAdd(map: Map): this;
+        onRemove(map: Map): this;
         getEvents?(): {[name: string]: (event: Event) => void};
         getAttribution?(): string | null;
         beforeAdd?(map: Map): this;

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -424,11 +424,11 @@ declare namespace L {
         getTooltip(): Tooltip | undefined;
 
         // Extension methods
-        onAdd?(map: Map) : this;
-        onRemove?(map: Map) : this;
-        getEvents?() : {[name: string]: (event: Event) => void};
-        getAttribution?() : string | null;
-        beforeAdd?(map: Map) : this;
+        onAdd?(map: Map): this;
+        onRemove?(map: Map): this;
+        getEvents?(): {[name: string]: (event: Event) => void};
+        getAttribution?(): string | null;
+        beforeAdd?(map: Map): this;
     }
 
     interface GridLayerOptions {
@@ -992,8 +992,8 @@ declare namespace L {
         remove(): this;
 
         // Extension methods
-        onAdd?(map: Map) : HTMLElement;
-        onRemove?(map: Map) : void;
+        onAdd?(map: Map): HTMLElement;
+        onRemove?(map: Map): void;
 
         options: ControlOptions;
     }
@@ -1175,8 +1175,8 @@ declare namespace L {
         enabled(): boolean;
 
         // Extension methods
-        addHooks?() : void;
-        removeHooks?() : void;
+        addHooks?(): void;
+        removeHooks?(): void;
     }
 
     interface Event {


### PR DESCRIPTION
In a previous pull request (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15039) I changed some methods to properties in order to make them optional. 

Now i figured out (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15459) that methods can be declared optional as well. 

So this changes the methods back to being declared as actual methods, and not as properties with a function-type.

Please fill in this template.

- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
