### PR TITLE
Fixed returns in kue typing

### DIFF
--- a/types/kue/index.d.ts
+++ b/types/kue/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for kue 0.9.x
+// Type definitions for kue 0.11.x
 // Project: https://github.com/Automattic/kue
 // Definitions by: Nicholas Penree <http://github.com/drudge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/kue/index.d.ts
+++ b/types/kue/index.d.ts
@@ -81,8 +81,8 @@ export declare class Job extends events.EventEmitter {
     get(key: string, fn?: Function): Job;
     progress(complete: number, total: number, data?: any): Job;
     delay(ms: number | Date): Job;
-    removeOnComplete(param: any): void;
-    backoff(param: any): void;
+    removeOnComplete(param: any): Job;
+    backoff(param: any): Job;
     ttl(param: any): Job;
     private _getBackoffImpl(): void;
     priority(level: string | number): Job;


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Automattic/kue/blob/master/lib/queue/job.js#L468
- [x] Increase the version number in the header if appropriate.
