### PR TITLE
Add new types for TabBar in types/react-native

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5098,6 +5098,11 @@ export interface TabBarItemProperties extends ViewProperties {
     badge?: string | number
 
     /**
+     * Background color for the badge. Available since iOS 10.
+     */
+    badgeColor?: string
+
+    /**
      * A custom icon for the tab. It is ignored when a system icon is defined.
      */
     icon?: ImageURISource
@@ -5182,6 +5187,11 @@ export interface TabBarIOSProperties extends ViewProperties {
      * Color of text on unselected tabs
      */
     unselectedTintColor?: string
+
+    /**
+     * Color of unselected tab icons. Available since iOS 10.
+     */
+    unselectedItemTintColor?: string
 }
 
 export interface TabBarIOSStatic extends React.ComponentClass<TabBarIOSProperties> {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-native 0.43
+// Type definitions for react-native 0.44
 // Project: https://github.com/facebook/react-native
 // Definitions by: Eloy Durán <https://github.com/alloy>, Fedor Nezhivoi <https://github.com/gyzerok>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -34,6 +34,7 @@ import {
     ScrollView,
     ScrollViewProps,
     RefreshControl,
+    TabBarIOS,
 } from 'react-native';
 
 function testDimensions() {
@@ -253,5 +254,32 @@ class ScrollerListComponentTest extends React.Component<{}, { dataSource: ListVi
                 }
             } />
         )
+    }
+}
+
+
+class TabBarTest extends React.Component<{}, {}> {
+    render() {
+        return (
+            <TabBarIOS
+                barTintColor="darkslateblue"
+                itemPositioning="center"
+                tintColor="white"
+                translucent={ true }
+                unselectedTintColor="black"
+                unselectedItemTintColor="red">
+                <TabBarIOS.Item
+                    badge={ 0 }
+                    badgeColor="red"
+                    icon={{uri: undefined}}
+                    selected={ true }
+                    onPress={() => {}}
+                    renderAsOriginal={ true }
+                    selectedIcon={ undefined }
+                    systemIcon="history"
+                    title="Item 1">
+                </TabBarIOS.Item>
+            </TabBarIOS>
+        );
     }
 }


### PR DESCRIPTION
- Because the types are available since iOS 10.
- The test code for TabBar added.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [https://facebook.github.io/react-native/docs/tabbarios.html#props](https://facebook.github.io/react-native/docs/tabbarios.html#props)
  - [https://facebook.github.io/react-native/docs/tabbarios-item.html#props](https://facebook.github.io/react-native/docs/tabbarios-item.html#props)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
