### PR TITLE
Added types for mongoose-unique-validator

### DIFF
--- a/types/mongoose-unique-validator/index.d.ts
+++ b/types/mongoose-unique-validator/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for mongoose-unique-validator 1.0
+// Project: https://github.com/blakehaswell/mongoose-unique-validator#readme
+// Definitions by: Steve Hipwell <https://github.com/stevehipwell>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Schema } from "mongoose";
+
+export = mongooseUniqueValidator;
+
+declare function mongooseUniqueValidator(schema: Schema, options?: any): void;
+
+declare namespace mongooseUniqueValidator {
+}

--- a/types/mongoose-unique-validator/mongoose-unique-validator-tests.ts
+++ b/types/mongoose-unique-validator/mongoose-unique-validator-tests.ts
@@ -1,0 +1,8 @@
+import { Schema } from "mongoose";
+import * as uniqueValidator from "mongoose-unique-validator";
+
+const schema = new Schema({
+    test: { type: String }
+});
+
+schema.plugin(uniqueValidator);

--- a/types/mongoose-unique-validator/tsconfig.json
+++ b/types/mongoose-unique-validator/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mongoose-unique-validator-tests.ts"
+    ]
+}

--- a/types/mongoose-unique-validator/tslint.json
+++ b/types/mongoose-unique-validator/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
