### PR TITLE
Match klaw's Options with implementation

### DIFF
--- a/types/klaw/index.d.ts
+++ b/types/klaw/index.d.ts
@@ -22,9 +22,9 @@ declare module "klaw" {
 
         interface Options extends ReadableOptions {
             queueMethod?: QueueMethod
-            pathSorter?: (a: Array<Item>) => Array<Item>
+            pathSorter?: (pathA: string, pathB: string) => number
             fs?: any // fs or mock-fs
-            filter?: (a: Item) => boolean
+            filter?: (path: string) => boolean
         }
 
         type Event = "close" | "data" | "end" | "readable" | "error"

--- a/types/klaw/klaw-tests.ts
+++ b/types/klaw/klaw-tests.ts
@@ -32,8 +32,8 @@ klaw('/some/dir')
 
 // README.md: Example (ignore hidden directories):
 
-var filterFunc = function(item: klaw.Item): boolean {
-    var basename = path.basename(item.path)
+var filterFunc = function(item: string): boolean {
+    var basename = path.basename(item);
     return basename === '.' || basename[0] !== '.'
 }
 


### PR DESCRIPTION
`pathSorter` and `filter` are callbacks passed to sort/filter of an array of **strings** (that is returned by fs.readdir).
See: https://github.com/jprichardson/node-klaw/blob/master/src/index.js#L44

I saw the actual runtime failure when using the current types (a.path/stats is undefined in that context), which made me check the actual implementation.