### PR TITLE
Use correct response typings in request-promise-native

### DIFF
--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -8,8 +8,8 @@ import http = require('http');
 
 declare namespace requestPromise {
     interface RequestPromise extends request.Request {
-        then<TResult>(onfulfilled?: (value: request.RequestResponse) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
-        then<TResult>(onfulfilled?: (value: request.RequestResponse) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
+        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
         catch(onrejected?: (reason: any) => any | PromiseLike<any>): Promise<any>;
         catch(onrejected?: (reason: any) => void): Promise<any>;
         promise(): Promise<any>;
@@ -22,6 +22,7 @@ declare namespace requestPromise {
         resolveWithFullResponse?: boolean;
     }
 
+    export type FullResponse = request.RequestResponse;
     export type OptionsWithUri = request.UriOptions & RequestPromiseOptions;
     export type OptionsWithUrl = request.UrlOptions & RequestPromiseOptions;
     export type Options = OptionsWithUri | OptionsWithUrl;

--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -8,8 +8,8 @@ import http = require('http');
 
 declare namespace requestPromise {
     interface RequestPromise extends request.Request {
-        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
-        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
+        then<TResult>(onfulfilled?: (value: request.RequestResponse) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+        then<TResult>(onfulfilled?: (value: request.RequestResponse) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
         catch(onrejected?: (reason: any) => any | PromiseLike<any>): Promise<any>;
         catch(onrejected?: (reason: any) => void): Promise<any>;
         promise(): Promise<any>;


### PR DESCRIPTION
Use `request.RequestResponse` instead of `any`

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/request/request
