### PR TITLE
Updating template function defintion

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -152,7 +152,7 @@ export interface TimelineOptions {
   groupEditable?: TimelineOptionsGroupEditableType;
   groupOrder?: TimelineOptionsGroupOrderType;
   groupOrderSwap?: TimelineOptionsGroupOrderSwapFunction;
-  groupTemplate?(): void; // TODO
+  groupTemplate?(item?: any, element?: any, data?: any): any;
   height?: HeightWidthType;
   hiddenDates?: any; // TODO
   horizontalScroll?: boolean;
@@ -187,7 +187,7 @@ export interface TimelineOptions {
   stack?: boolean;
   snap?: TimelineOptionsSnapFunction;
   start?: DateType;
-  template?(): void; // TODO
+  template?(item?: any, element?: any, data?: any): any;
   throttleRedraw?: number;
   timeAxis?: TimelineTimeAxisOption;
   type?: string;

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -152,7 +152,7 @@ export interface TimelineOptions {
   groupEditable?: TimelineOptionsGroupEditableType;
   groupOrder?: TimelineOptionsGroupOrderType;
   groupOrderSwap?: TimelineOptionsGroupOrderSwapFunction;
-  groupTemplate?: (item?: any, element?: any, data?: any) => any;
+  groupTemplate?(item?: any, element?: any, data?: any): any;
   height?: HeightWidthType;
   hiddenDates?: any; // TODO
   horizontalScroll?: boolean;
@@ -187,7 +187,7 @@ export interface TimelineOptions {
   stack?: boolean;
   snap?: TimelineOptionsSnapFunction;
   start?: DateType;
-  template?: (item?: any, element?: any, data?: any) => any;
+  template?(item?: any, element?: any, data?: any): any;
   throttleRedraw?: number;
   timeAxis?: TimelineTimeAxisOption;
   type?: string;

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -152,7 +152,7 @@ export interface TimelineOptions {
   groupEditable?: TimelineOptionsGroupEditableType;
   groupOrder?: TimelineOptionsGroupOrderType;
   groupOrderSwap?: TimelineOptionsGroupOrderSwapFunction;
-  groupTemplate?(item?: any, element?: any, data?: any): any;
+  groupTemplate?: (item?: any, element?: any, data?: any) => any;
   height?: HeightWidthType;
   hiddenDates?: any; // TODO
   horizontalScroll?: boolean;
@@ -187,7 +187,7 @@ export interface TimelineOptions {
   stack?: boolean;
   snap?: TimelineOptionsSnapFunction;
   start?: DateType;
-  template?(item?: any, element?: any, data?: any): any;
+  template?: (item?: any, element?: any, data?: any) => any;
   throttleRedraw?: number;
   timeAxis?: TimelineTimeAxisOption;
   type?: string;


### PR DESCRIPTION
As mentioned [here](https://github.com/seveves/ng2-vis/issues/32) there is a problem with the definition of the template functions. We really should allow any as a return value because you can return a string, Handlebars, mustache or even react templates. As you can see [here](http://visjs.org/docs/timeline/#Templates) the template function always has three parameters. I made them optional because you don't have to use them at all.
