### PR TITLE
Update util.inspect in Node.js contract to match docs

### DIFF
--- a/types/imap/imap-tests.ts
+++ b/types/imap/imap-tests.ts
@@ -40,7 +40,7 @@ imap.once('ready', function() {
                 });
             });
             msg.once('attributes', function(attrs : Object) {
-                console.log(prefix + 'Attributes: %s', inspect(attrs, false, 8));
+                console.log(prefix + 'Attributes: %s', inspect(attrs, { showHidden: false, depth: 8}));
             });
             msg.once('end', function() {
                 console.log(prefix + 'Finished');
@@ -94,7 +94,7 @@ openInbox(function(err : Error, box : IMAP.Box) {
             });
         });
         msg.once('attributes', function(attrs : Object) {
-            console.log(prefix + 'Attributes: %s', inspect(attrs, false, 8));
+            console.log(prefix + 'Attributes: %s', inspect(attrs, { showHidden: false, depth: 8}));
         });
         msg.once('end', function() {
             console.log(prefix + 'Finished');
@@ -129,7 +129,7 @@ openInbox(function(err : Error, box : IMAP.Box) {
                 stream.pipe(fs.createWriteStream('msg-' + seqno + '-body.txt'));
             });
             msg.once('attributes', function(attrs : Object) {
-                console.log(prefix + 'Attributes: %s', inspect(attrs, false, 8));
+                console.log(prefix + 'Attributes: %s', inspect(attrs, { showHidden: false, depth: 8}));
             });
             msg.once('end', function() {
                 console.log(prefix + 'Finished');

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -3640,6 +3640,9 @@ declare module "util" {
         depth?: number;
         colors?: boolean;
         customInspect?: boolean;
+        showProxy?: boolean;
+        maxArrayLength?: number;
+        breakLength?: number;
     }
 
     export function format(format: any, ...param: any[]): string;
@@ -3648,8 +3651,7 @@ declare module "util" {
     export function puts(...param: any[]): void;
     export function print(...param: any[]): void;
     export function log(string: string): void;
-    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
-    export function inspect(object: any, options: InspectOptions): string;
+    export function inspect(object: any, options?: InspectOptions): string;
     export function isArray(object: any): object is any[];
     export function isRegExp(object: any): object is RegExp;
     export function isDate(object: any): object is Date;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -501,9 +501,15 @@ namespace url_tests {
 
 namespace util_tests {
     {
-        // Old and new util.inspect APIs
-        util.inspect(["This is nice"], false, 5);
-        util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });
+        util.inspect(["This is nice"], {
+            colors: true,
+            depth: 5,
+            customInspect: false,
+            showHidden: true,
+            showProxy: true,
+            maxArrayLength: 5,
+            breakLength: 4
+        });
     }
 }
 

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -3560,6 +3560,9 @@ declare module "util" {
         depth?: number;
         colors?: boolean;
         customInspect?: boolean;
+        showProxy?: boolean;
+        maxArrayLength?: number;
+        breakLength?: number;
     }
 
     export function format(format: any, ...param: any[]): string;
@@ -3568,8 +3571,7 @@ declare module "util" {
     export function puts(...param: any[]): void;
     export function print(...param: any[]): void;
     export function log(string: string): void;
-    export function inspect(object: any, showHidden?: boolean, depth?: number, color?: boolean): string;
-    export function inspect(object: any, options: InspectOptions): string;
+    export function inspect(object: any, options?: InspectOptions): string;
     export function isArray(object: any): boolean;
     export function isRegExp(object: any): boolean;
     export function isDate(object: any): boolean;

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -427,9 +427,15 @@ namespace url_tests {
 
 namespace util_tests {
     {
-        // Old and new util.inspect APIs
-        util.inspect(["This is nice"], false, 5);
-        util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });
+        util.inspect(["This is nice"], {
+            colors: true,
+            depth: 5,
+            customInspect: false,
+            showHidden: true,
+            showProxy: true,
+            maxArrayLength: 5,
+            breakLength: 4
+        });
     }
 }
 


### PR DESCRIPTION
Two things here:
1. [util.inspect](https://nodejs.org/dist/latest-v6.x/docs/api/util.html#util_util_inspect_object_options) As of Node.js v6 and beyond has additional properties in the options that were missing
2. I could not find a doc that suggested the method of passing flags in a particular order outside of the opts object was supported, so I deleted that from the contract.  It's possible it works, but it is not documented in the official Node.js docs. If @mylesborins could verify here, that would be nice :) 

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v6.x/docs/api/util.html#util_util_inspect_object_options