### PR TITLE
@types/recompose: Improve this typing in the lifecycle method

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -160,10 +160,10 @@ declare module 'recompose' {
     interface ReactLifeCycleFunctions<TProps, TState> {
         componentWillMount?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>) => void;
         componentDidMount?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>) => void;
-        componentWillReceiveProps?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps:TProps) => void;
-        shouldComponentUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps:TProps, nextState: TState) => boolean;
-        componentWillUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps:TProps, nextState: TState) => void;
-        componentDidUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, prevProps:TProps, prevState: TState) => void;
+        componentWillReceiveProps?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps: TProps) => void;
+        shouldComponentUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps: TProps, nextState: TState) => boolean;
+        componentWillUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps: TProps, nextState: TState) => void;
+        componentDidUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, prevProps: TProps, prevState: TState) => void;
         componentWillUnmount?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>) => void;
     }
 

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -143,18 +143,32 @@ declare module 'recompose' {
         contextTypes: ValidationMap<TContext>
     ) : InferableComponentEnhancer;
 
-    // lifecycle: https://github.com/acdlite/recompose/blob/master/docs/API.md#lifecycle
-    interface ReactLifeCycleFunctions {
-        componentWillMount?: Function;
-        componentDidMount?: Function;
-        componentWillReceiveProps?: Function;
-        shouldComponentUpdate?: Function;
-        componentWillUpdate?: Function;
-        componentDidUpdate?: Function;
-        componentWillUnmount?: Function;
+    interface ReactLifeCycleFunctionsThisArguments<TProps, TState> {
+        props: TProps,
+        state: TState,
+        setState<TKeyOfState extends keyof TState>(f: (prevState: TState, props: TProps) => Pick<TState, TKeyOfState>, callback?: () => any): void;
+        setState<TKeyOfState extends keyof TState>(state: Pick<TState, TKeyOfState>, callback?: () => any): void;
+        forceUpdate(callBack?: () => any): void;
+
+        context: any;
+        refs: {
+            [key: string]: React.ReactInstance
+        };
     }
-    export function lifecycle(
-        spec: ReactLifeCycleFunctions
+    
+    // lifecycle: https://github.com/acdlite/recompose/blob/master/docs/API.md#lifecycle
+    interface ReactLifeCycleFunctions<TProps, TState> {
+        componentWillMount?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>) => void;
+        componentDidMount?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>) => void;
+        componentWillReceiveProps?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps:TProps) => void;
+        shouldComponentUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps:TProps, nextState: TState) => boolean;
+        componentWillUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, nextProps:TProps, nextState: TState) => void;
+        componentDidUpdate?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>, prevProps:TProps, prevState: TState) => void;
+        componentWillUnmount?: (this: ReactLifeCycleFunctionsThisArguments<TProps, TState>) => void;
+    }
+
+    export function lifecycle<TProps, TState>(
+        spec: ReactLifeCycleFunctions<TProps, TState>
     ): InferableComponentEnhancer;
 
     // toClass: https://github.com/acdlite/recompose/blob/master/docs/API.md#toClass

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Recompose v0.22.0
+// Type definitions for Recompose v0.22.1
 // Project: https://github.com/acdlite/recompose
 // Definitions by: Iskander Sierra <https://github.com/iskandersierra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Hey 

I have added some more typing information to the lifecycle method the reason for this changes is there is no way to set the `this` parameter in lifecycle methods. This is a an issue when the compiler option --noImplicitThis is enabled.

Please let me know if there is anything more I need to do :)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/functions.html#this
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
