### PR TITLE
[react-bootstrap] Add block to DropdownButtonBaseProps

### DIFF
--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -180,6 +180,7 @@ declare namespace ReactBootstrap {
 
     // <DropdownButton />
     interface DropdownButtonBaseProps extends DropdownBaseProps {
+        block?: boolean;
         bsSize?: Sizes;
         bsStyle?: string;
         navItem?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [O] Use a meaningful title for the pull request. Include the name of the package modified.
- [O] Test the change in your own code. (Compile and run.)
- [O] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [O] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [O] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [O] Provide a URL to documentation or source code which provides context for the suggested changes: 

`DropdownButton` DOES support `block` field, but the documentation does not mention it.

https://react-bootstrap.github.io/components.html#btn-dropdowns-props-dropdown-button

http://stackoverflow.com/a/20646616/2028189
