### PR TITLE
Adding missing property (onTouchTap) to material-ui GridTile component

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1046,6 +1046,7 @@ declare namespace __MaterialUI {
             title?: React.ReactNode;
             titleBackground?: string;
             titlePosition?: "top" | "bottom";
+			onTouchTap?: TouchTapEventHandler;
         }
         export class GridTile extends React.Component<GridTileProps, {}> {
         }

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1046,7 +1046,7 @@ declare namespace __MaterialUI {
             title?: React.ReactNode;
             titleBackground?: string;
             titlePosition?: "top" | "bottom";
-			onTouchTap?: TouchTapEventHandler;
+            onTouchTap?: TouchTapEventHandler;
         }
         export class GridTile extends React.Component<GridTileProps, {}> {
         }


### PR DESCRIPTION
Please fill in this template.

- [X] Make your PR against the `master` branch.
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `tsc` without errors.
- [ ] Run `npm run lint package-name` if a `tslint.json` is present.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
http://www.material-ui.com/#/components/grid-list

onTapTouch is not specifically called out in the component doc referenced above, but onTapTouch is suppose to be available on every component as noted here - https://github.com/callemall/material-ui/issues/2413.