### PR TITLE
react-navigation: NavigationActions/back param should be optional

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -321,7 +321,7 @@ export type NavigationAction =
 export namespace NavigationActions {
   function navigate(options: NavigationNavigateAction): any;
   function reset(options: NavigationResetAction): any;
-  function back(options: NavigationBackAction): any;
+  function back(options?: NavigationBackAction): any;
   function setParams(options: NavigationSetParamsAction): any;
 }
 

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-navigation 1.0
 // Project: https://github.com/react-community/react-navigation
 // Definitions by: Huhuanming <https://github.com/huhuanming>
+//                 mhcgrq <https://github.com/mhcgrq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as React from 'react'


### PR DESCRIPTION
According to the doc as mentioned below, the param of the function `NavigationActions.back` should be optional.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/react-community/react-navigation/blob/master/docs/guides/Navigation-Actions.md>>
