### PR TITLE
Fixes a symbol name on @types/react-router-redux package.

### DIFF
--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -41,7 +41,7 @@ export function go(n: number): RouterAction;
 export function goBack(): RouterAction;
 export function goForward(): RouterAction;
 
-export const routerAction: {
+export const routerActions: {
     push: typeof push
     replace: typeof replace
     go: typeof go


### PR DESCRIPTION
It wasn't allowing me to import routerActions from the package, so I found that there is a typo on the symbol's name. Changing symbol's name from 'routerAction' to 'routerActions' fixes the issue.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/dec6492718e532f48d907cc5f1e93549a60d0bc2/packages/react-router-redux/modules/index.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `talent.json` containing `{ "extends": "dtslint/dt.json" }`.
