### PR TITLE
[hapi] Various fixes

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -477,7 +477,7 @@ export class Server extends Podium {
     table(host?: string): RoutingTableEntry[];
 }
 
-export interface RoutePlugins {}
+export interface PluginSpecificConfiguration {}
 
 /**
  * Server Options
@@ -511,7 +511,7 @@ export interface ServerOptions {
     /** options passed to the mimos module (https://github.com/hapijs/mimos) when generating the mime database used by the server and accessed via server.mime. */
     mime?: MimosOptions;
     /** plugin-specific configuration which can later be accessed via server.settings.plugins. plugins is an object where each key is a plugin name and the value is the configuration. Note the difference between server.settings.plugins which is used to store static configuration values and server.plugins which is meant for storing run-time state. Defaults to {}. */
-    plugins?: RoutePlugins;
+    plugins?: PluginSpecificConfiguration;
     /** if false, will not use node domains to protect against exceptions thrown in handlers and other external code. Defaults to true. */
     useDomains?: boolean;
 }
@@ -724,7 +724,7 @@ export interface ConnectionConfigurationServerDefaults {
         maxEventLoopDelay: number;
     };
     /** plugin-specific configuration which can later be accessed via connection.settings.plugins. Provides a place to store and pass connection-specific plugin configuration. plugins is an object where each key is a plugin name and the value is the configuration. Note the difference between connection.settings.plugins which is used to store configuration values and connection.plugins which is meant for storing run-time state. */
-    plugins?: any;
+    plugins?: PluginSpecificConfiguration;
     /** controls how incoming request URIs are matched against the routing table: */
     router?: {
         /** determines whether the paths '/example' and '/EXAMPLE' are considered different resources. Defaults to true.  */
@@ -1152,7 +1152,7 @@ export interface RouteAdditionalConfigurationOptions {
      */
     payload?: RoutePayloadConfigurationObject;
     /** plugin-specific configuration. plugins is an object where each key is a plugin name and the value is the plugin configuration. */
-    plugins?: Object;
+    plugins?: PluginSpecificConfiguration;
     /** an array with [route prerequisites](https://hapijs.com/api/16.1.1#route-prerequisites) methods which are executed in serial or in parallel before the handler is called. */
     pre?: RoutePrerequisitesArray;
     /** processing rules for the outgoing response */

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2198,7 +2198,7 @@ export type AnyAuthenticationResponseAction = any;
 /** [See docs](https://hapijs.com/api/16.1.1#serverauthschemename-scheme) */
 export interface AuthenticationResult {
     credentials?: AuthenticatedCredentials;
-    artefacts?: any;
+    artifacts?: any;
 }
 export interface AuthenticatedCredentials {
     // Disabled to allow typing within a project

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -886,8 +886,6 @@ export interface CorsConfigurationObject {
  * [See docs](https://hapijs.com/api/16.1.1#serverextevents)
  * For context see RouteAdditionalConfigurationOptions > ext
  */
-
-// STUFF
 export interface ServerStartExtConfigurationObject {
     /** the extension point event name. */
     type: ServerStartExtPoints;
@@ -898,26 +896,39 @@ export interface ServerStartExtConfigurationObject {
     options?: ServerExtOptions;
 }
 
+/**
+ * An object describing the extension function used whilst registering the extension function in one of the available extension points
+ * [See docs](https://hapijs.com/api/16.1.1#serverextevents)
+ * For context see RouteAdditionalConfigurationOptions > ext
+ */
 export interface ServerRequestExtConfigurationObject {
     /** the extension point event name. */
     type: ServerRequestExtPointsBase;
     /**
      * a function or an array of functions to be executed at a specified point during request processing. The required extension function signature is see ServerExtFunction or see ServerExtRequestHandler
      */
-    method: ServerExtRequestHandler
+    method: ServerExtRequestHandler | ServerExtRequestHandler[]
     options?: ServerExtOptions;
 }
 
+/**
+ * An object describing the extension function used whilst registering the extension function in one of the available extension points
+ * [See docs](https://hapijs.com/api/16.1.1#serverextevents)
+ * For context see RouteAdditionalConfigurationOptions > ext
+ */
 export interface ServerRequestExtConfigurationObjectWithRequest {
     /** the extension point event name. */
     type: ServerRequestExtPoints;
     /**
      * a function or an array of functions to be executed at a specified point during request processing. The required extension function signature is see ServerExtFunction or see ServerExtRequestHandler
      */
-    method: ServerExtRequestHandler
+    method: ServerExtRequestHandler | ServerExtRequestHandler[];
     options?: ServerExtOptions;
 }
 
+/**
+ * [See docs](https://hapijs.com/api/16.1.1#route-configuration) > ext
+ */
 export type RouteExtConfigurationObject = ServerStartExtConfigurationObject | ServerRequestExtConfigurationObject;
 
 /**
@@ -940,16 +951,19 @@ export interface ServerExtOptions {
 }
 
 /**
- * [See docs](https://hapijs.com/api/16.1.1#request-lifecycle)
- * The available extension points include the request extension points as well as the following server extension points:
+ * [See docs](https://hapijs.com/api/16.1.1#serverextevents) > events > type
  *  * 'onPreStart' - called before the connection listeners are started.
  *  * 'onPostStart' - called after the connection listeners are started.
  *  * 'onPreStop' - called before the connection listeners are stopped.
  *  * 'onPostStop' - called after the connection listeners are stopped.
- * [See docs](https://hapijs.com/api/16.1.1#serverextevents) > events > type
  */
 export type ServerStartExtPoints = 'onPreStart' | 'onPostStart' | 'onPreStop' | 'onPostStop';
+/**
+ * [See docs](https://hapijs.com/api/16.1.1#request-lifecycle)
+ *  * The available extension points include the request extension points as well as the following server extension points:
+ */
 export type ServerRequestExtPointsBase = 'onPreResponse' | 'onPreAuth' | 'onPostAuth' | 'onPreHandler' | 'onPostHandler' | 'onPreResponse';
+
 export type ServerRequestExtPoints = ServerRequestExtPointsBase | 'onRequest';
 
 /**
@@ -2033,11 +2047,11 @@ export interface RequestHandler<T> {
 /**
  * Used by server extension points
  * err can be BoomError or Error that will be wrapped as a BoomError
- * For source [See docs](https://github.com/hapijs/hapi/blob/v16.1.1/lib/reply.js#L109-L118)
- * For source [See docs](https://github.com/hapijs/hapi/blob/v16.1.1/lib/response.js#L60-L65)
+ * For source [See code](https://github.com/hapijs/hapi/blob/v16.1.1/lib/reply.js#L109-L118)
+ * For source [See code](https://github.com/hapijs/hapi/blob/v16.1.1/lib/response.js#L60-L65)
  */
 export interface ContinuationFunction {
-    (err: Boom.BoomError): void;
+    (err?: Boom.BoomError): void;
 }
 /**
  * For source [See docs](https://github.com/hapijs/hapi/blob/v16.1.1/lib/response.js#L60-L65)

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -477,6 +477,8 @@ export class Server extends Podium {
     table(host?: string): RoutingTableEntry[];
 }
 
+export interface RoutePlugins {}
+
 /**
  * Server Options
  * Note that the options object is deeply cloned and cannot contain any values that are unsafe to perform deep copy on.
@@ -509,7 +511,7 @@ export interface ServerOptions {
     /** options passed to the mimos module (https://github.com/hapijs/mimos) when generating the mime database used by the server and accessed via server.mime. */
     mime?: MimosOptions;
     /** plugin-specific configuration which can later be accessed via server.settings.plugins. plugins is an object where each key is a plugin name and the value is the configuration. Note the difference between server.settings.plugins which is used to store static configuration values and server.plugins which is meant for storing run-time state. Defaults to {}. */
-    plugins?: Object;
+    plugins?: RoutePlugins;
     /** if false, will not use node domains to protect against exceptions thrown in handlers and other external code. Defaults to true. */
     useDomains?: boolean;
 }

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -892,7 +892,7 @@ export interface ServerStartExtConfigurationObject {
     /**
      * a function or an array of functions to be executed at a specified point during request processing. The required extension function signature is see ServerExtFunction or see ServerExtRequestHandler
      */
-    method: ServerExtFunction
+    method: ServerExtFunction | ServerExtFunction[];
     options?: ServerExtOptions;
 }
 

--- a/types/hapi/test/route/additional-options.ts
+++ b/types/hapi/test/route/additional-options.ts
@@ -3,29 +3,35 @@
 import * as Hapi from 'hapi';
 
 var authConfig: Hapi.RouteAdditionalConfigurationOptions = {
-  app: {}
+    app: {},
+    payload: {},
 };
 
 var extConfigSingle: Hapi.RouteAdditionalConfigurationOptions = {
-  ext: {
-    type: 'onPreAuth',
-    method: <Hapi.ServerExtRequestHandler> function (request, reply) {
-      reply('ok');
+    ext: {
+        type: 'onPreAuth',
+        method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+            reply('ok');
+        }
     }
-  }
 }
 
 var extConfigMulti: Hapi.RouteAdditionalConfigurationOptions = {
-  ext: [{
-    type: 'onPreAuth',
-    method: <Hapi.ServerExtRequestHandler> function (request, reply) {
-      reply('ok');
-    }
-  }, {
-    type: 'onPostAuth',
-    method: <Hapi.ServerExtRequestHandler> function (request, reply) {
-      reply('ok');
-    }
+    ext: [{
+        type: 'onPreAuth',
+        method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+          reply('ok');
+        }
+      }, {
+        type: 'onPostAuth',
+        method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+          reply('ok');
+        }
+    }, {
+    type: 'onPostStart',
+      method: <Hapi.ServerExtFunction> function (server, next) {
+          next();
+      }
   }]
 }
 
@@ -62,7 +68,7 @@ var cache: Hapi.RouteCacheOptions = {
 */
 
 var payloadOptions: Hapi.RoutePayloadConfigurationObject = {
-  allow: 'multipart/form-data',
-  maxBytes: 123,
-  output: 'file',
+    allow: 'multipart/form-data',
+    maxBytes: 123,
+    output: 'file',
 };

--- a/types/hapi/test/route/additional-options.ts
+++ b/types/hapi/test/route/additional-options.ts
@@ -20,18 +20,18 @@ var extConfigMulti: Hapi.RouteAdditionalConfigurationOptions = {
     ext: [{
         type: 'onPreAuth',
         method: <Hapi.ServerExtRequestHandler> function (request, reply) {
-          reply('ok');
-        }
-      }, {
-        type: 'onPostAuth',
-        method: <Hapi.ServerExtRequestHandler> function (request, reply) {
-          reply('ok');
+            reply('ok');
         }
     }, {
-    type: 'onPostStart',
-      method: <Hapi.ServerExtFunction> function (server, next) {
-          next();
-      }
+        type: 'onPostAuth',
+        method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+            reply('ok');
+        }
+    }, {
+        type: 'onPostStart',
+        method: <Hapi.ServerExtFunction> function (server, next) {
+            next();
+        }
   }]
 }
 
@@ -39,7 +39,6 @@ var extConfigMulti: Hapi.RouteAdditionalConfigurationOptions = {
 const user: Hapi.RouteAdditionalConfigurationOptions = {
     cache: { expiresIn: 5000, statuses: [200, 201] },
     handler: function (request, reply) {
-
         return reply({ name: 'John' });
     }
 };

--- a/types/hapi/test/route/additional-options.ts
+++ b/types/hapi/test/route/additional-options.ts
@@ -6,6 +6,29 @@ var authConfig: Hapi.RouteAdditionalConfigurationOptions = {
   app: {}
 };
 
+var extConfigSingle: Hapi.RouteAdditionalConfigurationOptions = {
+  ext: {
+    type: 'onPreAuth',
+    method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+      reply('ok');
+    }
+  }
+}
+
+var extConfigMulti: Hapi.RouteAdditionalConfigurationOptions = {
+  ext: [{
+    type: 'onPreAuth',
+    method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+      reply('ok');
+    }
+  }, {
+    type: 'onPostAuth',
+    method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+      reply('ok');
+    }
+  }]
+}
+
 // Handler in config
 const user: Hapi.RouteAdditionalConfigurationOptions = {
     cache: { expiresIn: 5000, statuses: [200, 201] },
@@ -37,3 +60,9 @@ var cache: Hapi.RouteCacheOptions = {
     expiresAt: '22:44',
 };
 */
+
+var payloadOptions: Hapi.RoutePayloadConfigurationObject = {
+  allow: 'multipart/form-data',
+  maxBytes: 123,
+  output: 'file',
+};

--- a/types/hapi/test/route/config.ts
+++ b/types/hapi/test/route/config.ts
@@ -43,4 +43,6 @@ const user: Hapi.RouteAdditionalConfigurationOptions = {
     }
 };
 
+
+
 server.route({method: 'GET', path: '/user', config: user });

--- a/types/hapi/test/route/config.ts
+++ b/types/hapi/test/route/config.ts
@@ -43,6 +43,4 @@ const user: Hapi.RouteAdditionalConfigurationOptions = {
     }
 };
 
-
-
 server.route({method: 'GET', path: '/user', config: user });

--- a/types/hapi/test/route/plugins.ts
+++ b/types/hapi/test/route/plugins.ts
@@ -1,0 +1,18 @@
+// from https://hapijs.com/api#route-configuration > plugins
+
+import * as Hapi from 'hapi';
+
+declare module 'hapi' {
+    interface RoutePlugins {
+        coolPlugin: {
+            optionA: string;
+            optionB?: boolean;
+        }
+    }
+}
+
+var pluginsConfig: Hapi.RouteAdditionalConfigurationOptions = {
+    plugins: {
+        coolPlugin: 'test',
+    }
+};

--- a/types/hapi/test/route/plugins.ts
+++ b/types/hapi/test/route/plugins.ts
@@ -1,9 +1,10 @@
-// from https://hapijs.com/api#route-configuration > plugins
+// Added in addition to code from https://hapijs.com/api/16.1.1#route-options > plugins
 
 import * as Hapi from 'hapi';
 
+// In the plugin code
 declare module 'hapi' {
-    interface RoutePlugins {
+    interface PluginSpecificConfiguration {
         coolPlugin: {
             optionA: string;
             optionB?: boolean;
@@ -11,8 +12,27 @@ declare module 'hapi' {
     }
 }
 
-var pluginsConfig: Hapi.RouteAdditionalConfigurationOptions = {
+// In the consumer code
+const pluginsServerConfig: Hapi.ServerOptions = {
     plugins: {
-        coolPlugin: 'test',
+        coolPlugin: {
+            optionA: "test",
+        }
+    }
+};
+
+const pluginsConnectionConfig: Hapi.ConnectionConfigurationServerDefaults = {
+    plugins: {
+        coolPlugin: {
+            optionA: "test",
+        }
+    }
+};
+
+const pluginsRouteConfig: Hapi.RouteAdditionalConfigurationOptions = {
+    plugins: {
+        coolPlugin: {
+            optionA: "test",
+        }
     }
 };

--- a/types/hapi/test/server/ext.ts
+++ b/types/hapi/test/server/ext.ts
@@ -7,7 +7,7 @@ server.connection({ port: 80 });
 
 server.ext({
     type: 'onRequest',
-    method: <Hapi.ServerExtRequestHandler> function (request, reply) {
+    method: function (request, reply) {
 
         // Change all requests to '/test'
         request.setUrl('/test');
@@ -28,7 +28,7 @@ server.start((err) => { });
 
 // Example 2
 
-server.ext('onRequest', <Hapi.ServerExtRequestHandler> function (request, reply) {
+server.ext('onRequest', function (request, reply) {
 
     // Change all requests to '/test'
     request.setUrl('/test');

--- a/types/hapi/test/server/new.ts
+++ b/types/hapi/test/server/new.ts
@@ -44,6 +44,15 @@ new Hapi.Server({
     }]
 });
 
+//+ Code added in addition to docs
+declare module 'hapi' {
+    interface PluginSpecificConfiguration {
+        // Set this to non optional if plugin config is non optional
+        'some-plugin-name'?: {options: string;};
+    }
+}
+//- Code added in addition to docs
+
 new Hapi.Server({
     connections: {
         app: {},
@@ -54,7 +63,8 @@ new Hapi.Server({
             maxEventLoopDelay: 10,
         },
         plugins: {
-            'some-plugin-name': {options: 'here'}
+            'some-plugin-name': {options: 'here'},
+            coolPlugin: {optionA: ""},
         },
         router: {
             isCaseSensitive: false,

--- a/types/hapi/tsconfig.json
+++ b/types/hapi/tsconfig.json
@@ -45,6 +45,7 @@
         "test/route/auth.ts",
         "test/route/config.ts",
         "test/route/handler.ts",
+        "test/route/plugins.ts",
         "test/route/prerequisites.ts",
         "test/route/public-interface.ts",
         "test/server/app.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://hapijs.com/api#request-lifecycle, https://hapijs.com/api#route-configuration
- [] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

- fixed `ext` option and narrowed the type
- fixed `compression` being mandatory 
- made route plugins an interface for 3rd party extension
- fixed `artefacts` typo.

I attempted to narrow the typings for start/stop vs request extension points improving validation here, unfortunately TS still isn't able to auto detect the arguments of `method` quite yet (thus the cast).

I'm _not_ use if the start/stop extension points are actually available on a route level, the documentation isn't super specific about that.

Additionally I made the `compression` attribute optional as it's not required according to API docs (and our full up to date code base 😄  )