### PR TITLE
babel-types: fix use of Pattern type definition

### DIFF
--- a/types/babel-types/babel-types-tests.ts
+++ b/types/babel-types/babel-types-tests.ts
@@ -14,6 +14,9 @@ traverse(ast, {
         if (t.isIdentifier(node, { name: "n" })) {
             node.name = "x";
         }
+        if (t.isFunctionExpression(node)) {
+            node.params = [t.identifier('param')];
+        }
     }
 });
 

--- a/types/babel-types/index.d.ts
+++ b/types/babel-types/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for babel-types v6.7
 // Project: https://github.com/babel/babel/tree/master/packages/babel-types
-// Definitions by: Troy Gerwien <https://github.com/yortus>
+// Definitions by: Troy Gerwien <https://github.com/yortus>, Sam Baxter <https://github.com/baxtersa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Comment {
@@ -88,7 +88,7 @@ export interface CallExpression extends Node {
 
 export interface CatchClause extends Node {
     type: "CatchClause";
-    param: Pattern;
+    param: Identifier;
     body: BlockStatement;
 }
 
@@ -148,7 +148,7 @@ export interface ForStatement extends Node {
 export interface FunctionDeclaration extends Node {
     type: "FunctionDeclaration";
     id: Identifier;
-    params: Pattern[];
+    params: Array<LVal>;
     body: BlockStatement;
     generator: boolean;
     async: boolean;
@@ -159,7 +159,7 @@ export interface FunctionDeclaration extends Node {
 export interface FunctionExpression extends Node {
     type: "FunctionExpression";
     id: Identifier;
-    params: Pattern[];
+    params: Array<LVal>;
     body: BlockStatement;
     generator: boolean;
     async: boolean;
@@ -252,7 +252,7 @@ export interface ObjectMethod extends Node {
     value: Expression;
     decorators?: Decorator[];
     id: Identifier;
-    params: Pattern[];
+    params: Array<LVal>;
     body: BlockStatement;
     generator: boolean;
     async: boolean;
@@ -353,20 +353,20 @@ export interface WithStatement extends Node {
 
 export interface AssignmentPattern extends Node {
     type: "AssignmentPattern";
-    left: Pattern;
+    left: Identifier;
     right: Expression;
 }
 
 export interface ArrayPattern extends Node {
     type: "ArrayPattern";
-    elements: Array<Pattern>;
+    elements: Array<Expression>;
     typeAnnotation?: TypeAnnotation;
 }
 
 export interface ArrowFunctionExpression extends Node {
     type: "ArrowFunctionExpression";
     id: Identifier;
-    params: Pattern[];
+    params: Array<LVal>;
     body: BlockStatement | Expression;
     generator: boolean;
     async: boolean;
@@ -472,7 +472,7 @@ export interface ClassMethod extends Node {
     static: boolean;
     decorators?: Decorator[];
     id: Identifier;
-    params: Pattern[];
+    params: Array<LVal>;
     body: BlockStatement;
     generator: boolean;
     async: boolean;
@@ -925,8 +925,8 @@ export function expressionStatement(expression?: Expression): ExpressionStatemen
 export function file(program?: Program, comments?: Comment[], tokens?: any[]): File;
 export function forInStatement(left?: VariableDeclaration | LVal, right?: Expression, body?: Statement): ForInStatement;
 export function forStatement(init?: VariableDeclaration | Expression, test?: Expression, update?: Expression, body?: Statement): ForStatement;
-export function functionDeclaration(id?: Identifier, params?: Pattern[], body?: BlockStatement, generator?: boolean, async?: boolean): FunctionDeclaration;
-export function functionExpression(id?: Identifier, params?: Pattern[], body?: BlockStatement, generator?: boolean, async?: boolean): FunctionExpression;
+export function functionDeclaration(id?: Identifier, params?: Array<LVal>, body?: BlockStatement, generator?: boolean, async?: boolean): FunctionDeclaration;
+export function functionExpression(id?: Identifier, params?: Array<LVal>, body?: BlockStatement, generator?: boolean, async?: boolean): FunctionExpression;
 export function identifier(name?: string): Identifier;
 export function ifStatement(test?: Expression, consequent?: Statement, alternate?: Statement): IfStatement;
 export function labeledStatement(label?: Identifier, body?: Statement): LabeledStatement;
@@ -940,7 +940,7 @@ export function memberExpression(object?: Expression | Super, property?: Express
 export function newExpression(callee?: Expression | Super, _arguments?: Array<Expression | SpreadElement>): NewExpression;
 export function program(body?: Array<Statement | ModuleDeclaration>, directives?: Directive[]): Program;
 export function objectExpression(properties?: Array<ObjectProperty | ObjectMethod | SpreadProperty>): ObjectExpression;
-export function objectMethod(kind?: "get" | "set" | "method", key?: Expression, params?: Pattern[], body?: BlockStatement, computed?: boolean): ObjectMethod;
+export function objectMethod(kind?: "get" | "set" | "method", key?: Expression, params?: Array<LVal>, body?: BlockStatement, computed?: boolean): ObjectMethod;
 export function objectProperty(key?: Expression, value?: Expression, computed?: boolean, shorthand?: boolean, decorators?: Decorator[]): ObjectProperty;
 export function restElement(argument?: LVal, typeAnnotation?: TypeAnnotation): RestElement;
 export function returnStatement(argument?: Expression): ReturnStatement;
@@ -957,8 +957,8 @@ export function variableDeclarator(id?: LVal, init?: Expression): VariableDeclar
 export function whileStatement(test?: Expression, body?: BlockStatement | Statement): WhileStatement;
 export function withStatement(object?: Expression, body?: BlockStatement | Statement): WithStatement;
 export function assignmentPattern(left?: Identifier, right?: Expression): AssignmentPattern;
-export function arrayPattern(elements?: Array<Pattern>, typeAnnotation?: TypeAnnotation): ArrayPattern;
-export function arrowFunctionExpression(params?: Pattern[], body?: BlockStatement | Expression, async?: boolean): ArrowFunctionExpression;
+export function arrayPattern(elements?: Array<Expression>, typeAnnotation?: TypeAnnotation): ArrayPattern;
+export function arrowFunctionExpression(params?: Array<LVal>, body?: BlockStatement | Expression, async?: boolean): ArrowFunctionExpression;
 export function classBody(body?: Array<ClassMethod | ClassProperty>): ClassBody;
 export function classDeclaration(id?: Identifier, superClass?: Expression, body?: ClassBody, decorators?: Decorator[]): ClassDeclaration;
 export function classExpression(id?: Identifier, superClass?: Expression, body?: ClassBody, decorators?: Decorator[]): ClassExpression;
@@ -972,7 +972,7 @@ export function importDefaultSpecifier(local?: Identifier): ImportDefaultSpecifi
 export function importNamespaceSpecifier(local?: Identifier): ImportNamespaceSpecifier;
 export function importSpecifier(local?: Identifier, imported?: Identifier): ImportSpecifier;
 export function metaProperty(meta?: string, property?: string): MetaProperty;
-export function classMethod(kind?: "constructor" | "method" | "get" | "set", key?: Expression, params?: Pattern[], body?: BlockStatement, computed?: boolean, _static?: boolean): ClassMethod;
+export function classMethod(kind?: "constructor" | "method" | "get" | "set", key?: Expression, params?: Array<LVal>, body?: BlockStatement, computed?: boolean, _static?: boolean): ClassMethod;
 export function objectPattern(properties?: Array<AssignmentProperty | RestProperty>, typeAnnotation?: TypeAnnotation): ObjectPattern;
 export function spreadElement(argument?: Expression): SpreadElement;
 export function taggedTemplateExpression(tag?: Expression, quasi?: TemplateLiteral): TaggedTemplateExpression;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/tree/master/packages/babel-types/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
