### PR TITLE
update to react-virtualized 9.5

### DIFF
--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -126,16 +126,13 @@ export type GridCellRangeProps = {
     scrollTop: number
 }
 export type GridCellRangeRenderer = (params: GridCellRangeProps) => React.ReactNode[];
-// TODO  add proper typing
-export type GridProps = {
+
+export type GridCoreProps = {
     'aria-label'?: string;
     autoContainerWidth?: boolean;
     autoHeight?: boolean;
-    cellRenderer: GridCellRenderer;
     cellRangeRenderer?: GridCellRangeRenderer;
     className?: string;
-    columnCount: number;
-    columnWidth: number | ((params: Index) => number);
     containerStyle?: React.CSSProperties;
     deferredMeasurementCache?: CellMeasurerCache;
     estimatedColumnSize?: number;
@@ -143,6 +140,7 @@ export type GridProps = {
     getScrollbarSize?: () => number;
     height: number;
     id?: string;
+    isScrolling?: boolean,
     noContentRenderer?: () => React.ReactNode;
     onScroll?: (params: ScrollParams) => any;
     onSectionRendered?: (params: SectionRenderedParams) => any;
@@ -160,6 +158,12 @@ export type GridProps = {
     style?: React.CSSProperties;
     tabIndex?: number;
     width: number;
+}
+
+export type GridProps = GridCoreProps & {
+    cellRenderer: GridCellRenderer;
+    columnCount: number;
+    columnWidth: number | ((params: Index) => number);
 };
 
 export type ScrollDirection = 'horizontal' | 'vertical';
@@ -273,6 +277,12 @@ export class Grid extends PureComponent<GridProps, GridState> {
          * Optional custom id to attach to root Grid element.
          */
         id: Requireable<string>,
+
+        /**
+         * Override internal is-scrolling state tracking.
+         * This property is primarily intended for use with the WindowScroller component.
+         */
+        isScrolling: Requireable<boolean>,
 
         /**
          * Optional renderer to be used in place of rows when either :rowCount or :columnCount is 0.

--- a/types/react-virtualized/dist/es/List.d.ts
+++ b/types/react-virtualized/dist/es/List.d.ts
@@ -1,12 +1,12 @@
 import { PureComponent, Validator, Requireable } from 'react'
-import { Grid, GridCellProps } from './Grid'
+import { Grid, GridCoreProps, GridCellProps } from './Grid'
 import { Index, IndexRange, Alignment } from '../../index'
 import { CellMeasurerCache } from './CellMeasurer'
 
 export type ListRowProps = GridCellProps & { index: number, style: React.CSSProperties };
 
 export type ListRowRenderer = (props: ListRowProps) => React.ReactNode;
-export type ListProps = {
+export type ListProps = GridCoreProps & {
     deferredMeasurementCache?: CellMeasurerCache;
     className?: string;
     autoHeight?: boolean;

--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -1,7 +1,7 @@
 import { Validator, Requireable, PureComponent, Component } from 'react';
 import { CellMeasurerCache } from './CellMeasurer';
 import { Index, Alignment, ScrollEventData, IndexRange, OverscanIndexRange } from '../../index';
-import { Grid } from './Grid';
+import { Grid, GridCoreProps } from './Grid';
 
 export type TableCellDataGetterParams = {
     columnData?: any,
@@ -155,7 +155,7 @@ export type HeaderMouseEventHandlerParams = {
 }
 
 // ref: https://github.com/bvaughn/react-virtualized/blob/master/docs/Table.md
-export type TableProps = {
+export type TableProps = GridCoreProps & {
     deferredMeasurementCache?: CellMeasurerCache;
     autoHeight?: boolean;
     children?: React.ReactChildren;

--- a/types/react-virtualized/index.d.ts
+++ b/types/react-virtualized/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-virtualized 9.4
+// Type definitions for react-virtualized 9.5
 // Project: https://github.com/bvaughn/react-virtualized
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -1700,6 +1700,7 @@ export class WindowScrollerExample extends PureComponent<any, any> {
                                     autoHeight
                                     className={'styles.List'}
                                     height={height}
+                                    isScrolling={isScrolling}
                                     overscanRowCount={2}
                                     rowCount={list.size}
                                     rowHeight={30}


### PR DESCRIPTION
API Change in GridProps:
new optional property isScrolling

Table- and List-Props extend now the GridCoreProps type to enable full API access 