### PR TITLE
declaration now exports public API + made var const

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -9,18 +9,18 @@ import stream = require('stream');
 
 type CallbackHandler = (err: any, res: request.Response) => void;
 
-declare var request: request.SuperAgentStatic;
+declare const request: request.SuperAgentStatic;
 
 declare namespace request {
-    interface SuperAgentRequest extends Request { }
-    interface SuperAgentStatic extends SuperAgent<SuperAgentRequest> {
+    export interface SuperAgentRequest extends Request { }
+    export interface SuperAgentStatic extends SuperAgent<SuperAgentRequest> {
         (url: string): SuperAgentRequest;
         (method: string, url: string): SuperAgentRequest;
 
         agent(): SuperAgent<SuperAgentRequest>;
     }
 
-    interface SuperAgent<Req> extends stream.Stream {
+    export interface SuperAgent<Req> extends stream.Stream {
         get(url: string, callback?: CallbackHandler): Req;
         post(url: string, callback?: CallbackHandler): Req;
         put(url: string, callback?: CallbackHandler): Req;
@@ -54,7 +54,7 @@ declare namespace request {
       attachCookies(req: Req): void;
     }
 
-    interface Response extends NodeJS.ReadableStream {
+    export interface Response extends NodeJS.ReadableStream {
         text: string;
         body: any;
         files: any;

--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for SuperAgent v2.0.0
+// Type definitions for SuperAgent 2.1
 // Project: https://github.com/visionmedia/superagent
 // Definitions by: Alex Varju <https://github.com/varju/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
This declaration did not exports anything making usages result in errors. See https://github.com/Microsoft/TypeScript/issues/14121
I also took the liberty of changing `declare var request` to a `const`.
No other changes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.