### PR TITLE
[d3-path] [Chore] Update validated patch version

### DIFF
--- a/types/d3-path/index.d.ts
+++ b/types/d3-path/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Last module patch version validated against: 1.0.3
+// Last module patch version validated against: 1.0.5
 
 /**
  * A D3 path serializer implementing CanvasPathMethods


### PR DESCRIPTION
* This PR only updates the last patch version of d3-path this definition was validated against. No other changes necessary. It serves to create a new content hash to trigger publication to `npm/@types` after merge.

@andy-ms This is the `d3-path` forced content hash change we discussed. Whenever you can pull the trigger. No rush on this one. Cheers, T

cc @gustavderdrache No review required. It's a "no-op" to force republication to npm as README for `d3-path` was not showing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<n/a>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
