### PR TITLE
ADD missing property freeModeMomentumVelocityRatio to SwiperOptions

### DIFF
--- a/types/swiper/index.d.ts
+++ b/types/swiper/index.d.ts
@@ -28,6 +28,7 @@ interface SwiperOptions {
     freeMode?: boolean;
     freeModeMomentum?: boolean;
     freeModeMomentumRatio?: number;
+    freeModeMomentumVelocityRatio?: number;
     freeModeMomentumBounce?: boolean;
     freeModeMomentumBounceRatio?: number;
     freeModeMinimumVelocity?: number;


### PR DESCRIPTION
From the swiper API docs:
freeModeMomentumVelocityRatio	number	1	Higher value produces larger momentum velocity after you release slider