### PR TITLE
FullCalendar: Callback Fixes

### DIFF
--- a/types/fullcalendar/fullcalendar-tests.ts
+++ b/types/fullcalendar/fullcalendar-tests.ts
@@ -631,8 +631,8 @@ $('#calendar').fullCalendar({
 interface EventWithDescription extends FullCalendar.EventObject {
     description: string;
 }
-interface JQuery {
-    qtip: any; // dummy plugin interface
+interface JQueryQTip extends JQuery {
+    qtip(options: Object): JQuery; // dummy plugin interface
 }
 
 $('#calendar').fullCalendar({
@@ -644,7 +644,7 @@ $('#calendar').fullCalendar({
         }
         // more events here
     ],
-    eventRender(event: EventWithDescription, element: any, view: any) {
+    eventRender(event: EventWithDescription, element: JQueryQTip, view: FullCalendar.ViewObject) {
         element.qtip({
             content: event.description
         });

--- a/types/fullcalendar/index.d.ts
+++ b/types/fullcalendar/index.d.ts
@@ -57,7 +57,7 @@ export interface Options extends AgendaOptions, EventDraggingResizingOptions, Dr
     views?: ViewSpecificOptions;
     viewRender?(view: ViewObject, element: JQuery): void;
     viewDestroy?(view: ViewObject, element: JQuery): void;
-    dayRender?(date: Date, cell: HTMLTableDataCellElement): void;
+    dayRender?(date: Date, cell: JQuery): void;
     windowResize?(view: ViewObject): void;
 
     // Timezone
@@ -130,8 +130,8 @@ export interface Options extends AgendaOptions, EventDraggingResizingOptions, Dr
     eventBackgroundColor?: string;
     eventBorderColor?: string;
     eventTextColor?: string;
-    eventRender?(event: EventObject, element: HTMLDivElement, view: ViewObject): void;
-    eventAfterRender?(event: EventObject, element: HTMLDivElement, view: ViewObject): void;
+    eventRender?(event: EventObject, element: JQuery, view: ViewObject): void;
+    eventAfterRender?(event: EventObject, element: JQuery, view: ViewObject): void;
     eventAfterAllRender?(view: ViewObject): void;
     eventDestroy?(event: EventObject, element: JQuery, view: ViewObject): void;
 

--- a/types/fullcalendar/index.d.ts
+++ b/types/fullcalendar/index.d.ts
@@ -184,7 +184,7 @@ export interface EventDraggingResizingOptions {
 */
 export interface SelectionOptions {
     selectable?: boolean;
-    selectHelper?: boolean | ((start: moment.Moment, end: moment.Moment) => HTMLElement);
+    selectHelper?: boolean;
     unselectAuto?: boolean;
     unselectCancel?: string;
     selectOverlap?: boolean | ((event: EventObject) => boolean);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [`dayRender`](https://fullcalendar.io/docs/display/dayRender/) is triggered [here](https://github.com/fullcalendar/fullcalendar/blob/3ac1ea7f4166a78b9b3043f2a6938419c76529af/src/common/DayGrid.js#L53), which ultimately returns an element from [here](https://github.com/fullcalendar/fullcalendar/blob/3ac1ea7f4166a78b9b3043f2a6938419c76529af/src/common/DayGrid.js#L35)
  - [`eventRender`](https://fullcalendar.io/docs/event_rendering/eventRender/) is triggered [here](https://github.com/fullcalendar/fullcalendar/blob/24db2103d062a183328ed1162e44f3583d2f3b6e/src/common/View.js#L857) with an element that comes from [here](https://github.com/fullcalendar/fullcalendar/blob/42388fff0080560e534649ce1c8827df6c8351dd/src/common/Grid.events.js#L114)
  - [`eventAfterRender`](https://fullcalendar.io/docs/event_rendering/eventAfterRender/) is triggered [here](https://github.com/fullcalendar/fullcalendar/blob/24db2103d062a183328ed1162e44f3583d2f3b6e/src/common/View.js#L811) and is being made to match [`eventDestroy`](https://fullcalendar.io/docs/event_rendering/eventDestroy/),
 which is fired [here](https://github.com/fullcalendar/fullcalendar/blob/24db2103d062a183328ed1162e44f3583d2f3b6e/src/common/View.js#L822)
  - [`selectHelper`](https://fullcalendar.io/docs/selection/selectHelper/) docs reference obsolete function usage, confirmed by [2.1.0 release notes](https://github.com/fullcalendar/fullcalendar/releases/tag/v2.1.0)
- [x] Increase the version number in the header if appropriate. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`. **Already exists**

Closes https://github.com/fullcalendar/fullcalendar/issues/3691