### PR TITLE
Correct return type for no parameters in `return` method in bluebird

### DIFF
--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -228,8 +228,8 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
    *
    * Alias `.thenReturn();` for compatibility with earlier ECMAScript version.
    */
-  return(): Bluebird<any>;
-  thenReturn(): Bluebird<any>;
+  return(): Bluebird<void>;
+  thenReturn(): Bluebird<void>;
   return<U>(value: U): Bluebird<U>;
   thenReturn<U>(value: U): Bluebird<U>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://bluebirdjs.com/docs/api/return.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

The docs do not explicitly state that no values means no value will be resolved, but no value is => undefined, so `any` not not appropriate here.

Simple poc:

```
> void(b = require('bluebird'))
undefined
> b.version
'3.5.0'
> void(b.resolve().return().then(console.log))
undefined
> undefined
```

Regarding the test case: I'm not sure how to properly augment the test case here as the previous return value was `any`.