### PR TITLE
fix Streamjs GroupingResult

### DIFF
--- a/types/streamjs/index.d.ts
+++ b/types/streamjs/index.d.ts
@@ -126,7 +126,7 @@ declare namespace Stream {
 	}
 
 	export interface GroupingResult<T> {
-		[index: string]: T
+		[index: string]: T[]
 	}
 
 	export interface Iterator<T> {

--- a/types/streamjs/streamjs-tests.ts
+++ b/types/streamjs/streamjs-tests.ts
@@ -97,7 +97,7 @@ numStream.collect({
 });
 
 var groupingResult = myStream.groupBy(lst => lst.name);
-var elems = groupingResult["hello"].elems;
+var length = groupingResult["hello"].length;
 groupingResult = myStream.groupingBy(lst => lst.name);
 groupingResult = myStream.groupBy("name");
 groupingResult = myStream.groupingBy("name");


### PR DESCRIPTION
GroupingResult return an array of element
Exemple : 
Stream.of({'firstname': 'john', 'lastname':'doe'}).groupBy(obj => obj.lastname)['doe']
=> is an Array