### PR TITLE
Upgrade PouchDB support to v6.1.2 (applies to all pouchdb-* packages) 

### DIFF
--- a/types/pouchdb-adapter-fruitdown/index.d.ts
+++ b/types/pouchdb-adapter-fruitdown/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-adapter-fruitdown v5.4.4
+// Type definitions for pouchdb-adapter-fruitdown v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-adapter-fruitdown/index.d.ts
+++ b/types/pouchdb-adapter-fruitdown/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-adapter-fruitdown v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-adapter-http/index.d.ts
+++ b/types/pouchdb-adapter-http/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-http v5.4.4
+// Type definitions for pouchdb-http v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-adapter-http/index.d.ts
+++ b/types/pouchdb-adapter-http/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-http v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-adapter-idb/index.d.ts
+++ b/types/pouchdb-adapter-idb/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-adapter-idb v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-adapter-idb/index.d.ts
+++ b/types/pouchdb-adapter-idb/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-adapter-idb v5.4.4
+// Type definitions for pouchdb-adapter-idb v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-adapter-leveldb/index.d.ts
+++ b/types/pouchdb-adapter-leveldb/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-adapter-leveldb v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-adapter-leveldb/index.d.ts
+++ b/types/pouchdb-adapter-leveldb/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-adapter-leveldb v5.4.4
+// Type definitions for pouchdb-adapter-leveldb v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-adapter-localstorage/index.d.ts
+++ b/types/pouchdb-adapter-localstorage/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-adapter-localstorage v5.4.4
+// Type definitions for pouchdb-adapter-localstorage v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-adapter-localstorage/index.d.ts
+++ b/types/pouchdb-adapter-localstorage/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-adapter-localstorage v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-adapter-memory/index.d.ts
+++ b/types/pouchdb-adapter-memory/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-adapter-memory v5.4.4
+// Type definitions for pouchdb-adapter-memory v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-adapter-memory/index.d.ts
+++ b/types/pouchdb-adapter-memory/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-adapter-memory v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-adapter-node-websql/index.d.ts
+++ b/types/pouchdb-adapter-node-websql/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-adapter-node-websql v5.4.4
+// Type definitions for pouchdb-adapter-node-websql v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-adapter-node-websql/index.d.ts
+++ b/types/pouchdb-adapter-node-websql/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-adapter-node-websql v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-adapter-websql/index.d.ts
+++ b/types/pouchdb-adapter-websql/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-adapter-websql v5.4.4
+// Type definitions for pouchdb-adapter-websql v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-adapter-websql/index.d.ts
+++ b/types/pouchdb-adapter-websql/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-adapter-websql v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-browser/index.d.ts
+++ b/types/pouchdb-browser/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-browser v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Simon Paulger <https://github.com/spaulg>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-browser/index.d.ts
+++ b/types/pouchdb-browser/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for pouchdb-browser v5.4.4
+// Type definitions for pouchdb-browser v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />
 /// <reference types="pouchdb-adapter-idb" />
+/// <reference types="pouchdb-adapter-websql" />
 /// <reference types="pouchdb-adapter-http" />
 /// <reference types="pouchdb-mapreduce" />
 /// <reference types="pouchdb-replication" />

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for pouchdb-core v6.0.7
+// Type definitions for pouchdb-core v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Jakub Navratil <https://github.com/trubit>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Jakub Navratil <https://github.com/trubit>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -54,6 +54,15 @@ declare namespace PouchDB {
         interface RevisionInfo {
             rev: RevisionId;
             status: Availability;
+        }
+        interface RevisionDiffList {
+            [documentId : string]: string[];
+        }
+        interface RevisionDiff {
+            [change : string]: string[];
+        }
+        interface RevisionDiffResponse {
+            [documentId : string]: RevisionDiff
         }
 
         interface IdMeta {
@@ -206,6 +215,13 @@ declare namespace PouchDB {
             new_edits?: boolean;
         }
 
+        interface BulkGetOptions extends Options {
+            docs: any,
+            revs?: boolean,
+            attachments?: boolean,
+            binary?: boolean
+        }
+
         interface ChangesMeta {
             _conflicts?: RevisionId[];
             _deleted?: boolean;
@@ -320,6 +336,9 @@ declare namespace PouchDB {
 
             /** Return attachment data as Blobs/Buffers, instead of as base64-encoded strings. */
             binary?: boolean;
+
+            /** Forces retrieving latest “leaf” revision, no matter what rev was requested. */
+            latest?: boolean;
         }
 
         interface GetOpenRevisions extends Options {
@@ -332,7 +351,6 @@ declare namespace PouchDB {
             revs?: boolean;
         }
 
-        /** @todo does this have any other properties? */
         interface PutOptions extends Options {
         }
         interface PostOptions extends PutOptions {
@@ -340,9 +358,6 @@ declare namespace PouchDB {
 
         interface CompactOptions extends Core.Options {
           interval?: number;
-        }
-
-        interface InfoOptions extends Options {
         }
 
         interface RemoveAttachmentResponse extends BasicResponse {
@@ -563,8 +578,6 @@ declare namespace PouchDB {
          * see inconsistent results.
          */
         put(doc: Core.PutDocument<Content>,
-            id: Core.DocumentId | null,
-            revision: Core.RevisionId | null,
             options: Core.PutOptions | null,
             callback: Core.Callback<Core.Error, Core.Response>): void;
 
@@ -577,8 +590,6 @@ declare namespace PouchDB {
          * see inconsistent results.
          */
         put(doc: Core.PutDocument<Content>,
-            id?: Core.DocumentId,
-            revision?: Core.RevisionId,
             options?: Core.PutOptions): Promise<Core.Response>;
 
         /** Remove a doc from the database */
@@ -602,11 +613,10 @@ declare namespace PouchDB {
                options?: Core.Options): Promise<Core.Response>;
 
         /** Get database information */
-        info(options: Core.InfoOptions | null,
-            callback: Core.Callback<any, Core.DatabaseInfo>): void;
+        info(callback: Core.Callback<any, Core.DatabaseInfo>): void;
 
         /** Get database information */
-        info(options?: Core.InfoOptions): Promise<Core.DatabaseInfo>;
+        info(): Promise<Core.DatabaseInfo>;
 
         /**
          * A list of changes made to documents in the database, in the order they were made.
@@ -711,11 +721,18 @@ declare namespace PouchDB {
             rev: Core.RevisionId): Promise<Core.RemoveAttachmentResponse>;
 
         /** Given a set of document/revision IDs, returns the document bodies (and, optionally, attachment data) for each ID/revision pair specified. */
-        bulkGet(options: any,
+        bulkGet(options: Core.BulkGetOptions,
             callback: Core.Callback<any, any>): void;
 
         /** Given a set of document/revision IDs, returns the document bodies (and, optionally, attachment data) for each ID/revision pair specified. */
-        bulkGet(options: any): Promise<any>;
+        bulkGet(options: Core.BulkGetOptions): Promise<any>;
+
+        /** Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database */
+        revsDiff(diff : Core.RevisionDiffList,
+            callback: Core.Callback<Core.Error, Core.RevisionDiffResponse>): void;
+
+        /** Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database */
+        revsDiff(diff : Core.RevisionDiffList): Promise<Core.RevisionDiffResponse>;
     }
 }
 

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -59,7 +59,8 @@ declare namespace PouchDB {
             [DocumentId : string]: string[];
         }
         interface RevisionDiff {
-            [change : string]: string[];
+            missing?: string[];
+            possible_ancestors?: string[];
         }
         interface RevisionDiffResponse {
             [DocumentId : string]: RevisionDiff

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-core v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Simon Paulger <https://github.com/spaulg>, Jakub Navratil <https://github.com/trubit>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Jakub Navratil <https://github.com/trubit>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -55,14 +55,14 @@ declare namespace PouchDB {
             rev: RevisionId;
             status: Availability;
         }
-        interface RevisionDiffList {
-            [documentId : string]: string[];
+        interface RevisionDiffOptions {
+            [DocumentId : string]: string[];
         }
         interface RevisionDiff {
             [change : string]: string[];
         }
         interface RevisionDiffResponse {
-            [documentId : string]: RevisionDiff
+            [DocumentId : string]: RevisionDiff
         }
 
         interface IdMeta {
@@ -728,11 +728,11 @@ declare namespace PouchDB {
         bulkGet(options: Core.BulkGetOptions): Promise<any>;
 
         /** Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database */
-        revsDiff(diff : Core.RevisionDiffList,
+        revsDiff(diff : Core.RevisionDiffOptions,
             callback: Core.Callback<Core.Error, Core.RevisionDiffResponse>): void;
 
         /** Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database */
-        revsDiff(diff : Core.RevisionDiffList): Promise<Core.RevisionDiffResponse>;
+        revsDiff(diff : Core.RevisionDiffOptions): Promise<Core.RevisionDiffResponse>;
     }
 }
 

--- a/types/pouchdb-core/pouchdb-core-tests.ts
+++ b/types/pouchdb-core/pouchdb-core-tests.ts
@@ -53,6 +53,18 @@ namespace PouchDBCoreTests {
         });
     }
 
+    function testBulkGet() {
+        const db = new PouchDB<{}>();
+        db.bulkGet({docs: [{id: 'a', rev: 'b'}, {id: 'b', rev: 'c'}, {id: 'c', rev: 'd'}]}).then((result) => {});
+        db.bulkGet({docs: [{id: 'a', rev: 'b'}, {id: 'b', rev: 'c'}, {id: 'c', rev: 'd'}]}, (error, response) => {});
+    }
+
+    function testRevsDiff() {
+        const db = new PouchDB<{}>();
+        db.revsDiff({'a': ['1-a', '2-b']}).then((result) => {});
+        db.revsDiff({'a': ['1-a', '2-b']}, (error, response) => {});
+    }
+
     function testCompact() {
       const db = new PouchDB<{}>();
       // Promise version
@@ -92,12 +104,12 @@ namespace PouchDBCoreTests {
 
         db.put(model).then((error) => {
         });
-        db.put(model, null, null, null, (error) => {
+        db.put(model, null, (error) => {
         });
 
         db.info().then((info) => {
         });
-        db.info({ ajax: { cache: true }}, (error, result) => {
+        db.info((error, result) => {
         });
 
         PouchDB.debug.enable('*');

--- a/types/pouchdb-http/index.d.ts
+++ b/types/pouchdb-http/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-http v5.4.4
+// Type definitions for pouchdb-http v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-http/index.d.ts
+++ b/types/pouchdb-http/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-http v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-mapreduce v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Simon Paulger <https://github.com/spaulg>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for pouchdb-mapreduce v5.4.4
+// Type definitions for pouchdb-mapreduce v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>, Simon Paulger <https://github.com/spaulg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />
@@ -76,7 +76,7 @@ declare namespace PouchDB {
          * to take up space on disk. viewCleanup() removes these unnecessary
          * index files.
          */
-        viewCleanup(callback: PouchDB.Core.Callback<any,void>): void;
+        viewCleanup(callback: PouchDB.Core.Callback<any,Core.BasicResponse>): void;
         /**
          * Cleans up any stale map/reduce indexes.
          *
@@ -85,7 +85,7 @@ declare namespace PouchDB {
          * to take up space on disk. viewCleanup() removes these unnecessary
          * index files.
          */
-        viewCleanup(): Promise<void>;
+        viewCleanup(): Promise<Core.BasicResponse>;
 
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-mapreduce v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Simon Paulger <https://github.com/spaulg>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>, Simon Paulger <https://github.com/spaulg>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-node/index.d.ts
+++ b/types/pouchdb-node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-node v5.4.4
+// Type definitions for pouchdb-node v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb-node/index.d.ts
+++ b/types/pouchdb-node/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pouchdb-node v6.1.2
 // Project: https://pouchdb.com/
-// Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
+// Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="pouchdb-core" />

--- a/types/pouchdb-replication/index.d.ts
+++ b/types/pouchdb-replication/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-replication v6.0.7
+// Type definitions for pouchdb-replication v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Jakub Navratil <https://github.com/trubit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb/index.d.ts
+++ b/types/pouchdb/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb v5.4.4
+// Type definitions for pouchdb v6.1.2
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/pouchdb/pouchdb-tests.ts
+++ b/types/pouchdb/pouchdb-tests.ts
@@ -92,12 +92,12 @@ namespace PouchDBTests {
 
         db.put(model).then((error) => {
         });
-        db.put(model, null, null, null, (error) => {
+        db.put(model, null, (error) => {
         });
 
         db.info().then((info) => {
         });
-        db.info({ ajax: { cache: true }}, (error, result) => {
+        db.info((error, result) => {
         });
 
         db.viewCleanup().catch((error) => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pouchdb.com/api.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.

This change adds support for the current (latest) version of PouchDB (v6.1.2 as of this PR, v6.2.0 is still pending).

The change applies to multiple packages, but for the most part of version updates to confirm support for the newer versions, are minimal and under the "pouchdb-*" prefix.

I have not copied the original file to a new file with the version number - I can do this if required.
