### PR TITLE
google-protobuf: Add type inference to ...WrapperField methods, mark some optional fields

### DIFF
--- a/types/google-protobuf/google-protobuf-tests.ts
+++ b/types/google-protobuf/google-protobuf-tests.ts
@@ -331,7 +331,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest {
-    return jspb.Message.getWrapperField(this, google_protobuf_compiler_plugin_pb.CodeGeneratorRequest, 4) as google_protobuf_compiler_plugin_pb.CodeGeneratorRequest;
+    return jspb.Message.getWrapperField(this, google_protobuf_compiler_plugin_pb.CodeGeneratorRequest, 4);
   }
 
   setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest) {
@@ -347,7 +347,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeAny(): google_protobuf_any_pb.Any {
-    return jspb.Message.getWrapperField(this, google_protobuf_any_pb.Any, 5) as google_protobuf_any_pb.Any;
+    return jspb.Message.getWrapperField(this, google_protobuf_any_pb.Any, 5);
   }
 
   setSomeAny(value?: google_protobuf_any_pb.Any) {
@@ -363,7 +363,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeMethod(): google_protobuf_api_pb.Method {
-    return jspb.Message.getWrapperField(this, google_protobuf_api_pb.Method, 6) as google_protobuf_api_pb.Method;
+    return jspb.Message.getWrapperField(this, google_protobuf_api_pb.Method, 6);
   }
 
   setSomeMethod(value?: google_protobuf_api_pb.Method) {
@@ -379,7 +379,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo {
-    return jspb.Message.getWrapperField(this, google_protobuf_descriptor_pb.GeneratedCodeInfo, 7) as google_protobuf_descriptor_pb.GeneratedCodeInfo;
+    return jspb.Message.getWrapperField(this, google_protobuf_descriptor_pb.GeneratedCodeInfo, 7);
   }
 
   setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo) {
@@ -395,7 +395,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeDuration(): google_protobuf_duration_pb.Duration {
-    return jspb.Message.getWrapperField(this, google_protobuf_duration_pb.Duration, 8) as google_protobuf_duration_pb.Duration;
+    return jspb.Message.getWrapperField(this, google_protobuf_duration_pb.Duration, 8);
   }
 
   setSomeDuration(value?: google_protobuf_duration_pb.Duration) {
@@ -411,7 +411,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeEmpty(): google_protobuf_empty_pb.Empty {
-    return jspb.Message.getWrapperField(this, google_protobuf_empty_pb.Empty, 9) as google_protobuf_empty_pb.Empty;
+    return jspb.Message.getWrapperField(this, google_protobuf_empty_pb.Empty, 9);
   }
 
   setSomeEmpty(value?: google_protobuf_empty_pb.Empty) {
@@ -427,7 +427,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeFieldMask(): google_protobuf_field_mask_pb.FieldMask {
-    return jspb.Message.getWrapperField(this, google_protobuf_field_mask_pb.FieldMask, 10) as google_protobuf_field_mask_pb.FieldMask;
+    return jspb.Message.getWrapperField(this, google_protobuf_field_mask_pb.FieldMask, 10);
   }
 
   setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask) {
@@ -443,7 +443,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeSourceContext(): google_protobuf_source_context_pb.SourceContext {
-    return jspb.Message.getWrapperField(this, google_protobuf_source_context_pb.SourceContext, 11) as google_protobuf_source_context_pb.SourceContext;
+    return jspb.Message.getWrapperField(this, google_protobuf_source_context_pb.SourceContext, 11);
   }
 
   setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext) {
@@ -459,7 +459,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeStruct(): google_protobuf_struct_pb.Struct {
-    return jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Struct, 12) as google_protobuf_struct_pb.Struct;
+    return jspb.Message.getWrapperField(this, google_protobuf_struct_pb.Struct, 12);
   }
 
   setSomeStruct(value?: google_protobuf_struct_pb.Struct) {
@@ -475,7 +475,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp {
-    return jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 13) as google_protobuf_timestamp_pb.Timestamp;
+    return jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 13);
   }
 
   setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp) {
@@ -491,7 +491,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeType(): google_protobuf_type_pb.Type {
-    return jspb.Message.getWrapperField(this, google_protobuf_type_pb.Type, 14) as google_protobuf_type_pb.Type;
+    return jspb.Message.getWrapperField(this, google_protobuf_type_pb.Type, 14);
   }
 
   setSomeType(value?: google_protobuf_type_pb.Type) {
@@ -507,7 +507,7 @@ class MySimple extends jspb.Message {
   }
 
   getSomeDoubleValue(): google_protobuf_wrappers_pb.DoubleValue {
-    return jspb.Message.getWrapperField(this, google_protobuf_wrappers_pb.DoubleValue, 15) as google_protobuf_wrappers_pb.DoubleValue;
+    return jspb.Message.getWrapperField(this, google_protobuf_wrappers_pb.DoubleValue, 15);
   }
 
   setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue) {

--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -68,16 +68,16 @@ export abstract class Message {
     oneof: number[],
     value: FieldValue): void;
   static computeOneofCase(msg: Message, oneof: number[]): number;
-  static getWrapperField<T>(
+  static getWrapperField<T extends Message>(
     msg: Message,
     ctor: {new() : T},
     fieldNumber: number,
     required?: number): T;
-  static getRepeatedWrapperField<T>(
+  static getRepeatedWrapperField<T extends Message>(
     msg: Message,
     ctor: {new() : T},
     fieldNumber: number): T[];
-  static setWrapperField<T>(
+  static setWrapperField<T extends Message>(
     msg: Message,
     fieldNumber: number,
     value?: (T|Map<any, any>)): void;
@@ -86,11 +86,11 @@ export abstract class Message {
     fieldNumber: number,
     oneof: number[],
     value: any): void;
-  static setRepeatedWrapperField<T>(
+  static setRepeatedWrapperField<T extends Message>(
     msg: Message,
     fieldNumber: number,
-    value?: T): void;
-  static addToRepeatedWrapperField<T>(
+    value?: T[]): void;
+  static addToRepeatedWrapperField<T extends Message>(
     msg: Message,
     fieldNumber: number,
     value: T | undefined,

--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -76,7 +76,7 @@ export abstract class Message {
   static getRepeatedWrapperField<T>(
     msg: Message,
     ctor: {new() : T},
-    fieldNumber: number): Message[];
+    fieldNumber: number): T[];
   static setWrapperField<T>(
     msg: Message,
     fieldNumber: number,

--- a/types/google-protobuf/index.d.ts
+++ b/types/google-protobuf/index.d.ts
@@ -17,7 +17,7 @@ export abstract class Message {
     data: Message.MessageArray,
     messageId: (string | number),
     suggestedPivot: number,
-    repeatedFields: number[],
+    repeatedFields?: number[],
     oneofFields?: number[][] | null): void;
   static toObjectList<T extends Message>(
     field: T[],
@@ -68,34 +68,34 @@ export abstract class Message {
     oneof: number[],
     value: FieldValue): void;
   static computeOneofCase(msg: Message, oneof: number[]): number;
-  static getWrapperField(
+  static getWrapperField<T>(
     msg: Message,
-    ctor: typeof Message,
+    ctor: {new() : T},
     fieldNumber: number,
-    required?: number): Message;
-  static getRepeatedWrapperField(
+    required?: number): T;
+  static getRepeatedWrapperField<T>(
     msg: Message,
-    ctor: typeof Message,
+    ctor: {new() : T},
     fieldNumber: number): Message[];
-  static setWrapperField(
+  static setWrapperField<T>(
     msg: Message,
     fieldNumber: number,
-    value?: (Message|Map<any, any>)): void;
+    value?: (T|Map<any, any>)): void;
   static setOneofWrapperField(
     msg: Message,
     fieldNumber: number,
     oneof: number[],
     value: any): void;
-  static setRepeatedWrapperField(
+  static setRepeatedWrapperField<T>(
     msg: Message,
     fieldNumber: number,
-    value: any): void;
-  static addToRepeatedWrapperField(
+    value?: T): void;
+  static addToRepeatedWrapperField<T>(
     msg: Message,
     fieldNumber: number,
-    value: any,
-    ctor: typeof Message,
-    index: number): any;
+    value: T | undefined,
+    ctor: {new() : T},
+    index?: number): T;
   static toMap(
     field: any[],
     mapKeyGetterFn: (field: any) => string,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/google/protobuf/blob/master/js/message.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

The WrapperField methods all take a class and return an object of that class, so this updates the definitions to infer the type from the passed constructor argument.  Also, some of these fields are optional and are passed undefined/null even in google's generated protobufs.