### PR TITLE
Add support for loading daterangepicker using AMD

### DIFF
--- a/types/daterangepicker/daterangepicker-tests.ts
+++ b/types/daterangepicker/daterangepicker-tests.ts
@@ -1,4 +1,5 @@
 import moment = require("moment")
+import daterangepicker = require("daterangepicker");
 
 function tests_simple() {
     $('#daterange').daterangepicker();
@@ -65,5 +66,15 @@ function tests_simple() {
         showCustomRangeLabel: false
     }, cb);
 
+    $('#endDate').daterangepicker({
+        singleDatePicker: true,
+        startDate: moment()
+    });
 });
+}
+
+declare const host: HTMLElement;
+function test_from_amd() {
+    var picker = new daterangepicker(host);
+    console.log(picker.startDate.format("YYYY-MM-DD");)
 }

--- a/types/daterangepicker/daterangepicker-tests.ts
+++ b/types/daterangepicker/daterangepicker-tests.ts
@@ -76,5 +76,5 @@ function tests_simple() {
 declare const host: HTMLElement;
 function test_from_amd() {
     var picker = new daterangepicker(host);
-    console.log(picker.startDate.format("YYYY-MM-DD");)
+    console.log(picker.startDate.format("YYYY-MM-DD"));
 }

--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -9,11 +9,21 @@ import moment = require("moment");
 declare global {
     interface JQuery {
         daterangepicker(settings?: daterangepicker.Settings): JQuery;
-        daterangepicker(settings?: daterangepicker.Settings, callback?: (start?: string | Date | moment.Moment, end?: string | Date | moment.Moment, label?: string) => any): JQuery;
+        daterangepicker(settings?: daterangepicker.Settings, callback?: daterangepicker.DataRangePickerCallback): JQuery;
     }
 }
 
+declare const daterangepicker: daterangepicker.DateRangePicker;
+
 declare namespace daterangepicker {
+    type DataRangePickerCallback = (start?: string | Date | moment.Moment, end?: string | Date | moment.Moment, label?: string) => any;
+
+    interface DateRangePicker {
+        new (element: HTMLElement, settings?: daterangepicker.Settings, callback?: DataRangePickerCallback): DateRangePicker;
+
+        startDate: moment.Moment;
+        endDate: moment.Moment;
+    }
 
     interface DatepickerEventObject extends JQueryEventObject {
         date: Date;


### PR DESCRIPTION
This is to allow directly create component without jQuery.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dangrossman/bootstrap-daterangepicker/blob/master/daterangepicker.js#L1625
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

