### PR TITLE
Lodash: Use dtslint for map tests and add pluck variant

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -5654,7 +5654,7 @@ declare namespace _ {
     //_.zipObject
     interface LoDashStatic {
         /**
-         * This method is like _.fromPairs except that it accepts two arrays, one of property 
+         * This method is like _.fromPairs except that it accepts two arrays, one of property
          * identifiers and one of corresponding values.
          *
          * @param props The property names.
@@ -8415,21 +8415,38 @@ declare namespace _ {
          */
         map<T, TResult>(
             collection: List<T>,
-            iteratee?: ListIterator<T, TResult>
+            iteratee: ListIterator<T, TResult>
         ): TResult[];
+
+        /**
+         * @see _.map
+         */
+        map<T>(collection: List<T>): T[];
 
         /**
          * @see _.map
          */
         map<T extends {}, TResult>(
             collection: Dictionary<T>,
-            iteratee?: DictionaryIterator<T, TResult>
+            iteratee: DictionaryIterator<T, TResult>
         ): TResult[];
+
+        /** @see _.map */
+        map<T, K extends keyof T>(
+            collection: Dictionary<T>,
+            iteratee: K
+        ): T[K][];
+
+        /** @see _.map */
+        map<T>(collection: Dictionary<T>): T[];
 
         map<T extends {}, TResult>(
             collection: NumericDictionary<T>,
             iteratee?: NumericDictionaryIterator<T, TResult>
         ): TResult[];
+
+        /** @see _.map */
+        map<T, K extends keyof T>(collection: List<T>, iteratee: K): T[K][];
 
         /**
          * @see _.map
@@ -8453,21 +8470,29 @@ declare namespace _ {
          * @see _.map
          */
         map<TResult>(
-            iteratee?: ListIterator<T, TResult>
+            iteratee: ListIterator<T, TResult>
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
          * @see _.map
          */
+        map(): LoDashImplicitArrayWrapper<T>;
+
+        /** @see _.map */
+        map<K extends keyof T>(iteratee: K): LoDashImplicitArrayWrapper<T[K]>;
+
+        /**
+         * @see _.map
+         */
         map<TResult>(
-            iteratee?: string
+            iteratee: string
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
          * @see _.map
          */
         map<TObject extends {}>(
-            iteratee?: TObject
+            iteratee: TObject
         ): LoDashImplicitArrayWrapper<boolean>;
     }
 
@@ -8476,21 +8501,27 @@ declare namespace _ {
          * @see _.map
          */
         map<TValue, TResult>(
-            iteratee?: ListIterator<TValue, TResult>|DictionaryIterator<TValue, TResult>
+            iteratee: ListIterator<TValue, TResult>|DictionaryIterator<TValue, TResult>
         ): LoDashImplicitArrayWrapper<TResult>;
+
+        /** @see _.map */
+        map(): LoDashImplicitArrayWrapper<T[keyof T]>;
+
+        /** @see _.map */
+        map<K extends keyof T>(iteratee: K): LoDashImplicitArrayWrapper<T[K]>;
 
         /**
          * @see _.map
          */
         map<TValue, TResult>(
-            iteratee?: string
+            iteratee: string
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
          * @see _.map
          */
         map<TObject extends {}>(
-            iteratee?: TObject
+            iteratee: TObject
         ): LoDashImplicitArrayWrapper<boolean>;
     }
 
@@ -8499,21 +8530,27 @@ declare namespace _ {
          * @see _.map
          */
         map<TResult>(
-            iteratee?: ListIterator<T, TResult>
+            iteratee: ListIterator<T, TResult>
         ): LoDashExplicitArrayWrapper<TResult>;
+
+        /** @see _.map */
+        map(): LoDashExplicitArrayWrapper<T>;
+
+        /** @see _.map */
+        map<K extends keyof T>(iteratee: K): LoDashExplicitArrayWrapper<T[K]>;
 
         /**
          * @see _.map
          */
         map<TResult>(
-            iteratee?: string
+            iteratee: string
         ): LoDashExplicitArrayWrapper<TResult>;
 
         /**
          * @see _.map
          */
         map<TObject extends {}>(
-            iteratee?: TObject
+            iteratee: TObject
         ): LoDashExplicitArrayWrapper<boolean>;
     }
 
@@ -8522,21 +8559,24 @@ declare namespace _ {
          * @see _.map
          */
         map<TValue, TResult>(
-            iteratee?: ListIterator<TValue, TResult>|DictionaryIterator<TValue, TResult>
+            iteratee: ListIterator<TValue, TResult>|DictionaryIterator<TValue, TResult>
         ): LoDashExplicitArrayWrapper<TResult>;
+
+        /** @see _.map */
+        map(): LoDashExplicitArrayWrapper<T[keyof T]>;
 
         /**
          * @see _.map
          */
         map<TValue, TResult>(
-            iteratee?: string
+            iteratee: string
         ): LoDashExplicitArrayWrapper<TResult>;
 
         /**
          * @see _.map
          */
         map<TObject extends {}>(
-            iteratee?: TObject
+            iteratee: TObject
         ): LoDashExplicitArrayWrapper<boolean>;
     }
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4591,75 +4591,75 @@ namespace TestMap {
     let dictionaryIterator: (value: number, key: string, collection: _.Dictionary<number>) => TResult;
 
     {
-        let result: TResult[];
+        _.map(array);  // $ExpectType number[]
+        _.map(array, listIterator);  // $ExpectType TResult[]
 
-        result = _.map<number, TResult>(array);
-        result = _.map<number, TResult>(array, listIterator);
-        result = _.map<number, TResult>(array, '');
+        _.map(list);  // $ExpectType number[]
+        _.map(list, listIterator);  // $ExpectType TResult[]
 
-        result = _.map<number, TResult>(list);
-        result = _.map<number, TResult>(list, listIterator);
-        result = _.map<number, TResult>(list, '');
-
-        result = _.map<number, TResult>(dictionary);
-        result = _.map<number, TResult>(dictionary, dictionaryIterator);
-        result = _.map<number, TResult>(dictionary, '');
+        _.map(dictionary);  // $ExpectType number[]
+        _.map(dictionary, dictionaryIterator);  // $ExpectType TResult[]
     }
 
     {
-        let result: boolean[];
-
-        result = _.map<number, {}>(array, {});
-        result = _.map<number, {}>(list, {});
-        result = _.map<number, {}>(dictionary, {});
+        // _.matches iteratee shorthand.
+        _.map(array, {});  // $ExpectType boolean[]
+        _.map(list, {});  // $ExpectType boolean[]
+        _.map(dictionary, {});  // $ExpectType boolean[]
     }
 
     {
-        let result: _.LoDashImplicitArrayWrapper<TResult>;
+        _(array).map().value();  // $ExpectType number[]
+        _(array).map(listIterator).value();  // $ExpectType TResult[]
 
-        result = _<number>(array).map<TResult>();
-        result = _<number>(array).map<TResult>(listIterator);
-        result = _<number>(array).map<TResult>('');
+        _(list).map().value();  // $ExpectType number[]
+        _(list).map(listIterator).value();  // $ExpectType TResult[]
 
-        result = _(list).map<number, TResult>();
-        result = _(list).map<number, TResult>(listIterator);
-        result = _(list).map<number, TResult>('');
-
-        result = _(dictionary).map<number, TResult>();
-        result = _(dictionary).map<number, TResult>(dictionaryIterator);
-        result = _(dictionary).map<number, TResult>('');
+        _(dictionary).map().value();  // $ExpectType number[]
+        _(dictionary).map(dictionaryIterator).value();  // $ExpectType TResult[]
     }
 
     {
-        let result: _.LoDashImplicitArrayWrapper<boolean>;
-
-        result = _<number>(array).map<{}>({});
-        result = _(list).map<{}>({});
-        result = _(dictionary).map<{}>({});
+        _(array).map({}).value();  // $ExpectType boolean[]
+        _(list).map({}).value();  // $ExpectType boolean[]
+        _(dictionary).map({}).value();  // $ExpectType boolean[]
     }
 
     {
-        let result: _.LoDashExplicitArrayWrapper<TResult>;
+        _(array).chain().map().value();  // $ExpectType number[]
+        _(array).chain().map(listIterator).value();  // $ExpectType TResult[]
 
-        result = _<number>(array).chain().map<TResult>();
-        result = _<number>(array).chain().map<TResult>(listIterator);
-        result = _<number>(array).chain().map<TResult>('');
+        _(list).chain().map().value();  // $ExpectType number[]
+        _(list).chain().map(listIterator).value();  // $ExpectType TResult[]
 
-        result = _(list).chain().map<number, TResult>();
-        result = _(list).chain().map<number, TResult>(listIterator);
-        result = _(list).chain().map<number, TResult>('');
-
-        result = _(dictionary).chain().map<number, TResult>();
-        result = _(dictionary).chain().map<number, TResult>(dictionaryIterator);
-        result = _(dictionary).chain().map<number, TResult>('');
+        _(dictionary).chain().map().value();  // $ExpectType number[]
+        _(dictionary).chain().map(dictionaryIterator).value();  // $ExpectType TResult[]
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<boolean>;
 
-        result = _<number>(array).chain().map<{}>({});
-        result = _(list).chain().map<{}>({});
-        result = _(dictionary).chain().map<{}>({});
+        result = _<number>(array).chain().map({});
+        result = _(list).chain().map({});
+        result = _(dictionary).chain().map({});
+    }
+
+    {
+        // "pluck"-style map.
+        _.map([{a: 1}, {a: 2}], 'a');  // $ExpectType number[]
+        _.map({a: {b: 'str'}, c: {b: 1}}, 'b');  // ExpectType (string | number)[]
+
+        _([{a: 1}, {a: 2}]).map('a').value();  // $ExpectType number[]
+        _.chain([{a: 1}, {a: 2}]).map('a').value();  // $ExpectType number[]
+        _([{a: 1}, {a: 2}]).chain().map('a').value();  // $ExpectType number[]
+    }
+
+    {
+        // $ExpectType number[]
+        _.map(['a', 'b', 'c'], (
+            v,  // $ExpectType string
+            k  // $ExpectType number
+          ) => k);
     }
 }
 


### PR DESCRIPTION
This reworks the Lodash tests for `map` to use the new dtslint `$ExpectType` assertions. I've removed template parameters from the tests for `map` to test that types are inferred correctly. Where they were not, I've updated the definitions.

This also improves the typings for the "pluck" variant of `_.map` which takes a string as its iteratee. Previously this would result in a non-useful `{}[]` type. Now it produces correct results, e.g.

```ts
const v = _.map([{a: 1, b: 's'}, {a: 2, b: 't'}], 'a');  // number[]
const v = _.map([{a: 1, b: 's'}, {a: 2, b: 't'}], 'b');  // string[]
```

If this seems reasonable, I can try migrating more of the tests to the new style. I'd also like to switch `chain` to use overloading on `this` ala [this comment](https://github.com/Microsoft/TypeScript/issues/13852#issuecomment-290941826) rather than the current mess of wrapper classes.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.4#map

