### PR TITLE
owlcarousel: Update options to use interface instead of any

### DIFF
--- a/types/owlcarousel/index.d.ts
+++ b/types/owlcarousel/index.d.ts
@@ -8,53 +8,53 @@
 interface IOwlCarouselOptions {
 
     // options
-    items: number;
-    itemsDesktop: number[];
-    itemsDesktopSmall: number[];
-    itemsTablet: number[];
-    itemsTabletSmall: any;
-    itemsMobile: number[];
-    itemsCustom: any;
-    singleItem: boolean;
-    itemsScaleUp: boolean;
-    slideSpeed: number;
-    paginationSpeed: number;
-    rewindSpeed: number;
-    autoPlay: any;
-    stopOnHover: boolean;
-    navigation: boolean;
-    navigationText: any;
-    rewindNav: boolean;
-    scrollPerPage: boolean;
-    pagination: boolean;
-    paginationNumbers: boolean;
-    responsive: boolean;
-    responsiveRefreshRate: number;
-    responsiveBaseWidth: JQuery;
-    baseClass: string;
-    theme: string;
-    lazyLoad: boolean;
-    lazyFollow: boolean;
-    lazyEffect: any;
-    autoHeight: boolean;
-    jsonPath: any;
-    jsonSuccess: (data: any) => void;
-    dragBeforeAnimFinish: boolean;
-    mouseDrag: boolean;
-    touchDrag: boolean;
-    addClassActive: boolean;
-    transitionStyle: any;
+    items?: number;
+    itemsDesktop?: number[];
+    itemsDesktopSmall?: number[];
+    itemsTablet?: number[];
+    itemsTabletSmall?: any;
+    itemsMobile?: number[];
+    itemsCustom?: any;
+    singleItem?: boolean;
+    itemsScaleUp?: boolean;
+    slideSpeed?: number;
+    paginationSpeed?: number;
+    rewindSpeed?: number;
+    autoPlay?: any;
+    stopOnHover?: boolean;
+    navigation?: boolean;
+    navigationText?: any;
+    rewindNav?: boolean;
+    scrollPerPage?: boolean;
+    pagination?: boolean;
+    paginationNumbers?: boolean;
+    responsive?: boolean;
+    responsiveRefreshRate?: number;
+    responsiveBaseWidth?: JQuery;
+    baseClass?: string;
+    theme?: string;
+    lazyLoad?: boolean;
+    lazyFollow?: boolean;
+    lazyEffect?: any;
+    autoHeight?: boolean;
+    jsonPath?: any;
+    jsonSuccess?: (data: any) => void;
+    dragBeforeAnimFinish?: boolean;
+    mouseDrag?: boolean;
+    touchDrag?: boolean;
+    addClassActive?: boolean;
+    transitionStyle?: any;
 
     // callbacks
-    beforeUpdate: (params?: any) => void;
-    afterUpdate: (params?: any) => void;
-    beforeInit: (params?: any) => void;
-    afterInit: (params?: any) => void;
-    beforeMove: (params?: any) => void;
-    afterMove: (params?: any) => void;
-    afterAction: (params?: any) => void;
-    startDragging: (params?: any) => void;
-    afterLazyLoad: (params?: any) => void;
+    beforeUpdate?: (params?: any) => void;
+    afterUpdate?: (params?: any) => void;
+    beforeInit?: (params?: any) => void;
+    afterInit?: (params?: any) => void;
+    beforeMove?: (params?: any) => void;
+    afterMove?: (params?: any) => void;
+    afterAction?: (params?: any) => void;
+    startDragging?: (params?: any) => void;
+    afterLazyLoad?: (params?: any) => void;
 }
 
 interface JQuery {

--- a/types/owlcarousel/index.d.ts
+++ b/types/owlcarousel/index.d.ts
@@ -58,5 +58,5 @@ interface IOwlCarouselOptions {
 }
 
 interface JQuery {
-    owlCarousel(options?: any): JQuery;
+    owlCarousel(options?: IOwlCarouselOptions): JQuery;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

I'm not sure why `any` was used instead of `IOwlCarouselOptions` since you lose type checking when you in-line them, but this fixes that.