### PR TITLE
doT.js: API allows modification of the exported templateSettings

### DIFF
--- a/types/dot/dot-tests.ts
+++ b/types/dot/dot-tests.ts
@@ -23,6 +23,8 @@ const data = {
 	name: "My name"
 };
 
+doT.templateSettings.varname = 'test';
+
 let pagefn = doT.template(pagetmpl, undefined, def);
 const content = pagefn(data);
 

--- a/types/dot/index.d.ts
+++ b/types/dot/index.d.ts
@@ -8,8 +8,8 @@ export as namespace doT;
 /** Version number */
 export const version: string;
 
-/** Default template settings */
-export const templateSettings: TemplateSettings;
+/** Template settings */
+export let templateSettings: TemplateSettings;
 
 export type RenderFunction = (...args: any[]) => string;
 


### PR DESCRIPTION
This changes the exported `templateSettings` property to a let from a const as per the docs (http://olado.github.io/doT/index.html `doT.templateSettings` section) the correct way to modify the doT compilation settings globally is to edit this object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://olado.github.io/doT/index.html `doT.templateSettings` section
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
