### PR TITLE
@types/graphlib -- parent should be an optional parameter in setParent

### DIFF
--- a/types/graphlib/graphlib-tests.ts
+++ b/types/graphlib/graphlib-tests.ts
@@ -23,6 +23,7 @@ function test_graph() {
   g.setDefaultEdgeLabel(() => 'e42');
   g.setNodes(['a', 'b', 'c'], 42);
   g.setParent('d', 'a');
+  g.setParent('d');
   g.parent('d');
   g.children('a');
   g.filterNodes(v => true);

--- a/types/graphlib/index.d.ts
+++ b/types/graphlib/index.d.ts
@@ -65,8 +65,8 @@ declare module "graphlib" {
 		setNodes(names: string[], label?: any): Graph;
 
 		/**
-     * Sets node p as a parent for node v if it is defined, or removes the
-     * parent for v if p is undefined. Method throws an exception in case of
+		 * Sets node p as a parent for node v if it is defined, or removes the
+		 * parent for v if p is undefined. Method throws an exception in case of
 		 * invoking it in context of noncompound graph.
 		 * Average-case complexity: O(1).
 		 * 
@@ -74,7 +74,7 @@ declare module "graphlib" {
 		 * @argument p - node to be parent for v.
 		 * @returns the graph, allowing this to be chained with other functions.
 		 */
-    setParent(v: string, p?: string): Graph;
+		setParent(v: string, p?: string): Graph;
 
 		/**
 		 * Gets parent node for node v.

--- a/types/graphlib/index.d.ts
+++ b/types/graphlib/index.d.ts
@@ -65,7 +65,8 @@ declare module "graphlib" {
 		setNodes(names: string[], label?: any): Graph;
 
 		/**
-		 * Sets node p as a parent for node v. Method throws an exception in case of
+     * Sets node p as a parent for node v if it is defined, or removes the
+     * parent for v if p is undefined. Method throws an exception in case of
 		 * invoking it in context of noncompound graph.
 		 * Average-case complexity: O(1).
 		 * 
@@ -73,7 +74,7 @@ declare module "graphlib" {
 		 * @argument p - node to be parent for v.
 		 * @returns the graph, allowing this to be chained with other functions.
 		 */
-		setParent(v: string, p: string): Graph;
+    setParent(v: string, p?: string): Graph;
 
 		/**
 		 * Gets parent node for node v.


### PR DESCRIPTION
See issue #15674 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/cpettitt/graphlib/wiki/API-Reference#setParent](https://github.com/cpettitt/graphlib/wiki/API-Reference#setParent)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
