### PR TITLE
Add koa-helmet type definitions

### DIFF
--- a/types/koa-helmet/index.d.ts
+++ b/types/koa-helmet/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for koa-helmet 3.1
+// Project: https://github.com/venables/koa-helmet#readme
+// Definitions by: Nick Simmons <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import {
+    IHelmetConfiguration,
+    IHelmetFrameguardConfiguration,
+    IHelmetHstsConfiguration,
+    IHelmetXssFilterConfiguration,
+    IHelmetDnsPrefetchControlConfiguration,
+    IHelmetHpkpConfiguration,
+    IHelmetReferrerPolicyConfiguration } from 'helmet';
+import {Middleware, Context} from 'koa';
+
+declare namespace koaHelmet {
+    type KoaHelmetContentSecurityPolicyDirectiveFunction = (ctx: Context) => string;
+
+    type KoaHelmetCspDirectiveValue = string | KoaHelmetContentSecurityPolicyDirectiveFunction;
+
+    interface KoaHelmetContentSecurityPolicyDirectives {
+        baseUri?: KoaHelmetCspDirectiveValue[];
+        childSrc?: KoaHelmetCspDirectiveValue[];
+        connectSrc?: KoaHelmetCspDirectiveValue[];
+        defaultSrc?: KoaHelmetCspDirectiveValue[];
+        fontSrc?: KoaHelmetCspDirectiveValue[];
+        formAction?: KoaHelmetCspDirectiveValue[];
+        frameAncestors?: KoaHelmetCspDirectiveValue[];
+        frameSrc?: KoaHelmetCspDirectiveValue[];
+        imgSrc?: KoaHelmetCspDirectiveValue[];
+        mediaSrc?: KoaHelmetCspDirectiveValue[];
+        objectSrc?: KoaHelmetCspDirectiveValue[];
+        pluginTypes?: KoaHelmetCspDirectiveValue[];
+        reportUri?: string;
+        sandbox?: KoaHelmetCspDirectiveValue[];
+        scriptSrc?: KoaHelmetCspDirectiveValue[];
+        styleSrc?: KoaHelmetCspDirectiveValue[];
+    }
+
+    interface KoaHelmetContentSecurityPolicyConfiguration {
+        reportOnly?: boolean;
+        setAllHeaders?: boolean;
+        disableAndroid?: boolean;
+        browserSniff?: boolean;
+        directives?: KoaHelmetContentSecurityPolicyDirectives;
+    }
+
+    interface KoaHelmet {
+        (options?: IHelmetConfiguration): Middleware;
+        contentSecurityPolicy(options?: KoaHelmetContentSecurityPolicyConfiguration): Middleware;
+        dnsPrefetchControl(options?: IHelmetDnsPrefetchControlConfiguration): Middleware;
+        frameguard(options?: IHelmetFrameguardConfiguration): Middleware;
+        hpkp(options?: IHelmetHpkpConfiguration): Middleware;
+        hsts(options?: IHelmetHstsConfiguration): Middleware;
+        ieNoOpen(): Middleware;
+        noCache(options?: any): Middleware;
+        noSniff(): Middleware;
+        referrerPolicy(options?: IHelmetReferrerPolicyConfiguration): Middleware;
+        xssFilter(options?: IHelmetXssFilterConfiguration): Middleware;
+    }
+}
+
+declare const koaHelmet: koaHelmet.KoaHelmet;
+export = koaHelmet;

--- a/types/koa-helmet/koa-helmet-tests.ts
+++ b/types/koa-helmet/koa-helmet-tests.ts
@@ -1,0 +1,197 @@
+import * as Koa from 'koa';
+import helmet = require('koa-helmet');
+
+const app = new Koa();
+
+/**
+ * @summary Test for {@see helmet}.
+ */
+function helmetTest() {
+    app.use(helmet());
+    app.use(helmet({}));
+    app.use(helmet({ frameguard: false }));
+    app.use(helmet({ frameguard: true }));
+    app.use(helmet({
+      frameguard: {
+        action: 'deny'
+      }
+    }));
+}
+
+/**
+ * @summary Test for {@see helmet#contentSecurityPolicy} function.
+ */
+function contentSecurityPolicyTest() {
+    const emptyArray: string[] =  [];
+    const config = {
+        directives: {
+            baseUri: ['base.example.com'],
+            childSrc: ['child.example.com'],
+            connectSrc: ['connect.example.com'],
+            defaultSrc: ['*'],
+            fontSrc: ['font.example.com'],
+            formAction: ['formaction.example.com'],
+            frameAncestors: ["'none'"],
+            frameSrc: emptyArray,
+            imgSrc: ['images.example.com'],
+            mediaSrc: ['media.example.com'],
+            objectSrc: ['objects.example.com'],
+            pluginTypes: emptyArray,
+            reportUri: '/some-url',
+            sandbox: emptyArray,
+            scriptSrc: ['scripts.example.com', (ctx: Koa.Context) => {
+              return "'nonce-abc123'";
+            }],
+            styleSrc: ['css.example.com']
+        },
+        reportOnly: false,
+        setAllHeaders: false,
+        disableAndroid: false
+    };
+
+    app.use(helmet.contentSecurityPolicy());
+    app.use(helmet.contentSecurityPolicy({}));
+    app.use(helmet.contentSecurityPolicy(config));
+    app.use(helmet.contentSecurityPolicy({
+        directives: {
+            defaultSrc: ["'self'"]
+        },
+        setAllHeaders: true
+    }));
+}
+
+/**
+ * @summary Test for {@see helmet#dnsPrefetchControl} function.
+ */
+function dnsPrefetchControlTest() {
+    app.use(helmet.dnsPrefetchControl());
+    app.use(helmet.dnsPrefetchControl({ allow: false }));
+    app.use(helmet.dnsPrefetchControl({ allow: true }));
+}
+
+/**
+ * @summary Test for {@see helmet#frameguard} function.
+ */
+function frameguardTest() {
+    app.use(helmet.frameguard());
+    app.use(helmet.frameguard({}));
+    app.use(helmet.frameguard({ action: 'deny' }));
+    app.use(helmet.frameguard({ action: 'sameorigin' }));
+    app.use(helmet.frameguard({
+      action: 'allow-from',
+      domain: 'http://example.com'
+    }));
+}
+
+/**
+ * @summary Test for {@see helmet#hpkp} function.
+ */
+function hpkpTest() {
+    app.use(helmet.hpkp({
+        maxAge: 7776000000,
+        sha256s: ['AbCdEf123=', 'ZyXwVu456='],
+    }));
+
+    app.use(helmet.hpkp({
+        maxAge: 7776000000,
+        sha256s: ['AbCdEf123=', 'ZyXwVu456='],
+        includeSubdomains: false
+    }));
+
+    app.use(helmet.hpkp({
+        maxAge: 7776000000,
+        sha256s: ['AbCdEf123=', 'ZyXwVu456='],
+        includeSubdomains: true
+    }));
+
+    app.use(helmet.hpkp({
+        maxAge: 7776000000,
+        sha256s: ['AbCdEf123=', 'ZyXwVu456='],
+        reportUri: 'http://example.com'
+    }));
+
+    app.use(helmet.hpkp({
+        maxAge: 7776000000,
+        sha256s: ['AbCdEf123=', 'ZyXwVu456='],
+        reportOnly: true
+    }));
+
+    app.use(helmet.hpkp({
+        maxAge: 7776000000,
+        sha256s: ['AbCdEf123=', 'ZyXwVu456='],
+        setIf: (req, res) => true
+    }));
+}
+
+/**
+ * @summary Test for {@see helmet#hsts} function.
+ */
+function hstsTest() {
+    app.use(helmet.hsts());
+
+    app.use(helmet.hsts({ maxAge: 7776000000 }));
+
+    app.use(helmet.hsts({
+      maxAge: 7776000000,
+    }));
+
+    app.use(helmet.hsts({
+      maxAge: 7776000000,
+      includeSubdomains: true
+    }));
+
+    app.use(helmet.hsts({
+      maxAge: 7776000000,
+      preload: true
+    }));
+
+    app.use(helmet.hsts({
+      maxAge: 7776000000,
+      force: true
+    }));
+
+    app.use(helmet.hsts({
+      maxAge: 7776000000,
+      setIf: (req, res) => true
+    }));
+}
+
+/**
+ * @summary Test for {@see helmet#ieNoOpen} function.
+ */
+function ieNoOpenTest() {
+    app.use(helmet.ieNoOpen());
+}
+
+/**
+ * @summary Test for {@see helmet#noCache} function.
+ */
+function noCacheTest() {
+    app.use(helmet.noCache());
+    app.use(helmet.noCache({}));
+    app.use(helmet.noCache({ noEtag: true }));
+}
+
+/**
+ * @summary Test for {@see helmet#noSniff} function.
+ */
+function noSniffTest() {
+    app.use(helmet.noSniff());
+}
+
+/**
+ * @summary Test for {@see helmet#referrerPolicy} function.
+ */
+function referrerPolicyTest() {
+    app.use(helmet.referrerPolicy({ policy: 'same-origin' }));
+}
+
+/**
+ * @summary Test for {@see helmet#xssFilter} function.
+ */
+function xssFilterTest() {
+    app.use(helmet.xssFilter());
+    app.use(helmet.xssFilter({}));
+    app.use(helmet.xssFilter({ setOnOldIE: false }));
+    app.use(helmet.xssFilter({ setOnOldIE: true }));
+}

--- a/types/koa-helmet/tsconfig.json
+++ b/types/koa-helmet/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "koa-helmet-tests.ts"
+    ]
+}

--- a/types/koa-helmet/tslint.json
+++ b/types/koa-helmet/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds type definitions for https://github.com/venables/koa-helmet, which is a Koa wrapper around https://github.com/helmetjs/helmet

**Note: `hidePoweredBy` is excluded because Koa does not add `X-Powered-By` header like Express does.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
