### PR TITLE
@types/react-native update layout props in accordance to 0.43 release

### DIFF
--- a/types/react-native-sortable-list/react-native-sortable-list-tests.tsx
+++ b/types/react-native-sortable-list/react-native-sortable-list-tests.tsx
@@ -8,8 +8,9 @@ import {
     Image,
     View,
     Dimensions,
-    FlexJustifyType,
-    FlexAlignType
+    ViewStyle,
+    TextStyle,
+    ImageStyle,
 } from 'react-native';
 import SortableList, {RowProps} from 'react-native-sortable-list';
 
@@ -61,20 +62,20 @@ const data = {
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        justifyContent: "center" as FlexJustifyType,
-        alignItems: "center" as FlexAlignType,
+        justifyContent: 'center',
+        alignItems: 'center',
         backgroundColor: '#eee',
         paddingTop: 60,
-    },
+    } as ViewStyle,
 
     list: {
         flex: 1,
-    },
+    } as ViewStyle,
 
     contentContainer: {
         width: window.width,
         paddingHorizontal: 30,
-    },
+    } as ViewStyle,
 
     row: {
         flexDirection: 'row',
@@ -89,18 +90,18 @@ const styles = StyleSheet.create({
         shadowOpacity: 1,
         shadowOffset: {height: 2, width: 2},
         shadowRadius: 2,
-    },
+    } as ViewStyle,
 
     image: {
         width: 60,
         height: 60,
         marginRight: 30,
         borderRadius: 30,
-    },
+    } as ImageStyle,
 
     text: {
         fontSize: 24,
-    },
+    } as TextStyle,
 
 });
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-native 0.43
 // Project: https://github.com/facebook/react-native
 // Definitions by: Eloy Durán <https://github.com/alloy>
+//                 Fedor Nezhivoi <https://github.com/gyzerok>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native 0.42
+// Type definitions for react-native 0.43
 // Project: https://github.com/facebook/react-native
 // Definitions by: Eloy Durán <https://github.com/alloy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -531,9 +531,7 @@ export interface LayoutAnimationStatic {
     spring: (config: LayoutAnimationConfig, onAnimationDidEnd?: () => void) => void
 }
 
-export type FlexAlignType = "flex-start" | "flex-end" | "center" | "stretch" | "baseline";
-export type FlexJustifyType = "flex-start" | "flex-end" | "center" | "space-between" | "space-around";
-export type FlexDirection = "row" | "column" | "row-reverse" | "column-reverse";
+type FlexAlignType = "flex-start" | "flex-end" | "center" | "stretch" | "baseline";
 
 /**
  * Flex Prop Types
@@ -541,9 +539,9 @@ export type FlexDirection = "row" | "column" | "row-reverse" | "column-reverse";
  * @see LayoutPropTypes.js
  */
 export interface FlexStyle {
-
-    alignItems?: FlexAlignType;
-    alignSelf?: "auto" | FlexAlignType;
+    alignContent?: "flex-start" | "flex-end" | "center" | "stretch" | "space-between" | "space-around"
+    alignItems?: FlexAlignType
+    alignSelf?: "auto" | FlexAlignType
     borderBottomWidth?: number
     borderLeftWidth?: number
     borderRightWidth?: number
@@ -551,18 +549,14 @@ export interface FlexStyle {
     borderWidth?: number
     bottom?: number | string
     flex?: number
+    flexBasis?: number | string
+    flexDirection?: "row" | "column" | "row-reverse" | "column-reverse"
     flexGrow?: number
     flexShrink?: number
-    flexBasis?: number | string
-    flexDirection?: FlexDirection
     flexWrap?: "wrap" | "nowrap"
     height?: number | string
-    justifyContent?: FlexJustifyType
+    justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around"
     left?: number | string
-    minWidth?: number | string
-    maxWidth?: number | string
-    minHeight?: number | string
-    maxHeight?: number | string
     margin?: number | string
     marginBottom?: number | string
     marginHorizontal?: number | string
@@ -570,6 +564,10 @@ export interface FlexStyle {
     marginRight?: number | string
     marginTop?: number | string
     marginVertical?: number | string
+    maxHeight?: number | string
+    maxWidth?: number | string
+    minHeight?: number | string
+    minWidth?: number | string
     overflow?: "visible" | "hidden" | "scroll"
     padding?: number | string
     paddingBottom?: number | string
@@ -582,11 +580,12 @@ export interface FlexStyle {
     right?: number | string
     top?: number | string
     width?: number | string
+    zIndex?: number
 
     /**
      * @platform ios
      */
-    zIndex?: number
+    direction?: 'inherit' | 'ltr' | 'rtl'
 }
 
 /**


### PR DESCRIPTION
I made a bit of refactoring alongside update as well:
1. Properties are now alphabetically ordered as in documentation
2. Some definitions have been inlined since they are anyway used only in single place and do not worth having an abstraction. Also one my think to reuse them in incorrect way (I first were thinking about reusing `FlexJustifyType` for `alignContent` which is not the greatest idea).
3. Removed `FlexAlignType` being exported.

Regarding inline definitions it is breaking change, however one can just use for example `FlexStyle['justifyContent']` as a type, so overall no features was removed.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/layout-props.html and https://github.com/facebook/react-native/releases/tag/v0.43.1
