### PR TITLE
corrected property name for DataSource in kendo-ui

### DIFF
--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -1039,7 +1039,7 @@ declare namespace kendo.data {
     class DataSource extends Observable{
         options: DataSourceOptions;
 
-        transports: any;
+        transport: any;
 
         static create(options?: DataSourceOptions): DataSource;
 


### PR DESCRIPTION
According to docs and reality it's 'transport', not 'transports' 
http://docs.telerik.com/kendo-ui/api/javascript/data/datasource#configuration-transport

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
