### PR TITLE
swagger-node-runner - Fix incorrect API version

### DIFF
--- a/types/swagger-node-runner/index.d.ts
+++ b/types/swagger-node-runner/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for swagger-node-runner 0.7
+// Type definitions for swagger-node-runner 0.5
 // Project: https://www.npmjs.com/package/swagger-node-runner
 // Definitions by: Michael Mrowetz <https://github.com/micmro/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -42,24 +42,28 @@ import * as Restify from "restify";
 export interface Config {
     /** Path to app */
     appRoot: string;
-    /** If `true` API is in mock mode
+    /**
+     * If `true` API is in mock mode
      *
      * default is `false`
      */
     mockMode?: boolean;
-    /** If `true` resonse is validated
+    /**
+     * If `true` resonse is validated
      *
      * default is `true`
      */
     validateResponse?: boolean;
     /** Sets `NODE_CONFIG_DIR` env if not set yet */
     configDir?: string;
-    /** Swagger controller directories
+    /**
+     * Swagger controller directories
      *
      * default is array with `/api/controllers` relative to `appRoot`
      */
     controllersDirs?: string[];
-    /** Swagger mock controller directories
+    /**
+     * Swagger mock controller directories
      *
      * default is array with `/api/mocks` relative to `appRoot`
      */
@@ -70,7 +74,8 @@ export interface Config {
      * default is `[api/fittings]`
      */
     fittingsDirs?: string[];
-    /** Define Middleware for using Swagger security information to authenticate requests. Part of _swagger-tools_
+    /**
+     * Define Middleware for using Swagger security information to authenticate requests. Part of _swagger-tools_
      *
      * default is `undefined`
      * @see {@link https://github.com/apigee-127/swagger-tools/blob/master/middleware/swagger-security.js|Github Source}
@@ -202,7 +207,7 @@ export interface Runner extends EventEmitter {
 
 /** base used by all middleware versions */
 export interface Middleware {
-    /** Back-reference to `Runner` that has created this middleware */
+    /** Back-reference to `swagger-node-runner`s `Runner` that has created this middleware */
     runner: Runner;
 }
 


### PR DESCRIPTION
I had accidentally marked the swagger-node-runner definition as `v0.7` but in fact it was `v0.5`. This PR fixes this, so I can provide typings for the latest version.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/theganyo/swagger-node-runner/blob/v0.5.13/index.js
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.