### PR TITLE
[pg] Add the error parameter to Client.release

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -87,7 +87,7 @@ export declare class Client extends events.EventEmitter {
 
     connect(callback?: (err: Error) => void): void;
     end(callback?: (err: Error) => void): void;
-    release(): void;
+    release(err?: Error): void;
 
     query(queryStream: QueryConfig & stream.Readable): stream.Readable;
     query(queryTextOrConfig: string | QueryConfig): Promise<QueryResult>;


### PR DESCRIPTION
Client.release accepts an optional error parameter to destroy the client instead of returning it to the pool in case of failure. This PR adds this parameter.

Source:
```js
client.release = function (err) {
  delete client.release
  if (err) {
    this.log('destroy client. error:', err)
    this.pool.destroy(client)
  } else {
    this.log('release client')
    this.pool.release(client)
  }
}.bind(this)
```

https://github.com/brianc/node-pg-pool/blob/master/index.js#L125


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/brianc/node-pg-pool/blob/master/index.js#L125
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

