### PR TITLE
[react-intl] Allow using JSX elements with <FormattedMessage>

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -11,6 +11,10 @@
 declare namespace ReactIntl {
 
     interface Values {
+        [key: string]: string | JSX.Element;
+    }
+
+    interface HTMLValues {
         [key: string]: string;
     }
 
@@ -71,7 +75,7 @@ declare namespace ReactIntl {
         formatNumber: (value: number, options?: FormattedNumber.PropsBase) => string;
         formatPlural: (value: number, options?: FormattedPlural.Base) => keyof FormattedPlural.PropsBase;
         formatMessage: (messageDescriptor: FormattedMessage.MessageDescriptor, values?: Values) => string;
-        formatHTMLMessage: (messageDescriptor: FormattedMessage.MessageDescriptor, values?: Values) => string;
+        formatHTMLMessage: (messageDescriptor: FormattedMessage.MessageDescriptor, values?: HTMLValues) => string;
         locale: string;
         formats: any;
         messages: { [id: string]: string };

--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -10,14 +10,6 @@
 
 declare namespace ReactIntl {
 
-    interface Values {
-        [key: string]: string | JSX.Element;
-    }
-
-    interface HTMLValues {
-        [key: string]: string;
-    }
-
     interface Locale {
         locale: string;
         fields?: { [key: string]: string },
@@ -74,8 +66,8 @@ declare namespace ReactIntl {
         formatRelative: (value: number, options?: FormattedRelative.PropsBase & { now?: any }) => string;
         formatNumber: (value: number, options?: FormattedNumber.PropsBase) => string;
         formatPlural: (value: number, options?: FormattedPlural.Base) => keyof FormattedPlural.PropsBase;
-        formatMessage: (messageDescriptor: FormattedMessage.MessageDescriptor, values?: Values) => string;
-        formatHTMLMessage: (messageDescriptor: FormattedMessage.MessageDescriptor, values?: HTMLValues) => string;
+        formatMessage: (messageDescriptor: FormattedMessage.MessageDescriptor, values?: {[key: string]: string}) => string;
+        formatHTMLMessage: (messageDescriptor: FormattedMessage.MessageDescriptor, values?: {[key: string]: string}) => string;
         locale: string;
         formats: any;
         messages: { [id: string]: string };
@@ -143,7 +135,7 @@ declare namespace ReactIntl {
         }
 
         export interface Props extends MessageDescriptor {
-            values?: Values;
+            values?: {[key: string]: string | JSX.Element};
             tagName?: string;
         }
     }

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -87,6 +87,13 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 values={{ name: "bob" }}
                 tagName="div" />
 
+            <FormattedMessage
+                id="test"
+                description="Test"
+                defaultMessage="Hi nested component {name}!"
+                values={{ name: <p>p</p> }}
+                tagName="div" />
+
             <FormattedHTMLMessage
                 id="test"
                 description="Test"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yahoo/react-intl/wiki/Components#formattedmessage
https://github.com/yahoo/react-intl/wiki/Components#formattedhtmlmessage
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.~~