### PR TITLE
Fix Ramda  for Global 'R' Symbol

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1807,6 +1807,5 @@ declare namespace R {
     }
 }
 
-declare module "ramda" {
-    export = R;
-}
+export = R;
+export as namespace R;

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1807,4 +1807,6 @@ declare namespace R {
     }
 }
 
-export = R;
+declare module "ramda" {
+    export = R;
+}


### PR DESCRIPTION
From https://github.com/Microsoft/vscode/issues/26009

**bug**
The Ramda global `R` symbol is not defined. This means that Ramda must be used as module. This breaks intellisense for some JavaScript project setups in VSCode

**fix**
Declare a 'ramda' module. This preserves the global `R` symbol

----

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/Microsoft/vscode/issues/26009 https://github.com/Ramda/ramda#installation
- [ ] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

