### PR TITLE
[rewire] Added generics to rewire

### DIFF
--- a/types/rewire/index.d.ts
+++ b/types/rewire/index.d.ts
@@ -1,36 +1,34 @@
-// Type definitions for rewire v2.5.1
+// Type definitions for rewire 2.5
 // Project: https://github.com/jhnns/rewire
 // Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov>
+//                 Federico Caselli <https://github.com/CaselIT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Typescript Version: 2.3
 
 declare namespace RewireInterfaces {
-    interface Rewire {
-        /**
-         * Returns a rewired version of the module found at filename. Use rewire() exactly like require().
-         */
-        (filename: string): RewiredModule;
-    }
-
     interface RewiredModule {
         /**
          * Takes all enumerable keys of obj as variable names and sets the values respectively. Returns a function which can be called to revert the change.
          */
-        __set__(obj: Object): Function;
+        __set__(obj: { [variable: string]: any }): () => void;
         /**
          * Sets the internal variable name to the given value. Returns a function which can be called to revert the change.
          */
-        __set__(name: string, value: any): Function;
+        __set__(name: string, value: any): () => void;
         /**
          * Returns the private variable with the given name.
          */
-        __get__(name: string): any;
+        __get__<T = any>(name: string): T;
         /**
          * Returns a function which - when being called - sets obj, executes the given callback and reverts obj. If callback returns a promise, obj is only reverted after
          * the promise has been resolved or rejected. For your convenience the returned function passes the received promise through.
          */
-        __with__(obj: Object): (callback: Function) => any;
+        __with__(obj: { [variable: string]: any }): (callback: () => any) => any;
     }
 }
 
-declare var rewire: RewireInterfaces.Rewire;
+/**
+ * Returns a rewired version of the module found at filename. Use rewire() exactly like require().
+ */
+declare function rewire<T = { [key: string]: any }>(filename: string): RewireInterfaces.RewiredModule & T;
 export = rewire;

--- a/types/rewire/index.d.ts
+++ b/types/rewire/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov>
 //                 Federico Caselli <https://github.com/CaselIT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Typescript Version: 2.3
+// TypeScript Version: 2.3
 
 declare namespace RewireInterfaces {
     interface RewiredModule {

--- a/types/rewire/rewire-tests.ts
+++ b/types/rewire/rewire-tests.ts
@@ -1,12 +1,12 @@
 import rewire = require("rewire");
 
-var myModule = rewire("../lib/myModule.js");
+const myModule = rewire("../lib/myModule.js");
 
 myModule.__set__("path", "/dev/null");
 myModule.__get__("path"); // = '/dev/null'
 
-var fsMock = {
-    readFile: function (path: string, encoding: string, cb: Function) {
+const fsMock = {
+    readFile(path: string, encoding: string, cb: (a: any, b: any) => any) {
         cb(null, "Success!");
     }
 };
@@ -19,14 +19,14 @@ myModule.__set__({
 
 myModule.__set__({
     console: {
-        log: function () { /* be quiet */ }
+        log() { /* be quiet */ }
     },
     process: {
         argv: ["testArg1", "testArg2"]
     }
 });
 
-var revert = myModule.__set__("port", 3000);
+const revert = myModule.__set__("port", 3000);
 
 // port is now 3000
 revert();
@@ -34,15 +34,15 @@ revert();
 
 myModule.__with__({
     port: 3000
-})(function () {
+})(() => {
     // within this function port is 3000
 });
 // now port is the previous value again
 
 myModule.__with__({
     port: 3000
-})(function () {
-}).then(function () {
+})(() => {
+}).then(() => {
     // now port is the previous value again
 });
 // port is still 3000 here because the promise hasn't been resolved yet

--- a/types/rewire/tslint.json
+++ b/types/rewire/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jhnns/rewire
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

Added generics to rewire using the default values introduced in typescript 2.3
The build at the moment fails, but I'm not sure if dtslint support typescript 2.3
