### PR TITLE
fix(react-router): change Location to LocationDescriptor

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React Router 4.1
+// Type definitions for React Router 4.0
 // Project: https://github.com/ReactTraining/react-router
 // Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>
 //                 Yuichi Murata <https://github.com/mrk21>

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React Router 4.0
+// Type definitions for React Router 4.1
 // Project: https://github.com/ReactTraining/react-router
 // Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>
 //                 Yuichi Murata <https://github.com/mrk21>

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -24,13 +24,13 @@ declare module 'react-router' {
 		router: {
 			history: H.History
 			route: {
-				location: H.Location,
+				location: H.LocationDescriptor,
 				match: match<P>
 			}
 		}
 	}
   interface MemoryRouterProps {
-    initialEntries?: H.Location[];
+    initialEntries?: H.LocationDescriptor[];
     initialIndex?: number;
     getUserConfirmation?: () => void;
     keyLength?: number;
@@ -39,7 +39,7 @@ declare module 'react-router' {
 
 
   interface PromptProps {
-    message: string | ((location: H.Location) => void);
+    message: string | ((location: H.LocationDescriptor) => void);
     when?: boolean;
   }
   class Prompt extends React.Component<PromptProps, void> {}
@@ -55,12 +55,12 @@ declare module 'react-router' {
 
   interface RouteComponentProps<P> {
     match: match<P>;
-    location: H.Location;
+    location: H.LocationDescriptor;
     history: H.History;
   }
 
   interface RouteProps {
-    location?: H.Location;
+    location?: H.LocationDescriptor;
     component?: React.SFC<RouteComponentProps<any> | void> | React.ComponentClass<RouteComponentProps<any> | void>;
     render?: (props: RouteComponentProps<any>) => React.ReactNode;
     children?: (props: RouteComponentProps<any>) => React.ReactNode | React.ReactNode;


### PR DESCRIPTION
Currently we can't put Path(string) nor partial Location. 
LocationDescriptor instead of Location should do the job.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/history/index.d.ts#L43
- [x] Increase the version number in the header if appropriate.
