### PR TITLE
React-native: export ImageURISource type

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3123,9 +3123,9 @@ export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
 }
 
 /*
-    * @see https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageSourcePropType.js
-    */
-interface ImageURISource {
+ * @see https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageSourcePropType.js
+ */
+export interface ImageURISource {
     /**
      * `uri` is a string representing the resource identifier for the image, which
      * could be an http address, a local file path, or the name of a static image


### PR DESCRIPTION
Useful for passing around the struct before giving to to the \<Image> component.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageSource.js
- [x] Increase the version number in the header if appropriate. (not needed)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`. (not needed)
