### PR TITLE
Typescript 2.3 fixes for webappsec-credential-management

### DIFF
--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for W3C (WebAppSec) Credential Management API Level 1, 0.1
+// Type definitions for W3C (WebAppSec) Credential Management API Level 1, 0.2
 // Project: https://github.com/w3c/webappsec-credential-management
 // Definitions by: Iain McGinniss <https://github.com/iainmcgin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -27,27 +27,9 @@ interface GlobalFetch {
 }
 
 /**
- * Original definition from TS 2.2 dom.
- */
-interface RequestInit {
-    method?: string;
-    headers?: any;
-    body?: any;
-    referrer?: string;
-    referrerPolicy?: string;
-    mode?: string;
-    credentials?: string;
-    cache?: string;
-    redirect?: string;
-    integrity?: string;
-    keepalive?: boolean;
-    window?: any;
-}
-
-/**
- * Variant of {@link RequestInit} that permits a {@link PasswordCredential} to
- * be used in the {@code credentials} property. All other properties are
- * identical to {@link RequestInit}.
+ * Variant of TS 2.2 {@link RequestInit} that permits a
+ * {@link PasswordCredential} to be used in the {@code credentials} property.
+ * All other properties are identical to {@link RequestInit}.
  */
 interface CMRequestInit {
     method?: string;


### PR DESCRIPTION
Removes the copied (now out of date) definition of RequestInit, updates the "forked" version used for CM API credentials field to match TS 2.3 definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
  - Change pertains to typescript itself, not the API.
- [x] Increase the version number in the header if appropriate.
  - Bumped to 0.2.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
  - Was already present.