### PR TITLE
Add types for Mithril 1.1 global version

### DIFF
--- a/types/mithril-global/index.d.ts
+++ b/types/mithril-global/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for Mithril 1.1
+// Project: https://mithril.js.org/
+// Definitions by: Mike Linkovich <https://github.com/spacejack>, Isiah Meadows <https://github.com/isiahmeadows>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+// Global Mithril types
+
+/// <reference types="mithril" />
+
+import * as mithril from 'mithril';
+import * as stream from 'mithril/stream';
+
+declare namespace MithrilGlobal {
+	export type Lifecycle<A,S> = mithril.Lifecycle<A,S>;
+	export type Hyperscript = mithril.Hyperscript;
+	export type RouteResolver<S,P> = mithril.RouteResolver<S,P>;
+	export type RouteDefs = mithril.RouteDefs;
+	export type RouteOptions = mithril.RouteOptions;
+	export type Route = mithril.Route;
+	export type RequestOptions<T> = mithril.RequestOptions<T>;
+	export type JsonpOptions = mithril.JsonpOptions;
+	export type Child = mithril.Child;
+	export type ChildArray = mithril.ChildArray;
+	export type Children = mithril.Children;
+	export type ChildArrayOrPrimitive = mithril.ChildArrayOrPrimitive;
+	export type Vnode<A,S> = mithril.Vnode<A,S>;
+	export type VnodeDOM<A,S> = mithril.VnodeDOM<A,S>;
+	export type CVnode<A> = mithril.CVnode<A>;
+	export type CVnodeDOM<A> = mithril.CVnodeDOM<A>;
+	export type Component<A,S> = mithril.Component<A,S>;
+	export type Comp<A,S> = mithril.Comp<A,S>
+	export type ClassComponent<A> = mithril.ClassComponent<A>;
+	export type FactoryComponent<A> = mithril.FactoryComponent<A>;
+	export type ComponentTypes<A,S> = mithril.ComponentTypes<A,S>;
+	export type Attributes = mithril.Attributes;
+	export type Stream<T> = stream.Stream<T>;
+	export type Static = mithril.Static & {stream: stream.Static};
+}
+
+declare const MithrilGlobal: MithrilGlobal.Static;
+export = MithrilGlobal;
+export as namespace m;

--- a/types/mithril-global/mithril-global-tests.ts
+++ b/types/mithril-global/mithril-global-tests.ts
@@ -1,0 +1,13 @@
+// Test global mithril types
+
+const comp = {
+	view() {
+		return m('span', "Test")
+	}
+} as m.Comp<{},{}>
+
+m.mount(document.getElementById('comp')!, comp)
+
+const vnode = m('div', 'Test')
+
+const s: m.Stream<number> = m.stream(1)

--- a/types/mithril-global/tsconfig.json
+++ b/types/mithril-global/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es2015", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "../",
+    "typeRoots": ["../"],
+    "types": []
+  },
+  "files": [
+    "index.d.ts",
+    "mithril-global-tests.ts"
+  ],
+  "atom": {
+    "rewriteTsconfig": false
+  }
+}

--- a/types/mithril-global/tslint.json
+++ b/types/mithril-global/tslint.json
@@ -1,0 +1,23 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "array-type": [false, "array"],
+        "quotemark": [false, "double"],
+        "semicolon": [false, "always"],
+        "space-before-function-paren": [false, "always"],
+        "max-line-length": [false, 200],
+        "no-empty-interface": false,
+        "no-redundant-modifiers": false,
+        "only-arrow-functions": [false],
+        "prefer-for-of": false,
+        "unified-signatures": false,
+        "whitespace": [
+            false,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type"
+        ]
+    }
+}


### PR DESCRIPTION
This follows up on the recent merge of types for Mithril 1.1. Differences between module and script distributions required a separate set of definitions for global usage. This set of definitions references the module version to minimize duplication.

Pinging @isiahmeadows, though he has already [reviewed](https://github.com/spacejack/mithril-global.d.ts/issues/1) in the development repo.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
