### PR TITLE
Fix musicmetadata genre type

### DIFF
--- a/types/musicmetadata/index.d.ts
+++ b/types/musicmetadata/index.d.ts
@@ -31,7 +31,7 @@ declare namespace MM {
         year: string;
         track: NoOf;
         disk: NoOf;
-        genre: string;
+        genre: string[];
         picture: Picture[];
         duration: number;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/musicmetadata
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

No more to add, only one line fix - genre property is an array of string as showed in the npmjs package readme. Also SS from debbuger to provide runtime correctness:
![2017-03-31 19_06_29-tags ts - backend - visual studio code](https://cloud.githubusercontent.com/assets/10618781/24561574/84777e44-1647-11e7-9143-534496a2927e.png)
