### PR TITLE
improve passReqToCallback in passport-{google,facebook,twiter,local}

### DIFF
--- a/types/passport-facebook/index.d.ts
+++ b/types/passport-facebook/index.d.ts
@@ -11,9 +11,9 @@ import passport = require('passport');
 import express = require('express');
 
 interface Profile extends passport.Profile {
-    gender: string;
-    profileUrl: string;
-    username: string;
+    gender?: string;
+    profileUrl?: string;
+    username?: string;
 
     _raw: string;
     _json: any;
@@ -33,15 +33,8 @@ interface IStrategyOption {
     profileFields?: string[];
 }
 
-interface IStrategyOptionWithRequest {
-    clientID: string;
-    clientSecret: string;
-    callbackURL: string;
-
-    scopeSeparator?: string;
-    enableProof?: boolean;
-    profileFields?: string[];
-    passReqToCallback: boolean;
+interface IStrategyOptionWithRequest extends IStrategyOption {
+    passReqToCallback: true;
 }
 
 interface VerifyFunction {

--- a/types/passport-facebook/passport-facebook-tests.ts
+++ b/types/passport-facebook/passport-facebook-tests.ts
@@ -4,6 +4,7 @@
  */
 import passport = require('passport');
 import facebook = require('passport-facebook');
+import express = require('express');
 
 // just some test model
 var User = {
@@ -18,6 +19,20 @@ passport.use(new facebook.Strategy({
             callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL
     },
     function(accessToken:string, refreshToken:string, profile:facebook.Profile, done:(error:any, user?:any) => void) {
+         User.findOrCreate(profile.id, profile.provider, function(err, user) {
+             if (err) { return done(err); }
+             done(null, user);
+         });
+    })
+);
+
+passport.use(new facebook.Strategy({
+            clientID: process.env.PASSPORT_FACEBOOK_CLIENT_ID,
+            clientSecret: process.env.PASSPORT_FACEBOOK_CLIENT_SECRET,
+            callbackURL: process.env.PASSPORT_FACEBOOK_CALLBACK_URL,
+            passReqToCallback: true
+    },
+    function(req: express.Request, accessToken:string, refreshToken:string, profile:facebook.Profile, done:(error:any, user?:any) => void) {
          User.findOrCreate(profile.id, profile.provider, function(err, user) {
              if (err) { return done(err); }
              done(null, user);

--- a/types/passport-google-oauth/index.d.ts
+++ b/types/passport-google-oauth/index.d.ts
@@ -62,9 +62,16 @@ interface IOAuth2StrategyOption {
     openIDRealm?: string;
 }
 
+interface IOAuth2StrategyOptionWithRequest extends IOAuth2StrategyOption {
+    passReqToCallback: true;
+}
+
 declare class OAuth2Strategy implements passport.Strategy {
     constructor(options: IOAuth2StrategyOption,
         verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any) => void) => void);
+    constructor(options: IOAuth2StrategyOptionWithRequest,
+        verify: (req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any) => void) => void);
+
     name: string;
     authenticate: (req: express.Request, options?: Object) => void;
 }

--- a/types/passport-google-oauth/passport-google-oauth-tests.ts
+++ b/types/passport-google-oauth/passport-google-oauth-tests.ts
@@ -2,6 +2,7 @@
 /**
  * Created by jcabresos on 4/19/2014.
  */
+import express = require("express");
 import passport = require('passport');
 import google = require('passport-google-oauth');
 
@@ -32,6 +33,20 @@ passport.use(new google.OAuth2Strategy({
             callbackURL: process.env.PASSPORT_GOOGLE_CALLBACK_URL
     },
     function(accessToken:string, refreshToken:string, profile:google.Profile, done:(error:any, user?:any) => void) {
+         User.findOrCreate(profile.id, profile.provider, function(err, user) {
+             if (err) { return done(err); }
+             done(null, user);
+         });
+    })
+);
+
+passport.use(new google.OAuth2Strategy({
+            clientID: process.env.GOOGLE_CLIENT_ID,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+            callbackURL: process.env.PASSPORT_GOOGLE_CALLBACK_URL,
+            passReqToCallback: true
+    },
+    function(req: express.Request, accessToken:string, refreshToken:string, profile:google.Profile, done:(error:any, user?:any) => void) {
          User.findOrCreate(profile.id, profile.provider, function(err, user) {
              if (err) { return done(err); }
              done(null, user);

--- a/types/passport-local/index.d.ts
+++ b/types/passport-local/index.d.ts
@@ -13,13 +13,13 @@ import express = require('express');
 interface IStrategyOptions {
     usernameField?: string;
     passwordField?: string;
-    passReqToCallback?: boolean;
+    passReqToCallback?: false;
 }
 
 interface IStrategyOptionsWithRequest {
     usernameField?: string;
     passwordField?: string;
-    passReqToCallback: boolean;
+    passReqToCallback: true;
 }
 
 interface IVerifyOptions {

--- a/types/passport-twitter/index.d.ts
+++ b/types/passport-twitter/index.d.ts
@@ -19,7 +19,7 @@ interface Profile extends passport.Profile {
     _accessLevel: string;
 }
 
-interface IStrategyOption {
+interface IStrategyOptionBase {
     consumerKey: string;
     consumerSecret: string;
     callbackURL: string;
@@ -35,7 +35,11 @@ interface IStrategyOption {
     skipExtendedUserProfile?: boolean;
 }
 
-interface IStrategyOptionWithRequest  extends IStrategyOption {
+interface IStrategyOption extends IStrategyOptionBase {
+    passReqToCallback?: false;
+}
+
+interface IStrategyOptionWithRequest  extends IStrategyOptionBase {
     passReqToCallback: true;
 }
 

--- a/types/passport-twitter/index.d.ts
+++ b/types/passport-twitter/index.d.ts
@@ -24,7 +24,6 @@ interface IStrategyOption {
     consumerSecret: string;
     callbackURL: string;
 
-    passReqToCallback?: true;
     includeEmail?: true;
 
     reguestTokenURL?: string;
@@ -36,9 +35,16 @@ interface IStrategyOption {
     skipExtendedUserProfile?: boolean;
 }
 
+interface IStrategyOptionWithRequest  extends IStrategyOption {
+    passReqToCallback: true;
+}
+
 declare class Strategy implements passport.Strategy {
     constructor(options: IStrategyOption,
         verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any) => void) => void);
+    constructor(options: IStrategyOptionWithRequest,
+        verify: (req: express.Request, accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any) => void) => void);
+
     name: string;
     authenticate: (req: express.Request, options?: Object) => void;
 }

--- a/types/passport-twitter/passport-twitter-tests.ts
+++ b/types/passport-twitter/passport-twitter-tests.ts
@@ -2,6 +2,7 @@
 /**
  * Created by jcabresos on 4/19/2014.
  */
+import express = require("express");
 import passport = require('passport');
 import twitter = require('passport-twitter');
 
@@ -15,11 +16,38 @@ var User = {
 passport.use(new twitter.Strategy({
             consumerKey: process.env.PASSPORT_TWITTER_CONSUMER_KEY,
             consumerSecret: process.env.PASSPORT_TWITTER_CONSUMER_SECRET,
+            callbackURL: process.env.PASSPORT_TWITTER_CALLBACK_URL
+    },
+    function(accessToken:string, refreshToken:string, profile:twitter.Profile, done:(error:any, user?:any) => void) {
+         User.findOrCreate(profile.id, profile.provider, function(err, user) {
+             if (err) { return done(err); }
+             done(null, user);
+         });
+    })
+);
+
+passport.use(new twitter.Strategy({
+            consumerKey: process.env.PASSPORT_TWITTER_CONSUMER_KEY,
+            consumerSecret: process.env.PASSPORT_TWITTER_CONSUMER_SECRET,
+            callbackURL: process.env.PASSPORT_TWITTER_CALLBACK_URL,
+            passReqToCallback : false
+    },
+    function(accessToken:string, refreshToken:string, profile:twitter.Profile, done:(error:any, user?:any) => void) {
+         User.findOrCreate(profile.id, profile.provider, function(err, user) {
+             if (err) { return done(err); }
+             done(null, user);
+         });
+    })
+);
+
+passport.use(new twitter.Strategy({
+            consumerKey: process.env.PASSPORT_TWITTER_CONSUMER_KEY,
+            consumerSecret: process.env.PASSPORT_TWITTER_CONSUMER_SECRET,
             callbackURL: process.env.PASSPORT_TWITTER_CALLBACK_URL,
             passReqToCallback : true,
             includeEmail: true
     },
-    function(accessToken:string, refreshToken:string, profile:twitter.Profile, done:(error:any, user?:any) => void) {
+    function(req: express.Request, accessToken:string, refreshToken:string, profile:twitter.Profile, done:(error:any, user?:any) => void) {
          User.findOrCreate(profile.id, profile.provider, function(err, user) {
              if (err) { return done(err); }
              done(null, user);


### PR DESCRIPTION
improve support of passReqToCallback option in passport Strategies for facebook, google-oauth2, local and twitter.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: try to run this tutorial https://www.youtube.com/watch?v=9vmas8Pwhqc&t=704s in typescript.
- [-] Increase the version number in the header if appropriate.
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
