### PR TITLE
[node] pause() and resume() return `this`

### DIFF
--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -281,8 +281,8 @@ declare namespace NodeJS {
         readable: boolean;
         read(size?: number): string | Buffer;
         setEncoding(encoding: string | null): void;
-        pause(): ReadableStream;
-        resume(): ReadableStream;
+        pause(): this;
+        resume(): this;
         isPaused(): boolean;
         pipe<T extends WritableStream>(destination: T, options?: { end?: boolean; }): T;
         unpipe<T extends WritableStream>(destination?: T): void;
@@ -301,10 +301,7 @@ declare namespace NodeJS {
         end(str: string, encoding?: string, cb?: Function): void;
     }
 
-    export interface ReadWriteStream extends ReadableStream, WritableStream {
-        pause(): ReadWriteStream;
-        resume(): ReadWriteStream;
-    }
+    export interface ReadWriteStream extends ReadableStream, WritableStream {}
 
     export interface Events extends EventEmitter { }
 
@@ -1431,8 +1428,8 @@ declare module "readline" {
         setPrompt(prompt: string): void;
         prompt(preserveCursor?: boolean): void;
         question(query: string, callback: (answer: string) => void): void;
-        pause(): ReadLine;
-        resume(): ReadLine;
+        pause(): this;
+        resume(): this;
         close(): void;
         write(data: string | Buffer, key?: Key): void;
 
@@ -1939,8 +1936,6 @@ declare module "net" {
         setEncoding(encoding?: string): void;
         write(data: any, encoding?: string, callback?: Function): void;
         destroy(): void;
-        pause(): Socket;
-        resume(): Socket;
         setTimeout(timeout: number, callback?: Function): void;
         setNoDelay(noDelay?: boolean): void;
         setKeepAlive(enable?: boolean, initialDelay?: number): void;
@@ -3432,8 +3427,8 @@ declare module "stream" {
             _read(size: number): void;
             read(size?: number): any;
             setEncoding(encoding: string): void;
-            pause(): Readable;
-            resume(): Readable;
+            pause(): this;
+            resume(): this;
             isPaused(): boolean;
             pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
             unpipe<T extends NodeJS.WritableStream>(destination?: T): void;

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -542,6 +542,32 @@ function simplified_stream_ctor_test() {
     })
 }
 
+// Subclassing stream classes
+{
+    class SubclassedReadable extends stream.Readable {};
+
+    let subclassedReadable: SubclassedReadable = new SubclassedReadable();
+    subclassedReadable = subclassedReadable.pause();
+    subclassedReadable = subclassedReadable.resume();
+
+    class SubclassedTransform extends stream.Transform {};
+
+    let subclassedTransform: SubclassedTransform = new SubclassedTransform();
+    subclassedTransform = subclassedTransform.pause();
+    subclassedTransform = subclassedTransform.resume();
+
+    class SubclassedDuplex extends stream.Duplex {};
+
+    let subclassedDuplex: SubclassedDuplex = new SubclassedDuplex();
+    subclassedDuplex = subclassedDuplex.pause();
+    subclassedDuplex = subclassedDuplex.resume();
+
+    // assignability
+    let readable: stream.Readable = subclassedDuplex;
+    readable = subclassedTransform;
+    let duplex: stream.Duplex = subclassedTransform;
+}
+
 ////////////////////////////////////////////////////////
 /// Crypto tests : http://nodejs.org/api/crypto.html ///
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
Readable streams and streamlike interfaces in node have pause() and resume() methods. They're defined to return `this` in the documentation: https://nodejs.org/api/stream.html#stream_readable_pause https://nodejs.org/api/stream.html#stream_readable_resume

This is relevant when someone extends a stream, as the pause and resume methods on a subtype should return the subtype, not the super type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_readable_pause
- [x] Increase the version number in the header if appropriate. (not appropriate)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.
