### PR TITLE
react-color: Extended definitions for common/{Saturation,Hue} components

### DIFF
--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-color 2.11
 // Project: https://github.com/casesandberg/react-color/
-// Definitions by: Karol Janyst <https://github.com/LKay>
+// Definitions by: Karol Janyst <https://github.com/LKay>, Vitalie Lazu <https://github.com/vitaliel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -13,6 +13,13 @@ export interface HSLColor {
     s: number;
 }
 
+export interface HSVColor {
+    a?: number;
+    h: number;
+    s: number;
+    v: number;
+}
+
 export interface RGBColor {
     a?: number;
     b: number;
@@ -26,6 +33,15 @@ export interface ColorResult {
     hex: string;
     hsl: HSLColor;
     rgb: RGBColor;
+}
+
+export interface ColorState {
+    hex: string;
+    hsl?: HSLColor;
+    hsv?: HSVColor;
+    rgb?: RGBColor;
+    oldHue?: number;
+    source?: string;
 }
 
 export type ColorChangeHandler = (color: ColorResult) => void;

--- a/types/react-color/lib/components/common/Hue.d.ts
+++ b/types/react-color/lib/components/common/Hue.d.ts
@@ -1,8 +1,9 @@
 import { Component } from "react";
-import { CustomPickerProps } from "react-color";
+import { CustomPickerProps, HSLColor } from "react-color";
 
 export interface HueProps extends CustomPickerProps<Hue> {
     direction?: "horizontal" | "vertical";
+    hsl: HSLColor;
 }
 
 export default class Hue extends Component<HueProps, any> {}

--- a/types/react-color/lib/components/common/Saturation.d.ts
+++ b/types/react-color/lib/components/common/Saturation.d.ts
@@ -1,6 +1,9 @@
 import { Component } from "react";
-import { CustomPickerProps } from "react-color";
+import { Color, CustomPickerProps, HSLColor, HSVColor } from "react-color";
 
-export type SaturationProps = CustomPickerProps<Saturation>;
+export interface SaturationProps extends CustomPickerProps<Saturation> {
+  hsl: HSLColor;
+  hsv: HSVColor;
+}
 
 export default class Saturation extends Component<SaturationProps, any> {}

--- a/types/react-color/lib/helpers/color.d.ts
+++ b/types/react-color/lib/helpers/color.d.ts
@@ -1,0 +1,11 @@
+import { HSLColor, HSVColor, RGBColor, ColorState } from "../../index";
+
+declare module "react-color/lib/helpers/color" {
+  interface Helpers {
+      simpleCheckForValidColor(data: ColorState): boolean;
+      toState(data: ColorState, oldHue?: number): ColorState;
+  }
+}
+
+declare const _: Helpers;
+export default _;

--- a/types/react-color/react-color-tests.tsx
+++ b/types/react-color/react-color-tests.tsx
@@ -24,8 +24,8 @@ const CustomComponent: StatelessComponent<CustomProps> = (props: CustomProps) =>
             <Alpha color={ props.color } onChange={ onChange } />
             <Checkboard size={ 10 } white="transparent" grey="#333" />
             <EditableInput value={ props.color } label="Test" onChange={ onChange } />
-            <Hue color={ props.color } direction="horizontal" onChange={ onChange } />
-            <Saturation color={ props.color } onChange={ onChange } />
+            <Hue color={ props.color } hsl={ {h: 100, s: 20, l: 20} } direction="horizontal" onChange={ onChange } />
+            <Saturation color={ props.color } hsl={ {h: 100, s: 20, l: 20} } hsv={ {h: 100, s: 20, v: 20} } onChange={ onChange } />
         </div>
     );
 };

--- a/types/react-color/tsconfig.json
+++ b/types/react-color/tsconfig.json
@@ -41,6 +41,7 @@
         "lib/components/slider/Slider.d.ts",
         "lib/components/swatches/Swatches.d.ts",
         "lib/components/twitter/Twitter.d.ts",
+        "lib/helpers/color.d.ts",
         "react-color-tests.tsx"
     ]
 }


### PR DESCRIPTION
If you do not specify hsl/hsv for saturation/hue, it fails with error
like below on rendering:

TypeError: Cannot read property 'h' of undefined
  at Saturation.render (node_modules/react-color/lib/components/common/Saturation.js:89:48)
  at ReactCompositeComponentWrapper._renderValidatedComponentWithoutOwnerOrContext (node_modules/react/lib/ReactCompositeComponent.js:808:34)

I also added definitions for react-color/lib/helpers/color module

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/casesandberg/react-color/blob/master/src/helpers/color.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
