### PR TITLE
Add missing "multiple" prop to SelectField of material-ui

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1327,6 +1327,7 @@ declare namespace __MaterialUI {
         iconStyle?: React.CSSProperties;
         id?: string;
         labelStyle?: React.CSSProperties;
+        multiple?: boolean;
         onBlur?: React.FocusEventHandler<{}>;
         onChange?: (e: TouchTapEvent, index: number, menuItemValue: any) => void;
         onFocus?: React.FocusEventHandler<{}>;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1332,6 +1332,7 @@ declare namespace __MaterialUI {
         onChange?: (e: TouchTapEvent, index: number, menuItemValue: any) => void;
         onFocus?: React.FocusEventHandler<{}>;
         selectFieldRoot?: React.CSSProperties;
+        selectionRenderer?: (value: any) => React.ReactNode;
         style?: React.CSSProperties;
         underlineDisabledStyle?: React.CSSProperties;
         underlineFocusStyle?: React.CSSProperties;

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -3454,6 +3454,55 @@ class SelectFieldExampleError extends React.Component<{}, {value?: number}> {
   }
 }
 
+const names = [
+  'Oliver Hansen',
+  'Van Henry',
+  'April Tucker',
+  'Ralph Hubbard',
+  'Omar Alexander',
+  'Carlos Abbott',
+  'Miriam Wagner',
+  'Bradley Wilkerson',
+  'Virginia Andrews',
+  'Kelly Snyder',
+];
+
+class SelectFieldExampleMultiSelect extends React.Component<{}, {values?: string[]}> {
+
+  constructor(props) {
+    super(props);
+    this.state = {values: []};
+  }
+
+  handleChange = (event, index, values) => this.setState({values});
+
+  menuItems(values) {
+    return names.map((name) => (
+      <MenuItem
+        key={name}
+        insetChildren={true}
+        checked={values && values.includes(name)}
+        value={name}
+        primaryText={name}
+      />
+    ));
+  }
+
+  render() {
+    const {values} = this.state;
+    return (
+      <SelectField
+        multiple={true}
+        hintText="Select a name"
+        value={values}
+        onChange={this.handleChange}
+      >
+        {this.menuItems(values)}
+      </SelectField>
+    );
+  }
+}
+
 
 // "http://www.material-ui.com/#/components/slider"
 const SliderExampleSimple = () => (

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -3503,6 +3503,66 @@ class SelectFieldExampleMultiSelect extends React.Component<{}, {values?: string
   }
 }
 
+const persons = [
+  {value: 0, name: 'Oliver Hansen'},
+  {value: 1, name: 'Van Henry'},
+  {value: 2, name: 'April Tucker'},
+  {value: 3, name: 'Ralph Hubbard'},
+  {value: 4, name: 'Omar Alexander'},
+  {value: 5, name: 'Carlos Abbott'},
+  {value: 6, name: 'Miriam Wagner'},
+  {value: 7, name: 'Bradley Wilkerson'},
+  {value: 8, name: 'Virginia Andrews'},
+  {value: 9, name: 'Kelly Snyder'},
+];
+
+class SelectFieldExampleSelectionRenderer extends React.Component<{}, {values?: string[]}> {
+
+  constructor(props) {
+    super(props);
+    this.state = {values: []};
+  }
+
+  handleChange = (event, index, values) => this.setState({values});
+
+  selectionRenderer = (values) => {
+    switch (values.length) {
+      case 0:
+        return '';
+      case 1:
+        return persons[values[0]].name;
+      default:
+        return `${values.length} names selected`;
+    }
+  }
+
+  menuItems(persons) {
+    return persons.map((person) => (
+      <MenuItem
+        key={person.value}
+        insetChildren={true}
+        checked={this.state.values.indexOf(person.value) >= 0}
+        value={person.value}
+        primaryText={person.name}
+      />
+    ));
+  }
+
+  render() {
+    return (
+      <SelectField
+        multiple={true}
+        hintText="Select a name"
+        value={this.state.values}
+        onChange={this.handleChange}
+        selectionRenderer={this.selectionRenderer}
+      >
+        {this.menuItems(persons)}
+      </SelectField>
+    );
+  }
+}
+
 
 // "http://www.material-ui.com/#/components/slider"
 const SliderExampleSimple = () => (


### PR DESCRIPTION
material-ui's SelectField component has a boolean prop named `multiple`.
It enables SelectField select multiple items.
However, current definition lacks it.
This PR adds `multiple` to `SelectFieldProps`.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://www.material-ui.com/#/components/select-field>>