### PR TITLE
node - process.exit() should never return

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -378,7 +378,7 @@ declare namespace NodeJS {
         chdir(directory: string): void;
         cwd(): string;
         env: any;
-        exit(code?: number): void;
+        exit(code?: number): never;
         exitCode: number;
         getgid(): number;
         setgid(id: number): void;


### PR DESCRIPTION
process.exit() should never return, so never is the correct return type

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/api/process.html#process_process_exit_code>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.