### PR TITLE
Autobahn: Add missing Publish Options

### DIFF
--- a/types/autobahn/index.d.ts
+++ b/types/autobahn/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for AutobahnJS v0.9.7
 // Project: http://autobahn.ws/js/
-// Definitions by: Elad Zelingher <https://github.com/darkl/>, Andy Hawkins <https://github.com/a904guy/,http://a904guy.com/,http://www.bmbsqd.com>
+// Definitions by: Elad Zelingher <https://github.com/darkl/>, Andy Hawkins <https://github.com/a904guy/,http://a904guy.com/,http://www.bmbsqd.com>, Wladimir Totino <https://github.com/valepu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="when" />
@@ -167,8 +167,14 @@ declare namespace autobahn {
     interface IPublishOptions {
         acknowledge?: boolean;
         exclude?: number[];
+        exclude_authid?: string[];
+        exclude_authrole?: string[];
         eligible?: number[];
-        disclose_me?: Boolean;
+        eligible_authid?: string[];
+        eligible_authrole?: string[];
+        retain?: boolean;
+        disclose_me?: boolean;
+        exclude_me?: boolean;
     }
 
     interface ISubscribeOptions {


### PR DESCRIPTION
Add all the missing publish options to interface IPublishOptions (according to documentation https://github.com/crossbario/autobahn-js/blob/master/doc/programming.md#publishing-events ). "**disclose_me**" is undocumented but it is indeed used inside autobahn's code

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `tsc`

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/crossbario/autobahn-js/blob/master/doc/programming.md#publishing-events