### PR TITLE
Fix decimal.js es6 default export

### DIFF
--- a/types/decimal.js/index.d.ts
+++ b/types/decimal.js/index.d.ts
@@ -189,6 +189,8 @@ declare namespace decimal {
     }
 
     interface IDecimalStatic extends IDecimalConfig {
+        default: IDecimalStatic;
+
         (value: number | string | Decimal, base?: number): Decimal;
 
         new(value: number | string | Decimal, base?: number): Decimal;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


`decimal.js` supports default export. And it's new es6 version only supports es6 default exports. so this is needed when using rollup or webpack 2.