### PR TITLE
ndarray should support generic arrays

### DIFF
--- a/types/ndarray/index.d.ts
+++ b/types/ndarray/index.d.ts
@@ -3,12 +3,12 @@
 // Definitions by: Giff Song <https://github.com/pawsong/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function ndarray(
-	data: ndarray.Data, shape?: number[], stride?: number[], offset?: number
-): ndarray;
+declare function ndarray<T>(
+	data: ndarray.Data<T>, shape?: number[], stride?: number[], offset?: number
+): ndarray<T>;
 
-interface ndarray {
-	data: ndarray.Data;
+interface ndarray<T> {
+	data: ndarray.Data<T>;
 	shape: number[];
 	stride: number[];
 	offset: number;
@@ -17,18 +17,18 @@ interface ndarray {
 	size: number;
 	order: number[];
 	dimension: number;
-	get(...args: number[]): number;
-	set(...args: number[]): number;
+	get(...args: number[]): T;
+	set(...args: number[]): T;
 	index(...args: number[]): number;
-	lo(...args: number[]): ndarray;
-	hi(...args: number[]): ndarray;
-	step(...args: number[]): ndarray;
-	transpose(...args: number[]): ndarray;
-	pick(...args: number[]): ndarray;
+	lo(...args: number[]): ndarray<T>;
+	hi(...args: number[]): ndarray<T>;
+	step(...args: number[]): ndarray<T>;
+	transpose(...args: number[]): ndarray<T>;
+	pick(...args: number[]): ndarray<T>;
 }
 
 declare namespace ndarray {
-	type Data = number[] | Int8Array | Int16Array | Int32Array |
+	type Data<T> = T[] | Int8Array | Int16Array | Int32Array |
 		Uint8Array | Uint16Array | Uint32Array |
 		Float32Array | Float64Array | Uint8ClampedArray;
 }


### PR DESCRIPTION
Proposed change for @pawsong

I'm using ndarray to handle a multi-dimensional array of objects but this typing is not allowing me to. It requires the array to be `number[]`.

After this change ndarray can still be used without generic notation, it will just be inferred from the passed argument:

```typescript
const sut1 = ndarray(new Int8Array([1,2,3]);
const value1 = sut.get(0);
// value1 has inferred type: number

const sut2 = ndarray([ 'testing', 'foo' ]);
const value2 = sut2.get(0);
// value2 has inferred type: string
```