### PR TITLE
react-intl - modify Values definition to support element instead of just string

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -11,7 +11,7 @@
 declare namespace ReactIntl {
 
     interface Values {
-        [key: string]: string;
+        [key: string]: string | JSX.Element;
     }
 
     interface Locale {


### PR DESCRIPTION
Add back support to output message with elements. Not sure if JSX.Element suffice as Object was used before. Please add back the support.

