### PR TITLE
[azure] make types compliant with strictNullChecks

### DIFF
--- a/types/azure/index.d.ts
+++ b/types/azure/index.d.ts
@@ -1627,7 +1627,7 @@ export interface Entity {
     RowKey: string;
     Timestamp?: Date;
     etag?: string;
-    [property: string]: string | number | boolean | Date;
+    [property: string]: string | number | boolean | Date | undefined;
 }
 //#endregion
 //#region BlobService Interfaces

--- a/types/azure/tsconfig.json
+++ b/types/azure/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Without this change the types are not usable in a project that enables `strictNullChecks`. Compilation will fail with:

```
TS2411: Property 'Timestamp' of type 'Date | undefined' is not assignable to string index type 'string | number | boolean | Date'.

TS2411: Property 'etag' of type 'string | undefined' is not assignable to string index type 'string | number | boolean | Date'.
```