### PR TITLE
Fix wrong signature for Kue testMode.enter().

### DIFF
--- a/types/kue/index.d.ts
+++ b/types/kue/index.d.ts
@@ -133,7 +133,7 @@ interface Redis {
 
 interface TestMode {
     jobs: Job[];
-    enter(): void;
+    enter(process?: Boolean): void;
     exit(): void;
     clear(): void;
 }

--- a/types/kue/kue-tests.ts
+++ b/types/kue/kue-tests.ts
@@ -4,6 +4,18 @@ import kue = require('kue');
 
 var jobs = kue.createQueue();
 
+// do quick test with testmode enabled
+
+// testMode enabled where the jobs are not processed
+jobs.testMode.enter();
+jobs.testMode.clear();
+jobs.testMode.exit();
+
+// testMode enabled where the jobs are processed
+jobs.testMode.enter(true);
+jobs.testMode.clear();
+jobs.testMode.exit();
+
 // start redis with $ redis-server
 
 // create some jobs at random,


### PR DESCRIPTION
The function look like this
module.exports.enter = function(process) {
  processQueue         = process || false;
  Job.prototype.save   = testJobSave;
  Job.prototype.update = testJobUpdate;
};

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Automattic/kue/blob/master/lib/queue/test_mode.js#L41
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

