### PR TITLE
koa-jwt: fix `secret` option can be a function

### DIFF
--- a/types/koa-jwt/index.d.ts
+++ b/types/koa-jwt/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-jwt 2.1
+// Type definitions for koa-jwt 3.2
 // Project: https://github.com/koajs/jwt
 // Definitions by: Bruno Krebs <https://github.com/brunokrebs/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,7 +11,7 @@ declare function jwt(options: jwt.Options): jwt.Middleware;
 
 declare namespace jwt {
     interface Options {
-        secret: string | Buffer;
+        secret: string | Buffer | jwt.SecretProvider;
         key?: string;
         getToken?(opts: jwt.Options): string;
         passthrough?: boolean;
@@ -30,4 +30,12 @@ declare namespace jwt {
     type Middleware = Koa.Middleware & {
         unless(options?: jwt.UnlessOptions): any;
     };
+
+    type SecretProvider = (header: jwt.TokenHeader) => Promise<string>;
+
+    interface TokenHeader {
+      alg: string;
+      kid: string;
+      typ: string;
+    }
 }

--- a/types/koa-jwt/koa-jwt-tests.ts
+++ b/types/koa-jwt/koa-jwt-tests.ts
@@ -15,3 +15,9 @@ app.use(jwt({
 app.use(jwt({
     secret: 'some-secret-key'
 }).unless({method: 'OPTIONS'}));
+
+app.use(jwt({
+    secret: (header: jwt.TokenHeader): Promise<string> => {
+    	return Promise.resolve("some-secret-key");
+    }
+}));


### PR DESCRIPTION
koa-jwt `secret` option may accept a function that will receive the token header and returns a promise that resolves the secret.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/jwt/blob/master/lib/index.js#L28
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
