### PR TITLE
[pixi.js] Fixed definition of renderer options

### DIFF
--- a/types/pixi.js/index.d.ts
+++ b/types/pixi.js/index.d.ts
@@ -836,18 +836,12 @@ declare namespace PIXI {
         destroy(): void;
     }
 
-    interface IWebGLRendererOptions {
-        view?: HTMLCanvasElement;
-        transparent?: boolean;
-        autoResize?: boolean;
-        antialias?: boolean;
+    interface IWebGLRendererOptions extends IRendererOptions {
         forceFXAA?: boolean;
-        resolution?: number;
-        clearBeforeRender?: boolean;
         preserveDrawingBuffer?: boolean;
-        roundPixels?: boolean;
         legacy?: boolean;
     }
+
     class WebGLRenderer extends SystemRenderer {
         // plugintarget mixin start
         static __plugins: Object;

--- a/types/pixi.js/pixi.js-tests.ts
+++ b/types/pixi.js/pixi.js-tests.ts
@@ -21,10 +21,10 @@ function basics() {
     }
 
     class Renderer {
-        private renderer: PIXI.WebGLRenderer
+        private renderer: PIXI.WebGLRenderer;
         constructor() {
             // Renderer should allow options from both WebGLRenderer and underlying SystemRenderer
-            this.renderer = new PIXI.WebGLRenderer(0, 0, { backgroundColor : 0x272d37, forceFXAA: true })
+            this.renderer = new PIXI.WebGLRenderer(0, 0, { backgroundColor : 0x272d37, forceFXAA: true });
         }
     }
 

--- a/types/pixi.js/pixi.js-tests.ts
+++ b/types/pixi.js/pixi.js-tests.ts
@@ -20,6 +20,14 @@ function basics() {
         }
     }
 
+    class Renderer {
+        private renderer: PIXI.WebGLRenderer
+        constructor() {
+            // Renderer should allow options from both WebGLRenderer and underlying SystemRenderer
+            this.renderer = new PIXI.WebGLRenderer(0, 0, { backgroundColor : 0x272d37, forceFXAA: true })
+        }
+    }
+
     class Click {
         private app: PIXI.Application;
 


### PR DESCRIPTION
In pixi.js `WebGLRenderer` passes on it's options to it's super class `SystemRenderer`, so the options `IWebGLRendererOptions` should be a superset of `IRendererOptions`.

By extending `IRendererOptions` I could also clean up a lot of duplicate properties in `IWebGLRendererOptions`.

I failed to run `npm run lint` with any package name. I get the error `Object.entries is not a function`. But i testet the code myself and I added a test for the change.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pixijs/pixi.js/blob/dev/src/core/renderers/webgl/WebGLRenderer.js#L58
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
