### PR TITLE
Data Params declared as select2 option rather than string

### DIFF
--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -26,7 +26,6 @@ interface Select2AjaxOptions {
     dataType?: string;
     delay?: number;
     cache?: boolean;
-    data?: (term: string, page: number, context: any) => any;
     results?: (term: any, page: number, context: any) => any;
     processResults?:(data: any, params: any) => any;
 }

--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -26,6 +26,7 @@ interface Select2AjaxOptions {
     dataType?: string;
     delay?: number;
     cache?: boolean;
+    data?: (params: Select2QueryOptions, page: number, context: any) => any;
     results?: (term: any, page: number, context: any) => any;
     processResults?:(data: any, params: any) => any;
 }

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -58,9 +58,7 @@ $("#e6").select2({
         url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
         dataType: 'jsonp',
         cache: false,
-        data: function (term, page) {
             return {
-                q: term,
                 page_limit: 10,
                 apikey: "ju6z9mjyajq2djue3gbvv26t"
             };
@@ -79,9 +77,7 @@ $("#e6").select2({
     ajax: {
         url: () => { return "http://api.rottentomatoes.com/api/public/v1.0/movies.json"; },
         dataType: 'jsonp',
-        data: function (term, page) {
             return {
-                q: term,
                 page_limit: 10,
                 apikey: "ju6z9mjyajq2djue3gbvv26t"
             };
@@ -101,9 +97,7 @@ $("#e7").select2({
         url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
         dataType: 'jsonp',
         delay: 100,
-        data: function (term, page) {
             return {
-                q: term,
                 page_limit: 10,
                 page: page,
                 apikey: "ju6z9mjyajq2djue3gbvv26t"

--- a/types/select2/select2-tests.ts
+++ b/types/select2/select2-tests.ts
@@ -58,7 +58,9 @@ $("#e6").select2({
         url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
         dataType: 'jsonp',
         cache: false,
+        data: function (params, page) {
             return {
+                q: params.term,
                 page_limit: 10,
                 apikey: "ju6z9mjyajq2djue3gbvv26t"
             };
@@ -77,7 +79,9 @@ $("#e6").select2({
     ajax: {
         url: () => { return "http://api.rottentomatoes.com/api/public/v1.0/movies.json"; },
         dataType: 'jsonp',
+        data: function (params, page) {
             return {
+                q: params.term,
                 page_limit: 10,
                 apikey: "ju6z9mjyajq2djue3gbvv26t"
             };
@@ -97,7 +101,9 @@ $("#e7").select2({
         url: "http://api.rottentomatoes.com/api/public/v1.0/movies.json",
         dataType: 'jsonp',
         delay: 100,
+        data: function (params, page) {
             return {
+                q: params.term,
                 page_limit: 10,
                 page: page,
                 apikey: "ju6z9mjyajq2djue3gbvv26t"


### PR DESCRIPTION
Params for data should have been declared as something other than string because selecting from Ajax does not quite work. 

Take into account this code below: 

`$('select').select2({
  ajax: {
    data: function (params) {
      var query = {
        search: params.term,
        page: params.page
      }
      return query;
    }
  }
});`

There would be no way to access the term from the parameter. I have changed the data parameter to select2option but if this is not correct please let me know.



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
-  [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.