### PR TITLE
Ramda - Fix typing of assoc, objOf, and transpose

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/donnut/typescript-ramda
 // Definitions by: Erwin Poeze <https://github.com/donnut>, Matt DeKrey <https://github.com/mdekrey>, Liam Goodacre <https://github.com/LiamGoodacre>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 declare var R: R.Static;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for ramda
 // Project: https://github.com/donnut/typescript-ramda
-// Definitions by: Erwin Poeze <https://github.com/donnut>, Matt DeKrey <https://github.com/mdekrey>
+// Definitions by: Erwin Poeze <https://github.com/donnut>, Matt DeKrey <https://github.com/mdekrey>, Liam Goodacre <https://github.com/LiamGoodacre>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var R: R.Static;
@@ -214,9 +214,9 @@ declare namespace R {
         /**
          * Makes a shallow clone of an object, setting or overriding the specified property with the given value.
          */
-        assoc<T,U>(prop: string, val: T, obj: U): {prop: T} & U;
-        assoc(prop: string): <T,U>(val: T, obj: U) => {prop: T} & U;
-        assoc<T>(prop: string, val: T): <U>(obj: U) => {prop: T} & U;
+        assoc<T,U,K extends string>(prop: K, val: T, obj: U): Record<K, T> & U;
+        assoc<K extends string>(prop: K): <T,U>(val: T, obj: U) => Record<K, T> & U;
+        assoc<T,K extends string>(prop: K, val: T): <U>(obj: U) => Record<K, T> & U;
 
 
         /**
@@ -1055,8 +1055,8 @@ declare namespace R {
         /**
          * Creates an object containing a single key:value pair.
          */
-        objOf<T>(key: string, value: T): {string: T};
-        objOf(key: string): <T>(value: T) => {string: T};
+        objOf<T, K extends string>(key: K, value: T): Record<K, T>;
+        objOf<K extends string>(key: K): <T>(value: T) => Record<K, T>;
 
         /**
          * Returns a singleton array containing the value provided.
@@ -1584,7 +1584,7 @@ declare namespace R {
         /**
          * Transposes the rows and columns of a 2D list. When passed a list of n lists of length x, returns a list of x lists of length n.
          */
-        transpose<T>(list: any[][]): any[][];
+        transpose<T>(list: T[][]): T[][];
 
         /**
          * Removes (strips) whitespace from both ends of the string.

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -965,9 +965,9 @@ type Pair = KeyValuePair<string, number>
 }
 
 () => {
-    const a: any[][] = R.transpose([[1, 'a'], [2, 'b'], [3, 'c']]) //=> [[1, 2, 3], ['a', 'b', 'c']]
-    const b: any[][] = R.transpose([[1, 2, 3], ['a', 'b', 'c']]) //=> [[1, 'a'], [2, 'b'], [3, 'c']]
-    const c: any[][] = R.transpose([[10, 11], [20], [], [30, 31, 32]]) //=> [[10, 20, 30], [11, 31], [32]]
+    const a: (number | string)[][] = R.transpose<number | string>([[1, 'a'], [2, 'b'], [3, 'c']]) //=> [[1, 2, 3], ['a', 'b', 'c']]
+    const b: (number | string)[][] = R.transpose<number | string>([[1, 2, 3], ['a', 'b', 'c']]) //=> [[1, 'a'], [2, 'b'], [3, 'c']]
+    const c: number[][] = R.transpose([[10, 11], [20], [], [30, 31, 32]]) //=> [[10, 20, 30], [11, 31], [32]]
 }
 
 () => {
@@ -1024,9 +1024,10 @@ type Pair = KeyValuePair<string, number>
  * Object category
  */
 () => {
-    const a = R.assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
-    const b = R.assoc('c')(3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
-    const c = R.assoc('c', 3)({a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
+    type ABC = {a: number, b: number, c: number}
+    const a: ABC = R.assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
+    const b: ABC = R.assoc('c')(3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
+    const c: ABC = R.assoc('c', 3)({a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
 }
 
 () => {
@@ -1296,12 +1297,15 @@ class Rectangle {
 }
 
 () => {
-    var matchPhrases = R.compose(
-    R.objOf('must'),
-    R.map(R.objOf('match_phrase'))
-)
+    const matchPhrases = (xs: string[]) => R.objOf('must',
+        R.map(
+            (x: string) => R.objOf('match_phrase', x),
+            xs
+        )
+    )
 
-matchPhrases(['foo', 'bar', 'baz']);
+    const out: {must: Array<{match_phrase: string}>} =
+        matchPhrases(['foo', 'bar', 'baz']);
 }
 () => {
     R.omit(['a', 'd'], {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, c: 3}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
    > tested by running tsc in the ramda directory
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    - http://ramdajs.com/docs/#assoc
    - http://ramdajs.com/docs/#objOf
    - http://ramdajs.com/docs/#transpose
- [x] Increase the version number in the header if appropriate.

Changes:

- `assoc` was returning an object with the key `prop` when it should be returning one with the key referred to by the variable `prop`
- `objOf` similarly to `assoc`, but was using `string` as the key
- `transpose` wasn't using its type parameter