### PR TITLE
[fs-extra] added file descriptors for fs methods

### DIFF
--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for fs-extra 3.0
 // Project: https://github.com/jprichardson/node-fs-extra
-// Definitions by: Alan Agius <https://github.com/alan-agius4>, midknight41 <https://github.com/midknight41>, Brendan Forster <https://github.com/shiftkey>
+// Definitions by: Alan Agius <https://github.com/alan-agius4>
+//                 midknight41 <https://github.com/midknight41>
+//                 Brendan Forster <https://github.com/shiftkey>
+//                 Mees van Dijk <https://github.com/mees->
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -103,6 +106,10 @@ export function access(path: string | Buffer, mode?: number): Promise<void>;
 export function appendFile(filename: string, data: any, options: { encoding?: string; mode?: number | string; flag?: string; }, callback: (err: NodeJS.ErrnoException) => void): void;
 export function appendFile(filename: string, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
 export function appendFile(filename: string, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
+export function appendFile(fd: number, data: any, options: { encoding?: string; mode?: number | string; flag?: string; }, callback: (err: NodeJS.ErrnoException) => void): void;
+export function appendFile(fd: number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+export function appendFile(fd: number, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
+
 
 export function chmod(path: string | Buffer, mode: string | number, callback: (err?: NodeJS.ErrnoException) => void): void;
 export function chmod(path: string | Buffer, mode: string | number): Promise<void>;
@@ -178,6 +185,14 @@ export function readFile(filename: string, options: { flag?: string; } | { encod
 export function readFile(filename: string, encoding: string): Promise<string>;
 export function readFile(filename: string): Promise<Buffer>;
 
+export function readFile(fd: number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+export function readFile(fd: number, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
+export function readFile(fd: number, options: { flag?: string; } | { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+export function readFile(fd: number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
+// tslint:disable-next-line:unified-signatures
+export function readFile(fd: number, encoding: string): Promise<string>;
+export function readFile(fd: number): Promise<Buffer>;
+
 export function readdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
 export function readdir(path: string | Buffer): Promise<string[]>;
 
@@ -235,6 +250,10 @@ export function write(fd: number, data: any, offset: number, encoding?: string):
 export function writeFile(filename: string, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
 export function writeFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
 export function writeFile(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): Promise<void>;
+
+export function writeFile(fd: number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+export function writeFile(fd: number, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
+export function writeFile(fd: number, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): Promise<void>;
 
 /**
  * Asynchronous mkdtemp - Creates a unique temporary directory. Generates six random characters to be appended behind a required prefix to create a unique temporary directory.

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -103,13 +103,9 @@ export function access(path: string | Buffer, callback: (err: NodeJS.ErrnoExcept
 export function access(path: string | Buffer, mode: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function access(path: string | Buffer, mode?: number): Promise<void>;
 
-export function appendFile(filename: string, data: any, options: { encoding?: string; mode?: number | string; flag?: string; }, callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(filename: string, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(filename: string, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
-export function appendFile(fd: number, data: any, options: { encoding?: string; mode?: number | string; flag?: string; }, callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(fd: number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(fd: number, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
-
+export function appendFile(filename: string | number, data: any, options: { encoding?: string; mode?: number | string; flag?: string; }, callback: (err: NodeJS.ErrnoException) => void): void;
+export function appendFile(filename: string | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+export function appendFile(filename: string | number, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
 
 export function chmod(path: string | Buffer, mode: string | number, callback: (err?: NodeJS.ErrnoException) => void): void;
 export function chmod(path: string | Buffer, mode: string | number): Promise<void>;
@@ -177,21 +173,13 @@ export function open(path: string | Buffer, flags: string | number, mode?: numbe
 export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null, callback: (err: NodeJS.ErrnoException, bytesRead: number, buffer: Buffer) => void): void;
 export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null): Promise<[number, Buffer]>;
 
-export function readFile(filename: string, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(filename: string, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
-export function readFile(filename: string, options: { flag?: string; } | { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(filename: string, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
+export function readFile(filename: string | number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+export function readFile(filename: string | number, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
+export function readFile(filename: string | number, options: { flag?: string; } | { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+export function readFile(filename: string | number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
 // tslint:disable-next-line:unified-signatures
-export function readFile(filename: string, encoding: string): Promise<string>;
-export function readFile(filename: string): Promise<Buffer>;
-
-export function readFile(fd: number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(fd: number, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
-export function readFile(fd: number, options: { flag?: string; } | { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(fd: number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
-// tslint:disable-next-line:unified-signatures
-export function readFile(fd: number, encoding: string): Promise<string>;
-export function readFile(fd: number): Promise<Buffer>;
+export function readFile(filename: string | number, encoding: string): Promise<string>;
+export function readFile(filename: string | number): Promise<Buffer>;
 
 export function readdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
 export function readdir(path: string | Buffer): Promise<string[]>;
@@ -247,13 +235,9 @@ export function write(fd: number, data: any, offset: number, encoding: string, c
 export function write(fd: number, buffer: Buffer, offset: number, length: number, position?: number | null): Promise<[number, Buffer]>;
 export function write(fd: number, data: any, offset: number, encoding?: string): Promise<[number, string]>;
 
-export function writeFile(filename: string, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function writeFile(filename: string, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
-export function writeFile(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): Promise<void>;
-
-export function writeFile(fd: number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function writeFile(fd: number, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
-export function writeFile(fd: number, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): Promise<void>;
+export function writeFile(filename: string | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+export function writeFile(filename: string | number, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
+export function writeFile(filename: string | number, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): Promise<void>;
 
 /**
  * Asynchronous mkdtemp - Creates a unique temporary directory. Generates six random characters to be appended behind a required prefix to create a unique temporary directory.

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -103,9 +103,9 @@ export function access(path: string | Buffer, callback: (err: NodeJS.ErrnoExcept
 export function access(path: string | Buffer, mode: number, callback: (err: NodeJS.ErrnoException) => void): void;
 export function access(path: string | Buffer, mode?: number): Promise<void>;
 
-export function appendFile(filename: string | number, data: any, options: { encoding?: string; mode?: number | string; flag?: string; }, callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(filename: string | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function appendFile(filename: string | number, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
+export function appendFile(file: string | Buffer | number, data: any, options: { encoding?: string; mode?: number | string; flag?: string; }, callback: (err: NodeJS.ErrnoException) => void): void;
+export function appendFile(file: string | Buffer | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+export function appendFile(file: string | Buffer | number, data: any, options?: { encoding?: string; mode?: number | string; flag?: string; }): Promise<void>;
 
 export function chmod(path: string | Buffer, mode: string | number, callback: (err?: NodeJS.ErrnoException) => void): void;
 export function chmod(path: string | Buffer, mode: string | number): Promise<void>;
@@ -173,13 +173,13 @@ export function open(path: string | Buffer, flags: string | number, mode?: numbe
 export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null, callback: (err: NodeJS.ErrnoException, bytesRead: number, buffer: Buffer) => void): void;
 export function read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null): Promise<[number, Buffer]>;
 
-export function readFile(filename: string | number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(filename: string | number, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
-export function readFile(filename: string | number, options: { flag?: string; } | { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
-export function readFile(filename: string | number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
+export function readFile(file: string | Buffer | number, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+export function readFile(file: string | Buffer | number, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
+export function readFile(file: string | Buffer | number, options: { flag?: string; } | { encoding: string; flag?: string; }, callback: (err: NodeJS.ErrnoException, data: Buffer) => void): void;
+export function readFile(file: string | Buffer | number, options: { flag?: string; } | { encoding: string; flag?: string; }): Promise<string>;
 // tslint:disable-next-line:unified-signatures
-export function readFile(filename: string | number, encoding: string): Promise<string>;
-export function readFile(filename: string | number): Promise<Buffer>;
+export function readFile(file: string | Buffer | number, encoding: string): Promise<string>;
+export function readFile(file: string | Buffer | number): Promise<Buffer>;
 
 export function readdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
 export function readdir(path: string | Buffer): Promise<string[]>;
@@ -235,9 +235,9 @@ export function write(fd: number, data: any, offset: number, encoding: string, c
 export function write(fd: number, buffer: Buffer, offset: number, length: number, position?: number | null): Promise<[number, Buffer]>;
 export function write(fd: number, data: any, offset: number, encoding?: string): Promise<[number, string]>;
 
-export function writeFile(filename: string | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
-export function writeFile(filename: string | number, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
-export function writeFile(filename: string | number, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): Promise<void>;
+export function writeFile(file: string | Buffer | number, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+export function writeFile(file: string | Buffer | number, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback?: (err: NodeJS.ErrnoException) => void): void;
+export function writeFile(file: string | Buffer | number, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): Promise<void>;
 
 /**
  * Asynchronous mkdtemp - Creates a unique temporary directory. Generates six random characters to be appended behind a required prefix to create a unique temporary directory.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
-  [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v7.x/docs/api/fs.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
