### PR TITLE
Add type definitions for react-loadable

### DIFF
--- a/types/react-loadable/babel.d.ts
+++ b/types/react-loadable/babel.d.ts
@@ -1,0 +1,3 @@
+import * as babel from 'babel-core';
+
+export default function(context: Pick<typeof babel, 'types'|'template'>): { visitor: any };

--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -1,0 +1,118 @@
+// Type definitions for react-loadable 3.3
+// Project: https://github.com/thejameskyle/react-loadable#readme
+// Definitions by: Diogo Franco <https://github.com/Kovensky>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import * as React from 'react';
+
+// tslint:disable-next-line strict-export-declare-modifiers
+type LoadedComponent<Props> = React.ComponentClass<Props> | React.SFC<Props>;
+
+export interface LoadingComponentProps {
+    isLoading: boolean;
+    pastDelay: boolean;
+    error: any;
+}
+
+export type Options<Props, T extends object> = OptionsWithoutResolve<Props> | OptionsWithResolve<Props, T>;
+
+export interface CommonOptions {
+    /**
+     * React component displayed after delay until loader() succeeds. Also responsible for displaying errors.
+     *
+     * If you don't want to render anything you can pass a function that returns null
+     * (this is considered a valid React component).
+     */
+    // NOTE: () => null is only needed until React.SFC supports components returning null
+    LoadingComponent: React.ComponentClass<LoadingComponentProps> | React.SFC<LoadingComponentProps> | (() => null);
+    /**
+     * Defaults to 200, in milliseconds
+     *
+     * Only show the LoadingComponent if the loader() has taken this long to succeed or error.
+     */
+    delay?: number;
+    /**
+     * When rendering server-side, require() this path to load the component instead, this way it happens
+     * synchronously. If you are rendering server-side you should use this option.
+     *
+     * If you are using Babel, you might want to use the Babel plugin to add this option automatically.
+     */
+    serverSideRequirePath?: string;
+    /**
+     * In order for Loadable to require() a component synchronously (when possible) instead of waiting for
+     * the promise returned by import() to resolve. If you are using Webpack you should use this option.
+     *
+     * ```ts
+     * Loadable({
+     *     // ...
+     *     webpackRequireWeakId: () => require.resolveWeak('./MyComponent')
+     * });
+     * ```
+     *
+     * If you are using Babel, you might want to use the Babel plugin to add this option automatically.
+     */
+    webpackRequireWeakId?(): number|string;
+}
+
+export interface OptionsWithoutResolve<Props> extends CommonOptions {
+    /**
+     * Function returning promise returning a React component displayed on success.
+     *
+     * Resulting React component receives all the props passed to the generated component.
+     */
+    loader(): Promise<LoadedComponent<Props> | { default: LoadedComponent<Props> }>;
+}
+
+export interface OptionsWithResolve<Props, T extends object> extends CommonOptions {
+    /**
+     * Function returning promise returning a React component displayed on success.
+     *
+     * Resulting React component receives all the props passed to the generated component.
+     */
+    loader(): Promise<T>;
+    /**
+     * If the component that you want to load is not the default exported from a module you can use this
+     * function to resolve it.
+     *
+     * ```ts
+     * Loadable({
+     *     // ...
+     *     resolveModule: module => module.MyComponent
+     * });
+     * ```
+     */
+    resolveModule(obj: T): LoadedComponent<Props>;
+}
+
+export interface LoadableComponent {
+    /**
+     * The generated component has a static method preload() for calling the loader function ahead of time.
+     * This is useful for scenarios where you think the user might do something next and want to load the
+     * next component eagerly.
+     *
+     * Note: preload() intentionally does not return a promise. You should not be depending on the timing of
+     * preload(). It's meant as a performance optimization, not for creating UI logic.
+     */
+    preload(): void;
+}
+
+export default function Loadable<Props, T extends object>(options: Options<Props, T>): LoadedComponent<Props> & LoadableComponent;
+
+/**
+ * In case you are rendering server-side and want to find out after a render cycle which
+ * serverSideRequirePath's and webpackRequireWeakId's were actually rendered, you can use
+ * flushServerSideRequirePaths or flushWebpackRequireWeakIds to get an array of them.
+ *
+ * Note: These are flushed individually, one does not affect the other.
+ */
+export function flushServerSideRequirePaths(): string[];
+
+/**
+ * In case you are rendering server-side and want to find out after a render cycle which
+ * serverSideRequirePath's and webpackRequireWeakId's were actually rendered, you can use
+ * flushServerSideRequirePaths or flushWebpackRequireWeakIds to get an array of them.
+ *
+ * Note: These are flushed individually, one does not affect the other.
+ */
+export function flushWebpackRequireWeakIds(): string[]|number[];

--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -6,8 +6,7 @@
 
 import * as React from 'react';
 
-// tslint:disable-next-line strict-export-declare-modifiers
-type LoadedComponent<Props> = React.ComponentClass<Props> | React.SFC<Props>;
+export type LoadedComponent<Props> = React.ComponentClass<Props> | React.SFC<Props>;
 
 export interface LoadingComponentProps {
     isLoading: boolean;

--- a/types/react-loadable/react-loadable-tests.tsx
+++ b/types/react-loadable/react-loadable-tests.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import Loadable, { LoadingComponentProps } from 'react-loadable';
+
+class LoadingComponent extends React.Component<LoadingComponentProps, {}> {
+  render() {
+    return <div>{this.props.isLoading}</div>;
+  }
+}
+
+interface ComponentProps {
+  text: string;
+}
+
+const Component: React.SFC<ComponentProps> = ({ text }) => <div>{text}</div>;
+
+const Loadable100 = Loadable({
+  // a module shape with 'export = Component' / 'module.exports = Component'
+  loader: () => Promise.resolve(Component),
+  LoadingComponent,
+  delay: 100
+});
+
+const Loadable200 = Loadable({
+  // a module shape with 'export default Component'
+  loader: () => Promise.resolve({ default: Component }),
+  LoadingComponent,
+  delay: 200
+});
+
+const Loadable300 = Loadable({
+  // a module shape with 'export { Component }'
+  loader: () => Promise.resolve({ Component }),
+  LoadingComponent,
+  delay: 300,
+  resolveModule: shape => shape.Component
+});
+
+const Loadable400 = Loadable({
+  // a module shape with both 'export default Component' and 'export { Component }'
+  loader: () => Promise.resolve({ default: Component, Component }),
+  LoadingComponent: () => null,
+  delay: 300,
+  resolveModule: shape => shape.Component
+});
+
+const used100 = <Loadable100 text='100'/>;
+const used200 = <Loadable200 text='200'/>;
+const used300 = <Loadable300 text='300'/>;
+const used400 = <Loadable400 text='400'/>;
+
+Loadable100.preload();

--- a/types/react-loadable/tsconfig.json
+++ b/types/react-loadable/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-loadable-tests.tsx"
+    ]
+}

--- a/types/react-loadable/tsconfig.json
+++ b/types/react-loadable/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
+        "babel.d.ts",
         "react-loadable-tests.tsx"
     ]
 }

--- a/types/react-loadable/tslint.json
+++ b/types/react-loadable/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Mostly based off the Flow type annotations in the original code or readme snippets, but with some additional generics tricks for more accurate typing.

JSDoc comments copied off the README.