### PR TITLE
Change return type of Paper.group() and Paper.g() to "Paper"

### DIFF
--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -306,8 +306,8 @@ declare namespace Snap {
         el(name:string, attr:Object):Snap.Element;
         filter(filstr:string):Snap.Element;
         gradient(gradient:string):any;
-        g(varargs?:any):any;
-        group(...els:any[]):any;
+        g(varargs?:any):Paper;
+        group(...els:any[]):Paper;
         mask(varargs:any):Object;
         ptrn(x:number,y:number,width:number,height:number,vbx:number,vby:number,vbw:number,vbh:number):Object;
         svg(x:number,y:number,width:number,height:number,vbx:number,vby:number,vbw:number,vbh:number):Object;

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -306,8 +306,8 @@ declare namespace Snap {
         el(name:string, attr:Object):Snap.Element;
         filter(filstr:string):Snap.Element;
         gradient(gradient:string):any;
-        g(varargs?:any):Paper;
-        group(...els:any[]):Paper;
+        g(varargs?:any):Snap.Paper;
+        group(...els:any[]):Snap.Paper;
         mask(varargs:any):Object;
         ptrn(x:number,y:number,width:number,height:number,vbx:number,vby:number,vbw:number,vbh:number):Object;
         svg(x:number,y:number,width:number,height:number,vbx:number,vby:number,vbw:number,vbh:number):Object;

--- a/types/snapsvg/test/3.ts
+++ b/types/snapsvg/test/3.ts
@@ -337,6 +337,6 @@ window.onload=()=>{
         var myInvertedMatrix = myMatrix.invert();
 
         g.animate({ transform: myMatrix },3000, mina.bounce, function() { g.animate({ transform: myInvertedMatrix }, 3000, mina.bounce) } );
-        console.log( g.transform(), g.matrix, myMatrix.split() );
+        console.log( g.transform(), myMatrix.split() );
     }
 }


### PR DESCRIPTION
@lhk, @mattanja (original authors of SnapSvg typings)

Prior to this change, the return type of Paper.group() was specified as "any" which was not very helpful.  In my code I was declaring the variable i was storing the group in as "Element" which seemed to make sense at first, but then I later realized that operations like myGroup.line (to add a line in the group) were resulting in type errors.  The "group" type has a line method but the "Element" type does not.

Looking in to the source code a bit more I found that groups are instantiated as Elements but then use the following code (in the Element construcor) to copy methods from the Paper prototype, which I believe makes the group type essentially equal to a "Paper":

```
    if (this.type in {g: 1, mask: 1, pattern: 1, symbol: 1}) {
        for (var method in Paper.prototype) if (Paper.prototype[has](method)) {
            this[method] = Paper.prototype[method];
        }
    }
```

I'm not exactly familiar with this syntax though; it's not clear to me what ```Paper.prototype[has](method)``` exactly means or whether this means that a group object only inherits a subset of the methods from Paper, and therefore there should be some other type in the Type Definition file which corresponds to groups, masks, patterns and symbols.

Perhaps the Paper.mask and Paper.ptrn should be changed to return Paper as well?  I'm not familiar with those so I didn't touch them in the type def file.
