### PR TITLE
jquery: allow propertyNames array parameter to `css()`

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -1658,6 +1658,14 @@ interface JQuery {
      */
     css(propertyName: string): string;
     /**
+     * Get the value of style properties for the first element in the set of matched elements.
+     * Results in an object of property-value pairs.
+     *
+     * @param propertyNames An array of one or more CSS properties.
+     * @see {@link https://api.jquery.com/css/#css-propertyNames}
+     */
+    css(propertyNames: string[]): any;
+    /**
      * Set one or more CSS properties for the set of matched elements.
      *
      * @param propertyName A CSS property name.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). ***A lot of errors not related to this PR***

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.jquery.com/css/#css-propertyNames
- [ ] Increase the version number in the header if appropriate. ***Not appropriate***
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`. ***Not appropriate***

