### PR TITLE
Changed optional property to required property to sequelize's types

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Sequelize 4.0.0
 // Project: http://sequelizejs.com
-// Definitions by: samuelneff <https://github.com/samuelneff>, Peter Harris <https://github.com/codeanimal>, Ivan Drinchev <https://github.com/drinchev>
+// Definitions by: samuelneff <https://github.com/samuelneff>, Peter Harris <https://github.com/codeanimal>, Ivan Drinchev <https://github.com/drinchev>, Brendan Abolivier <https://github.com/babolivier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -4323,7 +4323,7 @@ declare namespace sequelize {
         /**
          * If this column references another table, provide it here as a Model, or a string
          */
-        model?: string | Model<any, any>;
+        model: string | Model<any, any>;
 
         /**
          * The column of the foreign table that this column references


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.sequelizejs.com/en/v3/api/sequelize/#definemodelname-attributes-options-model
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.


I ran into some issues while using Sequelize with this `.d.ts` file. It seems like I didn't know how to use Sequelize references in the models, and assumed I was doing it right because `tsc` didn't warn me of any wrong parameter, so I didn't understand the runtime errors. I found later that it was because of a wrong parameter, and TypeScript didn't warn me about it because none of the properties were required (which is also opposed to Sequelize's documentation as `attributes.column.references.model` doesn't have a default value and should be provided if `attributes.column.references` is). 