### PR TITLE
[moment-duration-format] Update type definitions

### DIFF
--- a/types/moment-duration-format/index.d.ts
+++ b/types/moment-duration-format/index.d.ts
@@ -1,21 +1,55 @@
 // Type definitions for moment-duration-format 1.3
 // Project: https://github.com/jsmreese/moment-duration-format
-// Definitions by: Swint De Coninck <https://github.com/SwintDC>, Niklas Walter <https://github.com/TwoStone>
+// Definitions by: Swint De Coninck <https://github.com/SwintDC>, Niklas Walter <https://github.com/TwoStone>, Leonard Thieu <https://github.com/leonard-thieu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as moment from "moment";
 
 declare module "moment" {
+    namespace duration {
+        const fn: Duration;
+    }
+
     interface Duration {
-        format(template: string, precision?: number, settings?: DurationFormatSettings): string;
-        format(template: string, settings?: DurationFormatSettings): string;
-        format(settings: DurationFormatSettings): string;
+        format: Format;
+    }
+
+    interface Format {
+        defaults: DurationFormatSettings;
+
+        (template: string | TemplateFunction, precision: number, settings?: DurationFormatSettings): string;
+        (template: string | TemplateFunction, settings?: DurationFormatSettings): string;
+        (settings?: DurationFormatSettings): string;
     }
 
     interface DurationFormatSettings {
-        template?: string;
+        escape?: RegExp;
+        years?: RegExp;
+        months?: RegExp;
+        weeks?: RegExp;
+        days?: RegExp;
+        hours?: RegExp;
+        minutes?: RegExp;
+        seconds?: RegExp;
+        milliseconds?: RegExp;
+        general?: RegExp;
+
+        types?: string;
+
+        // "left" - template tokens are trimmed from the left until the first moment token that has a value >= 1
+        // "right" - template tokens are trimmed from the right until the first moment token that has a value >= 1
+        // (the final moment token is not trimmed, regardless of value)
+        // `false` - template tokens are not trimmed
+        trim?: 'left' | 'right' | false;
+
+        // number of decimal digits to include after (to the right of) the decimal point (positive integer)
+        // or the number of digits to truncate to 0 before (to the left of) the decimal point (negative integer)
         precision?: number;
-        trim?: boolean | "right";
-        forceLength?: boolean;
+
+        // force first moment token with a value to render at full length even when template is trimmed and first moment token has length of 1
+        forceLength?: boolean | null;
+        template?: string | TemplateFunction;
     }
+
+    type TemplateFunction = ((this: DurationFormatSettings) => string);
 }

--- a/types/moment-duration-format/moment-duration-format-tests.ts
+++ b/types/moment-duration-format/moment-duration-format-tests.ts
@@ -1,0 +1,72 @@
+import * as moment from "moment";
+import 'moment-duration-format';
+
+moment.duration(123, "minutes").format();
+// "2:03:00"
+
+moment.duration(123, "months").format();
+// "10y 3m"
+
+moment.duration(123, "minutes").format("h:mm");
+// "2:03"
+
+moment.duration(123, "minutes").format("h [hrs], m [min]");
+// "2 hrs, 3 min"
+
+moment.duration(123, "minutes").format("h [hrs]");
+// "2 hrs"
+
+moment.duration(123, "minutes").format("h [hrs]", 2);
+// "2.04 hrs"
+
+moment.duration(123, "minutes").format("m [min]", -1);
+// "120 min"
+
+moment.duration(123, "minutes").format({ template: "h [hrs]", precision: 2 });
+// "2.04 hrs"
+
+moment.duration(123, "minutes").format("d[d] h:mm:ss");
+// "2:03:00"
+
+moment.duration(123, "minutes").format("d[d] h:mm:ss", { trim: false });
+// "0d 2:03:00"
+
+moment.duration(123, "minutes").format("[seconds:] s -- [minutes:] m -- [hours:] h -- [days:] d", { trim: "right" });
+// "seconds: 0 -- minutes: 3 -- hours: 2"
+
+moment.duration(123, "seconds").format("h:mm:ss");
+// "2:03"
+
+moment.duration(123, "seconds").format("hh:mm:ss");
+// "02:03"
+
+moment.duration(123, "seconds").format("h:mm:ss", { forceLength: true });
+// "02:03"
+
+moment.duration.fn.format.defaults.escape = /\((.+?)\)/;
+moment.duration(123, "seconds").format("m (minutes)", 2);
+// "2.04 minutes"
+
+moment.duration.fn.format.defaults.years = /[Aa]+/;
+moment.duration(123, "weeks").format("a [años]", 2);
+// "2.35 años"
+
+moment.duration.fn.format.defaults.months = /m+/;
+moment.duration(123, "weeks").format("m M", 2);
+// "28.36 M"
+
+moment.duration.fn.format.defaults.weeks = /w+/;
+moment.duration(123, "days").format("w W", 2);
+// "17.57 W"
+
+moment.duration.fn.format.defaults.days = /d+/;
+moment.duration(123, "hours").format("d D", 2);
+// "5.12 D"
+
+moment.duration.fn.format.defaults.hours = /h+/;
+moment.duration(123, "minutes").format("h H", 2);
+// "2.04 H"
+
+moment.duration.fn.format.defaults.minutes = /n+/;
+moment.duration(123, "seconds").format("n:ss");
+// "2:03"

--- a/types/moment-duration-format/tsconfig.json
+++ b/types/moment-duration-format/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
@@ -16,6 +16,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "moment-duration-format-tests.ts"
     ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jsmreese/moment-duration-format#usage
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

**Summary of changes**
- Adds parameterless overload for `format()`
- Adds missing settings
- Adds declaration for default settings property
- Adds tests