### PR TITLE
the return of topojson.feature() contains the `type:string` field

### DIFF
--- a/types/topojson/index.d.ts
+++ b/types/topojson/index.d.ts
@@ -5,7 +5,7 @@
 
 export function bbox(topology: any): any;
 
-export function feature(topology: any, o: any): { features: any[]; };
+export function feature(topology: any, o: any): { features: any[]; type: string };
 
 export function filter(topology: any, filter: any): any;
 

--- a/types/topojson/index.d.ts
+++ b/types/topojson/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for topojson 3.0
 // Project: https://github.com/topojson/topojson
 // Definitions by: Ricardo Mello <https://github.com/ricardo-mello>
+//                 Zhutian Chen  <https://github.com/chenzhutian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export function bbox(topology: any): any;

--- a/types/topojson/topojson-tests.ts
+++ b/types/topojson/topojson-tests.ts
@@ -2,5 +2,5 @@ import * as topojson from 'topojson';
 
 // TODO: complete tests.
 
-topojson.feature(null, null); // $ExpectType { features: any[]; }
+topojson.feature(null, null); // $ExpectType { features: any[]; type: string; }
 topojson.mesh(null, null, (a: any, b: any) => a !== b); // $ExpectType { type: any; coordinates: any[]; }


### PR DESCRIPTION
According to https://github.com/topojson/topojson-client/blob/master/src/feature.js, the return of topojson.feature() contains the `type:string` field.
Otherwise, typescript will raise an error when using the result of `topojson.feature`  in d3-geo(https://github.com/d3/d3-geo).