### PR TITLE
Update react-datepicker to 0.46 and add linter config

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,65 +1,70 @@
-// Type definitions for react-datepicker v0.40.0
+// Type definitions for react-datepicker 0.46
 // Project: https://github.com/Hacker0x01/react-datepicker
-// Definitions by: Rajab Shakirov <https://github.com/radziksh>, Andrey Balokha <https://github.com/andrewBalekha>
+// Definitions by: Rajab Shakirov <https://github.com/radziksh>,
+//     Andrey Balokha <https://github.com/andrewBalekha>,
+//     Greg Smith <https://github.com/smrq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-declare module "react-datepicker" {
-    import * as React from "react";
-    import * as moment from "moment";
+import * as React from "react";
+import * as moment from "moment";
 
-    interface ReactDatePickerProps {
-        autoComplete?: string;
-        autoFocus?: boolean;
-        className?: string;
-        customInput?: React.ReactNode;
-        dateFormat?: string;
-        dateFormatCalendar?: string;
-        disabled?: boolean;
-        dropdownMode?: string;
-        endDate?: moment.Moment;
-        excludeDates?: any[];
-        filterDate?(): any;
-        fixedHeight?: boolean;
-        forceShowMonthNavigation?: boolean;
-        highlightDates?: any[];
-        id?: string;
-        includeDates?: any[];
-        inline?: boolean;
-        isClearable?: boolean;
-        locale?: string;
-        maxDate?: moment.Moment;
-        minDate?: moment.Moment;
-        monthsShown?: number;
-        name?: string;
-        onBlur?(event: React.FocusEvent<HTMLInputElement>): void;
-        onChange(date: moment.Moment | null, event: React.SyntheticEvent<any> | undefined): any;
-        onChangeRaw?(event: React.FocusEvent<HTMLInputElement>): void;
-        onFocus?(event: React.FocusEvent<HTMLInputElement>): void;
-        onMonthChange?(date: moment.Moment): void;
-        openToDate?: moment.Moment;
-        peekNextMonth?: boolean;
-        placeholderText?: string;
-        popoverAttachment?: string;
-        popoverTargetAttachment?: string;
-        popoverTargetOffset?: string;
-        readOnly?: boolean;
-        renderCalendarTo?: any;
-        required?: boolean;
-        scrollableYearDropdown?: boolean;
-        selected?: moment.Moment | null;
-        selectsEnd?: boolean;
-        selectsStart?: boolean;
-        showMonthDropdown?: boolean;
-        showYearDropdown?: boolean;
-        showWeekNumbers?: boolean;
-        startDate?: moment.Moment;
-        tabIndex?: number;
-        tetherConstraints?: any[];
-        title?: string;
-        todayButton?: string;
-        utcOffset?: number;
-    }
-    let ReactDatePicker: React.ClassicComponentClass<ReactDatePickerProps>;
-    export = ReactDatePicker;
+interface ReactDatePickerProps {
+	autoComplete?: string;
+	autoFocus?: boolean;
+	calendarClassName?: string;
+	className?: string;
+	customInput?: React.ReactNode;
+	dateFormat?: string | string[];
+	dateFormatCalendar?: string;
+	disabled?: boolean;
+	disabledKeyboardNavigation?: boolean;
+	dropdownMode?: string;
+	endDate?: moment.Moment;
+	excludeDates?: any[];
+	filterDate?(): any;
+	fixedHeight?: boolean;
+	forceShowMonthNavigation?: boolean;
+	highlightDates?: any[];
+	id?: string;
+	includeDates?: any[];
+	inline?: boolean;
+	isClearable?: boolean;
+	locale?: string;
+	maxDate?: moment.Moment;
+	minDate?: moment.Moment;
+	monthsShown?: number;
+	name?: string;
+	onBlur?(event: React.FocusEvent<HTMLInputElement>): void;
+	onChange(date: moment.Moment | null, event: React.SyntheticEvent<any> | undefined): any;
+	onChangeRaw?(event: React.FocusEvent<HTMLInputElement>): void;
+	onClickOutside?(event: React.MouseEvent<HTMLDivElement>): void;
+	onFocus?(event: React.FocusEvent<HTMLInputElement>): void;
+	onMonthChange?(date: moment.Moment): void;
+	openToDate?: moment.Moment;
+	peekNextMonth?: boolean;
+	placeholderText?: string;
+	popoverAttachment?: string;
+	popoverTargetAttachment?: string;
+	popoverTargetOffset?: string;
+	readOnly?: boolean;
+	renderCalendarTo?: any;
+	required?: boolean;
+	scrollableYearDropdown?: boolean;
+	selected?: moment.Moment | null;
+	selectsEnd?: boolean;
+	selectsStart?: boolean;
+	showMonthDropdown?: boolean;
+	showWeekNumbers?: boolean;
+	showYearDropdown?: boolean;
+	startDate?: moment.Moment;
+	tabIndex?: number;
+	tetherConstraints?: any[];
+	title?: string;
+	todayButton?: string;
+	utcOffset?: number;
+	value?: string;
+	withPortal?: boolean;
 }
+declare const ReactDatePicker: React.ClassicComponentClass<ReactDatePickerProps>;
+export default ReactDatePicker;

--- a/types/react-datepicker/react-datepicker-tests.tsx
+++ b/types/react-datepicker/react-datepicker-tests.tsx
@@ -1,30 +1,28 @@
-import * as React from "react";
+import * as React from 'react';
 import * as moment from 'moment';
-import * as DatePicker from 'react-datepicker';
+import DatePicker from 'react-datepicker';
 
-class ReactDatePicker extends React.Component<{}, { startDate: moment.Moment; displayName:string; }> {
-     constructor(props: {}) {
-        super();
-        this.state = {
-          startDate: moment(),
-          displayName: 'Example'
-        }
-        this.handleChange = this.handleChange.bind(this);
-     }
+class ReactDatePicker extends React.Component<{}, { startDate: moment.Moment; displayName: string; }> {
+	constructor(props: {}) {
+		super();
+		this.state = {
+			startDate: moment(),
+			displayName: 'Example'
+		};
+		this.handleChange = this.handleChange.bind(this);
+	}
 
-     handleChange = function(date?: moment.Moment | null) {
-        this.setState({
-          startDate: date
-        });
-     }
+	handleChange = function(date?: moment.Moment | null) {
+		this.setState({
+			startDate: date
+		});
+	};
 
-     render(){
-         return (
-           <div>
-             <DatePicker
-                 selected={this.state.startDate}
-                 onChange={this.handleChange} />
-           </div>
-         );
-    }
-};
+	render() {
+		return (
+			<DatePicker
+				selected={this.state.startDate}
+				onChange={this.handleChange} />
+		);
+	}
+}

--- a/types/react-datepicker/tslint.json
+++ b/types/react-datepicker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

The primary motivation for this update is that with 0.46 this module changed from an `export =` declaration to an `export default` declaration: https://github.com/Hacker0x01/react-datepicker/blob/v0.46.0/src/datepicker.jsx

I also added a couple props listed in the documentation here which were missing: https://github.com/Hacker0x01/react-datepicker/blob/v0.46.0/docs/datepicker.md
(Note that this documentation has some errors, though. `onSelect` is not a valid prop, at least in 0.46.)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
