### PR TITLE
[angular-local-storage] updates definition to reflect changes in latest versions

### DIFF
--- a/types/angular-local-storage/index.d.ts
+++ b/types/angular-local-storage/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for angular-local-storage v0.1.5
+// Type definitions for angular-local-storage v0.1.6
 // Project: https://github.com/grevory/angular-local-storage
 // Definitions by: Ken Fukuyama <https://github.com/kenfdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/angular-local-storage/index.d.ts
+++ b/types/angular-local-storage/index.d.ts
@@ -87,6 +87,8 @@ declare module 'angular' {
 
         }
 
+        type StorageType = 'localStorage' | 'sessionStorage';
+        
         interface ILocalStorageService {
             /**
              * Checks if the browser support the current storage type(e.g: localStorage, sessionStorage).
@@ -104,19 +106,19 @@ declare module 'angular' {
              * @param key
              * @param value
              */
-            set<T>(key: string, value: T): boolean;
+            set<T>(key: string, value: T, storageType?: StorageType): boolean;
             /**
              * Directly get a value from local storage.
              * If local storage is not supported, use cookies instead.
              * Returns: value from local storage
              * @param key
              */
-            get<T>(key: string): T;
+            get<T>(key: string, storageType?: StorageType): T;
             /**
              * Return array of keys for local storage, ignore keys that not owned.
              * Returns: value from local storage
              */
-            keys(): string[];
+            keys(storageType?: StorageType): string[];
             /**
              * Remove an item from local storage by key.
              * If local storage is not supported, use cookies instead.
@@ -131,7 +133,7 @@ declare module 'angular' {
              * Returns: Boolean
              * @param regularExpression
              */
-            clearAll(regularExpression?: RegExp): boolean;
+            clearAll(regularExpression?: RegExp, storageType?: StorageType): boolean;
             /**
              * Bind $scope key to localStorageService.
              * Usage: localStorageService.bind(scope, property, value[optional], key[optional])
@@ -141,7 +143,7 @@ declare module 'angular' {
              * @param value optional
              * @param key The corresponding key used in local storage
              */
-            bind(scope: angular.IScope, property: string, value?: any, key?: string): Function;
+            bind(scope: angular.IScope, property: string, value?: any, key?: string, storageType?: StorageType): Function;
             /**
              * Return the derive key
              * Returns String
@@ -152,7 +154,7 @@ declare module 'angular' {
              * Return localStorageService.length, ignore keys that not owned.
              * Returns Number
              */
-            length(): number;
+            length(storageType?: StorageType): number;
             /**
              * Deal with browser's cookies directly.
              */

--- a/types/angular-local-storage/index.d.ts
+++ b/types/angular-local-storage/index.d.ts
@@ -3,162 +3,159 @@
 // Definitions by: Ken Fukuyama <https://github.com/kenfdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="angular" />
+/// <reference path='../angularjs/angular.d.ts' />
 
-import * as angular from 'angular';
+declare module angular.local.storage {
 
-declare module 'angular' {
-    export namespace local.storage {
-        interface ILocalStorageServiceProvider extends angular.IServiceProvider {
-            /**
-             * Setter for the prefix
-             * You should set a prefix to avoid overwriting any local storage variables from the rest of your app
-             * e.g. localStorageServiceProvider.setPrefix('youAppName');
-             * With provider you can use config as this:
-             * myApp.config(function (localStorageServiceProvider) {
-             *  localStorageServiceProvider.prefix = 'yourAppName';
-             * });
-             * @param prefix default: ls.<your-key>
-             */
-            setPrefix(prefix: string): ILocalStorageServiceProvider;
-            /**
-             * Setter for the storageType
-             * @param storageType localstorage or sessionStorage. default: localStorage
-             */
-            setStorageType(storageType: string): ILocalStorageServiceProvider;
-            /**
-             * Setter for cookie config
-             * @param exp number of days before cookies expire (0 = does not expire). default: 30
-             * @param path the web path the cookie represents. default: '/'
-             */
-            setStorageCookie(exp: number, path: string): ILocalStorageServiceProvider;
-            /**
-             * Set the cookie domain, since this runs inside a the config() block, only providers and constants can be injected. As a result, $location service can't be used here, use a hardcoded string or window.location.
-             * No default value
-             */
-            setStorageCookieDomain(domain: string): ILocalStorageServiceProvider;
-            /**
-             * Send signals for each of the following actions:
-             * @param setItem default: true
-             * @param removeItem default: false
-             */
-            setNotify(setItem: boolean, removeItem: boolean): ILocalStorageServiceProvider;
-        }
+    interface ILocalStorageServiceProvider extends angular.IServiceProvider {
+        /**
+         * Setter for the prefix
+         * You should set a prefix to avoid overwriting any local storage variables from the rest of your app
+         * e.g. localStorageServiceProvider.setPrefix('youAppName');
+         * With provider you can use config as this:
+         * myApp.config(function (localStorageServiceProvider) {
+         *  localStorageServiceProvider.prefix = 'yourAppName';
+         * });
+         * @param prefix default: ls.<your-key>
+         */
+        setPrefix(prefix: string): ILocalStorageServiceProvider;
+        /**
+         * Setter for the storageType
+         * @param storageType localstorage or sessionStorage. default: localStorage
+         */
+        setStorageType(storageType: string): ILocalStorageServiceProvider;
+        /**
+         * Setter for cookie config
+         * @param exp number of days before cookies expire (0 = does not expire). default: 30
+         * @param path the web path the cookie represents. default: '/'
+         */
+        setStorageCookie(exp: number, path: string): ILocalStorageServiceProvider;
+        /**
+         * Set the cookie domain, since this runs inside a the config() block, only providers and constants can be injected. As a result, $location service can't be used here, use a hardcoded string or window.location.
+         * No default value
+         */
+        setStorageCookieDomain(domain: string): ILocalStorageServiceProvider;
+        /**
+         * Send signals for each of the following actions:
+         * @param setItem default: true
+         * @param removeItem default: false
+         */
+        setNotify(setItem: boolean, removeItem: boolean): ILocalStorageServiceProvider;
+    }
 
-        interface ICookie {
-            /**
-             * Checks if cookies are enabled in the browser.
-             * Returns: Boolean
-             */
-            isSupported: boolean;
-            /**
-             * Directly adds a value to cookies.
-             * Note: Typically used as a fallback if local storage is not supported.
-             * Returns: Boolean
-             * @param key
-             * @param val
-             */
-            set(key: string, val: string): boolean;
-            /**
-     * Directly adds a value to cookies with an expiration.
-     * Note: Typically used as a fallback if local storage is not supported.
-     * Returns: Boolean
-     * @param key
-     * @param val
-     * @param daysToExpiry
-     */
-            set(key: string, val: string, daysToExpiry: number): boolean;
-            /**
-                     * Directly get a value from a cookie.
-                     * Returns: value from local storage
-                     * @param key
-                     */
-            get(key: string): string;
-            /**
-             * Remove directly value from a cookie.
-             * Returns: Boolean
-             * @param key
-             */
-            remove(key: string): boolean;
-            /**
-             * Remove all data for this app from cookie.
-             */
-            clearAll(): any;
+    interface ICookie {
+        /**
+         * Checks if cookies are enabled in the browser.
+         * Returns: Boolean
+         */
+        isSupported: boolean;
+        /**
+         * Directly adds a value to cookies.
+         * Note: Typically used as a fallback if local storage is not supported.
+         * Returns: Boolean
+         * @param key
+         * @param val
+         */
+        set(key: string, val: string): boolean;
+        /**
+         * Directly adds a value to cookies with an expiration.
+         * Note: Typically used as a fallback if local storage is not supported.
+         * Returns: Boolean
+         * @param key
+         * @param val
+         * @param daysToExpiry
+         */
+        set(key: string, val: string, daysToExpiry: number): boolean;
+        /**
+         * Directly get a value from a cookie.
+         * Returns: value from local storage
+         * @param key
+         */
+        get(key: string): string;
+        /**
+         * Remove directly value from a cookie.
+         * Returns: Boolean
+         * @param key
+         */
+        remove(key: string): boolean;
+        /**
+         * Remove all data for this app from cookie.
+         */
+        clearAll(): any;
 
-        }
+    }
 
-        type StorageType = 'localStorage' | 'sessionStorage';
-        
-        interface ILocalStorageService {
-            /**
-             * Checks if the browser support the current storage type(e.g: localStorage, sessionStorage).
-             * Returns: Boolean
-             */
-            isSupported: boolean;
-            /**
-             * Returns: String
-             */
-            getStorageType(): string;
-            /**
-             * Directly adds a value to local storage.
-             * If local storage is not supported, use cookies instead.
-             * Returns: Boolean
-             * @param key
-             * @param value
-             */
-            set<T>(key: string, value: T, storageType?: StorageType): boolean;
-            /**
-             * Directly get a value from local storage.
-             * If local storage is not supported, use cookies instead.
-             * Returns: value from local storage
-             * @param key
-             */
-            get<T>(key: string, storageType?: StorageType): T;
-            /**
-             * Return array of keys for local storage, ignore keys that not owned.
-             * Returns: value from local storage
-             */
-            keys(storageType?: StorageType): string[];
-            /**
-             * Remove an item from local storage by key.
-             * If local storage is not supported, use cookies instead.
-             * Returns: Boolean
-             * @param key
-             */
-            remove(key: string): boolean;
-            /**
-             * Remove all data for this app from local storage.
-             * If local storage is not supported, use cookies instead.
-             * Note: Optionally takes a regular expression string and removes matching.
-             * Returns: Boolean
-             * @param regularExpression
-             */
-            clearAll(regularExpression?: RegExp, storageType?: StorageType): boolean;
-            /**
-             * Bind $scope key to localStorageService.
-             * Usage: localStorageService.bind(scope, property, value[optional], key[optional])
-             * Returns: deregistration function for this listener.
-             * @param scope
-             * @param property
-             * @param value optional
-             * @param key The corresponding key used in local storage
-             */
-            bind(scope: angular.IScope, property: string, value?: any, key?: string, storageType?: StorageType): Function;
-            /**
-             * Return the derive key
-             * Returns String
-             * @param key
-             */
-            deriveKey(key: string): string;
-            /**
-             * Return localStorageService.length, ignore keys that not owned.
-             * Returns Number
-             */
-            length(storageType?: StorageType): number;
-            /**
-             * Deal with browser's cookies directly.
-             */
-            cookie: ICookie;
-        }
+    type StorageType = 'localStorage' | 'sessionStorage';
+
+    interface ILocalStorageService {
+        /**
+         * Checks if the browser support the current storage type(e.g: localStorage, sessionStorage).
+         * Returns: Boolean
+         */
+        isSupported: boolean;
+        /**
+         * Returns: String
+         */
+        getStorageType(): string;
+        /**
+         * Directly adds a value to local storage.
+         * If local storage is not supported, use cookies instead.
+         * Returns: Boolean
+         * @param key
+         * @param value
+         */
+        set<T>(key: string, value: T, storageType?: StorageType): boolean;
+        /**
+         * Directly get a value from local storage.
+         * If local storage is not supported, use cookies instead.
+         * Returns: value from local storage
+         * @param key
+         */
+        get<T>(key: string, storageType?: StorageType): T;
+        /**
+         * Return array of keys for local storage, ignore keys that not owned.
+         * Returns: value from local storage
+         */
+        keys(storageType?: StorageType): string[];
+        /**
+         * Remove an item from local storage by key.
+         * If local storage is not supported, use cookies instead.
+         * Returns: Boolean
+         * @param key
+         */
+        remove(key: string): boolean;
+        /**
+         * Remove all data for this app from local storage.
+         * If local storage is not supported, use cookies instead.
+         * Note: Optionally takes a regular expression string and removes matching.
+         * Returns: Boolean
+         * @param regularExpression
+         */
+        clearAll(regularExpression?: RegExp, storageType?: StorageType): boolean;
+        /**
+         * Bind $scope key to localStorageService.
+         * Usage: localStorageService.bind(scope, property, value[optional], key[optional])
+         * Returns: deregistration function for this listener.
+         * @param scope
+         * @param property
+         * @param value optional
+         * @param key The corresponding key used in local storage
+         */
+        bind(scope: angular.IScope, property: string, value?: any, key?: string, storageType?: StorageType): Function;
+        /**
+         * Return the derive key
+         * Returns String
+         * @param key
+         */
+        deriveKey(key: string): string;
+        /**
+         * Return localStorageService.length, ignore keys that not owned.
+         * Returns Number
+         */
+        length(storageType?: StorageType): number;
+        /**
+         * Deal with browser's cookies directly.
+         */
+        cookie: ICookie;
     }
 }


### PR DESCRIPTION
In latest versions of angular-local-storage library it is possible now to pass type of storage to some methods e.g.
https://github.com/grevory/angular-local-storage/blob/master/src/angular-local-storage.js#L147
Changes to this definition file reflects all changes made in original library related to storage type except one which reverts using reference path and module declaration so it is still possible to compile this dts using TypeScript compiler in version older than 2.0.