### PR TITLE
Angular: re-add generic Function type to IInjector.invoke() sygnature.

### DIFF
--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -484,7 +484,14 @@ namespace TestInjector {
         function foobar(v: boolean): number {
             return 7;
         }
-        let result: number = $injector.invoke(foobar);
+        let result = $injector.invoke(foobar);
+        if (!(typeof result === 'number')) {
+            // This fails to compile if 'result' is not exactly a number.
+            let expectNever: never = result;
+        }
+
+        let anyFunction: Function = foobar;
+        let anyResult: string = $injector.invoke(anyFunction);
     }
 }
 

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1981,6 +1981,7 @@ declare namespace angular {
             instantiate<T>(typeConstructor: {new(...args: any[]): T}, locals?: any): T;
             invoke(inlineAnnotatedFunction: any[]): any;
             invoke<T>(func: (...args: any[]) => T, context?: any, locals?: any): T;
+            invoke(func: Function, context?: any, locals?: any): any;
             strictDi: boolean;
         }
 


### PR DESCRIPTION
Looks like it is used in some projects. 'Function' should be treated
as a function with '(..args: any[]) => any' signature.

It was previously replaced by more specific type in 30b9603.
Fixes #16017

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 - "invoke(fn, [self], [locals]) [..] Returns the value returned by the invoked fn function." from https://docs.angularjs.org/api/auto/service/$injector#invoke
- [ ] Increase the version number in the header if appropriate.
