### PR TITLE
Joi: added truthy, falsy, insensitive method definitions to BooleanSchema

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for joi v10.0.0
 // Project: https://github.com/hapijs/joi
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Laurence Dougal Myers <https://github.com/laurence-myers>, Christopher Glantschnig <https://github.com/cglantschnig>, David Broder-Rodgers <https://github.com/DavidBR-SW>, Gael Magnan de Bornier <hhttps://github.com/GaelMagnan>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Laurence Dougal Myers <https://github.com/laurence-myers>, Christopher Glantschnig <https://github.com/cglantschnig>, David Broder-Rodgers <https://github.com/DavidBR-SW>, Gael Magnan de Bornier <hhttps://github.com/GaelMagnan>, Rytis Alekna <hhttps://github.com/ralekna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // TODO express type of Schema in a type-parameter (.default, .valid, .example etc)
@@ -313,6 +313,28 @@ export interface AnySchema<T extends AnySchema<Schema>> {
 
 export interface BooleanSchema extends AnySchema<BooleanSchema> {
 
+    /**
+     * Allows for additional values to be considered valid booleans by converting them to true during validation.
+     * Accepts a value or an array of values. String comparisons are by default case insensitive,
+     * see boolean.insensitive() to change this behavior.
+     * @param values - strings, numbers or arrays of them
+     */
+    truthy(... values: Array<string | number | string[] | number[]>): BooleanSchema;
+
+    /**
+     * Allows for additional values to be considered valid booleans by converting them to false during validation.
+     * Accepts a value or an array of values. String comparisons are by default case insensitive,
+     * see boolean.insensitive() to change this behavior.
+     * @param values - strings, numbers or arrays of them
+     */
+    falsy(... values: Array<string | number | string[] | number[]>): BooleanSchema;
+
+    /**
+     * Allows the values provided to truthy and falsy as well as the "true" and "false" default conversion
+     * (when not in strict() mode) to be matched in a case insensitive manner.
+     * @param enabled
+     */
+    insensitive(enabled: boolean): BooleanSchema;
 }
 
 export interface NumberSchema extends AnySchema<NumberSchema> {

--- a/types/joi/joi-tests.ts
+++ b/types/joi/joi-tests.ts
@@ -345,6 +345,24 @@ namespace common_copy_paste {
 	boolSchema = boolSchema.strict();
 	boolSchema = boolSchema.concat(x);
 
+	boolSchema = boolSchema.truthy(str);
+	boolSchema = boolSchema.truthy(num);
+	boolSchema = boolSchema.truthy(strArr);
+	boolSchema = boolSchema.truthy(numArr);
+	boolSchema = boolSchema.truthy(str, str);
+	boolSchema = boolSchema.truthy(strArr, str);
+	boolSchema = boolSchema.truthy(str, strArr);
+	boolSchema = boolSchema.truthy(strArr, strArr);
+	boolSchema = boolSchema.falsy(str);
+	boolSchema = boolSchema.falsy(num);
+	boolSchema = boolSchema.falsy(strArr);
+	boolSchema = boolSchema.falsy(numArr);
+	boolSchema = boolSchema.falsy(str, str);
+	boolSchema = boolSchema.falsy(strArr, str);
+	boolSchema = boolSchema.falsy(str, strArr);
+	boolSchema = boolSchema.falsy(strArr, strArr);
+	boolSchema = boolSchema.insensitive(bool);
+
 	altSchema = boolSchema.when(str, whenOpts);
 	altSchema = boolSchema.when(ref, whenOpts);
 }


### PR DESCRIPTION
Joi: added truthy, falsy, insensitive method definitions to BooleanSchema

These new methods were added in this commit: https://github.com/hapijs/joi/commit/752cf85b510386936b48565a1666e8759c677d56

Tests for new methods created, all passing.

CC: @Bartvds , @cglantschnig , @DavidBR-SW , @GaelMagnan , @laurence-myers