### PR TITLE
ramda: fix inference for generic in functor

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -15,7 +15,7 @@ declare namespace R {
     }
 
     interface Functor<T> {
-        map<T>(a: any): T;
+        map<U>(fn: (t: T) => U): Functor<U>;
     }
 
     interface ObjectIterator<T, TResult> {

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -668,7 +668,7 @@ interface Obj { a: number; b: number };
     const stringFunctor = {
         map: (fn: (c: number) => number) => {
             var chars = "Ifmmp!Xpsme".split("");
-            return chars.map((char) => String.fromCharCode(fn(char.charCodeAt(0)))).join("");
+            return chars.map((char) => String.fromCharCode(fn(char.charCodeAt(0)))).join("") as any;
         }
     };
     R.map((x: number) => x-1, stringFunctor); // => "Hello World"
@@ -1984,4 +1984,11 @@ class Why {
     R.intersperse(',', ['foo', 'bar']); //=> ['foo', ',', 'bar']
     R.intersperse(0, [1, 2]); //=> [1, 0, 2]
     R.intersperse(0, [1]); //=> [1]
+}
+
+{
+    const functor = {
+        map: (fn: (x: string) => string) => functor
+    }
+    R.map(x => x.trim(), functor)
 }


### PR DESCRIPTION
Previously, this code would fail:

``` ts
{
    const functor = {
        map: (fn: (x: string) => string) => functor
    }
    R.map(x => x.trim(), functor) // Property 'trim' does not exist on type '{}'.
}
```

This is because we were failing to infer the generic from the `functor`, as the interface did not describe how to find the generic in the value.

With this change to the `Functor` interface, generic inference now works. The above code compiles and `x` is inferred as a string.

--

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.