### PR TITLE
[highcharts] Add the scrollbar property to the xAxis and yAxis to optionally enable scrolling in charts

### DIFF
--- a/types/highcharts/highstock.d.ts
+++ b/types/highcharts/highstock.d.ts
@@ -81,10 +81,16 @@ declare namespace Highstock {
         trackBorderWidth?: number;
     }
 
+    interface AxisOptions extends Highcharts.AxisOptions {
+        scrollbar?: ScrollbarOptions;
+    }
+
     interface Options extends Highcharts.Options {
         navigator?: NavigatorOptions;
         rangeSelector?: RangeSelectorOptions;
         scrollbar?: ScrollbarOptions;
+        xAxis?: AxisOptions[] | AxisOptions;
+        yAxis?: AxisOptions[] | AxisOptions;
     }
 
     interface Chart {

--- a/types/highcharts/test/highstock.ts
+++ b/types/highcharts/test/highstock.ts
@@ -9,6 +9,10 @@ $(() => {
             type: "arearange"
         },
 
+        xAxis: {
+            scrollbar: { enabled: true }
+        },
+
         navigator: {
             height: 80,
             maskFill: 'rgba(255, 198, 220, 0.75)',

--- a/types/highcharts/tslint.json
+++ b/types/highcharts/tslint.json
@@ -4,6 +4,7 @@
     "ban-types": false,
     "unified-signatures": false,
     "no-empty-interface": false,
-    "dt-header": false
+    "dt-header": false,
+    "no-object-literal-type-assertion": false
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
   - _Note_: Running `npm run lint highcharts` generated the error `Object.entries is not a function` however this error was generated on the master branch as well. It was not introduced with this pull request. `tsc` generated no errors.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://api.highcharts.com/highstock/scrollbar
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
