### PR TITLE
[bson,mongodb] Added missing bson methods and removed duplication on mongodb

### DIFF
--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for bson 1.0
 // Project: https://github.com/mongodb/js-bson
 // Definitions by: Hiroki Horiuchi <https://github.com/horiuchi/>
+//                 Federico Caselli <https://github.com/CaselIT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
@@ -37,6 +38,17 @@ export class Binary {
     static SUBTYPE_USER_DEFINED: number;
 
     constructor(buffer: Buffer, subType?: number);
+
+    /** The length of the binary. */
+    length(): number;
+    /** Updates this binary with byte_value */
+    put(byte_value: number | string): void;
+    /** Reads length bytes starting at position. */
+    read(position: number, length: number): Buffer;
+    /** Returns the value of this binary as a string. */
+    value(): string;
+    /** Writes a buffer or string to the binary */
+    write(buffer: Buffer | string, offset: number): void;
 }
 export class Code {
     constructor(code: string | Function, scope?: any);
@@ -45,15 +57,55 @@ export class DBRef {
     constructor(namespace: string, oid: ObjectID, db?: string);
 }
 export class Double {
-    constructor (value: number);
+    constructor(value: number);
+
+    valueOf(): number;
 }
 export class Long {
+    static MAX_VALUE: Long;
+    static MIN_VALUE: Long;
+    static NEG_ONE: Long;
+    static ONE: Long;
+    static ZERO: Long;
+
     static fromInt(i: number): Long;
     static fromNumber(n: number): Long;
     static fromBits(lowBits: number, highBits: number): Long;
     static fromString(s: string, opt_radix?: number): Long;
 
     constructor(low: number, high: number);
+
+    add(other: Long): Long;
+    and(other: Long): Long;
+    compare(other: Long): number;
+    div(other: Long): Long;
+    equals(other: Long): boolean;
+    getHighBits(): number;
+    getLowBits(): number;
+    getLowBitsUnsigned(): number;
+    getNumBitsAbs(): number;
+    greaterThan(other: Long): number;
+    greaterThanOrEqual(other: Long): number;
+    isNegative(): boolean;
+    isOdd(): boolean;
+    isZero(): boolean;
+    lessThan(other: Long): boolean;
+    lessThanOrEqual(other: Long): boolean;
+    modulo(other: Long): Long;
+    multiply(other: Long): Long;
+    negate(): Long;
+    not(): Long;
+    notEquals(other: Long): boolean;
+    or(other: Long): Long;
+    shiftLeft(other: number): Long;
+    shiftRight(other: number): Long;
+    shiftRightUnsigned(other: number): Long;
+    subtract(other: Long): Long;
+    toInt(): number;
+    toJSON(): string;
+    toNumber(): number;
+    toString(radix?: number): string;
+    xor(other: Long): Long;
 }
 export class MaxKey {
     constructor();
@@ -61,17 +113,56 @@ export class MaxKey {
 export class MinKey {
     constructor();
 }
-export class ObjectId {
-    static createPk(): ObjectId;
-    static createFromTime(time: number): ObjectId;
-    static createFromHexString(hexString: string): ObjectId;
-    static isValid(id: number | string | ObjectId): boolean;
-
-    constructor(id?: number | string | ObjectId);
-    toHexString(): string;
+export class ObjectID {
+    /**
+     * Create a new ObjectID instance
+     * @param {(string|number|ObjectID)} id Can be a 24 byte hex string, 12 byte binary string or a Number.
+     */
+    constructor(id?: string | number | ObjectID);
+    /** The generation time of this ObjectID instance */
+    generationTime: number;
+    /**
+     * Creates an ObjectID from a hex string representation of an ObjectID.
+     * @param {string} hexString create a ObjectID from a passed in 24 byte hexstring.
+     * @return {ObjectID} return the created ObjectID
+     */
+    static createFromHexString(hexString: string): ObjectID;
+    /**
+     * Creates an ObjectID from a second based number, with the rest of the ObjectID zeroed out. Used for comparisons or sorting the ObjectID.
+     * @param {number} time an integer number representing a number of seconds.
+     * @return {ObjectID} return the created ObjectID
+     */
+    static createFromTime(time: number): ObjectID;
+    /**
+     * Checks if a value is a valid bson ObjectID
+     * 
+     * @return {boolean} return true if the value is a valid bson ObjectID, return false otherwise.
+     */
+    static isValid(id: string | number | ObjectID): boolean;
+    /**
+     * Compares the equality of this ObjectID with `otherID`.
+     * @param {object} otherID ObjectID instance to compare against.
+     * @return {boolean} the result of comparing two ObjectID's
+     */
+    equals(otherID: ObjectID): boolean;
+    /**
+     * Generate a 12 byte id string used in ObjectID's
+     * @param {number} time optional parameter allowing to pass in a second based timestamp.
+     * @return {string} return the 12 byte id binary string.
+     */
+    generate(time?: number): string;
+    /**
+     * Returns the generation date (accurate up to the second) that this ID was generated.
+     * @return {date} the generation date
+     */
     getTimestamp(): Date;
+    /**
+     * Return the ObjectID id as a 24 byte hex string representation
+     * @return {string} return the 24 byte hex string representation.
+     */
+    toHexString(): string;
 }
-export type ObjectID = ObjectId;
+export { ObjectID as ObjectId };
 export class BSONRegExp {
     constructor(pattern: string, options: string);
 }
@@ -79,10 +170,48 @@ export class Symbol {
     constructor(value: string);
 }
 export class Timestamp {
-    static fromInt(i: number): Timestamp;
-    static fromNumber(n: number): Timestamp;
-    static fromBits(lowBits: number, highBits: number): Timestamp;
-    static fromString(s: string, opt_radix?: number): Timestamp;
-
     constructor(low: number, high: number);
+
+    static MAX_VALUE: Timestamp;
+    static MIN_VALUE: Timestamp;
+    static NEG_ONE: Timestamp;
+    static ONE: Timestamp;
+    static ZERO: Timestamp;
+
+    static fromBits(lowBits: number, highBits: number): Timestamp;
+    static fromInt(value: number): Timestamp;
+    static fromNumber(value: number): Timestamp;
+    static fromString(str: string, radix?: number): Timestamp;
+
+    add(other: Timestamp): Timestamp;
+    and(other: Timestamp): Timestamp;
+    compare(other: Timestamp): number;
+    div(other: Timestamp): Timestamp;
+    equals(other: Timestamp): boolean;
+    getHighBits(): number;
+    getLowBits(): number;
+    getLowBitsUnsigned(): number;
+    getNumBitsAbs(): number;
+    greaterThan(other: Timestamp): number;
+    greaterThanOrEqual(other: Timestamp): number;
+    isNegative(): boolean;
+    isOdd(): boolean;
+    isZero(): boolean;
+    lessThan(other: Timestamp): boolean;
+    lessThanOrEqual(other: Timestamp): boolean;
+    modulo(other: Timestamp): Timestamp;
+    multiply(other: Timestamp): Timestamp;
+    negate(): Timestamp;
+    not(): Timestamp;
+    notEquals(other: Timestamp): boolean;
+    or(other: Timestamp): Timestamp;
+    shiftLeft(other: number): Timestamp;
+    shiftRight(other: number): Timestamp;
+    shiftRightUnsigned(other: number): Timestamp;
+    subtract(other: Timestamp): Timestamp;
+    toInt(): number;
+    toJSON(): string;
+    toNumber(): number;
+    toString(radix?: number): string;
+    xor(other: Timestamp): Timestamp;
 }

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -6,9 +6,13 @@
 // Documentation : http://mongodb.github.io/node-mongodb-native/2.1/api/
 
 /// <reference types="node" />
+/// <reference types="bson" />
 
-import {EventEmitter} from 'events';
+import { ObjectID } from 'bson';
+import { EventEmitter } from 'events';
 import { Readable, Writable } from "stream";
+
+export { Binary, Double, Long, MaxKey, MinKey, ObjectID, Timestamp } from 'bson';
 
 // Class documentation : http://mongodb.github.io/node-mongodb-native/2.1/api/MongoClient.html
 export class MongoClient {
@@ -240,8 +244,6 @@ export class Db extends EventEmitter {
     stats(options: { scale?: number }, callback: MongoCallback<any>): void;
 }
 
-
-
 // Deprecated http://mongodb.github.io/node-mongodb-native/2.1/api/Server.html
 export class Server extends EventEmitter {
     constructor(host: string, port: number, options?: ServerOptions);
@@ -401,166 +403,6 @@ export interface FSyncOptions {
     wtimeout?: number;
     j?: boolean;
     fsync?: boolean
-}
-
-// Class documentation : http://mongodb.github.io/node-mongodb-native/2.1/api/ObjectID.html
-export class ObjectID {
-    constructor(s?: string | number);
-
-    generationTime: number;
-
-    // Creates an ObjectID from a hex string representation of an ObjectID.
-    // hexString – create a ObjectID from a passed in 24 byte hexstring.
-    static createFromHexString(hexString: string): ObjectID;
-    // Creates an ObjectID from a second based number, with the rest of the ObjectID zeroed out. Used for comparisons or sorting the ObjectID.
-    // time – an integer number representing a number of seconds.
-    static createFromTime(time: number): ObjectID;
-    // Checks if a value is a valid bson ObjectId
-    // id - Value to be checked
-    static isValid(id: any): boolean;
-    //Compares the equality of this ObjectID with otherID.
-    equals(otherID: ObjectID): boolean;
-    // Generate a 12 byte id string used in ObjectID's
-    // time - optional parameter allowing to pass in a second based timestamp
-    generate(time?: number): string;
-    // Returns the generation date (accurate up to the second) that this ID was generated.
-    getTimestamp(): Date;
-    // Returns the ObjectID id as a 24 byte hex string representation
-    toHexString(): string;
-    // Returns the ObjectID id as a 24 byte hex string representation
-    toString(): string;
-}
-
-// Class documentation : http://mongodb.github.io/node-mongodb-native/2.1/api/Binary.html
-export class Binary {
-    constructor(buffer: Buffer, subType?: number);
-
-    static SUBTYPE_BYTE_ARRAY: number;
-    static SUBTYPE_DEFAULT: number;
-    static SUBTYPE_FUNCTION: number;
-    static SUBTYPE_MD5: number;
-    static SUBTYPE_USER_DEFINED: number;
-    static SUBTYPE_UUID: number;
-    static SUBTYPE_UUID_OLD: number;
-
-    // The length of the binary.
-    length(): number;
-    // Updates this binary with byte_value
-    put(byte_value: number | string): void;
-    // Reads length bytes starting at position.
-    read(position: number, length: number): Buffer;
-    // Returns the value of this binary as a string.
-    value(): string;
-    // Writes a buffer or string to the binary
-    write(buffer: Buffer | string, offset: number): void;
-}
-//http://mongodb.github.io/node-mongodb-native/2.1/api/Double.html
-export class Double {
-    constructor(value: number);
-
-    valueOf(): number;
-}
-
-//http://mongodb.github.io/node-mongodb-native/2.1/api/Long.html
-export class Long {
-    constructor(low: number, high: number);
-
-    static MAX_VALUE: Long;
-    static MIN_VALUE: Long;
-    static NEG_ONE: Long;
-    static ONE: Long;
-    static ZERO: Long;
-
-    static fromBits(lowBits: number, highBits: number): Long;
-    static fromInt(value: number): Long;
-    static fromNumber(value: number): Long;
-    static fromString(str: string, radix?: number): Long;
-
-    add(other: Long): Long;
-    and(other: Long): Long;
-    compare(other: Long): number;
-    div(other: Long): Long;
-    equals(other: Long): boolean;
-    getHighBits(): number;
-    getLowBits(): number;
-    getLowBitsUnsigned(): number;
-    getNumBitsAbs(): number;
-    greaterThan(other: Long): number;
-    greaterThanOrEqual(other: Long): number;
-    isNegative(): boolean;
-    isOdd(): boolean;
-    isZero(): boolean;
-    lessThan(other: Long): boolean;
-    lessThanOrEqual(other: Long): boolean;
-    modulo(other: Long): Long;
-    multiply(other: Long): Long;
-    negate(): Long;
-    not(): Long;
-    notEquals(other: Long): boolean;
-    or(other: Long): Long;
-    shiftLeft(other: number): Long;
-    shiftRight(other: number): Long;
-    shiftRightUnsigned(other: number): Long;
-    subtract(other: Long): Long;
-    toInt(): number;
-    toJSON(): string;
-    toNumber(): number;
-    toString(radix?: number): string;
-    xor(other: Long): Long;
-}
-
-//http://mongodb.github.io/node-mongodb-native/2.1/api/MaxKey.html
-export class MaxKey { }
-
-//http://mongodb.github.io/node-mongodb-native/2.1/api/MinKey.html
-export class MinKey { }
-
-//http://mongodb.github.io/node-mongodb-native/2.1/api/Timestamp.html
-export class Timestamp {
-    constructor(low: number, high: number);
-
-    static MAX_VALUE: Timestamp;
-    static MIN_VALUE: Timestamp;
-    static NEG_ONE: Timestamp;
-    static ONE: Timestamp;
-    static ZERO: Timestamp;
-
-    static fromBits(lowBits: number, highBits: number): Timestamp;
-    static fromInt(value: number): Timestamp;
-    static fromNumber(value: number): Timestamp;
-    static fromString(str: string, radix?: number): Timestamp;
-
-    add(other: Timestamp): Timestamp;
-    and(other: Timestamp): Timestamp;
-    compare(other: Timestamp): number;
-    div(other: Timestamp): Timestamp;
-    equals(other: Timestamp): boolean;
-    getHighBits(): number;
-    getLowBits(): number;
-    getLowBitsUnsigned(): number;
-    getNumBitsAbs(): number;
-    greaterThan(other: Timestamp): number;
-    greaterThanOrEqual(other: Timestamp): number;
-    isNegative(): boolean;
-    isOdd(): boolean;
-    isZero(): boolean;
-    lessThan(other: Timestamp): boolean;
-    lessThanOrEqual(other: Timestamp): boolean;
-    modulo(other: Timestamp): Timestamp;
-    multiply(other: Timestamp): Timestamp;
-    negate(): Timestamp;
-    not(): Timestamp;
-    notEquals(other: Timestamp): boolean;
-    or(other: Timestamp): Timestamp;
-    shiftLeft(other: number): Timestamp;
-    shiftRight(other: number): Timestamp;
-    shiftRightUnsigned(other: number): Timestamp;
-    subtract(other: Timestamp): Timestamp;
-    toInt(): number;
-    toJSON(): string;
-    toNumber(): number;
-    toString(radix?: number): string;
-    xor(other: Timestamp): Timestamp;
 }
 
 // Documentation : http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html
@@ -983,7 +825,7 @@ export interface FindOperatorsOrdered {
     upsert(): FindOperatorsOrdered;
 }
 
-  //http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html
+//http://mongodb.github.io/node-mongodb-native/2.1/api/UnorderedBulkOperation.html
 export interface UnorderedBulkOperation {
     //http://mongodb.github.io/node-mongodb-native/2.1/api/lib_bulk_unordered.js.html line 339
     length: number;
@@ -1371,8 +1213,8 @@ export interface GridFSBucketReadStreamOptions {
 }
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketWriteStream.html
-export class GridFSBucketWriteStream extends Writable{
-    constructor(bucket: GridFSBucket, filename:string, options?: GridFSBucketWriteStreamOptions);
+export class GridFSBucketWriteStream extends Writable {
+    constructor(bucket: GridFSBucket, filename: string, options?: GridFSBucketWriteStreamOptions);
 }
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketWriteStream.html


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- The package mongodb redefined some types from bson. It now imports them from the bson package. I've also exported them since the original package does export them.
- Added missing methods on the bson package that were present in the mongodb definitions and in the documentation
