### PR TITLE
Remove `string[]` from ApplePayJS's `ApplePayPaymentRequest.shippingMethods`

### DIFF
--- a/types/applepayjs/index.d.ts
+++ b/types/applepayjs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Apple Pay JS 1.0
+// Type definitions for Apple Pay JS 1.0.1
 // Project: https://developer.apple.com/reference/applepayjs
 // Definitions by: Martin Costello <https://martincostello.com/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -392,7 +392,7 @@ declare namespace ApplePayJS {
         /**
          * A set of shipping method objects that describe the available shipping methods.
          */
-        shippingMethods?: ApplePayShippingMethod[] | string[];
+        shippingMethods?: ApplePayShippingMethod[];
 
         /**
          * How the items are to be shipped.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.apple.com/reference/applepayjs/applepaypaymentrequest/1916121-shippingmethods
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.