### PR TITLE
Add unmount method declaration to the react-test-renderer package

### DIFF
--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-test-renderer 15.4
 // Project: https://facebook.github.io/react/
-// Definitions by: Arvitaly <https://github.com/arvitaly>
+// Definitions by: Arvitaly <https://github.com/arvitaly>, Lochbrunner <https://github.com/lochbrunner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -8,6 +8,7 @@ import { ReactElement } from "react";
 
 export interface Renderer {
     toJSON(): ReactTestRendererJSON;
+    unmount(nextElement: any): void;
 }
 export interface ReactTestRendererJSON {
     type: string;

--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -8,7 +8,7 @@ import { ReactElement } from "react";
 
 export interface Renderer {
     toJSON(): ReactTestRendererJSON;
-    unmount(nextElement: any): void;
+    unmount(nextElement?: ReactElement<any>): void;
 }
 export interface ReactTestRendererJSON {
     type: string;


### PR DESCRIPTION
# Add unmount method declaration to the react-test-renderer package.

Declaration according to: https://github.com/facebook/react/blob/b1b4a2fb252f26fe10d29ba60d85ff89a85ff3ec/src/renderers/testing/stack/ReactTestMount.js#L122