### PR TITLE
[material-ui] add fullWidth to FlatButtonProps

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for material-ui v0.16.0
+// Type definitions for material-ui v0.16.1
 // Project: https://github.com/callemall/material-ui
 // Definitions by: Nathan Brown <https://github.com/ngbrown>, Oliver Herrmann <https://github.com/herrmanno>, Igor Belagorudsky <https://github.com/theigor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for material-ui v0.16.0
 // Project: https://github.com/callemall/material-ui
-// Definitions by: Nathan Brown <https://github.com/ngbrown>, Oliver Herrmann <https://github.com/herrmanno>
+// Definitions by: Nathan Brown <https://github.com/ngbrown>, Oliver Herrmann <https://github.com/herrmanno>, Igor Belagorudsky <https://github.com/theigor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -651,6 +651,7 @@ declare namespace __MaterialUI {
         // <EnhancedButton/> is the element that get the 'other' properties
         backgroundColor?: string;
         disabled?: boolean;
+				fullWidth?: boolean;
         hoverColor?: string;
         icon?: React.ReactNode;
         label?: React.ReactNode;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -651,7 +651,7 @@ declare namespace __MaterialUI {
         // <EnhancedButton/> is the element that get the 'other' properties
         backgroundColor?: string;
         disabled?: boolean;
-				fullWidth?: boolean;
+        fullWidth?: boolean;
         hoverColor?: string;
         icon?: React.ReactNode;
         label?: React.ReactNode;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for material-ui v0.16.1
+// Type definitions for material-ui v0.17.1
 // Project: https://github.com/callemall/material-ui
 // Definitions by: Nathan Brown <https://github.com/ngbrown>, Oliver Herrmann <https://github.com/herrmanno>, Igor Belagorudsky <https://github.com/theigor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). Note that there were some issues with finding `React` namespace that are unrelated to my changes and don't affect the code. Same errors were happening on my local types install when running tsc.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/callemall/material-ui
Additionally, discussion here - https://github.com/callemall/material-ui/issues/6569
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.