### PR TITLE
Update react-native-snap-carousel to v2.1.4

### DIFF
--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -7,6 +7,8 @@
 import * as React from 'react';
 import {
     Animated,
+    NativeSyntheticEvent,
+    NativeScrollEvent,
     ScrollViewProperties,
     ScrollViewStyle,
     ViewStyle
@@ -109,6 +111,13 @@ export interface CarouselProps extends React.Props<ScrollViewProperties> {
     slideStyle?: ViewStyle;
 
     // Callbacks
+
+    /**
+     * Callback fired while scrolling; direct equivalent of ScrollView's onScroll
+     * Since onScroll is overriden by plugin's implementation, you should use prop onScrollViewScroll
+     * if you need a callback while scrolling.
+     */
+    onScrollViewScroll?(event: NativeSyntheticEvent<NativeScrollEvent>): void;
 
     /**
      * Callback fired when navigating to an item

--- a/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
+++ b/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import {
+    NativeSyntheticEvent,
+    NativeScrollEvent,
     StyleSheet,
     Text,
     View,
@@ -23,6 +25,7 @@ class SnapCarouselTest extends React.Component<{}, {}> {
                     enableMomentum={true}
                     keyboardDismissMode='interactive'
                     onSnapToItem={this.onSnapToItem}
+                    onScrollViewScroll={this.onScroll}
                 >
                     <View
                         style={styles.item}
@@ -36,6 +39,10 @@ class SnapCarouselTest extends React.Component<{}, {}> {
 
     private onSnapToItem = (index: number) => {
         console.log("Snapped to: ", index);
+    }
+
+    private onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+        console.log("Scrolled: ", event);
     }
 }
 


### PR DESCRIPTION
`react-native-snap-carousel` introduced a new callback `onScrollViewScroll ` in version 2.1.4

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/archriss/react-native-snap-carousel/blob/master/CHANGELOG.md#v214
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.