### PR TITLE
baconjs: doLog accepts a label, use PromiseLike in fromPromise

### DIFF
--- a/types/baconjs/baconjs-tests.ts
+++ b/types/baconjs/baconjs-tests.ts
@@ -190,6 +190,11 @@ function CommonMethodsInEventStreamsAndProperties() {
                 console.log(sum); // returns [-1, 2, 8] in an order
             });
     }
+
+    {
+        var src = Bacon.fromArray([1, 2, 3]);
+        src.doLog('element value');
+    }
 }
 
 function EventStream() {

--- a/types/baconjs/index.d.ts
+++ b/types/baconjs/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Bacon.js 0.7.0
 // Project: https://baconjs.github.io/
 // Definitions by: Alexander Matsievsky <https://github.com/alexander-matsievsky>
+//                 Joonas Javanainen <https://github.com/gekkio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="jquery" />
@@ -1026,9 +1027,10 @@ declare namespace Bacon {
         /**
          * @method EventStream#doLog
          * @description Logs each value of the [EventStream]{@link Bacon.EventStream} to the console. [doLog]{@link Bacon.EventStream#doLog} behaves like [log]{@link Bacon.EventStream#log} but does not subscribe to the EventStream. You can think of `doLog` as a logger function that – unlike `log` – is safe to use in production. `doLog` is safe, because it does not cause the same surprising side-effects as `log` does.
+         * @param {string} [label]
          * @returns {EventStream<E, A>}
          */
-        doLog():EventStream<E, A>;
+        doLog(label?:string):EventStream<E, A>;
 
         /**
          * @method
@@ -1613,9 +1615,10 @@ declare namespace Bacon {
         /**
          * @method Property#doLog
          * @description Logs each value of the [Property]{@link Bacon.Property} to the console. [doLog]{@link Bacon.Property#doLog} behaves like [log]{@link Bacon.Property#log} but does not subscribe to the Property. You can think of `doLog` as a logger function that – unlike `log` – is safe to use in production. `doLog` is safe, because it does not cause the same surprising side-effects as `log` does.
+         * @param {string} [label]
          * @returns {Property<E, A>}
          */
-        doLog():Property<E, A>;
+        doLog(label?:string):Property<E, A>;
 
         /**
          * @method

--- a/types/baconjs/index.d.ts
+++ b/types/baconjs/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for Bacon.js 0.7.0
 // Project: https://baconjs.github.io/
-// Definitions by: Alexander Matsievsky <https://github.com/alexander-matsievsky>
-//                 Joonas Javanainen <https://github.com/gekkio>
+// Definitions by: Alexander Matsievsky <https://github.com/alexander-matsievsky>, Joonas Javanainen <https://github.com/gekkio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="jquery" />

--- a/types/baconjs/index.d.ts
+++ b/types/baconjs/index.d.ts
@@ -70,7 +70,7 @@ declare namespace Bacon {
     /**
      * @function
      * @description Creates an [EventStream]{@link Bacon.EventStream} from a `promise` Promise object such as JQuery Ajax. This stream will contain a single value or an error, followed immediately by stream end. You can use the optional `abort` flag (i.e. ´Bacon.fromPromise(p, true)´ to have the `abort` method of the given promise be called when all subscribers have been removed from the created stream.
-     * @param {Promise<A>|JQueryXHR} promise
+     * @param {PromiseLike<A>} promise
      * @param {boolean} [abort]
      * @returns {EventStream<E, A>}
      * @example
@@ -79,7 +79,7 @@ declare namespace Bacon {
      * Bacon.fromPromise($.ajax("https://baconjs.github.io/"), true);
      * Bacon.fromPromise(Promise.resolve(1), false);
      */
-    function fromPromise<E, A>(promise:Promise<A>|JQueryXHR, abort?:boolean):EventStream<E, A>;
+    function fromPromise<E, A>(promise:PromiseLike<A>, abort?:boolean):EventStream<E, A>;
 
     /**
      * @callback Bacon.fromPromise~eventTransformer
@@ -89,7 +89,7 @@ declare namespace Bacon {
     /**
      * @function Bacon.fromPromise
      * @description Creates an [EventStream]{@link Bacon.EventStream} from a `promise` Promise object such as JQuery Ajax. This stream will contain a single value or an error, followed immediately by stream end. You can use the `abort` flag (i.e. ´Bacon.fromPromise(p, true)´ to have the `abort` method of the given promise be called when all subscribers have been removed from the created stream, and also pass a function `eventTransformer` that transforms the promise value into Events. The default is to transform the value into `[new Bacon.Next(value), new Bacon.End()]`.
-     * @param {Promise<A>|JQueryXHR} promise
+     * @param {PromiseLike<A>} promise
      * @param {boolean} abort
      * @param {Bacon.fromPromise~eventTransformer} eventTransformer
      * @returns {EventStream<E, B>}
@@ -101,7 +101,7 @@ declare namespace Bacon {
      *     return [new Bacon.Next(n), new Bacon.Next(() => n), new Bacon.End()];
      * });
      */
-    function fromPromise<E, A, B>(promise:Promise<A>|JQueryXHR, abort:boolean, eventTransformer:(value:A) => (Initial<B>|Next<B>|End<B>|Error<E>)[]):EventStream<E, B>;
+    function fromPromise<E, A, B>(promise:PromiseLike<A>, abort:boolean, eventTransformer:(value:A) => (Initial<B>|Next<B>|End<B>|Error<E>)[]):EventStream<E, B>;
 
     /**
      * @function

--- a/types/baconjs/index.d.ts
+++ b/types/baconjs/index.d.ts
@@ -70,7 +70,7 @@ declare namespace Bacon {
     /**
      * @function
      * @description Creates an [EventStream]{@link Bacon.EventStream} from a `promise` Promise object such as JQuery Ajax. This stream will contain a single value or an error, followed immediately by stream end. You can use the optional `abort` flag (i.e. ´Bacon.fromPromise(p, true)´ to have the `abort` method of the given promise be called when all subscribers have been removed from the created stream.
-     * @param {PromiseLike<A>} promise
+     * @param {PromiseLike<A>|JQueryXHR} promise
      * @param {boolean} [abort]
      * @returns {EventStream<E, A>}
      * @example
@@ -79,7 +79,7 @@ declare namespace Bacon {
      * Bacon.fromPromise($.ajax("https://baconjs.github.io/"), true);
      * Bacon.fromPromise(Promise.resolve(1), false);
      */
-    function fromPromise<E, A>(promise:PromiseLike<A>, abort?:boolean):EventStream<E, A>;
+    function fromPromise<E, A>(promise:PromiseLike<A>|JQueryXHR, abort?:boolean):EventStream<E, A>;
 
     /**
      * @callback Bacon.fromPromise~eventTransformer
@@ -89,7 +89,7 @@ declare namespace Bacon {
     /**
      * @function Bacon.fromPromise
      * @description Creates an [EventStream]{@link Bacon.EventStream} from a `promise` Promise object such as JQuery Ajax. This stream will contain a single value or an error, followed immediately by stream end. You can use the `abort` flag (i.e. ´Bacon.fromPromise(p, true)´ to have the `abort` method of the given promise be called when all subscribers have been removed from the created stream, and also pass a function `eventTransformer` that transforms the promise value into Events. The default is to transform the value into `[new Bacon.Next(value), new Bacon.End()]`.
-     * @param {PromiseLike<A>} promise
+     * @param {PromiseLike<A>|JQueryXHR} promise
      * @param {boolean} abort
      * @param {Bacon.fromPromise~eventTransformer} eventTransformer
      * @returns {EventStream<E, B>}
@@ -101,7 +101,7 @@ declare namespace Bacon {
      *     return [new Bacon.Next(n), new Bacon.Next(() => n), new Bacon.End()];
      * });
      */
-    function fromPromise<E, A, B>(promise:PromiseLike<A>, abort:boolean, eventTransformer:(value:A) => (Initial<B>|Next<B>|End<B>|Error<E>)[]):EventStream<E, B>;
+    function fromPromise<E, A, B>(promise:PromiseLike<A>|JQueryXHR, abort:boolean, eventTransformer:(value:A) => (Initial<B>|Next<B>|End<B>|Error<E>)[]):EventStream<E, B>;
 
     /**
      * @function


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://baconjs.github.io/api.html#observable-dolog
https://github.com/baconjs/bacon.js/blob/master/src/frompromise.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.