### PR TITLE
add a new definition of constructor of Sequelize

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5443,8 +5443,7 @@ declare namespace sequelize {
          *     database.
          * @param options An object with options.
          */
-        new (database: string, username: string, password: string, options?: Options): Sequelize;
-        new (database: string, username: string, options?: Options): Sequelize;
+        new (database: string, username: string, password?: string, options?: Options): Sequelize;
 
         /**
          * Instantiate sequelize with an URI

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5267,6 +5267,13 @@ declare namespace sequelize {
          * Defaults to false
          */
         benchmark?: boolean;
+
+        /**
+         * Run built in type validators on insert and update, e.g. validate that arguments passed to integer fields are integer-like.
+         *
+         * Defaults to false
+         */
+        typeValidation?: boolean;
     }
 
     /**

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -5105,6 +5105,27 @@ declare namespace sequelize {
     interface Options {
 
         /**
+         * The username which is used to authenticate against the database.
+         *
+         * Defaults to null
+         */
+        username?: string;
+
+        /**
+         * The password which is used to authenticate against the database.
+         *
+         * Defaults to null
+         */
+        password?: string;
+
+        /**
+         * The name of the database
+         *
+         *  Defaults to null
+         */
+        database?: string;
+
+        /**
          * The dialect of the database you are connecting to. One of mysql, postgres, sqlite, mariadb and mssql.
          *
          * Defaults to 'mysql'
@@ -5434,6 +5455,15 @@ declare namespace sequelize {
          * @param options See above for possible options
          */
         new (uri: string, options?: Options): Sequelize;
+
+        /**
+         * Instantiate sequelize with Options
+         * @name Sequelize
+         * @constructor
+         *
+         * @param options See above for possible options
+         */
+        new (options: Options): Sequelize;
 
         /**
          * Provide access to continuation-local-storage (http://docs.sequelizejs.com/en/latest/api/sequelize/#transactionoptions-promise)

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -1188,7 +1188,12 @@ new Sequelize( 'sequelize', null, null, {
             password : 'lol'
         }
     }
-} );
+});
+new Sequelize({
+    host: 'localhost',
+    username: 'omg',
+    password: 'lol'
+});
 
 s.model( 'Project' );
 s.models['Project'];


### PR DESCRIPTION
add a new definition of Sequelize constructor
`Sequelize(options:Option)`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor

