### PR TITLE
[sequelize] add `force` option for TruncateOptions and `where` option for DefineIndexesOptions

### DIFF
--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -3407,6 +3407,11 @@ declare namespace sequelize {
         limit?: number;
 
         /**
+         * Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
+         */
+        force?: boolean;
+
+        /**
          * If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is
          * truncated the where and limit options are ignored
          */

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -3211,7 +3211,7 @@ declare namespace sequelize {
              * https://github.com/sequelize/sequelize/blob/master/docs/docs/models-usage.md#user-content-manipulating-the-dataset-with-limit-offset-order-and-group
          */
         group?: string | string[] | Object;
-                     
+
         /**
          * Apply DISTINCT(col) for FindAndCount(all)
          */
@@ -3371,6 +3371,13 @@ declare namespace sequelize {
          * Defaults to false;
          */
         cascade?: boolean;
+
+        /**
+         * Delete instead of setting deletedAt to current timestamp (only applicable if paranoid is enabled)
+         *
+         * Defaults to false;
+         */
+        force?: boolean;
     }
 
     /**
@@ -3398,11 +3405,6 @@ declare namespace sequelize {
          * How many rows to delete
          */
         limit?: number;
-
-        /**
-         * Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
-         */
-        force?: boolean;
 
         /**
          * If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -4752,6 +4752,11 @@ declare namespace sequelize {
          */
         fields?: Array<string | { attribute: string, length: number, order: string, collate: string }>;
 
+        /**
+         * Condition of partial index
+         */
+        where?: WhereOptions;
+
     }
 
     /**

--- a/types/sequelize/v3/sequelize-tests.ts
+++ b/types/sequelize/v3/sequelize-tests.ts
@@ -992,6 +992,9 @@ User.bulkCreate( [{ name : 'foo', code : '123' }, { code : '1234' }], { fields :
 User.bulkCreate( [{ name : 'a', c : 'b' }, { name : 'e', c : 'f' }], { fields : ['e', 'f'], ignoreDuplicates : true } );
 
 User.truncate();
+User.truncate( { cascade : true } );
+User.truncate( { force : true } );
+User.truncate( { cascade: true, force : true } );
 
 User.destroy( { where : { client_id : 13 } } ).then( ( a ) => a.toFixed() );
 User.destroy( { force : true } );

--- a/types/sequelize/v3/sequelize-tests.ts
+++ b/types/sequelize/v3/sequelize-tests.ts
@@ -1261,7 +1261,7 @@ s.define( 'UserWithUniqueUsername', {
     username : { type : Sequelize.STRING, unique : { name : 'user_and_email', msg : 'User and email must be unique' } },
     email : { type : Sequelize.STRING, unique : 'user_and_email' }
 } );
-/* NOTE https://github.com/DefinitelyTyped/DefinitelyTyped/pull/5590
+
 s.define( 'UserWithUniqueUsername', {
     user_id : { type : Sequelize.INTEGER },
     email : { type : Sequelize.STRING }
@@ -1269,13 +1269,15 @@ s.define( 'UserWithUniqueUsername', {
     indexes : [
         {
             name : 'user_and_email_index',
-            msg : 'User and email must be unique',
             unique : true,
             method : 'BTREE',
-            fields : ['user_id', { attribute : 'email', collate : 'en_US', order : 'DESC', length : 5 }]
+            fields : ['user_id', { attribute : 'email', collate : 'en_US', order : 'DESC', length : 5 }],
+            where: {
+                user_id : { $not: null }
+            }
         }]
 } );
- */
+
 s.define( 'TaskBuild', {
     title : { type : Sequelize.STRING, defaultValue : 'a task!' },
     foo : { type : Sequelize.INTEGER, defaultValue : 2 },


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/sequelize/sequelize/blob/3e5b8772ef75169685fc96024366bca9958fee63/lib/model.js#L2234> <http://docs.sequelizejs.com/en/v3/docs/models-definition/#indexes>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
