### PR TITLE
Fix FusionCharts modules type definition issue

### DIFF
--- a/types/fusioncharts/fusioncharts.charts.d.ts
+++ b/types/fusioncharts/fusioncharts.charts.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Charts {}
-declare var Charts: (H: FusionChartStatic) => FusionChartStatic;
+declare function Charts(H: FusionChartStatic): FusionChartStatic;
 export = Charts;
 export as namespace Charts;
-

--- a/types/fusioncharts/fusioncharts.charts.d.ts
+++ b/types/fusioncharts/fusioncharts.charts.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function charts(H: FusionChartStatic): FusionChartStatic;
-export = charts;
-export as namespace charts;
+declare namespace Charts {}
+declare var Charts: (H: FusionChartStatic) => FusionChartStatic;
+export = Charts;
+export as namespace Charts;
+

--- a/types/fusioncharts/fusioncharts.gantt.d.ts
+++ b/types/fusioncharts/fusioncharts.gantt.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function gantt(H: FusionChartStatic): FusionChartStatic;
-export = gantt;
-export as namespace gantt;
+declare namespace Gantt {}
+declare var Gantt: (H: FusionChartStatic) => FusionChartStatic;
+export = Gantt;
+export as namespace Gantt;
+

--- a/types/fusioncharts/fusioncharts.gantt.d.ts
+++ b/types/fusioncharts/fusioncharts.gantt.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Gantt {}
-declare var Gantt: (H: FusionChartStatic) => FusionChartStatic;
+declare function Gantt(H: FusionChartStatic): FusionChartStatic;
 export = Gantt;
 export as namespace Gantt;
-

--- a/types/fusioncharts/fusioncharts.maps.d.ts
+++ b/types/fusioncharts/fusioncharts.maps.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Maps {}
-declare var Maps: (H: FusionChartStatic) => FusionChartStatic;
+declare function Maps(H: FusionChartStatic): FusionChartStatic;
 export = Maps;
 export as namespace Maps;
-

--- a/types/fusioncharts/fusioncharts.maps.d.ts
+++ b/types/fusioncharts/fusioncharts.maps.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function maps(H: FusionChartStatic): FusionChartStatic;
-export = maps;
-export as namespace maps;
+declare namespace Maps {}
+declare var Maps: (H: FusionChartStatic) => FusionChartStatic;
+export = Maps;
+export as namespace Maps;
+

--- a/types/fusioncharts/fusioncharts.powercharts.d.ts
+++ b/types/fusioncharts/fusioncharts.powercharts.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Powercharts {}
-declare var Powercharts: (H: FusionChartStatic) => FusionChartStatic;
+declare function Powercharts(H: FusionChartStatic): FusionChartStatic;
 export = Powercharts;
 export as namespace Powercharts;
-

--- a/types/fusioncharts/fusioncharts.powercharts.d.ts
+++ b/types/fusioncharts/fusioncharts.powercharts.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function powercharts(H: FusionChartStatic): FusionChartStatic;
-export = powercharts;
-export as namespace powercharts;
+declare namespace Powercharts {}
+declare var Powercharts: (H: FusionChartStatic) => FusionChartStatic;
+export = Powercharts;
+export as namespace Powercharts;
+

--- a/types/fusioncharts/fusioncharts.ssgrid.d.ts
+++ b/types/fusioncharts/fusioncharts.ssgrid.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function ssgrid(H: FusionChartStatic): FusionChartStatic;
-export = ssgrid;
-export as namespace ssgrid;
+declare namespace Ssgrid {}
+declare var Ssgrid: (H: FusionChartStatic) => FusionChartStatic;
+export = Ssgrid;
+export as namespace Ssgrid;
+

--- a/types/fusioncharts/fusioncharts.ssgrid.d.ts
+++ b/types/fusioncharts/fusioncharts.ssgrid.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Ssgrid {}
-declare var Ssgrid: (H: FusionChartStatic) => FusionChartStatic;
+declare function Ssgrid(H: FusionChartStatic): FusionChartStatic;
 export = Ssgrid;
 export as namespace Ssgrid;
-

--- a/types/fusioncharts/fusioncharts.treemap.d.ts
+++ b/types/fusioncharts/fusioncharts.treemap.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function treemap(H: FusionChartStatic): FusionChartStatic;
-export = treemap;
-export as namespace treemap;
+declare namespace Treemap {}
+declare var Treemap: (H: FusionChartStatic) => FusionChartStatic;
+export = Treemap;
+export as namespace Treemap;
+

--- a/types/fusioncharts/fusioncharts.treemap.d.ts
+++ b/types/fusioncharts/fusioncharts.treemap.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Treemap {}
-declare var Treemap: (H: FusionChartStatic) => FusionChartStatic;
+declare function Treemap(H: FusionChartStatic): FusionChartStatic;
 export = Treemap;
 export as namespace Treemap;
-

--- a/types/fusioncharts/fusioncharts.widgets.d.ts
+++ b/types/fusioncharts/fusioncharts.widgets.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function widgets(H: FusionChartStatic): FusionChartStatic;
-export = widgets;
-export as namespace widgets;
+declare namespace Widgets {}
+declare var Widgets: (H: FusionChartStatic) => FusionChartStatic;
+export = Widgets;
+export as namespace Widgets;
+

--- a/types/fusioncharts/fusioncharts.widgets.d.ts
+++ b/types/fusioncharts/fusioncharts.widgets.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Widgets {}
-declare var Widgets: (H: FusionChartStatic) => FusionChartStatic;
+declare function Widgets(H: FusionChartStatic): FusionChartStatic;
 export = Widgets;
 export as namespace Widgets;
-

--- a/types/fusioncharts/fusioncharts.zoomscatter.d.ts
+++ b/types/fusioncharts/fusioncharts.zoomscatter.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Zoomscatter {}
-declare var Zoomscatter: (H: FusionChartStatic) => FusionChartStatic;
+declare function Zoomscatter(H: FusionChartStatic): FusionChartStatic;
 export = Zoomscatter;
 export as namespace Zoomscatter;
-

--- a/types/fusioncharts/fusioncharts.zoomscatter.d.ts
+++ b/types/fusioncharts/fusioncharts.zoomscatter.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function zoomscatter(H: FusionChartStatic): FusionChartStatic;
-export = zoomscatter;
-export as namespace zoomscatter;
+declare namespace Zoomscatter {}
+declare var Zoomscatter: (H: FusionChartStatic) => FusionChartStatic;
+export = Zoomscatter;
+export as namespace Zoomscatter;
+

--- a/types/fusioncharts/index.d.ts
+++ b/types/fusioncharts/index.d.ts
@@ -3,7 +3,9 @@
 // Definitions by: Rohit Kumar <https://github.com/rohitkr>, Shivaraj KV <https://github.com/shivarajkv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+
 declare namespace FusionCharts {
+
     type ChartDataFormats = 'json' | 'jsonurl' | 'csv' | 'xml' | 'xmlurl';
 
     type ImageHAlign = 'left' | 'right' | 'middle';
@@ -19,18 +21,19 @@ declare namespace FusionCharts {
 
         cancelled: boolean;
 
-        stopPropagation(): void;
+        stopPropagation: () => void;
 
         prevented: boolean;
 
-        preventDefault(): void;
+        preventDefault: () => void;
 
         detached: boolean;
 
-        detachHandler(): void;
+        detachHandler: () => void;
     }
 
     interface ChartObject {
+
         type?: string;
 
         id?: string;
@@ -248,6 +251,7 @@ declare namespace FusionCharts {
         configure(options: {}): void;
 
         ref: {};
+
     }
 
     interface FusionChartStatic {
@@ -282,7 +286,10 @@ declare namespace FusionCharts {
         options: {};
 
         debugger: Debugger;
+
+
     }
+
 }
 
 declare var FusionCharts: FusionCharts.FusionChartStatic;

--- a/types/fusioncharts/index.d.ts
+++ b/types/fusioncharts/index.d.ts
@@ -3,9 +3,7 @@
 // Definitions by: Rohit Kumar <https://github.com/rohitkr>, Shivaraj KV <https://github.com/shivarajkv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
 declare namespace FusionCharts {
-
     type ChartDataFormats = 'json' | 'jsonurl' | 'csv' | 'xml' | 'xmlurl';
 
     type ImageHAlign = 'left' | 'right' | 'middle';
@@ -21,19 +19,18 @@ declare namespace FusionCharts {
 
         cancelled: boolean;
 
-        stopPropagation: () => void;
+        stopPropagation(): void;
 
         prevented: boolean;
 
-        preventDefault: () => void;
+        preventDefault(): void;
 
         detached: boolean;
 
-        detachHandler: () => void;
+        detachHandler(): void;
     }
 
     interface ChartObject {
-
         type?: string;
 
         id?: string;
@@ -251,7 +248,6 @@ declare namespace FusionCharts {
         configure(options: {}): void;
 
         ref: {};
-
     }
 
     interface FusionChartStatic {
@@ -286,10 +282,7 @@ declare namespace FusionCharts {
         options: {};
 
         debugger: Debugger;
-
-
     }
-
 }
 
 declare var FusionCharts: FusionCharts.FusionChartStatic;

--- a/types/fusioncharts/maps/fusioncharts.usa.d.ts
+++ b/types/fusioncharts/maps/fusioncharts.usa.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Usa {}
-declare var Usa: (H: FusionChartStatic) => FusionChartStatic;
+declare function Usa(H: FusionChartStatic): FusionChartStatic;
 export = Usa;
 export as namespace Usa;
-

--- a/types/fusioncharts/maps/fusioncharts.usa.d.ts
+++ b/types/fusioncharts/maps/fusioncharts.usa.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function usa(H: FusionChartStatic): FusionChartStatic;
-export = usa;
-export as namespace usa;
+declare namespace Usa {}
+declare var Usa: (H: FusionChartStatic) => FusionChartStatic;
+export = Usa;
+export as namespace Usa;
+

--- a/types/fusioncharts/maps/fusioncharts.world.d.ts
+++ b/types/fusioncharts/maps/fusioncharts.world.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function world(H: FusionChartStatic): FusionChartStatic;
-export = world;
-export as namespace world;
+declare namespace World {}
+declare var World: (H: FusionChartStatic) => FusionChartStatic;
+export = World;
+export as namespace World;
+

--- a/types/fusioncharts/maps/fusioncharts.world.d.ts
+++ b/types/fusioncharts/maps/fusioncharts.world.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace World {}
-declare var World: (H: FusionChartStatic) => FusionChartStatic;
+declare function World(H: FusionChartStatic): FusionChartStatic;
 export = World;
 export as namespace World;
-

--- a/types/fusioncharts/themes/fusioncharts.theme.carbon.d.ts
+++ b/types/fusioncharts/themes/fusioncharts.theme.carbon.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function carbon(H: FusionChartStatic): FusionChartStatic;
-export = carbon;
-export as namespace carbon;
+declare namespace Carbon {}
+declare var Carbon: (H: FusionChartStatic) => FusionChartStatic;
+export = Carbon;
+export as namespace Carbon;
+

--- a/types/fusioncharts/themes/fusioncharts.theme.carbon.d.ts
+++ b/types/fusioncharts/themes/fusioncharts.theme.carbon.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Carbon {}
-declare var Carbon: (H: FusionChartStatic) => FusionChartStatic;
+declare function Carbon(H: FusionChartStatic): FusionChartStatic;
 export = Carbon;
 export as namespace Carbon;
-

--- a/types/fusioncharts/themes/fusioncharts.theme.fint.d.ts
+++ b/types/fusioncharts/themes/fusioncharts.theme.fint.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Fint {}
-declare var Fint: (H: FusionChartStatic) => FusionChartStatic;
+declare function Fint(H: FusionChartStatic): FusionChartStatic;
 export = Fint;
 export as namespace Fint;
-

--- a/types/fusioncharts/themes/fusioncharts.theme.fint.d.ts
+++ b/types/fusioncharts/themes/fusioncharts.theme.fint.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function fint(H: FusionChartStatic): FusionChartStatic;
-export = fint;
-export as namespace fint;
+declare namespace Fint {}
+declare var Fint: (H: FusionChartStatic) => FusionChartStatic;
+export = Fint;
+export as namespace Fint;
+

--- a/types/fusioncharts/themes/fusioncharts.theme.ocean.d.ts
+++ b/types/fusioncharts/themes/fusioncharts.theme.ocean.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function ocean(H: FusionChartStatic): FusionChartStatic;
-export = ocean;
-export as namespace ocean;
+declare namespace Ocean {}
+declare var Ocean: (H: FusionChartStatic) => FusionChartStatic;
+export = Ocean;
+export as namespace Ocean;
+

--- a/types/fusioncharts/themes/fusioncharts.theme.ocean.d.ts
+++ b/types/fusioncharts/themes/fusioncharts.theme.ocean.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Ocean {}
-declare var Ocean: (H: FusionChartStatic) => FusionChartStatic;
+declare function Ocean(H: FusionChartStatic): FusionChartStatic;
 export = Ocean;
 export as namespace Ocean;
-

--- a/types/fusioncharts/themes/fusioncharts.theme.zune.d.ts
+++ b/types/fusioncharts/themes/fusioncharts.theme.zune.d.ts
@@ -1,5 +1,8 @@
+
 import { FusionChartStatic } from "fusioncharts";
 
-declare function zune(H: FusionChartStatic): FusionChartStatic;
-export = zune;
-export as namespace zune;
+declare namespace Zune {}
+declare var Zune: (H: FusionChartStatic) => FusionChartStatic;
+export = Zune;
+export as namespace Zune;
+

--- a/types/fusioncharts/themes/fusioncharts.theme.zune.d.ts
+++ b/types/fusioncharts/themes/fusioncharts.theme.zune.d.ts
@@ -1,8 +1,6 @@
-
 import { FusionChartStatic } from "fusioncharts";
 
 declare namespace Zune {}
-declare var Zune: (H: FusionChartStatic) => FusionChartStatic;
+declare function Zune(H: FusionChartStatic): FusionChartStatic;
 export = Zune;
 export as namespace Zune;
-


### PR DESCRIPTION
- The actual issue was, `non-module entity and cannot be imported using this construct`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
