### PR TITLE
Fix types of some fields in gapi.auth2.AuthResponse

### DIFF
--- a/types/gapi.auth2/index.d.ts
+++ b/types/gapi.auth2/index.d.ts
@@ -131,9 +131,9 @@ declare namespace gapi.auth2 {
     id_token: string;
     login_hint: string;
     scope: string;
-    expires_in: string;
-    first_issued_at: string;
-    expires_at: string;
+    expires_in: number;
+    first_issued_at: number;
+    expires_at: number;
   }
 
   /**


### PR DESCRIPTION
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/api-client-library/javascript/reference/referencedocs#googleusergetauthresponseincludeauthorizationdata
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.