### PR TITLE
Added typings for the http-aws-es package.

### DIFF
--- a/types/http-aws-es/http-aws-es-tests.ts
+++ b/types/http-aws-es/http-aws-es-tests.ts
@@ -1,0 +1,42 @@
+import { EnvironmentCredentials } from "aws-sdk/lib/core";
+import { Client } from "elasticsearch";
+import HttpAmazonESConnector = require("http-aws-es");
+
+new Client({
+    amazonES: {
+        accessKey: "AKID",
+        region: "us-east-1",
+        secretKey: "secret",
+    },
+    connectionClass: HttpAmazonESConnector,
+    host: "https://amazon-es-host.us-east-1.es.amazonaws.com",
+});
+
+new Client({
+    amazonES: {
+        accessKey: "AKID",
+        region: "us-east-1",
+        secretKey: "secret",
+    },
+    connectionClass: require("http-aws-es"),
+    host: "https://amazon-es-host.us-east-1.es.amazonaws.com",
+});
+
+const myCredentials = new EnvironmentCredentials("AWS");
+new Client({
+    amazonES: {
+        credentials: myCredentials,
+        region: "us-east-1",
+    },
+    connectionClass: HttpAmazonESConnector,
+    host: "https://amazon-es-host.us-east-1.es.amazonaws.com",
+});
+
+new Client({
+    amazonES: {
+        credentials: myCredentials,
+        region: "us-east-1",
+    },
+    connectionClass: require("http-aws-es"),
+    host: "https://amazon-es-host.us-east-1.es.amazonaws.com",
+});

--- a/types/http-aws-es/index.d.ts
+++ b/types/http-aws-es/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for http-aws-es 1.1
+// Project: https://github.com/TheDeveloper/http-aws-es#readme
+// Definitions by: Marco Gonzalez <https://github.com/marcogrcr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import * as e from "elasticsearch";
+import { Credentials } from "aws-sdk/lib/core";
+
+declare module "elasticsearch" {
+    interface AmazonESOptions {
+        accessKey?: string;
+        credentials?: Credentials;
+        region: string;
+        secretKey?: string;
+    }
+
+    interface ConfigOptions {
+        amazonES?: AmazonESOptions;
+    }
+}
+
+declare const HttpAmazonESConnector: any;
+export = HttpAmazonESConnector;

--- a/types/http-aws-es/package.json
+++ b/types/http-aws-es/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "aws-sdk": "^2.7.0"
+    }
+}

--- a/types/http-aws-es/tsconfig.json
+++ b/types/http-aws-es/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "http-aws-es-tests.ts"
+    ]
+}

--- a/types/http-aws-es/tslint.json
+++ b/types/http-aws-es/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

Other comments:

- I cannot add the types directly to the `http-aws-es` package because it would introduce an undesired dependency to the `@types/node` package. One alternative would be have a `peerDependency`, however, it can cause confusion for non TypeScript users.
- These typings have dependencies on the following packages: `@types/node`, `@types/elasticsearch` and `aws-sdk`. I had to add a `package.json` file for specifying the dependency with the `aws-sdk` package. Nonetheless, the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request) does not provide clarity on whether the `@types/*` dependencies need to be specified explicitly, or if they can be omitted and they will be automatically populated based on the `import` and `/// <reference types="" />` statements present in the `index.d.ts` file.
- I was able to run `tsc`, however I cannot run `npm run lint package-name` because I'm getting the error reported on #16692