### PR TITLE
three: Prevent test deps from being in @types package

### DIFF
--- a/types/three/test/references.d.ts
+++ b/types/three/test/references.d.ts
@@ -1,9 +1,0 @@
-// References used by tests
-// Includes using THREE as a global namespace rather than as a module
-
-/// <reference types="dat-gui" />
-/// <reference types="stats.js" />
-/// <reference types="tween.js" />
-
-/// <reference path="../index.d.ts" />
-/// <reference path="../detector.d.ts" />

--- a/types/three/test/references.ts
+++ b/types/three/test/references.ts
@@ -1,0 +1,5 @@
+// References used by tests
+
+/// <reference types="dat-gui" />
+/// <reference types="stats.js" />
+/// <reference types="tween.js" />

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -17,7 +17,9 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "test/references.d.ts",
+        "index.d.ts",
+        "detector.d.ts",
+        "test/references.ts",
         "test/math/test_unit_math.ts",
         "test/webgl/webgl_animation_cloth.ts",
         "test/webgl/webgl_animation_skinning_morph.ts",


### PR DESCRIPTION
@andy-ms @RyanCavanaugh Can one of you confirm whether this change is likely to fix the issue? Your attention is probably more relevant than a review from the definitions owners as this is mainly a matter of interaction with [the types publisher](https://github.com/Microsoft/types-publisher).

It seems with [my last change](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15861) the dependencies used by the tests are now listed in the dependencies of the npm package [\@types/three](https://www.npmjs.com/package/@types/three). I'm not precisely sure how that happened but suspect it's because I used a `.d.ts` file in the tests for pulling in references. I've switched it to a `.ts` file.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).