### PR TITLE
Add options to Map class

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1302,6 +1302,7 @@ declare namespace L {
 
     class Map extends Evented {
         constructor(element: string | HTMLElement, options?: MapOptions);
+        options: MapOptions;
         getRenderer(layer: Path): Renderer;
 
         // Methods for layers and controls


### PR DESCRIPTION
The only way to change options after creating the map is to modify `map.options`