### PR TITLE
[FullCalendar] Removing allDay parameter in dayClick function

### DIFF
--- a/types/fullcalendar/fullcalendar-tests.ts
+++ b/types/fullcalendar/fullcalendar-tests.ts
@@ -417,7 +417,7 @@ $('#calendar').fullCalendar({
 });
 
 $('#calendar').fullCalendar({
-    dayClick(date, jsEvent, view) {      
+    dayClick(date, jsEvent, view) {
         alert('Coordinates: ' + jsEvent.pageX + ',' + jsEvent.pageY);
 
         alert('Current view: ' + view.name);

--- a/types/fullcalendar/fullcalendar-tests.ts
+++ b/types/fullcalendar/fullcalendar-tests.ts
@@ -417,13 +417,7 @@ $('#calendar').fullCalendar({
 });
 
 $('#calendar').fullCalendar({
-    dayClick(date, allDay, jsEvent, view) {
-        if (allDay) {
-            alert('Clicked on the entire day: ' + date);
-        } else {
-            alert('Clicked on the slot: ' + date);
-        }
-
+    dayClick(date, jsEvent, view) {      
         alert('Coordinates: ' + jsEvent.pageX + ',' + jsEvent.pageY);
 
         alert('Current view: ' + view.name);

--- a/types/fullcalendar/index.d.ts
+++ b/types/fullcalendar/index.d.ts
@@ -90,7 +90,7 @@ export interface Options extends AgendaOptions, EventDraggingResizingOptions, Dr
 
     // Clicking & Hovering - http://fullcalendar.io/docs/mouse/
 
-    dayClick?(date: Date, allDay: boolean, jsEvent: MouseEvent, view: ViewObject): void;
+    dayClick?(date: Date, jsEvent: MouseEvent, view: ViewObject): void;
     eventClick?(event: EventObject, jsEvent: MouseEvent, view: ViewObject): any; // return type boolean or void
     eventMouseover?(event: EventObject, jsEvent: MouseEvent, view: ViewObject): void;
     eventMouseout?(event: EventObject, jsEvent: MouseEvent, view: ViewObject): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  dayClick function has already removed param allDay: boolean <<https://fullcalendar.io/docs/mouse/dayClick/>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
