### PR TITLE
react-navigation: NavigationContainerProps/navigation param should be optional

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -476,7 +476,7 @@ export interface LayoutEvent {
 }
 
 interface NavigationContainerProps {
-  navigation: NavigationProp<any, NavigationAction>
+  navigation?: NavigationProp<any, NavigationAction>
   onNavigationStateChange?: (
     preNavigationState: NavigationState,
     nextNavigationState: NavigationState,
@@ -489,7 +489,7 @@ interface NavigationContainerState {
 
 export interface NavigationContainer extends React.ComponentClass<
   NavigationContainerProps
-> {
+  > {
   router: any
 }
 
@@ -509,7 +509,7 @@ export function StackNavigator(
  */
 export interface DrawNavigatorConfig {
   drawerWidth?: number,
-  drawerPosition?: 'left'|'right',
+  drawerPosition?: 'left' | 'right',
   contentComponent?: React.ReactElement<any>,
   contentOptions?: {
     activeTintColor?: string,
@@ -531,7 +531,7 @@ export function DrawerNavigator(
  */
 export interface TabNavigatorConfig {
   tabBarComponent?: React.ReactElement<any>,
-  tabBarPosition?: 'top'|'bottom',
+  tabBarPosition?: 'top' | 'bottom',
   swipeEnabled?: boolean,
   animationEnabled?: boolean,
   lazy?: boolean,
@@ -556,7 +556,7 @@ export interface TabNavigatorConfig {
   initialRouteName?: string,
   order?: string[],
   paths?: any     // TODO: better def
-  backBehavior?: 'initialRoute'|'none'
+  backBehavior?: 'initialRoute' | 'none'
 }
 
 export function TabNavigator(
@@ -569,8 +569,8 @@ export function TabNavigator(
 export interface StackNavigatorScreenOptions {
   title?: string;
   headerVisible?: boolean;
-  headerTitle?: string|React.ReactElement<any>;
-  headerBackTitle?: string|null;
+  headerTitle?: string | React.ReactElement<any>;
+  headerBackTitle?: string | null;
   headerTruncatedBackTitle?: string;
   headerRight?: React.ReactElement<any>;
   headerLeft?: React.ReactElement<any>;
@@ -586,18 +586,18 @@ export interface TabNavigatorScreenOptions {
   tabBarVisible?: boolean;
   tabBarIcon?: React.ReactElement<any>;
   tabBarLaben?: string
-      |React.ReactElement<any>
-      | ((options: {focused: boolean, tintColor: string}) => React.ReactElement<any>)
+  | React.ReactElement<any>
+  | ((options: { focused: boolean, tintColor: string }) => React.ReactElement<any>)
   ;
 }
 
 export interface DrawerNavigatorScreenOptions {
   title?: string;
   drawerLabel?: string
-      |React.ReactElement<any>
-      | ((options: {focused: boolean, tintColor: string}) => React.ReactElement<any>)
+  | React.ReactElement<any>
+  | ((options: { focused: boolean, tintColor: string }) => React.ReactElement<any>)
   ;
   drawerIcon?: React.ReactElement<any>
-      | ((options: {focused: boolean, tintColor: string}) => React.ReactElement<any>)
+  | ((options: { focused: boolean, tintColor: string }) => React.ReactElement<any>)
   ;
 }

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -570,7 +570,7 @@ export interface StackNavigatorScreenOptions {
   title?: string;
   headerVisible?: boolean;
   headerTitle?: string|React.ReactElement<any>;
-  headerBackTitle?: string|null;
+  headerBackTitle?: string;
   headerTruncatedBackTitle?: string;
   headerRight?: React.ReactElement<any>;
   headerLeft?: React.ReactElement<any>;

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -489,7 +489,7 @@ interface NavigationContainerState {
 
 export interface NavigationContainer extends React.ComponentClass<
   NavigationContainerProps
-  > {
+> {
   router: any
 }
 
@@ -509,7 +509,7 @@ export function StackNavigator(
  */
 export interface DrawNavigatorConfig {
   drawerWidth?: number,
-  drawerPosition?: 'left' | 'right',
+  drawerPosition?: 'left'|'right',
   contentComponent?: React.ReactElement<any>,
   contentOptions?: {
     activeTintColor?: string,
@@ -531,7 +531,7 @@ export function DrawerNavigator(
  */
 export interface TabNavigatorConfig {
   tabBarComponent?: React.ReactElement<any>,
-  tabBarPosition?: 'top' | 'bottom',
+  tabBarPosition?: 'top'|'bottom',
   swipeEnabled?: boolean,
   animationEnabled?: boolean,
   lazy?: boolean,
@@ -556,7 +556,7 @@ export interface TabNavigatorConfig {
   initialRouteName?: string,
   order?: string[],
   paths?: any     // TODO: better def
-  backBehavior?: 'initialRoute' | 'none'
+  backBehavior?: 'initialRoute'|'none'
 }
 
 export function TabNavigator(
@@ -569,8 +569,8 @@ export function TabNavigator(
 export interface StackNavigatorScreenOptions {
   title?: string;
   headerVisible?: boolean;
-  headerTitle?: string | React.ReactElement<any>;
-  headerBackTitle?: string | null;
+  headerTitle?: string|React.ReactElement<any>;
+  headerBackTitle?: string|null;
   headerTruncatedBackTitle?: string;
   headerRight?: React.ReactElement<any>;
   headerLeft?: React.ReactElement<any>;
@@ -586,18 +586,18 @@ export interface TabNavigatorScreenOptions {
   tabBarVisible?: boolean;
   tabBarIcon?: React.ReactElement<any>;
   tabBarLaben?: string
-  | React.ReactElement<any>
-  | ((options: { focused: boolean, tintColor: string }) => React.ReactElement<any>)
+      |React.ReactElement<any>
+      | ((options: {focused: boolean, tintColor: string}) => React.ReactElement<any>)
   ;
 }
 
 export interface DrawerNavigatorScreenOptions {
   title?: string;
   drawerLabel?: string
-  | React.ReactElement<any>
-  | ((options: { focused: boolean, tintColor: string }) => React.ReactElement<any>)
+      |React.ReactElement<any>
+      | ((options: {focused: boolean, tintColor: string}) => React.ReactElement<any>)
   ;
   drawerIcon?: React.ReactElement<any>
-  | ((options: { focused: boolean, tintColor: string }) => React.ReactElement<any>)
+      | ((options: {focused: boolean, tintColor: string}) => React.ReactElement<any>)
   ;
 }


### PR DESCRIPTION
When using StackNavigator, there are times when you would like to trigger custom side effects on
navigation by setting the "onNavigationStateChange" prop, but don't want to override default
navigation. This PR allows for that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/react-community/react-navigation/blob/master/docs/guides/Screen-Tracking.md>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
