### PR TITLE
memcached: Use union types instead of overloads

### DIFF
--- a/types/memcached/index.d.ts
+++ b/types/memcached/index.d.ts
@@ -13,25 +13,11 @@ declare class Memcached extends events.EventEmitter {
     static config: Memcached.options;
 
     /**
-     * Connect to a single server.
-     * @param location Server location e.g. "127.0.0.1:11211"
+     * Connect to a single Memcached server or cluster
+     * @param location Server locations
      * @param options options
      */
-    constructor(location: string, options?: Memcached.options);
-
-    /**
-     * Connect to a cluster of Memcached servers.
-     * @param location Server locations e.g. ["127.0.0.1:11211","127.0.0.1:11212"]
-     * @param options options
-     */
-    constructor(location: string[], options?: Memcached.options);
-
-    /**
-     * Connect to servers with weight.
-     * @param location Server locations e.g. {"127.0.0.1:11211": 1,"127.0.0.1:11212": 2}
-     * @param options options
-     */
-    constructor(location: {[server: string]: number}, options ?: Memcached.options);
+    constructor(location: Memcached.Location, options?: Memcached.options);
 
     /**
      * Touches the given key.
@@ -185,29 +171,9 @@ declare class Memcached extends events.EventEmitter {
     flush(cb: (this: undefined, err: any, results: boolean[]) => void): void;
 
     /**
-     * a issue occurred on one a server, we are going to attempt a retry next.
+     * Register event listener
      */
-    on(event: "issue", cb: (err: Memcached.IssueData) => void): this;
-
-    /**
-     * a server has been marked as failure or dead.
-     */
-    on(event: "failure", cb: (err: Memcached.IssueData) => void): this;
-
-    /**
-     * we are going to attempt to reconnect the to the failed server.
-     */
-    on(event: "reconnecting", cb: (err: Memcached.IssueData) => void): this;
-
-    /**
-     * successfully reconnected to the memcached server.
-     */
-    on(event: "reconnect", cb: (err: Memcached.IssueData) => void): this;
-
-    /**
-     * removing the server from our consistent hashing.
-     */
-    on( event: "remove", cb: (err: Memcached.IssueData) => void): this;
+    on(event: Memcached.EventNames, cb: (err: Memcached.IssueData) => void): this;
 
     /**
      * Closes all active memcached connections.
@@ -259,6 +225,31 @@ declare namespace Memcached {
         b: number;
         s: number;
     }
+
+    /**
+     * <ul>
+     *     <li><b>issue</b> a issue occurred on a server, we are going to attempt a retry next.</li>
+     *     <li><b>failure</b> a server has been marked as failure or dead.</li>
+     *     <li><b>reconnecting</b> we are going to attempt to reconnect the to the failed server.</li>
+     *     <li><b>reconnect</b> successfully reconnected to the memcached server.</li>
+     *     <li><b>remove</b> removing the server from our consistent hashing.</li>
+     * </ul>
+     */
+    type EventNames = "issue" | "failure" | "reconnecting" | "reconnect" | "remove";
+
+    /**
+     * Declaration for single server or Memcached cluster location
+     *
+     * to connect to a single server use
+     * "127.0.0.1:11211"
+     *
+     * to connect to a cluster of Memcached servers use
+     * ["127.0.0.1:11211","127.0.0.1:11212"]
+     *
+     * to connect to servers with weight use
+     * {"127.0.0.1:11211": 1,"127.0.0.1:11212": 2}
+     */
+    type Location = string | string[] | {[server: string]: number};
 
     interface options {
         /**

--- a/types/memcached/tslint.json
+++ b/types/memcached/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "unified-signatures": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.typescriptlang.org/docs/handbook/advanced-types.html>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.


The tslint rule exception is no longer needed with this change.