### PR TITLE
Add type definitions for graphql-type-json package

### DIFF
--- a/types/graphql-type-json/graphql-type-json-tests.ts
+++ b/types/graphql-type-json/graphql-type-json-tests.ts
@@ -1,0 +1,20 @@
+import {GraphQLObjectType, GraphQLInputObjectType} from "graphql";
+import * as GraphQLJSON from "graphql-type-json";
+
+const TestType = new GraphQLObjectType({
+    name: "TestType",
+    fields: {
+        test: {
+            type: GraphQLJSON
+        }
+    }
+});
+
+const TestInputType = new GraphQLInputObjectType({
+    name: "TestInputType",
+    fields: {
+        test: {
+            type: GraphQLJSON
+        }
+    }
+});

--- a/types/graphql-type-json/index.d.ts
+++ b/types/graphql-type-json/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for graphql-type-json 0.1
+// Project: https://github.com/taion/graphql-type-json#readme
+// Definitions by: Pavel Ivanov <https://github.com/schfkt>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import {GraphQLScalarType} from "graphql";
+
+declare const GraphQLJSON: GraphQLScalarType;
+export = GraphQLJSON;

--- a/types/graphql-type-json/tsconfig.json
+++ b/types/graphql-type-json/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "graphql-type-json-tests.ts"
+    ]
+}

--- a/types/graphql-type-json/tslint.json
+++ b/types/graphql-type-json/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
