### PR TITLE
Added single type option to AutocompleteOptions in googlemaps types

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2464,7 +2464,7 @@ declare namespace google.maps {
             placeIdOnly?: boolean;
             strictBounds?: boolean;
             types?: string[];
-            type: string;
+            type?: string;
         }
 
         export interface AutocompletePrediction {

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2464,6 +2464,7 @@ declare namespace google.maps {
             placeIdOnly?: boolean;
             strictBounds?: boolean;
             types?: string[];
+            type: string;
         }
 
         export interface AutocompletePrediction {


### PR DESCRIPTION
Google places API have deprecated the `types` array in favour of a single `type` string. I have updated the AutocompleteOptions interface by adding this new option.

[Google places API deprecation](https://developers.google.com/maps/documentation/javascript/places#deprecation)
