### PR TITLE
ramda: Add support for curry on view definition

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -839,8 +839,7 @@ declare namespace R {
 
         /**
          * Returns a lens whose focus is the specified path.
-         * See also         view<T,U>(lens: Lens, obj: T): U;
- +        view<T,U>(lens: Lens): (obj: T) => U;, set, over.
+         * See also view, set, over.
          */
         lensPath(path: Path): Lens;
 

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1728,6 +1728,7 @@ declare namespace R {
          * portion of the data structure is visible.
          */
         view<T,U>(lens: Lens, obj: T): U;
+        view<T,U>(lens: Lens): (obj: T) => U;
 
         /**
          * Tests the final argument by passing it to the given predicate function. If the predicate is satisfied, the function

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -839,7 +839,8 @@ declare namespace R {
 
         /**
          * Returns a lens whose focus is the specified path.
-         * See also view, set, over.
+         * See also         view<T,U>(lens: Lens, obj: T): U;
+ +        view<T,U>(lens: Lens): (obj: T) => U;, set, over.
          */
         lensPath(path: Path): Lens;
 
@@ -1727,8 +1728,8 @@ declare namespace R {
          * Returns a "view" of the given data structure, determined by the given lens. The lens's focus determines which
          * portion of the data structure is visible.
          */
-        view<T,U>(lens: Lens, obj: T): U;
         view<T,U>(lens: Lens): (obj: T) => U;
+        view<T,U>(lens: Lens, obj: T): U;
 
         /**
          * Tests the final argument by passing it to the given predicate function. If the predicate is satisfied, the function

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1161,6 +1161,7 @@ class Rectangle {
 () => {
     var xLens = R.lens(R.prop('x'), R.assoc('x'));
     R.view(xLens, {x: 1, y: 2});            //=> 1
+    R.view(xLens)({x: 1, y: 2});            //=> 1
     R.set(xLens, 4, {x: 1, y: 2});          //=> {x: 4, y: 2}
     R.set(xLens)(4, {x: 1, y: 2});          //=> {x: 4, y: 2}
     R.set(xLens, 4)({x: 1, y: 2});          //=> {x: 4, y: 2}


### PR DESCRIPTION
view template was missing definition for currying (single argument).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). (ran `tsc`)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/types/npm-ramda/blob/master/index.d.ts#L3544
- [x] Increase the version number in the header if appropriate. (not applicable)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (not substantial)


