### PR TITLE
react-router: Allow empty props on route component.

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -61,7 +61,7 @@ declare module 'react-router' {
 
   interface RouteProps {
     location?: H.Location;
-    component?: React.SFC<RouteComponentProps<any> | void> | React.ComponentClass<RouteComponentProps<any> | void>;
+    component?: React.SFC<RouteComponentProps<any> | void | {}> | React.ComponentClass<RouteComponentProps<any> | void | {}>;
     render?: (props: RouteComponentProps<any>) => React.ReactNode;
     children?: (props: RouteComponentProps<any>) => React.ReactNode | React.ReactNode;
     path?: string;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -61,7 +61,7 @@ declare module 'react-router' {
 
   interface RouteProps {
     location?: H.Location;
-    component?: React.SFC<RouteComponentProps<any> | void | {}> | React.ComponentClass<RouteComponentProps<any> | void | {}>;
+    component?: React.SFC<void | {}> | React.ComponentClass<void | {}>;
     render?: (props: RouteComponentProps<any>) => React.ReactNode;
     children?: (props: RouteComponentProps<any>) => React.ReactNode | React.ReactNode;
     path?: string;

--- a/types/react-router/test/EmptyObjectProps.tsx
+++ b/types/react-router/test/EmptyObjectProps.tsx
@@ -19,7 +19,7 @@ class EmptyPropsClassComponent extends React.Component<{}, void> {
   }
 }
 
-const ConnectedComponent = connect(() => ({}), {})((props) => {
+const ConnectedComponent = connect(() => ({}), () => ({}))((props) => {
   return <div>
     <h2>Empty Props Connected Class</h2>
   </div>

--- a/types/react-router/test/EmptyObjectProps.tsx
+++ b/types/react-router/test/EmptyObjectProps.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import {
+  BrowserRouter as Router,
+  Route
+} from 'react-router-dom'
+import { connect } from "react-redux"
+
+const EmptyPropsSfc = (props: {}) => (
+  <div>
+    <h2>Empty Props SFC</h2>
+  </div>
+)
+
+class EmptyPropsClassComponent extends React.Component<{}, void> {
+  render() {
+    return <div>
+      <h2>Empty Props Class</h2>
+    </div>
+  }
+}
+
+const ConnectedComponent = connect(() => ({}), {})((props) => {
+  return <div>
+    <h2>Empty Props Connected Class</h2>
+  </div>
+})
+
+const Routing = () => (
+  // Cannot pass this component.
+  <Router>
+    <Route path="/sfc" component={EmptyPropsSfc} />
+    <Route path="/class" component={EmptyPropsClassComponent} />
+    <Route path="/connected" component={ConnectedComponent} />
+  </Router>
+)

--- a/types/react-router/test/EmptyObjectProps.tsx
+++ b/types/react-router/test/EmptyObjectProps.tsx
@@ -26,7 +26,6 @@ const ConnectedComponent = connect(() => ({}), () => ({}))((props) => {
 })
 
 const Routing = () => (
-  // Cannot pass this component.
   <Router>
     <Route path="/sfc" component={EmptyPropsSfc} />
     <Route path="/class" component={EmptyPropsClassComponent} />

--- a/types/react-router/test/RouterComponentProps.tsx
+++ b/types/react-router/test/RouterComponentProps.tsx
@@ -5,6 +5,8 @@ import {
 } from 'react-router-dom'
 import { connect } from "react-redux"
 
+// Empty Props
+
 const EmptyPropsSfc = (props: {}) => (
   <div>
     <h2>Empty Props SFC</h2>
@@ -18,6 +20,8 @@ class EmptyPropsClassComponent extends React.Component<{}, void> {
     </div>
   }
 }
+
+// Redux connect Props
 
 const ConnectedComponent = connect(() => ({}), () => ({}))((props) => {
   return <div>

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -19,7 +19,7 @@
     "test/Auth.tsx",
     "test/Basic.tsx",
     "test/CustomLink.tsx",
-    "test/EmptyObjectProps.tsx",
+    "test/RouterComponentProps.tsx",
     "test/ModalGallery.tsx",
     "test/NavigateWithContext.tsx",
     "test/MemoryRouter.tsx",

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -19,6 +19,7 @@
     "test/Auth.tsx",
     "test/Basic.tsx",
     "test/CustomLink.tsx",
+    "test/EmptyObjectProps.tsx",
     "test/ModalGallery.tsx",
     "test/NavigateWithContext.tsx",
     "test/MemoryRouter.tsx",


### PR DESCRIPTION
I use this definition with `react-redux` and I got some confuse.

```js
// For example
import * as React from 'react'
import {
  BrowserRouter as Router,
  Route,
  LinkProps,
  Link
} from 'react-router-dom'
import { connect } from 'react-redux'

const ConnectedContainer = connect(() => ({}), () => ({}))( props => <div>foo</div>)
// Update: First times my example `connect({}, {})` was incorrect and fix it. 

const Routing = () => (
  // Cannot pass this component.
  <Route path="/" compnent={ConnectedContainer} />
)
```



It's can pass with 
`const ConnectedContainer = connect<{}, {}, void>({}, {})( props => <div>foo</div>)`
but I think it is so confusable and redundant.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: no url
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "../tslint.json" }`.
