### PR TITLE
boom: add missing internal() alias

### DIFF
--- a/types/boom/boom-tests.ts
+++ b/types/boom/boom-tests.ts
@@ -33,6 +33,7 @@ Boom.tooManyRequests('message', {some: 'data'});
 Boom.illegal('message', {some: 'data'});
 
 Boom.badImplementation('message', {some: 'data'});
+Boom.internal('message', {some: 'data'});
 Boom.notImplemented('message', {some: 'data'});
 Boom.badGateway('message', {some: 'data'});
 Boom.serverUnavailable('message', {some: 'data'});

--- a/types/boom/index.d.ts
+++ b/types/boom/index.d.ts
@@ -272,6 +272,15 @@ declare namespace Boom {
     export function badImplementation(message?: string, data?: any): BoomError;
 
     /**
+     * Returns a 500 Internal Server Error error
+     * Only 500 errors will hide your message from the end user. Your message is recorded in the server log.
+     * @param message optional message.
+     * @param data optional additional error data.
+     * @see {@link https://github.com/hapijs/boom#boombadimplementationmessage-data---alias-internal}
+     */
+    export function internal(message?: string, data?: any): BoomError;
+
+    /**
      * Returns a 501 Not Implemented error with your error message to the user
      * @param message optional message.
      * @param data optional additional error data.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

alias added to documentation: https://github.com/hapijs/boom/pull/129/files (Sep 27, 2016)
`internal` already [existed in 1.0.0](https://github.com/hapijs/boom/blob/v1.0.0/lib/index.js#L237)

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
