### PR TITLE
Remove unneeded and broken react-router dependency from react-i18next

### DIFF
--- a/types/react-i18next/index.d.ts
+++ b/types/react-i18next/index.d.ts
@@ -6,7 +6,6 @@
 
 import * as I18next from "i18next";
 import * as React from "react";
-import * as ReactRouter from "react-router";
 
 export type TranslationFunction = I18next.TranslationFunction;
 
@@ -53,6 +52,6 @@ interface TranslateOptions {
 
 export function translate(namespaces?: string[] | string, options?: TranslateOptions): <C extends Function>(WrappedComponent: C) => C;
 
-export function loadNamespaces({ components, i18n }: { components: ReactRouter.RouteComponent[], i18n: I18next.I18n }): Promise<void>;
+export function loadNamespaces({ components, i18n }: { components: (React.ComponentClass<any> | React.StatelessComponent<any>)[], i18n: I18next.I18n }): Promise<void>;
 
 export as namespace ReactI18Next;

--- a/types/react-i18next/tsconfig.json
+++ b/types/react-i18next/tsconfig.json
@@ -9,11 +9,6 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "baseUrl": "../",
-        "paths": {
-            "history": ["history/v2"],
-            "history/*": ["history/v2/*"],
-            "react-router": ["react-router/v2"]
-        },
         "typeRoots": [
             "../"
         ],


### PR DESCRIPTION
`RouteComponent` does not exist anymore and is unneeded as it's simply an alias of `React.ComponentClass<any> | React.StatelessComponent<any>`.
