### PR TITLE
Gridstack: addWidget() should also take jQuery or HTMLElement

### DIFF
--- a/types/gridstack/gridstack-tests.ts
+++ b/types/gridstack/gridstack-tests.ts
@@ -17,6 +17,8 @@ var gsFromElement: GridStack = element.data("gridstack");
 if (gridstack !== gsFromElement) throw Error('These should match!');
 
 gridstack.addWidget("test", 1, 2, 3, 4, true);
+gridstack.addWidget(document.createElement('div'), 1, 2, 3, 4, true);
+gridstack.addWidget($(document.createElement('div')), 1, 2, 3, 4, true);
 gridstack.batchUpdate();
 gridstack.cellHeight();;
 gridstack.cellHeight(2);

--- a/types/gridstack/index.d.ts
+++ b/types/gridstack/index.d.ts
@@ -14,14 +14,14 @@ interface GridStack {
      *
      *   Widget will be always placed even if result height is more than actual grid height. You need to use willItFit method before calling addWidget for additional check.
      *
-     * @param {string} el widget to add
+     * @param {string | HTMLElement | JQuery} el widget to add
      * @param {number} x widget position x
      * @param {number} y widget position y
      * @param {number} width  widget dimension width
      * @param {number} height widget dimension height
      * @param {boolean} autoPosition if true then x, y parameters will be ignored and widget will be places on the first available position
      */
-    addWidget(el: string, x?: number, y?: number, width?: number, height?: number, autoPosition?: boolean, minWidth?: number, maxWidth?: number, minHeight?: number, maxHeight?: number, id?: number): JQuery
+    addWidget(el: string | HTMLElement | JQuery, x?: number, y?: number, width?: number, height?: number, autoPosition?: boolean, minWidth?: number, maxWidth?: number, minHeight?: number, maxHeight?: number, id?: number): JQuery
     /**
     * Initializes batch updates. You will see no changes until commit method is called.
     */


### PR DESCRIPTION
Although the docs are not 100% accurate, [this code here](https://github.com/troolee/gridstack.js/blob/develop/src/gridstack.js#L1271) shows that the first parameter is wrapped with jQuery, thus making `HTMLElement` and `JQuery` also valid types.

As this is my first PR, I might have got something wrong. However, I followed the docs and ran the tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [this code here](https://github.com/troolee/gridstack.js/blob/develop/src/gridstack.js#L1271)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.