### PR TITLE
[ws] Add missing binaryType property

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -25,6 +25,7 @@ declare class WebSocket extends events.EventEmitter {
     upgradeReq: http.IncomingMessage;
     protocol: string;
     bufferedAmount: number;
+    binaryType: string;
 
     CONNECTING: number;
     OPEN: number;


### PR DESCRIPTION
ref: https://github.com/websockets/ws/blob/master/lib/WebSocket.js#L91