### PR TITLE
Cleaning up both react transition group type definitions

### DIFF
--- a/types/react-addons-css-transition-group/index.d.ts
+++ b/types/react-addons-css-transition-group/index.d.ts
@@ -5,10 +5,10 @@
 // TypeScript Version: 2.1
 
 import 'react-addons-transition-group';
-import { ComponentClass, ReactCSSTransitionGroupProps } from 'react';
+import { ComponentClass, CSSTransitionGroupProps } from 'react';
 
 declare module 'react' {
-    interface ReactCSSTransitionGroupTransitionName {
+    interface CSSTransitionGroupTransitionName {
         enter: string;
         enterActive?: string;
         leave: string;
@@ -17,8 +17,8 @@ declare module 'react' {
         appearActive?: string;
     }
 
-    export interface ReactCSSTransitionGroupProps extends TransitionGroupProps<ReactCSSTransitionGroup> {
-        transitionName: string | ReactCSSTransitionGroupTransitionName;
+    export interface CSSTransitionGroupProps extends HTMLTransitionGroupProps<ReactCSSTransitionGroup> {
+        transitionName: string | CSSTransitionGroupTransitionName;
         transitionAppear?: boolean;
         transitionAppearTimeout?: number;
         transitionEnter?: boolean;
@@ -29,5 +29,5 @@ declare module 'react' {
 }
 
 declare var ReactCSSTransitionGroup: ReactCSSTransitionGroup;
-type ReactCSSTransitionGroup = ComponentClass<ReactCSSTransitionGroupProps>;
+type ReactCSSTransitionGroup = ComponentClass<CSSTransitionGroupProps>;
 export = ReactCSSTransitionGroup;

--- a/types/react-addons-css-transition-group/index.d.ts
+++ b/types/react-addons-css-transition-group/index.d.ts
@@ -5,10 +5,10 @@
 // TypeScript Version: 2.1
 
 import 'react-addons-transition-group';
-import { ComponentClass, TransitionGroupProps, CSSTransitionGroupProps } from 'react';
+import { ComponentClass, ReactCSSTransitionGroupProps } from 'react';
 
 declare module 'react' {
-    interface CSSTransitionGroupTransitionName {
+    interface ReactCSSTransitionGroupTransitionName {
         enter: string;
         enterActive?: string;
         leave: string;
@@ -17,8 +17,8 @@ declare module 'react' {
         appearActive?: string;
     }
 
-    export interface CSSTransitionGroupProps extends TransitionGroupProps {
-        transitionName: string | CSSTransitionGroupTransitionName;
+    export interface ReactCSSTransitionGroupProps extends TransitionGroupProps<ReactCSSTransitionGroup> {
+        transitionName: string | ReactCSSTransitionGroupTransitionName;
         transitionAppear?: boolean;
         transitionAppearTimeout?: number;
         transitionEnter?: boolean;
@@ -28,7 +28,6 @@ declare module 'react' {
     }
 }
 
-declare var CSSTransitionGroup: CSSTransitionGroup;
-type CSSTransitionGroup = ComponentClass<CSSTransitionGroupProps>;
-export = CSSTransitionGroup;
-
+declare var ReactCSSTransitionGroup: ReactCSSTransitionGroup;
+type ReactCSSTransitionGroup = ComponentClass<ReactCSSTransitionGroupProps>;
+export = ReactCSSTransitionGroup;

--- a/types/react-addons-transition-group/index.d.ts
+++ b/types/react-addons-transition-group/index.d.ts
@@ -1,18 +1,21 @@
-// Type definitions for React (react-addons-transition-group) 0.14
+// Type definitions for React (react-addons-transition-group) 15.0
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-import { ReactElement, ComponentClass, ReactType, TransitionGroupProps } from 'react';
+import { ComponentClass, ReactTransitionGroupProps } from 'react';
 
 declare module 'react' {
-    export interface TransitionGroupProps extends HTMLAttributes<{}> {
+    export interface TransitionGroupProps<T> extends HTMLAttributes<T> {
         component?: ReactType;
-        className?: string;
         childFactory?: (child: ReactElement<any>) => ReactElement<any>;
+    }
+
+    export interface ReactTransitionGroupProps extends TransitionGroupProps<ReactTransitionGroup> {
     }
 }
 
-declare var ReactCSSTransitionGroup : ComponentClass<TransitionGroupProps>;
-export = ReactCSSTransitionGroup;
+declare var ReactTransitionGroup: ReactTransitionGroup;
+type ReactTransitionGroup = ComponentClass<ReactTransitionGroupProps>;
+export = ReactTransitionGroup;

--- a/types/react-addons-transition-group/index.d.ts
+++ b/types/react-addons-transition-group/index.d.ts
@@ -4,18 +4,18 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-import { ComponentClass, ReactTransitionGroupProps } from 'react';
+import { ComponentClass, TransitionGroupProps } from 'react';
 
 declare module 'react' {
-    export interface TransitionGroupProps<T> extends HTMLAttributes<T> {
+    export interface HTMLTransitionGroupProps<T> extends HTMLAttributes<T> {
         component?: ReactType;
         childFactory?: (child: ReactElement<any>) => ReactElement<any>;
     }
 
-    export interface ReactTransitionGroupProps extends TransitionGroupProps<ReactTransitionGroup> {
+    export interface TransitionGroupProps extends HTMLTransitionGroupProps<ReactTransitionGroup> {
     }
 }
 
 declare var ReactTransitionGroup: ReactTransitionGroup;
-type ReactTransitionGroup = ComponentClass<ReactTransitionGroupProps>;
+type ReactTransitionGroup = ComponentClass<TransitionGroupProps>;
 export = ReactTransitionGroup;


### PR DESCRIPTION
this patch cleans up some misc typing inefficiencies and makes the type definitions more consistent with naming and react usage conventions. additionally updating the version for react-addons-transition-group to `15.0`

See inline review notes for more context.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Changes are all just typing, no signature or structural changes were made.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
