### PR TITLE
Expose classname members inside the module only

### DIFF
--- a/types/classnames/index.d.ts
+++ b/types/classnames/index.d.ts
@@ -3,20 +3,19 @@
 // Definitions by: Dave Keen <http://www.keendevelopment.ch>, Adi Dahiya <https://github.com/adidahiya>, Jason Killian <https://github.com/JKillian>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
-
-interface ClassDictionary {
-	[id: string]: boolean | undefined | null;
-}
-
-interface ClassArray extends Array<ClassValue> { }
-
-interface ClassNamesFn {
-	(...classes: ClassValue[]): string;
-}
-
-declare var classNames: ClassNamesFn;
-
 declare module "classnames" {
-	export = classNames
+    export type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;
+
+    export interface ClassDictionary {
+        [id: string]: boolean | undefined | null;
+    }
+
+    export interface ClassArray extends Array<ClassValue> { }
+
+    export interface ClassNamesFn {
+        (...classes: ClassValue[]): string;
+    }
+    
+    var classNames: ClassNamesFn;
+	export default classNames
 }


### PR DESCRIPTION
I am not sure whether this is a good change and what the side effects of this. Think of this change as a discussion opener. I am trying to export members of classNames in a way that it would make it possible for `classNames` inside a module without an import and it would give the error of "classNames refers to a UMD global, but the current file is a module. Consider adding an import instead. 
export namespace React" or not export it globally at all if it's not needed.

I think my change here accomplishes it but breaks the contract for `import * as classnames from 'classnames';` and requires it to be `import classnames from 'classnames';`. Would be nice to find the middle-ground here.
