### PR TITLE
ramda: Fix R.tryCatch definition

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for ramda
 // Project: https://github.com/donnut/typescript-ramda
-// Definitions by: Erwin Poeze <https://github.com/donnut>, Matt DeKrey <https://github.com/mdekrey>, Liam Goodacre <https://github.com/LiamGoodacre>
+// Definitions by: Erwin Poeze <https://github.com/donnut>, Matt DeKrey <https://github.com/mdekrey>, Liam Goodacre <https://github.com/LiamGoodacre>, Matt Dziuban <https://github.com/mrdziuban>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -1598,7 +1598,7 @@ declare namespace R {
          * function and returns its result. Note that for effective composition with this function, both the tryer and
          * catcher functions must return the same type of results.
          */
-        tryCatch<T>(tryer: (...args: any[]) => T, catcher: (...args: any[]) => T, x: any): T;
+        tryCatch<T>(tryer: (...args: any[]) => T, catcher: (...args: any[]) => T): (...args: any[]) => T;
 
         /**
          * Gives a single-word string description of the (native) type of a value, returning such answers as 'Object',

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -972,8 +972,9 @@ type Pair = KeyValuePair<string, number>
 
 () => {
     const x = R.prop('x');
-    const a: boolean = R.tryCatch<boolean>(R.prop('x'), R.F, {x: true}); //=> true
-    const b: boolean = R.tryCatch<boolean>(R.prop('x'), R.F, null);      //=> false
+    const a: boolean = R.tryCatch<boolean>(R.prop('x'), R.F)({x: true}); //=> true
+    const b: boolean = R.tryCatch<boolean>(R.prop('x'), R.F)(null);      //=> false
+    const c: boolean = R.tryCatch<boolean>(R.and, R.F)(true, true);      //=> true
 }
 
 () => {


### PR DESCRIPTION
The definition for ramda's `R.tryCatch` function does not match the documentation or implementation. The function takes a tryer and a catcher and returns a function with the same arity as the tryer. The definition is currently written to accept `x: any` as the third argument, but an argument passed that way is ignored. Here are two examples using the ramda repl:

- [Bad call](http://ramdajs.com/repl/?v=0.23.0#?R.tryCatch%28R.prop%28%27x%27%29%2C%20R.F%2C%20%7B%20x%3A%20true%20%7D%29%3B) -- this is how the function needs to be called with the current typings. Notice how the result is a function rather than a boolean.
- [Good call](http://ramdajs.com/repl/?v=0.23.0#?R.tryCatch%28R.prop%28%27x%27%29%2C%20R.F%29%28%7B%20x%3A%20true%20%7D%29%3B)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://ramdajs.com/docs/#tryCatch
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.