### PR TITLE
Add typings for restify-errors

### DIFF
--- a/types/restify-errors/index.d.ts
+++ b/types/restify-errors/index.d.ts
@@ -1,0 +1,130 @@
+// Type definitions for restify-errors 4.3
+// Project: http://www.restify.com
+// Definitions by: Steve Hipwell <https://github.com/stevehipwell>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { VError, Options as vErrorOptions } from "verror";
+
+interface HttpErrors {
+    BadRequestError: HttpError;
+    UnauthorizedError: HttpError;
+    PaymentRequiredError: HttpError;
+    ForbiddenError: HttpError;
+    NotFoundError: HttpError;
+    MethodNotAllowedError: HttpError;
+    NotAcceptableError: HttpError;
+    ProxyAuthenticationRequiredError: HttpError;
+    RequestTimeoutError: HttpError;
+    ConflictError: HttpError;
+    GoneError: HttpError;
+    LengthRequiredError: HttpError;
+    PreconditionFailedError: HttpError;
+    RequestEntityTooLargeError: HttpError;
+    RequesturiTooLargeError: HttpError;
+    UnsupportedMediaTypeError: HttpError;
+    RangeNotSatisfiableError: HttpError;
+    ExpectationFailedError: HttpError;
+    ImATeapotError: HttpError;
+    UnprocessableEntityError: HttpError;
+    LockedError: HttpError;
+    FailedDependencyError: HttpError;
+    UnorderedCollectionError: HttpError;
+    UpgradeRequiredError: HttpError;
+    PreconditionRequiredError: HttpError;
+    TooManyRequestsError: HttpError;
+    RequestHeaderFieldsTooLargeError: HttpError;
+    InternalServerError: HttpError;
+    NotImplementedError: HttpError;
+    BadGatewayError: HttpError;
+    ServiceUnavailableError: HttpError;
+    GatewayTimeoutError: HttpError;
+    HttpVersionNotSupportedError: HttpError;
+    VariantAlsoNegotiatesError: HttpError;
+    InsufficientStorageError: HttpError;
+    BandwidthLimitExceededError: HttpError;
+    NotExtendedError: HttpError;
+    NetworkAuthenticationRequiredError: HttpError;
+}
+
+interface RestErrors {
+    BadDigestError: RestError;
+    BadMethodError: RestError;
+    InternalError: RestError;
+    InvalidArgumentError: RestError;
+    InvalidContentError: RestError;
+    InvalidCredentialsError: RestError;
+    InvalidHeaderError: RestError;
+    InvalidVersionError: RestError;
+    MissingParameterError: RestError;
+    NotAuthorizedError: RestError;
+    PreconditionFailedError: RestError;
+    RequestExpiredError: RestError;
+    RequestThrottledError: RestError;
+    ResourceNotFoundError: RestError;
+    WrongAcceptError: RestError;
+}
+
+export interface RestifyHttpErrorOptions extends vErrorOptions {
+    statusCode?: number;
+
+    message?: string;
+
+    code?: string;
+
+    context?: object;
+}
+
+export class HttpError extends VError {
+    constructor(message: string);
+
+    constructor(printf: string, ...args: any[]);
+
+    constructor(options: RestifyHttpErrorOptions, printf?: string, ...args: any[]);
+
+    constructor(priorErr: object, message: string);
+
+    constructor(priorErr: object, printf?: string, ...args: any[]);
+
+    constructor(priorErr: object, options: RestifyHttpErrorOptions, printf?: string, ...args: any[]);
+
+    message: string;
+
+    statusCode: number;
+
+    code: string;
+
+    body: object;
+
+    displayName: string;
+}
+
+export interface RestifyRestErrorOptions extends RestifyHttpErrorOptions {
+    restCode?: string
+}
+
+export class RestError extends HttpError {
+    constructor(message: string);
+
+    constructor(printf: string, ...args: any[]);
+
+    constructor(options: RestifyRestErrorOptions, printf?: string, ...args: any[]);
+
+    constructor(priorErr: object, message: string);
+
+    constructor(priorErr: object, printf?: string, ...args: any[]);
+
+    constructor(priorErr: object, options: RestifyRestErrorOptions, printf?: string, ...args: any[]);
+
+
+    restCode: string;
+}
+
+export function makeConstructor(name: string, defaults?: object): void;
+
+export function makeErrFromCode(statusCode: number, ...args: any[]): HttpError;
+
+export const bunyanSerializer: (err: object) => object;
+
+export const httpErrors: HttpErrors;
+
+export const restErrors: RestErrors;

--- a/types/restify-errors/index.d.ts
+++ b/types/restify-errors/index.d.ts
@@ -5,7 +5,61 @@
 
 import { VError, Options as vErrorOptions } from "verror";
 
-interface HttpErrors {
+export interface RestifyHttpErrorOptions extends vErrorOptions {
+    statusCode?: number;
+
+    message?: string;
+
+    code?: string;
+
+    context?: any;
+}
+
+export class HttpError extends VError {
+    constructor(printf: string, ...args: any[]);
+
+    constructor(options: RestifyHttpErrorOptions, printf?: string, ...args: any[]);
+
+    // tslint:disable-next-line unified-signatures
+    constructor(priorErr: any, printf?: string, ...args: any[]);
+
+    constructor(priorErr: any, options: RestifyHttpErrorOptions, printf?: string, ...args: any[]);
+
+    message: string;
+
+    statusCode: number;
+
+    code: string;
+
+    body: any;
+
+    displayName: string;
+}
+
+export interface RestifyRestErrorOptions extends RestifyHttpErrorOptions {
+    restCode?: string;
+}
+
+export class RestError extends HttpError {
+    constructor(printf: string, ...args: any[]);
+
+    constructor(options: RestifyRestErrorOptions, printf?: string, ...args: any[]);
+
+    // tslint:disable-next-line unified-signatures
+    constructor(priorErr: any, printf?: string, ...args: any[]);
+
+    constructor(priorErr: any, options: RestifyRestErrorOptions, printf?: string, ...args: any[]);
+
+    restCode: string;
+}
+
+export function makeConstructor(name: string, defaults?: any): void;
+
+export function makeErrFromCode(statusCode: number, ...args: any[]): HttpError;
+
+export function bunyanSerializer(err: any): any;
+
+export interface HttpErrors {
     BadRequestError: HttpError;
     UnauthorizedError: HttpError;
     PaymentRequiredError: HttpError;
@@ -46,7 +100,7 @@ interface HttpErrors {
     NetworkAuthenticationRequiredError: HttpError;
 }
 
-interface RestErrors {
+export interface RestErrors {
     BadDigestError: RestError;
     BadMethodError: RestError;
     InternalError: RestError;
@@ -63,68 +117,3 @@ interface RestErrors {
     ResourceNotFoundError: RestError;
     WrongAcceptError: RestError;
 }
-
-export interface RestifyHttpErrorOptions extends vErrorOptions {
-    statusCode?: number;
-
-    message?: string;
-
-    code?: string;
-
-    context?: object;
-}
-
-export class HttpError extends VError {
-    constructor(message: string);
-
-    constructor(printf: string, ...args: any[]);
-
-    constructor(options: RestifyHttpErrorOptions, printf?: string, ...args: any[]);
-
-    constructor(priorErr: object, message: string);
-
-    constructor(priorErr: object, printf?: string, ...args: any[]);
-
-    constructor(priorErr: object, options: RestifyHttpErrorOptions, printf?: string, ...args: any[]);
-
-    message: string;
-
-    statusCode: number;
-
-    code: string;
-
-    body: object;
-
-    displayName: string;
-}
-
-export interface RestifyRestErrorOptions extends RestifyHttpErrorOptions {
-    restCode?: string
-}
-
-export class RestError extends HttpError {
-    constructor(message: string);
-
-    constructor(printf: string, ...args: any[]);
-
-    constructor(options: RestifyRestErrorOptions, printf?: string, ...args: any[]);
-
-    constructor(priorErr: object, message: string);
-
-    constructor(priorErr: object, printf?: string, ...args: any[]);
-
-    constructor(priorErr: object, options: RestifyRestErrorOptions, printf?: string, ...args: any[]);
-
-
-    restCode: string;
-}
-
-export function makeConstructor(name: string, defaults?: object): void;
-
-export function makeErrFromCode(statusCode: number, ...args: any[]): HttpError;
-
-export const bunyanSerializer: (err: object) => object;
-
-export const httpErrors: HttpErrors;
-
-export const restErrors: RestErrors;

--- a/types/restify-errors/index.d.ts
+++ b/types/restify-errors/index.d.ts
@@ -59,7 +59,7 @@ export function makeErrFromCode(statusCode: number, ...args: any[]): HttpError;
 
 export function bunyanSerializer(err: any): any;
 
-export interface HttpErrors {
+export const HttpErrors: {
     BadRequestError: HttpError;
     UnauthorizedError: HttpError;
     PaymentRequiredError: HttpError;
@@ -100,7 +100,7 @@ export interface HttpErrors {
     NetworkAuthenticationRequiredError: HttpError;
 }
 
-export interface RestErrors {
+export const RestErrors: {
     BadDigestError: RestError;
     BadMethodError: RestError;
     InternalError: RestError;

--- a/types/restify-errors/index.d.ts
+++ b/types/restify-errors/index.d.ts
@@ -98,7 +98,7 @@ export const HttpErrors: {
     BandwidthLimitExceededError: HttpError;
     NotExtendedError: HttpError;
     NetworkAuthenticationRequiredError: HttpError;
-}
+};
 
 export const RestErrors: {
     BadDigestError: RestError;
@@ -116,4 +116,4 @@ export const RestErrors: {
     RequestThrottledError: RestError;
     ResourceNotFoundError: RestError;
     WrongAcceptError: RestError;
-}
+};

--- a/types/restify-errors/restify-errors-tests.ts
+++ b/types/restify-errors/restify-errors-tests.ts
@@ -18,10 +18,64 @@ const restErrorD = new restifyErrors.RestError(prevErr, "Hello World!");
 const restErrorE = new restifyErrors.RestError(prevErr, "Hello %s!", "World");
 const restErrorF = new restifyErrors.RestError(prevErr, { statusCode: 404, restCode: "TEST" }, "Hello %s!", "World");
 
-// makeConstructor
+// Functions
 restifyErrors.makeConstructor("TestError", {});
-
-// makeErrFromCode
 const customError = restifyErrors.makeErrFromCode(500, "Testing....");
-
 const bunyanSerializer = restifyErrors.bunyanSerializer;
+
+// HttpErrors
+let httpError = restifyErrors.HttpErrors.BadRequestError;
+httpError = restifyErrors.HttpErrors.UnauthorizedError;
+httpError = restifyErrors.HttpErrors.PaymentRequiredError;
+httpError = restifyErrors.HttpErrors.ForbiddenError;
+httpError = restifyErrors.HttpErrors.NotFoundError;
+httpError = restifyErrors.HttpErrors.MethodNotAllowedError;
+httpError = restifyErrors.HttpErrors.NotAcceptableError;
+httpError = restifyErrors.HttpErrors.ProxyAuthenticationRequiredError;
+httpError = restifyErrors.HttpErrors.RequestTimeoutError;
+httpError = restifyErrors.HttpErrors.ConflictError;
+httpError = restifyErrors.HttpErrors.GoneError;
+httpError = restifyErrors.HttpErrors.LengthRequiredError;
+httpError = restifyErrors.HttpErrors.PreconditionFailedError;
+httpError = restifyErrors.HttpErrors.RequestEntityTooLargeError;
+httpError = restifyErrors.HttpErrors.RequesturiTooLargeError;
+httpError = restifyErrors.HttpErrors.UnsupportedMediaTypeError;
+httpError = restifyErrors.HttpErrors.RangeNotSatisfiableError;
+httpError = restifyErrors.HttpErrors.ExpectationFailedError;
+httpError = restifyErrors.HttpErrors.ImATeapotError;
+httpError = restifyErrors.HttpErrors.UnprocessableEntityError;
+httpError = restifyErrors.HttpErrors.LockedError;
+httpError = restifyErrors.HttpErrors.FailedDependencyError;
+httpError = restifyErrors.HttpErrors.UnorderedCollectionError;
+httpError = restifyErrors.HttpErrors.UpgradeRequiredError;
+httpError = restifyErrors.HttpErrors.PreconditionRequiredError;
+httpError = restifyErrors.HttpErrors.TooManyRequestsError;
+httpError = restifyErrors.HttpErrors.RequestHeaderFieldsTooLargeError;
+httpError = restifyErrors.HttpErrors.InternalServerError;
+httpError = restifyErrors.HttpErrors.NotImplementedError;
+httpError = restifyErrors.HttpErrors.BadGatewayError;
+httpError = restifyErrors.HttpErrors.ServiceUnavailableError;
+httpError = restifyErrors.HttpErrors.GatewayTimeoutError;
+httpError = restifyErrors.HttpErrors.HttpVersionNotSupportedError;
+httpError = restifyErrors.HttpErrors.VariantAlsoNegotiatesError;
+httpError = restifyErrors.HttpErrors.InsufficientStorageError;
+httpError = restifyErrors.HttpErrors.BandwidthLimitExceededError;
+httpError = restifyErrors.HttpErrors.NotExtendedError;
+httpError = restifyErrors.HttpErrors.NetworkAuthenticationRequiredError;
+
+// RestErrors
+let restError = restifyErrors.RestErrors.BadDigestError;
+restError = restifyErrors.RestErrors.BadMethodError;
+restError = restifyErrors.RestErrors.InternalError;
+restError = restifyErrors.RestErrors.InvalidArgumentError;
+restError = restifyErrors.RestErrors.InvalidContentError;
+restError = restifyErrors.RestErrors.InvalidCredentialsError;
+restError = restifyErrors.RestErrors.InvalidHeaderError;
+restError = restifyErrors.RestErrors.InvalidVersionError;
+restError = restifyErrors.RestErrors.MissingParameterError;
+restError = restifyErrors.RestErrors.NotAuthorizedError;
+restError = restifyErrors.RestErrors.PreconditionFailedError;
+restError = restifyErrors.RestErrors.RequestExpiredError;
+restError = restifyErrors.RestErrors.RequestThrottledError;
+restError = restifyErrors.RestErrors.ResourceNotFoundError;
+restError = restifyErrors.RestErrors.WrongAcceptError;

--- a/types/restify-errors/restify-errors-tests.ts
+++ b/types/restify-errors/restify-errors-tests.ts
@@ -1,0 +1,27 @@
+import * as restifyErrors from "restify-errors";
+
+const prevErr = new Error();
+
+// HttpError
+const httpErrorA = new restifyErrors.HttpError("Hello World!");
+const httpErrorB = new restifyErrors.HttpError("Hello %s!", "World");
+const httpErrorC = new restifyErrors.HttpError({ statusCode: 404 }, "Hello %s!", "World");
+const httpErrorD = new restifyErrors.HttpError(prevErr, "Hello World!");
+const httpErrorE = new restifyErrors.HttpError(prevErr, "Hello %s!", "World");
+const httpErrorF = new restifyErrors.HttpError(prevErr, { statusCode: 404 }, "Hello %s!", "World");
+
+// RestError
+const restErrorA = new restifyErrors.RestError("Hello World!");
+const restErrorB = new restifyErrors.RestError("Hello %s!", "World");
+const restErrorC = new restifyErrors.RestError({ statusCode: 404, restCode: "TEST" }, "Hello %s!", "World");
+const restErrorD = new restifyErrors.RestError(prevErr, "Hello World!");
+const restErrorE = new restifyErrors.RestError(prevErr, "Hello %s!", "World");
+const restErrorF = new restifyErrors.RestError(prevErr, { statusCode: 404, restCode: "TEST" }, "Hello %s!", "World");
+
+// makeConstructor
+restifyErrors.makeConstructor("TestError", {});
+
+// makeErrFromCode
+const customError = restifyErrors.makeErrFromCode(500, "Testing....");
+
+const bunyanSerializer = restifyErrors.bunyanSerializer;

--- a/types/restify-errors/tsconfig.json
+++ b/types/restify-errors/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "restify-errors-tests.ts"
+    ]
+}

--- a/types/restify-errors/tslint.json
+++ b/types/restify-errors/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
