### PR TITLE
node: Change NodeBuffer#slice() return type to this

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -518,7 +518,7 @@ interface NodeBuffer extends Uint8Array {
     equals(otherBuffer: Buffer): boolean;
     compare(otherBuffer: Buffer, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
-    slice(start?: number, end?: number): Buffer;
+    slice(start?: number, end?: number): this;
     writeUIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeUIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;

--- a/types/node/v0/index.d.ts
+++ b/types/node/v0/index.d.ts
@@ -361,7 +361,7 @@ interface NodeBuffer {
     equals(otherBuffer: Buffer): boolean;
     compare(otherBuffer: Buffer): number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
-    slice(start?: number, end?: number): Buffer;
+    slice(start?: number, end?: number): this;
     writeUIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeUIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
@@ -398,7 +398,7 @@ interface NodeBuffer {
     writeFloatBE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleLE(value: number, offset: number, noAssert?: boolean): number;
     writeDoubleBE(value: number, offset: number, noAssert?: boolean): number;
-    fill(value: any, offset?: number, end?: number): Buffer;
+    fill(value: any, offset?: number, end?: number): this;
 }
 
 /************************************************

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -459,7 +459,7 @@ interface NodeBuffer extends Uint8Array {
     equals(otherBuffer: Buffer): boolean;
     compare(otherBuffer: Buffer): number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
-    slice(start?: number, end?: number): Buffer;
+    slice(start?: number, end?: number): this;
     writeUIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeUIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -510,7 +510,7 @@ interface NodeBuffer extends Uint8Array {
     equals(otherBuffer: Buffer): boolean;
     compare(otherBuffer: Buffer, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number;
     copy(targetBuffer: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number;
-    slice(start?: number, end?: number): Buffer;
+    slice(start?: number, end?: number): this;
     writeUIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeUIntBE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;
     writeIntLE(value: number, offset: number, byteLength: number, noAssert?: boolean): number;


### PR DESCRIPTION
Based on Microsoft/TypeScript#15402, it looks like the `Uint8Array` interface will extend a `TypedArray` interface with a `slice()` method that looks like this:

```ts
interface TypedArray {
    // ...
    slice(start?: number, end?: number): this;  // currently returns Buffer
    // ...
}

interface Uint8Array extends TypedArray { }
```

This causes the [`NodeBuffer`][node-buffer] type in the [node][node] package to generate a compiler error, as it extends `Uint8Array` and has its own incompatible `slice()` declaration:

```
node_modules/@types/node/index.d.ts(514,11): error TS2430: Interface 'NodeBuffer' incorrectly extends interface 'Uint8Array'.
  Types of property 'slice' are incompatible.
    Type '(start?: number, end?: number) => Buffer' is not assignable to type '(start?: number, end?: number) => this'.
      Type 'Buffer' is not assignable to type 'this'.
```

This also affects [`Buffer`][buffer] of course, since it extends `NodeBuffer`.

The ideal solution would be to remove the `slice()` method from the `NodeBuffer` interface, since it inherits the `slice()` method from `Uint8Array`. But with the existing `Uint8Array` declaration, `NodeBuffer#slice()` would then return a `Uint8Array` instead of a `Buffer`, so that won't work.

This PR changes the `NodeBuffer` interface so that its `slice()` declaration matches the prospective `TypedArray` interface. This fixes the compiler error while remaining compatible with the existing `Uint8Array` declaration, and is unlikely to cause other problems.

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Microsoft/TypeScript#15402

[node-buffer]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c340b2e633af705e01a6837324879ee0dea8be2f/types/node/index.d.ts#L514
[node]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/c340b2e633af705e01a6837324879ee0dea8be2f/types/node
[buffer]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c340b2e633af705e01a6837324879ee0dea8be2f/types/node/index.d.ts#L114