### PR TITLE
[react-select] Update types for loadOptions to support Async options with Promises

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -434,7 +434,7 @@ declare namespace ReactSelectClass {
         /**
          *  function to call to load options asynchronously
          */
-        loadOptions: (input: string, callback: (err: any, result: AutocompleteResult) => any) => any;
+        loadOptions: (input: string, callback?: (err: any, result: AutocompleteResult) => any) => any | Promise<AutocompleteResult>;
 
         /**
          *  replaces the placeholder while options are loading

--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -434,7 +434,9 @@ declare namespace ReactSelectClass {
         /**
          *  function to call to load options asynchronously
          */
-        loadOptions: (input: string, callback?: (err: any, result: AutocompleteResult) => any) => any | Promise<AutocompleteResult>;
+        loadOptions:
+            | ((input: string) => Promise<AutocompleteResult>)
+            | ((input: string, callback: (err: any, result: AutocompleteResult) => void) => void);
 
         /**
          *  replaces the placeholder while options are loading

--- a/types/react-select/react-select-tests.tsx
+++ b/types/react-select/react-select-tests.tsx
@@ -209,6 +209,52 @@ class SelectAsyncTest extends React.Component<React.Props<{}>, {}> {
 
 }
 
+class SelectAsyncPromiseTest extends React.Component<React.Props<{}>, {}> {
+
+    render() {
+        const getOptions = (input: string): Promise<AutocompleteResult> => {
+            return new Promise(resolve => {
+                setTimeout(function() {
+                    return resolve({
+                        options: options,
+                        complete: true
+                    });
+                }, 500);
+            });
+        };
+        const options: Option[] = [{ label: "Foo", value: "bar" }];
+        const onChange = (value: any) => console.log(value);
+
+        const asyncSelectProps: ReactAsyncSelectProps = {
+            name: "test-select-async-promise",
+            className: "test-select",
+            key: "1",
+            matchPos: "any",
+            matchProp: "any",
+            multi: true,
+            onValueClick: onChange,
+            valueKey: "github",
+            labelKey: "name",
+            onChange: onChange,
+            simpleValue: undefined,
+            value: options,
+            loadOptions: getOptions,
+            cache: {},
+            ignoreAccents: false,
+            ignoreCase: true,
+            isLoading: false,
+            minimumInput: 5,
+            searchPromptText: "search...",
+            searchingText: "searching...",
+        };
+
+        return <div>
+            <Select.Async {...asyncSelectProps} />
+        </div>;
+    }
+
+}
+
 class SelectCreatableTest extends React.Component<React.Props<{}>, {}> {
 
     render() {


### PR DESCRIPTION
As per https://github.com/JedWatson/react-select#async-options-with-promises `loadOptions` can either be a function that takes input and a callback or that takes input and returns a Promise.

