### PR TITLE
graphql: Fix for getTypeMap() return type in graphql schema.d.ts.

### DIFF
--- a/types/graphql/type/schema.d.ts
+++ b/types/graphql/type/schema.d.ts
@@ -51,7 +51,7 @@ export class GraphQLSchema {
     getQueryType(): GraphQLObjectType;
     getMutationType(): GraphQLObjectType;
     getSubscriptionType(): GraphQLObjectType;
-    getTypeMap(): GraphQLNamedType;
+    getTypeMap(): { [typeName: string]: GraphQLNamedType };
     getType(name: string): GraphQLType;
     getPossibleTypes(abstractType: GraphQLAbstractType): Array<GraphQLObjectType>;
 


### PR DESCRIPTION
The declaration for `GraphQLSchema.getTypeMap()` was incorrect. As you can see in graphql-js, `getTypeMap()` returns a `TypeMap` (https://github.com/graphql/graphql-js/blob/5f6ce9095d1aaf7fccd749475e7d5b34b87cb12c/src/type/schema.js#L168) where a `TypeMap` is `type TypeMap = { [typeName: string]: GraphQLNamedType }` (https://github.com/graphql/graphql-js/blob/5f6ce9095d1aaf7fccd749475e7d5b34b87cb12c/src/type/schema.js#L222)