### PR TITLE
Fix error in jsyaml typings (property that allows bool or function only showed one valid type)

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -43,7 +43,7 @@ declare namespace jsyaml {
 		// specifies a schema to use.
 		schema?: any;
 		// if true, sort keys when dumping YAML. If a function, use the function to sort the keys. (default: false)
-		sortKeys?: boolean;
+		sortKeys?: boolean | ((a: any, b: any) => number);
 		// set max line width. (default: 80)
 		lineWidth?: number;
 		// if true, don't convert duplicate objects into references (default: false)


### PR DESCRIPTION
Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
> See the "sortKeys" property in "safeDump", documented on https://github.com/nodeca/js-yaml/blob/master/README.md.
> You can also see it in action in one of their tests:
https://github.com/nodeca/js-yaml/blob/c76b837cacc69de6b86a0781db31a9bb7a193875/test/units/sort-keys.js
- [x] Increase the version number in the header if appropriate.
> N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
> N/A