### PR TITLE
node.js: Add type guards as return types of util methods

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -3650,23 +3650,23 @@ declare module "util" {
     export function log(string: string): void;
     export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
     export function inspect(object: any, options: InspectOptions): string;
-    export function isArray(object: any): boolean;
-    export function isRegExp(object: any): boolean;
-    export function isDate(object: any): boolean;
-    export function isError(object: any): boolean;
+    export function isArray(object: any): object is any[];
+    export function isRegExp(object: any): object is RegExp;
+    export function isDate(object: any): object is Date;
+    export function isError(object: any): object is Error;
     export function inherits(constructor: any, superConstructor: any): void;
     export function debuglog(key: string): (msg: string, ...param: any[]) => void;
-    export function isBoolean(object: any): boolean;
-    export function isBuffer(object: any): boolean;
+    export function isBoolean(object: any): object is boolean;
+    export function isBuffer(object: any): object is Buffer;
     export function isFunction(object: any): boolean;
-    export function isNull(object: any): boolean;
-    export function isNullOrUndefined(object: any): boolean;
-    export function isNumber(object: any): boolean;
-    export function isObject(object: any): boolean;
+    export function isNull(object: any): object is null;
+    export function isNullOrUndefined(object: any): object is null | undefined;
+    export function isNumber(object: any): object is number;
+    export function isObject(object: any): object is Object;
     export function isPrimitive(object: any): boolean;
-    export function isString(object: any): boolean;
-    export function isSymbol(object: any): boolean;
-    export function isUndefined(object: any): boolean;
+    export function isString(object: any): object is string;
+    export function isSymbol(object: any): object is Symbol;
+    export function isUndefined(object: any): object is undefined;
     export function deprecate(fn: Function, message: string): Function;
 }
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -3662,7 +3662,7 @@ declare module "util" {
     export function isNull(object: any): object is null;
     export function isNullOrUndefined(object: any): object is null | undefined;
     export function isNumber(object: any): object is number;
-    export function isObject(object: any): object is Object;
+    export function isObject(object: any): object is object;
     export function isPrimitive(object: any): boolean;
     export function isString(object: any): object is string;
     export function isSymbol(object: any): object is Symbol;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -3662,7 +3662,7 @@ declare module "util" {
     export function isNull(object: any): object is null;
     export function isNullOrUndefined(object: any): object is null | undefined;
     export function isNumber(object: any): object is number;
-    export function isObject(object: any): object is object;
+    export function isObject(object: any): boolean;
     export function isPrimitive(object: any): boolean;
     export function isString(object: any): object is string;
     export function isSymbol(object: any): object is Symbol;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -3665,7 +3665,7 @@ declare module "util" {
     export function isObject(object: any): boolean;
     export function isPrimitive(object: any): boolean;
     export function isString(object: any): object is string;
-    export function isSymbol(object: any): object is Symbol;
+    export function isSymbol(object: any): object is symbol;
     export function isUndefined(object: any): object is undefined;
     export function deprecate(fn: Function, message: string): Function;
 }

--- a/types/node/tsconfig.json
+++ b/types/node/tsconfig.json
@@ -5,7 +5,6 @@
     ],
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2016",
         "lib": [
             "es5"
         ],

--- a/types/node/tsconfig.json
+++ b/types/node/tsconfig.json
@@ -5,6 +5,7 @@
     ],
     "compilerOptions": {
         "module": "commonjs",
+        "target": "es2016",
         "lib": [
             "es5"
         ],


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Under the section typeof type guards at https://www.typescriptlang.org/docs/handbook/advanced-types.html

Currently using any of the util methods does not have any effect on the type of the variable in typescript. With these changes, the we can typeguard the variable with the utils methods.
