### PR TITLE
Reactstrap - extending some components with HTMLProps

### DIFF
--- a/types/reactstrap/index.d.ts
+++ b/types/reactstrap/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for reactstrap 4.3
 // Project: https://github.com/reactstrap/reactstrap#readme
-// Definitions by: Ali Hammad Baig <https://github.com/alihammad>, Marco Falkenberg <https://github.com/mfal>
+// Definitions by: Ali Hammad Baig <https://github.com/alihammad>, Marco Falkenberg <https://github.com/mfal>, Danilo Barros <https://github.com/danilobjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/reactstrap/lib/Col.d.ts
+++ b/types/reactstrap/lib/Col.d.ts
@@ -10,6 +10,8 @@ export type ColumnProps
   };
 
 interface Props {
+  className?: string;
+
   xs?: ColumnProps;
   sm?: ColumnProps;
   md?: ColumnProps;

--- a/types/reactstrap/lib/Col.d.ts
+++ b/types/reactstrap/lib/Col.d.ts
@@ -9,9 +9,7 @@ export type ColumnProps
     offset?: string | number
   };
 
-interface Props {
-  className?: string;
-
+interface Props extends React.HTMLProps<HTMLDivElement> {
   xs?: ColumnProps;
   sm?: ColumnProps;
   md?: ColumnProps;

--- a/types/reactstrap/lib/FormGroup.d.ts
+++ b/types/reactstrap/lib/FormGroup.d.ts
@@ -4,7 +4,7 @@ interface Props {
   disabled?: boolean;
   tag?: React.ReactType;
   color?: string;
-  className?: boolean;
+  className?: string;
 }
 
 declare var FormGroup: React.StatelessComponent<Props>;

--- a/types/reactstrap/lib/FormGroup.d.ts
+++ b/types/reactstrap/lib/FormGroup.d.ts
@@ -1,4 +1,4 @@
-interface Props {
+interface Props extends React.HTMLProps<HTMLDivElement> {
   row?: boolean;
   check?: boolean;
   disabled?: boolean;

--- a/types/reactstrap/lib/Label.d.ts
+++ b/types/reactstrap/lib/Label.d.ts
@@ -1,6 +1,10 @@
 import { ColumnProps } from './Col';
 
-interface Props {
+interface Intermediate extends React.ChangeTargetHTMLProps<HTMLLabelElement> {
+  size?: any;
+}
+
+interface Props extends Intermediate {
   hidden?: boolean;
   check?: boolean;
   inline?: boolean;

--- a/types/reactstrap/lib/Nav.d.ts
+++ b/types/reactstrap/lib/Nav.d.ts
@@ -7,6 +7,7 @@ interface Props {
   navbar?: boolean;
   tag?: React.ReactType;
   className?: string;
+  vertical?: boolean;
 }
 
 declare var Nav: React.StatelessComponent<Props>;

--- a/types/reactstrap/lib/Nav.d.ts
+++ b/types/reactstrap/lib/Nav.d.ts
@@ -1,4 +1,4 @@
-interface Props {
+interface Props extends React.HTMLProps<HTMLUListElement> {
   inline?: boolean;
   disabled?: boolean;
   tabs?: boolean;

--- a/types/reactstrap/lib/NavLink.d.ts
+++ b/types/reactstrap/lib/NavLink.d.ts
@@ -1,4 +1,4 @@
-interface Props {
+interface Props extends React.HTMLProps<HTMLAnchorElement> {
   tag?: React.ReactType;
   disabled?: boolean;
   active?: boolean;

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -3221,3 +3221,66 @@ function Example() {
     </div>
   );
 }
+
+function Example104() {
+  const props = {
+    className: 'my-input',
+    style: {
+      borderColor: 'black',
+    }
+  };
+
+  return (
+    <FormGroup
+      className="some-class"
+      aria-labelledby="label"
+    >
+      <Label sm={3} id="label">
+        Label
+      </Label>
+
+      <Col className="col-12" sm={9}>
+        <Input type="text" size="lg" {...props} />
+      </Col>
+    </FormGroup>
+  );
+}
+
+function Example105() {
+  return (
+    <Dropdown
+      className="main-nav-avatar"
+      isOpen={true}
+      aria-labelledby="menu"
+    >
+      <a
+        href="javascript:void(0)"
+        id="menu"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false"
+      >
+        Toggle
+      </a>
+
+      <DropdownMenu right>
+        <div className="d-block">
+          Item
+        </div>
+      </DropdownMenu>
+    </Dropdown>
+  );
+}
+
+function Example106() {
+  return (
+    <Nav vertical>
+      <NavLink
+        className="toggle-drawer"
+        href="#"
+      >
+        Details
+      </NavLink>
+    </Nav>
+  );
+}


### PR DESCRIPTION
Hello guys.

I'm work on a project and we are using reactstrap heavily from now. So, probably I'll write a lot of improvements in this if we need.

For instance, I created this PR extending some components with its _React.HTMLProps<T>_ interface. Where T is the appropriate HTMLElement. For example, we need to pass some common anchor props to _<NavLink>_, link *href*. _<NavLink>_ is rendered in a _<a>_, but the definitions are not extending from _React.HTMLProps<HTMLAnchorElement>_. Now I can do something like this:

`<NavLink  className="my-class"  href="#">Link</NavLink>`

You authors can review this code? I write some tests too.