### PR TITLE
#15580 Alter invalid usage instruction in `@types/bluebird-global`

### DIFF
--- a/types/bluebird-global/index.d.ts
+++ b/types/bluebird-global/index.d.ts
@@ -11,15 +11,24 @@
  *
  * 2. How to use it?
  *
- * Add `bluebird-global` to the `types` array in your `tsconfig.json` like this:
+ * It should just work, but there are a couple of points to be wary about:
  *
- * {
- *   "compilerOptions": {
- *     "types": [
- *       "bluebird-global"
- *     ],
- *   }
- * }
+ * a) If you already use `compilerOptions.types` in your `tsconfig.json`, then add `bluebird-global`
+ *    to the list:
+ *
+ *    {
+ *      "compilerOptions": {
+ *        "types": [
+ *          (other types ...)
+ *
+ *          "bluebird-global"
+ *        ],
+ *      }
+ *    }
+ *
+ * b) Be aware, that you still need to get the global Promise symbol to be replaced with bluebird.js
+ *    in the runtime. Do this by either importing bluebird.js via a `<script />` tag in your html or
+ *    via importing it in your js entry file AND assigning it to the global Promise symbol.
  *
  * 3. Why so much effort?
  *


### PR DESCRIPTION
* Setting bluebird-global in compilerOptions.types
  is not required, so don't mention it in that
  tone in the docs
* Mention in the docs, that it's dev's
  responsibility to provide Bluebird in the
  runtime.

Closes #15580

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15580
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`