### PR TITLE
added simpleParser to mailparser

### DIFF
--- a/types/mailparser/index.d.ts
+++ b/types/mailparser/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for mailparser v0.5.2
+// Type definitions for mailparser v2.0.0
 // Project: https://www.npmjs.com/package/mailparser
 // Definitions by: Peter Snider <https://github.com/psnider/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -82,3 +82,7 @@ export class MailParser extends StreamModule.Writable {
     emit(event: string, ...args: any[]): boolean;
     listenerCount(type: string): number;
 }
+
+export type Source = Buffer | Stream | string;
+export function simpleParser(source: Source, callback: (err: any, mail: ParsedMail) => void): void;
+export function simpleParser(source: Source): Promise<ParsedMail>;

--- a/types/mailparser/mailparser-tests.ts
+++ b/types/mailparser/mailparser-tests.ts
@@ -2,6 +2,7 @@ import mailparser_mod = require("mailparser");
 import MailParser = mailparser_mod.MailParser;
 import ParsedMail = mailparser_mod.ParsedMail;
 import Attachment = mailparser_mod.Attachment;
+import simpleParser = mailparser_mod.simpleParser;
 
 var mailparser = new MailParser();
 
@@ -62,3 +63,16 @@ mp.on("attachment", function(attachment : Attachment, mail : ParsedMail){
     var output = fs.createWriteStream(attachment.generatedFileName);
     attachment.stream.pipe(output);
 });
+
+// check different sources and promise/callback api for simpleParser
+var sourceString = "";
+var sourceBuffer = new Buffer("");
+var sourceStream = fs.createReadStream("foo.eml");
+
+simpleParser(sourceString, (err, mail) => err ? err : mail.html);
+simpleParser(sourceBuffer, (err, mail) => err ? err : mail.html);
+simpleParser(sourceStream, (err, mail) => err ? err : mail.html);
+
+simpleParser(sourceString).then(mail => mail.html).catch(err => err);
+simpleParser(sourceBuffer).then(mail => mail.html).catch(err => err);
+simpleParser(sourceStream).then(mail => mail.html).catch(err => err);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodemailer.com/extras/mailparser/#simpleparser
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

`simpleParser` is exported [here](https://github.com/nodemailer/mailparser/blob/master/index.js#L8) and documented [here](https://nodemailer.com/extras/mailparser/).
