### PR TITLE
[node] Adds missing character encodings to BufferEncoding global type.

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -110,7 +110,7 @@ declare var SlowBuffer: {
 
 
 // Buffer class
-type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "binary" | "hex";
+type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "latin1" | "binary" | "hex";
 interface Buffer extends NodeBuffer { }
 
 /**

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -103,7 +103,7 @@ declare var SlowBuffer: {
 
 
 // Buffer class
-type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "binary" | "hex";
+type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "binary" | "hex";
 interface Buffer extends NodeBuffer {}
 
 /**

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -99,7 +99,7 @@ declare var SlowBuffer: {
 
 
 // Buffer class
-type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "binary" | "hex";
+type BufferEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "latin1" | "binary" | "hex";
 interface Buffer extends NodeBuffer { }
 
 /**


### PR DESCRIPTION
So "latin1" and "base64" are both valid character encodings when used with the Buffer class. It's documented on the [node docs](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings), and at least base64 is mentioned a [few lines down](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L119) in the actual type definition files currently in the repo.

"base64" is supported in v4+ ([source](https://nodejs.org/dist/v4.8.3/docs/doc/api/buffer.html#buffer_buffers_and_character_encodings))

"latin1" is supported in v6+ ([source](https://nodejs.org/dist/v6.9.5/docs/doc/api/buffer.html#buffer_buffers_and_character_encodings))


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings
- [ ] Increase the version number in the header if appropriate. 

