### PR TITLE
Angular: Improve types of 'instantiate' and 'invoke' of IInjectorService.

### DIFF
--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -470,6 +470,22 @@ namespace TestInjector {
 
     $injector.annotate(() => {});
     $injector.annotate(() => {}, true);
+
+    // $injector.instantiate
+    {
+        class Foobar {
+            constructor($q) {}
+        }
+        let result: Foobar = $injector.instantiate(Foobar);
+    }
+
+    // $injector.invoke
+    {
+        function foobar(v: boolean): number {
+            return 7;
+        }
+        let result: number = $injector.invoke(foobar);
+    }
 }
 
 // Promise signature tests

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1978,9 +1978,9 @@ declare namespace angular {
             get(name: '$window'): IWindowService;
             get<T>(name: '$xhrFactory'): IXhrFactory<T>;
             has(name: string): boolean;
-            instantiate<T>(typeConstructor: Function, locals?: any): T;
+            instantiate<T>(typeConstructor: {new(...args: any[]): T}, locals?: any): T;
             invoke(inlineAnnotatedFunction: any[]): any;
-            invoke(func: Function, context?: any, locals?: any): any;
+            invoke<T>(func: (...args: any[]) => T, context?: any, locals?: any): T;
             strictDi: boolean;
         }
 


### PR DESCRIPTION
The result is inferred form the argument, which removes the need of a cast.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I couldn't run tests or linter. I'm getting "Object.entries is not a function".

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 - "instantiate(Type, [locals]): The method takes a constructor function, invokes the new operator [..]. Returns new instance of Type." from https://docs.angularjs.org/api/auto/service/$injector#instantiate
 - "invoke(fn, [self], [locals]) [..] Returns the value returned by the invoked fn function." from https://docs.angularjs.org/api/auto/service/$injector#invoke
- [ ] Increase the version number in the header if appropriate.
