### PR TITLE
[through2] Add 'this' type to callbacks and fix through2.ctor() signature for optional 'options' parameter

### DIFF
--- a/types/through2/index.d.ts
+++ b/types/through2/index.d.ts
@@ -1,24 +1,22 @@
-// Type definitions for through2 v 2.0.0
+// Type definitions for through2 v 2.0
 // Project: https://github.com/rvagg/through2
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, jedmao <https://github.com/jedmao>, Georgios Valotasios <https://github.com/valotas>, Ben Chauvette <https://github.com/bdchauvette>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, jedmao <https://github.com/jedmao>, Georgios Valotasios <https://github.com/valotas>
+//                 Ben Chauvette < https://github.com/bdchauvette>, TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-
-
 import stream = require('stream');
 
 type TransformCallback = (err?: any, data?: any) => void;
-type TransformFunction = (chunk: any, enc: string, callback: TransformCallback) => void;
-type FlushCallback = (flushCallback: () => void) => void;
+type TransformFunction = (this: stream.Transform, chunk: any, enc: string, callback: TransformCallback) => void;
+type FlushCallback = (this: stream.Transform, flushCallback: () => void) => void;
 
 declare function through2(transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
-
 declare function through2(opts?: stream.DuplexOptions, transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
 
 declare namespace through2 {
-    export interface Through2Constructor extends stream.Transform {
+    interface Through2Constructor extends stream.Transform {
         new (opts?: stream.DuplexOptions): stream.Transform;
         (opts?: stream.DuplexOptions): stream.Transform;
     }
@@ -26,13 +24,14 @@ declare namespace through2 {
 	/**
 	 * Convenvience method for creating object streams
 	 */
-    export function obj(transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
+    function obj(transform?: TransformFunction, flush?: FlushCallback): stream.Transform;
 
 	/**
 	 * Creates a constructor for a custom Transform. This is useful when you
 	 * want to use the same transform logic in multiple instances.
 	 */
-    export function ctor(opts?: stream.DuplexOptions, transfrom?: TransformFunction, flush?: FlushCallback): Through2Constructor;
+    function ctor(transform?: TransformFunction, flush?: FlushCallback): Through2Constructor;
+    function ctor(opts?: stream.DuplexOptions, transform?: TransformFunction, flush?: FlushCallback): Through2Constructor;
 }
 
 export = through2;

--- a/types/through2/through2-tests.ts
+++ b/types/through2/through2-tests.ts
@@ -4,6 +4,8 @@ import through2 = require('through2');
 var rws: stream.Transform;
 var Rws: through2.Through2Constructor;
 
+rws = through2();
+
 rws = through2({
 	objectMode: true,
 	allowHalfOpen: true
@@ -21,6 +23,14 @@ rws = through2(function (entry: any, enc: string, callback: () => void) {
 
 });
 
+rws = through2(function (entry, enc, callback) {
+    var str: string = enc;
+    this.push(entry, str);
+    callback(null, 'continue');
+}, () => {
+
+});
+
 rws = through2(function (entry: any, enc: string, callback: (error: any, data?: any) => void) {
 	callback(null, 'foo');
 }, (flushCallback: () => void) => {
@@ -30,9 +40,9 @@ rws = through2(function (entry: any, enc: string, callback: (error: any, data?: 
 rws = through2(function (entry: any, enc: string, callback: () => void) {
 	this.push('foo');
 	callback();
+}, (flushCallback) => {
+    flushCallback();
 });
-
-rws = through2();
 
 // obj
 rws = through2.obj(function (entry: any, enc: string, callback: () => void) {
@@ -42,9 +52,10 @@ rws = through2.obj(function (entry: any, enc: string, callback: () => void) {
 
 });
 
-rws = through2.obj(function (entry: any, enc: string, callback: () => void) {
-	this.push('foo');
-	callback();
+rws = through2.obj(function (entry, enc, callback) {
+    var str: string = enc;
+	this.push('foo', enc);
+	callback(null, entry);
 });
 
 rws = through2.obj(function (entry: any, enc: string, callback: (err: any) => void) {
@@ -68,7 +79,7 @@ rws = Rws();
 rws = new Rws();
 rws = new Rws({ objectMode: true, allowHalfOpen: true });
 
-Rws = through2.ctor(function (entry: any, enc: string, callback: () => void) {
+Rws = through2.ctor(function (entry, enc, callback) {
 	this.push('foo');
 	callback();
 }, () => {
@@ -80,8 +91,9 @@ rws = new Rws();
 rws = new Rws({ objectMode: true, allowHalfOpen: true });
 
 Rws = through2.ctor(function (entry: any, enc: string, callback: (error: any, data?: any) => void) {
+    this.emit("data", "more data");
 	callback(null, 'foo');
-}, (flushCallback: () => void) => {
+}, (flushCallback) => {
 	flushCallback();
 });
 
@@ -93,7 +105,3 @@ Rws = through2.ctor(function (entry: any, enc: string, callback: () => void) {
 	this.push('foo');
 	callback();
 });
-
-rws = Rws();
-rws = new Rws();
-rws = new Rws({ objectMode: true, allowHalfOpen: true });

--- a/types/through2/tslint.json
+++ b/types/through2/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/through2/tslint.json
+++ b/types/through2/tslint.json
@@ -1,3 +1,0 @@
-{
-    "extends": "dtslint/dt.json"
-}


### PR DESCRIPTION
Updating through2, adding through2.ctor() overload to match package behavior, adding 'this' type to callbacks.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rvagg/through2
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
