### PR TITLE
Add type definitions for country-select-js

### DIFF
--- a/types/country-select-js/country-select-js-tests.ts
+++ b/types/country-select-js/country-select-js-tests.ts
@@ -1,7 +1,7 @@
 $('#country').countrySelect();
 
 $('#country').countrySelect({
-  'defaultCountry': 'gb'
+  defaultCountry: 'gb'
 });
 
 $('#country').countrySelect('destroy');

--- a/types/country-select-js/country-select-js-tests.ts
+++ b/types/country-select-js/country-select-js-tests.ts
@@ -1,1 +1,7 @@
 $('#country').countrySelect();
+
+$('#country').countrySelect({
+  'defaultCountry': 'gb'
+});
+
+$('#country').countrySelect('destroy');

--- a/types/country-select-js/country-select-js-tests.ts
+++ b/types/country-select-js/country-select-js-tests.ts
@@ -1,0 +1,1 @@
+$('#country').countrySelect();

--- a/types/country-select-js/index.d.ts
+++ b/types/country-select-js/index.d.ts
@@ -1,0 +1,55 @@
+// Type definitions for country-select-js 1.0
+// Project: https://github.com/mrmarkfrench/country-select-js
+// Definitions by: Humberto Rocha <https://github.com/humrochagf>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace CountrySelectJs {
+  interface Options {
+    /**
+     * Set the default country by it's country code. Otherwise it will just be
+     * the first country in the list.
+     */
+    defaultCountry?: string;
+
+    /**
+     * Display only the countries you specify. Takes an array of country codes.
+     */
+    onlyCountries?: string[];
+
+    /**
+     * Specify the countries to appear at the top of the list. Defaults to
+     * ["us", "gb"]
+     */
+    preferredCountries?: string[];
+
+    /**
+     * Set the dropdown's width to be the same as the input. This is
+     * automatically enabled for small screens.
+     */
+    responsiveDropdown?: boolean;
+  }
+
+  interface CountryData {
+    name: string;
+    iso2: string;
+  }
+}
+
+interface JQuery {
+  /**
+   * Remove the plugin from the input, and unbind any event listeners.
+   */
+  countrySelect(method: 'destroy'): void;
+
+  /**
+   * Get the country data for the currently selected flag.
+   */
+  countrySelect(method: 'getSelectedCountryData'): CountrySelectJs.CountryData;
+
+  countrySelect(method: string, value: string): void;
+
+  /**
+   * initialize the plugin with optional options.
+   */
+  countrySelect(options?: CountrySelectJs.Options): JQueryDeferred<any>;
+}

--- a/types/country-select-js/index.d.ts
+++ b/types/country-select-js/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Humberto Rocha <https://github.com/humrochagf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="jquery" />
+
 declare namespace CountrySelectJs {
   interface Options {
     /**

--- a/types/country-select-js/tsconfig.json
+++ b/types/country-select-js/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/country-select-js/tsconfig.json
+++ b/types/country-select-js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "country-select-js-tests.ts"
+    ]
+}

--- a/types/country-select-js/tslint.json
+++ b/types/country-select-js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.