### PR TITLE
Added wait to i18n.Options interface

### DIFF
--- a/types/i18next/i18next-tests.ts
+++ b/types/i18next/i18next-tests.ts
@@ -53,7 +53,8 @@ i18n.init({
     interpolation: <i18n.InterpolationOptions>{},
     detection: null,
     backend: null,
-    cache: null
+    cache: null,
+    wait: false
 });
 
 i18n.t('helloWorld', <i18n.TranslationOptions> {

--- a/types/i18next/index.d.ts
+++ b/types/i18next/index.d.ts
@@ -83,6 +83,7 @@ declare namespace i18n {
         detection?: any;
         backend?: any;
         cache?: any;
+        wait?: boolean;
     }
 
     type TranslationFunction = (key: string, options?: TranslationOptions) => string;

--- a/types/i18next/index.d.ts
+++ b/types/i18next/index.d.ts
@@ -83,7 +83,11 @@ declare namespace i18n {
         detection?: any;
         backend?: any;
         cache?: any;
-        wait?: boolean;
+    }
+
+    // init options for react-i18next
+    interface ReactOptions {
+      wait?: boolean;
     }
 
     type TranslationFunction = (key: string, options?: TranslationOptions) => string;
@@ -91,7 +95,7 @@ declare namespace i18n {
     interface I18n {
         //constructor(options?: Options, callback?: (err: any, t: TranslationFunction) => void);
 
-        init(options?: Options, callback?: (err: any, t: TranslationFunction) => void): I18n;
+        init(options?: Options&ReactOptions, callback?: (err: any, t: TranslationFunction) => void): I18n;
 
         loadResources(callback?: (err: any) => void): void;
 


### PR DESCRIPTION
Enables setting global wait-flag. Important for react-i18next>=3.1.0
(https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md#310)