### PR TITLE
Change "object" to "Object" in index.d.ts

### DIFF
--- a/types/es6-shim/index.d.ts
+++ b/types/es6-shim/index.d.ts
@@ -594,7 +594,7 @@ interface SetConstructor {
 
 declare var Set: SetConstructor;
 
-interface WeakMap<K extends object, V> {
+interface WeakMap<K extends Object, V> {
     delete(key: K): boolean;
     get(key: K): V;
     has(key: K): boolean;
@@ -602,8 +602,8 @@ interface WeakMap<K extends object, V> {
 }
 
 interface WeakMapConstructor {
-    new <K extends object, V>(): WeakMap<K, V>;
-    new <K extends object, V>(iterable: IterableShim<[K, V]>): WeakMap<K, V>;
+    new <K extends Object, V>(): WeakMap<K, V>;
+    new <K extends Object, V>(iterable: IterableShim<[K, V]>): WeakMap<K, V>;
     prototype: WeakMap<any, any>;
 }
 


### PR DESCRIPTION
"object" is now a keyword in Typescript. In Typescript 2.1, this throws an error "Cannot find name 'object'." This change resolves the error.

Please fill in this template.

- [ y ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ y ] Test the change in your own code. (Compile and run.)
- [ y ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ y ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ y ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ y ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/issues/14647
- [ n ] Increase the version number in the header if appropriate.
- [ n ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

