### PR TITLE
Add variadic versions for catch

### DIFF
--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -361,6 +361,22 @@ fooProm = fooProm.catch(CustomError, reason => {
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+{
+	class CustomError1 extends Error {}
+	class CustomError2 extends Error {}
+	class CustomError3 extends Error {}
+	class CustomError4 extends Error {}
+	class CustomError5 extends Error {}
+
+	fooProm = fooProm.catch(CustomError1, error => {});
+	fooProm = fooProm.catch(CustomError1, CustomError2, error => {});
+	fooProm = fooProm.catch(CustomError1, CustomError2, CustomError3, error => {});
+	fooProm = fooProm.catch(CustomError1, CustomError2, CustomError3, CustomError4, error => {});
+	fooProm = fooProm.catch(CustomError1, CustomError2, CustomError3, CustomError4, CustomError5, error => {});
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 barProm = fooProm.error((reason: any) => {
 	return bar;
 });

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -65,24 +65,133 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
    * This method also supports predicate-based filters. If you pass a predicate function instead of an error constructor, the predicate will receive the error as an argument. The return result of the predicate will be used determine whether the error handler should be called.
    *
    * Alias `.caught();` for compatibility with earlier ECMAScript version.
+   *
+   * TODO: disallow non-objects
    */
-  catch(predicate: (error: any) => boolean, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
-  caught(predicate: (error: any) => boolean, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
+  catch<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  caught<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  catch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
 
-  catch<U>(predicate: (error: any) => boolean, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
-  caught<U>(predicate: (error: any) => boolean, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
+  catch<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  caught<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  catch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
 
-  catch<E extends Error>(ErrorClass: new (...args: any[]) => E, onReject: (error: E) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
-  caught<E extends Error>(ErrorClass: new (...args: any[]) => E, onReject: (error: E) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
+  catch<E1 extends Error, E2 extends Error, E3 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  caught<E1 extends Error, E2 extends Error, E3 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  catch<U, E1 extends Error, E2 extends Error, E3 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1 extends Error, E2 extends Error, E3 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
 
-  catch<E extends Error, U>(ErrorClass: new (...args: any[]) => E, onReject: (error: E) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
-  caught<E extends Error, U>(ErrorClass: new (...args: any[]) => E, onReject: (error: E) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
+  catch<E1 extends Error, E2 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  caught<E1 extends Error, E2 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  catch<U, E1 extends Error, E2 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1 extends Error, E2 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
 
-  catch(predicate: Object, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
-  caught(predicate: Object, onReject: (error: any) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>): Bluebird<R>;
-
-  catch<U>(predicate: Object, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
-  caught<U>(predicate: Object, onReject: (error: any) => U | Bluebird.Thenable<U>): Bluebird<U | R>;
+  catch<E1 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    onReject: (error: E1) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  caught<E1 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    onReject: (error: E1) => R | Bluebird.Thenable<R> | void | Bluebird.Thenable<void>,
+  ): Bluebird<R>;
+  catch<U, E1 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    onReject: (error: E1) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    onReject: (error: E1) => U | Bluebird.Thenable<U>,
+  ): Bluebird<U | R>;
 
   /**
    * Like `.catch` but instead of catching all types of exceptions, it only catches those that don't originate from thrown errors but rather from explicit rejections.
@@ -116,11 +225,40 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
 
   /**
    * Like `.catch()` but rethrows the error
+   * TODO: disallow non-objects
    */
-  tapCatch<U>(onReject: (error?: any) => U | Bluebird.Thenable<U> | void | Bluebird.Thenable<void>): Bluebird<R>;
-  tapCatch<U, E extends Error>(ErrorClass: new (...args: any[]) => E, onReject: (error: E) => U | Bluebird.Thenable<U> | void | Bluebird.Thenable<void>): Bluebird<R>;
-  tapCatch<U>(predicate: (error?: any) => boolean, onReject: (error?: any) => U | Bluebird.Thenable<U> | void | Bluebird.Thenable<void>): Bluebird<R>;
+  tapCatch<U>(onReject: (error?: any) => U | Bluebird.Thenable<U>): Bluebird<R>;
 
+  tapCatch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => U | Bluebird.Thenable<U>,
+  ): Bluebird<R>;
+  tapCatch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3 | E4) => U | Bluebird.Thenable<U>,
+  ): Bluebird<R>;
+  tapCatch<U, E1 extends Error, E2 extends Error, E3 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2 | E3) => U | Bluebird.Thenable<U>,
+  ): Bluebird<R>;
+  tapCatch<U, E1 extends Error, E2 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    onReject: (error: E1 | E2) => U | Bluebird.Thenable<U>,
+  ): Bluebird<R>;
+  tapCatch<U, E1 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    onReject: (error: E1) => U | Bluebird.Thenable<U>,
+  ): Bluebird<R>;
 
   /**
    * Same as calling `Promise.delay(ms, this)`.
@@ -258,11 +396,40 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
    * </code>
    *
    * in the case where `value` doesn't change its value. That means `value` is bound at the time of calling `.catchReturn()`
+   * TODO: disallow non-objects
    */
   catchReturn<U>(value: U): Bluebird<U>;
-  catchReturn<U>(predicate: (error: any) => boolean, value: U): Bluebird<U | R>;
-  catchReturn<E extends Error, U>(ErrorClass: new (...args: any[]) => E, value: U): Bluebird<U | R>;
-  catchReturn<U>(predicate: Object, value: U): Bluebird<U | R>;
+
+  catchReturn<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    value: U,
+  ): Bluebird<U>;
+  catchReturn<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    value: U,
+  ): Bluebird<U>;
+  catchReturn<U, E1 extends Error, E2 extends Error, E3 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    value: U,
+  ): Bluebird<U>;
+  catchReturn<U, E1 extends Error, E2 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    value: U,
+  ): Bluebird<U>;
+  catchReturn<U, E1 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    value: U,
+  ): Bluebird<U>;
 
   /**
    * Convenience method for:
@@ -273,11 +440,40 @@ declare class Bluebird<R> implements Bluebird.Thenable<R>, Bluebird.Inspection<R
    * });
    * </code>
    * Same limitations apply as with `.catchReturn()`.
+   * TODO: disallow non-objects
    */
   catchThrow(reason: Error): Bluebird<R>;
-  catchThrow(predicate: (error: any) => boolean, reason: Error): Bluebird<R>;
-  catchThrow<E extends Error, U>(ErrorClass: new (...args: any[]) => E, reason: Error): Bluebird<R>;
-  catchThrow(predicate: Object, reason: Error): Bluebird<R>;
+
+  catchThrow<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    reason: Error,
+  ): Bluebird<R>;
+  catchThrow<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    reason: Error,
+  ): Bluebird<R>;
+  catchThrow<E1 extends Error, E2 extends Error, E3 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    reason: Error,
+  ): Bluebird<R>;
+  catchThrow<E1 extends Error, E2 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    reason: Error,
+  ): Bluebird<R>;
+  catchThrow<E1 extends Error>(
+    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    reason: Error,
+  ): Bluebird<R>;
 
   /**
    * Convert to String.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://bluebirdjs.com/docs/api/catch.html#filtered-catch
- [ ] Increase the version number in the header if appropriate. <-- **NOT SURE** 
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


Hi, so I wanted to extend the typings definition for `bluebird` since as noted in the [link](http://bluebirdjs.com/docs/api/catch.html#filtered-catch) it can be variadic and accept several types of errors.

![image](https://cloud.githubusercontent.com/assets/2164411/26460210/90fe75f6-413e-11e7-946c-e10950b720dd.png)

Currently, left variadic functions [are not supported properly](https://github.com/Microsoft/TypeScript/issues/5453). So, a workaround is to implement for several functions definitions. However, I'm not sure if my approach is the correct because of the reasons below:

thanks @lhecker for your help. I just learned a lot more thanks to you 👍 

