### PR TITLE
fixed typo in react-color EditableInput (styles->style), added dragLabel and dragMax

### DIFF
--- a/types/react-color/lib/components/common/EditableInput.d.ts
+++ b/types/react-color/lib/components/common/EditableInput.d.ts
@@ -11,8 +11,10 @@ export interface EditableInputProps extends ClassAttributes<EditableInput> {
     color?: Color;
     label?: string;
     onChange?: ColorChangeHandler;
-    styles?: EditableInputStyles;
-    value?: any;
+    style?: EditableInputStyles;
+    value?: any;    
+    dragLabel?: string;
+    dragMax?: string;
 }
 
 export default class EditableInput extends Component<EditableInputProps, any> {}

--- a/types/react-color/lib/components/common/EditableInput.d.ts
+++ b/types/react-color/lib/components/common/EditableInput.d.ts
@@ -12,7 +12,7 @@ export interface EditableInputProps extends ClassAttributes<EditableInput> {
     label?: string;
     onChange?: ColorChangeHandler;
     style?: EditableInputStyles;
-    value?: any;    
+    value?: any;
     dragLabel?: string;
     dragMax?: string;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://casesandberg.github.io/react-color/ 

see EditableInput section
