### PR TITLE
[algoliasearch] Updated nbPages parameters 

### DIFF
--- a/types/algoliasearch/algoliasearch-tests.ts
+++ b/types/algoliasearch/algoliasearch-tests.ts
@@ -1,19 +1,19 @@
-import algoliasearch = require('algoliasearch');
+import * as algoliasearch from "algoliasearch";
 import { ClientOptions, SynonymOption, AlgoliaUserKeyOptions, SearchSynonymOptions,
     AlgoliaSecuredApiOptions, AlgoliaIndexSettings, AlgoliaQueryParameters, AlgoliaIndex } from "algoliasearch";
 
-var _clientOptions: ClientOptions = {
-    timeout : 12,
+let _clientOptions: ClientOptions = {
+    timeout: 12,
     protocol: "",
     httpAgent: ""
 };
 
-var _synonymOption: SynonymOption = {
+let _synonymOption: SynonymOption = {
     forwardToSlaves: false,
     replaceExistingSynonyms: false
 };
 
-var _algoliaUserKeyOptions : AlgoliaUserKeyOptions = {
+let _algoliaUserKeyOptions: AlgoliaUserKeyOptions = {
     validity: 0,
     maxQueriesPerIPPerHour: 0,
     indexes: [""],
@@ -21,21 +21,21 @@ var _algoliaUserKeyOptions : AlgoliaUserKeyOptions = {
     description: ""
 };
 
-var _searchSynonymOptions : SearchSynonymOptions = {
+let _searchSynonymOptions: SearchSynonymOptions = {
     query: "",
     page: 0,
     type: "",
     hitsPerPage: 0
 };
 
-var _algoliaSecuredApiOptions: AlgoliaSecuredApiOptions = {
+let _algoliaSecuredApiOptions: AlgoliaSecuredApiOptions = {
     filters: "",
     validUntil: 0,
     restrictIndices: "",
     userToken: ""
 };
 
-var _algoliaIndexSettings : AlgoliaIndexSettings = {
+let _algoliaIndexSettings: AlgoliaIndexSettings = {
     attributesToIndex: [""],
     attributesforFaceting: [""],
     unretrievableAttributes: [""],
@@ -43,12 +43,12 @@ var _algoliaIndexSettings : AlgoliaIndexSettings = {
     ranking: [""],
     customRanking: [""],
     slaves: [""],
-    maxValuesPerFacet: '',
+    maxValuesPerFacet: "",
     attributesToHighlight: [""],
     attributesToSnippet: [""],
-    highlightPreTag: '',
-    highlightPostTag: '',
-    snippetEllipsisText: '',
+    highlightPreTag: "",
+    highlightPostTag: "",
+    snippetEllipsisText: "",
     restrictHighlightAndSnippetArrays: false,
     hitsPerPage: 0,
     minWordSizefor1Typo: 0,
@@ -56,16 +56,16 @@ var _algoliaIndexSettings : AlgoliaIndexSettings = {
     typoTolerance: false,
     allowTyposOnNumericTokens: false,
     ignorePlurals: false,
-    disableTypoToleranceOnAttributes: '',
-    separatorsToIndex: '',
-    queryType: '',
-    removeWordsIfNoResults: '',
+    disableTypoToleranceOnAttributes: "",
+    separatorsToIndex: "",
+    queryType: "",
+    removeWordsIfNoResults: "",
     advancedSyntax: false,
     optionalWords: [""],
     removeStopWords: [""],
     disablePrefixOnAttributes: [""],
     disableExactOnAttributes: [""],
-    exactOnSingleWordQuery: '',
+    exactOnSingleWordQuery: "",
     alternativesAsExact: false,
     attributeForDistinct: "",
     distinct: false,
@@ -73,21 +73,21 @@ var _algoliaIndexSettings : AlgoliaIndexSettings = {
     allowCompressionOfIntegerArray: false,
     altCorrections: [{}],
     minProximity: 0,
-    placeholders: ''
+    placeholders: ""
 };
 
-var _algoliaQueryParameters : AlgoliaQueryParameters = {
-    query: '',
-    filters: '',
+let _algoliaQueryParameters: AlgoliaQueryParameters = {
+    query: "",
+    filters: "",
     attributesToRetrieve: [""],
     restrictSearchableAttributes: [""],
-    facets: '',
-    maxValuesPerFacet: '',
-    attributesToHighlight: [''],
-    attributesToSnippet: [''],
-    highlightPreTag: '',
-    highlightPostTag: '',
-    snippetEllipsisText: '',
+    facets: "",
+    maxValuesPerFacet: "",
+    attributesToHighlight: [""],
+    attributesToSnippet: [""],
+    highlightPreTag: "",
+    highlightPostTag: "",
+    snippetEllipsisText: "",
     restrictHighlightAndSnippetArrays: false,
     hitsPerPage: 0,
     page: 0,
@@ -98,38 +98,36 @@ var _algoliaQueryParameters : AlgoliaQueryParameters = {
     typoTolerance: false,
     allowTyposOnNumericTokens: false,
     ignorePlurals: false,
-    disableTypoToleranceOnAttributes: '',
-    aroundLatLng: '',
-    aroundLatLngViaIP: '',
-    aroundRadius: '',
+    disableTypoToleranceOnAttributes: "",
+    aroundLatLng: "",
+    aroundLatLngViaIP: "",
+    aroundRadius: "",
     aroundPrecision: 0,
     minimumAroundRadius: 0,
-    insideBoundingBox: '',
-    queryType: '',
-    insidePolygon: '',
-    removeWordsIfNoResults: '',
+    insideBoundingBox: "",
+    queryType: "",
+    insidePolygon: "",
+    removeWordsIfNoResults: "",
     advancedSyntax: false,
-    optionalWords: [''],
-    removeStopWords: [''],
-    disableExactOnAttributes: [''],
-    exactOnSingleWordQuery: '',
+    optionalWords: [""],
+    removeStopWords: [""],
+    disableExactOnAttributes: [""],
+    exactOnSingleWordQuery: "",
     alternativesAsExact: true,
     distinct: 0,
     getRankingInfo: false,
-    numericAttributesToIndex: [''],
-    numericFilters: [''],
-    tagFilters: '',
-    facetFilters: '',
+    numericAttributesToIndex: [""],
+    numericFilters: [""],
+    tagFilters: "",
+    facetFilters: "",
     analytics: false,
-    analyticsTags: [''],
+    analyticsTags: [""],
     synonyms: true,
     replaceSynonymsInHighlight: false,
     minProximity: 0
 };
 
-var index: AlgoliaIndex = algoliasearch('', '').initIndex('');
+let index: AlgoliaIndex = algoliasearch("", "").initIndex("");
 
-var search = index.search({query: ""});
-index.search({query: ""}, function(err, res){});
-
-
+let search = index.search({query: ""});
+             index.search({query: ""}, (err, res) => {});

--- a/types/algoliasearch/algoliasearch-tests.ts
+++ b/types/algoliasearch/algoliasearch-tests.ts
@@ -1,16 +1,27 @@
 import * as algoliasearch from "algoliasearch";
-import { ClientOptions, SynonymOption, AlgoliaUserKeyOptions, SearchSynonymOptions,
+import { ClientOptions, SynonymOption, AlgoliaUserKeyOptions, SearchSynonymOptions, AlgoliaResponse,
     AlgoliaSecuredApiOptions, AlgoliaIndexSettings, AlgoliaQueryParameters, AlgoliaIndex } from "algoliasearch";
+
+let _algoliaResponse: AlgoliaResponse = {
+    hits: [{}, {}],
+    page: 0,
+    nbHits: 12,
+    nbPages: 6,
+    hitsPerPage: 2,
+    processingTimeMS: 32,
+    query: "",
+    params: "",
+};
 
 let _clientOptions: ClientOptions = {
     timeout: 12,
     protocol: "",
-    httpAgent: ""
+    httpAgent: "",
 };
 
 let _synonymOption: SynonymOption = {
     forwardToSlaves: false,
-    replaceExistingSynonyms: false
+    replaceExistingSynonyms: false,
 };
 
 let _algoliaUserKeyOptions: AlgoliaUserKeyOptions = {
@@ -18,21 +29,21 @@ let _algoliaUserKeyOptions: AlgoliaUserKeyOptions = {
     maxQueriesPerIPPerHour: 0,
     indexes: [""],
     queryParameters: { attributesToRetrieve: ["algolia"] },
-    description: ""
+    description: "",
 };
 
 let _searchSynonymOptions: SearchSynonymOptions = {
     query: "",
     page: 0,
     type: "",
-    hitsPerPage: 0
+    hitsPerPage: 0,
 };
 
 let _algoliaSecuredApiOptions: AlgoliaSecuredApiOptions = {
     filters: "",
     validUntil: 0,
     restrictIndices: "",
-    userToken: ""
+    userToken: "",
 };
 
 let _algoliaIndexSettings: AlgoliaIndexSettings = {
@@ -73,7 +84,7 @@ let _algoliaIndexSettings: AlgoliaIndexSettings = {
     allowCompressionOfIntegerArray: false,
     altCorrections: [{}],
     minProximity: 0,
-    placeholders: ""
+    placeholders: "",
 };
 
 let _algoliaQueryParameters: AlgoliaQueryParameters = {
@@ -124,7 +135,7 @@ let _algoliaQueryParameters: AlgoliaQueryParameters = {
     analyticsTags: [""],
     synonyms: true,
     replaceSynonymsInHighlight: false,
-    minProximity: 0
+    minProximity: 0,
 };
 
 let index: AlgoliaIndex = algoliasearch("", "").initIndex("");

--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -24,7 +24,7 @@ declare namespace algoliasearch {
          * Number of pages
          * https://github.com/algolia/algoliasearch-client-js#response-format
          */
-        nbPage: number;
+        nbPages: number;
         /**
          * Number of hits per pages
          * https://github.com/algolia/algoliasearch-client-js#response-format
@@ -407,7 +407,7 @@ declare namespace algoliasearch {
          * @param cb(err, res)
          * https://github.com/algolia/algoliasearch-client-js#save-synonym---savesynonym
          */
-        saveSynonym(synonym: AlgoliaSynonym, option: SynonymOption, cb: (err: Error, res: any) => void): void;
+        saveSynonym(synonym: AlgoliaSynonym, options: SynonymOption, cb: (err: Error, res: any) => void): void;
         /**
          * Save a synonym object
          * @param synonyms
@@ -659,7 +659,7 @@ declare namespace algoliasearch {
          * return {Promise}
          * https://github.com/algolia/algoliasearch-client-js#save-synonym---savesynonym
          */
-        saveSynonym(synonym: AlgoliaSynonym, option: SynonymOption): Promise<any> ;
+        saveSynonym(synonym: AlgoliaSynonym, options: SynonymOption): Promise<any> ;
         /**
          * Save a synonym object
          * @param synonyms


### PR DESCRIPTION
When using the algoliasearch typing  the returned request from Algolia's api returns `nbPages` not `nbPage` as defined in the typing. Also converted the test file to ES6 and changed the `option` param to `options` for continuity in the typing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://www.algolia.com/doc/api-client/javascript/search/#fields>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.