### PR TITLE
Missing typing on OpenLayers

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -12461,6 +12461,7 @@ declare module olx {
          *     geometryName: (string|undefined),
          *     condition: (ol.EventsConditionType|undefined),
          *     freehandCondition: (ol.EventsConditionType|undefined),
+         *     freehand: (boolean|undefined)
          *     wrapX: (boolean|undefined)}}
          */
         interface DrawOptions {
@@ -12477,6 +12478,7 @@ declare module olx {
             geometryName?: string;
             condition?: ol.EventsConditionType;
             freehandCondition?: ol.EventsConditionType;
+            freehand?:boolean;
             wrapX?: boolean;
         }
 


### PR DESCRIPTION
Missing typing on OpenLayers 
freehand option was missing from DrawOptions.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://openlayers.org/en/latest/apidoc/ol.interaction.Draw.html
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

