### PR TITLE
Instead of adding overload, fix the return type

### DIFF
--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -5408,8 +5408,7 @@ declare namespace kendo.ui {
         slotByPosition(xPosition: number, yPosition: number): any;
         slotByElement(element: Element): any;
         slotByElement(element: JQuery): any;
-        view(type?: string): void;
-	view(): kendo.ui.SchedulerView;
+        view(type?: string): kendo.ui.SchedulerView;
         viewName(): string;
 
     }

--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -5408,7 +5408,8 @@ declare namespace kendo.ui {
         slotByPosition(xPosition: number, yPosition: number): any;
         slotByElement(element: Element): any;
         slotByElement(element: JQuery): any;
-        view(type?: string): kendo.ui.SchedulerView;
+        view(): kendo.ui.SchedulerView;
+        view(name: string): void;
         viewName(): string;
 
     }


### PR DESCRIPTION
I had mistakenly added an overload. The correct fix is to add the return type to the existing method.
