### PR TITLE
adding missing property 'textComponent' in IntlProvider of react-intl definition

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -188,6 +188,7 @@ declare namespace ReactIntl {
             locale?: string;
             formats?: any;
             messages?: any;
+            textComponent?: any;
             defaultLocale?: string;
             defaultFormats?: any;
         }

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -183,7 +183,7 @@ class TestApp extends React.Component<{}, {}> {
             "hello": "Hello, {name}!"
         };
         return (
-            <IntlProvider locale="en" formats={{}} messages={messages} defaultLocale="en" defaultFormats={messages}>
+            <IntlProvider locale="en" formats={{}} messages={messages} textComponent='span' defaultLocale="en" defaultFormats={messages}>
                 <SomeComponentWithIntl className="just-for-test" />
                 <SomeFunctionalComponentWithIntl className="another-one" />
             </IntlProvider>


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/yahoo/react-intl/wiki/Components#intlprovider>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
