### PR TITLE
Change transaction() autoCallback param type from Blueburd to PromiseLike

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5726,8 +5726,8 @@ declare namespace sequelize {
          * @param autoCallback Callback for the transaction
          */
         transaction(options: TransactionOptions,
-            autoCallback: (t: Transaction) => Promise<any>): Promise<any>;
-        transaction(autoCallback: (t: Transaction) => Promise<any>): Promise<any>;
+            autoCallback: (t: Transaction) => PromiseLike<any>): Promise<any>;
+        transaction(autoCallback: (t: Transaction) => PromiseLike<any>): Promise<any>;
         transaction(): Promise<Transaction>;
 
         /**

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -1,5 +1,6 @@
 import Sequelize = require("sequelize");
-import Promise = require('bluebird');
+import Q = require('q');
+import Bluebird = require('bluebird');
 
 //
 //  Fixtures
@@ -978,7 +979,7 @@ User.create( { title : 'Chair', creator : { first_name : 'Matt', last_name : 'Ha
 User.create( { id : 1, title : 'e', Tags : [{ id : 1, name : 'c' }, { id : 2, name : 'd' }] }, { include : [User] } );
 User.create( { id : 'My own ID!' } ).then( ( i ) => i.isNewRecord );
 
-let findOrRetVal: Promise<[AnyInstance, boolean]>;
+let findOrRetVal: Bluebird<[AnyInstance, boolean]>;
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' } } );
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, transaction : t } );
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, defaults : { foo : 'asd' }, transaction : t } );
@@ -1617,18 +1618,33 @@ s.transaction().then( function( t ) {
 } );
 
 s.transaction( function() {
-    return Promise.resolve();
+    return Bluebird.resolve();
 } );
-s.transaction( { isolationLevel : 'SERIALIZABLE' }, function( t ) { return Promise.resolve(); } );
-s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, (t) => Promise.resolve() );
-s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, (t) => Promise.resolve() );
+s.transaction( { isolationLevel : 'SERIALIZABLE' }, function( t ) { return Bluebird.resolve(); } );
+s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, (t) => Bluebird.resolve() );
+s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, (t) => Bluebird.resolve() );
 
 // transaction types
 new Sequelize( '', { transactionType: 'DEFERRED' } );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.DEFERRED} );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.IMMEDIATE} );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.EXCLUSIVE} );
-s.transaction( { type : 'DEFERRED' }, (t) => Promise.resolve() );
-s.transaction( { type : s.Transaction.TYPES.DEFERRED }, (t) => Promise.resolve() );
-s.transaction( { type : s.Transaction.TYPES.IMMEDIATE }, (t) => Promise.resolve() );
-s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Promise.resolve() );
+s.transaction( { type : 'DEFERRED' }, (t) => Bluebird.resolve() );
+s.transaction( { type : s.Transaction.TYPES.DEFERRED }, (t) => Bluebird.resolve() );
+s.transaction( { type : s.Transaction.TYPES.IMMEDIATE }, (t) => Bluebird.resolve() );
+s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Bluebird.resolve() );
+
+// promise transaction
+s.transaction(async () => {
+});
+s.transaction((): Promise<void> => {
+    return Promise.resolve();
+});
+s.transaction((): Bluebird<void> => {
+    return Bluebird.resolve();
+});
+s.transaction((): Q.Promise<void> => {
+    return Q.Promise<void>((resolve) => {
+        resolve(null);
+    });
+});

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -5692,8 +5692,8 @@ declare namespace sequelize {
          * @param autoCallback Callback for the transaction
          */
         transaction(options: TransactionOptions,
-            autoCallback: (t: Transaction) => Promise<any>): Promise<any>;
-        transaction(autoCallback: (t: Transaction) => Promise<any>): Promise<any>;
+            autoCallback: (t: Transaction) => PromiseLike<any>): Promise<any>;
+        transaction(autoCallback: (t: Transaction) => PromiseLike<any>): Promise<any>;
         transaction(): Promise<Transaction>;
 
         /**


### PR DESCRIPTION
`autoCallback` param in `transaction()` must be `PromiseLike` not `Bluebird`, so that you can perform:
````.ts
return sequelize.transaction(async () => {
    //Some code
});
````
Because, `async function` return native promise.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

