### PR TITLE
stream-buffers: Correct return type for WritableStreamBuffer.getContents()

### DIFF
--- a/types/stream-buffers/index.d.ts
+++ b/types/stream-buffers/index.d.ts
@@ -15,7 +15,7 @@ export class WritableStreamBuffer extends stream.Writable {
     constructor(options?: WritableStreamBufferOptions);
     size(): number;
     maxSize(): number;
-    getContents(length?: number): any;
+    getContents(length?: number): Buffer;
     getContentsAsString(encoding?: string, length?: number): string;
 }
 

--- a/types/stream-buffers/stream-buffers-tests.ts
+++ b/types/stream-buffers/stream-buffers-tests.ts
@@ -20,16 +20,16 @@ myWritableStreamBuffer.size();
 myWritableStreamBuffer.maxSize();
 
 // Gets all held data as a Buffer.
-myWritableStreamBuffer.getContents();
+const contents: Buffer = myWritableStreamBuffer.getContents();
 
 // Gets all held data as a utf8 string.
-myWritableStreamBuffer.getContentsAsString('utf8');
+const stringContents: string = myWritableStreamBuffer.getContentsAsString('utf8');
 
 // Gets first 5 bytes as a Buffer.
-myWritableStreamBuffer.getContents(5);
+const contents2: Buffer = myWritableStreamBuffer.getContents(5);
 
 // Gets first 5 bytes as a utf8 string.
-myWritableStreamBuffer.getContentsAsString('utf8', 5);
+const stringContents2: string = myWritableStreamBuffer.getContentsAsString('utf8', 5);
 
 const myReadableStreamBuffer = new streamBuffers.ReadableStreamBuffer({
     frequency: 10,   // in milliseconds.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/samcday/node-stream-buffer
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.