### PR TITLE
Added index argument to FlatList renderItem prop

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3518,7 +3518,7 @@ export interface FlatListProperties<ItemT> {
      * ```
      * Provides additional metadata like `index` if you need it.
      */
-    renderItem: (info: ItemT) => React.ReactElement<any> | null
+    renderItem: (info: ItemT, index?: number) => React.ReactElement<any> | null
 
     /**
      * See `ViewabilityHelper` for flow type and further documentation.

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3518,7 +3518,7 @@ export interface FlatListProperties<ItemT> {
      * ```
      * Provides additional metadata like `index` if you need it.
      */
-    renderItem: (info: ItemT, index?: number) => React.ReactElement<any> | null
+    renderItem: (info: ItemT, index: number) => React.ReactElement<any> | null
 
     /**
      * See `ViewabilityHelper` for flow type and further documentation.


### PR DESCRIPTION
The index argument is missing from the definition:

https://facebook.github.io/react-native/docs/flatlist.html#renderitem
