### PR TITLE
[knex] adds mssql configuration options

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -456,7 +456,7 @@ declare namespace Knex {
         client?: string;
         dialect?: string;
         connection?: string | ConnectionConfig | MariaSqlConnectionConfig |
-            MySqlConnectionConfig | Sqlite3ConnectionConfig | SocketConnectionConfig;
+            MySqlConnectionConfig | MsSqlConnectionConfig | Sqlite3ConnectionConfig | SocketConnectionConfig;
         pool?: PoolConfig;
         migrations?: MigratorConfig;
         acquireConnectionTimeout?: number;
@@ -473,6 +473,14 @@ declare namespace Knex {
         instanceName?: string;
         debug?: boolean;
         requestTimeout?: number;
+    }
+
+    interface MsSqlConnectionConfig {
+        user: string;
+        password: string;
+        server: string;
+        database: string;
+        options: MsSqlOptionsConfig;
     }
 
     // Config object for mariasql: https://github.com/mscdex/node-mariasql#client-methods
@@ -537,6 +545,17 @@ declare namespace Knex {
     interface Sqlite3ConnectionConfig {
         filename: string;
         debug?: boolean;
+    }
+
+    interface MsSqlOptionsConfig {
+        encrypt?: boolean;
+        port?: number;
+        domain?: string;
+        connectionTimeout?: number;
+        requestTimeout?: number;
+        stream?: boolean;
+        parseJSON?: boolean;
+        pool?: PoolConfig;
     }
 
     interface SocketConnectionConfig {

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -22,6 +22,19 @@ var knex = Knex({
   }
 });
 
+var knex = Knex({
+  debug: true,
+  client: 'mssql',
+  connection: {
+    user    : 'your_database_user',
+    password: 'your_database_password',
+    server  : 'your_database_server',
+    options : {
+      database: 'myapp_test'
+    }
+  }
+});
+
 // Mariasql configuration
 var knex = Knex({
   debug: true,


### PR DESCRIPTION
Add configuration support for MSSQL. Options were taken from here https://github.com/patriksimek/node-mssql

and through my own testing.

Configuration ends up looking similar to;

```
      client: 'mssql',
      connection: {
        user: 'user',
        password: 'pass',
        server: 'server',
        options: {
          encrypt: true,
          port: 1433,
          database: 'database',
          connectionTimeout: 200,
          pool: {
            max: 10,
            min: 0,
          },
        },
      },
```