### PR TITLE
synaptic: fix - change string to any

### DIFF
--- a/types/synaptic/index.d.ts
+++ b/types/synaptic/index.d.ts
@@ -328,7 +328,7 @@ export class Network {
     /**
      * Networks can be stored as JSON's.
      */
-    toJSON(): string;
+    toJSON(): any;
 
     /**
      * Creates a static String to store the source code of the functions that are identical for all the workers (train, _trainSet, test).
@@ -339,7 +339,7 @@ export class Network {
     /**
      * Rebuild a network that has been stored in a json using the method toJSON().
      */
-    static fromJSON(exported: string): Network;
+    static fromJSON(exported: any): Network;
 
     /**
      * The network can be converted into a WebWorker. This feature doesn't work in node.js, and it's not supported on every browser (it must support Blob).


### PR DESCRIPTION
this change should not break anything.

toJSON will not generate a string - instead you get an object (or `any` because it's less restrictive)

```
const obj =  myNetwork.toJSON();
fs.writeFile('train.json', JSON.stringify(obj));

...
fs.readFile('train.json', 'utf-8', (err, data) => {
   const myNetwork2 = Network.fromJSON(<any>JSON.parse(data));
});
```
