### PR TITLE
Fix commonjs import method

### DIFF
--- a/types/website-scraper/index.d.ts
+++ b/types/website-scraper/index.d.ts
@@ -43,8 +43,12 @@ declare namespace websiteScraper {
     interface Callback {
         (error: any | null, result: Resource[] | null): void;
     }
-    function scrape(options: Options, callback: Callback): void;
-    function scrape(options: Options): Promise<Resource[]>;
+    interface scrape {
+        (options: Options, callback: Callback): void;
+        (options: Options): Promise<Resource[]>;
+    }
 }
+
+declare var websiteScraper: websiteScraper.scrape;
 
 export = websiteScraper;

--- a/types/website-scraper/website-scraper-tests.ts
+++ b/types/website-scraper/website-scraper-tests.ts
@@ -1,29 +1,31 @@
-import * as scraper from 'website-scraper';
+import * as scraper from "website-scraper";
 
-scraper.scrape({
+scraper({
     urls: [
-        'http://nodejs.org/',
-        {url: 'http://nodejs.org/about', filename: 'about.html'},
-        {url: 'http://blog.nodejs.org/', filename: 'blog.html'}
+        "http://nodejs.org/",
+        { url: "http://nodejs.org/about", filename: "about.html" },
+        { url: "http://blog.nodejs.org/", filename: "blog.html" }
     ],
-    directory: '/path/to/save',
+    directory: "/path/to/save",
     subdirectories: [
-        {directory: 'img', extensions: ['.jpg', '.png', '.svg']},
-        {directory: 'js', extensions: ['.js']},
-        {directory: 'css', extensions: ['.css']}
+        { directory: "img", extensions: [".jpg", ".png", ".svg"] },
+        { directory: "js", extensions: [".js"] },
+        { directory: "css", extensions: [".css"] }
     ],
     sources: [
-        {selector: 'img', attr: 'src'},
-        {selector: 'link[rel="stylesheet"]', attr: 'href'},
-        {selector: 'script', attr: 'src'}
+        { selector: "img", attr: "src" },
+        { selector: "link[rel=\"stylesheet\"]", attr: "href" },
+        { selector: "script", attr: "src" }
     ],
     request: {
         headers: {
-            'User-Agent': 'Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 4 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19'
+            "User-Agent":
+            "Mozilla/5.0 (Linux; Android 4.2.1; en-us; Nexus 4 Build/JOP40D)\
+             AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19"
         }
     }
-}).then(function (result) {
+}).then(function(result) {
     console.log(result);
-}).catch(function(err){
+}).catch(function(err) {
     console.log(err);
 });


### PR DESCRIPTION
Could you have a look at this changes?

When I tried to use your d.ts file, I faced with commonjs problem because as in your test It implemented as

```
import * as scraper from 'website-scraper';
scraper.scrape({})
```

but commonjs gives me. That's why I got error scraper.scraper does not exist.

```
var scrape = require('website-scraper');

scrape(options).then((result) => {
	/* some code here */
})
```
Thank you

