### PR TITLE
Winston: make export let not const to properly allow editing of properties

### DIFF
--- a/types/winston/index.d.ts
+++ b/types/winston/index.d.ts
@@ -505,5 +505,5 @@ declare namespace winston {
     type LogCallback = (error?: any, level?: string, msg?: string, meta?: any) => void;
 }
 
-declare const winston: winston.Winston;
+declare let winston: winston.Winston;
 export = winston;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/winstonjs/winston
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

According to the Winston package, one should be able to write statements like `winston.level = 'debug';`  Currently, since the exported `winston` is `const`, this can't be done.  Hence this MR changes the export to be `let` rather than `const` so that Winston can be used as intended.