### PR TITLE
sinon: Add array matcher, set matcher and map matcher

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1,9 +1,9 @@
 // Type definitions for Sinon 2.2
 // Project: http://sinonjs.org/
-// Definitions by: William Sears <https://github.com/mrbigdog2u>, Jonathan Little <https://github.com/rationull>, Lukas Spieß <https://github.con/lumaxis>
+// Definitions by: William Sears <https://github.com/mrbigdog2u>, Jonathan Little <https://github.com/rationull>, Lukas Spieß <https://github.com/lumaxis>, Nico Jansen <https://github.com/nicojs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// sinon uses DOM dependencies which are absent in browserless envoronment like node.js
+// sinon uses DOM dependencies which are absent in browser-less environment like node.js
 // to avoid compiler errors this monkey patch is used
 // see more details in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11351
 // tslint:disable no-empty-interface
@@ -363,6 +363,47 @@ declare namespace Sinon {
         or(expr: SinonMatcher): SinonMatcher;
     }
 
+    interface SinonArrayMatcher extends SinonMatcher {
+        /**
+         * Requires an Array to be deep equal another one.
+         */
+        deepEquals(expected: any[]): SinonMatcher;
+        /**
+         * Requires an Array to start with the same values as another one.
+         */
+        startsWith(expected: any[]): SinonMatcher;
+        /**
+         * Requires an Array to end with the same values as another one.
+         */
+        endsWith(expected: any[]): SinonMatcher;
+        /**
+         * Requires an Array to contain each one of the values the given array has.
+         */
+        contains(expected: any[]): SinonMatcher;
+    }
+
+    interface SinonMapMatcher extends SinonMatcher {
+        /**
+         * Requires a Map to be deep equal another one.
+         */
+        deepEquals(expected: Map<any, any>): SinonMatcher;
+        /**
+         * Requires a Map to contain each one of the items the given map has.
+         */
+        contains(expected: Map<any, any>): SinonMatcher;
+    }
+
+    interface SinonSetMatcher extends SinonMatcher {
+        /**
+         *  Requires a Set to be deep equal another one.
+         */
+        deepEquals(expected: Set<any>): SinonMatcher;
+        /**
+         * Requires a Set to contain each one of the items the given set has.
+         */
+        contains(expected: Set<any>): SinonMatcher;
+    }
+
     interface SinonMatch {
         (value: number): SinonMatcher;
         (value: string): SinonMatcher;
@@ -378,7 +419,18 @@ declare namespace Sinon {
         string: SinonMatcher;
         object: SinonMatcher;
         func: SinonMatcher;
-        array: SinonMatcher;
+        /**
+         * Requires the value to be a Map.
+         */
+        map: SinonMapMatcher;
+        /**
+         * Requires the value to be a Set.
+         */
+        set: SinonSetMatcher;
+        /**
+         * Requires the value to be an Array.
+         */
+        array: SinonArrayMatcher;
         regexp: SinonMatcher;
         date: SinonMatcher;
         symbol: SinonMatcher;

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -4,7 +4,7 @@ function once(fn: Function) {
     let called = false;
     let returnValue: any;
 
-    return function() {
+    return function(this: any) {
         if (!called) {
             called = true;
             returnValue = fn.apply(this, arguments);
@@ -21,7 +21,7 @@ function testOne() {
 }
 
 function testTwo() {
-    let callback = sinon.spy(() => {});
+    let callback = sinon.spy(() => { });
     let proxy = once(callback);
     proxy();
     proxy();
@@ -68,7 +68,7 @@ function testSix() {
 }
 
 function testSeven() {
-    let obj = { functionToTest : () => { } };
+    let obj = { functionToTest: () => { } };
     let mockObj = sinon.mock(obj);
     obj.functionToTest();
     mockObj.expects('functionToTest').once();
@@ -79,15 +79,15 @@ function testEight() {
 }
 
 function testNine() {
-	let callback = sinon.stub().returns(42);
-	callback({ x: 5, y: 5 });
-	callback.calledWithMatch({ x: 5 });
-	callback.alwaysCalledWithMatch({ y: 5 });
-	callback.neverCalledWithMatch({ x: 6 });
-	callback.notCalledWithMatch({ x: 6 });
-	sinon.assert.calledWithMatch(callback, { x: 5 });
-	sinon.assert.alwaysCalledWithMatch(callback, { y: 5 });
-	sinon.assert.neverCalledWithMatch(callback, { x: 6 });
+    let callback = sinon.stub().returns(42);
+    callback({ x: 5, y: 5 });
+    callback.calledWithMatch({ x: 5 });
+    callback.alwaysCalledWithMatch({ y: 5 });
+    callback.neverCalledWithMatch({ x: 6 });
+    callback.notCalledWithMatch({ x: 6 });
+    sinon.assert.calledWithMatch(callback, { x: 5 });
+    sinon.assert.alwaysCalledWithMatch(callback, { y: 5 });
+    sinon.assert.neverCalledWithMatch(callback, { x: 6 });
 }
 
 function testSandbox() {
@@ -133,6 +133,32 @@ function testUsingPromises() {
     const stub: sinon.SinonStub = sinon.stub().usingPromise(Promise);
 }
 
+function testArrayMatchers() {
+    const stub = sinon.stub();
+    stub([{ a: 'b' }]);
+    stub.calledWithMatch(sinon.match.array);
+    stub.calledWithMatch(sinon.match.array.deepEquals([{ a: 'b' }]));
+    stub.calledWithMatch(sinon.match.array.startsWith([{ a: 'b' }]));
+    stub.calledWithMatch(sinon.match.array.deepEquals([{ a: 'b' }]));
+    stub.calledWithMatch(sinon.match.array.contains([{ a: 'b' }]));
+}
+
+function testMapMatcher() {
+    const stub = sinon.stub();
+    stub(new Map([['a', true], ['b', false]]));
+    stub.calledWithMatch(sinon.match.map);
+    stub.calledWithMatch(sinon.match.map.deepEquals(new Map([['a', true], ['b', false]])));
+    stub.calledWithMatch(sinon.match.map.contains(new Map([['a', true]])));
+}
+
+function testSetMatcher() {
+    const stub = sinon.stub();
+    stub(new Set(['a', true]));
+    stub.calledWithMatch(sinon.match.set);
+    stub.calledWithMatch(sinon.match.set.deepEquals(new Set(['a', true])));
+    stub.calledWithMatch(sinon.match.set.contains(new Set([true])));
+}
+
 function testSpy() {
     const otherSpy = sinon.spy();
     sinon.spy().calledAfter(otherSpy);
@@ -162,7 +188,7 @@ clock.setSystemTime(1000);
 clock.setSystemTime(new Date());
 
 class TestCreateStubInstance {
-    someTestMethod(testArg: string) {}
+    someTestMethod(testArg: string) { }
 }
 
 sinon.createStubInstance(TestCreateStubInstance).someTestMethod('some argument');
@@ -172,5 +198,8 @@ function testGetCalls() {
     double(2);
     double(4);
     double.getCall(0).args.length === 1;
-    double.getCalls().find(call => call.args[0] === 4).returnValue === 8;
+    const secondCall = double.getCalls().find(call => call.args[0] === 4);
+    if (secondCall) {
+        secondCall.returnValue === 8;
+    }
 }

--- a/types/sinon/tsconfig.json
+++ b/types/sinon/tsconfig.json
@@ -6,8 +6,8 @@
             "dom"
         ],
         "noImplicitAny": true,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
The matchers are documented here: http://sinonjs.org/releases/v2.2.0/matchers/

Also added `noImplicitThis` and `strictNullChecks`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x]  Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint sinon` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://sinonjs.org/releases/v2.2.0/matchers/
- [x] Increase the version number in the header if appropriate. (not appropriate)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`. (no substantial change)
