### PR TITLE
Add SpyObj<T> typing for createSpyObj.

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -515,7 +515,7 @@ declare namespace jasmine {
     }
 
     type SpyObj<T> = T & {
-      [k in keyof T]: T[k] & Spy;
+      [k in keyof T]: Spy;
     }
 
     interface SpyAnd {

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Jasmine 2.5.2
 // Project: http://jasmine.github.io/
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb>, David Pärsson <https://github.com/davidparsson/>
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb>, David Pärsson <https://github.com/davidparsson/>, Gabe Moothart <https://github.com/gmoothart>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -59,7 +59,7 @@ declare namespace jasmine {
     function createSpy(name: string, originalFn?: Function): Spy;
 
     function createSpyObj(baseName: string, methodNames: any[]): any;
-    function createSpyObj<T>(baseName: string, methodNames: any[]): T;
+    function createSpyObj<T>(baseName: string, methodNames: any[]): SpyObj<T>;
 
     function pp(value: any): string;
 
@@ -512,6 +512,10 @@ declare namespace jasmine {
         calls: Calls;
         mostRecentCall: {args: any[]; };
         argsForCall: any[];
+    }
+
+    type SpyObj<T> = T & {
+      [k in keyof T]: T[k] & Spy;
     }
 
     interface SpyAnd {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -616,9 +616,14 @@ describe("A spy, when created manually", () => {
 
 describe("Multiple spies, when created manually", () => {
     var tape: any;
+    var el: jasmine.SpyObj<Element>;
 
     beforeEach(() => {
         tape = jasmine.createSpyObj('tape', ['play', 'pause', 'stop', 'rewind']);
+        el = jasmine.createSpyObj<Element>('Element', ['hasAttribute']);
+
+        el.hasAttribute.and.returnValue(false);
+        el.hasAttribute("href");
 
         tape.play();
         tape.pause();


### PR DESCRIPTION
Adding a mapped type SpyObj<T>, and make it the return value of
createSpyObj.

This update makes the return value of createSpyObj more flexible; You can use it as the original type but you can also treat the members as Spys without having to cast to jasmine.Spy.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
