### PR TITLE
swagger-schema-official: fix Schema.additionalProperties (boolean -> Schema)

### DIFF
--- a/types/swagger-schema-official/index.d.ts
+++ b/types/swagger-schema-official/index.d.ts
@@ -140,7 +140,7 @@ export interface BaseSchema {
 export interface Schema extends BaseSchema {
   $ref?: string;
   allOf?: Schema[];
-  additionalProperties?: boolean;
+  additionalProperties?: Schema;
   properties?: {[propertyName: string]: Schema};
   discriminator?: string;
   readOnly?: boolean;

--- a/types/swagger-schema-official/index.d.ts
+++ b/types/swagger-schema-official/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for swagger-schema-official 2.0
 // Project: http://swagger.io/specification/
-// Definitions by: Mohsen Azimi <https://github.com/mohsen1>
+// Definitions by: Mohsen Azimi <https://github.com/mohsen1>, Ben Southgate <https://github.com/bsouthga>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Info {


### PR DESCRIPTION
This change swiches the type of `Schema.additionalProperties` from `boolean` to `Schema` to align with the definition provided in the [OpenAPI Spec here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#model-with-mapdictionary-properties) and the [Swagger Spec here](http://swagger.io/specification/#model-with-map-dictionary-properties-88)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#model-with-mapdictionary-properties
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
