### PR TITLE
[mongodb] Added support for default generic types

### DIFF
--- a/types/acl/index.d.ts
+++ b/types/acl/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/optimalbits/node_acl
 // Definitions by: Qubo <https://github.com/tkQubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="bluebird" />
 /// <reference types="node"/>

--- a/types/agenda/index.d.ts
+++ b/types/agenda/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/rschmukler/agenda
 // Definitions by: Meir Gottlieb <https://github.com/meirgottlieb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/connect-mongo/index.d.ts
+++ b/types/connect-mongo/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/kcbanner/connect-mongo
 // Definitions by: Mizuki Yamamoto <https://github.com/Syati>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="express-session" />
 

--- a/types/easy-jsend/easy-jsend-tests.ts
+++ b/types/easy-jsend/easy-jsend-tests.ts
@@ -1,14 +1,15 @@
 
 
-import mongoose = require('mongoose');
+// import mongoose = require('mongoose');
 import express = require('express');
 import jSend = require('easy-jsend');
 
-var schema = new mongoose.Schema({
-    name: {type: String}
-});
+// var schema = new mongoose.Schema({
+//     name: {type: String}
+// });
 
-var Model = mongoose.model('model', schema);
+// var Model = mongoose.model('model', schema);
+var Model = {};
 
 jSend.init({partial: true});
 

--- a/types/express-brute-mongo/index.d.ts
+++ b/types/express-brute-mongo/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://github.com/auth0/express-brute-mongo
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-
-
+import { Collection } from "mongodb";
 
 /**
  * @summary MongoDB store adapter.
@@ -17,5 +17,5 @@ export = class MongoStore {
      * @param {Function} getCollection The collection.
      * @param {Object}   options       The otpions.
      */
-    constructor(getCollection: (collection: any) => void, options?: Object);
+    constructor(getCollection: (collection: (c: Collection) => void) => void, options?: Object);
 }

--- a/types/gridfs-stream/index.d.ts
+++ b/types/gridfs-stream/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/aheckmann/gridfs-stream
 // Definitions by: Lior Mualem <https://github.com/liorm/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -497,14 +497,13 @@ export interface Collection {
     dropIndexes(): Promise<any>;
     dropIndexes(callback?: MongoCallback<any>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#find
-    find(query?: Object): Cursor<any>;
-    find<T>(query?: Object): Cursor<T>;
+    find<T = Default>(query?: Object): Cursor<T>;
     /** @deprecated */
-    find(query: Object, fields?: Object, skip?: number, limit?: number, timeout?: number): Cursor<any>;
+    find<T = Default>(query: Object, fields?: Object, skip?: number, limit?: number, timeout?: number): Cursor<T>;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#findOne
-    findOne(filter: Object, callback: MongoCallback<any>): void;
-    findOne(filter: Object, options?: FindOneOptions): Promise<any>;
-    findOne(filter: Object, options: FindOneOptions, callback: MongoCallback<any>): void;
+    findOne<T = Default>(filter: Object, callback: MongoCallback<T>): void;
+    findOne<T = Default>(filter: Object, options?: FindOneOptions): Promise<T>;
+    findOne<T = Default>(filter: Object, options: FindOneOptions, callback: MongoCallback<T>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#findOneAndDelete
     findOneAndDelete(filter: Object, callback: MongoCallback<FindAndModifyWriteOpResultObject>): void;
     findOneAndDelete(filter: Object, options?: { projection?: Object, sort?: Object, maxTimeMS?: number }): Promise<FindAndModifyWriteOpResultObject>;

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://github.com/mongodb/node-mongodb-native/tree/2.2
 // Definitions by: Federico Caselli <https://github.com/CaselIT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Documentation : http://mongodb.github.io/node-mongodb-native/2.2/api/
 // TypeScript Version: 2.3
 
+// Documentation : http://mongodb.github.io/node-mongodb-native/2.2/api/
 
 /// <reference types="node" />
 /// <reference types="bson" />

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://github.com/mongodb/node-mongodb-native/tree/2.2
 // Definitions by: Federico Caselli <https://github.com/CaselIT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Typescript Version: 2.3
-
 // Documentation : http://mongodb.github.io/node-mongodb-native/2.2/api/
+// TypeScript Version: 2.3
+
 
 /// <reference types="node" />
 /// <reference types="bson" />

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/mongodb/node-mongodb-native/tree/2.2
 // Definitions by: Federico Caselli <https://github.com/CaselIT>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Typescript Version: 2.3
 
 // Documentation : http://mongodb.github.io/node-mongodb-native/2.2/api/
 
@@ -996,8 +997,10 @@ export interface WriteOpResult {
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#~resultCallback
 export type CursorResult = any | void | boolean;
 
+type Default = { [key: string]: any };
+
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html
-export class Cursor<T> extends Readable {
+export class Cursor<T = Default> extends Readable {
 
     sortValue: string;
     timeout: boolean;
@@ -1048,8 +1051,8 @@ export class Cursor<T> extends Readable {
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#min
     min(min: number): Cursor<T>;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#next
-    next(): Promise<CursorResult>;
-    next(callback: MongoCallback<CursorResult>): void;
+    next(): Promise<T>;
+    next(callback: MongoCallback<T>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#project
     project(value: Object): Cursor<T>;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#read
@@ -1101,7 +1104,7 @@ export interface EndCallback {
 //http://mongodb.github.io/node-mongodb-native/2.1/api/AggregationCursor.html#~resultCallback
 export type AggregationCursorResult = any | void;
 //http://mongodb.github.io/node-mongodb-native/2.1/api/AggregationCursor.html
-export class AggregationCursor<T> extends Readable {
+export class AggregationCursor<T = Default> extends Readable {
     // http://mongodb.github.io/node-mongodb-native/2.1/api/AggregationCursor.html#batchSize
     batchSize(value: number): AggregationCursor<T>;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/AggregationCursor.html#clone
@@ -1127,8 +1130,8 @@ export class AggregationCursor<T> extends Readable {
     // http://mongodb.github.io/node-mongodb-native/2.1/api/AggregationCursor.html#maxTimeMS
     maxTimeMS(value: number): AggregationCursor<T>;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/AggregationCursor.html#next
-    next(): Promise<AggregationCursorResult>;
-    next(callback: MongoCallback<AggregationCursorResult>): void;
+    next(): Promise<T>;
+    next(callback: MongoCallback<T>): void;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/AggregationCursor.html#out
     out(destination: string): AggregationCursor<T>;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/AggregationCursor.html#project

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -53,7 +53,7 @@ let options = {
     });
 
     {
-    let cursor: mongodb.Cursor  <any>;
+    let cursor: mongodb.Cursor;
         cursor = collection.find();
         cursor = cursor.addCursorFlag('',true);
         cursor = cursor.addQueryModifier('',true);
@@ -81,14 +81,14 @@ let options = {
     // Collection .findM<T>() & .agggregate<T>() generic tests
     {
     let bag : {cost: number, color: string};
-   type bag = typeof bag;
+    type bag = typeof bag;
     let cursor: mongodb.Cursor<bag> = collection.find<bag>({color: 'black'})
         cursor.toArray(function (err,r) { r[0].cost} );
         cursor.forEach(function (bag  ) { bag.color }, () => {});
     }
     {
     let payment: {total: number};
-   type payment = typeof payment;
+    type payment = typeof payment;
     let cursor: mongodb.AggregationCursor<payment> = collection.aggregate<payment>([{}])
     }
 })

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -85,6 +85,8 @@ let options = {
     let cursor: mongodb.Cursor<bag> = collection.find<bag>({color: 'black'})
         cursor.toArray(function (err,r) { r[0].cost} );
         cursor.forEach(function (bag  ) { bag.color }, () => {});
+        collection.findOne({ color: 'white' }).then(() => { })
+        collection.findOne<bag>({ color: 'white' }).then(b => { b.cost; })
     }
     {
     let payment: {total: number};

--- a/types/mongoose-auto-increment/index.d.ts
+++ b/types/mongoose-auto-increment/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/codetunnel/mongoose-auto-increment
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+// TypeScript Version: 2.3
 
 import { Connection, Schema, Mongoose } from 'mongoose';
 

--- a/types/mongoose-deep-populate/index.d.ts
+++ b/types/mongoose-deep-populate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/buunguyen/mongoose-deep-populate
 // Definitions by: Aya Morisawa <https://github.com/AyaMorisawa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+// TypeScript Version: 2.3
 
 import { Mongoose, Schema } from 'mongoose';
 

--- a/types/mongoose-mock/index.d.ts
+++ b/types/mongoose-mock/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/JohanObrink/mongoose-mock
 // Definitions by: jt000 <https://github.com/jt000>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+// TypeScript Version: 2.3
 
 import mongoose = require('mongoose');
 

--- a/types/mongoose-paginate/index.d.ts
+++ b/types/mongoose-paginate/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/edwardhotchkiss/mongoose-paginate
 // Definitions by: Linus Brolin <https://github.com/linusbrolin/>, simonxca <https://github.com/simonxca/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="mongoose" />
 

--- a/types/mongoose-promise/index.d.ts
+++ b/types/mongoose-promise/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://mongoosejs.com/
 // Definitions by: simonxca <https://github.com/simonxca/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="mongoose" />
 /// <reference types="mpromise" />

--- a/types/mongoose-sequence/index.d.ts
+++ b/types/mongoose-sequence/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/ramiel/mongoose-sequence
 // Definitions by: Linus Brolin <https://github.com/linusbrolin/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="mongoose" />
 

--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://mongoosejs.com/
 // Definitions by: simonxca <https://github.com/simonxca/>, horiuchi <https://github.com/horiuchi/>, sindrenm <https://github.com/sindrenm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="mongodb" />
 /// <reference types="node" />

--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/saintedlama/passport-local-mongoose
 // Definitions by: Linus Brolin <https://github.com/linusbrolin/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="mongoose" />
 /// <reference types="passport-local" />


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

Added support for default types introduced in ts2.3.
Once https://github.com/Microsoft/dtslint/issues/31 is fixed I'll add tslint support when I have time
