### PR TITLE
make rosie options arguments optional

### DIFF
--- a/rosie/rosie.d.ts
+++ b/rosie/rosie.d.ts
@@ -187,9 +187,9 @@ declare namespace rosie {
      * @param {object=} options
      * @return {*}
      */
-    build(attributes: Object, options: Object): Object;
+    build(attributes: Object, options?: Object): Object;
 
-    buildList(size: number, attributes: Object, options: Object): Object[];
+    buildList(size: number, attributes: Object, options?: Object): Object[];
 
     /**
      * Extends a given factory by copying over its attributes, options,


### PR DESCRIPTION
Please fill in this template.

Rosie package options should be optional

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rosiejs/rosie
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.