### PR TITLE
[angular-local-storage] updates definition to reflect latest changes

### DIFF
--- a/types/angular-local-storage/index.d.ts
+++ b/types/angular-local-storage/index.d.ts
@@ -60,19 +60,19 @@ declare module 'angular' {
              */
             set(key: string, val: string): boolean;
             /**
-     * Directly adds a value to cookies with an expiration.
-     * Note: Typically used as a fallback if local storage is not supported.
-     * Returns: Boolean
-     * @param key
-     * @param val
-     * @param daysToExpiry
-     */
+             * Directly adds a value to cookies with an expiration.
+             * Note: Typically used as a fallback if local storage is not supported.
+             * Returns: Boolean
+             * @param key
+             * @param val
+             * @param daysToExpiry
+             */
             set(key: string, val: string, daysToExpiry: number): boolean;
             /**
-                     * Directly get a value from a cookie.
-                     * Returns: value from local storage
-                     * @param key
-                     */
+             * Directly get a value from a cookie.
+             * Returns: value from local storage
+             * @param key
+             */
             get(key: string): string;
             /**
              * Remove directly value from a cookie.
@@ -84,7 +84,6 @@ declare module 'angular' {
              * Remove all data for this app from cookie.
              */
             clearAll(): any;
-
         }
         
         type StorageType = 'localStorage' | 'sessionStorage';

--- a/types/angular-local-storage/index.d.ts
+++ b/types/angular-local-storage/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for angular-local-storage v0.1.5
+// Type definitions for angular-local-storage v0.1.6
 // Project: https://github.com/grevory/angular-local-storage
 // Definitions by: Ken Fukuyama <https://github.com/kenfdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -86,6 +86,8 @@ declare module 'angular' {
             clearAll(): any;
 
         }
+        
+        type StorageType = 'localStorage' | 'sessionStorage';
 
         interface ILocalStorageService {
             /**
@@ -104,19 +106,19 @@ declare module 'angular' {
              * @param key
              * @param value
              */
-            set<T>(key: string, value: T): boolean;
+            set<T>(key: string, value: T, storageType?: StorageType): boolean;
             /**
              * Directly get a value from local storage.
              * If local storage is not supported, use cookies instead.
              * Returns: value from local storage
              * @param key
              */
-            get<T>(key: string): T;
+            get<T>(key: string, storageType?: StorageType): T;
             /**
              * Return array of keys for local storage, ignore keys that not owned.
              * Returns: value from local storage
              */
-            keys(): string[];
+            keys(storageType?: StorageType): string[];
             /**
              * Remove an item from local storage by key.
              * If local storage is not supported, use cookies instead.
@@ -131,7 +133,7 @@ declare module 'angular' {
              * Returns: Boolean
              * @param regularExpression
              */
-            clearAll(regularExpression?: RegExp): boolean;
+            clearAll(regularExpression?: RegExp, storageType?: StorageType): boolean;
             /**
              * Bind $scope key to localStorageService.
              * Usage: localStorageService.bind(scope, property, value[optional], key[optional])
@@ -141,7 +143,7 @@ declare module 'angular' {
              * @param value optional
              * @param key The corresponding key used in local storage
              */
-            bind(scope: angular.IScope, property: string, value?: any, key?: string): Function;
+            bind(scope: angular.IScope, property: string, value?: any, key?: string, storageType?: StorageType): Function;
             /**
              * Return the derive key
              * Returns String
@@ -152,7 +154,7 @@ declare module 'angular' {
              * Return localStorageService.length, ignore keys that not owned.
              * Returns Number
              */
-            length(): number;
+            length(storageType?: StorageType): number;
             /**
              * Deal with browser's cookies directly.
              */


### PR DESCRIPTION
Changes to this definition file reflects changes made in original library related to storage type.
It is possible now to pass type of storage to some methods e.g.
https://github.com/grevory/angular-local-storage/blob/master/src/angular-local-storage.js#L147