### PR TITLE
[redux-actions] extend parameter type with string

### DIFF
--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -116,5 +116,5 @@ export function handleActions<State, Payload>(
 ): Reducer<State, Payload>;
 
 export function combineActions(
-    ...actionTypes: Array<ActionFunctions<any>>
+    ...actionTypes: Array<ActionFunctions<any> | string>
 ): Array<ActionFunctions<any>>;


### PR DESCRIPTION
The combineActions() method can take also an Array<string> as actionTypes input parameter.
