### PR TITLE
classnames: allow all truthy and falsy values for ClassDictionary property values

### DIFF
--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -22,3 +22,24 @@ classNames(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
 
 // Supporting booleans is tricky since we should only support passing in false, which is ignored
 //classNames(false, 'bar', 0, 1, { baz: null }, ''); // => 'bar 1'
+
+// truthy and falsy values (not only booleans) are allowed for ClassDictionary parameters
+classNames({
+    // falsy:
+    emptyString: "",
+    noNumber: NaN,
+    null: null,
+    zero: 0,
+    negativeZero: -0,
+    false: false,
+    undefined: undefined,
+
+    // truthy (literally anything else):
+    nonEmptyString: "foobar",
+    whitespace: ' ',
+    function: Object.prototype.toString,
+    emptyObject: {},
+    nonEmptyObject: {a: 1, b: 2},
+    emptyList: [],
+    nonEmptyList: [1, 2, 3]
+}) // => 'nonEmptyString whitespace function emptyObject nonEmptyObject emptyList nonEmptyList'

--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -6,7 +6,7 @@
 declare type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
 
 interface ClassDictionary {
-	[id: string]: boolean | undefined | null;
+	[id: string]: any | undefined | null;
 }
 
 interface ClassArray extends Array<ClassValue> { }


### PR DESCRIPTION
Allow all truthy and falsy values for ClassDictionary property values, not just booleans.
This conforms to the implementation (and description of) the classnames lib, as shown by the following (successful) test: https://github.com/goldsaucer/classnames/commit/decb0caa6d799b403ffaab5874cd0bece4a2380c:

```javascript
assert.equal(classNames({
    // falsy:
    null: null,
    emptyString: "",
    noNumber: NaN,
    zero: 0,
    negativeZero: -0,
    false: false,
    undefined: undefined,

    // truthy (literally anything else):
    nonEmptyString: "foobar",
    whitespace: ' ',
    function: Object.prototype.toString,
    emptyObject: {},
    nonEmptyObject: {a: 1, b: 2},
    emptyList: [],
    nonEmptyList: [1, 2, 3],
    greaterZero: 1
}), 'nonEmptyString whitespace function emptyObject nonEmptyObject emptyList nonEmptyList greaterZero')
```