### PR TITLE
Add d3-sankey Definitions

### DIFF
--- a/types/d3-sankey/d3-sankey-tests.ts
+++ b/types/d3-sankey/d3-sankey-tests.ts
@@ -1,4 +1,192 @@
+/**
+ * Typescript definition tests for d3/d3-sankey module
+ *
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
 import * as d3Sankey from 'd3-sankey';
 import {select, Selection} from 'd3-selection';
 
-// TODO: include shape tests
+// ---------------------------------------------------------------------------
+// Preparatory Steps
+// ---------------------------------------------------------------------------
+
+interface SNode extends d3Sankey.SankeyNode {
+    nodeId: number;
+    name: string;
+}
+
+interface SLink extends d3Sankey.SankeyLink<SNode>{
+    uom: string;
+}
+
+interface DAG {
+    nodes: SNode[];
+    links: SLink[];
+}
+
+const graph: DAG = {
+  "nodes": [{
+    nodeId: 0,
+    name: "node0"
+  }, {
+    nodeId: 1,
+    name: "node1"
+  }, {
+    nodeId: 2,
+    name: "node2"
+  }, {
+    nodeId: 3,
+    name: "node3"
+  }, {
+    nodeId: 4,
+    name: "node4"
+  }],
+  "links": [{
+    source: 0,
+    target: 2,
+    value: 2,
+    uom: 'Widget(s)'
+  }, {
+    source: 1,
+    target: 2,
+    value: 2,
+    uom: 'Widget(s)'
+  }, {
+    source: 1,
+    target: 3,
+    value: 2,
+    uom: 'Widget(s)'
+  }, {
+    source: 0,
+    target: 4,
+    value: 2,
+    uom: 'Widget(s)'
+  }, {
+    source: 2,
+    target: 3,
+    value: 2,
+    uom: 'Widget(s)'
+  }, {
+    source: 2,
+    target: 4,
+    value: 2,
+    uom: 'Widget(s)'
+  }, {
+    source: 3,
+    target: 4,
+    value: 4,
+    uom: 'Widget(s)'
+  }]
+};
+
+let sNode: SNode;
+let sLink: SLink;
+
+let sNodes: SNode[];
+let sLinks: SLink[];
+
+let num: number;
+let size: [number, number];
+
+const svgLinkPaths = select<SVGSVGElement, undefined>('svg').selectAll<SVGPathElement, SLink>('.linkPath');
+let svgPathString: string;
+
+// ---------------------------------------------------------------------------
+// Obtain SankeyLayout Generator
+// ---------------------------------------------------------------------------
+
+let slgDefault: d3Sankey.SankeyLayout<d3Sankey.SankeyNode, d3Sankey.SankeyLink<d3Sankey.SankeyNode>> = d3Sankey.sankey();
+let slgDAG: d3Sankey.SankeyLayout<SNode, SLink> = d3Sankey.sankey<SNode, SLink>();
+
+// ---------------------------------------------------------------------------
+// NodeWidth
+// ---------------------------------------------------------------------------
+
+// Set -----------------------------------------------------------------------
+
+// test return type for chainability
+slgDAG = slgDAG.nodeWidth(32);
+
+// Get -----------------------------------------------------------------------
+
+num = slgDAG.nodeWidth();
+
+// ---------------------------------------------------------------------------
+// NodePadding
+// ---------------------------------------------------------------------------
+
+// Set -----------------------------------------------------------------------
+
+// test return type for chainability
+slgDAG = slgDAG.nodePadding(8);
+
+// Get -----------------------------------------------------------------------
+
+num = slgDAG.nodePadding();
+
+// ---------------------------------------------------------------------------
+// Size
+// ---------------------------------------------------------------------------
+
+// Set -----------------------------------------------------------------------
+
+// test return type for chainability
+slgDAG = slgDAG.size([1200, 800]);
+
+// Get -----------------------------------------------------------------------
+
+size = slgDAG.size();
+
+// ---------------------------------------------------------------------------
+// Nodes
+// ---------------------------------------------------------------------------
+
+// Set -----------------------------------------------------------------------
+
+// test return type for chainability
+slgDAG = slgDAG.nodes(graph.nodes);
+
+// Get -----------------------------------------------------------------------
+
+sNodes = slgDAG.nodes();
+
+// ---------------------------------------------------------------------------
+// Links
+// ---------------------------------------------------------------------------
+
+// Set -----------------------------------------------------------------------
+
+// test return type for chainability
+slgDAG = slgDAG.links(graph.links);
+
+// Get -----------------------------------------------------------------------
+
+sLinks = slgDAG.links();
+
+
+// ---------------------------------------------------------------------------
+// Compute Layout
+// ---------------------------------------------------------------------------
+
+// test return type for chainability
+slgDAG = slgDAG.layout(32);
+
+// ---------------------------------------------------------------------------
+// Relayout
+// ---------------------------------------------------------------------------
+
+// test return type for chainability
+slgDAG = slgDAG.relayout();
+
+// ---------------------------------------------------------------------------
+// Obtain and Use Link SVG Path Generator
+// ---------------------------------------------------------------------------
+
+let pathGen: (link: SLink) => string;
+
+pathGen = slgDAG.link();
+
+svgLinkPaths.attr('d', pathGen);

--- a/types/d3-sankey/d3-sankey-tests.ts
+++ b/types/d3-sankey/d3-sankey-tests.ts
@@ -1,0 +1,4 @@
+import * as d3Sankey from 'd3-sankey';
+import {select, Selection} from 'd3-selection';
+
+// TODO: include shape tests

--- a/types/d3-sankey/d3-sankey-tests.ts
+++ b/types/d3-sankey/d3-sankey-tests.ts
@@ -13,14 +13,21 @@ import {select, Selection} from 'd3-selection';
 // Preparatory Steps
 // ---------------------------------------------------------------------------
 
-interface SNode extends d3Sankey.SankeyNode {
+// Create interfaces for the user-provided node/link attributes, which are NOT mandated or calculated by
+// the Sankey layout generator. The latter are reflected in the SankeyNode and SankeyLink interfaces provided
+// by the definitions file
+interface SNodeExtra {
     nodeId: number;
     name: string;
 }
 
-interface SLink extends d3Sankey.SankeyLink<SNode>{
+interface SLinkExtra {
     uom: string;
 }
+
+// For convenience
+type SNode = d3Sankey.SankeyNode<SNodeExtra, SLinkExtra>;
+type SLink = d3Sankey.SankeyLink<SNodeExtra, SLinkExtra>;
 
 interface DAG {
     nodes: SNode[];
@@ -82,9 +89,6 @@ const graph: DAG = {
   }]
 };
 
-let sNode: SNode;
-let sLink: SLink;
-
 let sNodes: SNode[];
 let sLinks: SLink[];
 
@@ -98,8 +102,8 @@ let svgPathString: string;
 // Obtain SankeyLayout Generator
 // ---------------------------------------------------------------------------
 
-let slgDefault: d3Sankey.SankeyLayout<d3Sankey.SankeyNode, d3Sankey.SankeyLink<d3Sankey.SankeyNode>> = d3Sankey.sankey();
-let slgDAG: d3Sankey.SankeyLayout<SNode, SLink> = d3Sankey.sankey<SNode, SLink>();
+let slgDefault: d3Sankey.SankeyLayout<{}, {}> = d3Sankey.sankey();
+let slgDAG: d3Sankey.SankeyLayout<SNodeExtra, SLinkExtra> = d3Sankey.sankey<SNodeExtra, SLinkExtra>();
 
 // ---------------------------------------------------------------------------
 // NodeWidth
@@ -172,7 +176,7 @@ sLinks = slgDAG.links();
 // ---------------------------------------------------------------------------
 
 // test return type for chainability
-slgDAG = slgDAG.layout(32);
+slgDAG = slgDAG.layout(22);
 
 // ---------------------------------------------------------------------------
 // Relayout

--- a/types/d3-sankey/d3-sankey-tests.ts
+++ b/types/d3-sankey/d3-sankey-tests.ts
@@ -93,6 +93,8 @@ let sNodes: SNode[];
 let sLinks: SLink[];
 
 let num: number;
+let numMaybe: number | undefined;
+let str: string;
 let size: [number, number];
 
 const svgLinkPaths = select<SVGSVGElement, undefined>('svg').selectAll<SVGPathElement, SLink>('.linkPath');
@@ -206,6 +208,51 @@ svgLinkPaths.attr('d', pathGen);
 // Shape test Node/Link related interfaces and types
 // ---------------------------------------------------------------------------
 
+// Sankey Node --------------------------------------------------------------
 
+let sNode = sNodes[0];
 
+// User-specified extra properties:
 
+num = sNode.nodeId;
+str = sNode.name;
+
+// Sankey Layout calculated (if layout has been run, otherwise undefined):
+
+numMaybe = sNode.dx;
+numMaybe = sNode.x;
+numMaybe = sNode.dy;
+numMaybe = sNode.y;
+numMaybe = sNode.value;
+
+let linksArrMaybe: SLink[] | undefined;
+
+linksArrMaybe = sNode.sourceLinks;
+linksArrMaybe = sNode.targetLinks;
+
+// Sankey Link --------------------------------------------------------------
+
+let sLink = sLinks[0];
+
+// User-specified extra properties:
+
+str = sLink.uom;
+
+// Sankey Layout mandated link properties:
+
+num = sLink.value;
+
+// Node depending on initialization strategy and whether
+// layout(...) was invoked, the source and target nodes may be numbers
+// objects without the Sankey layout coordinates, or objects with calculated
+// information
+let numOrSankeyNode: number  | SNode;
+
+numOrSankeyNode = sLink.source;
+numOrSankeyNode = sLink.target;
+
+// Sankey Layout calculated (if layout has been run, otherwise undefined):
+
+numMaybe = sLink.sy;
+numMaybe = sLink.ty;
+numMaybe = sLink.dy;

--- a/types/d3-sankey/d3-sankey-tests.ts
+++ b/types/d3-sankey/d3-sankey-tests.ts
@@ -189,8 +189,23 @@ slgDAG = slgDAG.relayout();
 // Obtain and Use Link SVG Path Generator
 // ---------------------------------------------------------------------------
 
-let pathGen: (link: SLink) => string;
+let pathGen: d3Sankey.SankeyLinkPathGenerator<SNodeExtra, SLinkExtra>;
 
 pathGen = slgDAG.link();
 
+// Adjust Link SVG Path Generator curvature ----------------------------------
+
+// test return type
+pathGen = pathGen.curvature(0.6);
+num = pathGen.curvature();
+
+
 svgLinkPaths.attr('d', pathGen);
+
+// ---------------------------------------------------------------------------
+// Shape test Node/Link related interfaces and types
+// ---------------------------------------------------------------------------
+
+
+
+

--- a/types/d3-sankey/d3-sankey-tests.ts
+++ b/types/d3-sankey/d3-sankey-tests.ts
@@ -35,7 +35,7 @@ interface DAG {
 }
 
 const graph: DAG = {
-  "nodes": [{
+  nodes: [{
     nodeId: 0,
     name: "node0"
   }, {
@@ -51,7 +51,7 @@ const graph: DAG = {
     nodeId: 4,
     name: "node4"
   }],
-  "links": [{
+  links: [{
     source: 0,
     target: 2,
     value: 2,
@@ -170,7 +170,6 @@ slgDAG = slgDAG.links(graph.links);
 // Get -----------------------------------------------------------------------
 
 sLinks = slgDAG.links();
-
 
 // ---------------------------------------------------------------------------
 // Compute Layout

--- a/types/d3-sankey/d3-sankey-tests.ts
+++ b/types/d3-sankey/d3-sankey-tests.ts
@@ -97,8 +97,7 @@ let numMaybe: number | undefined;
 let str: string;
 let size: [number, number];
 
-const svgLinkPaths = select<SVGSVGElement, undefined>('svg').selectAll<SVGPathElement, SLink>('.linkPath');
-let svgPathString: string;
+const svgLinkPaths = select<SVGSVGElement, undefined>('svg').selectAll<SVGPathElement, SLink>('.linkPath'); // assume mock DOM
 
 // ---------------------------------------------------------------------------
 // Obtain SankeyLayout Generator
@@ -201,7 +200,9 @@ pathGen = slgDAG.link();
 pathGen = pathGen.curvature(0.6);
 num = pathGen.curvature();
 
+// uses
 
+let svgPathString: string = pathGen(slgDAG.links()[0]);
 svgLinkPaths.attr('d', pathGen);
 
 // ---------------------------------------------------------------------------

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -135,7 +135,7 @@ export interface SankeyLinkPathGenerator<N extends SankeyExtraProperties, L exte
     /**
      * Return svg path string for a given link.
      *
-     * IMPORTANT: Only invoke for link data with Sankey Layout information previosuly calculated.
+     * IMPORTANT: Only invoke for link data with Sankey Layout information previously calculated.
      *
      * @param link A Sankey diagram link, for which the layout has already been calculated.
      */

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -119,13 +119,13 @@ export interface SankeyLayout<N extends SankeyNode, L extends SankeyLink> {
      */
     nodePadding(padding: number): this;
 
-    nodes(): () => N[];
+    nodes(): N[];
     nodes(nodes: N[]): this;
 
-    links(): () => L[];
+    links(): L[];
     links(links: L[]): this;
 
-    layout(iterations?: number):this;
+    layout(iterations: number):this;
 
     /**
      * Recalculate the depth of links and return this Sankey layout generator.
@@ -152,4 +152,5 @@ export interface SankeyLayout<N extends SankeyNode, L extends SankeyLink> {
 
 }
 
-export function sankey<N extends SankeyNode, L extends SankeyLink>(): SankeyLayout<N, L>;
+export function sankey(): SankeyLayout<SankeyNode, SankeyLink<SankeyNode>>;
+export function sankey<N extends SankeyNode, L extends SankeyLink<N>>(): SankeyLayout<N, L>;

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-sankey module 0.4
 // Project: https://github.com/d3/d3-sankey/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 0.4.2

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -26,12 +26,12 @@ export interface SankeyExtraProperties { [key: string]: any; }
  */
 export interface SankeyNodeMinimal<N extends SankeyExtraProperties, L extends SankeyExtraProperties> {
     /**
-     * Array of links which have this node as source.
+     * Array of links which have this node as their source.
      * This property is calculated internally by the Sankey layout generator.
      */
     sourceLinks?: Array<SankeyLink<N, L>>;
     /**
-     * Array of links which have this node as target.
+     * Array of links which have this node as their target.
      * This property is calculated internally by the Sankey layout generator.
      */
     targetLinks?: Array<SankeyLink<N, L>>;
@@ -101,7 +101,7 @@ export interface SankeyLinkMinimal<N extends SankeyExtraProperties, L extends Sa
      */
     value: number;
     /**
-     * Link width calculated by Sankey layout generator
+     * Link breadth calculated by Sankey layout generator based on the link value
      */
     dy?: number;
     /**
@@ -166,7 +166,7 @@ export interface SankeyLinkPathGenerator<N extends SankeyExtraProperties, L exte
  */
 export interface SankeyLayout<N extends SankeyExtraProperties, L extends SankeyExtraProperties> {
     /**
-     * Return the current width of a node in pixels, which defaults to 24.
+     * Return the current node width, which defaults to 24.
      */
     nodeWidth(): number;
     /**
@@ -177,7 +177,7 @@ export interface SankeyLayout<N extends SankeyExtraProperties, L extends SankeyE
     nodeWidth(width: number): this;
 
     /**
-     * Return the current node padding in pixels, which defaults to 8.
+     * Return the current node padding, which defaults to 8.
      *
      * Node padding refers to the vertical space between nodes which occupy the same horizontal space.
      */
@@ -192,54 +192,56 @@ export interface SankeyLayout<N extends SankeyExtraProperties, L extends SankeyE
     nodePadding(padding: number): this;
 
     /**
-     * Return the current array of nodes.
+     * Return the current array of nodes, which defaults to [].
      */
     nodes(): Array<SankeyNode<N, L>>;
     /**
-     * Set the array of nodes to be used for the Sankey layout and return this Sankey layout generator.
+     * Set the sankey generator's nodes to the specified array of objects and returns this sankey layout generator.
      *
      * @param nodes Array of nodes.
      */
     nodes(nodes: Array<SankeyNode<N, L>>): this;
 
     /**
-     * Return the current array of links.
+     * Return the current array of links, which defaults to [].
      */
     links(): Array<SankeyLink<N, L>>;
     /**
-     * Set the array of links to be used for the Sankey layout and return this Sankey layout generator.
+     * Set the sankey generator's links to the specified array of objects and returns this sankey layout generator.
      *
      * @param links Array of links.
      */
     links(links: Array<SankeyLink<N, L>>): this;
 
     /**
-     * Calculate the Sankey layout.
+     * Runs the sankey layout algorithm updating the nodes and links with their respective layout information and returns this sankey generator.
      *
-     * @param iterations Number of iterations to run the iterative relaxation algorithm for node placement.
+     * @param iterations Number of passes to be used in the iterative relaxation algorithm for node placement.
      */
     layout(iterations: number): this;
 
     /**
      * Recalculate the depth of links and return this Sankey layout generator.
-     * Primarily used when a node is moved vertically.
+     * This methods is primarily used when a node is moved vertically, e.g. using d3-drag.
      */
     relayout(): this;
 
     /**
-     * Get the current size of the layout in pixels. The size is a two element array of [width, height] which defaults to [1, 1].
+     * Return the current layout size in pixels. The size is a two element array of [width, height] which defaults to [1, 1].
      */
     size(): [number, number];
     /**
-     * Set the size of the layout in pixels and return this Sankey layout generator.
+     * Set the size of the layout and return this Sankey layout generator.
      *
      * @param size A two element array of [width, height] in pixels which defaults to [1, 1].
      */
     size(size: [number, number]): this;
 
     /**
-     * Obtain an svg path generator for the links of the calculated Sankey diagram layout.
-     * By default the path  generator uses a curvature of 0.5.
+     * Return a Sankey link path generator for the links based on the calculated Sankey diagram layout.
+     * The link path generator can be invoked as a function being passed as its argument a link object
+     * with calculated layout information. It returns the computed <svg> path string for the link.
+     * By default the link path generator uses a curvature of 0.5.
      */
     link(): SankeyLinkPathGenerator<N, L>;
 }

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -6,11 +6,11 @@
 // Last module patch version validated against: 0.4.2
 
 /**
- * A helper type as an extension reference for user-provided properties of
+ * A helper interface as an extension reference for user-provided properties of
  * nodes and links in the graph, which are not required or calculated by
  * the Sankey Layout Generator
  */
-export type SankeyExtraProperties = { [key: string]: any };
+export interface SankeyExtraProperties { [key: string]: any }
 
 /**
  * Helper interface to define the properties of Sankey Nodes. Calculated properties may only be defined,
@@ -29,12 +29,12 @@ export interface SankeyNodeMinimal<N extends SankeyExtraProperties, L extends Sa
      * Array of links which have this node as source.
      * This property is calculated internally by the Sankey layout generator.
      */
-    sourceLinks?: SankeyLink<N, L>[];
+    sourceLinks?: Array<SankeyLink<N, L>>;
     /**
      * Array of links which have this node as target.
      * This property is calculated internally by the Sankey layout generator.
      */
-    targetLinks?: SankeyLink<N, L>[];
+    targetLinks?: Array<SankeyLink<N, L>>;
     /**
      * Node value calculated by Sankey Layout Generator based on values of incoming and outgoing links
      */
@@ -112,7 +112,6 @@ export interface SankeyLinkMinimal<N extends SankeyExtraProperties, L extends Sa
      * Vertical end position of the link (at target node) calculated by Sankey layout generator
      */
     ty?: number;
-
 }
 
 /**
@@ -195,24 +194,24 @@ export interface SankeyLayout<N extends SankeyExtraProperties, L extends SankeyE
     /**
      * Return the current array of nodes.
      */
-    nodes(): SankeyNode<N, L>[];
+    nodes(): Array<SankeyNode<N, L>>;
     /**
      * Set the array of nodes to be used for the Sankey layout and return this Sankey layout generator.
      *
      * @param nodes Array of nodes.
      */
-    nodes(nodes: SankeyNode<N, L>[]): this;
+    nodes(nodes: Array<SankeyNode<N, L>>): this;
 
     /**
      * Return the current array of links.
      */
-    links(): SankeyLink<N, L>[];
+    links(): Array<SankeyLink<N, L>>;
     /**
      * Set the array of links to be used for the Sankey layout and return this Sankey layout generator.
      *
      * @param links Array of links.
      */
-    links(links: SankeyLink<N, L>[]): this;
+    links(links: Array<SankeyLink<N, L>>): this;
 
     /**
      * Calculate the Sankey layout.
@@ -243,7 +242,6 @@ export interface SankeyLayout<N extends SankeyExtraProperties, L extends SankeyE
      * By default the path  generator uses a curvature of 0.5.
      */
     link(): SankeyLinkPathGenerator<N, L>;
-
 }
 
 /**

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -5,8 +5,25 @@
 
 // Last module patch version validated against: 0.4.2
 
-export type SankeyExtraProperties = {[key: string]: any};
+/**
+ * A helper type as an extension reference for user-provided properties of
+ * nodes and links in the graph, which are not required or calculated by
+ * the Sankey Layout Generator
+ */
+export type SankeyExtraProperties = { [key: string]: any };
 
+/**
+ * Helper interface to define the properties of Sankey Nodes. Calculated properties may only be defined,
+ * once the layout(...) method of the Sankey layout generator has been invoked.
+ *
+ * The first generic N refers to user-defined properties contained in the node data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyNodeMinimal interface.
+ *
+ * The second generic L refers to user-defined properties contained in the link data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyLinkMinimal interface.
+ */
 export interface SankeyNodeMinimal<N extends SankeyExtraProperties, L extends SankeyExtraProperties> {
     /**
      * Array of links which have this node as source.
@@ -40,8 +57,32 @@ export interface SankeyNodeMinimal<N extends SankeyExtraProperties, L extends Sa
     dy?: number;
 }
 
+/**
+ * Sankey Node type including both user-defined node data elements as well as those
+ * calculated once the layout(...) method of the Sankey layout generators has been invoked.
+ *
+ * The first generic N refers to user-defined properties contained in the node data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyNodeMinimal interface.
+ *
+ * The second generic L refers to user-defined properties contained in the link data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyLinkMinimal interface.
+ */
 export type SankeyNode<N extends SankeyExtraProperties, L extends SankeyExtraProperties> = N & SankeyNodeMinimal<N, L>;
 
+/**
+ * Helper interface to define the properties of Sankey Links. Calculated properties may only be defined,
+ * once the layout(...) method of the Sankey layout generator has been invoked.
+ *
+ * The first generic N refers to user-defined properties contained in the node data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyNodeMinimal interface.
+ *
+ * The second generic L refers to user-defined properties contained in the link data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyLinkMinimal interface.
+ */
 export interface SankeyLinkMinimal<N extends SankeyExtraProperties, L extends SankeyExtraProperties> {
     /**
      * Source node of the link. For convenience, when initializing a Sankey layout, source may be the index of the source node in the nodes array
@@ -74,11 +115,28 @@ export interface SankeyLinkMinimal<N extends SankeyExtraProperties, L extends Sa
 
 }
 
+/**
+ * Sankey Link type including both user-defined link data elements, those required by the Sankey layout generator,
+ *  as well as those calculated once the layout(...) method of the layout generator has been invoked.
+ *
+ * The first generic N refers to user-defined properties contained in the node data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyNodeMinimal interface.
+ *
+ * The second generic L refers to user-defined properties contained in the link data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyLinkMinimal interface.
+ */
 export type SankeyLink<N extends SankeyExtraProperties, L extends SankeyExtraProperties> = L & SankeyLinkMinimal<N, L>;
 
+/**
+ * An svg path generator factory for the link paths in a calculated Sankey Layout.
+ */
 export interface SankeyLinkPathGenerator<N extends SankeyExtraProperties, L extends SankeyExtraProperties> {
     /**
      * Return svg path string for a given link.
+     *
+     * IMPORTANT: Only invoke for link data with Sankey Layout information previosuly calculated.
      *
      * @param link A Sankey diagram link, for which the layout has already been calculated.
      */
@@ -87,7 +145,7 @@ export interface SankeyLinkPathGenerator<N extends SankeyExtraProperties, L exte
      * Returns the current curvature used to calculate svg paths for links.
      * The default curvature is 0.5.
      */
-    curvature():number;
+    curvature(): number;
     /**
      * Set the curvature used to calculate svg paths for links and return the updated link path generator.
      *
@@ -96,7 +154,17 @@ export interface SankeyLinkPathGenerator<N extends SankeyExtraProperties, L exte
     curvature(curvature: number): this;
 }
 
-
+/**
+ * A Sankey layout generator.
+ *
+ * The first generic N refers to user-defined properties contained in the node data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyNodeMinimal interface.
+ *
+ * The second generic L refers to user-defined properties contained in the link data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyLinkMinimal interface.
+ */
 export interface SankeyLayout<N extends SankeyExtraProperties, L extends SankeyExtraProperties> {
     /**
      * Return the current width of a node in pixels, which defaults to 24.
@@ -127,19 +195,37 @@ export interface SankeyLayout<N extends SankeyExtraProperties, L extends SankeyE
     /**
      * Return the current array of nodes.
      */
-    nodes(): SankeyNode<N,L>[];
-    nodes(nodes: SankeyNode<N,L>[]): this;
+    nodes(): SankeyNode<N, L>[];
+    /**
+     * Set the array of nodes to be used for the Sankey layout and return this Sankey layout generator.
+     *
+     * @param nodes Array of nodes.
+     */
+    nodes(nodes: SankeyNode<N, L>[]): this;
 
-    links(): SankeyLink<N,L>[];
-    links(links: SankeyLink<N,L>[]): this;
+    /**
+     * Return the current array of links.
+     */
+    links(): SankeyLink<N, L>[];
+    /**
+     * Set the array of links to be used for the Sankey layout and return this Sankey layout generator.
+     *
+     * @param links Array of links.
+     */
+    links(links: SankeyLink<N, L>[]): this;
 
-    layout(iterations: number):this;
+    /**
+     * Calculate the Sankey layout.
+     *
+     * @param iterations Number of iterations to run the iterative relaxation algorithm for node placement.
+     */
+    layout(iterations: number): this;
 
     /**
      * Recalculate the depth of links and return this Sankey layout generator.
      * Primarily used when a node is moved vertically.
      */
-    relayout():this;
+    relayout(): this;
 
     /**
      * Get the current size of the layout in pixels. The size is a two element array of [width, height] which defaults to [1, 1].
@@ -150,15 +236,32 @@ export interface SankeyLayout<N extends SankeyExtraProperties, L extends SankeyE
      *
      * @param size A two element array of [width, height] in pixels which defaults to [1, 1].
      */
-    size(size: [number, number]):this;
+    size(size: [number, number]): this;
 
     /**
      * Obtain an svg path generator for the links of the calculated Sankey diagram layout.
      * By default the path  generator uses a curvature of 0.5.
      */
-    link():SankeyLinkPathGenerator<N, L>;
+    link(): SankeyLinkPathGenerator<N, L>;
 
 }
 
+/**
+ * Get a Sankey layout generator.
+ *
+ * Invoking sankey() without generics, means the node type and link type assume no user-defined attributes, i.e.
+ * only the attributes internally used by the Sankey layout generator.
+ */
 export function sankey(): SankeyLayout<{}, {}>;
+/**
+ * Get a Sankey layout generator.
+ *
+ * The first generic N refers to user-defined properties contained in the node data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyNodeMinimal interface.
+ *
+ * The second generic L refers to user-defined properties contained in the link data passed into
+ * Sankey layout generator. These properties are IN EXCESS to the properties explicitly identified in the
+ * SankeyLinkMinimal interface.
+ */
 export function sankey<N extends SankeyExtraProperties, L extends SankeyExtraProperties>(): SankeyLayout<N, L>;

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -10,7 +10,7 @@
  * nodes and links in the graph, which are not required or calculated by
  * the Sankey Layout Generator
  */
-export interface SankeyExtraProperties { [key: string]: any }
+export interface SankeyExtraProperties { [key: string]: any; }
 
 /**
  * Helper interface to define the properties of Sankey Nodes. Calculated properties may only be defined,

--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -1,0 +1,155 @@
+// Type definitions for D3JS d3-sankey module 0.4
+// Project: https://github.com/d3/d3-sankey/
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Last module patch version validated against: 0.4.2
+
+// TODO: Find robust approach to defining SankeyNode and SankeyLink given the circular definitons inherent in the JS implementation
+// TODO: Definitions are based on actural JS code, as d3-sankey API documentation misses key methods and refers to the use of accessor functions, when
+// the source code does not support it. API documentation should be clarified as a separate step.
+
+export interface SankeyNode {
+    /**
+     * Array of links which have this node as source
+     */
+    sourceLinks?: SankeyLink[];
+    /**
+     * Array of links which have this node as target
+     */
+    targetLinks?: SankeyLink[];
+    /**
+     * Node value calculated by Sankey Layout Generator based on values of incoming and outgoing links
+     */
+    value?: number;
+    /**
+     * Node horizontal position calculated by Sankey layout generator
+     */
+    x?: number;
+    /**
+     * Node width calculated by Sankey layout generator
+     */
+    dx?: number;
+    /**
+     * Node vertical position (depth) calculated by Sankey layout generator
+     */
+    y?: number;
+    /**
+     * Node height (vertical extent based on node value) calculated by Sankey layout generator
+     */
+    dy?: number;
+}
+
+export interface SankeyLink<N extends SankeyNode> {
+    /**
+     * Source node of the link. For convenience, when initializing a Sankey layout, source may be the index of the source node in the nodes array
+     * passed into the Sankey layout generator. Once the layout(...) method is invoked, the numeric index will be replaced with the corresponding
+     * source node object.
+     */
+    source: number | N;
+    /**
+     * Target node of the link. For convenience, when initializing a Sankey layout, target may be the index of the target node in the nodes array
+     * passed into the Sankey layout generator. Once the layout(...) method is invoked, the numeric index will be replaced with the corresponding
+     * target node object.
+     */
+    target: number | N;
+    /**
+     * Value of the link
+     */
+    value: number;
+    /**
+     * Link width calculated by Sankey layout generator
+     */
+    dy?: number;
+    /**
+     * Vertical starting position of the link (at source node) calculated by Sankey layout generator
+     */
+    sy?: number;
+    /**
+     * Vertical end position of the link (at target node) calculated by Sankey layout generator
+     */
+    ty?: number;
+
+}
+
+export interface SankeyLinkPathGenerator<L extends SankeyLink> {
+    /**
+     * Return svg path string for a given link.
+     *
+     * @param link A Sankey diagram link, for which the layout has already been calculated.
+     */
+    (link: L): string;
+    /**
+     * Returns the current curvature used to calculate svg paths for links.
+     * The default curvature is 0.5.
+     */
+    curvature():number;
+    /**
+     * Set the curvature used to calculate svg paths for links and return the updated link path generator.
+     *
+     * @param curvature Curvature to be used when calculating svg paths for links. The default curvature is 0.5.
+     */
+    curvature(curvature: number): this;
+}
+
+export interface SankeyLayout<N extends SankeyNode, L extends SankeyLink> {
+    /**
+     * Return the current width of a node in pixels, which defaults to 24.
+     */
+    nodeWidth(): number;
+    /**
+     * Set the node width to the specified number and return this Sankey layout generator.
+     *
+     * @param width Width of node in pixels, which defaults to 24.
+     */
+    nodeWidth(width: number): this;
+
+    /**
+     * Return the current node padding in pixels, which defaults to 8.
+     *
+     * Node padding refers to the vertical space between nodes which occupy the same horizontal space.
+     */
+    nodePadding(): number;
+    /**
+     * Set the node padding to the specified number and return this Sankey layout generator.
+     *
+     * Node padding refers to the vertical space between nodes which occupy the same horizontal space.
+     *
+     * @param padding Node padding in pixels, which defaults to 8.
+     */
+    nodePadding(padding: number): this;
+
+    nodes(): () => N[];
+    nodes(nodes: N[]): this;
+
+    links(): () => L[];
+    links(links: L[]): this;
+
+    layout(iterations?: number):this;
+
+    /**
+     * Recalculate the depth of links and return this Sankey layout generator.
+     * Primarily used when a node is moved vertically.
+     */
+    relayout():this;
+
+    /**
+     * Get the current size of the layout in pixels. The size is a two element array of [width, height] which defaults to [1, 1].
+     */
+    size(): [number, number];
+    /**
+     * Set the size of the layout in pixels and return this Sankey layout generator.
+     *
+     * @param size A two element array of [width, height] in pixels which defaults to [1, 1].
+     */
+    size(size: [number, number]):this;
+
+    /**
+     * Obtain an svg path generator for the links of the calculated Sankey diagram layout.
+     * By default the path  generator uses a curvature of 0.5.
+     */
+    link():SankeyLinkPathGenerator<L>;
+
+}
+
+export function sankey<N extends SankeyNode, L extends SankeyLink>(): SankeyLayout<N, L>;

--- a/types/d3-sankey/tsconfig.json
+++ b/types/d3-sankey/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "d3-sankey-tests.ts"
+    ]
+}

--- a/types/d3-sankey/tslint.json
+++ b/types/d3-sankey/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

This PR adds definitions for **d3-sankey** the folder structure corresponds to the one used for the core D3 module definitions.

In reviewing the definition, please be advised, that it is based on a source code review of [d3-sankey](https://github.com/d3/d3-sankey/blob/master/src/sankey.js). This approach was chosen, as the current API documentation of the repo misses key methods of the methods of the Sankey Layout generator. The documentation also makes misguiding statements about the use of accessor functions, when none are used in the code.

I will open a separate issue in the d3-sankey repo to ask for changes to be made and submit a PR there, if agreeable.

Closes #14797.

Kindly asking for a review @gustavderdrache @Ledragon 
cc @ravibha