### PR TITLE
Fix swagger-schema-official security type

### DIFF
--- a/types/swagger-schema-official/index.d.ts
+++ b/types/swagger-schema-official/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for swagger-schema-official 2.0
 // Project: http://swagger.io/specification/
-// Definitions by: Mohsen Azimi <https://github.com/mohsen1>, Ben Southgate <https://github.com/bsouthga>
+// Definitions by: Mohsen Azimi <https://github.com/mohsen1>, Ben Southgate <https://github.com/bsouthga>, Nicholas Merritt <https://github.com/nimerritt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Info {
@@ -224,7 +224,7 @@ export interface Spec {
   definitions?: {[definitionsName: string]: Schema };
   parameters?: {[parameterName: string]: BodyParameter|QueryParameter};
   responses?: {[responseName: string]: Response };
-  security?: Security[];
+  security?: Array<{[securityDefinitionName: string]: string[]}>;
   securityDefinitions?: { [securityDefinitionName: string]: Security};
   tags?: Tag[];
 }

--- a/types/swagger-schema-official/swagger-schema-official-tests.ts
+++ b/types/swagger-schema-official/swagger-schema-official-tests.ts
@@ -1324,3 +1324,16 @@ const uber: swagger.Spec = {
     }
   }
 };
+
+const basic_auth: swagger.Spec = {
+  "swagger": "2.0",
+  "info": { "version": "1.0.0", "title": "Minimal example with basic auth"},
+  "schemes": [
+    "https"
+  ],
+  "paths": {},
+  "securityDefinitions": {
+    basicAuth: { type: 'basic' },
+  },
+  "security": [{basicAuth: []}]
+};


### PR DESCRIPTION
See https://github.com/OAI/OpenAPI-Specification/blob/ae9322eb2df1555acf3163e30cd84779d98afec5/schemas/v2.0/schema.json#L1177
for the original JSON-schema definition of the security field.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OAI/OpenAPI-Specification/blob/ae9322eb2df1555acf3163e30cd84779d98afec5/schemas/v2.0/schema.json#L1177
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.