### PR TITLE
radium: Add radiumConfig prop to StyleRoot

### DIFF
--- a/types/radium/index.d.ts
+++ b/types/radium/index.d.ts
@@ -44,7 +44,7 @@ declare namespace Radium {
      * StyleRoot component properties
      */
     export interface StyleRootProps extends React.HTMLProps<StyleRoot> {
-         radiumConfig: RadiumConfig
+         radiumConfig?: RadiumConfig
     }
     /**
      * <StyleRoot />

--- a/types/radium/index.d.ts
+++ b/types/radium/index.d.ts
@@ -44,6 +44,7 @@ declare namespace Radium {
      * StyleRoot component properties
      */
     export interface StyleRootProps extends React.HTMLProps<StyleRoot> {
+         radiumConfig: RadiumConfig
     }
     /**
      * <StyleRoot />

--- a/types/radium/radium-tests.tsx
+++ b/types/radium/radium-tests.tsx
@@ -5,19 +5,19 @@ import * as Radium from 'radium';
 @Radium
 class TestComponent extends React.Component<{ a: number }, any> {
 
-	render() {
-		return (
-			<div >
-				Test with Radium
+    render() {
+        return (
+            <div >
+                Test with Radium
 			</div>
-		);
-	}
+        );
+    }
 }
 
-let TestStatelessComponent = (props: { a: number }) => <div/>;
+let TestStatelessComponent = (props: { a: number }) => <div />;
 TestStatelessComponent = Radium(TestStatelessComponent);
 
-<TestStatelessComponent a={5}/>
+<TestStatelessComponent a={5} />
 
 
 @Radium({
@@ -38,19 +38,52 @@ class TestComponentWithConfig extends React.Component<{ a?: number }, {}> {
                                 textAlign: "center"
                             }
                         }}
-                        >
+                    >
                     </Style>
                     <Style scopeSelector="test"
                         rules={{
                             background: "green"
                         }}
-                        >
+                    >
                     </Style>
                 </Radium.StyleRoot>
             </div>
         )
     }
 }
-<TestComponentWithConfig a={5}/>
+<TestComponentWithConfig a={5} />
+
+class TestComponentWithConfigInStyleRoot
+    extends React.Component<{ a?: number }, {}> {
+    render() {
+        return (
+            <div>
+                <Radium.StyleRoot radiumConfig={{
+                    userAgent: "test",
+                    matchMedia: window.matchMedia
+                }} >
+                    <Style scopeSelector="test"
+                        rules={{
+                            a: {
+                                background: "green"
+                            },
+                            body: {
+                                textAlign: "center"
+                            }
+                        }}
+                    >
+                    </Style>
+                    <Style scopeSelector="test"
+                        rules={{
+                            background: "green"
+                        }}
+                    >
+                    </Style>
+                </Radium.StyleRoot>
+            </div>
+        )
+    }
+}
+<TestComponentWithConfigInStyleRoot a={5} />
 
 Radium.TestMode.enable();


### PR DESCRIPTION
This PR fixes errors when trying to pass `radiumConfig` as a prop to `StyleRoot`. This is used mostly in server rendering.

The [offical docs](https://github.com/FormidableLabs/radium/tree/master/docs/api#styleroot-component) say of the props for StyleRoot (empasis mine)

> Accepts all props valid on div and **optional radiumConfig**
