### PR TITLE
nodemailer-smtp-transport: adding OAuth2 options to AuthOptions interface

### DIFF
--- a/types/nodemailer-smtp-transport/index.d.ts
+++ b/types/nodemailer-smtp-transport/index.d.ts
@@ -18,6 +18,30 @@ declare namespace smtpTransport {
 
         /** indicates the authetication type, defaults to ‘login’, other option is ‘oauth2’ */
         type?: any;
+
+        /** is the registered client id of the application */
+        clientId?: string;
+
+        /** is the registered client secret of the application */
+        clientSecret?: string;
+        
+        /** is an optional refresh token. If it is provided then Nodemailer tries to generate a new access token if existing one expires or fails */
+        refreshToken?: string;
+        
+        /** is the access token for the user. Required only if refreshToken is not available and there is no token refresh callback specified */
+        accessToken?: string;
+        
+        /** is an optional expiration time for the current accessToken */
+        expires?: number;
+        
+        /** is an optional HTTP endpoint for requesting new access tokens. This value defaults to Gmail */
+        accessUrl?: string;
+
+        /** service client id, you can find it from the “client_id” field in the service key file */
+        serviceClient?: string;
+
+        /** is the private key contents, you can find it from the “private_key” field in the service key file */
+        privateKey?: string;
     }
 
     export interface SmtpOptions {

--- a/types/nodemailer-smtp-transport/nodemailer-smtp-transport-tests.ts
+++ b/types/nodemailer-smtp-transport/nodemailer-smtp-transport-tests.ts
@@ -4,7 +4,21 @@ import nodemailer = require('nodemailer');
 
 var opts: smtpTransport.SmtpOptions = {
 	host: "localhost",
-	port: 25
+	port: 25,
+    auth: {
+        type: 'OAuth2',
+        user: 'user@example.com',
+        // 3LO auth
+        clientId: '000000000000-xxx0.apps.googleusercontent.com',
+        clientSecret: 'XxxxxXXxX0xxxxxxxx0XXxX0',
+        refreshToken: '1/XXxXxsss-xxxXXXXXxXxx0XXXxxXXx0x00xxx',
+        accessToken: 'ya29.Xx_XX0xxxxx-xX0X0XxXXxXxXXXxX0x',
+        expires: 1484314697598,
+        // 2LO auth (test only, dont mix with 3LO)
+        serviceClient: '113600000000000000000',
+        privateKey: '-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBg...',
+    },
+    service: 'Gmail'
 };
 
 var transport: nodemailer.Transport = smtpTransport(opts);


### PR DESCRIPTION
These OAuth2 authentication options are missing from the `smtpTransport.AuthOptions` interface and thus cause compilation errors when attempting to use any method aside from simple username/password authentication.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
docs:
https://nodemailer.com/smtp/oauth2/#oauth-3lo
https://nodemailer.com/smtp/oauth2/#oauth-2lo
examples:
https://nodemailer.com/smtp/oauth2/#examples
