### PR TITLE
requirejs: RequireError.requireModules can be null

### DIFF
--- a/types/requirejs/index.d.ts
+++ b/types/requirejs/index.d.ts
@@ -48,7 +48,7 @@ interface RequireError extends Error {
 	/**
 	* Required modules.
 	**/
-	requireModules: string[];
+	requireModules: string[] | null;
 
 	/**
 	* The original error, if there is one (might be null).


### PR DESCRIPTION
In the require.js source code (line 901 in v2.3.3), requireModules is set to `null`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://requirejs.org/docs/release/2.3.3/comments/require.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
