### PR TITLE
three-core.d.ts - correction to CubeTextureLoader

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -2243,7 +2243,7 @@ export class CubeTextureLoader {
     corssOrigin: string;
     path: string;
 
-    load(urls: Array<string>, onLoad?: (texture: CubeTexture) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): void;
+    load(urls: Array<string>, onLoad?: (texture: CubeTexture) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): CubeTexture;
     setCrossOrigin(crossOrigin: string): CubeTextureLoader;
     setPath(path: string): CubeTextureLoader;
 }


### PR DESCRIPTION
please change the return type of the load method of CubeTextureLoader to reflect the behaviour of the library.