### PR TITLE
@types/ckeditor: Allow all HTML elements for CKEDITOR.appendTo()

### DIFF
--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -77,7 +77,7 @@ declare namespace CKEDITOR {
     function addCss(css: string): void;
     function addTemplate(name: string, source: string): template;
     function appendTo(element: string, config?: config, data?: string): editor;
-    function appendTo(element: HTMLTextAreaElement, config?: config, data?: string): editor;
+    function appendTo(element: HTMLElement, config?: config, data?: string): editor;
     function domReady(): void;
     function dialogCommand(dialogName: string): void;
     function editorConfig(config: config): void;


### PR DESCRIPTION
See http://docs.ckeditor.com/#!/api/CKEDITOR-method-appendTo