### PR TITLE
[d3-geo/d3-contour] Chores

### DIFF
--- a/types/d3-contour/d3-contour-tests.ts
+++ b/types/d3-contour/d3-contour-tests.ts
@@ -45,7 +45,7 @@ const thresholdArrayGen: ThresholdArrayGenerator<number> = (values: number[], mi
 };
 
 let thresholdGenerator: ThresholdArrayGenerator<number> | ThresholdCountGenerator;
-let pathStringMaybe: string | undefined;
+let pathStringMaybe: string | null;
 let num: number;
 
 const pathSolo = geoPath<any, d3Contour.ContourMultiPolygon>();

--- a/types/d3-contour/index.d.ts
+++ b/types/d3-contour/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for d3-contour 1.1
 // Project: https://d3js.org/d3-contour/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Hugues Stefanski <https://github.com/Ledragon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 1.1.0

--- a/types/d3-geo/index.d.ts
+++ b/types/d3-geo/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Hugues Stefanski <https://github.com/Ledragon>, Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="geojson" />
-
 // Last module patch version validated against: 1.6.1
+
+import * as GeoJSON from 'geojson';
 
 // ----------------------------------------------------------------------
 // Shared Interfaces and Types
@@ -926,7 +926,8 @@ export interface GeoPath<This, DatumObject extends GeoPermissibleObjects> {
      *
      * Any additional arguments are passed along to the pointRadius accessor.
      *
-     * If the rendering context is null, the function returns an SVG Path string, otherwise the function renders to the current context.
+     * IMPORTANT: If the rendering context of the geoPath generator is null,
+     * then the geoPath is returned as an SVG path data string.
      *
      * Separate path elements are typically slower than a single path element. However, distinct path elements are useful for styling and interation (e.g., click or mouseover).
      * Canvas rendering (see path.context) is typically faster than SVG, but requires more effort to implement styling and interaction.
@@ -935,7 +936,36 @@ export interface GeoPath<This, DatumObject extends GeoPermissibleObjects> {
      *
      * @param object An object to be rendered.
      */
-    (this: This, object: DatumObject, ...args: any[]): string | undefined;
+    (this: This, object: DatumObject, ...args: any[]): string | null;
+    /**
+     * Renders the given object, which may be any GeoJSON feature or geometry object:
+     *
+     * + Point - a single position.
+     * + MultiPoint - an array of positions.
+     * + LineString - an array of positions forming a continuous line.
+     * + MultiLineString - an array of arrays of positions forming several lines.
+     * + Polygon - an array of arrays of positions forming a polygon (possibly with holes).
+     * + MultiPolygon - a multidimensional array of positions forming multiple polygons.
+     * + GeometryCollection - an array of geometry objects.
+     * + Feature - a feature containing one of the above geometry objects.
+     * + FeatureCollection - an array of feature objects.
+     *
+     * The type Sphere is also supported, which is useful for rendering the outline of the globe; a sphere has no coordinates.
+     *
+     *
+     * Any additional arguments are passed along to the pointRadius accessor.
+     *
+     * IMPORTANT: If the geoPath generator has been configured with a rendering context,
+     * then the geoPath is rendered to this context as a sequence of path method calls and this function returns void.
+     *
+     * Separate path elements are typically slower than a single path element. However, distinct path elements are useful for styling and interation (e.g., click or mouseover).
+     * Canvas rendering (see path.context) is typically faster than SVG, but requires more effort to implement styling and interaction.
+     *
+     * The first generic type of the GeoPath generator used, must correspond to the "this" context bound to the function upon invocation.
+     *
+     * @param object An object to be rendered.
+     */
+    (this: This, object: DatumObject, ...args: any[]): void;
 
     /**
      * Returns the projected planar area (typically in square pixels) for the specified GeoJSON object.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/d3/d3-geo/pull/98>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

EDIT:

* **d3-geo**
   - Import geoJSON module (as opposed to previously necessary use of global)
   - Change return type of `geoPath(...)` invocation to reflect behavior of d3-geo as per [PR 98](https://github.com/d3/d3-geo/pull/98). (This is in preparation of validating these definitions completely for `strictNullChecks`) The behavior is now consistent with **d3-shape**. The changes were made to allow geoPath(...) to be passed into `Selection.attr('d', geoPath(...))` without creating a  type conflict, as it currently does not allow `undefined` as a path string return type.

* **d3-contour**
   - Added co-maintainer. Thanks for volunteering @Ledragon You're it 😜 

