### PR TITLE
Improvements to parse' typing

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -82,7 +82,7 @@ declare namespace Parse {
     class Promise<T> implements IPromise<T> {
 
         static as<U>(resolvedValue: U): Promise<U>;
-        static error<U, V>(error: U): Promise<V>;
+        static error(error: any): Promise<any>;
         static is(possiblePromise: any): Boolean;
         static when(promises: IPromise<any>[]): Promise<any>;
         static when(...promises: IPromise<any>[]): Promise<any>;
@@ -285,10 +285,6 @@ declare namespace Parse {
         remove(object: T): void;
     }
 
-    interface ObjectConstructor<T> {
-        new (options?: any): T;
-    }
-
     /**
      * Creates a new model with defined attributes. A client id (cid) is
      * automatically generated and assigned for you.
@@ -330,12 +326,12 @@ declare namespace Parse {
         constructor(attributes?: string[], options?: any);
 
         static extend(className: string, protoProps?: any, classProps?: any): any;
-        static fetchAll<T extends Object>(list: T[], options: SuccessFailureOptions): Promise<T>;
-        static fetchAllIfNeeded<T extends Object>(list: T[], options: SuccessFailureOptions): Promise<T>;
-        static destroyAll<T>(list: T[], options?: Object.DestroyAllOptions): Promise<T>;
+        static fetchAll<T extends Object>(list: T[], options: SuccessFailureOptions): Promise<T[]>;
+        static fetchAllIfNeeded<T extends Object>(list: T[], options: SuccessFailureOptions): Promise<T[]>;
+        static destroyAll<T>(list: T[], options?: Object.DestroyAllOptions): Promise<T[]>;
         static saveAll<T extends Object>(list: T[], options?: Object.SaveAllOptions): Promise<T[]>;
 
-        static registerSubclass<T extends Object>(className: string, clazz: ObjectConstructor<T>): void;
+        static registerSubclass<T extends Object>(className: string, clazz: new (options?: any) => T): void;
 
         initialize(): void;
         add(attr: string, item: any): Object;
@@ -581,7 +577,7 @@ declare namespace Parse {
         className: string;
 
         constructor(objectClass: string);
-        constructor(objectClass: ObjectConstructor<T>);
+        constructor(objectClass: new(...args: any[]) => T);
 
         static or<U extends Object>(...var_args: Query<U>[]): Query<U>;
 
@@ -740,7 +736,7 @@ declare namespace Parse {
         isCurrent(): boolean;
 
         getEmail(): string | undefined;
-        setEmail(email: string, options: SuccessFailureOptions): boolean;
+        setEmail(email: string, options?: SuccessFailureOptions): boolean;
 
         getUsername(): string | undefined;
         setUsername(username: string, options?: SuccessFailureOptions): boolean;
@@ -868,8 +864,8 @@ declare namespace Parse {
         }
 
         interface FunctionResponse {
-            success?: (response: any) => void;
-            error?: (response: any) => void;
+            success: (response: any) => void;
+            error: (response: any) => void;
         }
 
         interface Cookie {
@@ -888,7 +884,7 @@ declare namespace Parse {
         interface BeforeDeleteResponse extends FunctionResponse {}
         interface BeforeSaveRequest extends SaveRequest {}
         interface BeforeSaveResponse extends FunctionResponse {
-            success?: () => void;
+            success: () => void;
         }
 
         function afterDelete(arg1: any, func?: (request: AfterDeleteRequest) => void): void;
@@ -909,7 +905,7 @@ declare namespace Parse {
          *     import Buffer = require("buffer").Buffer;
          */
         var HTTPOptions: new () => HTTPOptions;
-        interface HTTPOptions extends FunctionResponse {
+        interface HTTPOptions {
             /**
              * The body of the request.
              * If it is a JSON object, then the Content-Type set in the headers must be application/x-www-form-urlencoded or application/json.
@@ -939,6 +935,9 @@ declare namespace Parse {
              * The url to send the request to.
              */
             url: string;
+
+            success?: (response: any) => void;
+            error?: (response: any) => void;
         }
     }
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -267,22 +267,22 @@ declare namespace Parse {
      * A class that is used to access all of the children of a many-to-many relationship.
      * Each instance of Parse.Relation is associated with a particular parent object and key.
      */
-    class Relation<S extends Object, T extends Object> extends BaseObject {
+    class Relation extends BaseObject {
 
-        parent: S;
+        parent: Object;
         key: string;
         targetClassName: string;
 
-        constructor(parent?: S, key?: string);
+        constructor(parent?: Object, key?: string);
 
         //Adds a Parse.Object or an array of Parse.Objects to the relation.
-        add(object: T): void;
+        add(object: Object): void;
 
         // Returns a Parse.Query that is limited to objects in this relation.
-        query(): Query<T>;
+        query(): Query;
 
         // Removes a Parse.Object or an array of Parse.Objects from this relation.
-        remove(object: T): void;
+        remove(object: Object): void;
     }
 
     /**
@@ -355,7 +355,7 @@ declare namespace Parse {
         op(attr: string): any;
         previous(attr: string): any;
         previousAttributes(): any;
-        relation(attr: string): Relation<this, Object>;
+        relation(attr: string): Relation;
         remove(attr: string, item: any): any;
         save(attrs?: { [key: string]: any } | null, options?: Object.SaveOptions): Promise<this>;
         save(key: string, value: any, options?: Object.SaveOptions): Promise<this>;
@@ -429,7 +429,7 @@ declare namespace Parse {
 
         model: Object;
         models: Object[];
-        query: Query<Object>;
+        query: Query;
         comparator: (object: Object) => any;
 
         constructor(models?: Object[], options?: Collection.Options);
@@ -454,7 +454,7 @@ declare namespace Parse {
     namespace Collection {
         interface Options {
             model?: Object;
-            query?: Query<Object>;
+            query?: Query;
             comparator?: string;
         }
 
@@ -571,59 +571,59 @@ declare namespace Parse {
      *   }
      * });</pre></p>
      */
-    class Query<T extends Object> extends BaseObject {
+    class Query extends BaseObject {
 
         objectClass: any;
         className: string;
 
         constructor(objectClass: string);
-        constructor(objectClass: new(...args: any[]) => T);
+        constructor(objectClass: new(...args: any[]) => Object);
 
-        static or<U extends Object>(...var_args: Query<U>[]): Query<U>;
+        static or<U extends Object>(...var_args: Query[]): Query;
 
-        addAscending(key: string): Query<T>;
-        addAscending(key: string[]): Query<T>;
-        addDescending(key: string): Query<T>;
-        addDescending(key: string[]): Query<T>;
-        ascending(key: string): Query<T>;
-        ascending(key: string[]): Query<T>;
+        addAscending(key: string): Query;
+        addAscending(key: string[]): Query;
+        addDescending(key: string): Query;
+        addDescending(key: string[]): Query;
+        ascending(key: string): Query;
+        ascending(key: string[]): Query;
         collection(items?: Object[], options?: Collection.Options): Collection<Object>;
-        containedIn(key: string, values: any[]): Query<T>;
-        contains(key: string, substring: string): Query<T>;
-        containsAll(key: string, values: any[]): Query<T>;
+        containedIn(key: string, values: any[]): Query;
+        contains(key: string, substring: string): Query;
+        containsAll(key: string, values: any[]): Query;
         count(options?: Query.CountOptions): Promise<number>;
-        descending(key: string): Query<T>;
-        descending(key: string[]): Query<T>;
-        doesNotExist(key: string): Query<T>;
-        doesNotMatchKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query<U>): Query<T>;
-        doesNotMatchQuery<U extends Object>(key: string, query: Query<U>): Query<T>;
+        descending(key: string): Query;
+        descending(key: string[]): Query;
+        doesNotExist(key: string): Query;
+        doesNotMatchKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query): Query;
+        doesNotMatchQuery<U extends Object>(key: string, query: Query): Query;
         each(callback: Function, options?: Query.EachOptions): Promise<void>;
-        endsWith(key: string, suffix: string): Query<T>;
-        equalTo(key: string, value: any): Query<T>;
-        exists(key: string): Query<T>;
-        find(options?: Query.FindOptions): Promise<T[]>;
-        first(options?: Query.FirstOptions): Promise<T | undefined>;
-        get(objectId: string, options?: Query.GetOptions): Promise<T>;
-        greaterThan(key: string, value: any): Query<T>;
-        greaterThanOrEqualTo(key: string, value: any): Query<T>;
-        include(key: string): Query<T>;
-        include(keys: string[]): Query<T>;
-        lessThan(key: string, value: any): Query<T>;
-        lessThanOrEqualTo(key: string, value: any): Query<T>;
-        limit(n: number): Query<T>;
-        matches(key: string, regex: RegExp, modifiers: any): Query<T>;
-        matchesKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query<U>): Query<T>;
-        matchesQuery<U extends Object>(key: string, query: Query<U>): Query<T>;
-        near(key: string, point: GeoPoint): Query<T>;
-        notContainedIn(key: string, values: any[]): Query<T>;
-        notEqualTo(key: string, value: any): Query<T>;
-        select(...keys: string[]): Query<T>;
-        skip(n: number): Query<T>;
-        startsWith(key: string, prefix: string): Query<T>;
-        withinGeoBox(key: string, southwest: GeoPoint, northeast: GeoPoint): Query<T>;
-        withinKilometers(key: string, point: GeoPoint, maxDistance: number): Query<T>;
-        withinMiles(key: string, point: GeoPoint, maxDistance: number): Query<T>;
-        withinRadians(key: string, point: GeoPoint, maxDistance: number): Query<T>;
+        endsWith(key: string, suffix: string): Query;
+        equalTo(key: string, value: any): Query;
+        exists(key: string): Query;
+        find(options?: Query.FindOptions): Promise<Object[]>;
+        first(options?: Query.FirstOptions): Promise<Object | undefined>;
+        get(objectId: string, options?: Query.GetOptions): Promise<Object>;
+        greaterThan(key: string, value: any): Query;
+        greaterThanOrEqualTo(key: string, value: any): Query;
+        include(key: string): Query;
+        include(keys: string[]): Query;
+        lessThan(key: string, value: any): Query;
+        lessThanOrEqualTo(key: string, value: any): Query;
+        limit(n: number): Query;
+        matches(key: string, regex: RegExp, modifiers: any): Query;
+        matchesKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query): Query;
+        matchesQuery<U extends Object>(key: string, query: Query): Query;
+        near(key: string, point: GeoPoint): Query;
+        notContainedIn(key: string, values: any[]): Query;
+        notEqualTo(key: string, value: any): Query;
+        select(...keys: string[]): Query;
+        skip(n: number): Query;
+        startsWith(key: string, prefix: string): Query;
+        withinGeoBox(key: string, southwest: GeoPoint, northeast: GeoPoint): Query;
+        withinKilometers(key: string, point: GeoPoint, maxDistance: number): Query;
+        withinMiles(key: string, point: GeoPoint, maxDistance: number): Query;
+        withinRadians(key: string, point: GeoPoint, maxDistance: number): Query;
     }
 
     namespace Query {
@@ -651,8 +651,8 @@ declare namespace Parse {
 
         constructor(name: string, acl: ACL);
 
-        getRoles(): Relation<Role, Role>;
-        getUsers(): Relation<Role, User>;
+        getRoles(): Relation;
+        getUsers(): Relation;
         getName(): string;
         setName(name: string, options?: SuccessFailureOptions): any;
     }
@@ -1068,7 +1068,7 @@ declare namespace Parse {
             push_time?: Date;
             expiration_time?: Date;
             expiration_interval?: number;
-            where?: Query<Object>;
+            where?: Query;
             data?: any;
             alert?: string;
             badge?: string;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -334,18 +334,18 @@ declare namespace Parse {
         static registerSubclass<T extends Object>(className: string, clazz: new (options?: any) => T): void;
 
         initialize(): void;
-        add(attr: string, item: any): Object;
+        add(attr: string, item: any): this;
         addUnique(attr: string, item: any): any;
-        change(options: any): Object;
+        change(options: any): this;
         changedAttributes(diff: any): boolean;
         clear(options: any): any;
-        clone(): Object;
-        destroy(options?: Object.DestroyOptions): Promise<Object>;
+        clone(): this;
+        destroy(options?: Object.DestroyOptions): Promise<this>;
         dirty(attr: String): boolean;
         dirtyKeys(): string[];
         escape(attr: string): string;
         existed(): boolean;
-        fetch(options?: Object.FetchOptions): Promise<Object>;
+        fetch(options?: Object.FetchOptions): Promise<this>;
         get(attr: string): any | undefined;
         getACL(): ACL | undefined;
         has(attr: string): boolean;
@@ -355,10 +355,10 @@ declare namespace Parse {
         op(attr: string): any;
         previous(attr: string): any;
         previousAttributes(): any;
-        relation(attr: string): Relation<Object, Object>;
+        relation(attr: string): Relation<this, Object>;
         remove(attr: string, item: any): any;
-        save(attrs?: { [key: string]: any } | null, options?: Object.SaveOptions): Promise<Object>;
-        save(key: string, value: any, options?: Object.SaveOptions): Promise<Object>;
+        save(attrs?: { [key: string]: any } | null, options?: Object.SaveOptions): Promise<this>;
+        save(key: string, value: any, options?: Object.SaveOptions): Promise<this>;
         set(key: string, value: any, options?: Object.SetOptions): boolean;
         setACL(acl: ACL, options?: SuccessFailureOptions): boolean;
         unset(attr: string, options?: any): any;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -730,8 +730,8 @@ declare namespace Parse {
         static requestPasswordReset(email: string, options?: SuccessFailureOptions): Promise<User>;
         static extend(protoProps?: any, classProps?: any): any;
 
-        signUp(attrs: any, options?: SuccessFailureOptions): Promise<User>;
-        logIn(options?: SuccessFailureOptions): Promise<User>;
+        signUp(attrs: any, options?: SuccessFailureOptions): Promise<this>;
+        logIn(options?: SuccessFailureOptions): Promise<this>;
         authenticated(): boolean;
         isCurrent(): boolean;
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Parse v1.2.19
+// Type definitions for parse v1.9.2
 // Project: https://parse.com/
 // Definitions by: Ullisen Media Group <http://ullisenmedia.com>, David Poetzsch-Heffter <https://github.com/dpoetzsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Parse v1.2.19
 // Project: https://parse.com/
-// Definitions by: Ullisen Media Group <http://ullisenmedia.com>
+// Definitions by: Ullisen Media Group <http://ullisenmedia.com>, David Poetzsch-Heffter <https://github.com/dpoetzsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -10,8 +10,8 @@
 declare namespace Parse {
 
     var applicationId: string;
-    var javaScriptKey: string;
-    var masterKey: string;
+    var javaScriptKey: string | undefined;
+    var masterKey: string | undefined;
     var serverURL: string;
     var VERSION: string;
 
@@ -191,7 +191,7 @@ declare namespace Parse {
         constructor(name: string, data: any, type?: string);
         name(): string;
         url(): string;
-        save<T>(options?: SuccessFailureOptions): Promise<T>;
+        save(options?: SuccessFailureOptions): Promise<File>;
 
     }
 
@@ -267,22 +267,26 @@ declare namespace Parse {
      * A class that is used to access all of the children of a many-to-many relationship.
      * Each instance of Parse.Relation is associated with a particular parent object and key.
      */
-    class Relation extends BaseObject {
+    class Relation<S extends Object, T extends Object> extends BaseObject {
 
-        parent: Object;
+        parent: S;
         key: string;
         targetClassName: string;
 
-        constructor(parent?: Object, key?: string);
+        constructor(parent?: S, key?: string);
 
         //Adds a Parse.Object or an array of Parse.Objects to the relation.
-        add(object: Object): void;
+        add(object: T): void;
 
         // Returns a Parse.Query that is limited to objects in this relation.
-        query(): Query;
+        query(): Query<T>;
 
         // Removes a Parse.Object or an array of Parse.Objects from this relation.
-        remove(object: Object): void;
+        remove(object: T): void;
+    }
+
+    interface ObjectConstructor<T> {
+        new (options?: any): T;
     }
 
     /**
@@ -326,12 +330,12 @@ declare namespace Parse {
         constructor(attributes?: string[], options?: any);
 
         static extend(className: string, protoProps?: any, classProps?: any): any;
-        static fetchAll<T>(list: Object[], options: SuccessFailureOptions): Promise<T>;
-        static fetchAllIfNeeded<T>(list: Object[], options: SuccessFailureOptions): Promise<T>;
-        static destroyAll<T>(list: Object[], options?: Object.DestroyAllOptions): Promise<T>;
+        static fetchAll<T extends Object>(list: T[], options: SuccessFailureOptions): Promise<T>;
+        static fetchAllIfNeeded<T extends Object>(list: T[], options: SuccessFailureOptions): Promise<T>;
+        static destroyAll<T>(list: T[], options?: Object.DestroyAllOptions): Promise<T>;
         static saveAll<T extends Object>(list: T[], options?: Object.SaveAllOptions): Promise<T[]>;
 
-        static registerSubclass<T extends Object>(className: string, clazz: new (options?: any) => T): void;
+        static registerSubclass<T extends Object>(className: string, clazz: ObjectConstructor<T>): void;
 
         initialize(): void;
         add(attr: string, item: any): Object;
@@ -340,14 +344,14 @@ declare namespace Parse {
         changedAttributes(diff: any): boolean;
         clear(options: any): any;
         clone(): Object;
-        destroy<T>(options?: Object.DestroyOptions): Promise<T>;
+        destroy(options?: Object.DestroyOptions): Promise<Object>;
         dirty(attr: String): boolean;
         dirtyKeys(): string[];
         escape(attr: string): string;
         existed(): boolean;
-        fetch<T extends Object>(options?: Object.FetchOptions): Promise<T>;
-        get(attr: string): any;
-        getACL(): ACL;
+        fetch(options?: Object.FetchOptions): Promise<Object>;
+        get(attr: string): any | undefined;
+        getACL(): ACL | undefined;
         has(attr: string): boolean;
         hasChanged(attr: string): boolean;
         increment(attr: string, amount?: number): any;
@@ -355,10 +359,10 @@ declare namespace Parse {
         op(attr: string): any;
         previous(attr: string): any;
         previousAttributes(): any;
-        relation(attr: string): Relation;
+        relation(attr: string): Relation<Object, Object>;
         remove(attr: string, item: any): any;
-        save<T extends Object>(attrs?: { [key: string]: any }, options?: Object.SaveOptions): Promise<T>;
-        save<T extends Object>(key: string, value: any, options?: Object.SaveOptions): Promise<T>;
+        save(attrs?: { [key: string]: any }, options?: Object.SaveOptions): Promise<Object>;
+        save(key: string, value: any, options?: Object.SaveOptions): Promise<Object>;
         set(key: string, value: any, options?: Object.SetOptions): boolean;
         setACL(acl: ACL, options?: SuccessFailureOptions): boolean;
         unset(attr: string, options?: any): any;
@@ -429,7 +433,7 @@ declare namespace Parse {
 
         model: Object;
         models: Object[];
-        query: Query;
+        query: Query<Object>;
         comparator: (object: Object) => any;
 
         constructor(models?: Object[], options?: Collection.Options);
@@ -454,7 +458,7 @@ declare namespace Parse {
     namespace Collection {
         interface Options {
             model?: Object;
-            query?: Query;
+            query?: Query<Object>;
             comparator?: string;
         }
 
@@ -508,7 +512,7 @@ declare namespace Parse {
         static unbind(): Events;
 
         on(eventName: string, callback?: Function, context?: any): Events;
-        off(eventName?: string, callback?: Function, context?: any): Events;
+        off(eventName?: string | null, callback?: Function | null, context?: any): Events;
         trigger(eventName: string, ...args: any[]): Events;
         bind(eventName: string, callback: Function, context?: any): Events;
         unbind(eventName?: string, callback?: Function, context?: any): Events;
@@ -571,58 +575,59 @@ declare namespace Parse {
      *   }
      * });</pre></p>
      */
-    class Query extends BaseObject {
+    class Query<T extends Object> extends BaseObject {
 
         objectClass: any;
         className: string;
 
-        constructor(objectClass: any);
+        constructor(objectClass: string);
+        constructor(objectClass: ObjectConstructor<T>);
 
-        static or(...var_args: Query[]): Query;
+        static or<U extends Object>(...var_args: Query<U>[]): Query<U>;
 
-        addAscending(key: string): Query;
-        addAscending(key: string[]): Query;
-        addDescending(key: string): Query;
-        addDescending(key: string[]): Query;
-        ascending(key: string): Query;
-        ascending(key: string[]): Query;
+        addAscending(key: string): Query<T>;
+        addAscending(key: string[]): Query<T>;
+        addDescending(key: string): Query<T>;
+        addDescending(key: string[]): Query<T>;
+        ascending(key: string): Query<T>;
+        ascending(key: string[]): Query<T>;
         collection(items?: Object[], options?: Collection.Options): Collection<Object>;
-        containedIn(key: string, values: any[]): Query;
-        contains(key: string, substring: string): Query;
-        containsAll(key: string, values: any[]): Query;
-        count<T>(options?: Query.CountOptions): Promise<T>;
-        descending(key: string): Query;
-        descending(key: string[]): Query;
-        doesNotExist(key: string): Query;
-        doesNotMatchKeyInQuery(key: string, queryKey: string, query: Query): Query;
-        doesNotMatchQuery(key: string, query: Query): Query;
-        each<T>(callback: Function, options?: Query.EachOptions): Promise<T>;
-        endsWith(key: string, suffix: string): Query;
-        equalTo(key: string, value: any): Query;
-        exists(key: string): Query;
-        find<T extends Object>(options?: Query.FindOptions): Promise<T[]>;
-        first<T>(options?: Query.FirstOptions): Promise<T>;
-        get(objectId: string, options?: Query.GetOptions): Promise<any>;
-        greaterThan(key: string, value: any): Query;
-        greaterThanOrEqualTo(key: string, value: any): Query;
-        include(key: string): Query;
-        include(keys: string[]): Query;
-        lessThan(key: string, value: any): Query;
-        lessThanOrEqualTo(key: string, value: any): Query;
-        limit(n: number): Query;
-        matches(key: string, regex: RegExp, modifiers: any): Query;
-        matchesKeyInQuery(key: string, queryKey: string, query: Query): Query;
-        matchesQuery(key: string, query: Query): Query;
-        near(key: string, point: GeoPoint): Query;
-        notContainedIn(key: string, values: any[]): Query;
-        notEqualTo(key: string, value: any): Query;
-        select(...keys: string[]): Query;
-        skip(n: number): Query;
-        startsWith(key: string, prefix: string): Query;
-        withinGeoBox(key: string, southwest: GeoPoint, northeast: GeoPoint): Query;
-        withinKilometers(key: string, point: GeoPoint, maxDistance: number): Query;
-        withinMiles(key: string, point: GeoPoint, maxDistance: number): Query;
-        withinRadians(key: string, point: GeoPoint, maxDistance: number): Query;
+        containedIn(key: string, values: any[]): Query<T>;
+        contains(key: string, substring: string): Query<T>;
+        containsAll(key: string, values: any[]): Query<T>;
+        count(options?: Query.CountOptions): Promise<number>;
+        descending(key: string): Query<T>;
+        descending(key: string[]): Query<T>;
+        doesNotExist(key: string): Query<T>;
+        doesNotMatchKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query<U>): Query<T>;
+        doesNotMatchQuery<U extends Object>(key: string, query: Query<U>): Query<T>;
+        each(callback: Function, options?: Query.EachOptions): Promise<void>;
+        endsWith(key: string, suffix: string): Query<T>;
+        equalTo(key: string, value: any): Query<T>;
+        exists(key: string): Query<T>;
+        find(options?: Query.FindOptions): Promise<T[]>;
+        first(options?: Query.FirstOptions): Promise<T | undefined>;
+        get(objectId: string, options?: Query.GetOptions): Promise<T>;
+        greaterThan(key: string, value: any): Query<T>;
+        greaterThanOrEqualTo(key: string, value: any): Query<T>;
+        include(key: string): Query<T>;
+        include(keys: string[]): Query<T>;
+        lessThan(key: string, value: any): Query<T>;
+        lessThanOrEqualTo(key: string, value: any): Query<T>;
+        limit(n: number): Query<T>;
+        matches(key: string, regex: RegExp, modifiers: any): Query<T>;
+        matchesKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query<U>): Query<T>;
+        matchesQuery<U extends Object>(key: string, query: Query<U>): Query<T>;
+        near(key: string, point: GeoPoint): Query<T>;
+        notContainedIn(key: string, values: any[]): Query<T>;
+        notEqualTo(key: string, value: any): Query<T>;
+        select(...keys: string[]): Query<T>;
+        skip(n: number): Query<T>;
+        startsWith(key: string, prefix: string): Query<T>;
+        withinGeoBox(key: string, southwest: GeoPoint, northeast: GeoPoint): Query<T>;
+        withinKilometers(key: string, point: GeoPoint, maxDistance: number): Query<T>;
+        withinMiles(key: string, point: GeoPoint, maxDistance: number): Query<T>;
+        withinRadians(key: string, point: GeoPoint, maxDistance: number): Query<T>;
     }
 
     namespace Query {
@@ -650,8 +655,8 @@ declare namespace Parse {
 
         constructor(name: string, acl: ACL);
 
-        getRoles(): Relation;
-        getUsers(): Relation;
+        getRoles(): Relation<Role, Role>;
+        getUsers(): Relation<Role, User>;
         getName(): string;
         setName(name: string, options?: SuccessFailureOptions): any;
     }
@@ -720,24 +725,24 @@ declare namespace Parse {
      */
     class User extends Object {
 
-        static current(): User;
-        static signUp<T>(username: string, password: string, attrs: any, options?: SuccessFailureOptions): Promise<T>;
-        static logIn<T>(username: string, password: string, options?: SuccessFailureOptions): Promise<T>;
-        static logOut<T>(): Promise<T>;
+        static current(): User | undefined;
+        static signUp(username: string, password: string, attrs: any, options?: SuccessFailureOptions): Promise<User>;
+        static logIn(username: string, password: string, options?: SuccessFailureOptions): Promise<User>;
+        static logOut(): Promise<User>;
         static allowCustomUserClass(isAllowed: boolean): void;
-        static become<T>(sessionToken: string, options?: SuccessFailureOptions): Promise<T>;
-        static requestPasswordReset<T>(email: string, options?: SuccessFailureOptions): Promise<T>;
+        static become(sessionToken: string, options?: SuccessFailureOptions): Promise<User>;
+        static requestPasswordReset(email: string, options?: SuccessFailureOptions): Promise<User>;
         static extend(protoProps?: any, classProps?: any): any;
 
-        signUp<T>(attrs: any, options?: SuccessFailureOptions): Promise<T>;
-        logIn<T>(options?: SuccessFailureOptions): Promise<T>;
+        signUp(attrs: any, options?: SuccessFailureOptions): Promise<User>;
+        logIn(options?: SuccessFailureOptions): Promise<User>;
         authenticated(): boolean;
         isCurrent(): boolean;
 
-        getEmail(): string;
+        getEmail(): string | undefined;
         setEmail(email: string, options: SuccessFailureOptions): boolean;
 
-        getUsername(): string;
+        getUsername(): string | undefined;
         setUsername(username: string, options?: SuccessFailureOptions): boolean;
 
         setPassword(password: string, options?: SuccessFailureOptions): boolean;
@@ -801,7 +806,7 @@ declare namespace Parse {
 
     namespace Analytics {
 
-        function track<T>(name: string, dimensions: any):Promise<T>;
+        function track(name: string, dimensions: any): Promise<any>;
     }
 
     /**
@@ -893,7 +898,7 @@ declare namespace Parse {
         function define(name: string, func?: (request: FunctionRequest, response: FunctionResponse) => void): void;
         function httpRequest(options: HTTPOptions): Promise<HttpResponse>;
         function job(name: string, func?: (request: JobRequest, status: JobStatus) => void): HttpResponse;
-        function run<T>(name: string, data?: any, options?: RunOptions): Promise<T>;
+        function run(name: string, data?: any, options?: RunOptions): Promise<any>;
         function useMasterKey(): void;
 
         interface RunOptions extends SuccessFailureOptions, ScopeOptions { }
@@ -1064,7 +1069,7 @@ declare namespace Parse {
             push_time?: Date;
             expiration_time?: Date;
             expiration_interval?: number;
-            where?: Query;
+            where?: Query<Object>;
             data?: any;
             alert?: string;
             badge?: string;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -361,7 +361,7 @@ declare namespace Parse {
         previousAttributes(): any;
         relation(attr: string): Relation<Object, Object>;
         remove(attr: string, item: any): any;
-        save(attrs?: { [key: string]: any }, options?: Object.SaveOptions): Promise<Object>;
+        save(attrs?: { [key: string]: any } | null, options?: Object.SaveOptions): Promise<Object>;
         save(key: string, value: any, options?: Object.SaveOptions): Promise<Object>;
         set(key: string, value: any, options?: Object.SetOptions): boolean;
         setACL(acl: ACL, options?: SuccessFailureOptions): boolean;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -37,6 +37,8 @@ function test_object() {
 
     var game = new Game();
 
+    game.fetch((g: Game) => {});
+
 // Create a new instance of that class.
     var gameScore = new GameScore();
 
@@ -212,6 +214,10 @@ function test_analytics() {
     Parse.Analytics.track('error', { code: codeString })
 }
 
+function test_relation() {
+    new Parse.User().relation("games").query().find().then((g: Game[]) => {});
+}
+
 function test_user_acl_roles() {
 
     var user = new Parse.User();
@@ -238,11 +244,12 @@ function test_user_acl_roles() {
     var game = new Game();
     game.set("score", new GameScore());
     game.setACL(new Parse.ACL(Parse.User.current()));
-    game.save();
+    game.save().then((game: Game) => {
+    });
 
     var groupACL = new Parse.ACL();
 
-    var userList: Parse.User[] = [Parse.User.current()];
+    var userList: Parse.User[] = [Parse.User.current()!];
     // userList is an array with the users we are sending this message to.
     for (var i = 0; i < userList.length; i++) {
         groupACL.setReadAccess(userList[i], true);
@@ -261,7 +268,7 @@ function test_user_acl_roles() {
 
     // By specifying no write privileges for the ACL, we can ensure the role cannot be altered.
     var role = new Parse.Role("Administrator", groupACL);
-    role.getUsers().add(role);
+    role.getUsers().add(userList[0]);
     role.getRoles().add(role);
     role.save();
 
@@ -292,7 +299,7 @@ function test_facebook_util() {
         }
     });
 
-    var user = Parse.User.current();
+    var user = Parse.User.current()!;
 
     if (!Parse.FacebookUtils.isLinked(user)) {
         Parse.FacebookUtils.link(user, null, {
@@ -342,7 +349,7 @@ function test_geo_points() {
 
     var point = new Parse.GeoPoint({latitude: 40.0, longitude: -30.0});
 
-    var userObject = Parse.User.current();
+    var userObject = Parse.User.current()!;
 
     // User's location
     var userGeoPoint = userObject.get("location");
@@ -357,8 +364,10 @@ function test_geo_points() {
     var southwestOfSF = new Parse.GeoPoint(37.708813, -122.526398);
     var northeastOfSF = new Parse.GeoPoint(37.822802, -122.373962);
 
-    var query = new Parse.Query(PlaceObject);
-    query.withinGeoBox("location", southwestOfSF, northeastOfSF);
+    var query2 = new Parse.Query(PlaceObject);
+    query2.withinGeoBox("location", southwestOfSF, northeastOfSF);
+
+    var query3 = new Parse.Query("PlaceObject").find().then((o: Parse.Object[]) => {});
 }
 
 function test_push() {

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -244,8 +244,8 @@ function test_user_acl_roles() {
     var game = new Game();
     game.set("score", new GameScore());
     game.setACL(new Parse.ACL(Parse.User.current()));
-    game.save().then((game: Game) => {
-    });
+    game.save().then((game: Game) => {});
+    game.save(null, { useMasterKey: true });
 
     var groupACL = new Parse.ACL();
 

--- a/types/parse/tsconfig.json
+++ b/types/parse/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [X] Test the change in your own code. (Compile and run.) (code base of around 20k lines of typescript)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). (many improvements reflect exactly these)
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: See below
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`. Not done because I can't test it because I currently only have node 6.10.0 available which [causes problems](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15564).

### Changes

#### Compatibility with strict null checking

I tried to be permissive to not break existing code wherever I can. I tried it for ~20k lines of typescript and it compiles fine with strict null checking. Still, there might be corner cases missing. I see this as a first step towards a correct coverage of null awareness.

#### Fixes for "common mistakes"

If replaced a lot of idioms like `f<T extends Object>(): T` with the suggested `f(): Object` because of the reasons given in the [common mistakes section](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). For my code, this did not break anything.

#### Improved sub-classing of `Parse.Object`

I used the `this` type in method signatures returning parse objects where-ever possible to improve type inference:

```
new Game().save().then(game => { ... })
```

With the new typing `game` automatically has the correct type `Game`, no explicit typing needed.