### PR TITLE
material-ui: Updated width prop of drawer to be compliant with spec

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for material-ui v0.17.5
+// Type definitions for material-ui v0.17.51
 // Project: https://github.com/callemall/material-ui
 // Definitions by: Nathan Brown <https://github.com/ngbrown>, Igor Belagorudsky <https://github.com/theigor>, Ali Taheri Moghaddar <https://github.com/alitaheri>, Oliver Herrmann <https://github.com/herrmanno>, Daniel Roth <https://github.com/DaIgeb>, Aurelién Allienne <https://github.com/allienna>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1019,7 +1019,7 @@ declare namespace __MaterialUI {
         overlayStyle?: React.CSSProperties;
         style?: React.CSSProperties;
         swipeAreaWidth?: number;
-        width?: number;
+        width?: number | string;
         zDepth?: number;
     }
     export class Drawer extends React.Component<DrawerProps, {}> {

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -1662,7 +1662,7 @@ class DrawerOpenRightExample extends React.Component<{}, {open?: boolean}> {
           label="Toggle Drawer"
           onTouchTap={this.handleToggle}
         />
-                <Drawer width={200} openSecondary={true} open={this.state.open}>
+                <Drawer width="20%" openSecondary={true} open={this.state.open}>
                     <AppBar title="AppBar"/>
         </Drawer>
       </div>


### PR DESCRIPTION
Ran into this issue today trying to add a percentage to the width prop as defined in the spec.
So just need to change width from `number` to `number | string`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://www.material-ui.com/#/components/drawer>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
