### PR TITLE
Add possible null value to the match prop in react-router Route

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -59,11 +59,17 @@ declare module 'react-router' {
     history: H.History;
   }
 
+  interface RouteComponentMaybeProps<P> {
+    match: match<P>|null;
+    location: H.Location;
+    history: H.History;
+  }
+
   interface RouteProps {
     location?: H.Location;
     component?: React.SFC<RouteComponentProps<any> | void> | React.ComponentClass<RouteComponentProps<any> | void>;
     render?: (props: RouteComponentProps<any>) => React.ReactNode;
-    children?: (props: RouteComponentProps<any>) => React.ReactNode | React.ReactNode;
+    children?: (props: RouteComponentMaybeProps<any>) => React.ReactNode | React.ReactNode;
     path?: string;
     exact?: boolean;
     strict?: boolean;


### PR DESCRIPTION
If the children is a function, it is always called regardless of
whether there is a match or not. When there is not a match, the value
of the match prop is null.

https://reacttraining.com/react-router/web/api/Route/children-func

There is no example in the react-router-website demonstrating this
usage, though, other than the example in the children-func
documentation itself. Where could I put the test for this?