### PR TITLE
fix null in sequelize find

### DIFF
--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -3724,15 +3724,15 @@ declare namespace sequelize {
          * Search for a single instance by its primary key. This applies LIMIT 1, so the listener will
          * always be called with a single instance.
          */
-        findById(identifier?: number | string, options?: FindOptions): Promise<TInstance>;
-        findByPrimary(identifier?: number | string, options?: FindOptions): Promise<TInstance>;
+        findById(identifier?: number | string, options?: FindOptions): Promise<TInstance | null>;
+        findByPrimary(identifier?: number | string, options?: FindOptions): Promise<TInstance | null>;
 
         /**
          * Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single
          * instance.
          */
-        findOne(options?: FindOptions): Promise<TInstance>;
-        find(options?: FindOptions): Promise<TInstance>;
+        findOne(options?: FindOptions): Promise<TInstance | null>;
+        find(options?: FindOptions): Promise<TInstance | null>;
 
         /**
          * Run an aggregation method on the specified field


### PR DESCRIPTION
This is a small fix for sequelize v3. When querying a single row, of the row might not be found, in this case sequelize returns null.

This is inline with the v4 types: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/sequelize/