### PR TITLE
fix(mysql): Add definition for PoolCluster.end with callback

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -100,8 +100,7 @@ interface IPoolCluster {
     add(config: IPoolConfig): void;
     add(group: string, config: IPoolConfig): void;
 
-    end(): void;
-    end(callback: (err: IError, ...args: any[]) => void): void;
+    end(callback?: (err: IError, ...args: any[]) => void): void;
 
     getConnection(callback: (err: IError, connection: IConnection) => void): void;
     getConnection(group: string, callback: (err: IError, connection: IConnection) => void): void;

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -101,6 +101,7 @@ interface IPoolCluster {
     add(group: string, config: IPoolConfig): void;
 
     end(): void;
+    end(callback: (err: IError, ...args: any[]) => void): void;
 
     getConnection(callback: (err: IError, connection: IConnection) => void): void;
     getConnection(group: string, callback: (err: IError, connection: IConnection) => void): void;

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -17,7 +17,7 @@ connection.query('SELECT 1 + 1 AS solution', function (err, rows, fields) {
     console.log('The solution is: ', rows[0].solution);
 });
 
-connection.end();
+connection.end(function (err) {});
 
 connection = mysql.createConnection({
     host: 'example.org',


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mysqljs/mysql/blob/73d92f7fdcec3619278391427eeb1f91361f3172/lib/PoolCluster.js#L61
- [ ] Increase the version number in the header if appropriate.
  - ❓ [Help wanted] I have no idea what to do when header has no version num...
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
