### PR TITLE
[React-Router] Add missing `path`, `exact` and `strict` props in `Redirect` definition

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -11,6 +11,7 @@
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 //                 Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Huy Nguyen <https://github.com/huy-nguyen>
+//                 Jérémy Fauvel <https://github.com/grmiade>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -49,6 +50,9 @@ declare module 'react-router' {
     to: H.LocationDescriptor;
     push?: boolean;
     from?: string;
+    path?: string;
+    exact?: boolean;
+    strict?: boolean;
   }
   class Redirect extends React.Component<RedirectProps, void> {}
 

--- a/types/react-router/test/Switch.tsx
+++ b/types/react-router/test/Switch.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react'
+import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom'
+
+const Home = () => <h2>Home</h2>
+
+const SwitchTest = () => (
+  <BrowserRouter>
+    <Switch>
+      <Redirect exact from="/" to="/home"/>
+      <Route path="/home" component={Home}/>
+    </Switch>
+  </BrowserRouter>
+)
+
+export default SwitchTest

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -27,6 +27,7 @@
     "test/PreventingTransitions.tsx",
     "test/Recursive.tsx",
     "test/RouteConfig.tsx",
-    "test/Sidebar.tsx"
+    "test/Sidebar.tsx",
+    "test/Switch.tsx"
   ]
 }


### PR DESCRIPTION
https://reacttraining.com/react-router/web/api/Switch/children-node
> When you include a `<Redirect>` in a `<Switch>`, it can use any of the `<Route>`'s location matching props: path, exact, and strict. from is just an alias for the path prop.