### PR TITLE
Add overloads to account for `mergeProps`

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -19,6 +19,10 @@ interface ComponentDecorator<TStateProps, TDispatchProps, TOwnProps> {
     (component: Component<TStateProps & TDispatchProps & TOwnProps>): ComponentClass<TOwnProps>;
 }
 
+interface MergedComponentDecorator<TOwnProps, TMergedProps> {
+    (component: Component<TMergedProps>): ComponentClass<TOwnProps>;
+}
+
 /**
  * Decorator that infers the type from the original component
  *
@@ -49,12 +53,39 @@ export interface InferableComponentDecorator<TOwnProps> {
  */
 export declare function connect<TOwnProps>(): InferableComponentDecorator<TOwnProps>;
 
+export declare function connect<TStateProps, TOwnProps>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
+): ComponentDecorator<TStateProps, void, TOwnProps>;
+
+export declare function connect<TDispatchProps, TOwnProps>(
+    mapStateToProps: undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
+): ComponentDecorator<void, TDispatchProps, TOwnProps>;
+
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps?: MapStateToProps<TStateProps, TOwnProps> | MapStateToPropsFactory<TStateProps, TOwnProps>,
-    mapDispatchToProps?: MapDispatchToProps<TDispatchProps, TOwnProps> | MapDispatchToPropsFactory<TDispatchProps, TOwnProps>,
-    mergeProps?: MergeProps<TStateProps, TDispatchProps, TOwnProps>,
-    options?: Options
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
 ): ComponentDecorator<TStateProps, TDispatchProps, TOwnProps>;
+
+export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps> | undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps> | undefined,
+    mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
+): MergedComponentDecorator<TOwnProps, TMergedProps>;
+
+export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps> | undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps> | undefined,
+    mergeProps: undefined,
+    options: Options
+): ComponentDecorator<TStateProps, TDispatchProps, TOwnProps>;
+
+export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps> | undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps> | undefined,
+    mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
+    options: Options
+): MergedComponentDecorator<TOwnProps, TMergedProps>;
 
 interface MapStateToProps<TStateProps, TOwnProps> {
     (state: any, ownProps?: TOwnProps): TStateProps;
@@ -63,6 +94,8 @@ interface MapStateToProps<TStateProps, TOwnProps> {
 interface MapStateToPropsFactory<TStateProps, TOwnProps> {
     (initialState: any, ownProps?: TOwnProps): MapStateToProps<TStateProps, TOwnProps>;
 }
+
+type MapStateToPropsParam<TStateProps, TOwnProps> = MapStateToProps<TStateProps, TOwnProps> | MapStateToPropsFactory<TStateProps, TOwnProps>;
 
 interface MapDispatchToPropsFunction<TDispatchProps, TOwnProps> {
     (dispatch: Dispatch<any>, ownProps?: TOwnProps): TDispatchProps;
@@ -79,8 +112,10 @@ interface MapDispatchToPropsFactory<TDispatchProps, TOwnProps> {
     (dispatch: Dispatch<any>, ownProps?: TOwnProps): MapDispatchToProps<TDispatchProps, TOwnProps>;
 }
 
-interface MergeProps<TStateProps, TDispatchProps, TOwnProps> {
-    (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TStateProps & TDispatchProps;
+type MapDispatchToPropsParam<TDispatchProps, TOwnProps> = MapDispatchToProps<TDispatchProps, TOwnProps> | MapDispatchToPropsFactory<TDispatchProps, TOwnProps>;
+
+interface MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> {
+    (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TMergedProps;
 }
 
 interface Options {

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -49,11 +49,11 @@ export interface InferableComponentDecorator<TOwnProps> {
  */
 export declare function connect<TOwnProps>(): InferableComponentDecorator<TOwnProps>;
 
-export declare function connect<TStateProps, undefined, TOwnProps>(
+export declare function connect<TStateProps, no_dispatch, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
 ): ComponentDecorator<TOwnProps, TStateProps & TOwnProps>;
 
-export declare function connect<undefined, TDispatchProps, TOwnProps>(
+export declare function connect<no_state, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
 ): ComponentDecorator<TOwnProps, TDispatchProps & TOwnProps>;
@@ -63,19 +63,19 @@ export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
 ): ComponentDecorator<TOwnProps, TStateProps & TDispatchProps & TOwnProps>;
 
-export declare function connect<TStateProps, undefined, TOwnProps, TMergedProps>(
+export declare function connect<TStateProps, no_dispatch, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
 ): ComponentDecorator<TOwnProps, TMergedProps>;
 
-export declare function connect<undefined, TDispatchProps, TOwnProps, TMergedProps>(
+export declare function connect<no_state, TDispatchProps, TOwnProps, TMergedProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
 ): ComponentDecorator<TOwnProps, TMergedProps>;
 
-export declare function connect<undefined, undefined, TOwnProps, TMergedProps>(
+export declare function connect<no_state, no_dispatch, TOwnProps, TMergedProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
@@ -87,14 +87,14 @@ export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedP
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
 ): ComponentDecorator<TOwnProps, TMergedProps>;
 
-export declare function connect<TStateProps, undefined, TOwnProps>(
+export declare function connect<TStateProps, no_dispatch, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: null | undefined,
     mergeProps: null | undefined,
     options: Options
 ): ComponentDecorator<TOwnProps, TStateProps & TOwnProps>;
 
-export declare function connect<undefined, TDispatchProps, TOwnProps>(
+export declare function connect<no_state, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -58,7 +58,7 @@ export declare function connect<TStateProps, TOwnProps>(
 ): ComponentDecorator<TStateProps, void, TOwnProps>;
 
 export declare function connect<TDispatchProps, TOwnProps>(
-    mapStateToProps: undefined,
+    mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
 ): ComponentDecorator<void, TDispatchProps, TOwnProps>;
 
@@ -69,19 +69,19 @@ export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
 
 export declare function connect<TStateProps, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
-    mapDispatchToProps: undefined,
+    mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
 ): MergedComponentDecorator<TOwnProps, TMergedProps>;
 
 export declare function connect<TDispatchProps, TOwnProps, TMergedProps>(
-    mapStateToProps: undefined,
+    mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
 ): MergedComponentDecorator<TOwnProps, TMergedProps>;
 
 export declare function connect<TOwnProps, TMergedProps>(
-    mapStateToProps: undefined,
-    mapDispatchToProps: undefined,
+    mapStateToProps: null | undefined,
+    mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
 ): MergedComponentDecorator<TOwnProps, TMergedProps>;
 
@@ -93,28 +93,28 @@ export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedP
 
 export declare function connect<TStateProps, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
-    mapDispatchToProps: undefined,
-    mergeProps: undefined,
+    mapDispatchToProps: null | undefined,
+    mergeProps: null | undefined,
     options: Options
 ): ComponentDecorator<TStateProps, void, TOwnProps>;
 
 export declare function connect<TDispatchProps, TOwnProps>(
-    mapStateToProps: undefined,
+    mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-    mergeProps: undefined,
+    mergeProps: null | undefined,
     options: Options
 ): ComponentDecorator<void, TDispatchProps, TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
-    mergeProps: undefined,
+    mergeProps: null | undefined,
     options: Options
 ): ComponentDecorator<TStateProps, TDispatchProps, TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps> | undefined,
-    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps> | undefined,
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
     options: Options
 ): MergedComponentDecorator<TOwnProps, TMergedProps>;

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -53,11 +53,11 @@ export interface InferableComponentDecorator<TOwnProps> {
  */
 export declare function connect<TOwnProps>(): InferableComponentDecorator<TOwnProps>;
 
-export declare function connect<TStateProps, TOwnProps>(
+export declare function connect<TStateProps, undefined, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
 ): ComponentDecorator<TStateProps, void, TOwnProps>;
 
-export declare function connect<TDispatchProps, TOwnProps>(
+export declare function connect<undefined, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
 ): ComponentDecorator<void, TDispatchProps, TOwnProps>;
@@ -67,19 +67,19 @@ export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
 ): ComponentDecorator<TStateProps, TDispatchProps, TOwnProps>;
 
-export declare function connect<TStateProps, TOwnProps, TMergedProps>(
+export declare function connect<TStateProps, undefined, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
 ): MergedComponentDecorator<TOwnProps, TMergedProps>;
 
-export declare function connect<TDispatchProps, TOwnProps, TMergedProps>(
+export declare function connect<undefined, TDispatchProps, TOwnProps, TMergedProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
 ): MergedComponentDecorator<TOwnProps, TMergedProps>;
 
-export declare function connect<TOwnProps, TMergedProps>(
+export declare function connect<undefined, undefined, TOwnProps, TMergedProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
@@ -91,14 +91,14 @@ export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedP
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
 ): MergedComponentDecorator<TOwnProps, TMergedProps>;
 
-export declare function connect<TStateProps, TOwnProps>(
+export declare function connect<TStateProps, undefined, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: null | undefined,
     mergeProps: null | undefined,
     options: Options
 ): ComponentDecorator<TStateProps, void, TOwnProps>;
 
-export declare function connect<TDispatchProps, TOwnProps>(
+export declare function connect<undefined, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -67,15 +67,47 @@ export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
 ): ComponentDecorator<TStateProps, TDispatchProps, TOwnProps>;
 
+export declare function connect<TStateProps, TOwnProps, TMergedProps>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+    mapDispatchToProps: undefined,
+    mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
+): MergedComponentDecorator<TOwnProps, TMergedProps>;
+
+export declare function connect<TDispatchProps, TOwnProps, TMergedProps>(
+    mapStateToProps: undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
+): MergedComponentDecorator<TOwnProps, TMergedProps>;
+
+export declare function connect<TOwnProps, TMergedProps>(
+    mapStateToProps: undefined,
+    mapDispatchToProps: undefined,
+    mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
+): MergedComponentDecorator<TOwnProps, TMergedProps>;
+
 export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps> | undefined,
-    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps> | undefined,
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
 ): MergedComponentDecorator<TOwnProps, TMergedProps>;
 
+export declare function connect<TStateProps, TOwnProps>(
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+    mapDispatchToProps: undefined,
+    mergeProps: undefined,
+    options: Options
+): ComponentDecorator<TStateProps, void, TOwnProps>;
+
+export declare function connect<TDispatchProps, TOwnProps>(
+    mapStateToProps: undefined,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+    mergeProps: undefined,
+    options: Options
+): ComponentDecorator<void, TDispatchProps, TOwnProps>;
+
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
-    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps> | undefined,
-    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps> | undefined,
+    mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
+    mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: undefined,
     options: Options
 ): ComponentDecorator<TStateProps, TDispatchProps, TOwnProps>;

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -15,11 +15,7 @@ type Store<S> = Redux.Store<S>;
 type Dispatch<S> = Redux.Dispatch<S>;
 type ActionCreator<A> = Redux.ActionCreator<A>;
 
-interface ComponentDecorator<TStateProps, TDispatchProps, TOwnProps> {
-    (component: Component<TStateProps & TDispatchProps & TOwnProps>): ComponentClass<TOwnProps>;
-}
-
-interface MergedComponentDecorator<TOwnProps, TMergedProps> {
+interface ComponentDecorator<TOwnProps, TMergedProps> {
     (component: Component<TMergedProps>): ComponentClass<TOwnProps>;
 }
 
@@ -55,69 +51,69 @@ export declare function connect<TOwnProps>(): InferableComponentDecorator<TOwnPr
 
 export declare function connect<TStateProps, undefined, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
-): ComponentDecorator<TStateProps, void, TOwnProps>;
+): ComponentDecorator<TOwnProps, TStateProps & TOwnProps>;
 
 export declare function connect<undefined, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-): ComponentDecorator<void, TDispatchProps, TOwnProps>;
+): ComponentDecorator<TOwnProps, TDispatchProps & TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-): ComponentDecorator<TStateProps, TDispatchProps, TOwnProps>;
+): ComponentDecorator<TOwnProps, TStateProps & TDispatchProps & TOwnProps>;
 
 export declare function connect<TStateProps, undefined, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<TStateProps, undefined, TOwnProps, TMergedProps>,
-): MergedComponentDecorator<TOwnProps, TMergedProps>;
+): ComponentDecorator<TOwnProps, TMergedProps>;
 
 export declare function connect<undefined, TDispatchProps, TOwnProps, TMergedProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<undefined, TDispatchProps, TOwnProps, TMergedProps>,
-): MergedComponentDecorator<TOwnProps, TMergedProps>;
+): ComponentDecorator<TOwnProps, TMergedProps>;
 
 export declare function connect<undefined, undefined, TOwnProps, TMergedProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: null | undefined,
     mergeProps: MergeProps<undefined, undefined, TOwnProps, TMergedProps>,
-): MergedComponentDecorator<TOwnProps, TMergedProps>;
+): ComponentDecorator<TOwnProps, TMergedProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
-): MergedComponentDecorator<TOwnProps, TMergedProps>;
+): ComponentDecorator<TOwnProps, TMergedProps>;
 
 export declare function connect<TStateProps, undefined, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: null | undefined,
     mergeProps: null | undefined,
     options: Options
-): ComponentDecorator<TStateProps, void, TOwnProps>;
+): ComponentDecorator<TOwnProps, TStateProps & TOwnProps>;
 
 export declare function connect<undefined, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
     options: Options
-): ComponentDecorator<void, TDispatchProps, TOwnProps>;
+): ComponentDecorator<TOwnProps, TDispatchProps & TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
     options: Options
-): ComponentDecorator<TStateProps, TDispatchProps, TOwnProps>;
+): ComponentDecorator<TOwnProps, TStateProps & TDispatchProps & TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
     options: Options
-): MergedComponentDecorator<TOwnProps, TMergedProps>;
+): ComponentDecorator<TOwnProps, TMergedProps>;
 
 interface MapStateToProps<TStateProps, TOwnProps> {
     (state: any, ownProps?: TOwnProps): TStateProps;

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -357,13 +357,12 @@ namespace TestTOwnPropsInference {
         return { state: 'string' };
     }
 
-    // `OwnProps` can not be inferred, which is good
-    // const ConnectedWithoutOwnProps = connect(mapStateToPropsWithoutOwnProps)(OwnPropsComponent);
-    // Otherwise, this compiles, which is bad.
-    // React.createElement(ConnectedWithoutOwnProps, { anything: 'goes!' });
-
+    const ConnectedWithoutOwnProps = connect(mapStateToPropsWithoutOwnProps)(OwnPropsComponent);
     const ConnectedWithOwnProps = connect(mapStateToPropsWithOwnProps)(OwnPropsComponent);
     const ConnectedWithTypeHint = connect<StateProps, void, OwnProps>(mapStateToPropsWithoutOwnProps)(OwnPropsComponent);
+
+    // This compiles, which is bad.
+    React.createElement(ConnectedWithoutOwnProps, { anything: 'goes!' });
 
     // This compiles, as expected.
     React.createElement(ConnectedWithOwnProps, { own: 'string' });
@@ -375,7 +374,7 @@ namespace TestTOwnPropsInference {
     React.createElement(ConnectedWithTypeHint, { own: 'string' });
 
     // This should not compile, which is good.
-    // React.createElement(ConnectedWithTypeHint, { missingOwn: true });
+    // React.createElement(ConnectedWithTypeHint, { anything: 'goes!' });
 }
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16021

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -67,7 +67,7 @@ connect<ICounterStateProps, ICounterDispatchProps, {}>(
     (dispatch: Dispatch<CounterState>, ownProps: {}) => mapDispatchToProps
 )(Counter);
 // only first argument
-connect<ICounterStateProps, {}>(
+connect<ICounterStateProps, {}, {}>(
     () => mapStateToProps
 )(Counter);
 // wrap only one argument
@@ -129,10 +129,10 @@ declare var todoActionCreators: { [type: string]: (...args: any[]) => any; };
 declare var counterActionCreators: { [type: string]: (...args: any[]) => any; };
 
 ReactDOM.render(
-  <Provider store={store}>
-    {() => <MyRootComponent />}
-  </Provider>,
-  document.body
+    <Provider store={store}>
+        {() => <MyRootComponent />}
+    </Provider>,
+    document.body
 );
 
 //TODO: for React Router 0.13
@@ -363,7 +363,7 @@ namespace TestTOwnPropsInference {
     // React.createElement(ConnectedWithoutOwnProps, { anything: 'goes!' });
 
     const ConnectedWithOwnProps = connect(mapStateToPropsWithOwnProps)(OwnPropsComponent);
-    const ConnectedWithTypeHint = connect<StateProps, OwnProps>(mapStateToPropsWithoutOwnProps)(OwnPropsComponent);
+    const ConnectedWithTypeHint = connect<StateProps, void, OwnProps>(mapStateToPropsWithoutOwnProps)(OwnPropsComponent);
 
     // This compiles, as expected.
     React.createElement(ConnectedWithOwnProps, { own: 'string' });
@@ -410,7 +410,7 @@ namespace TestMergedPropsInference {
         return { dispatch: 'string' };
     }
 
-    const ConnectedWithOwnAndState: React.ComponentClass<OwnProps> = connect<StateProps, OwnProps, MergedProps>(
+    const ConnectedWithOwnAndState: React.ComponentClass<OwnProps> = connect<StateProps, void, OwnProps, MergedProps>(
         mapStateToProps,
         undefined,
         (stateProps: StateProps) => ({
@@ -418,7 +418,7 @@ namespace TestMergedPropsInference {
         }),
     )(MergedPropsComponent);
 
-    const ConnectedWithOwnAndDispatch: React.ComponentClass<OwnProps> = connect<DispatchProps, OwnProps, MergedProps>(
+    const ConnectedWithOwnAndDispatch: React.ComponentClass<OwnProps> = connect<void, DispatchProps, OwnProps, MergedProps>(
         undefined,
         mapDispatchToProps,
         (stateProps: undefined, dispatchProps: DispatchProps) => ({
@@ -426,7 +426,7 @@ namespace TestMergedPropsInference {
         }),
     )(MergedPropsComponent);
 
-    const ConnectedWithOwn: React.ComponentClass<OwnProps> = connect<OwnProps, MergedProps>(
+    const ConnectedWithOwn: React.ComponentClass<OwnProps> = connect<void, void, OwnProps, MergedProps>(
         undefined,
         undefined,
         () => ({


### PR DESCRIPTION
This also provides better typings for users of `strictNullChecks`.

For convenience, this also changes the required number of generics that need to be specified.

`export const ConnectedMain = connect<TStateProps, void, TOwnProps>(mapStateToProps)(Main);`
can now be
`export const ConnectedMain = connect<TStateProps, TOwnProps>(mapStateToProps)(Main);`
(no second `void` type parameter)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-redux/blob/master/docs/api.md#arguments
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
