### PR TITLE
electron: Add null type to get/setApplicationMenu

### DIFF
--- a/types/electron/index.d.ts
+++ b/types/electron/index.d.ts
@@ -2608,11 +2608,11 @@ declare namespace Electron {
 		 * Sets menu as the application menu on macOS. On Windows and Linux, the menu
 		 * will be set as each window's top menu.
 		 */
-		static setApplicationMenu(menu: Menu): void;
+		static setApplicationMenu(menu: Menu | null): void;
 		/**
 		 * @returns The application menu if set, or null if not set.
 		 */
-		static getApplicationMenu(): Menu;
+		static getApplicationMenu(): Menu | null;
 		/**
 		 * Sends the action to the first responder of application.
 		 * This is used for emulating default Cocoa menu behaviors,

--- a/types/electron/index.d.ts
+++ b/types/electron/index.d.ts
@@ -2605,8 +2605,11 @@ declare namespace Electron {
 		 */
 		constructor();
 		/**
-		 * Sets menu as the application menu on macOS. On Windows and Linux, the menu
-		 * will be set as each window's top menu.
+		 * Sets menu as the application menu on macOS. On Windows and Linux, the
+		 * menu will be set as each window's top menu.
+		 *
+		 * Passing null will remove the menu bar on Windows and Linux but has no
+		 * effect on macOS.
 		 */
 		static setApplicationMenu(menu: Menu | null): void;
 		/**

--- a/types/electron/test/main.ts
+++ b/types/electron/test/main.ts
@@ -734,6 +734,7 @@ var template = <Electron.MenuItemOptions[]>[
 menu = Menu.buildFromTemplate(template);
 
 Menu.setApplicationMenu(menu); // Must be called within app.on('ready', function(){ ... });
+Menu.setApplicationMenu(null);
 
 Menu.buildFromTemplate([
 	{ label: '4', id: '4' },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

Docs for `getApplicationMenu`: https://electron.atom.io/docs/api/menu/#menugetapplicationmenu

Docs for `setApplicationMenu` are currently missing the fact that you can pass `null`. You can see from the code that this is a valid option (https://github.com/electron/electron/blob/f7e3f9035da3bf3eb946294a4100b6700bd41bc4/lib/browser/api/menu.js#L276) and I've opened a PR to fix the docs too electron/electron#9072

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
