### PR TITLE
Added running to CronJob interface

### DIFF
--- a/types/cron/index.d.ts
+++ b/types/cron/index.d.ts
@@ -14,6 +14,7 @@ interface CronJobStatic {
 interface CronJob {
     start(): void;
     stop(): void;
+    running: boolean | undefined;
 }
 export declare var CronJob: CronJobStatic;
 


### PR DESCRIPTION
Please fill in this template.

Adding the running property to the CronJob interface

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/kelektiv/node-cron#how-to-check-if-a-job-is-running>>