### PR TITLE
Improve feedback & auto-completion in attribute objects.

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -52,9 +52,9 @@ declare namespace Mithril {
 		/** Creates a virtual element (Vnode). */
 		(selector: string, attributes: Attributes, ...children: Children[]): Vnode<any, any>;
 		/** Creates a virtual element (Vnode). */
-		<Attrs, State>(component: ComponentTypes<Attrs, State>, attributes: Attrs & Lifecycle<Attrs, State> & { key?: string | number }, ...args: Children[]): Vnode<Attrs, State>;
-		/** Creates a virtual element (Vnode). */
 		<Attrs, State>(component: ComponentTypes<Attrs, State>, ...args: Children[]): Vnode<Attrs, State>;
+		/** Creates a virtual element (Vnode). */
+		<Attrs, State>(component: ComponentTypes<Attrs, State>, attributes: Attrs & Lifecycle<Attrs, State> & { key?: string | number }, ...args: Children[]): Vnode<Attrs, State>;
 		/** Creates a fragment virtual element (Vnode). */
 		fragment(attrs: Lifecycle<any, any> & { [key: string]: any }, children: ChildArrayOrPrimitive): Vnode<any, any>;
 		/** Turns an HTML string into a virtual element (Vnode). Do not use trust on unsanitized user input. */

--- a/types/mithril/tslint.json
+++ b/types/mithril/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
+        "object-literal-key-quotes": false,
         "no-empty-interface": false
     }
 }


### PR DESCRIPTION
Swapping these two declarations makes TS offer much **better contextual feedback and auto-completion** in Component attribute objects.

**Before:**

> Argument of type '{ labe: string; }' is not assignable to parameter of type 'Children'.
>   Object literal may only specify known properties, and 'labe' does not exist in type 'Children'.

**After:**

> Argument of type '{ labe: string; }' is not assignable to parameter of type 'Attrs & Lifecycle<Attrs, State> & { key?: string | number; }'.
>   Object literal may only specify known properties, and 'labe' does not exist in type 'Attrs & Lifecycle<Attrs, State> & { key?: string | number; }'.

**And now it auto completes properties.**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _Not relevant._
- [x] Increase the version number in the header if appropriate. _Not appropriate._
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. _Not substantial._
