### PR TITLE
fix type of react-intl/{FormattedDate,FormattedTime,FormattedRelative} types

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -11,6 +11,8 @@
 
 declare namespace ReactIntl {
 
+    type DateSource = Date | string | number;
+
     interface Locale {
         locale: string;
         fields?: { [key: string]: string },
@@ -62,9 +64,9 @@ declare namespace ReactIntl {
     const intlShape: IntlShape;
 
     interface InjectedIntl {
-        formatDate: (date: Date, options?: FormattedDate.PropsBase) => string;
-        formatTime: (date: Date, options?: FormattedTime.PropsBase) => string;
-        formatRelative: (value: number, options?: FormattedRelative.PropsBase & { now?: any }) => string;
+        formatDate: (value: DateSource, options?: FormattedDate.PropsBase) => string;
+        formatTime: (value: DateSource, options?: FormattedTime.PropsBase) => string;
+        formatRelative: (value: DateSource, options?: FormattedRelative.PropsBase & { now?: any }) => string;
         formatNumber: (value: number, options?: FormattedNumber.PropsBase) => string;
         formatPlural: (value: number, options?: FormattedPlural.Base) => keyof FormattedPlural.PropsBase;
         formatMessage: (messageDescriptor: FormattedMessage.MessageDescriptor, values?: {[key: string]: string | number}) => string;
@@ -91,7 +93,7 @@ declare namespace ReactIntl {
         export interface PropsBase extends IntlComponent.DateTimeFormatProps {}
 
         export interface Props extends PropsBase {
-            value: Date;
+            value: DateSource;
         }
     }
 
@@ -101,7 +103,7 @@ declare namespace ReactIntl {
         export interface PropsBase extends IntlComponent.DateTimeFormatProps {}
 
         export interface Props extends PropsBase {
-            value: Date;
+            value: DateSource;
         }
     }
     class FormattedTime extends React.Component<FormattedTime.Props, any> { }
@@ -122,7 +124,7 @@ declare namespace ReactIntl {
         }
 
         export interface Props extends PropsBase {
-            value: number;
+            value: DateSource;
         }
     }
 

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -165,8 +165,42 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 second="2-digit"
                 timeZoneName="short" />
 
+            <FormattedDate
+                value={Date.now()}
+                format="short"
+                localeMatcher="best fit"
+                formatMatcher="basic"
+                timeZone="EDT"
+                hour12={false}
+                weekday="short"
+                era="short"
+                year="2-digit"
+                month="2-digit"
+                day="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                timeZoneName="short" />
+
             <FormattedTime
                 value={new Date()}
+                format="short"
+                localeMatcher="best fit"
+                formatMatcher="basic"
+                timeZone="EDT"
+                hour12={false}
+                weekday="short"
+                era="short"
+                year="2-digit"
+                month="2-digit"
+                day="2-digit"
+                hour="2-digit"
+                minute="2-digit"
+                second="2-digit"
+                timeZoneName="short" />
+
+            <FormattedTime
+                value={Date.now()}
                 format="short"
                 localeMatcher="best fit"
                 formatMatcher="basic"


### PR DESCRIPTION
react-intl's date-time things requires a value that can be passed to `new Date(value)`:

`<FormattedDate value={...}/>` is handled by `formatDate()`, which is:
https://github.com/yahoo/react-intl/blob/master/src/format.js#L63 

Same as `<FormattedTime/>`:

https://github.com/yahoo/react-intl/blob/master/src/format.js#L84 

and `<FormatRelative/>`:

https://github.com/yahoo/react-intl/blob/master/src/format.js#L110 

The `value` is considered as a `DateSource`, so I've defined it as an interface.