### PR TITLE
Add some new options for webpack-dev-server config

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for webpack-dev-server 1.12.1
+// Type definitions for webpack-dev-server 2.4.5
 // Project: https://github.com/webpack/webpack-dev-server
 // Definitions by: maestroh <https://github.com/maestroh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -26,6 +26,8 @@ declare module "webpack-dev-server" {
             publicPath: string;
             headers?: any;
             stats?: webpack.compiler.StatsOptions| webpack.compiler.StatsToStringOptions;
+            public?: string;
+            disableHostCheck?: boolean;
 
             setup?(app: core.Express): void;
         }

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -14,6 +14,12 @@ server = new WebpackDevServer(compiler, {
     contentBase: "/path/to/directory",
     // or: contentBase: "http://localhost/",
 
+    public: 'public-host.ru',
+    // Public host for server
+
+    disableHostCheck: true,
+    // Disable public host check, use it carefully
+
     hot: true,
     // Enable special support for Hot Module Replacement
     // Page is no longer updated, but a "webpackHotUpdate" message is send to the content


### PR DESCRIPTION
Add `public` and `disableHostCheck` for webpack-dev-server configuration according this release note: https://github.com/webpack/webpack-dev-server/releases/tag/v2.4.3
