### PR TITLE
[vexflow] Fixed type of stem_direction in TabNote (#16472)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DefinitelyTyped [![Build Status](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped.png?branch=master)](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped)
+# DefinitelyTyped [![Build Status](https://travis-ci.org/bohoffi/DefinitelyTyped.png?branch=master)](https://travis-ci.org/bohoffi/DefinitelyTyped)
 
 [![Join the chat at https://gitter.im/borisyankov/DefinitelyTyped](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/borisyankov/DefinitelyTyped?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DefinitelyTyped [![Build Status](https://travis-ci.org/bohoffi/DefinitelyTyped.png?branch=master)](https://travis-ci.org/bohoffi/DefinitelyTyped)
+# DefinitelyTyped [![Build Status](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped.png?branch=master)](https://travis-ci.org/DefinitelyTyped/DefinitelyTyped)
 
 [![Join the chat at https://gitter.im/borisyankov/DefinitelyTyped](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/borisyankov/DefinitelyTyped?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/types/vexflow/index.d.ts
+++ b/types/vexflow/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for VexFlow v1.2.83
 // Project: http://vexflow.com
-// Definitions by: Roman Quiring <https://github.com/rquiring>, Sebastian Haas <https://github.com/sebastianhaas/>
+// Definitions by: Roman Quiring <https://github.com/rquiring>
+//                 Sebastian Haas <https://github.com/sebastianhaas/>
+//                 Basti Hoffmann <https://github.com/bohoffi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 //inconsistent namespace: this is a helper funtion from tables.js and should not pollute the global namespace!
@@ -1174,7 +1176,7 @@ declare namespace Vex {
             setStave(stave : Stave) : Note;
             getModifierStartXY() : {x : number, y : number};
 
-            constructor(tab_struct : {positions : {str : number, fret : number}[], type? : string, dots? : number, duration : string, stem_direction? : boolean}, draw_stem? : boolean);
+            constructor(tab_struct : {positions : {str : number, fret : number}[], type? : string, dots? : number, duration : string, stem_direction? : number}, draw_stem? : boolean);
             getCategory() : string;
             setGhost(ghost : boolean) : TabNote;
             hasStem() : boolean;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/0xfe/vexflow/blob/master/src/tabnote.js>>

All other classes are using `number` as the `stem_direction` parameter. This is equal to the [definition in Stem](https://github.com/0xfe/vexflow/blob/master/src/stem.js)
