### PR TITLE
[react-native] global namespace

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -18,6 +18,8 @@
 
 /// <reference types="react" />
 
+export as namespace ReactNative;
+
 export type MeasureOnSuccessCallback = (
         x: number,
         y: number,


### PR DESCRIPTION
It needs to be exported in a namespace to be used in other definitions without import.

ITopKekProps {
style?: ReactNative.ViewStyle,
}

For some reason, imports in definition files break dependencies in my project.