### PR TITLE
Correct bonjour export and test

### DIFF
--- a/types/bonjour/bonjour-tests.ts
+++ b/types/bonjour/bonjour-tests.ts
@@ -1,20 +1,19 @@
 import * as bonjour from 'bonjour';
 
-var bonjourOptions: bonjour.BonjourOptions;
-var bonjourInstance: bonjour.Bonjour;
+let bonjourOptions: Bonjour.BonjourOptions;
+let bonjourInstance: Bonjour;
 
-var serviceOptions: bonjour.ServiceOptions;
-var service: bonjour.Service;
+let serviceOptions: Bonjour.ServiceOptions;
+let service: Bonjour.Service;
 
-var browserOptions: bonjour.BrowserOptions;
-var browser: bonjour.Browser;
+let browserOptions: Bonjour.BrowserOptions;
+let browser: Bonjour.Browser;
 
 bonjourOptions = { interface: '192.168.1.1', port: 5353 };
-bonjourInstance = new bonjour.Bonjour(bonjourOptions);
+bonjourInstance = bonjour(bonjourOptions);
 
 serviceOptions = { name: 'My Web Server', type: 'http', port: 3000 };
 service = bonjourInstance.publish(serviceOptions);
 
 browserOptions = { protocol: 'tcp', type: 'http' };
-browser = bonjour.find(browserOptions);
-
+browser = bonjourInstance.find(browserOptions, (service: Bonjour.Service) => { });

--- a/types/bonjour/index.d.ts
+++ b/types/bonjour/index.d.ts
@@ -1,68 +1,70 @@
-// Type definitions for bonjour v3.5.0
+// Type definitions for bonjour 3.5
 // Project: https://github.com/watson/bonjour
-// Definitions by: Quentin Lampin <https://github.com/quentin-ol/>
+// Definitions by: Meirion Hughes <https://github.com/MeirionHughes/>, Quentin Lampin <https://github.com/quentin-ol/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface BonjourOptions {
-    multicast?: boolean;
-    interface?: string;
-    port?: number;
-    ip?: string;
-    ttl?: number;
-    loopback?: boolean;
-    reuseAddr?: boolean;
+declare global {
+  namespace Bonjour {
+    interface BonjourOptions {
+      multicast?: boolean;
+      interface?: string;
+      port?: number;
+      ip?: string;
+      ttl?: number;
+      loopback?: boolean;
+      reuseAddr?: boolean;
+    }
+
+    interface BrowserOptions {
+      type?: string;
+      subtypes?: string[];
+      protocol?: string;
+      txt?: { [key: string]: string };
+    }
+    interface ServiceOptions {
+      name: string;
+      host?: string;
+      port: number;
+      type: string;
+      subtypes?: string[];
+      protocol?: 'udp' | 'tcp';
+      txt?: { [key: string]: string };
+    }
+    interface Service {
+      name: string;
+      type: string;
+      subtypes: string[];
+      protocol: string;
+      host: string;
+      port: number;
+      fqdn: string;
+      rawTxt: any;
+      txt: { [key: string]: string };
+      published: boolean;
+
+      stop(cb?: () => void): void;
+      start(): void;
+    }
+
+    interface Browser {
+      services: Bonjour.Service[];
+
+      start(): void;
+      update(): void;
+      stop(): void;
+    }
+  }
+  class Bonjour {
+    publish(options: Bonjour.ServiceOptions): Bonjour.Service;
+    unpublishAll(cb?: () => any): void;
+    find(options: Bonjour.BrowserOptions, onUp?: (service: Bonjour.Service) => any): Bonjour.Browser;
+    findOne(options: any, cb?: (service: Bonjour.Service) => any): Bonjour.Browser;
+    destroy(): void;
+  }
 }
 
-export interface BrowserOptions {
-    type?: string;
-    subtypes?: string[];
-    protocol?: string;
-    txt?: Object;
-}
+declare function BonjourConstructor(options: Bonjour.BonjourOptions): Bonjour;
 
-export interface ServiceOptions {
-    name: string;
-    host?: string;
-    port: number;
-    type: string;
-    subtypes?: string[];
-    protocol?: 'udp'|'tcp';
-    txt?: Object;
-}
+declare namespace BonjourConstructor { }
 
-export interface Service {
-    name: string;
-    type: string;
-    subtypes: string[];
-    protocol: string;
-    host: string;
-    port: number;
-    fqdn: string;
-    rawTxt: Object;
-    txt: Object;
-    published: boolean;
-
-    stop: (cb: ()=>any) => void;
-    start: () => void;
-}
-
-export class Bonjour {
-
-    constructor(opts: BonjourOptions);
-    publish(options: ServiceOptions):Service;
-    unpublishAll(cb: ()=>any): void;
-    find(options:BrowserOptions, onUp: ()=>any): Browser;
-    findOne(options:any, cb: (service: Service)=>any): Browser;
-    destroy():void;
-}
-
-export class Browser {
-    services: Service[];
-
-    start():void;
-    update():void;
-    stop():void;
-}
-
-export function find(options: BrowserOptions, onUp?: ()=>any): Browser;
-export function findOne(options: BrowserOptions): Browser;
+export = BonjourConstructor;

--- a/types/bonjour/tslint.json
+++ b/types/bonjour/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc`

> ref: https://github.com/watson/bonjour/blob/master/index.js

original typings make the library look like an es6 module, when it isn't - see ref. Also it exported a `Bonjour` class that doesn't exist in runtime either. 

I've updated the typings to make the types global, and exported the Generated Instance. I've tested against the actual run-time and its working. 

I also added an empty namespace, which enables use of the `import * as bonjour from 'bonjour'` syntax.

note: The[ runtime is using a callable constructor ](https://github.com/watson/bonjour/blob/master/index.js#L9-L10) which I don't know how to type for (I don't think you can yet?), that is why I went with typing it as a function instead

