### PR TITLE
(jquery) Add JQueryCssProperties interface for $.css(properties: object)

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -680,6 +680,13 @@ interface JQueryCoordinates {
 }
 
 /**
+ * The interface used to specify the properties parameter in css()
+ */
+interface JQueryCssProperties {
+	[propertyName: string]: string | number | Function;
+}
+
+/**
  * Elements in the array returned by serializeArray()
  */
 interface JQuerySerializeArrayElement {
@@ -1687,7 +1694,7 @@ interface JQuery {
      * @param properties An object of property-value pairs to set.
      * @see {@link https://api.jquery.com/css/#css-properties}
      */
-    css(properties: Object): JQuery;
+    css(properties: JQueryCssProperties): JQuery;
 
     /**
      * Get the current computed height for the first element in the set of matched elements.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -682,8 +682,9 @@ interface JQueryCoordinates {
 /**
  * The interface used to specify the properties parameter in css()
  */
+type cssPropertySetter = (index: number, value: string) => string | number;
 interface JQueryCssProperties {
-	[propertyName: string]: string | number | Function;
+	[propertyName: string]: string | number | cssPropertySetter;
 }
 
 /**

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -682,7 +682,7 @@ interface JQueryCoordinates {
 /**
  * The interface used to specify the properties parameter in css()
  */
-type cssPropertySetter = (index: number, value: string) => string | number;
+type cssPropertySetter = (index: number, value?: string) => string | number;
 interface JQueryCssProperties {
 	[propertyName: string]: string | number | cssPropertySetter;
 }

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -1062,6 +1062,9 @@ function test_css() {
         var color = $(this).css("background-color");
         $("#result").html("That div is <span style='color:" + color + ";'>" + color + "</span>.");
     });
+    $('div.example').css('width', function (index) {
+        return index * 50;
+    });
     $('div.example').css('width', function (index, style) {
         return style.length > 0 ? style : index * 50;
     });

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -1062,8 +1062,8 @@ function test_css() {
         var color = $(this).css("background-color");
         $("#result").html("That div is <span style='color:" + color + ";'>" + color + "</span>.");
     });
-    $('div.example').css('width', function (index) {
-        return index * 50;
+    $('div.example').css('width', function (index, style) {
+        return style.length > 0 ? style : index * 50;
     });
     $("p").mouseover(function () {
         $(this).css("color", "red");


### PR DESCRIPTION
Adding JQueryCssProperties interface and changing the signature for
$.css(properties: object) to $.css(properties: JQueryCssProperties)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16620
