### PR TITLE
Fixed ref definition in react-notifcation-system

### DIFF
--- a/types/react-notification-system/index.d.ts
+++ b/types/react-notification-system/index.d.ts
@@ -68,9 +68,8 @@ declare namespace NotificationSystem {
         ActionWrapper?: WrapperStyle;
     }
 
-    export interface Attributes {
+    export interface Attributes extends React.ClassAttributes<System> {
         noAnimation?: boolean;
-        ref?: string | ((instance: System) => any);
         style?: Style | boolean;
         allowHTML?: boolean;
     }

--- a/types/react-notification-system/index.d.ts
+++ b/types/react-notification-system/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for React Notification System 0.2
 // Project: https://www.npmjs.com/package/react-notification-system
-// Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>, Deividas Bakanas <https://github.com/DeividasBakanas>, Karol Janyst <https://github.com/LKay>
+// Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>, Deividas Bakanas <https://github.com/DeividasBakanas>, Karol Janyst <https://github.com/LKay>, Bartosz Szewczyk <https://github.com/sztobar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -8,7 +8,7 @@ import * as React from "react";
 
 declare namespace NotificationSystem {
 
-    export interface System extends React.Component<any, any> {
+    export interface System extends React.Component<Attributes, State> {
         addNotification(notification: Notification): Notification;
         removeNotification(uidOrNotification: number | string | Notification): void;
         clearNotifications(): void;
@@ -70,9 +70,13 @@ declare namespace NotificationSystem {
 
     export interface Attributes {
         noAnimation?: boolean;
-        ref?: string;
+        ref?: string | ((instance: System) => any);
         style?: Style | boolean;
         allowHTML?: boolean;
+    }
+
+    export interface State {
+        notifications: Notification[]
     }
 }
 

--- a/types/react-notification-system/react-notification-system-tests.ts
+++ b/types/react-notification-system/react-notification-system-tests.ts
@@ -21,7 +21,6 @@ class MyComponent extends React.Component<any, any> {
     }
 
     componentDidMount() {
-        this.notificationSystem = this.refs['notificationSystem'] as NotificationSystem.System;
         this.addNotification();
     }
 
@@ -54,6 +53,10 @@ class MyComponent extends React.Component<any, any> {
             }
         };
 
-        return React.createElement(NotificationSystem, { title: "NotificationTitile", style: style, } as NotificationSystem.Attributes);
+        var ref = (instance: NotificationSystem.System) => {
+            this.notificationSystem = instance
+        }
+
+        return React.createElement(NotificationSystem, { title: "NotificationTitile", style: style, ref: ref } as NotificationSystem.Attributes);
     }
 }

--- a/types/react-notification-system/react-notification-system-tests.tsx
+++ b/types/react-notification-system/react-notification-system-tests.tsx
@@ -1,11 +1,11 @@
-import React = require('react');
-import NotificationSystem = require('react-notification-system');
-
+import * as React from 'react';
+import * as NotificationSystem from 'react-notification-system';
 
 class MyComponent extends React.Component<any, any> {
     private notificationSystem: NotificationSystem.System = null;
 
     private notification: NotificationSystem.Notification = {
+        title: 'Notification title',
         message: 'Notification message',
         level: 'success',
         action: {
@@ -26,7 +26,7 @@ class MyComponent extends React.Component<any, any> {
 
     render() {
 
-        var style = {
+        const style: NotificationSystem.Style = {
             NotificationItem: { // Override the notification item
                 DefaultStyle: { // Applied to every notification, regardless of the notification level
                     margin: '10px 5px 2px 1px'
@@ -38,8 +38,9 @@ class MyComponent extends React.Component<any, any> {
             }
         };
 
-        var attributes: NotificationSystem.Attributes = {
+        const attributes: NotificationSystem.Attributes = {
             style: {
+                ...style,
                 Containers: {
                     DefaultStyle: {
                         margin: '10px 5px 2px 1px'
@@ -53,10 +54,12 @@ class MyComponent extends React.Component<any, any> {
             }
         };
 
-        var ref = (instance: NotificationSystem.System) => {
+        const ref = (instance: NotificationSystem.System) => {
             this.notificationSystem = instance
         }
 
-        return React.createElement(NotificationSystem, { title: "NotificationTitile", style: style, ref: ref } as NotificationSystem.Attributes);
+        return (
+            <NotificationSystem style={style} ref={ref}/>
+        )
     }
 }

--- a/types/react-notification-system/tsconfig.json
+++ b/types/react-notification-system/tsconfig.json
@@ -14,10 +14,11 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
     },
     "files": [
         "index.d.ts",
-        "react-notification-system-tests.ts"
+        "react-notification-system-tests.tsx"
     ]
 }


### PR DESCRIPTION
* String refs in React are considered legacy: https://facebook.github.io/react/docs/refs-and-the-dom.html#legacy-api-string-refs
* Updated `ref` definition to use callback pattern with proper type in the argument so that type casting won't be necessary
* string option in `ref` is left for backwards compatibility just like in React package
* added Attributes and State to NotificationSystem.System