### PR TITLE
file-saver: Allow saving files directly

### DIFF
--- a/types/file-saver/file-saver-tests.ts
+++ b/types/file-saver/file-saver-tests.ts
@@ -19,3 +19,12 @@ function testSaveAs() {
 
     saveAs(data, filename, disableAutoBOM);
 }
+
+/**
+ * @summary Test for "saveAs" function.
+ */
+function testSaveAsFile() {
+    const data = new File(["Hello, world!"], "hello world.txt" ,{type: "text/plain;charset=utf-8"});
+    
+    saveAs(data);
+}

--- a/types/file-saver/index.d.ts
+++ b/types/file-saver/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for FileSaver.js
 // Project: https://github.com/eligrey/FileSaver.js/
-// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
+// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>, Daniel Roth <https://github.com/DaIgeb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
@@ -27,6 +27,14 @@ interface FileSaver {
         * @type {boolean}
         */
         disableAutoBOM?: boolean
+    ): void
+
+    (
+        /**
+         * @summary File.
+         * @type {File}
+         */
+        data: File
     ): void
 }
 


### PR DESCRIPTION
As documented on https://github.com/eligrey/FileSaver.js/ saving a file
without using the Blob object should be possible

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/eligrey/FileSaver.js/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
