### PR TITLE
added promise.USE_PROMISE_MANAGER to selenium-webdriver

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -556,6 +556,13 @@ export namespace logging {
 
 export namespace promise {
   // region Functions
+  
+  /**
+   * Set `USE_PROMISE_MANAGER` to `false` to disable the promise manager.
+   * This is useful, if you use async/await (see https://github.com/SeleniumHQ/selenium/issues/2969
+   * and https://github.com/SeleniumHQ/selenium/issues/3037).
+   */
+  let USE_PROMISE_MANAGER: boolean;
 
   /**
    * Given an array of promises, will return a promise that will be fulfilled

--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -556,7 +556,7 @@ export namespace logging {
 
 export namespace promise {
   // region Functions
-  
+
   /**
    * Set `USE_PROMISE_MANAGER` to `false` to disable the promise manager.
    * This is useful, if you use async/await (see https://github.com/SeleniumHQ/selenium/issues/2969

--- a/types/selenium-webdriver/test/index.ts
+++ b/types/selenium-webdriver/test/index.ts
@@ -961,3 +961,7 @@ async function TestAsyncAwaitable() {
     let thenable: webdriver.promise.Promise<string> = new webdriver.promise.Promise<string>((resolve, reject) => resolve('foo'));
     let str: string = await thenable;
 }
+
+function TestPromiseManagerFlag() {
+    webdriver.promise.USE_PROMISE_MANAGER = false;
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SeleniumHQ/selenium/issues/2969, https://github.com/SeleniumHQ/selenium/issues/3037
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

[Example usage.](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/example/async_await_test.js#L44)