### PR TITLE
Make flatbuffers importable as module

### DIFF
--- a/types/flatbuffers/index.d.ts
+++ b/types/flatbuffers/index.d.ts
@@ -625,3 +625,5 @@ declare namespace flatbuffers {
     createLong(low: number, high: number): Long;
   }
 }
+
+export {flatbuffers}

--- a/types/flatbuffers/index.d.ts
+++ b/types/flatbuffers/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for flatbuffers 1.6
+// Type definitions for flatbuffers 1.6.0
 // Project: http://google.github.io/flatbuffers/index.html
 // Definitions by: Kamil Rojewski <kamil.rojewski@gmail.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/flatbuffers/index.d.ts
+++ b/types/flatbuffers/index.d.ts
@@ -1,7 +1,11 @@
-// Type definitions for flatbuffers 1.6.0
+// Type definitions for flatbuffers 1.6
 // Project: http://google.github.io/flatbuffers/index.html
 // Definitions by: Kamil Rojewski <kamil.rojewski@gmail.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "flatbuffers" {
+  export namespace flatbuffers {};
+}
 
 declare namespace flatbuffers {
   /**
@@ -625,5 +629,3 @@ declare namespace flatbuffers {
     createLong(low: number, high: number): Long;
   }
 }
-
-export {flatbuffers}


### PR DESCRIPTION
This change makes type declarations compatible with [flatbuffers library installed from npm](https://www.npmjs.com/package/flatbuffers). Without this change importing a library causes errors.

