### PR TITLE
fix return type of getText()

### DIFF
--- a/types/selenium-webdriver/index.d.ts
+++ b/types/selenium-webdriver/index.d.ts
@@ -1966,8 +1966,9 @@ export class Alert {
    * alert were opened with alert('hello'), then this would return 'hello'.
    * @return {!promise.Promise} A promise that will be resolved to the
    *     text displayed with this alert.
+   *     In cases where getText() is called on an ElementArrayFinder, an array of text is returned.
    */
-  getText(): promise.Promise<string>;
+  getText(): promise.Promise<any>;
 
   /**
    * Sets the username and password in an alert prompting for credentials (such


### PR DESCRIPTION
getText() works on ElementFinderArray type as well. In those cases, it is supposed to return an array of texts. However, array methods such as .filter or .map do not work at the moment with .getText() since TypeScript throws an error during compilation. For example, $$('locator').getText().filter(...) does not work at the moment.
