### PR TITLE
Remove "removeAll" method on event handlers

### DIFF
--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -2412,7 +2412,6 @@ declare module OfficeExtension {
         constructor(context: ClientRequestContext, parentObject: ClientObject, name: string, eventInfo: EventInfo<T>);
         add(handler: (args: T) => IPromise<any>): EventHandlerResult<T>;
         remove(handler: (args: T) => IPromise<any>): void;
-        removeAll(): void;
     }
 
     export class EventHandlerResult<T> {


### PR DESCRIPTION
The Office.js team (of which I am a member) has decided to remove this method.  It will still exist in silent deprecated mode, but we will no longer add new events that have a "removeAll", and we want to strongly discourage this method's existence.  Since this was only added very recently, we believe that it's best to just remove it outright, rather than add special notices about its deprecation, etc.  The likely number of folks using it today is close to 0.


- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: {No URL, as the feature was not yet documented in any case. That's why we feel OK with removing the method}
- [x] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
