### PR TITLE
fabric: callback and options object is optional in setSrc method

### DIFF
--- a/types/fabric/fabric-tests.ts
+++ b/types/fabric/fabric-tests.ts
@@ -124,11 +124,12 @@ function sample3() {
     }
   });
 
-  fabric.Image.fromURL('../assets/printio.png', img => {
+  const image = fabric.Image.fromURL('../assets/printio.png', img => {
     const oImg = img.set({ left: 300, top: 300, angle: -15 }).scale(0.9);
     canvas.add(oImg).renderAll();
     canvas.setActiveObject(oImg);
   });
+  image.setSrc('../assets/printio.png');
 
   $('grayscale').onclick = function(this: HTMLInputElement) {
     applyFilter(0, this.checked && new f.Grayscale());

--- a/types/fabric/fabric-tests.ts
+++ b/types/fabric/fabric-tests.ts
@@ -1,5 +1,3 @@
-import * as fabric from "fabric";
-
 function sample1() {
   const canvas = new fabric.Canvas('c', {
     hoverCursor: 'pointer',
@@ -261,18 +259,18 @@ function sample4() {
   });
 }
 
-declare module "fabric" {
-  export interface CircleWithLineInfos extends Circle {
-    line1?: Line;
-    line2?: Line;
-    line3?: Line;
-    line4?: Line;
+namespace myfabric {
+  export interface CircleWithLineInfos extends fabric.Circle {
+    line1?: fabric.Line;
+    line2?: fabric.Line;
+    line3?: fabric.Line;
+    line4?: fabric.Line;
   }
 }
 
 function sample5() {
   const makeCircle = (left: number, top: number, line1?: fabric.Line, line2?: fabric.Line, line3?: fabric.Line, line4?: fabric.Line): fabric.Circle => {
-    const c = <fabric.CircleWithLineInfos> new fabric.Circle({
+    const c = <myfabric.CircleWithLineInfos> new fabric.Circle({
       left,
       top,
       strokeWidth: 5,
@@ -319,7 +317,7 @@ function sample5() {
     );
 
   canvas.on('object:moving', e => {
-    const p = <fabric.CircleWithLineInfos> e.target;
+    const p = <myfabric.CircleWithLineInfos> e.target;
     p.line1 && p.line1.set({ 'x2': p.left, 'y2': p.top });
     p.line2 && p.line2.set({ 'x1': p.left, 'y1': p.top });
     p.line3 && p.line3.set({ 'x1': p.left, 'y1': p.top });
@@ -353,8 +351,8 @@ function sample6() {
   });
 }
 
-declare module "fabric" {
-  export interface ImageWithInfo extends Image {
+namespace myfabric {
+  export interface ImageWithInfo extends fabric.Image {
     movingLeft: boolean;
   }
 }
@@ -364,7 +362,7 @@ function sample7() {
 
   setInterval(() => {
     fabric.Image.fromURL('../assets/ladybug.png', obj => {
-      const img = <fabric.ImageWithInfo> obj;
+      const img = <myfabric.ImageWithInfo> obj;
       img.set('left', fabric.util.getRandomInt(200, 600)).set('top', -50);
       img.movingLeft = !!Math.round(Math.random());
       canvas.add(img);
@@ -373,7 +371,7 @@ function sample7() {
 
   const animate = (function animate() {
     canvas.forEachObject(obj => {
-      const img = <fabric.ImageWithInfo> obj;
+      const img = <myfabric.ImageWithInfo> obj;
       img.left += (img.movingLeft ? -1 : 1);
       img.top += 1;
       if (img.left > 900 || img.top > 500) {
@@ -610,7 +608,7 @@ function sample8() {
         const activeGroup = canvas.getActiveGroup();
 
         if (activeObject || activeGroup) {
-          (activeObject || activeGroup).setOpacity(parseInt(this.value, 10) / 100);
+          (activeObject || activeGroup).setOpacity(parseInt((<HTMLInputElement> this).value, 10) / 100);
           canvas.renderAll();
         }
       };
@@ -641,7 +639,7 @@ function sample8() {
         const activeGroup = canvas.getActiveGroup();
 
         if (activeObject || activeGroup) {
-          (activeObject || activeGroup).setFill(this.value);
+          (activeObject || activeGroup).setFill((<HTMLInputElement> this).value);
           canvas.renderAll();
         }
       };
@@ -850,16 +848,16 @@ function sample8() {
       const activeObject = canvas.getActiveObject();
 
       if (activeObject && activeObject.type === 'text') {
-        this.value = (<fabric.Text> activeObject).text;
+        (<HTMLInputElement> this).value = (<fabric.Text> activeObject).text;
       }
     };
     textEl.onkeyup = function(e) {
       const activeObject = canvas.getActiveObject();
       if (activeObject) {
-        if (!this.value) {
+        if (!(<HTMLInputElement> this).value) {
           canvas.discardActiveObject();
         } else {
-          (<fabric.Text> activeObject).text = this.value;
+          (<fabric.Text> activeObject).text = (<HTMLInputElement> this).value;
         }
         canvas.renderAll();
       }
@@ -1007,7 +1005,7 @@ function sample8() {
       slider.onchange = function() {
         const activeObject = <fabric.Text> canvas.getActiveObject();
         if (activeObject && activeObject.type === 'text') {
-          activeObject.lineHeight = +this.value;
+          activeObject.lineHeight = +(<HTMLInputElement> this).value;
           canvas.renderAll();
         }
       };

--- a/types/fabric/index.d.ts
+++ b/types/fabric/index.d.ts
@@ -1866,7 +1866,7 @@ export class Image {
 	 * @param {Function} [callback] Callback is invoked when image has been loaded (and all filters have been applied)
 	 * @param {Object} [options] Options object
 	 */
-	setSrc(src: string, callback: Function, options: IImageOptions): Image;
+	setSrc(src: string, callback?: Function, options?: IImageOptions): Image;
 
 	/**
 	 * Creates an instance of fabric.Image from an URL string


### PR DESCRIPTION
Typescript definition is wrong for fabric.Image.setSrc(src, callbackopt, optionsopt). At the moment callbackopt and optionsopt is required, but they are optional.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.) => **tsc**
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **http://fabricjs.com/docs/fabric.Image.html#setSrc**

