### PR TITLE
Added types for bunyan-winston-adapter

### DIFF
--- a/types/bunyan-winston-adapter/bunyan-winston-adapter-tests.ts
+++ b/types/bunyan-winston-adapter/bunyan-winston-adapter-tests.ts
@@ -1,0 +1,9 @@
+import { createAdapter } from "bunyan-winston-adapter";
+import { Logger, LoggerInstance, transports } from "winston";
+
+const logger = new Logger();
+const mapping = {
+  trace: 'silly'
+};
+const adapterA = createAdapter(logger);
+const adapterB = createAdapter(logger, mapping);

--- a/types/bunyan-winston-adapter/index.d.ts
+++ b/types/bunyan-winston-adapter/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for bunyan-winston-adapter 0.2
+// Project: https://github.com/gluwer/bunyan-winston-adapter
+// Definitions by: Steve Hipwell <https://github.com/stevehipwell>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as bunyan from "bunyan";
+import { LoggerInstance } from "winston";
+
+export function createAdapter(logger: LoggerInstance, mapping?: any): bunyan;

--- a/types/bunyan-winston-adapter/tsconfig.json
+++ b/types/bunyan-winston-adapter/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bunyan-winston-adapter-tests.ts"
+    ]
+}

--- a/types/bunyan-winston-adapter/tslint.json
+++ b/types/bunyan-winston-adapter/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
