### PR TITLE
react-native: Added scrollToEnd method on ScrollView

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -2936,6 +2936,16 @@ export interface RecyclerViewBackedScrollViewStatic extends ScrollResponderMixin
         x?: number,
         animated?: boolean
     ): void;
+                    
+    /**
+     * A helper function that scrolls to the end of the scrollview;
+     * If this is a vertical ScrollView, it scrolls to the bottom. 
+     * If this is a horizontal ScrollView scrolls to the right.
+     * 
+     * The options object has an animated prop, that enables the scrolling animation or not.
+     * The animated prop defaults to true
+     */
+    scrollToEnd(options?: {animated: boolean}): void;
 
     /**
      * Returns a reference to the underlying scroll responder, which supports

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -2936,12 +2936,12 @@ export interface RecyclerViewBackedScrollViewStatic extends ScrollResponderMixin
         x?: number,
         animated?: boolean
     ): void;
-                    
+
     /**
      * A helper function that scrolls to the end of the scrollview;
-     * If this is a vertical ScrollView, it scrolls to the bottom. 
+     * If this is a vertical ScrollView, it scrolls to the bottom.
      * If this is a horizontal ScrollView scrolls to the right.
-     * 
+     *
      * The options object has an animated prop, that enables the scrolling animation or not.
      * The animated prop defaults to true
      */


### PR DESCRIPTION
Adds the scrollToEnd method on ScrollView. Mentioned [here](https://facebook.github.io/react-native/docs/scrollview.html#scrolltoend) in the docs.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://facebook.github.io/react-native/docs/scrollview.html#scrolltoend>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.


