### PR TITLE
Adding global Rx definition for @reactivex/rxjs.

### DIFF
--- a/types/reactivex-rxjs/index.d.ts
+++ b/types/reactivex-rxjs/index.d.ts
@@ -1,7 +1,8 @@
-// Global Rx for @reactivex/rxjs
-// TypeScript Version: 2.1.
+// Type definitions for @reactivex/rxjs 5.1
+// Project: https://github.com/ReactiveX/rxjs
 // Definitions by: Ganesh <https://github.com/ganeshyb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1.
 
 import * as _Rx from '@reactivex/rxjs/dist/cjs/Rx';
 

--- a/types/reactivex-rxjs/index.d.ts
+++ b/types/reactivex-rxjs/index.d.ts
@@ -1,0 +1,9 @@
+// Global Rx for @reactivex/rxjs
+// TypeScript Version: 2.1.
+// Definitions by: Ganesh <https://github.com/ganeshyb>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as _Rx from '@reactivex/rxjs/dist/cjs/Rx';
+
+export as namespace Rx;
+export = _Rx;

--- a/types/reactivex-rxjs/index.d.ts
+++ b/types/reactivex-rxjs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ReactiveX/rxjs
 // Definitions by: Ganesh <https://github.com/ganeshyb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1.
+// TypeScript Version: 2.1
 
 import * as _Rx from '@reactivex/rxjs/dist/cjs/Rx';
 

--- a/types/reactivex-rxjs/package.json
+++ b/types/reactivex-rxjs/package.json
@@ -1,7 +1,5 @@
 {
-  "description": "Exposes Rx global namespace ",
   "main": "index.d.ts",
-
   "dependencies": {
     "@reactivex/rxjs": "^5.1.0"
   }

--- a/types/reactivex-rxjs/package.json
+++ b/types/reactivex-rxjs/package.json
@@ -1,5 +1,4 @@
 {
-  "main": "index.d.ts",
   "dependencies": {
     "@reactivex/rxjs": "^5.1.0"
   }

--- a/types/reactivex-rxjs/package.json
+++ b/types/reactivex-rxjs/package.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "description": "Exposes Rx global namespace ",
+  "main": "index.d.ts",
+  "dependencies": {
+    "@reactivex/rxjs": "^5.1.0"
+  }
+}

--- a/types/reactivex-rxjs/package.json
+++ b/types/reactivex-rxjs/package.json
@@ -1,5 +1,4 @@
 {
-  "version": "1.0.0",
   "description": "Exposes Rx global namespace ",
   "main": "index.d.ts",
 

--- a/types/reactivex-rxjs/package.json
+++ b/types/reactivex-rxjs/package.json
@@ -2,6 +2,7 @@
   "version": "1.0.0",
   "description": "Exposes Rx global namespace ",
   "main": "index.d.ts",
+
   "dependencies": {
     "@reactivex/rxjs": "^5.1.0"
   }

--- a/types/reactivex-rxjs/reactivex-rxjs-tests.ts
+++ b/types/reactivex-rxjs/reactivex-rxjs-tests.ts
@@ -1,0 +1,6 @@
+
+Rx.Observable.of(1);
+
+let x = new Rx.Subject();
+
+let y = new Rx.BehaviorSubject<string>("hello");

--- a/types/reactivex-rxjs/reactivex-rxjs-tests.ts
+++ b/types/reactivex-rxjs/reactivex-rxjs-tests.ts
@@ -1,4 +1,3 @@
-
 Rx.Observable.of(1);
 
 let x = new Rx.Subject();

--- a/types/reactivex-rxjs/tsconfig.json
+++ b/types/reactivex-rxjs/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "reactivex-rxjs-tests.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/types/reactivex-rxjs/tsconfig.json
+++ b/types/reactivex-rxjs/tsconfig.json
@@ -7,7 +7,11 @@
         "strictNullChecks": true,
         "baseUrl": "../",
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "lib": [
+            "es6",
+            "dom"
+        ]
     },
     "files": [
         "index.d.ts",

--- a/types/reactivex-rxjs/tslint.json
+++ b/types/reactivex-rxjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
Adding Rx global namespace for consuming within typescript using
namesapces

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
