### PR TITLE
when: Fix missing optional parameter

### DIFF
--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -278,7 +278,7 @@ declare namespace When {
         spread<A1, A2, A3, A4, T>(onFulfilled: _.Fn4<A1, A2, A3, A4, Promise<T> | T>): Promise<T>;
         spread<A1, A2, A3, A4, A5, T>(onFulfilled: _.Fn5<A1, A2, A3, A4, A5, Promise<T> | T>): Promise<T>;
 
-        done<U>(onFulfilled: (value: T) => void, onRejected?: (reason: any) => void): void;
+        done<U>(onFulfilled?: (value: T) => void, onRejected?: (reason: any) => void): void;
 
         fold<U, V>(combine: (value1: T, value2: V) => U | Promise<U>, value2: V | Promise<V>): Promise<U>;
     }

--- a/types/when/when-tests.ts
+++ b/types/when/when-tests.ts
@@ -172,6 +172,7 @@ deferred.reject(error);
 
 /* promise.done(handleResult, handleError) */
 
+when(1).done();
 when(1).done((val: number) => console.log(val));
 when(1).done((val: number) => console.log(val), (err: any) => console.log(err));
 


### PR DESCRIPTION
As you can see in [the original source code](https://github.com/cujojs/when/blob/master/lib/decorators/flow.js#L19), both parameters to `promise.done` are optional.