### PR TITLE
Adding ability to provide own picture for facebook share dialogs

### DIFF
--- a/types/facebook-js-sdk/facebook-js-sdk-tests.ts
+++ b/types/facebook-js-sdk/facebook-js-sdk-tests.ts
@@ -107,4 +107,5 @@ FB.ui({
     method: 'share',
     mobile_iframe: true,
     href: 'https://developers.facebook.com/docs/',
+    picture: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/2000px-Google_2015_logo.svg.png',
 }, response => {});

--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -113,7 +113,7 @@ declare namespace facebook {
     interface ShareDialogParams extends DialogParams {
         method: 'share';
         href: string;
-        picture: string;
+        picture?: string;
         hashtag?: string;
         quote?: string;
         mobile_iframe?: boolean;

--- a/types/facebook-js-sdk/index.d.ts
+++ b/types/facebook-js-sdk/index.d.ts
@@ -113,6 +113,7 @@ declare namespace facebook {
     interface ShareDialogParams extends DialogParams {
         method: 'share';
         href: string;
+        picture: string;
         hashtag?: string;
         quote?: string;
         mobile_iframe?: boolean;


### PR DESCRIPTION
Modifying @types/facebook-js-sdk

Adding support for custom thumbnail images for using the facebook share
dialog. Facebook will provide default images for your dialog if you
don't specify your own. This allows you to override this. It works but
it isn't documented under facebook documentation unfortunately.

Adding fix for #15908 in the master repo.

========================================================

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ Can't] Provide a URL to documentation or source code which provides context for the suggested changes: Can't because I can't find documentation for this. It does work however. I have attached screenshot showing this. You can see the stick man is clearly not what facebook would generate for that web page by default
![image](https://cloud.githubusercontent.com/assets/1182582/25303139/c3716f82-27a0-11e7-8971-03d5f9fd48b1.png)

- [ N/A?] Increase the version number in the header if appropriate.
- [ N/A? ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
