### PR TITLE
React: Use specific event type for nativeEvent property

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>, John Reilly <https://github.com/johnnyreilly/>, Benoit Benezech <https://github.com/bbenezech>, Patricio Zavolinsky <https://github.com/pzavolinsky>, Digiguru <https://github.com/digiguru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.2
 
 type NativeAnimationEvent = AnimationEvent;
 type NativeClipboardEvent = ClipboardEvent;
@@ -286,14 +286,14 @@ declare namespace React {
     // Event System
     // ----------------------------------------------------------------------
 
-    interface SyntheticEvent<T, NativeEvent extends Event = Event> {
+    interface SyntheticEvent<T> {
         bubbles: boolean;
         currentTarget: EventTarget & T;
         cancelable: boolean;
         defaultPrevented: boolean;
         eventPhase: number;
         isTrusted: boolean;
-        nativeEvent: NativeEvent;
+        nativeEvent: Event;
         preventDefault(): void;
         isDefaultPrevented(): boolean;
         stopPropagation(): void;
@@ -305,19 +305,23 @@ declare namespace React {
         type: string;
     }
 
-    interface ClipboardEvent<T> extends SyntheticEvent<T, NativeClipboardEvent> {
+    interface ClipboardEvent<T> extends SyntheticEvent<T> {
         clipboardData: DataTransfer;
+        nativeEvent: NativeClipboardEvent;
     }
 
-    interface CompositionEvent<T> extends SyntheticEvent<T, NativeCompositionEvent> {
+    interface CompositionEvent<T> extends SyntheticEvent<T> {
         data: string;
+        nativeEvent: NativeCompositionEvent;
     }
 
-    interface DragEvent<T> extends MouseEvent<T, NativeDragEvent> {
+    interface DragEvent<T> extends MouseEvent<T> {
         dataTransfer: DataTransfer;
+        nativeEvent: NativeDragEvent;
     }
 
-    interface FocusEvent<T> extends SyntheticEvent<T, NativeFocusEvent> {
+    interface FocusEvent<T> extends SyntheticEvent<T> {
+        nativeEvent: NativeFocusEvent;
         relatedTarget: EventTarget;
     }
 
@@ -328,7 +332,7 @@ declare namespace React {
         target: EventTarget & T;
     }
 
-    interface KeyboardEvent<T> extends SyntheticEvent<T, NativeKeyboardEvent> {
+    interface KeyboardEvent<T> extends SyntheticEvent<T> {
         altKey: boolean;
         charCode: number;
         ctrlKey: boolean;
@@ -338,12 +342,13 @@ declare namespace React {
         locale: string;
         location: number;
         metaKey: boolean;
+        nativeEvent: NativeKeyboardEvent;
         repeat: boolean;
         shiftKey: boolean;
         which: number;
     }
 
-    interface MouseEvent<T, NativeEvent extends NativeMouseEvent = NativeMouseEvent> extends SyntheticEvent<T, NativeEvent> {
+    interface MouseEvent<T> extends SyntheticEvent<T> {
         altKey: boolean;
         button: number;
         buttons: number;
@@ -352,6 +357,7 @@ declare namespace React {
         ctrlKey: boolean;
         getModifierState(key: string): boolean;
         metaKey: boolean;
+        nativeEvent: NativeMouseEvent;
         pageX: number;
         pageY: number;
         relatedTarget: EventTarget;
@@ -360,39 +366,44 @@ declare namespace React {
         shiftKey: boolean;
     }
 
-    interface TouchEvent<T> extends SyntheticEvent<T, NativeTouchEvent> {
+    interface TouchEvent<T> extends SyntheticEvent<T> {
         altKey: boolean;
         changedTouches: TouchList;
         ctrlKey: boolean;
         getModifierState(key: string): boolean;
         metaKey: boolean;
+        nativeEvent: NativeTouchEvent;
         shiftKey: boolean;
         targetTouches: TouchList;
         touches: TouchList;
     }
 
-    interface UIEvent<T> extends SyntheticEvent<T, NativeUIEvent> {
+    interface UIEvent<T> extends SyntheticEvent<T> {
         detail: number;
+        nativeEvent: NativeUIEvent;
         view: AbstractView;
     }
 
-    interface WheelEvent<T> extends MouseEvent<T, NativeWheelEvent> {
+    interface WheelEvent<T> extends MouseEvent<T> {
         deltaMode: number;
         deltaX: number;
         deltaY: number;
         deltaZ: number;
+        nativeEvent: NativeWheelEvent;
     }
 
-    interface AnimationEvent<T> extends SyntheticEvent<T, NativeAnimationEvent> {
+    interface AnimationEvent<T> extends SyntheticEvent<T> {
         animationName: string;
-        pseudoElement: string;
         elapsedTime: number;
+        nativeEvent: NativeAnimationEvent;
+        pseudoElement: string;
     }
 
-    interface TransitionEvent<T> extends SyntheticEvent<T, NativeTransitionEvent> {
+    interface TransitionEvent<T> extends SyntheticEvent<T> {
+        elapsedTime: number;
+        nativeEvent: NativeTransitionEvent;
         propertyName: string;
         pseudoElement: string;
-        elapsedTime: number;
     }
 
     //

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -4,6 +4,18 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+type NativeAnimationEvent = AnimationEvent;
+type NativeClipboardEvent = ClipboardEvent;
+type NativeCompositionEvent = CompositionEvent;
+type NativeDragEvent = DragEvent;
+type NativeFocusEvent = FocusEvent;
+type NativeKeyboardEvent = KeyboardEvent;
+type NativeMouseEvent = MouseEvent;
+type NativeTouchEvent = TouchEvent;
+type NativeTransitionEvent = TransitionEvent;
+type NativeUIEvent = UIEvent;
+type NativeWheelEvent = WheelEvent;
+
 export = React;
 export as namespace React;
 
@@ -274,14 +286,14 @@ declare namespace React {
     // Event System
     // ----------------------------------------------------------------------
 
-    interface SyntheticEvent<T> {
+    interface SyntheticEvent<T, NativeEvent extends Event> {
         bubbles: boolean;
         currentTarget: EventTarget & T;
         cancelable: boolean;
         defaultPrevented: boolean;
         eventPhase: number;
         isTrusted: boolean;
-        nativeEvent: Event;
+        nativeEvent: NativeEvent;
         preventDefault(): void;
         isDefaultPrevented(): boolean;
         stopPropagation(): void;
@@ -293,30 +305,30 @@ declare namespace React {
         type: string;
     }
 
-    interface ClipboardEvent<T> extends SyntheticEvent<T> {
+    interface ClipboardEvent<T> extends SyntheticEvent<T, NativeClipboardEvent> {
         clipboardData: DataTransfer;
     }
 
-    interface CompositionEvent<T> extends SyntheticEvent<T> {
+    interface CompositionEvent<T> extends SyntheticEvent<T, NativeCompositionEvent> {
         data: string;
     }
 
-    interface DragEvent<T> extends MouseEvent<T> {
+    interface DragEvent<T> extends BaseMouseEvent<T, NativeDragEvent> {
         dataTransfer: DataTransfer;
     }
 
-    interface FocusEvent<T> extends SyntheticEvent<T> {
+    interface FocusEvent<T> extends SyntheticEvent<T, NativeFocusEvent> {
         relatedTarget: EventTarget;
     }
 
-    interface FormEvent<T> extends SyntheticEvent<T> {
+    interface FormEvent<T> extends SyntheticEvent<T, Event> {
     }
 
-    interface ChangeEvent<T> extends SyntheticEvent<T> {
+    interface ChangeEvent<T> extends SyntheticEvent<T, Event> {
         target: EventTarget & T;
     }
 
-    interface KeyboardEvent<T> extends SyntheticEvent<T> {
+    interface KeyboardEvent<T> extends SyntheticEvent<T, NativeKeyboardEvent> {
         altKey: boolean;
         charCode: number;
         ctrlKey: boolean;
@@ -331,7 +343,7 @@ declare namespace React {
         which: number;
     }
 
-    interface MouseEvent<T> extends SyntheticEvent<T> {
+    interface BaseMouseEvent<T, NativeEvent extends NativeMouseEvent> extends SyntheticEvent<T, NativeEvent> {
         altKey: boolean;
         button: number;
         buttons: number;
@@ -348,7 +360,10 @@ declare namespace React {
         shiftKey: boolean;
     }
 
-    interface TouchEvent<T> extends SyntheticEvent<T> {
+    interface MouseEvent<T> extends BaseMouseEvent<T, NativeMouseEvent> {
+    }
+
+    interface TouchEvent<T> extends SyntheticEvent<T, NativeTouchEvent> {
         altKey: boolean;
         changedTouches: TouchList;
         ctrlKey: boolean;
@@ -359,25 +374,25 @@ declare namespace React {
         touches: TouchList;
     }
 
-    interface UIEvent<T> extends SyntheticEvent<T> {
+    interface UIEvent<T> extends SyntheticEvent<T, NativeUIEvent> {
         detail: number;
         view: AbstractView;
     }
 
-    interface WheelEvent<T> extends MouseEvent<T> {
+    interface WheelEvent<T> extends BaseMouseEvent<T, NativeWheelEvent> {
         deltaMode: number;
         deltaX: number;
         deltaY: number;
         deltaZ: number;
     }
 
-    interface AnimationEvent<T> extends SyntheticEvent<T> {
+    interface AnimationEvent<T> extends SyntheticEvent<T, NativeAnimationEvent> {
         animationName: string;
         pseudoElement: string;
         elapsedTime: number;
     }
 
-    interface TransitionEvent<T> extends SyntheticEvent<T> {
+    interface TransitionEvent<T> extends SyntheticEvent<T, NativeTransitionEvent> {
         propertyName: string;
         pseudoElement: string;
         elapsedTime: number;
@@ -387,11 +402,11 @@ declare namespace React {
     // Event Handler Types
     // ----------------------------------------------------------------------
 
-    interface EventHandler<E extends SyntheticEvent<any>> {
+    interface EventHandler<E extends SyntheticEvent<any, any>> {
         (event: E): void;
     }
 
-    type ReactEventHandler<T> = EventHandler<SyntheticEvent<T>>;
+    type ReactEventHandler<T> = EventHandler<SyntheticEvent<T, Event>>;
 
     type ClipboardEventHandler<T> = EventHandler<ClipboardEvent<T>>;
     type CompositionEventHandler<T> = EventHandler<CompositionEvent<T>>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>, John Reilly <https://github.com/johnnyreilly/>, Benoit Benezech <https://github.com/bbenezech>, Patricio Zavolinsky <https://github.com/pzavolinsky>, Digiguru <https://github.com/digiguru>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 type NativeAnimationEvent = AnimationEvent;
 type NativeClipboardEvent = ClipboardEvent;
@@ -286,7 +286,7 @@ declare namespace React {
     // Event System
     // ----------------------------------------------------------------------
 
-    interface SyntheticEvent<T, NativeEvent extends Event> {
+    interface SyntheticEvent<T, NativeEvent extends Event = Event> {
         bubbles: boolean;
         currentTarget: EventTarget & T;
         cancelable: boolean;
@@ -313,7 +313,7 @@ declare namespace React {
         data: string;
     }
 
-    interface DragEvent<T> extends BaseMouseEvent<T, NativeDragEvent> {
+    interface DragEvent<T> extends MouseEvent<T, NativeDragEvent> {
         dataTransfer: DataTransfer;
     }
 
@@ -321,10 +321,10 @@ declare namespace React {
         relatedTarget: EventTarget;
     }
 
-    interface FormEvent<T> extends SyntheticEvent<T, Event> {
+    interface FormEvent<T> extends SyntheticEvent<T> {
     }
 
-    interface ChangeEvent<T> extends SyntheticEvent<T, Event> {
+    interface ChangeEvent<T> extends SyntheticEvent<T> {
         target: EventTarget & T;
     }
 
@@ -343,7 +343,7 @@ declare namespace React {
         which: number;
     }
 
-    interface BaseMouseEvent<T, NativeEvent extends NativeMouseEvent> extends SyntheticEvent<T, NativeEvent> {
+    interface MouseEvent<T, NativeEvent extends NativeMouseEvent = NativeMouseEvent> extends SyntheticEvent<T, NativeEvent> {
         altKey: boolean;
         button: number;
         buttons: number;
@@ -358,9 +358,6 @@ declare namespace React {
         screenX: number;
         screenY: number;
         shiftKey: boolean;
-    }
-
-    interface MouseEvent<T> extends BaseMouseEvent<T, NativeMouseEvent> {
     }
 
     interface TouchEvent<T> extends SyntheticEvent<T, NativeTouchEvent> {
@@ -379,7 +376,7 @@ declare namespace React {
         view: AbstractView;
     }
 
-    interface WheelEvent<T> extends BaseMouseEvent<T, NativeWheelEvent> {
+    interface WheelEvent<T> extends MouseEvent<T, NativeWheelEvent> {
         deltaMode: number;
         deltaX: number;
         deltaY: number;
@@ -402,11 +399,11 @@ declare namespace React {
     // Event Handler Types
     // ----------------------------------------------------------------------
 
-    interface EventHandler<E extends SyntheticEvent<any, any>> {
+    interface EventHandler<E extends SyntheticEvent<any>> {
         (event: E): void;
     }
 
-    type ReactEventHandler<T> = EventHandler<SyntheticEvent<T, Event>>;
+    type ReactEventHandler<T> = EventHandler<SyntheticEvent<T>>;
 
     type ClipboardEventHandler<T> = EventHandler<ClipboardEvent<T>>;
     type CompositionEventHandler<T> = EventHandler<CompositionEvent<T>>;


### PR DESCRIPTION
This change probably needs discussion.

This allows event handlers to fully use the `ev.nativeEvent` property without casting. But it does make the `React.MouseEvent` type slightly more complicated and is a breaking change for users using `React.SyntheticEvent` directly.

The case that led me to opening the PR is: I have a mouse event I'd like to access the [`movementX`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/movementX) property on, but can see from React's [synthetic mouse event docs](https://facebook.github.io/react/docs/events.html#mouse-events) that they don't support `movementX`, so I need to get it through the `nativeEvent` property.

Something I'd like feedback on is whether the way I'm getting access to the native event types from within the namespace is the best way. Is there something like `::GlobalType` in Typescript?

Could be related to #6883, but I'm not thinking of the React Native case (I haven't used it before).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://developer.mozilla.org/en-US/docs/Web/API/Event
https://facebook.github.io/react/docs/events.html

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
