### PR TITLE
Ember: Missing optional parameter for `Ember.Helper.helper` function

### DIFF
--- a/types/ember/ember-tests.ts
+++ b/types/ember/ember-tests.ts
@@ -105,6 +105,17 @@ App.userController = Em.Object.create({
     })
 });
 
+Ember.Helper.helper((params) => {
+  let cents = params[0];
+  return `${cents * 0.01}`;
+});
+
+Ember.Helper.helper((params, hash) => {
+  let cents = params[0];
+  let currency = hash.currency;
+  return `${currency}${cents * 0.01}`;
+});
+
 Handlebars.registerHelper('highlight', (property: string, options: any) =>
     new Handlebars.SafeString('<span class="highlight">' + "some value" + '</span>'));
 

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1137,7 +1137,7 @@ declare namespace Ember {
        service(name?: string): Service;
     };
     class Helper extends Object {
-      static helper( h: (a: any) => any): Helper;
+      static helper( h: (params: any, hash?: any) => any): Helper;
       compute(params: any[], hash: any): any;
       recompute(params: any[], hash: any): any;
     }


### PR DESCRIPTION
Currently, the second `hash` parameter to the closure is not supported,
even though it's used in the Ember Documentation for the method.

I confirmed in the latest version of Ember.js that this `hash`
parameter works, so I believe the types should be updated to
support it.

---

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/ember.js/blob/v2.12.0/packages/ember-glimmer/lib/helper.js#L110-L114
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

