### PR TITLE
Add React.ReactInstance to OverlayProps.target

### DIFF
--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -442,7 +442,7 @@ declare namespace ReactBootstrap {
         placement?: string;
         rootClose?: boolean;
         show?: boolean;
-        target?: Function;
+        target?: Function | React.ReactInstance;
         shouldUpdatePosition?: boolean;
     }
     class Overlay extends React.Component<OverlayProps, {}> {


### PR DESCRIPTION
OverlayProps.target can be either a function or a React.ReactInstance.
See: https://github.com/react-bootstrap/react-overlays/blob/master/src/Position.js
Line: 82 and 83

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-bootstrap/react-overlays/blob/master/src/Position.js
