### PR TITLE
Enhance signature of create() for conversion from object

### DIFF
--- a/types/xmlbuilder/index.d.ts
+++ b/types/xmlbuilder/index.d.ts
@@ -85,5 +85,5 @@ declare class XMLElementOrXMLNode {
 }
 
 declare namespace xmlbuilder {
-    function create(name: string, xmldec?: Object, doctype?: any, options?: Object): XMLElementOrXMLNode;
+    function create(nameOrObjSpec: string | { [name:string]: Object }, xmldec?: Object, doctype?: any, options?: Object): XMLElementOrXMLNode;
 }

--- a/types/xmlbuilder/xmlbuilder-tests.ts
+++ b/types/xmlbuilder/xmlbuilder-tests.ts
@@ -41,3 +41,10 @@ xml('root')
     .up()
     .ele('atttest', 'text')
     .end();
+
+xml({
+  displayNotification: {
+      level: 'error',
+      message: 'an error occurred'
+  }
+});


### PR DESCRIPTION
Enhanced signature of `create()` to support [Conversion From Object](https://github.com/oozcitak/xmlbuilder-js/wiki/Conversion-From-Object).