### PR TITLE
Change react's ComponentLifecycle to class

### DIFF
--- a/types/react-native-scrollable-tab-view/react-native-scrollable-tab-view-tests.tsx
+++ b/types/react-native-scrollable-tab-view/react-native-scrollable-tab-view-tests.tsx
@@ -36,9 +36,9 @@ class ScrollableTabViewDemo extends React.Component<{}, {}> {
     );
   }
 
-  protected componentWillMount?(): void {
+  componentWillMount?(): void {
   }
 
-  protected componentWillUnmount?(): void {
+  componentWillUnmount?(): void {
   }
 }

--- a/types/react-virtualized/react-virtualized-tests.tsx
+++ b/types/react-virtualized/react-virtualized-tests.tsx
@@ -405,11 +405,7 @@ export class ColumnSizerExample extends PureComponent<any, any> {
     _noColumnMaxWidthChange(event) {
         let columnMaxWidth = parseInt(event.target.value, 10)
 
-        if (isNaN(columnMaxWidth)) {
-            columnMaxWidth = undefined
-        } else {
-            columnMaxWidth = Math.min(1000, columnMaxWidth)
-        }
+        columnMaxWidth = isNaN(columnMaxWidth) ? undefined : Math.min(1000, columnMaxWidth)
 
         this.setState({ columnMaxWidth })
     }
@@ -417,11 +413,7 @@ export class ColumnSizerExample extends PureComponent<any, any> {
     _noColumnMinWidthChange(event) {
         let columnMinWidth = parseInt(event.target.value, 10)
 
-        if (isNaN(columnMinWidth)) {
-            columnMinWidth = undefined
-        } else {
-            columnMinWidth = Math.max(1, columnMinWidth)
-        }
+        columnMinWidth = isNaN(columnMinWidth) ? undefined : Math.max(1, columnMinWidth)
 
         this.setState({ columnMinWidth })
     }

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -178,7 +178,7 @@ declare namespace React {
     type ReactInstance = Component<any, any> | Element;
 
     // Base component for plain JS classes
-    class Component<P, S> implements ComponentLifecycle<P, S> {
+    class Component<P, S> extends ComponentLifecycle<P, S> {
         constructor(props?: P, context?: any);
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
         setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
@@ -251,7 +251,7 @@ declare namespace React {
     // Component Specs and Lifecycle
     // ----------------------------------------------------------------------
 
-    interface ComponentLifecycle<P, S> {
+    class ComponentLifecycle<P, S> {
         componentWillMount?(): void;
         componentDidMount?(): void;
         componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -178,7 +178,8 @@ declare namespace React {
     type ReactInstance = Component<any, any> | Element;
 
     // Base component for plain JS classes
-    class Component<P, S> extends ComponentLifecycle<P, S> {
+    interface Component<P, S> extends ComponentLifecycle<P, S> { }
+    class Component<P, S> {
         constructor(props?: P, context?: any);
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
         setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
@@ -251,7 +252,7 @@ declare namespace React {
     // Component Specs and Lifecycle
     // ----------------------------------------------------------------------
 
-    class ComponentLifecycle<P, S> {
+    interface ComponentLifecycle<P, S> {
         componentWillMount?(): void;
         componentDidMount?(): void;
         componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;


### PR DESCRIPTION
ComponentLifecycle is intended to provide some methods to Component subclasses and enforce that overrides of those methods are correct in those same subclasses.

However, it does neither of these things as an interface that Component `implements`. It just checks that Component has all the required methods of ComponentLifecycle. Since there are no required methods, the `implements` check passes. And since Component doesn't actually *implement* any of the methods, its subclasses don't get them by default, and their 'overrides' are not checked for correctness.

Changing ComponentLifecycle to a class fixes both of these problems.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
