### PR TITLE
react-router: add missing onEnter and onLeave to RouteProps type

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -69,8 +69,8 @@ export interface RouteProps {
   path?: string;
   exact?: boolean;
   strict?: boolean;
-  onEnter?: Function;
-  onLeave?: Function;
+  onEnter?(nextState: {}, replace: any): void;
+  onLeave?(nextState: {}, replace: any): void;
 }
 export class Route extends React.Component<RouteProps, {}> { }
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -69,6 +69,8 @@ export interface RouteProps {
   path?: string;
   exact?: boolean;
   strict?: boolean;
+  onEnter?: Function;
+  onLeave?: Function;
 }
 export class Route extends React.Component<RouteProps, {}> { }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/v3/docs/guides/RouteConfiguration.md#enter-and-leave-hooks
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
