### PR TITLE
Add missing field bufferedAmount

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -24,6 +24,7 @@ declare class WebSocket extends events.EventEmitter {
     supports: any;
     upgradeReq: http.IncomingMessage;
     protocol: string;
+    bufferedAmount: number;
 
     CONNECTING: number;
     OPEN: number;


### PR DESCRIPTION
Missing a field `bufferedAmount` [described in docs](https://github.com/websockets/ws/blob/master/doc/ws.md#websocketbufferedamount).

### Filled template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

### Updating an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/blob/master/doc/ws.md#websocketbufferedamount
- [ ] Increase the version number in the header if appropriate.
- [x] tiny change
