### PR TITLE
[multer] Allow null in DiskStorageOptions.destination.callback first parameter

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -46,7 +46,7 @@ declare namespace multer {
 
     interface DiskStorageOptions {
         /** A function used to determine within which folder the uploaded files should be stored. Defaults to the system's default temporary directory. */
-        destination?: string | ((req: Express.Request, file: Express.Multer.File, callback: (error: Error, destination: string) => void) => void);
+        destination?: string | ((req: Express.Request, file: Express.Multer.File, callback: (error: Error | null, destination: string) => void) => void);
         /** A function used to determine what the file should be named inside the folder. Defaults to a random name with no file extension. */
         filename?: (req: Express.Request, file: Express.Multer.File, callback: (error: Error | null, filename: string) => void) => void;
     }


### PR DESCRIPTION
* `null` is used [in the docs](https://github.com/expressjs/multer#diskstorage)
* `null` was allowed in `callback` for brother interface element `filename` as part of PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14112/files , but `destination` wasn't updated at this time.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/multer#diskstorage
- [x] Increase the version number in the header if appropriate.  
→ I'm not sure I should do that; should I???
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
