### PR TITLE
Fix sinon's usingPromise return type definition

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -203,19 +203,19 @@ declare namespace Sinon {
         Date(year: number, month: number, day: number, hour: number, minute: number, second: number, ms: number): Date;
         restore(): void;
 
-		/**
-		 * Simulate the user changing the system clock while your program is running. It changes the 'now' timestamp
-		 * without affecting timers, intervals or immediates.
-		 * @param now The new 'now' in unix milliseconds
-		 */
-		setSystemTime(now: number): void;
-		/**
-		 * Simulate the user changing the system clock while your program is running. It changes the 'now' timestamp
-		 * without affecting timers, intervals or immediates.
-		 * @param now The new 'now' as a JavaScript Date
-		 */
-		setSystemTime(date: Date): void;
-	}
+        /**
+         * Simulate the user changing the system clock while your program is running. It changes the 'now' timestamp
+         * without affecting timers, intervals or immediates.
+         * @param now The new 'now' in unix milliseconds
+         */
+        setSystemTime(now: number): void;
+        /**
+         * Simulate the user changing the system clock while your program is running. It changes the 'now' timestamp
+         * without affecting timers, intervals or immediates.
+         * @param now The new 'now' as a JavaScript Date
+         */
+        setSystemTime(date: Date): void;
+    }
 
     interface SinonFakeTimersStatic {
         (): SinonFakeTimers;

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -102,7 +102,7 @@ declare namespace Sinon {
     interface SinonStub extends SinonSpy {
         resetBehavior(): void;
         resetHistory(): void;
-        usingPromise(promiseLibrary: any): void;
+        usingPromise(promiseLibrary: any): SinonStub;
 
         returns(obj: any): SinonStub;
         returnsArg(index: number): SinonStub;
@@ -415,7 +415,7 @@ declare namespace Sinon {
         reset(): void;
         resetHistory(): void;
         resetBehavior(): void;
-        usingPromise(promiseLibrary: any): void;
+        usingPromise(promiseLibrary: any): SinonSandbox;
         verify(): void;
         verifyAndRestore(): void;
     }

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -92,6 +92,7 @@ function testNine() {
 
 function testSandbox() {
     let sandbox = sinon.sandbox.create();
+    sandbox = sandbox.usingPromise(Promise);
 
     sandbox.assert.notCalled(sinon.spy());
 
@@ -106,7 +107,6 @@ function testSandbox() {
     sandbox.reset();
     sandbox.resetHistory();
     sandbox.resetBehavior();
-    sandbox.usingPromise(Promise);
     sandbox.verify();
     sandbox.verifyAndRestore();
 }
@@ -130,7 +130,7 @@ function testResetHistory() {
 }
 
 function testUsingPromises() {
-    sinon.stub().usingPromise(Promise);
+    const stub: sinon.SinonStub = sinon.stub().usingPromise(Promise);
 }
 
 function testSpy() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Sinon Sandbox return type](https://github.com/sinonjs/sinon/blob/3d4bc162e8b72c5a12189dbadea7cbd4bbed630c/lib/sinon/sandbox.js#L97), [Sinon Stub return type](https://github.com/sinonjs/sinon/blob/3d4bc162e8b72c5a12189dbadea7cbd4bbed630c/lib/sinon/collection.js#L74-L105)
- ~[ ] Increase the version number in the header if appropriate.~
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.~