### PR TITLE
@types/classnames - hide global definitions

### DIFF
--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -1,4 +1,4 @@
-import classNames = require('classnames')
+import classNames = require('classnames');
 
 classNames('foo', 'bar'); // => 'foo bar'
 
@@ -21,4 +21,4 @@ classNames(["foo", ["bar", {baz: true}]]); // => 'foo bar baz'
 classNames(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'
 
 // Supporting booleans is tricky since we should only support passing in false, which is ignored
-//classNames(false, 'bar', 0, 1, { baz: null }, ''); // => 'bar 1'
+// classNames(false, 'bar', 0, 1, { baz: null }, ''); // => 'bar 1'

--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -1,6 +1,7 @@
 import classNames = require('classnames');
+import * as classNames2 from 'classnames';
 
-classNames('foo', 'bar'); // => 'foo bar'
+classNames2('foo', 'bar'); // => 'foo bar'
 
 classNames('foo', 'bar'); // => 'foo bar'
 classNames('foo', { bar: true }); // => 'foo bar'

--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -13,6 +13,8 @@ interface ClassDictionary {
 	[id: string]: boolean | undefined | null;
 }
 
+// This is the only way I found to break circular references between ClassArray and ClassValue
+// https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540
 interface ClassArray extends Array<ClassValue> { } // tslint:disable-line no-empty-interface
 
 type ClassNamesFn = (...classes: ClassValue[]) => string;

--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -20,3 +20,4 @@ type ClassNamesFn = (...classes: ClassValue[]) => string;
 declare const classNames: ClassNamesFn;
 
 export = classNames;
+export as namespace classNames;

--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -1,22 +1,22 @@
-// Type definitions for classnames
+// Type definitions for classnames 2.2
 // Project: https://github.com/JedWatson/classnames
-// Definitions by: Dave Keen <http://www.keendevelopment.ch>, Adi Dahiya <https://github.com/adidahiya>, Jason Killian <https://github.com/JKillian>
+// Definitions by: Dave Keen <http://www.keendevelopment.ch>
+//                 Adi Dahiya <https://github.com/adidahiya>
+//                 Jason Killian <https://github.com/JKillian>
+//                 Sean Kelley <https://github.com/seansfkelley/>
+//                 Michal Adamczyk <https://github.com/mradamczyk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
+type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
 
 interface ClassDictionary {
 	[id: string]: boolean | undefined | null;
 }
 
-interface ClassArray extends Array<ClassValue> { }
+interface ClassArray extends Array<ClassValue> { } // tslint:disable-line no-empty-interface
 
-interface ClassNamesFn {
-	(...classes: ClassValue[]): string;
-}
+type ClassNamesFn = (...classes: ClassValue[]) => string;
 
-declare var classNames: ClassNamesFn;
+declare const classNames: ClassNamesFn;
 
-declare module "classnames" {
-	export = classNames
-}
+export = classNames;

--- a/types/classnames/tslint.json
+++ b/types/classnames/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I run into a problem of conflicting definitions of classnames used in separate apps in the same tree:

```
ERROR in /Volume/project1/packages/app1/node_modules/@types/classnames/index.d.ts
(6,14): error TS2300: Duplicate identifier 'ClassValue'.

ERROR in /Volume/project1/packages/app1/node_modules/@types/classnames/index.d.ts
(9,2): error TS2374: Duplicate string index signature.

ERROR in /Volume/project1/packages/app1/node_modules/@types/classnames/index.d.ts
(21,2): error TS2300: Duplicate identifier 'export='.

ERROR in /Volume/project1/packages/app2/node_modules/@types/classnames/index.d.ts
(6,14): error TS2300: Duplicate identifier 'ClassValue'.

ERROR in /Volume/project1/packages/app2/node_modules/@types/classnames/index.d.ts
(21,2): error TS2300: Duplicate identifier 'export='.
Child html-webpack-plugin for "index.html":
```

@seansfkelley helped me to debug the issue and rewrite definitions. 

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://jedwatson.github.io/classnames/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
