### PR TITLE
Add resolves and rejects to Jest Matchers interface

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -178,6 +178,8 @@ declare namespace jest {
     interface Matchers {
         /** If you know how to test something, `.not` lets you test its opposite. */
         not: Matchers;
+        resolves: Matchers;
+        rejects: Matchers;
         lastCalledWith(...args: any[]): void;
         /** Checks that a value is what you expect. It uses `===` to check strict equality. Don't use `toBe` with floating-point numbers. */
         toBe(expected: any): void;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -159,7 +159,7 @@ declare namespace jest {
          *
          * @param {any} actual The value to apply matchers against.
         */
-        (actual: any): Matchers;
+        (actual: any): Matchers<void>;
         anything(): any;
         /** Matches anything that was created with the given constructor. You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value. */
         any(classType: any): any;
@@ -175,69 +175,71 @@ declare namespace jest {
         stringMatching(str: string | RegExp): any;
     }
 
-    interface Matchers {
+    interface Matchers<R> {
         /** If you know how to test something, `.not` lets you test its opposite. */
-        not: Matchers;
-        resolves: Matchers;
-        rejects: Matchers;
-        lastCalledWith(...args: any[]): void;
+        not: Matchers<R>;
+        /** Use resolves to unwrap the value of a fulfilled promise so any other matcher can be chained. If the promise is rejected the assertion fails. */
+        resolves: Matchers<Promise<R>>;
+        /** Unwraps the reason of a rejected promise so any other matcher can be chained. If the promise is fulfilled the assertion fails. */
+        rejects: Matchers<Promise<R>>;
+        lastCalledWith(...args: any[]): R;
         /** Checks that a value is what you expect. It uses `===` to check strict equality. Don't use `toBe` with floating-point numbers. */
-        toBe(expected: any): void;
+        toBe(expected: any): R;
         /** Ensures that a mock function is called. */
-        toBeCalled(): void;
+        toBeCalled(): R;
         /** Ensure that a mock function is called with specific arguments. */
-        toBeCalledWith(...args: any[]): void;
+        toBeCalledWith(...args: any[]): R;
         /** Using exact equality with floating point numbers is a bad idea. Rounding means that intuitive things fail. */
-        toBeCloseTo(expected: number, delta?: number): void;
+        toBeCloseTo(expected: number, delta?: number): R;
         /** Ensure that a variable is not undefined. */
-        toBeDefined(): void;
+        toBeDefined(): R;
         /** When you don't care what a value is, you just want to ensure a value is false in a boolean context. */
-        toBeFalsy(): void;
+        toBeFalsy(): R;
         /** For comparing floating point numbers. */
-        toBeGreaterThan(expected: number): void;
+        toBeGreaterThan(expected: number): R;
         /** For comparing floating point numbers. */
-        toBeGreaterThanOrEqual(expected: number): void;
+        toBeGreaterThanOrEqual(expected: number): R;
         /** Ensure that an object is an instance of a class. This matcher uses `instanceof` underneath. */
-        toBeInstanceOf(expected: any): void
+        toBeInstanceOf(expected: any): R
         /** For comparing floating point numbers. */
-        toBeLessThan(expected: number): void;
+        toBeLessThan(expected: number): R;
         /** For comparing floating point numbers. */
-        toBeLessThanOrEqual(expected: number): void;
+        toBeLessThanOrEqual(expected: number): R;
         /** This is the same as `.toBe(null)` but the error messages are a bit nicer. So use `.toBeNull()` when you want to check that something is null. */
-        toBeNull(): void;
+        toBeNull(): R;
         /** Use when you don't care what a value is, you just want to ensure a value is true in a boolean context. In JavaScript, there are six falsy values: `false`, `0`, `''`, `null`, `undefined`, and `NaN`. Everything else is truthy. */
-        toBeTruthy(): void;
+        toBeTruthy(): R;
         /** Used to check that a variable is undefined. */
-        toBeUndefined(): void;
+        toBeUndefined(): R;
         /** Used when you want to check that an item is in a list. For testing the items in the list, this uses `===`, a strict equality check. */
-        toContain(expected: any): void;
+        toContain(expected: any): R;
         /** Used when you want to check that an item is in a list. For testing the items in the list, this  matcher recursively checks the equality of all fields, rather than checking for object identity. */
-        toContainEqual(expected: any): void;
+        toContainEqual(expected: any): R;
         /** Used when you want to check that two objects have the same value. This matcher recursively checks the equality of all fields, rather than checking for object identity. */
-        toEqual(expected: any): void;
+        toEqual(expected: any): R;
         /** Ensures that a mock function is called. */
-        toHaveBeenCalled(): boolean;
+        toHaveBeenCalled(): R;
         /** Ensures that a mock function is called an exact number of times. */
-        toHaveBeenCalledTimes(expected: number): boolean;
+        toHaveBeenCalledTimes(expected: number): R;
         /** Ensure that a mock function is called with specific arguments. */
-        toHaveBeenCalledWith(...params: any[]): boolean;
+        toHaveBeenCalledWith(...params: any[]): R;
         /** If you have a mock function, you can use `.toHaveBeenLastCalledWith` to test what arguments it was last called with. */
-        toHaveBeenLastCalledWith(...params: any[]): boolean;
+        toHaveBeenLastCalledWith(...params: any[]): R;
         /** Used to check that an object has a `.length` property and it is set to a certain numeric value. */
-        toHaveLength(expected: number): void;
-        toHaveProperty(propertyPath: string, value?: any): void;
+        toHaveLength(expected: number): R;
+        toHaveProperty(propertyPath: string, value?: any): R;
         /** Check that a string matches a regular expression. */
-        toMatch(expected: string | RegExp): void;
+        toMatch(expected: string | RegExp): R;
         /** Used to check that a JavaScript object matches a subset of the properties of an objec */
-        toMatchObject(expected: {}): void;
+        toMatchObject(expected: {}): R;
         /** This ensures that a value matches the most recent snapshot. Check out [the Snapshot Testing guide](http://facebook.github.io/jest/docs/snapshot-testing.html) for more information. */
-        toMatchSnapshot(snapshotName?: string): void;
+        toMatchSnapshot(snapshotName?: string): R;
         /** Used to test that a function throws when it is called. */
-        toThrow(error?: string | Constructable | RegExp): void;
+        toThrow(error?: string | Constructable | RegExp): R;
         /** If you want to test that a specific error is thrown inside a function. */
-        toThrowError(error?: string | Constructable | RegExp): void;
+        toThrowError(error?: string | Constructable | RegExp): R;
         /** Used to test that a function throws a error matching the most recent snapshot when it is called. */
-        toThrowErrorMatchingSnapshot(): void;
+        toThrowErrorMatchingSnapshot(): R;
     }
 
     interface Constructable {

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 19.2.0
+// Type definitions for Jest 20.0.4
 // Project: http://facebook.github.io/jest/
 // Definitions by: Asana <https://asana.com>, Ivo Stratev <https://github.com/NoHomey>, jwbay <https://github.com/jwbay>, Alexey Svetliakov <https://github.com/asvetliakov>, Alex Jover Morales <https://github.com/alexjoverm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -167,6 +167,8 @@ declare namespace jest {
         arrayContaining(arr: any[]): any;
         /** Verifies that a certain number of assertions are called during a test. This is often useful when testing asynchronous code, in order to make sure that assertions in a callback actually got called. */
         assertions(num: number): void;
+        /** Verifies that at least one assertion is called during a test. This is often useful when testing asynchronous code, in order to make sure that assertions in a callback actually got called. */
+        hasAssertions(): void;
         /** You can use `expect.extend` to add your own matchers to Jest. */
         extend(obj: ExpectExtendMap): void;
         /** Matches any object that recursively matches the provided keys. This is often handy in conjunction with other asymmetric matchers. */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -501,3 +501,18 @@ describe('Mocks', function () {
         anotherIns.testMethod.mockImplementation(() => 1);
     });
 });
+
+// https://facebook.github.io/jest/docs/en/expect.html#resolves
+describe('resolves', function () {
+    it('unwraps the expected Promise', function () {
+        return expect(Promise.resolve('test')).resolves.toEqual('test');
+    });
+});
+
+// https://facebook.github.io/jest/docs/en/expect.html#rejects
+describe('rejects', function () {
+    it('unwraps the expected Promise', function () {
+        const error = new Error('error');
+        return expect(Promise.reject(error)).rejects.toBeDefined();
+    });
+});

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -503,16 +503,39 @@ describe('Mocks', function () {
 });
 
 // https://facebook.github.io/jest/docs/en/expect.html#resolves
-describe('resolves', function () {
-    it('unwraps the expected Promise', function () {
-        return expect(Promise.resolve('test')).resolves.toEqual('test');
+describe('resolves', function() {
+    it('unwraps the expected Promise', function() {
+        const expectation = expect(Promise.resolve('test')).resolves.toEqual('test');
+        expect(expectation instanceof Promise).toBeTruthy();
+        return expectation;
+    });
+
+    it('unwraps a .toHaveBeenCalledX', function(done) {
+        expect.assertions(2);
+
+        const fn = jest.fn();
+        return expect(Promise.resolve(fn)).resolves.toHaveBeenCalledTimes(0).then(val => {
+            expect(val).toEqual(true);
+            done();
+        });
+    });
+
+    it('unwraps a not.toHaveBeenCalledX', function(done) {
+        expect.assertions(2);
+
+        const fn = jest.fn();
+        return expect(Promise.resolve(fn)).resolves.not.toHaveBeenCalledTimes(1).then(val => {
+            expect(val).toEqual(true);
+            done();
+        });
     });
 });
 
 // https://facebook.github.io/jest/docs/en/expect.html#rejects
-describe('rejects', function () {
-    it('unwraps the expected Promise', function () {
-        const error = new Error('error');
-        return expect(Promise.reject(error)).rejects.toBeDefined();
+describe('rejects', function() {
+    it('unwraps the expected Promise', function() {
+        const expectation = expect(Promise.reject(new Error('error'))).rejects.toMatch('error');
+        expect(expectation instanceof Promise).toBeTruthy();
+        return expectation;
     });
 });


### PR DESCRIPTION
- `.resolves` and `.rejects` were added in Jest 20. https://facebook.github.io/jest/docs/en/expect.html#resolves
- Also fixed return types for the `toHaveBeenCalledX` matchers as they return `undefined` and not a boolean.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
