### PR TITLE
Fix WeakMap references in es6-shim and es6-collections

### DIFF
--- a/types/es6-collections/index.d.ts
+++ b/types/es6-collections/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/WebReflection/es6-collections/
 // Definitions by: Ron Buckton <http://github.com/rbuckton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /* *****************************************************************************
 Copyright (c) Microsoft Corporation. All rights reserved.
@@ -74,7 +75,7 @@ interface SetConstructor {
 
 declare var Set: SetConstructor;
 
-interface WeakMap<K, V> {
+interface WeakMap<K extends object, V> {
     delete(key: K): boolean;
 	clear(): void;
     get(key: K): V;
@@ -83,8 +84,8 @@ interface WeakMap<K, V> {
 }
 
 interface WeakMapConstructor {
-    new <K, V>(): WeakMap<K, V>;
-    new <K, V>(iterable: ForEachable<[K, V]>): WeakMap<K, V>;
+    new <K extends object, V>(): WeakMap<K, V>;
+    new <K extends object, V>(iterable: ForEachable<[K, V]>): WeakMap<K, V>;
     prototype: WeakMap<any, any>;
 }
 

--- a/types/es6-shim/index.d.ts
+++ b/types/es6-shim/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/paulmillr/es6-shim
 // Definitions by: Ron Buckton <http://github.com/rbuckton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 declare type PropertyKey = string | number | symbol;
 
@@ -593,7 +594,7 @@ interface SetConstructor {
 
 declare var Set: SetConstructor;
 
-interface WeakMap<K, V> {
+interface WeakMap<K extends object, V> {
     delete(key: K): boolean;
     get(key: K): V;
     has(key: K): boolean;
@@ -601,8 +602,8 @@ interface WeakMap<K, V> {
 }
 
 interface WeakMapConstructor {
-    new <K, V>(): WeakMap<K, V>;
-    new <K, V>(iterable: IterableShim<[K, V]>): WeakMap<K, V>;
+    new <K extends object, V>(): WeakMap<K, V>;
+    new <K extends object, V>(iterable: IterableShim<[K, V]>): WeakMap<K, V>;
     prototype: WeakMap<any, any>;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: issues spotted here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14324#issuecomment-290352288
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

This is a minimal change that unblocks me, and possibly others with a similar issue, but I suspect someone more experienced might be able to remove those definitions altogether.