### PR TITLE
[semantic-ui-transition] Add type definitions

### DIFF
--- a/types/semantic-ui-transition/global.d.ts
+++ b/types/semantic-ui-transition/global.d.ts
@@ -102,13 +102,13 @@ declare namespace SemanticUI {
         (settings?: TransitionSettings | object): JQuery;
     }
 
-    interface TransitionSettings extends Pick<Transition._Settings, keyof Transition._Settings> { }
+    /**
+     * @see {@link http://semantic-ui.com/modules/transition.html#/settings}
+     */
+    interface TransitionSettings extends Pick<TransitionSettings._Impl, keyof TransitionSettings._Impl> { }
 
-    namespace Transition {
-        /**
-         * @see {@link http://semantic-ui.com/modules/transition.html#/settings}
-         */
-        interface _Settings {
+    namespace TransitionSettings {
+        interface _Impl {
             // region Transition Settings
 
             /**
@@ -182,13 +182,13 @@ declare namespace SemanticUI {
             /**
              * Class names used to attach style to state
              */
-            className: ClassNameSettings;
+            className: Transition.ClassNameSettings;
 
             // endregion
 
             // region Debug Settings
 
-            error: ErrorSettings;
+            error: Transition.ErrorSettings;
 
             // endregion
 
@@ -230,59 +230,65 @@ declare namespace SemanticUI {
 
             // endregion
         }
+    }
 
-        interface ClassNameSettings extends Pick<_ClassNameSettings, keyof _ClassNameSettings> { }
+    namespace Transition {
+        interface ClassNameSettings extends Pick<ClassNameSettings._Impl, keyof ClassNameSettings._Impl> { }
 
-        interface _ClassNameSettings {
-            /**
-             * @default 'animating'
-             */
-            animating: string;
-            /**
-             * @default 'disabled'
-             */
-            disabled: string;
-            /**
-             * @default 'hidden'
-             */
-            hidden: string;
-            /**
-             * @default 'in'
-             */
-            inward: string;
-            /**
-             * @default 'loading'
-             */
-            loading: string;
-            /**
-             * @default 'looping'
-             */
-            looping: string;
-            /**
-             * @default 'out'
-             */
-            outward: string;
-            /**
-             * @default 'transition'
-             */
-            transition: string;
-            /**
-             * @default 'visible'
-             */
-            visible: string;
+        namespace ClassNameSettings {
+            interface _Impl {
+                /**
+                 * @default 'animating'
+                 */
+                animating: string;
+                /**
+                 * @default 'disabled'
+                 */
+                disabled: string;
+                /**
+                 * @default 'hidden'
+                 */
+                hidden: string;
+                /**
+                 * @default 'in'
+                 */
+                inward: string;
+                /**
+                 * @default 'loading'
+                 */
+                loading: string;
+                /**
+                 * @default 'looping'
+                 */
+                looping: string;
+                /**
+                 * @default 'out'
+                 */
+                outward: string;
+                /**
+                 * @default 'transition'
+                 */
+                transition: string;
+                /**
+                 * @default 'visible'
+                 */
+                visible: string;
+            }
         }
 
-        interface ErrorSettings extends Pick<_ErrorSettings, keyof _ErrorSettings> { }
+        interface ErrorSettings extends Pick<ErrorSettings._Impl, keyof ErrorSettings._Impl> { }
 
-        interface _ErrorSettings {
-            /**
-             * @default 'There is no CSS animation matching the one you specified.'
-             */
-            noAnimation: string;
-            /**
-             * @default 'The method you called is not defined'
-             */
-            method: string;
+        namespace ErrorSettings {
+            interface _Impl {
+                /**
+                 * @default 'There is no CSS animation matching the one you specified.'
+                 */
+                noAnimation: string;
+                /**
+                 * @default 'The method you called is not defined'
+                 */
+                method: string;
+            }
         }
     }
 }

--- a/types/semantic-ui-transition/global.d.ts
+++ b/types/semantic-ui-transition/global.d.ts
@@ -1,0 +1,288 @@
+interface JQuery {
+    transition: SemanticUI.Transition;
+}
+
+declare namespace SemanticUI {
+    interface Transition {
+        settings: TransitionSettings;
+
+        /**
+         * Stop current animation and preserve queue
+         */
+        (behavior: 'stop'): JQuery;
+        /**
+         * Stop current animation and queued animations
+         */
+        (behavior: 'stop all'): JQuery;
+        /**
+         * Clears all queued animations
+         */
+        (behavior: 'clear queue'): JQuery;
+        /**
+         * Stop current animation and show element
+         */
+        (behavior: 'show'): JQuery;
+        /**
+         * Stop current animation and hide element
+         */
+        (behavior: 'hide'): JQuery;
+        /**
+         * Toggles between hide and show
+         */
+        (behavior: 'toggle'): JQuery;
+        /**
+         * Forces reflow using a more expensive but stable method
+         */
+        (behavior: 'force repaint'): JQuery;
+        /**
+         * Triggers reflow on element
+         */
+        (behavior: 'repaint'): JQuery;
+        /**
+         * Resets all conditions changes during transition
+         */
+        (behavior: 'reset'): JQuery;
+        /**
+         * Enables animation looping
+         */
+        (behavior: 'looping'): JQuery;
+        /**
+         * Removes looping state from element
+         */
+        (behavior: 'remove looping'): JQuery;
+        /**
+         * Adds disabled state (stops ability to animate)
+         */
+        (behavior: 'disable'): JQuery;
+        /**
+         * Removes disabled state
+         */
+        (behavior: 'enable'): JQuery;
+        /**
+         * Modifies element animation duration
+         */
+        (behavior: 'set duration', duration: number): JQuery;
+        /**
+         * Saves all class names and styles to cache to be retrieved after animation
+         */
+        (behavior: 'save conditions'): JQuery;
+        /**
+         * Adds back cached names and styles to element
+         */
+        (behavior: 'restore conditions'): JQuery;
+        /**
+         * Returns vendor prefixed animation property for animationname
+         */
+        (behavior: 'get animation name'): string;
+        /**
+         * Returns vendor prefixed animation property for animationend
+         */
+        (behavior: 'get animation event'): string;
+        /**
+         * Returns whether element is currently visible
+         */
+        (behavior: 'is visible'): boolean;
+        /**
+         * Returns whether transition is currently occurring
+         */
+        (behavior: 'is animating'): boolean;
+        /**
+         * Returns whether animation looping is set
+         */
+        (behavior: 'is looping'): boolean;
+        /**
+         * Returns whether animations are supported
+         */
+        (behavior: 'is supported'): boolean;
+        (behavior: 'destroy'): JQuery;
+        <K extends keyof TransitionSettings>(behavior: 'setting', name: K, value?: undefined): TransitionSettings[K];
+        <K extends keyof TransitionSettings>(behavior: 'setting', name: K, value: TransitionSettings[K]): JQuery;
+        (behavior: 'setting', value: TransitionSettings | object): JQuery;
+        (transition: string): JQuery;
+        (settings?: TransitionSettings | object): JQuery;
+    }
+
+    interface TransitionSettings extends Pick<Transition._Settings, keyof Transition._Settings> { }
+
+    namespace Transition {
+        /**
+         * @see {@link http://semantic-ui.com/modules/transition.html#/settings}
+         */
+        interface _Settings {
+            // region Transition Settings
+
+            /**
+             * Named animation event to used. Must be defined in CSS.
+             *
+             * @default 'fade'
+             */
+            animation: string;
+            /**
+             * Interval in MS between each elements transition
+             *
+             * @default 0
+             */
+            interval: number;
+            /**
+             * When an interval is specified, sets order of animations. auto reverses only animations that are hiding.
+             *
+             * @default 'auto'
+             */
+            reverse: 'auto' | boolean;
+            /**
+             * Specify the final display type (block, inline-block etc) so that it doesn't have to be calculated.
+             *
+             * @default false
+             */
+            displayType: false | string;
+            /**
+             * Duration of the CSS transition animation
+             *
+             * @default 500
+             */
+            duration: number;
+            /**
+             * If enabled a timeout will be added to ensure animationend callback occurs even if element is hidden
+             */
+            useFailSafe: boolean;
+            /**
+             * If enabled will allow same animation to be queued while it is already occurring
+             */
+            allowRepeats: boolean;
+            /**
+             * Whether to automatically queue animation if another is occurring
+             */
+            queue: boolean;
+
+            // endregion
+
+            // region Callbacks
+
+            /**
+             * Callback on each transition that changes visibility to shown
+             */
+            onShow(this: JQuery): void;
+            /**
+             * Callback on each transition that changes visibility to hidden
+             */
+            onHide(this: JQuery): void;
+            /**
+             * Callback on animation start, useful for queued animations
+             */
+            onStart(this: JQuery): void;
+            /**
+             * Callback on each transition complete
+             */
+            onComplete(this: JQuery): void;
+
+            // endregion
+
+            // region DOM Settings
+
+            /**
+             * Class names used to attach style to state
+             */
+            className: ClassNameSettings;
+
+            // endregion
+
+            // region Debug Settings
+
+            error: ErrorSettings;
+
+            // endregion
+
+            // region Component Settings
+
+            // region DOM Settings
+
+            /**
+             * Event namespace. Makes sure module teardown does not effect other events attached to an element.
+             */
+            namespace: string;
+
+            // endregion
+
+            // region Debug Settings
+
+            /**
+             * Name used in log statements
+             */
+            name: string;
+            /**
+             * Silences all console output including error messages, regardless of other debug settings.
+             */
+            silent: boolean;
+            /**
+             * Debug output to console
+             */
+            debug: boolean;
+            /**
+             * Show console.table output with performance metrics
+             */
+            performance: boolean;
+            /**
+             * Debug output includes all internal behaviors
+             */
+            verbose: boolean;
+
+            // endregion
+
+            // endregion
+        }
+
+        interface ClassNameSettings extends Pick<_ClassNameSettings, keyof _ClassNameSettings> { }
+
+        interface _ClassNameSettings {
+            /**
+             * @default 'animating'
+             */
+            animating: string;
+            /**
+             * @default 'disabled'
+             */
+            disabled: string;
+            /**
+             * @default 'hidden'
+             */
+            hidden: string;
+            /**
+             * @default 'in'
+             */
+            inward: string;
+            /**
+             * @default 'loading'
+             */
+            loading: string;
+            /**
+             * @default 'looping'
+             */
+            looping: string;
+            /**
+             * @default 'out'
+             */
+            outward: string;
+            /**
+             * @default 'transition'
+             */
+            transition: string;
+            /**
+             * @default 'visible'
+             */
+            visible: string;
+        }
+
+        interface ErrorSettings extends Pick<_ErrorSettings, keyof _ErrorSettings> { }
+
+        interface _ErrorSettings {
+            /**
+             * @default 'There is no CSS animation matching the one you specified.'
+             */
+            noAnimation: string;
+            /**
+             * @default 'The method you called is not defined'
+             */
+            method: string;
+        }
+    }
+}

--- a/types/semantic-ui-transition/index.d.ts
+++ b/types/semantic-ui-transition/index.d.ts
@@ -5,6 +5,7 @@
 // TypeScript Version: 2.2
 
 /// <reference types="jquery" />
+/// <reference path="global.d.ts" />
 
 declare const transition: SemanticUI.Transition;
 export = transition;

--- a/types/semantic-ui-transition/index.d.ts
+++ b/types/semantic-ui-transition/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for semantic-ui-transition 2.2
+// Project: http://www.semantic-ui.com
+// Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="jquery" />
+
+declare const transition: SemanticUI.Transition;
+export = transition;

--- a/types/semantic-ui-transition/semantic-ui-transition-tests.ts
+++ b/types/semantic-ui-transition/semantic-ui-transition-tests.ts
@@ -1,0 +1,92 @@
+function test_static() {
+    $.fn.transition.settings.error.method = 'method';
+    $.fn.transition.settings.namespace = 'namespace';
+    $.fn.transition.settings.name = 'name';
+    $.fn.transition.settings.silent = false;
+    $.fn.transition.settings.debug = true;
+    $.fn.transition.settings.performance = true;
+    $.fn.transition.settings.verbose = true;
+}
+
+function test_transition() {
+    const selector = '.ui.transition';
+    $(selector).transition('stop') === $();
+    $(selector).transition('stop all') === $();
+    $(selector).transition('clear queue') === $();
+    $(selector).transition('show') === $();
+    $(selector).transition('hide') === $();
+    $(selector).transition('toggle') === $();
+    $(selector).transition('force repaint') === $();
+    $(selector).transition('repaint') === $();
+    $(selector).transition('reset') === $();
+    $(selector).transition('looping') === $();
+    $(selector).transition('remove looping') === $();
+    $(selector).transition('disable') === $();
+    $(selector).transition('enable') === $();
+    $(selector).transition('set duration', 10) === $();
+    $(selector).transition('save conditions') === $();
+    $(selector).transition('restore conditions') === $();
+    $(selector).transition('get animation name') === 'animation name';
+    $(selector).transition('get animation event') === 'animation event';
+    $(selector).transition('is visible') === false;
+    $(selector).transition('is animating') === false;
+    $(selector).transition('is looping') === false;
+    $(selector).transition('is supported') === false;
+    $(selector).transition('destroy') === $();
+    $(selector).transition('setting', 'debug', undefined) === false;
+    $(selector).transition('setting', 'debug') === false;
+    $(selector).transition('setting', 'debug', true) === $();
+    $(selector).transition('setting', {
+        namespace: 'namespace',
+        name: 'name',
+        silent: false,
+        debug: true,
+        performance: true,
+        verbose: true
+    }) === $();
+    $(selector).transition('fade') === $();
+    $(selector).transition({
+        animation: 'fade',
+        interval: 200,
+        reverse: true,
+        displayType: 'inline-block',
+        duration: 300,
+        useFailSafe: false,
+        allowRepeats: true,
+        queue: false,
+        onShow() {
+            this === $();
+        },
+        onHide() {
+            this === $();
+        },
+        onStart() {
+            this === $();
+        },
+        onComplete() {
+            this === $();
+        },
+        className: {
+            animating: 'animating',
+            disabled: 'disabled',
+            hidden: 'hidden',
+            inward: 'inward',
+            loading: 'loading',
+            looping: 'looping',
+            outward: 'outward',
+            transition: 'transition',
+            visible: 'visible'
+        },
+        error: {
+            noAnimation: 'noAnimation',
+            method: 'method'
+        }
+    }) === $();
+    $(selector).transition() === $();
+}
+
+import transition = require('semantic-ui-transition');
+
+function test_module() {
+    $.fn.transition = transition;
+}

--- a/types/semantic-ui-transition/tsconfig.json
+++ b/types/semantic-ui-transition/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "global.d.ts",
+        "semantic-ui-transition-tests.ts"
+    ]
+}

--- a/types/semantic-ui-transition/tslint.json
+++ b/types/semantic-ui-transition/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-empty-interface": false,
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

`unified-signatures` is disabled as discussed at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14252.
`no-empty-interface` is disabled for a better debugging experience. Empty interfaces are used to alias a type alias.
- **Type Alias**
`Argument of type 'string' is not assignable to parameter of type 'object | Pick<_Settings, "namespace" | "name" | "silent" | "debug" | "performance" | "verbose" | ...'.`
- **Interface**
`Argument of type 'string' is not assignable to parameter of type 'object | DimmerSettings | undefined'.`