### PR TITLE
node: add 'stdio' to ForkOptions

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1744,6 +1744,7 @@ declare module "child_process" {
         execPath?: string;
         execArgv?: string[];
         silent?: boolean;
+        stdio?: any[];
         uid?: number;
         gid?: number;
     }


### PR DESCRIPTION
Documentation: https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options

See `stdio` in `options` parameter.