### PR TITLE
Updated 18next exists method and added ability to use string interpolation arguments

### DIFF
--- a/types/i18next/i18next-tests.ts
+++ b/types/i18next/i18next-tests.ts
@@ -10,12 +10,14 @@ i18n.init({
     resources: {
         en: {
             translation: {
-                helloWorld: 'Hello, world!'
+                helloWorld: 'Hello, world!',
+                helloWorldInterpolated: 'Hello, {{name}}!'
             }
         },
         ru: {
             translation: {
-                helloWorld: 'Привет, мир!'
+                helloWorld: 'Привет, мир!',
+                helloWorldInterpolated: 'Привет, {{name}}!'
             }
         }
     },
@@ -60,6 +62,14 @@ i18n.t('helloWorld', <i18n.TranslationOptions> {
     defaultValue: 'default',
     count: 10
 });
+
+i18n.t('helloWorldInterpolated', <i18n.TranslationOptions> {
+    defaultValue: 'default',
+    count: 10,
+    name: "world"
+});
+
+I18n.exists("helloWorld");
 
 const options:i18n.Options = i18n.options;
 const currentLanguage:string = i18n.language;

--- a/types/i18next/i18next-tests.ts
+++ b/types/i18next/i18next-tests.ts
@@ -69,7 +69,7 @@ i18n.t('helloWorldInterpolated', <i18n.TranslationOptions> {
     name: "world"
 });
 
-I18n.exists("helloWorld");
+i18n.exists("helloWorld");
 
 const options:i18n.Options = i18n.options;
 const currentLanguage:string = i18n.language;

--- a/types/i18next/index.d.ts
+++ b/types/i18next/index.d.ts
@@ -108,7 +108,7 @@ declare namespace i18n {
 
         t(key: string, options?: TranslationOptions): string | any | Array<any>;
 
-        exists(key, options?: TranslationOptions): boolean;
+        exists(key: string, options?: TranslationOptions): boolean;
 
         setDefaultNamespace(ns: string): void;
 

--- a/types/i18next/index.d.ts
+++ b/types/i18next/index.d.ts
@@ -49,6 +49,8 @@ declare namespace i18n {
         joinArrays?: string;
         postProcess?: string | any[];
         interpolation?: InterpolationOptions;
+        //add an indexer to assure that interpolation arguments can be passed
+        [x: string]: any;
     }
 
     interface Options {
@@ -106,7 +108,7 @@ declare namespace i18n {
 
         t(key: string, options?: TranslationOptions): string | any | Array<any>;
 
-        exists(): boolean;
+        exists(key, options?: TranslationOptions): boolean;
 
         setDefaultNamespace(ns: string): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
http://i18next.com/translate/interpolation/  for interpolation changes
and 
http://i18next.com/docs/api/  for changes for the exists function

