### PR TITLE
Type definitions for CSS Font Loading Module Level 3

### DIFF
--- a/types/css-font-loading-module/css-font-loading-module-tests.ts
+++ b/types/css-font-loading-module/css-font-loading-module-tests.ts
@@ -4,8 +4,8 @@ const font = new FontFace("Example", "url(...)", {
 });
 font.load();
 font.loaded.then((fontFace: FontFace) => {
-  fontFace.status
-  fontFace.family
+    fontFace.status;
+    fontFace.family;
 }, (fontFace: FontFace) => {});
 
 const a: boolean = document.fonts.check("12px Example");

--- a/types/css-font-loading-module/css-font-loading-module-tests.ts
+++ b/types/css-font-loading-module/css-font-loading-module-tests.ts
@@ -1,0 +1,14 @@
+const font = new FontFace("Example", "url(...)", {
+    style: "normal",
+    weight: "400"
+});
+font.load();
+font.loaded.then((fontFace: FontFace) => {
+  fontFace.status
+  fontFace.family
+}, (fontFace: FontFace) => {});
+
+const a: boolean = document.fonts.check("12px Example");
+const b: boolean = document.fonts.check("12px Example", "ß");
+const c: Promise<FontFace[]> = document.fonts.load("12px MyFont", "ß").then();
+const d: Promise<typeof document.fonts> = document.fonts.ready.then();

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -3,61 +3,59 @@
 // Definitions by: slikts <https://github.com/slikts>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-type FontFaceLoadStatus = 'unloaded' | 'loading' | 'loaded' | 'error'
-type FontFaceSetLoadStatus = 'loading' | 'loaded'
-type BinaryData = ArrayBuffer | ArrayBufferView
-type EventHandler = (event: Event) => void
+type FontFaceLoadStatus = 'unloaded' | 'loading' | 'loaded' | 'error';
+type FontFaceSetLoadStatus = 'loading' | 'loaded';
+type BinaryData = ArrayBuffer | ArrayBufferView;
+type EventHandler = (event: Event) => void;
 
 interface FontFaceDescriptors {
-    style?: string
-    weight?: string
-    stretch?: string
-    unicodeRange?: string
-    variant?: string
-    featureSettings?: string
+    style?: string;
+    weight?: string;
+    stretch?: string;
+    unicodeRange?: string;
+    variant?: string;
+    featureSettings?: string;
 }
 
 interface FontFaceSet extends Set<FontFace> {
     // events for when loading state changes
-    onloading: EventHandler
-    onloadingdone: EventHandler
-    onloadingerror: EventHandler
+    onloading: EventHandler;
+    onloadingdone: EventHandler;
+    onloadingerror: EventHandler;
 
     // check and start loads if appropriate
     // and fulfill promise when all loads complete
-    load(font: string, text?: string): Promise<FontFace[]>
+    load(font: string, text?: string): Promise<FontFace[]>;
     // return whether all fonts in the fontlist are loaded
     // (does not initiate load if not available)
-    check(font: string, text?: string): boolean
+    check(font: string, text?: string): boolean;
 
     // async notification that font loading and layout operations are done
-    readonly ready: Promise<FontFaceSet>
+    readonly ready: Promise<FontFaceSet>;
 
     // loading state, "loading" while one or more fonts loading, "loaded" otherwise
-    readonly status: FontFaceSetLoadStatus
+    readonly status: FontFaceSetLoadStatus;
 }
 
 declare global {
-    interface FontFace {
-        new (family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace
-        load(): Promise<FontFace>
+    class FontFace {
+        constructor(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors);
+        load(): Promise<FontFace>;
 
-        family: string
-        style: string
-        weight: string
-        stretch: string
-        unicodeRange: string
-        variant: string
-        featureSettings: string
-        readonly status: FontFaceLoadStatus
-        readonly loaded: Promise<FontFace>
+        family: string;
+        style: string;
+        weight: string;
+        stretch: string;
+        unicodeRange: string;
+        variant: string;
+        featureSettings: string;
+        readonly status: FontFaceLoadStatus;
+        readonly loaded: Promise<FontFace>;
     }
 
     interface Document {
-        fonts: FontFaceSet
+        fonts: FontFaceSet;
     }
-
-    var FontFace: FontFace
 }
 
-export {}
+export {};

--- a/types/css-font-loading-module/index.d.ts
+++ b/types/css-font-loading-module/index.d.ts
@@ -1,0 +1,63 @@
+// Type definitions for CSS Font Loading Module Level 3
+// Project: https://drafts.csswg.org/css-font-loading/
+// Definitions by: slikts <https://github.com/slikts>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type FontFaceLoadStatus = 'unloaded' | 'loading' | 'loaded' | 'error'
+type FontFaceSetLoadStatus = 'loading' | 'loaded'
+type BinaryData = ArrayBuffer | ArrayBufferView
+type EventHandler = (event: Event) => void
+
+interface FontFaceDescriptors {
+    style?: string
+    weight?: string
+    stretch?: string
+    unicodeRange?: string
+    variant?: string
+    featureSettings?: string
+}
+
+interface FontFaceSet extends Set<FontFace> {
+    // events for when loading state changes
+    onloading: EventHandler
+    onloadingdone: EventHandler
+    onloadingerror: EventHandler
+
+    // check and start loads if appropriate
+    // and fulfill promise when all loads complete
+    load(font: string, text?: string): Promise<FontFace[]>
+    // return whether all fonts in the fontlist are loaded
+    // (does not initiate load if not available)
+    check(font: string, text?: string): boolean
+
+    // async notification that font loading and layout operations are done
+    readonly ready: Promise<FontFaceSet>
+
+    // loading state, "loading" while one or more fonts loading, "loaded" otherwise
+    readonly status: FontFaceSetLoadStatus
+}
+
+declare global {
+    interface FontFace {
+        new (family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace
+        load(): Promise<FontFace>
+
+        family: string
+        style: string
+        weight: string
+        stretch: string
+        unicodeRange: string
+        variant: string
+        featureSettings: string
+        readonly status: FontFaceLoadStatus
+        readonly loaded: Promise<FontFace>
+    }
+
+    interface Document {
+        fonts: FontFaceSet
+    }
+
+    var FontFace: FontFace
+}
+
+export {}

--- a/types/css-font-loading-module/tsconfig.json
+++ b/types/css-font-loading-module/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "css-font-loading-module-tests.ts"
+    ]
+}

--- a/types/css-font-loading-module/tslint.json
+++ b/types/css-font-loading-module/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../tslint.json"
+}


### PR DESCRIPTION
[CSS Font Loading Module Level 3](https://www.w3.org/TR/css-font-loading-3/) is a draft Web API spec, so it doesn't belong with the DOM types yet, but is still implemented and usable in browsers.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.