### PR TITLE
Add defaultColor to GeoChartOptions in google.visualization typings

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -49,6 +49,7 @@ function test_geoChart() {
         sizeAxis: { minValue: 0, maxValue: 100 },
         region: '155', // Western Europe
         displayMode: 'markers',
+        defaultColor: '#ffffff',
         colorAxis: {colors: ['#e7711c', '#4374e0']} // orange to blue
     };
 

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Google Visualisation Apis
 // Project: https://developers.google.com/chart/
-// Definitions by: Dan Ludwig <https://github.com/danludwig>, Gregory Moore <https://github.com/gmoore-sjcorg>, Dan Manastireanu <https://github.com/danmana>
+// Definitions by: Dan Ludwig <https://github.com/danludwig>, Gregory Moore <https://github.com/gmoore-sjcorg>, Dan Manastireanu <https://github.com/danmana>, Michael Cheng <https://github.com/mlcheng>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace google {
@@ -301,6 +301,7 @@ declare namespace google {
             backgroundColor?: any;
             colorAxis?: ChartColorAxis;
             datalessRegionColor?: string;
+            defaultColor?: string;
             displayMode?: string;
             enableRegionInteractivity?: boolean;
             height?: number;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes - URL hasn't changed
- [x] Increase the version number in the header if appropriate. - No version number
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`. - No substantial changes


The `GeoChartOptions` is missing `defaultColor`. Thanks for reviewing!

For quick reference, here are the [`GeoChartOptions`](https://developers.google.com/chart/interactive/docs/gallery/geochart#configuration-options).