### PR TITLE
Moved method scrollToEnd to correct interface

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -2937,16 +2937,6 @@ export interface RecyclerViewBackedScrollViewStatic extends ScrollResponderMixin
     ): void;
 
     /**
-     * A helper function that scrolls to the end of the scrollview;
-     * If this is a vertical ScrollView, it scrolls to the bottom.
-     * If this is a horizontal ScrollView scrolls to the right.
-     *
-     * The options object has an animated prop, that enables the scrolling animation or not.
-     * The animated prop defaults to true
-     */
-    scrollToEnd(options?: {animated: boolean}): void;
-
-    /**
      * Returns a reference to the underlying scroll responder, which supports
      * operations like `scrollTo`. All ScrollView-like components should
      * implement this method so that they can be composed while providing access
@@ -5941,6 +5931,16 @@ interface ScrollViewStatic extends ScrollResponderMixin, React.ComponentClass<Sc
         x?: number,
         animated?: boolean
     ): void;
+
+    /**
+     * A helper function that scrolls to the end of the scrollview;
+     * If this is a vertical ScrollView, it scrolls to the bottom.
+     * If this is a horizontal ScrollView scrolls to the right.
+     *
+     * The options object has an animated prop, that enables the scrolling animation or not.
+     * The animated prop defaults to true
+     */
+    scrollToEnd(options?: {animated: boolean}): void;
 
     /**
      * Returns a reference to the underlying scroll responder, which supports


### PR DESCRIPTION
Moved scrollToEnd from RecyclerViewBackedScrollViewStatic to ScrollViewStatic

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).