### PR TITLE
Types for sinon-test 1.0.1 Promise sandbox wrapper after it was spun out of SinonJS

### DIFF
--- a/types/sinon-test/index.d.ts
+++ b/types/sinon-test/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for sinon-test v1.0.1
+// Project: https://github.com/sinonjs/sinon-test
+// Definitions by: Francis Saul <https://github.com/mummybot>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="sinon" />
+
+import * as Sinon from 'sinon';
+
+interface Configuration {
+    injectIntoThis?: boolean;
+    injectInto?: any;
+    properties?: Array<"spy"| "stub"| "mock"| "clock"| "server"| "requests">;
+    useFakeTimers?: boolean;
+    useFakeServer?: boolean;
+}
+
+interface sinonTest {
+    configureTest(sinon: Sinon.SinonStatic, config?: Configuration): any;
+    configureTestCase(sinon: Sinon.SinonStatic, config?: Configuration): any;
+}
+
+declare var sinonTest: sinonTest;
+
+export = sinonTest;

--- a/types/sinon-test/sinon-test-tests.ts
+++ b/types/sinon-test/sinon-test-tests.ts
@@ -1,0 +1,25 @@
+import * as sinon from 'sinon';
+import * as sinonTest from 'sinon-test';
+
+function testConfigure() {
+    const test = sinonTest.configureTest(sinon, {
+    injectIntoThis: true,
+    injectInto: true,
+    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+    useFakeTimers: true,
+    useFakeServer: true
+    });
+}
+
+function testConfigureTestCase() {
+    const test = sinonTest.configureTestCase(sinon, {
+    injectIntoThis: true,
+    injectInto: true,
+    properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+    useFakeTimers: true,
+    useFakeServer: true
+    });
+}
+
+testConfigure();
+testConfigureTestCase();

--- a/types/sinon-test/tsconfig.json
+++ b/types/sinon-test/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "sinon-test-tests.ts"
+    ]
+}

--- a/types/sinon-test/tslint.json
+++ b/types/sinon-test/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "../tslint.json" }


### PR DESCRIPTION
I believe the [sinon-test](https://github.com/sinonjs/sinon-test) functionality has been spun out of [SinonJS](https://github.com/sinonjs/sinon) and the Typings for sinon-test appear to have been missed. I am not a contributor to the Sinon project so am unsure whether this is an oversight, however when using sinon-test with Typescript I found I needed to add my own Typings as per this pull request.

**Answers to template regarding this PR**
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
