### PR TITLE
Fix express request.range function's return type

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Express 4.x
 // Project: http://expressjs.com
-// Definitions by: Boris Yankov <https://github.com/borisyankov/>
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Michał Lytek <https://github.com/19majkel94>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // This extracts the core definitions from express to prevent a circular dependency between express and serve-static
 /// <reference types="node" />
@@ -168,6 +168,10 @@ interface CookieOptions {
     sameSite?: boolean | string;
 }
 
+interface ByteRange { start: number; end: number; }
+
+interface RequestRanges extends Array<ByteRange> { type: string; }
+
 interface Errback { (err: Error): void; }
 
 interface Request extends http.IncomingMessage, Express.Request {
@@ -298,7 +302,7 @@ interface Request extends http.IncomingMessage, Express.Request {
         *
         * @param size
         */
-    range(size: number): any[];
+    range(size: number): RequestRanges|null|-1|-2;
 
     /**
         * Return an array of Accepted media types


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/api.html#req.range
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.