### PR TITLE
hapi: use native promise types for async/await compatibility

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -16,16 +16,9 @@ interface IDictionary<T> {
     [key: string]: T;
 }
 
-interface IThenable<R> {
-    then<U>(onFulfilled?: (value: R) => U | IThenable<U>, onRejected?: (error: any) => U | IThenable<U>): IThenable<U>;
-    then<U>(onFulfilled?: (value: R) => U | IThenable<U>, onRejected?: (error: any) => void): IThenable<U>;
-}
+export declare type IThenable<R> = PromiseLike<R>
 
-interface IPromise<R> extends IThenable<R> {
-    then<U>(onFulfilled?: (value: R) => U | IThenable<U>, onRejected?: (error: any) => U | IThenable<U>): IPromise<U>;
-    then<U>(onFulfilled?: (value: R) => U | IThenable<U>, onRejected?: (error: any) => void): IPromise<U>;
-    catch<U>(onRejected?: (error: any) => U | IThenable<U>): IPromise<U>;
-}
+export declare type IPromise<R> = Promise<R>
 
 export interface IHeaderOptions {
     append?: boolean;

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for hapi 16.0.0
+// Type definitions for hapi 16.0.1
 // Project: http://github.com/spumko/hapi
 // Definitions by: Jason Swearingen <http://github.com/jasonswearingen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
@jasonswearingen As a solution for #15481, this pull request changes Hapi type definitions of IThenable and IPromise so they are equivalent to standard types PromiseLike<R> and Promise<R> respectively as specified below.

```
export declare type IThenable<R> = PromiseLike<R>
export declare type IPromise<R> = Promise<R>
```
This means that typescript will accept async/await to be used with hapijs !

This is my first PR for DefinitelyTyped. I have kept the change as small as possible. I am not sure if there are any additional changes I should make (version numbers etc.).
