### PR TITLE
vex-js: added `defaultOptions`

### DIFF
--- a/types/vex-js/index.d.ts
+++ b/types/vex-js/index.d.ts
@@ -37,6 +37,7 @@ declare namespace vex {
     close(id?: number): boolean;
     closeAll(): boolean;
     closeByID(id: number): boolean;
+    defaultOptions?: IVexOptions;
   }
 
 }


### PR DESCRIPTION
To support
```js
vex.defaultOptions.className = 'vex-theme-os';
```

See
https://github.com/HubSpot/vex/blob/master/dist/js/vex.combined.js#L1585

