### PR TITLE
@types/bluebird: Make AggregateError ArrayLike

### DIFF
--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -726,7 +726,28 @@ declare namespace Bluebird {
    *
    * `Promise.some` and `Promise.any` use `AggregateError` as rejection reason when they fail.
    */
-  export class AggregateError extends Array<Error> {}
+  export class AggregateError extends Error implements ArrayLike<Error> {
+    length: number;
+    [index: number]: Error;
+    join(separator?: string): string;
+    pop(): Error;
+    push(...errors: Error[]): number;
+    shift(): Error;
+    unshift(...errors: Error[]): number;
+    slice(begin?: number, end?: number): AggregateError;
+    filter(callback: (element: Error, index: number, array: AggregateError) => boolean, thisArg?: any): AggregateError;
+    forEach(callback: (element: Error, index: number, array: AggregateError) => void, thisArg?: any): undefined;
+    some(callback: (element: Error, index: number, array: AggregateError) => boolean, thisArg?: any): boolean;
+    every(callback: (element: Error, index: number, array: AggregateError) => boolean, thisArg?: any): boolean;
+    map(callback: (element: Error, index: number, array: AggregateError) => boolean, thisArg?: any): AggregateError;
+    indexOf(searchElement: Error, fromIndex?: number): number;
+    lastIndexOf(searchElement: Error, fromIndex?: number): number;
+    reduce(callback: (accumulator: any, element: Error, index: number, array: AggregateError) => any, initialValue?: any): any;
+    reduceRight(callback: (previousValue: any, element: Error, index: number, array: AggregateError) => any, initialValue?: any): any;
+    sort(compareFunction?: (errLeft: Error, errRight: Error) => number): AggregateError;
+    reverse(): AggregateError;
+  }
+
 
   /**
    * returned by `Bluebird.disposer()`.

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -726,7 +726,7 @@ declare namespace Bluebird {
    *
    * `Promise.some` and `Promise.any` use `AggregateError` as rejection reason when they fail.
    */
-  export class AggregateError extends Error {}
+  export class AggregateError extends Array<Error> {}
 
   /**
    * returned by `Bluebird.disposer()`.


### PR DESCRIPTION
As code and api documentation states
(https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/bluebird/index.d.ts#L722)
AggregateError should be ArrayLike-type.

For simplification extend AggregateError from Array<Error>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15589
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
