### PR TITLE
improve fallback language definition for i18next

### DIFF
--- a/types/i18next/i18next-tests.ts
+++ b/types/i18next/i18next-tests.ts
@@ -59,6 +59,18 @@ i18n.init({
     wait: false
 });
 
+i18n.init({
+    fallbackLng: ['en', 'ru'],
+});
+
+i18n.init({
+    fallbackLng: {
+        'de-CH': ['fr', 'it'],
+        'zh-HANT': ['zh-HANS', 'en'],
+        'default': ['en']
+    },
+});
+
 i18n.t('helloWorld', <i18n.TranslationOptions> {
     defaultValue: 'default',
     count: 10
@@ -68,6 +80,22 @@ i18n.t('helloWorldInterpolated', <i18n.TranslationOptions> {
     defaultValue: 'default',
     count: 10,
     name: "world"
+});
+
+i18n.t('helloSingleFallbackLng', <i18n.TranslationOptions> {
+    fallbackLng: 'en'
+});
+
+i18n.t('helloMultiFallbackLng', <i18n.TranslationOptions> {
+    fallbackLng: ['en', 'ru']
+});
+
+i18n.t('helloObjectFallbackLng', <i18n.TranslationOptions> {
+    fallbackLng: {
+        'de-CH': ['fr', 'it'],
+        'zh-HANT': ['zh-HANS', 'en'],
+        'default': ['en']
+    },
 });
 
 i18n.exists("helloWorld");

--- a/types/i18next/index.d.ts
+++ b/types/i18next/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for i18next v2.3.4
+// Type definitions for i18next v2.3.5
 // Project: http://i18next.com
-// Definitions by: Michael Ledin <https://github.com/mxl>
+// Definitions by: Michael Ledin <https://github.com/mxl>, Budi Irawan <https://github.com/deerawan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Sources: https://github.com/i18next/i18next/
@@ -18,6 +18,12 @@ declare namespace i18n {
     interface ResourceStoreKey {
         [key: string]: any;
     }
+
+    interface FallbackLngObjList {
+        [language: string]: string[]
+    }
+
+    type FallbackLng = string | string[] | FallbackLngObjList;
 
     interface InterpolationOptions {
         escapeValue?: boolean;
@@ -41,7 +47,7 @@ declare namespace i18n {
         replace?: any;
         lng?: string;
         lngs?: string[];
-        fallbackLng?: string;
+        fallbackLng?: FallbackLng;
         ns?: string | string[];
         keySeparator?: string;
         nsSeparator?: string;
@@ -57,7 +63,7 @@ declare namespace i18n {
         debug?: boolean;
         resources?: ResourceStore;
         lng?: string;
-        fallbackLng?: string;
+        fallbackLng?: FallbackLng;
         ns?: string | string[];
         defaultNS?: string;
         fallbackNS?: string | string[];


### PR DESCRIPTION
## Issue
FallbackLng in i18next can have other values beside `string`. They are: 
- array of string
- object 

## Solution
- add definition for array of string
- add definition for object list

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://i18next.com/docs/options/
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
