### PR TITLE
[bootstrap] Fix typo in CarouselOptions

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -61,7 +61,7 @@ interface CarouselOptions {
     interval?: number;
     pause?: string;
     wrap?: boolean;
-    keybord?: boolean;
+    keyboard?: boolean;
 }
 
 interface TypeaheadOptions {


### PR DESCRIPTION
I don't currently have all the tools installed to properly test my change, as I only use these definitions for VS Code intellisense suggestions, so I apologise if this cannot be merged. Anyway, I noticed that there was a typo in the definition of CarouselOptions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://getbootstrap.com/javascript/#carousel
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

