### PR TITLE
fix(ioredis): allow RedisOptions.retryStrategy to return false

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -662,7 +662,11 @@ declare module IORedis {
          */
         enableReadyCheck?: boolean;
         keyPrefix?: string;
-        retryStrategy?: (times: number) => number;
+        /**
+         * When the return value isn't a number, ioredis will stop trying to reconnect.
+         * Fixed in: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15858
+         */
+        retryStrategy?: (times: number) => number | false;
         reconnectOnError?: (error: Error) => boolean;
         /**
          * By default, if there is no active connection to the Redis server, commands are added to a queue

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -29,7 +29,8 @@ new Redis({
     host: '127.0.0.1',   // Redis host
     family: 4,           // 4 (IPv4) or 6 (IPv6)
     password: 'auth',
-    db: 0
+    db: 0,
+    retryStrategy: function() { return false; }
 })
 
 var pub = new Redis();


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/luin/ioredis/tree/master#auto-reconnect
  - > When the return value isn't a number, ioredis will stop trying to reconnect
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
