### PR TITLE
Modified underscore _.pairs definition in chaining mode.

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5689,7 +5689,7 @@ declare module _ {
         * Wrapped type `object`.
         * @see _.pairs
         **/
-        pairs(): _Chain<T>;
+        pairs(): _Chain<T[]>;
 
         /**
         * Wrapped type `object`.

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -522,7 +522,7 @@ function chain_tests() {
         .value(); // { odd: [1], even: [0, 2] }
 
   var matrixOfString : string[][] = _.chain({'foo' : '1', 'bar': '1'})
-    .keys()    // return ['foo', 'bar'] : string[]
+  	.keys()    // return ['foo', 'bar'] : string[]
   	.pairs()   // return [['foo', '0'], ['bar', '1']] : string[][]
   	.value();
 }

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -520,6 +520,11 @@ function chain_tests() {
         .groupBy('property')
         .mapObject((objects: any) => _.pluck(objects, 'value'))
         .value(); // { odd: [1], even: [0, 2] }
+
+  var matrixOfString : string[][] = _.chain({'foo' : '1', 'bar': '1'})
+  			.keys() // return ['foo', 'bar'] : string[]
+  			.pairs() // return [['foo', '0'], ['bar', '1']] : string[][]
+  			.value();
 }
 
 var obj: { [k: string] : number } = {

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -522,9 +522,9 @@ function chain_tests() {
         .value(); // { odd: [1], even: [0, 2] }
 
   var matrixOfString : string[][] = _.chain({'foo' : '1', 'bar': '1'})
-  			.keys() // return ['foo', 'bar'] : string[]
-  			.pairs() // return [['foo', '0'], ['bar', '1']] : string[][]
-  			.value();
+    .keys()    // return ['foo', 'bar'] : string[]
+  	.pairs()   // return [['foo', '0'], ['bar', '1']] : string[][]
+  	.value();
 }
 
 var obj: { [k: string] : number } = {


### PR DESCRIPTION
In the same way that `_.pairs` in non-chaining mode returns a list of key value pair (a matrix), it should have the same definition in `chaining` mode.

Current definition in non chaining mode : 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/underscore/index.d.ts#L4732