### PR TITLE
Minor change to react-router-dom

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -50,7 +50,7 @@ declare module 'react-router-dom' {
     activeStyle?: React.CSSProperties;
     exact?: boolean;
     strict?: boolean;
-    isActive?(location: H.Location, props: any): boolean;
+    isActive?<P>(match: match<P>, location: H.Location): boolean;
   }
   class NavLink extends React.Component<NavLinkProps, void> {}
 

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -58,6 +58,7 @@ declare module 'react-router-dom' {
     BrowserRouter,
     HashRouter,
     LinkProps, // TypeScript specific, not from React Router itself
+    NavLinkProps, // TypeScript specific, not from React Router itself
     Link,
     NavLink,
     Prompt,

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import {
+  NavLink,
+  NavLinkProps,
+  match
+} from 'react-router-dom';
+import * as H from 'history';
+
+const getIsActive = (extraProp: string) => (match: match<any>, location: H.Location) => !!extraProp;
+
+interface Props extends NavLinkProps {
+  extraProp: string;
+}
+
+export default function(props: Props) {
+  const {extraProp, ...rest} = props;
+  const isActive = getIsActive(extraProp);
+  return (
+    <NavLink {...rest} isActive={isActive}/>
+  );
+}

--- a/types/react-router-dom/tsconfig.json
+++ b/types/react-router-dom/tsconfig.json
@@ -13,6 +13,7 @@
     "noEmit": true
   },
   "files": [
-    "index.d.ts"
+    "index.d.ts",
+    "react-router-dom-tests.tsx"
   ]
 }


### PR DESCRIPTION
- Change definition of `isActive` prop of `NavLink` because it differs from the [documentation](https://reacttraining.com/react-router/web/api/NavLink/isActive-func).
- Expose the `NavLinkProps` interface to help when people want to make a higher-order component for `NavLink`. For example, one might want some custom logic to determine if a `NavLink` should be active. One use case example (probably overly simplified) is in the test file.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reacttraining.com/react-router/web/api/NavLink/isActive-func
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.