### PR TITLE
Update archiver typings to v1.3.0

### DIFF
--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -1,14 +1,16 @@
 import Archiver = require('archiver');
 import FS = require('fs');
 
-var archiver = Archiver.create('zip');
+const archiver = Archiver.create('zip');
 
-var writeStream = FS.createWriteStream('./archiver.d.ts');
-var readStream = FS.createReadStream('./archiver.d.ts');
+const writeStream = FS.createWriteStream('./archiver.d.ts');
+const readStream = FS.createReadStream('./archiver.d.ts');
 
-archiver.pipe(writeStream);
-archiver.append(readStream, {name: 'archiver.d.ts'});
-archiver.finalize();
+archiver.abort();
+archiver.append(readStream, {name: 'archiver.d.ts'})
+.append(readStream, {name: 'archiver.d.ts'});
+
+archiver.bulk({ mappaing: {} });
 
 archiver.directory('./path', './someOtherPath');
 archiver.directory('./path', { name: "testName"} );
@@ -16,4 +18,14 @@ archiver.directory('./path', { name: "testName"} );
 archiver.directory('./', "", {});
 archiver.directory('./', {name: 'test'}, {});
 
-archiver.bulk({ mappaing: {} });
+archiver.file('./path', { name: 'test' });
+archiver.glob('./path', {}, {});
+archiver.finalize();
+
+archiver.setFormat('zip');
+archiver.setModule(() => {});
+
+archiver.pointer();
+archiver.use(() => {});
+
+archiver.pipe(writeStream);

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for archiver v0.15.0
+// Type definitions for archiver v1.3.0
 // Project: https://github.com/archiverjs/node-archiver
 // Definitions by: Esri <https://github.com/archiverjs/node-archiver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -18,30 +18,33 @@
 import * as FS from 'fs';
 import * as STREAM from 'stream';
 
-
-declare function archiver(format: string, options?: archiver.Options): archiver.Archiver;
+declare function archiver(format: string, options?: {}): archiver.Archiver;
 
 declare namespace archiver {
+    function create(format: string, options?: {}): Archiver;
+    function registerFormat(format: string, module: Function): void;
 
-    export function create(format: string, options?: Options): Archiver;
-
-
-    export interface nameInterface {
+    interface nameInterface {
         name?: string;
     }
 
-    export interface Archiver extends STREAM.Transform {
-        append(source: STREAM.Readable | Buffer | string, name: nameInterface): void;
+    interface Archiver extends STREAM.Transform {
+        abort(): this;
+        append(source: STREAM.Readable | Buffer | string, name: nameInterface): this;
 
-        directory(dirpath: string, destpath: nameInterface | string): void;
-        directory(dirpath: string, destpath: nameInterface | string, data: any | Function): void;
+        bulk(mappings: any): this;
 
-        bulk(mappings: any): void;
-        finalize(): void;
-    }
+        directory(dirpath: string, destpath: nameInterface | string, data?: any | Function): this;
 
-    export interface Options {
+        file(filepath: string, data: any): this;
+        glob(pattern: string, options: {}, data: any): this;
+        finalize(): this;
 
+        setFormat(format: string): this;
+        setModule(module: Function): this;
+
+        pointer(): number;
+        use(plugin: Function): this;
     }
 }
 

--- a/types/archiver/tslint.json
+++ b/types/archiver/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "ban-types": false
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/archiverjs/node-archiver/blob/master/lib/core.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.


`tsc types/archiver/index.d.ts` throws:

```
types/archiver/index.d.ts(16,1): error TS2688: Cannot find type definition file for 'node'.
types/archiver/index.d.ts(18,21): error TS2307: Cannot find module 'fs'.
types/archiver/index.d.ts(19,25): error TS2307: Cannot find module 'stream'.
types/archiver/index.d.ts(34,42): error TS2304: Cannot find name 'Buffer'.
```
It was before my changes also.