### PR TITLE
[material-ui] Improve DatePicker types

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -2066,6 +2066,11 @@ declare module 'material-ui/DatePicker' {
     export default DatePicker;
 }
 
+declare module 'material-ui/DatePicker/DatePickerDialog' {
+    export import DatePickerDialog = __MaterialUI.DatePicker.DatePickerDialog;
+    export default DatePickerDialog;
+}
+
 declare module 'material-ui/Dialog' {
     export import Dialog = __MaterialUI.Dialog;
     export default Dialog;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for material-ui v0.17.1
+// Type definitions for material-ui v0.17.4
 // Project: https://github.com/callemall/material-ui
-// Definitions by: Nathan Brown <https://github.com/ngbrown>, Oliver Herrmann <https://github.com/herrmanno>, Igor Belagorudsky <https://github.com/theigor>, Daniel Roth <https://github.com/DaIgeb>
+// Definitions by: Nathan Brown <https://github.com/ngbrown>, Igor Belagorudsky <https://github.com/theigor>, Ali Taheri Moghaddar <https://github.com/alitaheri>, Oliver Herrmann <https://github.com/herrmanno>, Daniel Roth <https://github.com/DaIgeb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -531,6 +531,17 @@ declare namespace __MaterialUI {
             vertical: vertical;
         }
 
+        interface utils {
+            getWeekArray: (date: Date, firstDayOfWeek: number) => (Date | null)[][];
+            getYear: (date: Date) => number;
+            setYear: (date: Date, year: number) => Date;
+            addDays: (date: Date, days: number) => Date;
+            addMonths: (date: Date, months: number) => Date;
+            addYears: (date: Date, years: number) => Date;
+            getFirstDayOfMonth: (date: Date) => Date;
+            monthDiff: (date1: Date, date2: Date) => number;
+        }
+
         type corners = 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
         type cornersAndCenter = 'bottom-center' | 'bottom-left' | 'bottom-right' | 'top-center' | 'top-left' | 'top-right';
     }
@@ -869,7 +880,7 @@ declare namespace __MaterialUI {
     namespace DatePicker {
         interface DatePickerProps {
             // <TextField/> is the element that get the 'other' properties
-            DateTimeFormat?: Intl.DateTimeFormat;
+            DateTimeFormat?: typeof Intl.DateTimeFormat;
             autoOk?: boolean;
             cancelLabel?: React.ReactNode;
             container?: "dialog" | "inline";
@@ -916,13 +927,14 @@ declare namespace __MaterialUI {
             underlineFocusStyle?: React.CSSProperties;
             underlineShow?: boolean;
             underlineStyle?: React.CSSProperties;
+            utils?: propTypes.utils;
         }
         export class DatePicker extends React.Component<DatePickerProps, {}> {
         }
 
         interface DatePickerDialogProps {
             // <Container/> is the element that get the 'other' properties
-            DateTimeFormat?: Intl.DateTimeFormat;
+            DateTimeFormat?: typeof Intl.DateTimeFormat;
             animation?: React.ComponentClass<Popover.PopoverAnimationProps>;
             autoOk?: boolean;
             cancelLabel?: React.ReactNode;
@@ -940,8 +952,11 @@ declare namespace __MaterialUI {
             onShow?: () => void;
             shouldDisableDate?: (day: Date) => boolean;
             style?: React.CSSProperties;
+            utils?: propTypes.utils;
         }
         export class DatePickerDialog extends React.Component<DatePickerDialogProps, {}> {
+            public show(): void;
+            public dismiss(): void;
         }
     }
 

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -1244,12 +1244,11 @@ const DatePickerExampleDisableDates = () => (
   </div>
 );
 
-let DateTimeFormat = new Intl.DateTimeFormat('fr');
 const DatePickerExampleInternational = () => (
   <div>
     <DatePicker
       hintText="fr locale"
-      DateTimeFormat={DateTimeFormat}
+      DateTimeFormat={Intl.DateTimeFormat}
       okLabel="OK"
       cancelLabel="Annuler"
       locale="fr"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

# Summery

This PR fixes a few issues with the DatePicker typings:

1. `DateTimeFormat` prop **should** an instantiatable class not an instance!
2. `DatePickerDialog` exposes 2 crucial methods `show` and `dismiss`. They are needed for customized DatePickers.
3. With my recent pull request ( not in 0.17.4, but the docs aren't updated yet) a new prop called `utils` was introduced that enables customizing the calendar system of the DatePicker.

Related: https://github.com/callemall/material-ui/pull/6565
