### PR TITLE
L.mapbox.accessToken is no longer a const but instead a settable vari…

### DIFF
--- a/types/mapbox/index.d.ts
+++ b/types/mapbox/index.d.ts
@@ -14,7 +14,7 @@ declare global {
 		// Map
 		//////////////////////////////////////////////////////////////////////
 
-		const accessToken: string;
+		let accessToken: string;
 
 		/**
 		 * Create and automatically configure a map with layers, markers, and interactivity.

--- a/types/mapbox/mapbox-tests.ts
+++ b/types/mapbox/mapbox-tests.ts
@@ -37,3 +37,6 @@ const marker2 = L.mapbox.featureLayer({
 marker2.eachLayer((marker: L.Marker) => {
   marker.openPopup();
 });
+
+// Can set the API key via left hand assignment
+L.mapbox.accessToken = "keyGoesHere";


### PR DESCRIPTION
L.mapbox.accessToken is now set-able for left hand assignment as opposed
to being a const. This matches the mapbox-gl typescript definition now
and the intended behavior of mapbox (js).

This solves the issue raised here:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15898
