### PR TITLE
Update moment-duration-format to work correctly again

### DIFF
--- a/moment-duration-format/package.json
+++ b/moment-duration-format/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "moment": ">=2.14.0"
+    }
+}

--- a/moment-duration-format/tslint.json
+++ b/moment-duration-format/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }

--- a/types/moment-duration-format/index.d.ts
+++ b/types/moment-duration-format/index.d.ts
@@ -1,10 +1,11 @@
-// Type definitions for moment-duration-format v1.3.0
+// Type definitions for moment-duration-format 1.3
 // Project: https://github.com/jsmreese/moment-duration-format
-// Definitions by: Swint De Coninck <https://github.com/SwintDC>
+// Definitions by: Swint De Coninck <https://github.com/SwintDC>, Niklas Walter <https://github.com/TwoStone>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import * as moment from "moment";
 
-declare namespace moment {
+declare module "moment" {
     interface Duration {
         format(template: string, precision?: string, settings?: any): string;
     }


### PR DESCRIPTION
The commited version of the typings for the moment-duration-format library was not working correctly when transpiling with Typescript 2.0+.
Please accept my changes for making it work again.
This time hopefully with the correct version number for the linter.


- [x] Make your PR against the `master` branch.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes).
- [x] Run `tsc` without errors.
- [x] Run `npm run lint package-name` if a `tslint.json` is present.

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
The commited version wasn't working.
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.


Signed-off-by: Niklas Walter <walter.niklas@gmail.com>