### PR TITLE
deep-freeze: Updated to use Mapped Types and align with Object.freeze in lib.d.ts

### DIFF
--- a/types/deep-freeze/deep-freeze-tests.ts
+++ b/types/deep-freeze/deep-freeze-tests.ts
@@ -3,5 +3,5 @@ import df = require('deep-freeze');
 class Foo {
     foo: string;
 }
-const foo: Foo = df(new Foo());
+const foo = df(new Foo());
 const items = [{id: 0, name: 'first'}];

--- a/types/deep-freeze/deep-freeze-tests.ts
+++ b/types/deep-freeze/deep-freeze-tests.ts
@@ -1,8 +1,7 @@
-
-
 import df = require('deep-freeze');
 
 class Foo {
-	foo: string;
+    foo: string;
 }
-var foo:Foo = df(new Foo());
+const foo: Foo = df(new Foo());
+const items = [{id: 0, name: 'first'}];

--- a/types/deep-freeze/deep-freeze-tests.ts
+++ b/types/deep-freeze/deep-freeze-tests.ts
@@ -4,4 +4,4 @@ class Foo {
     foo: string;
 }
 const foo = df(new Foo());
-const items = [{id: 0, name: 'first'}];
+const items = df([{id: 0, name: 'first'}]);

--- a/types/deep-freeze/index.d.ts
+++ b/types/deep-freeze/index.d.ts
@@ -1,13 +1,13 @@
-// Type definitions for deep-freeze
+// Type definitions for deep-freeze 0.1
 // Project: https://github.com/substack/deep-freeze
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
-declare var deepFreeze: DeepFreeze.DeepFreezeInterface;
 export = deepFreeze;
 
-declare namespace DeepFreeze {
-   export interface DeepFreezeInterface {
-      <T>(obj: T): T;
-    }
-}
+declare function deepFreeze<T>(a: T[]): ReadonlyArray<DeepReadonly<T>>;
+declare function deepFreeze<T extends Function>(f: T): T;
+declare function deepFreeze<T>(o: T): DeepReadonly<T>;
+
+declare type DeepReadonly<T> = Readonly<{ [P in keyof T]: Readonly<T[P]> }>;

--- a/types/deep-freeze/index.d.ts
+++ b/types/deep-freeze/index.d.ts
@@ -10,4 +10,4 @@ declare function deepFreeze<T>(a: T[]): ReadonlyArray<DeepReadonly<T>>;
 declare function deepFreeze<T extends Function>(f: T): T;
 declare function deepFreeze<T>(o: T): DeepReadonly<T>;
 
-type DeepReadonly<T> = Readonly<{ [P in keyof T]: Readonly<T[P]> }>;
+type DeepReadonly<T> = Readonly<{ [P in keyof T]: DeepReadonly<T[P]> }>;

--- a/types/deep-freeze/index.d.ts
+++ b/types/deep-freeze/index.d.ts
@@ -10,4 +10,4 @@ declare function deepFreeze<T>(a: T[]): ReadonlyArray<DeepReadonly<T>>;
 declare function deepFreeze<T extends Function>(f: T): T;
 declare function deepFreeze<T>(o: T): DeepReadonly<T>;
 
-declare type DeepReadonly<T> = Readonly<{ [P in keyof T]: Readonly<T[P]> }>;
+type DeepReadonly<T> = Readonly<{ [P in keyof T]: Readonly<T[P]> }>;

--- a/types/deep-freeze/index.d.ts
+++ b/types/deep-freeze/index.d.ts
@@ -11,5 +11,5 @@ declare function deepFreeze<T extends Function>(f: T): T;
 declare function deepFreeze<T>(o: T): deepFreeze.DeepReadonly<T>;
 
 declare namespace deepFreeze {
-    export type DeepReadonly<T> = Readonly<{ [P in keyof T]: DeepReadonly<T[P]> }>;
+    type DeepReadonly<T> = Readonly<{ [P in keyof T]: DeepReadonly<T[P]> }>;
 }

--- a/types/deep-freeze/index.d.ts
+++ b/types/deep-freeze/index.d.ts
@@ -6,8 +6,10 @@
 
 export = deepFreeze;
 
-declare function deepFreeze<T>(a: T[]): ReadonlyArray<DeepReadonly<T>>;
+declare function deepFreeze<T>(a: T[]): ReadonlyArray<deepFreeze.DeepReadonly<T>>;
 declare function deepFreeze<T extends Function>(f: T): T;
-declare function deepFreeze<T>(o: T): DeepReadonly<T>;
+declare function deepFreeze<T>(o: T): deepFreeze.DeepReadonly<T>;
 
-type DeepReadonly<T> = Readonly<{ [P in keyof T]: DeepReadonly<T[P]> }>;
+declare namespace deepFreeze {
+    export type DeepReadonly<T> = Readonly<{ [P in keyof T]: DeepReadonly<T[P]> }>;
+}

--- a/types/deep-freeze/tslint.json
+++ b/types/deep-freeze/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    // This package uses the Function type to align with lib.d.ts
+    "ban-types": false
+  }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/substack/deep-freeze/blob/master/index.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**Remarks:**

Updated the declaration to take advantage of Mapped Types. Specifically, I added a `DeepReadonly` recursive generic mapped type. 

Additionally, I took the opportunity to add overloads that mirroring those of `Object.freeze` as specified in the latest `lib.d.ts`.

I removed the interface as it is now unused.
