### PR TITLE
update declarations for leaflet.fullscreen

### DIFF
--- a/types/leaflet.fullscreen/index.d.ts
+++ b/types/leaflet.fullscreen/index.d.ts
@@ -9,24 +9,27 @@ declare namespace L {
 
   namespace Control {
 
-    export interface Fullscreen extends L.Control {}
-
+    export class Fullscreen extends L.Control {
+      constructor(options?: Control.FullscreenOptions);
+      options: FullscreenOptions;
+    }
     export interface FullscreenOptions {
       content?: string,
-      position?: string,
-  		title?: string,
-  		titleCancel?: string,
-  		forceSeparateButton?: boolean,
-  		forcePseudoFullscreen?: boolean
+      position?: L.ControlPosition,
+      title?: string,
+      titleCancel?: string,
+      forceSeparateButton?: boolean,
+      forcePseudoFullscreen?: boolean,
+      pseudoFullscreen?:boolean
     }
   }
 
   namespace control {
 
-      /**
-        * Creates a fullscreen control.
-        */
-      export function fullscreen(options?: Control.FullscreenOptions): L.Control.Fullscreen;
+    /**
+     * Creates a fullscreen control.
+     */
+    export function fullscreen(options?: Control.FullscreenOptions): L.Control.Fullscreen;
 
   }
 }


### PR DESCRIPTION
This helps fix TS2497 error Property 'Fullscreen' does not exist, when Leaflet.fullscreen is used with leaflet.
It can be found when being added by using something like this: `leafletMap.addControl(new L.Control.Fullscreen({pseudoFullscreen: true, position:"bottomleft"}));`

