### PR TITLE
added new types to support methodless Session and Cookie objects (when  express-session -middleware hydrates to and from a Store implementation). 

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -1,9 +1,7 @@
-
-
 import express = require('express');
 import session = require('express-session');
 
-var app = express();
+let app = express();
 
 app.use(session({
   secret: 'keyboard cat',
@@ -14,7 +12,7 @@ app.use(session({
   name: 'connect.sid',
   store: new session.MemoryStore(),
   cookie: { path: '/', httpOnly: true, secure: false, maxAge: null },
-  genid: (req: express.Request): string => { return ''; },
+  genid: (req: express.Request): string => '',
   rolling: false,
   resave: true,
   proxy: true,
@@ -22,21 +20,20 @@ app.use(session({
   unset: 'keep'
 }));
 
-
 interface MySession extends Express.Session {
   views: number;
 }
-app.use(function(req, res, next) {
-  var sess = <MySession>req.session;
+
+app.use((req, res, next) => {
+  let sess = <MySession>req.session;
   if (sess.views) {
-    sess.views++
-    res.setHeader('Content-Type', 'text/html')
-    res.write('<p>views: ' + sess.views + '</p>')
-    res.write('<p>expires in: ' + (sess.cookie.maxAge / 1000) + 's</p>')
-    res.end()
+    sess.views++;
+    res.setHeader('Content-Type', 'text/html');
+    res.write('<p>views: ' + sess.views + '</p>');
+    res.write('<p>expires in: ' + (sess.cookie.maxAge / 1000) + 's</p>');
+    res.end();
   } else {
-    sess.views = 1
-    res.end('welcome to the session demo. refresh!')
+    sess.views = 1;
+    res.end('welcome to the session demo. refresh!');
   }
 });
-

--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -25,7 +25,7 @@ interface MySession extends Express.Session {
 }
 
 app.use((req, res, next) => {
-  let sess = <MySession>req.session;
+  let sess = req.session as MySession;
   if (sess.views) {
     sess.views++;
     res.setHeader('Content-Type', 'text/html');

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for express-session
 // Project: https://www.npmjs.org/package/express-session
+// Definitions by: Jacob Bogers <http://github.com/jacobbogers
 // Definitions by: Hiroki Horiuchi <https://github.com/horiuchi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
@@ -14,8 +15,26 @@ declare namespace Express {
     sessionID?: string;
   }
 
-  export interface Session {
+  export interface SessionData {
     [key: string]: any;
+    cookie: Express.SessionCookieData;
+  }
+
+  export interface SessionCookieData {
+    originalMaxAge: number;
+    path: string;
+    maxAge: number;
+    secure?: boolean;
+    httpOnly: boolean;
+    domain?: string;
+    expires: Date | boolean;
+  }
+
+  export interface SessionCookie extends SessionCookieData {
+    serialize: (name: string, value: string) => string;
+  }
+
+  export interface Session extends SessionData {
     id: string;
 
     regenerate: (callback: (err: any) => void) => void;
@@ -26,16 +45,7 @@ declare namespace Express {
 
     cookie: SessionCookie;
   }
-  export interface SessionCookie {
-    originalMaxAge: number;
-    path: string;
-    maxAge: number;
-    secure?: boolean;
-    httpOnly: boolean;
-    domain?: string;
-    expires: Date | boolean;
-    serialize: (name: string, value: string) => string;
-  }
+
 }
 
 declare module "express-session" {
@@ -58,7 +68,7 @@ declare module "express-session" {
       unset?: string;
     }
 
-	export interface BaseMemoryStore {
+    export interface BaseMemoryStore {
       get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
       set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
       destroy: (sid: string, callback: (err: any) => void) => void;
@@ -67,16 +77,16 @@ declare module "express-session" {
     }
 
     export abstract class Store extends node.EventEmitter {
-	  constructor(config?: any);
+      constructor(config?: any);
 
-	  regenerate (req: express.Request, fn: (err: any) => any): void;
-      load (sid: string, fn: (err: any, session: Express.Session) => any): void;
-      createSession (req: express.Request, sess: Express.Session): void;
-      
+      regenerate(req: express.Request, fn: (err: any) => any): void;
+      load(sid: string, fn: (err: any, session: Express.Session) => any): void;
+      createSession(req: express.Request, sess: Express.SessionData): void;
+
       get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
       set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
       destroy: (sid: string, callback: (err: any) => void) => void;
-      all: (callback: (err: any, obj: { [sid: string]: Express.Session; }) => void) => void;
+      all: (callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void) => void;
       length: (callback: (err: any, length: number) => void) => void;
       clear: (callback: (err: any) => void) => void;
     }

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -1,26 +1,22 @@
 // Type definitions for express-session
 // Project: https://www.npmjs.org/package/express-session
-// Definitions by: Jacob Bogers <http://github.com/jacobbogers
 // Definitions by: Hiroki Horiuchi <https://github.com/horiuchi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
+// Definitions by: Jacob Bogers <http://github.com/jacobbogers
 
 /// <reference types="node" />
-/// <reference types="express" />
 
 declare namespace Express {
-
-  export interface Request {
+  interface Request {
     session?: Session;
     sessionID?: string;
   }
-
-  export interface SessionData {
+  interface SessionData {
     [key: string]: any;
     cookie: Express.SessionCookieData;
   }
 
-  export interface SessionCookieData {
+  interface SessionCookieData {
     originalMaxAge: number;
     path: string;
     maxAge: number;
@@ -30,22 +26,19 @@ declare namespace Express {
     expires: Date | boolean;
   }
 
-  export interface SessionCookie extends SessionCookieData {
-    serialize: (name: string, value: string) => string;
+  interface SessionCookie extends SessionCookieData {
+    serialize(name: string, value: string): string;
   }
 
-  export interface Session extends SessionData {
+  interface Session extends SessionData {
     id: string;
-
-    regenerate: (callback: (err: any) => void) => void;
-    destroy: (callback: (err: any) => void) => void;
-    reload: (callback: (err: any) => void) => void;
-    save: (callback: (err: any) => void) => void;
-    touch: (callback: (err: any) => void) => void;
-
+    regenerate(callback: (err: any) => void): void;
+    destroy(callback: (err: any) => void): void;
+    reload(callback: (err: any) => void): void;
+    save(callback: (err: any) => void): void;
+    touch(callback: (err: any) => void): void;
     cookie: SessionCookie;
   }
-
 }
 
 declare module "express-session" {
@@ -55,12 +48,12 @@ declare module "express-session" {
   function session(options?: session.SessionOptions): express.RequestHandler;
 
   namespace session {
-    export interface SessionOptions {
+    interface SessionOptions {
       secret: string;
       name?: string;
       store?: Store | MemoryStore;
       cookie?: express.CookieOptions;
-      genid?: (req: express.Request) => string;
+      genid?(req: express.Request): string;
       rolling?: boolean;
       resave?: boolean;
       proxy?: boolean;
@@ -68,39 +61,38 @@ declare module "express-session" {
       unset?: string;
     }
 
-    export interface BaseMemoryStore {
-      get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
-      set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
-      destroy: (sid: string, callback: (err: any) => void) => void;
-      length?: (callback: (err: any, length: number) => void) => void;
-      clear?: (callback: (err: any) => void) => void;
+    interface BaseMemoryStore {
+      get(sid: string, callback: (err: any, session: Express.Session) => void): void;
+      set(sid: string, session: Express.Session, callback: (err: any) => void): void;
+      destroy(sid: string, callback: (err: any) => void): void;
+      length?(callback: (err: any, length: number) => void): void;
+      clear?(callback: (err: any) => void): void;
     }
 
-    export abstract class Store extends node.EventEmitter {
+    abstract class Store extends node.EventEmitter {
       constructor(config?: any);
 
       regenerate(req: express.Request, fn: (err: any) => any): void;
       load(sid: string, fn: (err: any, session: Express.Session) => any): void;
       createSession(req: express.Request, sess: Express.SessionData): void;
 
-      get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
-      set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
-      destroy: (sid: string, callback: (err: any) => void) => void;
-      all: (callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void) => void;
-      length: (callback: (err: any, length: number) => void) => void;
-      clear: (callback: (err: any) => void) => void;
+      get(sid: string, callback: (err: any, session: Express.Session) => void): void;
+      set(sid: string, session: Express.Session, callback: (err: any) => void): void;
+      destroy(sid: string, callback: (err: any) => void): void;
+      all(callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void): void;
+      length(callback: (err: any, length: number) => void): void;
+      clear(callback: (err: any) => void): void;
     }
 
-    export class MemoryStore implements BaseMemoryStore {
-      get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
-      set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
-      destroy: (sid: string, callback: (err: any) => void) => void;
-      all: (callback: (err: any, obj: { [sid: string]: Express.Session; }) => void) => void;
-      length: (callback: (err: any, length: number) => void) => void;
-      clear: (callback: (err: any) => void) => void;
+    class MemoryStore implements BaseMemoryStore {
+      get(sid: string, callback: (err: any, session: Express.Session) => void): void;
+      set(sid: string, session: Express.Session, callback: (err: any) => void): void;
+      destroy(sid: string, callback: (err: any) => void): void;
+      all(callback: (err: any, obj: { [sid: string]: Express.Session; }) => void): void;
+      length(callback: (err: any, length: number) => void): void;
+      clear(callback: (err: any) => void): void;
     }
   }
 
   export = session;
 }
-

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -24,7 +24,7 @@ declare global {
     interface SessionCookieData {
       originalMaxAge: number;
       path: string;
-      maxAge: number;
+      maxAge: number | null;
       secure?: boolean;
       httpOnly: boolean;
       domain?: string;
@@ -64,35 +64,35 @@ declare namespace session {
   }
 
   interface BaseMemoryStore {
-    get(sid: string, callback: (err: any, session: Express.Session) => void): void;
-    set(sid: string, session: Express.Session, callback: (err: any) => void): void;
-    destroy(sid: string, callback: (err: any) => void): void;
-    length?(callback: (err: any, length: number) => void): void;
-    clear?(callback: (err: any) => void): void;
+    get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
+    set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
+    destroy: (sid: string, callback: (err: any) => void) => void;
+    length?: (callback: (err: any, length: number) => void) => void;
+    clear?: (callback: (err: any) => void) => void;
   }
 
   abstract class Store extends node.EventEmitter {
     constructor(config?: any);
 
-    regenerate(req: express.Request, fn: (err: any) => any): void;
-    load(sid: string, fn: (err: any, session: Express.Session) => any): void;
-    createSession(req: express.Request, sess: Express.SessionData): void;
+    regenerate: (req: express.Request, fn: (err: any) => any) => void;
+    load: (sid: string, fn: (err: any, session: Express.Session) => any) => void;
+    createSession: (req: express.Request, sess: Express.SessionData) => void;
 
-    get(sid: string, callback: (err: any, session: Express.Session) => void): void;
-    set(sid: string, session: Express.Session, callback: (err: any) => void): void;
-    destroy(sid: string, callback: (err: any) => void): void;
-    all(callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void): void;
-    length(callback: (err: any, length: number) => void): void;
-    clear(callback: (err: any) => void): void;
+    get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
+    set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
+    destroy: (sid: string, callback: (err: any) => void) => void;
+    all: (callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void) => void;
+    length: (callback: (err: any, length: number) => void) => void;
+    clear: (callback: (err: any) => void) => void;
   }
 
   class MemoryStore implements BaseMemoryStore {
-    get(sid: string, callback: (err: any, session: Express.Session) => void): void;
-    set(sid: string, session: Express.Session, callback: (err: any) => void): void;
-    destroy(sid: string, callback: (err: any) => void): void;
-    all(callback: (err: any, obj: { [sid: string]: Express.Session; }) => void): void;
-    length(callback: (err: any, length: number) => void): void;
-    clear(callback: (err: any) => void): void;
+    get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
+    set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
+    destroy: (sid: string, callback: (err: any) => void) => void;
+    all: (callback: (err: any, obj: { [sid: string]: Express.Session; }) => void) => void;
+    length: (callback: (err: any, length: number) => void) => void;
+    clear: (callback: (err: any) => void) => void;
   }
 }
 

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for express-session
+// Type definitions for express-session 1.15
 // Project: https://www.npmjs.org/package/express-session
 // Definitions by: Hiroki Horiuchi <https://github.com/horiuchi/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,93 +6,94 @@
 
 /// <reference types="node" />
 
-declare namespace Express {
-  interface Request {
-    session?: Session;
-    sessionID?: string;
-  }
-  interface SessionData {
-    [key: string]: any;
-    cookie: Express.SessionCookieData;
-  }
+import express = require('express');
+import node = require('events');
 
-  interface SessionCookieData {
-    originalMaxAge: number;
-    path: string;
-    maxAge: number;
-    secure?: boolean;
-    httpOnly: boolean;
-    domain?: string;
-    expires: Date | boolean;
-  }
+declare global {
+  namespace Express {
+    interface Request {
+      session?: Session;
+      sessionID?: string;
+    }
 
-  interface SessionCookie extends SessionCookieData {
-    serialize(name: string, value: string): string;
-  }
+    interface SessionData {
+      [key: string]: any;
+      cookie: Express.SessionCookieData;
+    }
 
-  interface Session extends SessionData {
-    id: string;
-    regenerate(callback: (err: any) => void): void;
-    destroy(callback: (err: any) => void): void;
-    reload(callback: (err: any) => void): void;
-    save(callback: (err: any) => void): void;
-    touch(callback: (err: any) => void): void;
-    cookie: SessionCookie;
+    interface SessionCookieData {
+      originalMaxAge: number;
+      path: string;
+      maxAge: number;
+      secure?: boolean;
+      httpOnly: boolean;
+      domain?: string;
+      expires: Date | boolean;
+    }
+
+    interface SessionCookie extends SessionCookieData {
+      serialize(name: string, value: string): string;
+    }
+
+    interface Session extends SessionData {
+      id: string;
+      regenerate(callback: (err: any) => void): void;
+      destroy(callback: (err: any) => void): void;
+      reload(callback: (err: any) => void): void;
+      save(callback: (err: any) => void): void;
+      touch(callback: (err: any) => void): void;
+      cookie: SessionCookie;
+    }
   }
 }
 
-declare module "express-session" {
-  import express = require('express');
-  import node = require('events');
+declare function session(options?: session.SessionOptions): express.RequestHandler;
 
-  function session(options?: session.SessionOptions): express.RequestHandler;
-
-  namespace session {
-    interface SessionOptions {
-      secret: string;
-      name?: string;
-      store?: Store | MemoryStore;
-      cookie?: express.CookieOptions;
-      genid?(req: express.Request): string;
-      rolling?: boolean;
-      resave?: boolean;
-      proxy?: boolean;
-      saveUninitialized?: boolean;
-      unset?: string;
-    }
-
-    interface BaseMemoryStore {
-      get(sid: string, callback: (err: any, session: Express.Session) => void): void;
-      set(sid: string, session: Express.Session, callback: (err: any) => void): void;
-      destroy(sid: string, callback: (err: any) => void): void;
-      length?(callback: (err: any, length: number) => void): void;
-      clear?(callback: (err: any) => void): void;
-    }
-
-    abstract class Store extends node.EventEmitter {
-      constructor(config?: any);
-
-      regenerate(req: express.Request, fn: (err: any) => any): void;
-      load(sid: string, fn: (err: any, session: Express.Session) => any): void;
-      createSession(req: express.Request, sess: Express.SessionData): void;
-
-      get(sid: string, callback: (err: any, session: Express.Session) => void): void;
-      set(sid: string, session: Express.Session, callback: (err: any) => void): void;
-      destroy(sid: string, callback: (err: any) => void): void;
-      all(callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void): void;
-      length(callback: (err: any, length: number) => void): void;
-      clear(callback: (err: any) => void): void;
-    }
-
-    class MemoryStore implements BaseMemoryStore {
-      get(sid: string, callback: (err: any, session: Express.Session) => void): void;
-      set(sid: string, session: Express.Session, callback: (err: any) => void): void;
-      destroy(sid: string, callback: (err: any) => void): void;
-      all(callback: (err: any, obj: { [sid: string]: Express.Session; }) => void): void;
-      length(callback: (err: any, length: number) => void): void;
-      clear(callback: (err: any) => void): void;
-    }
+declare namespace session {
+  interface SessionOptions {
+    secret: string;
+    name?: string;
+    store?: Store | MemoryStore;
+    cookie?: express.CookieOptions;
+    genid?(req: express.Request): string;
+    rolling?: boolean;
+    resave?: boolean;
+    proxy?: boolean;
+    saveUninitialized?: boolean;
+    unset?: string;
   }
 
-  export = session;
+  interface BaseMemoryStore {
+    get(sid: string, callback: (err: any, session: Express.Session) => void): void;
+    set(sid: string, session: Express.Session, callback: (err: any) => void): void;
+    destroy(sid: string, callback: (err: any) => void): void;
+    length?(callback: (err: any, length: number) => void): void;
+    clear?(callback: (err: any) => void): void;
+  }
+
+  abstract class Store extends node.EventEmitter {
+    constructor(config?: any);
+
+    regenerate(req: express.Request, fn: (err: any) => any): void;
+    load(sid: string, fn: (err: any, session: Express.Session) => any): void;
+    createSession(req: express.Request, sess: Express.SessionData): void;
+
+    get(sid: string, callback: (err: any, session: Express.Session) => void): void;
+    set(sid: string, session: Express.Session, callback: (err: any) => void): void;
+    destroy(sid: string, callback: (err: any) => void): void;
+    all(callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void): void;
+    length(callback: (err: any, length: number) => void): void;
+    clear(callback: (err: any) => void): void;
+  }
+
+  class MemoryStore implements BaseMemoryStore {
+    get(sid: string, callback: (err: any, session: Express.Session) => void): void;
+    set(sid: string, session: Express.Session, callback: (err: any) => void): void;
+    destroy(sid: string, callback: (err: any) => void): void;
+    all(callback: (err: any, obj: { [sid: string]: Express.Session; }) => void): void;
+    length(callback: (err: any, length: number) => void): void;
+    clear(callback: (err: any) => void): void;
+  }
 }
+
+export = session;

--- a/types/express-session/tsconfig.json
+++ b/types/express-session/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/express-session/tsconfig.json
+++ b/types/express-session/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
+        "strictNullChecks": false,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/express-session/tslint.json
+++ b/types/express-session/tslint.json
@@ -1,0 +1,2 @@
+{
+    "extends": "dtslint/dt.json" }

--- a/types/express-session/tslint.json
+++ b/types/express-session/tslint.json
@@ -1,2 +1,6 @@
 {
-    "extends": "dtslint/dt.json" }
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "prefer-method-signature": false
+    }
+}


### PR DESCRIPTION
package "express-session"
I have added 2 interface types ```SessionData``` and ```SessionCookieData```. which are the same as ```Session``` and ```SessionCookie``` but without definition for methods. Store implementers  (me) working with typescript need to hydrate/store Session and Cookie objects without their methods.

Also implemented  code styling proposed by tslint and DefinitelyTyped.


