### PR TITLE
[openlayers] DrawGeometryFunctionType: second argument is optional

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -11154,7 +11154,7 @@ declare module ol {
      *     Array.<Array.<ol.Coordinate>>), ol.geom.SimpleGeometry=):
      *     ol.geom.SimpleGeometry}
      */
-    type DrawGeometryFunctionType = (coords: (ol.Coordinate | ol.Coordinate[] | ol.Coordinate[][]), geo: ol.geom.SimpleGeometry) => ol.geom.SimpleGeometry;
+    type DrawGeometryFunctionType = (coords: (ol.Coordinate | ol.Coordinate[] | ol.Coordinate[][]), geo?: ol.geom.SimpleGeometry) => ol.geom.SimpleGeometry;
 
     /**
      * A function that takes an {@link ol.MapBrowserEvent} and returns a

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -19,6 +19,8 @@ let featureStyleFunction: ol.FeatureStyleFunction;
 let featureLoader: ol.FeatureLoader;
 let easingFunction: (t: number) => number;
 let drawGeometryFunction: ol.DrawGeometryFunctionType;
+drawGeometryFunction([0,0], new ol.geom.Point([0,0]));
+drawGeometryFunction([0,0]);
 
 // Type variables for OpenLayers
 let attribution: ol.Attribution;


### PR DESCRIPTION
[DrawGeometryFunctionType jsdoc](http://openlayers.org/en/latest/apidoc/ol.html#.DrawGeometryFunctionType):
> Function that takes coordinates **and an optional existing geometry** as
> arguments, and returns a geometry. The optional existing geometry is the
> geometry that is returned when the function is called without a second
> argument.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).