### PR TITLE
Improve inference and enable coercion in hyperscript

### DIFF
--- a/types/hyperscript/hyperscript-tests.ts
+++ b/types/hyperscript/hyperscript-tests.ts
@@ -56,3 +56,17 @@ h2('a', {href: '#',
 }, "Click this")
 
 h2.cleanup()
+
+/* Polymorphic type tests */
+
+// determine proper HTMLElement type from tagName
+let test1: HTMLCanvasElement = h('canvas');
+
+// allow coercion of decorated tagName to proper type
+let test2: HTMLCanvasElement = h<HTMLCanvasElement>('canvas#test2');
+
+// inline coercion if you were feeling pedantic
+// example
+h<HTMLDivElement>('div#page',
+	h<HTMLDivElement>('div#header',
+		h<HTMLHeadingElement>('h1.classy', 'h', { style: {'background-color': '#22f'} })));

--- a/types/hyperscript/hyperscript-tests.ts
+++ b/types/hyperscript/hyperscript-tests.ts
@@ -59,14 +59,25 @@ h2.cleanup()
 
 /* Polymorphic type tests */
 
-// determine proper HTMLElement type from tagName
-let test1: HTMLCanvasElement = h('canvas');
+// fall back to Element when in doubt
+let fallbackTest = h('canvas#test3');
+
+// determine proper Element type from tagName
+let htmlTest1: HTMLCanvasElement = h('canvas');
 
 // allow coercion of decorated tagName to proper type
-let test2: HTMLCanvasElement = h<HTMLCanvasElement>('canvas#test2');
+let htmlTest2: HTMLCanvasElement = h<HTMLCanvasElement>('canvas#test2');
+
+// if you need it to be an HTMLElement, you must coerce
+let htmlTest3 = h<HTMLElement>('canvas#test3');
+
+// support SVG elements
+let svgTest1 = h('svg');
+
+// allow coercions on SVG elements
+let svgTest2 = h<SVGSVGElement>('svg#test5');
 
 // inline coercion if you were feeling pedantic
-// example
 h<HTMLDivElement>('div#page',
 	h<HTMLDivElement>('div#header',
 		h<HTMLHeadingElement>('h1.classy', 'h', { style: {'background-color': '#22f'} })));

--- a/types/hyperscript/index.d.ts
+++ b/types/hyperscript/index.d.ts
@@ -1,18 +1,15 @@
 // Type definitions for hyperscript
 // Project: https://github.com/dominictarr/hyperscript
-// Definitions by: Mike Linkovich <https://github.com/spacejack>
+// Definitions by: Mike Linkovich <https://github.com/spacejack>, Justin Firth <https://github.com/jmfirth/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 declare module 'hyperscript' {
 
 	interface HyperScript {
-		/** Creates a typed HTMLElement */
-		<T extends keyof HTMLElementTagNameMap>(tagName: T, attrs?: Object, ...children: any[]): HTMLElementTagNameMap[T];
-		/** Creates a typed HTMLElement via coercion */
-		<T extends HTMLElement>(tagName: string, attrs?: Object, ...children: any[]): T;
-		/** Creates an HTMLElement */
-		<T extends string>(tagName: T, attrs?: Object, ...children: any[]): HTMLElement;
+		/** Creates an Element */
+		<T extends keyof ElementTagNameMap>(tagName: T, attrs?: Object, ...children: any[]): ElementTagNameMap[T];
+		<T extends Element>(tagName: string, attrs?: Object, ...children: any[]): T;
 		/** Cleans up any event handlers created by this hyperscript context */
 		cleanup(): void;
 		/** Creates a new hyperscript context */

--- a/types/hyperscript/index.d.ts
+++ b/types/hyperscript/index.d.ts
@@ -6,8 +6,12 @@
 declare module 'hyperscript' {
 
 	interface HyperScript {
-		/** Creates an HTML element */
-		(tagName: string, ...args: any[]): HTMLElement;
+		/** Creates a typed HTMLElement */
+		<T extends keyof HTMLElementTagNameMap>(tagName: T, attrs?: Object, ...children: any[]): HTMLElementTagNameMap[T];
+		/** Creates a typed HTMLElement via coercion */
+		<T extends HTMLElement>(tagName: string, attrs?: Object, ...children: any[]): T;
+		/** Creates an HTMLElement */
+		<T extends string>(tagName: T, attrs?: Object, ...children: any[]): HTMLElement;
 		/** Cleans up any event handlers created by this hyperscript context */
 		cleanup(): void;
 		/** Creates a new hyperscript context */

--- a/types/hyperscript/index.d.ts
+++ b/types/hyperscript/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/dominictarr/hyperscript
 // Definitions by: Mike Linkovich <https://github.com/spacejack>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 declare module 'hyperscript' {
 


### PR DESCRIPTION
This change allows TypeScript to infer the appropriate HTMLElement type when possible, falling back to existing behavior when not.  Additionally, this allows you to provide optional type hints to coerce the value when required.

No existing test was negatively impacted or the result in any way modified.  Added existing tests to cover and demonstrate the additional cases.

------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: None required.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
