### PR TITLE
[fullcalendar] non-standard fields (EventObject)

### DIFF
--- a/types/fullcalendar/fullcalendar-tests.ts
+++ b/types/fullcalendar/fullcalendar-tests.ts
@@ -622,9 +622,6 @@ $('#calendar').fullCalendar({
     eventColor: '#378006'
 });
 
-interface EventWithDescription extends FullCalendar.EventObject {
-    description: string;
-}
 interface JQueryQTip extends JQuery {
     qtip(options: Object): JQuery; // dummy plugin interface
 }
@@ -638,7 +635,7 @@ $('#calendar').fullCalendar({
         }
         // more events here
     ],
-    eventRender(event: EventWithDescription, element: JQueryQTip, view: FullCalendar.ViewObject) {
+    eventRender(event: FullCalendar.EventObject, element: JQueryQTip, view: FullCalendar.ViewObject) {
         element.qtip({
             content: event.description
         });

--- a/types/fullcalendar/index.d.ts
+++ b/types/fullcalendar/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://fullcalendar.io/
 // Definitions by: Neil Stalker <https://github.com/nestalk>, Marcelo Camargo <https://github.com/hasellcamargo>, Patrick Niemann <https://github.com/panic175>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="jquery"/>
 
@@ -229,6 +230,8 @@ export interface EventObject extends Timespan {
     backgroundColor?: string;
     borderColor?: string;
     textColor?: string;
+    // non-standard fields, see https://fullcalendar.io/docs/event_data/Event_Object/ and https://fullcalendar.io/docs/event_rendering/eventRender/
+    [x: string]: any;
 }
 
 export interface ViewObject extends Timespan {


### PR DESCRIPTION
Please fill in this template.

- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Use a meaningful title for the pull request. Include the name of the package modified.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

    "In addition to the fields above, you may also include your own non-standard fields in each Event Object. FullCalendar will not modify or delete these fields." - https://fullcalendar.io/docs/event_data/Event_Object/

    "Note that description is a non-standard Event Object field, which is allowed." -
 https://fullcalendar.io/docs/event_rendering/eventRender/

    "If the target type accepts additional properties, add an indexer:" - https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#strict-object-literal-assignment-checking

- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
