### PR TITLE
xlsx: Improve properties of IWorkSheet; add ExcelDataType; linting

### DIFF
--- a/types/xlsx/index.d.ts
+++ b/types/xlsx/index.d.ts
@@ -4,21 +4,21 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** Attempts to read filename and parse */
-export declare function readFile(filename: string, opts?: IParsingOptions): IWorkBook;
+export function readFile(filename: string, opts?: IParsingOptions): IWorkBook;
 /** Attempts to parse data */
-export declare function read(data: any, opts?: IParsingOptions): IWorkBook;
+export function read(data: any, opts?: IParsingOptions): IWorkBook;
 /** Attempts to write workbook data to filename */
-export declare function writeFile(data: IWorkBook, filename: string, opts?: IWritingOptions): any;
+export function writeFile(data: IWorkBook, filename: string, opts?: IWritingOptions): any;
 /** Attempts to write the workbook data */
-export declare function write(data: IWorkBook, opts?: IWritingOptions): any;
+export function write(data: IWorkBook, opts?: IWritingOptions): any;
 
-export declare var utils: IUtils;
+export const utils: IUtils;
 
 export interface IProperties {
-    LastAuthor?: string
+    LastAuthor?: string;
     Author?: string;
     CreatedDate?: Date;
-    ModifiedDate?: Date
+    ModifiedDate?: Date;
     Application?: string;
     AppVersion?: string;
     Company?: string;

--- a/types/xlsx/index.d.ts
+++ b/types/xlsx/index.d.ts
@@ -309,9 +309,9 @@ export interface IWorkSheet extends ISheet {
 }
 
 /**
-* The Excel data type for a cell.
-* b Boolean, n Number, e error, s String, d Date
-*/
+ * The Excel data type for a cell.
+ * b Boolean, n Number, e error, s String, d Date
+ */
 export type ExcelDataType = 'b' | 'n' | 'e' | 's' | 'd';
 
 export interface IWorkSheetCell {
@@ -326,9 +326,9 @@ export interface IWorkSheetCell {
     w?: string;
 
     /**
-    * The Excel Data Type of the cell.
-    * b Boolean, n Number, e error, s String, d Date
-    */
+     * The Excel Data Type of the cell.
+     * b Boolean, n Number, e error, s String, d Date
+     */
     t: ExcelDataType;
 
     /**
@@ -388,18 +388,18 @@ export interface IRange {
 
 export interface IUtils {
     /** converts an array of arrays of JS data to a worksheet. */
-    aoa_to_sheet<T>(data: T[], opts?:any): IWorkSheet;
+    aoa_to_sheet<T>(data: T[], opts?: any): IWorkSheet;
 
     /** Converts a worksheet object to an array of JSON objects */
-    sheet_to_json<T>(worksheet:IWorkSheet, opts?: {
+    sheet_to_json<T>(worksheet: IWorkSheet, opts?: {
         raw?: boolean;
         range?: any;
         header?: "A"|number|string[];
-    }):T[];
+    }): T[];
     /** Generates delimiter-separated-values output */
     sheet_to_csv(worksheet: IWorkSheet, options?: { FS: string, RS: string }): string;
     /** Generates a list of the formulae (with value fallbacks) */
-    sheet_to_formulae(worksheet: IWorkSheet):any;
+    sheet_to_formulae(worksheet: IWorkSheet): any;
 
     /** Converts 0-indexed cell address to A1 form */
     encode_cell(cell: ICell): string;

--- a/types/xlsx/index.d.ts
+++ b/types/xlsx/index.d.ts
@@ -300,8 +300,8 @@ export interface IProtectInfo {
  * object representing any sheet (worksheet or chartsheet)
  */
 export interface ISheet {
-    ['!ref']?: string;
-    ['!margins']?: {
+    '!ref'?: string;
+    '!margins'?: {
         left: number,
         right: number,
         top: number,
@@ -316,11 +316,11 @@ export interface ISheet {
  */
 export interface IWorkSheet extends ISheet {
     [cell: string]: IWorkSheetCell | any;
-    ['!cols']?: IColInfo[];
-    ['!rows']?: IRowInfo[];
-    ['!merges']?: IRange[];
-    ['!protect']?: IProtectInfo;
-    ['!autofilter']?: {ref: string};
+    '!cols'?: IColInfo[];
+    '!rows'?: IRowInfo[];
+    '!merges'?: IRange[];
+    '!protect'?: IProtectInfo;
+    '!autofilter'?: {ref: string};
 }
 
 /**

--- a/types/xlsx/index.d.ts
+++ b/types/xlsx/index.d.ts
@@ -308,6 +308,12 @@ export interface IWorkSheet extends ISheet {
     ['!autofilter']?: {ref: string};
 }
 
+/**
+* The Excel data type for a cell.
+* b Boolean, n Number, e error, s String, d Date
+*/
+export type ExcelDataType = 'b' | 'n' | 'e' | 's' | 'd';
+
 export interface IWorkSheetCell {
     /**
      * The raw value of the cell.
@@ -323,7 +329,7 @@ export interface IWorkSheetCell {
     * The Excel Data Type of the cell.
     * b Boolean, n Number, e error, s String, d Date
     */
-    t: 'b' | 'n' | 'e' | 's' | 'd';
+    t: ExcelDataType;
 
     /**
      * Cell formula (if applicable)

--- a/types/xlsx/index.d.ts
+++ b/types/xlsx/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for xlsx
 // Project: https://github.com/SheetJS/js-xlsx
-// Definitions by: themauveavenger <https://github.com/themauveavenger/>
+// Definitions by: themauveavenger <https://github.com/themauveavenger/>, Wolfgang Faust <https://github.com/wolfgang42>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** Attempts to read filename and parse */
@@ -173,11 +173,139 @@ export interface IWorkBook {
     Props: IProperties;
 }
 
+export interface IColInfo {
+    /**
+     * Excel's "Max Digit Width" unit, always integral
+     */
+    MDW?: number;
+    /**
+     * width in Excel's "Max Digit Width", width*256 is integral
+     */
+    width: number;
+    /**
+     * width in screen pixels
+     */
+    wpx?: number;
+    /**
+     * intermediate character calculation
+     */
+    wch?: number;
+    /**
+     * if true, the column is hidden
+     */
+    hidden?: boolean;
+}
+export interface IRowInfo {
+    /**
+     * height in screen pixels
+     */
+    hpx?: number;
+    /**
+     * height in points
+     */
+    hpt?: number;
+    /**
+     * if true, the column is hidden
+     */
+    hidden?: boolean;
+}
+
+/**
+ * Write sheet protection properties.
+ */
+export interface IProtectInfo {
+    /**
+     * The password for formats that support password-protected sheets
+     * (XLSX/XLSB/XLS). The writer uses the XOR obfuscation method.
+     */
+    password?: string;
+    /**
+     * Select locked cells (default: enabled)
+     */
+    selectLockedCells?: boolean;
+    /**
+     * Select unlocked cells (default: enabled)
+     */
+    selectUnlockedCells?: boolean;
+    /**
+     * Format cells (default: disabled)
+     */
+    formatCells?: boolean;
+    /**
+     * Format columns (default: disabled)
+     */
+    formatColumns?: boolean;
+    /**
+     * Format rows (default: disabled)
+     */
+    formatRows?: boolean;
+    /**
+     * Insert columns (default: disabled)
+     */
+    insertColumns?: boolean;
+    /**
+     * Insert rows (default: disabled)
+     */
+    insertRows?: boolean;
+    /**
+     * Insert hyperlinks (default: disabled)
+     */
+    insertHyperlinks?: boolean;
+    /**
+     * Delete columns (default: disabled)
+     */
+    deleteColumns?: boolean;
+    /**
+     * Delete rows (default: disabled)
+     */
+    deleteRows?: boolean;
+    /**
+     * Sort (default: disabled)
+     */
+    sort?: boolean;
+    /**
+     * Filter (default: disabled)
+     */
+    autoFilter?: boolean;
+    /**
+     * Use PivotTable reports (default: disabled)
+     */
+    pivotTables?: boolean;
+    /**
+     * Edit objects (default: enabled)
+     */
+    objects?: boolean;
+    /**
+     * Edit scenarios (default: enabled)
+     */
+    scenarios?: boolean;
+}
+
+/**
+ * object representing any sheet (worksheet or chartsheet)
+ */
+export interface ISheet {
+    ['!ref']?: string;
+    ['!margins']?: {
+        left: number,
+        right: number,
+        top: number,
+        bottom: number,
+        header: number,
+        footer: number,
+    };
+}
+
 /**
  * object representing the worksheet
  */
-export interface IWorkSheet {
+export interface IWorkSheet extends ISheet {
     [cell: string]: IWorkSheetCell | any;
+    ['!cols']?: IColInfo[];
+    ['!rows']?: IRowInfo[];
+    ['!merges']?: IRange[];
+    ['!protect']?: IProtectInfo;
+    ['!autofilter']?: {ref: string};
 }
 
 export interface IWorkSheetCell {

--- a/types/xlsx/index.d.ts
+++ b/types/xlsx/index.d.ts
@@ -220,63 +220,78 @@ export interface IProtectInfo {
      */
     password?: string;
     /**
-     * Select locked cells (default: enabled)
+     * Select locked cells
+     * @default: true
      */
     selectLockedCells?: boolean;
     /**
-     * Select unlocked cells (default: enabled)
+     * Select unlocked cells
+     * @default: true
      */
     selectUnlockedCells?: boolean;
     /**
-     * Format cells (default: disabled)
+     * Format cells
+     * @default: false
      */
     formatCells?: boolean;
     /**
-     * Format columns (default: disabled)
+     * Format columns
+     * @default: false
      */
     formatColumns?: boolean;
     /**
-     * Format rows (default: disabled)
+     * Format rows
+     * @default: false
      */
     formatRows?: boolean;
     /**
-     * Insert columns (default: disabled)
+     * Insert columns
+     * @default: false
      */
     insertColumns?: boolean;
     /**
-     * Insert rows (default: disabled)
+     * Insert rows
+     * @default: false
      */
     insertRows?: boolean;
     /**
-     * Insert hyperlinks (default: disabled)
+     * Insert hyperlinks
+     * @default: false
      */
     insertHyperlinks?: boolean;
     /**
-     * Delete columns (default: disabled)
+     * Delete columns
+     * @default: false
      */
     deleteColumns?: boolean;
     /**
-     * Delete rows (default: disabled)
+     * Delete rows
+     * @default: false
      */
     deleteRows?: boolean;
     /**
-     * Sort (default: disabled)
+     * Sort
+     * @default: false
      */
     sort?: boolean;
     /**
-     * Filter (default: disabled)
+     * Filter
+     * @default: false
      */
     autoFilter?: boolean;
     /**
-     * Use PivotTable reports (default: disabled)
+     * Use PivotTable reports
+     * @default: false
      */
     pivotTables?: boolean;
     /**
-     * Edit objects (default: enabled)
+     * Edit objects
+     * @default: true
      */
     objects?: boolean;
     /**
-     * Edit scenarios (default: enabled)
+     * Edit scenarios
+     * @default: true
      */
     scenarios?: boolean;
 }

--- a/types/xlsx/tslint.json
+++ b/types/xlsx/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/xlsx/tslint.json
+++ b/types/xlsx/tslint.json
@@ -1,1 +1,6 @@
-{ "extends": "dtslint/dt.json" }
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "interface-name": [true, "always-prefix"]
+    }
+}

--- a/types/xlsx/xlsx-tests.ts
+++ b/types/xlsx/xlsx-tests.ts
@@ -1,8 +1,7 @@
-
 import xlsx = require('xlsx');
 
-var options:xlsx.IParsingOptions = {
-    cellDates:true
+var options: xlsx.IParsingOptions = {
+    cellDates: true
 };
 
 var workbook = xlsx.readFile('test.xlsx', options);
@@ -10,17 +9,17 @@ var otherworkbook = xlsx.readFile('test.xlsx', {type: 'file'});
 
 console.log(workbook.Props.Author);
 
-var firstsheet:string = workbook.SheetNames[0];
+var firstsheet: string = workbook.SheetNames[0];
 
 var firstworksheet = workbook.Sheets[firstsheet];
 
 console.log(firstworksheet["A1"]);
 
 interface tester {
-    name:string;
+    name: string;
     age: number;
 }
 
-var jsonvalues:tester[] = xlsx.utils.sheet_to_json<tester>(firstworksheet);
+var jsonvalues: tester[] = xlsx.utils.sheet_to_json<tester>(firstworksheet);
 var csv = xlsx.utils.sheet_to_csv(firstworksheet);
 var formulae = xlsx.utils.sheet_to_formulae(firstworksheet);

--- a/types/xlsx/xlsx-tests.ts
+++ b/types/xlsx/xlsx-tests.ts
@@ -15,11 +15,11 @@ const firstworksheet = workbook.Sheets[firstsheet];
 
 console.log(firstworksheet["A1"]);
 
-interface tester {
+interface ITester {
     name: string;
     age: number;
 }
 
-const jsonvalues: tester[] = xlsx.utils.sheet_to_json<tester>(firstworksheet);
+const jsonvalues: ITester[] = xlsx.utils.sheet_to_json<ITester>(firstworksheet);
 const csv = xlsx.utils.sheet_to_csv(firstworksheet);
 const formulae = xlsx.utils.sheet_to_formulae(firstworksheet);

--- a/types/xlsx/xlsx-tests.ts
+++ b/types/xlsx/xlsx-tests.ts
@@ -1,17 +1,17 @@
 import xlsx = require('xlsx');
 
-var options: xlsx.IParsingOptions = {
+const options: xlsx.IParsingOptions = {
     cellDates: true
 };
 
-var workbook = xlsx.readFile('test.xlsx', options);
-var otherworkbook = xlsx.readFile('test.xlsx', {type: 'file'});
+const workbook = xlsx.readFile('test.xlsx', options);
+const otherworkbook = xlsx.readFile('test.xlsx', {type: 'file'});
 
 console.log(workbook.Props.Author);
 
-var firstsheet: string = workbook.SheetNames[0];
+const firstsheet: string = workbook.SheetNames[0];
 
-var firstworksheet = workbook.Sheets[firstsheet];
+const firstworksheet = workbook.Sheets[firstsheet];
 
 console.log(firstworksheet["A1"]);
 
@@ -20,6 +20,6 @@ interface tester {
     age: number;
 }
 
-var jsonvalues: tester[] = xlsx.utils.sheet_to_json<tester>(firstworksheet);
-var csv = xlsx.utils.sheet_to_csv(firstworksheet);
-var formulae = xlsx.utils.sheet_to_formulae(firstworksheet);
+const jsonvalues: tester[] = xlsx.utils.sheet_to_json<tester>(firstworksheet);
+const csv = xlsx.utils.sheet_to_csv(firstworksheet);
+const formulae = xlsx.utils.sheet_to_formulae(firstworksheet);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://sheetjs.gitbooks.io/docs/#sheet-objects
- [ ] Increase the version number in the header if appropriate. *(See 'Linting' below for details)*
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

## Improve properties of `IWorkSheet`
This follows on the discussion in #15129 between @DMan577, @DxCx, and @paulvanbrenk. Most of the properties of a worksheet are cells, but there are some special properties like `!ref` and `!margins` which have different formats. I have declared these as properties of the interface, but I had to leave `[cell: string]` itself as an <code>IWorkSheetCell <strong>| any</strong></code> to prevent type conflicts (since the other properties aren't worksheet cells). I raised the question of how to do this on Stack Overflow and someone suggested [declaring IWorkSheet as a union type](http://stackoverflow.com/questions/43943360/how-do-i-override-the-value-type-for-specific-keys-of-an-object#43943519); this achieves the desired result of making most of the values a union type but would break compatibility for anyone using IWorkSheet so I didn't do it.

## Add ExcelDataType
Instead of declaring `IWorkSheetCell.t`'s type directly, I abstracted it into a new ExcelDataType type. This allows improved typing of usages like the following:
```typescript
function makeCell(v):XLSX.IWorkSheetCell {
    let t:XLSX.ExcelDataType = 's'
    if (typeof v === 'number') {
        t = 'n'
    }
    return {t, v}
}
```

## Linting
While I was at it, I added a `tslint.json` and fixed some were some minor errors like missing whitespace and semicolons. The default dtslint rules disallow prefixing interfaces with `I`. Since the existing typings all do this I overrode the rule rather than changing the names and breaking compatibility.

There are three remaining linter failures in `index.d.ts`:
```
ERROR: 367:9  ban-types  Don't use 'Object' as a type. Avoid using the `Object` type. Did you mean `object`?
ERROR: 372:9  ban-types  Don't use 'Object' as a type. Avoid using the `Object` type. Did you mean `object`?
```
I *think* this is trying to tell me to use `object` instead of `Object`, but when I try that I just get `TypeScript compile error: Cannot find name 'object'.` instead. Since this is working I decided to let well enough alone.
```
ERROR: 1:25   dt-header  Error parsing header. Expected: foo MAJOR.MINOR (Needs MAJOR.MINOR)
```
I'm not clear on which versions of `xlsx` these rules cover, so I refrained from adding a version number.
