### PR TITLE
Koa-static: add support for the extensions option

### DIFF
--- a/types/koa-static/index.d.ts
+++ b/types/koa-static/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for koa-static v2.x
+// Type definitions for koa-static 3.0
 // Project: https://github.com/koajs/static
 // Definitions by: Jerry Chin <https://github.com/hellopao/>
 // Definitions: https://github.com/hellopao/DefinitelyTyped
@@ -13,11 +13,9 @@
 
  =============================================== */
 
-
 import * as Koa from "koa";
 
 declare function serve(root: string, opts?: {
-
     /**
      * Default file name, defaults to 'index.html'
      */
@@ -48,5 +46,5 @@ declare function serve(root: string, opts?: {
      */
     extensions?: string[];
 }): Koa.Middleware;
-declare namespace serve{}
+declare namespace serve {}
 export = serve;

--- a/types/koa-static/index.d.ts
+++ b/types/koa-static/index.d.ts
@@ -42,6 +42,11 @@ declare function serve(root: string, opts?: {
      * Try to serve the gzipped version of a file automatically when gzip is supported by a client and if the requested file with .gz extension exists. defaults to true.
      */
     gzip?: boolean;
+
+    /**
+     * Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
+     */
+    extensions?: string[];
 }): Koa.Middleware;
 declare namespace serve{}
 export = serve;

--- a/types/koa-static/koa-static-tests.ts
+++ b/types/koa-static/koa-static-tests.ts
@@ -3,6 +3,10 @@ import serve = require("koa-static");
 
 const app = new Koa();
 
-app.use(serve('.',{index:false,defer:false, extensions: ['html']}));
+app.use(serve('.', {
+  index: false,
+  defer: false,
+  extensions: ['html']
+}));
 
-app.listen(80)
+app.listen(80);

--- a/types/koa-static/koa-static-tests.ts
+++ b/types/koa-static/koa-static-tests.ts
@@ -3,6 +3,6 @@ import serve = require("koa-static");
 
 const app = new Koa();
 
-app.use(serve('.',{index:false,defer:false}));
+app.use(serve('.',{index:false,defer:false, extensions: ['html']}));
 
 app.listen(80)

--- a/types/koa-static/tslint.json
+++ b/types/koa-static/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
koa-static serve() method supports a `extensions` property in the options object. (see https://github.com/koajs/static#options)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/static#options
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
