### PR TITLE
three: Restore per-file attributions

### DIFF
--- a/types/three/detector.d.ts
+++ b/types/three/detector.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 export var canvas: boolean;
 export var webgl: boolean;

--- a/types/three/detector.d.ts
+++ b/types/three/detector.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 export var canvas: boolean;
 export var webgl: boolean;
 export var workers: boolean;

--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -1,18 +1,6 @@
 // Type definitions for three.js 0.84
 // Project: http://mrdoob.github.com/three.js/
-// Definitions by: Kon <http://phyzkit.net/>
-//                 Satoru Kimura <https://github.com/gyohk>
-//                 Florent Poujol <https://github.com/florentpoujol>
-//                 SereznoKot <https://github.com/SereznoKot>
-//                 HouChunlei <https://github.com/omni360>
-//                 Ivo <https://github.com/ivoisbelongtous>
-//                 David Asmuth <https://github.com/piranha771>
-//                 Brandon Roberge <>
-//                 Qinsi ZHU <https://github.com/qszhusightp>
-//                 Toshiya Nakakura <https://github.com/nakakura>
-//                 Poul Kjeldager Sørensen <https://github.com/s093294>
-//                 Stefan Profanter <https://github.com/Pro>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>, HouChunlei <https://github.com/omni360>, Ivo <https://github.com/ivoisbelongtous>, David Asmuth <https://github.com/piranha771>, Brandon Roberge <Brandon Roberge>, Qinsi ZHU <https://github.com/qszhusightp>, Toshiya Nakakura <https://github.com/nakakura>, Poul Kjeldager Sørensen <https://github.com/s093294>, Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>
 // Definitions: https://github.com//DefinitelyTyped
 
 export * from "./three-core";

--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -1,6 +1,18 @@
 // Type definitions for three.js 0.84
 // Project: http://mrdoob.github.com/three.js/
-// Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>, HouChunlei <https://github.com/omni360>, Ivo <https://github.com/ivoisbelongtous>, David Asmuth <https://github.com/piranha771>, Brandon Roberge, Qinsi ZHU <https://github.com/qszhusightp>, Toshiya Nakakura <https://github.com/nakakura>, Poul Kjeldager Sørensen <https://github.com/s093294>, Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Kon <http://phyzkit.net/>
+//                 Satoru Kimura <https://github.com/gyohk>
+//                 Florent Poujol <https://github.com/florentpoujol>
+//                 SereznoKot <https://github.com/SereznoKot>
+//                 HouChunlei <https://github.com/omni360>
+//                 Ivo <https://github.com/ivoisbelongtous>
+//                 David Asmuth <https://github.com/piranha771>
+//                 Brandon Roberge <>
+//                 Qinsi ZHU <https://github.com/qszhusightp>
+//                 Toshiya Nakakura <https://github.com/nakakura>
+//                 Poul Kjeldager Sørensen <https://github.com/s093294>
+//                 Stefan Profanter <https://github.com/Pro>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
 // Definitions: https://github.com//DefinitelyTyped
 
 export * from "./three-core";

--- a/types/three/three-FirstPersonControls.d.ts
+++ b/types/three/three-FirstPersonControls.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Poul Kjeldager Sørensen <https://github.com/s093294>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Camera, Object3D, Vector3 } from "./three-core";
 
 export class FirstPersonControls {

--- a/types/three/three-FirstPersonControls.d.ts
+++ b/types/three/three-FirstPersonControls.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Poul Kjeldager Sørensen <https://github.com/s093294>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Poul Kjeldager Sørensen <https://github.com/s093294>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Camera, Object3D, Vector3 } from "./three-core";
 

--- a/types/three/three-canvasrenderer.d.ts
+++ b/types/three/three-canvasrenderer.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import {
     Camera,
     Color,

--- a/types/three/three-canvasrenderer.d.ts
+++ b/types/three/three-canvasrenderer.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import {
     Camera,

--- a/types/three/three-colladaLoader.d.ts
+++ b/types/three/three-colladaLoader.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Brandon Roberge <>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Brandon Roberge <Brandon Roberge>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import {
     Scene

--- a/types/three/three-colladaLoader.d.ts
+++ b/types/three/three-colladaLoader.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Brandon Roberge <>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import {
     Scene
 } from "./three-core";

--- a/types/three/three-copyshader.d.ts
+++ b/types/three/three-copyshader.d.ts
@@ -1,2 +1,5 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Shader } from "./three-core";
 export var CopyShader: Shader;

--- a/types/three/three-copyshader.d.ts
+++ b/types/three/three-copyshader.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Shader } from "./three-core";
 export var CopyShader: Shader;

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -1,3 +1,12 @@
+// Definitions by: Kon <http://phyzkit.net/>
+//                 Satoru Kimura <https://github.com/gyohk>
+//                 Florent Poujol <https://github.com/florentpoujol>
+//                 SereznoKot <https://github.com/SereznoKot>
+//                 HouChunlei <https://github.com/omni360>
+//                 Ivo <https://github.com/ivoisbelongtous>
+//                 David Asmuth <https://github.com/piranha771>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 export const REVISION: string;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent.button

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -1,11 +1,4 @@
-// Definitions by: Kon <http://phyzkit.net/>
-//                 Satoru Kimura <https://github.com/gyohk>
-//                 Florent Poujol <https://github.com/florentpoujol>
-//                 SereznoKot <https://github.com/SereznoKot>
-//                 HouChunlei <https://github.com/omni360>
-//                 Ivo <https://github.com/ivoisbelongtous>
-//                 David Asmuth <https://github.com/piranha771>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>, HouChunlei <https://github.com/omni360>, Ivo <https://github.com/ivoisbelongtous>, David Asmuth <https://github.com/piranha771>, Edmund Fokschaner <https://github.com/efokschaner>
 
 export const REVISION: string;
 

--- a/types/three/three-css3drenderer.d.ts
+++ b/types/three/three-css3drenderer.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Camera, Object3D, Scene } from "./three-core";
 

--- a/types/three/three-css3drenderer.d.ts
+++ b/types/three/three-css3drenderer.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Camera, Object3D, Scene } from "./three-core";
 
 export class CSS3DObject extends Object3D {

--- a/types/three/three-ctmloader.d.ts
+++ b/types/three/three-ctmloader.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: HouChunlei <https://github.com/omni360>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Loader } from "./three-core";
 
 export class CTMLoader extends Loader {

--- a/types/three/three-ctmloader.d.ts
+++ b/types/three/three-ctmloader.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: HouChunlei <https://github.com/omni360>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: HouChunlei <https://github.com/omni360>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Loader } from "./three-core";
 

--- a/types/three/three-editorcontrols.d.ts
+++ b/types/three/three-editorcontrols.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Qinsi ZHU <https://github.com/qszhusightp>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Camera, EventDispatcher, Object3D, Vector3 } from "./three-core";
 
 export class EditorControls extends EventDispatcher {

--- a/types/three/three-editorcontrols.d.ts
+++ b/types/three/three-editorcontrols.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Qinsi ZHU <https://github.com/qszhusightp>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Qinsi ZHU <https://github.com/qszhusightp>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Camera, EventDispatcher, Object3D, Vector3 } from "./three-core";
 

--- a/types/three/three-effectcomposer.d.ts
+++ b/types/three/three-effectcomposer.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { WebGLRenderTarget, WebGLRenderer } from "./three-core";
 import { ShaderPass } from "./three-shaderpass";
 

--- a/types/three/three-effectcomposer.d.ts
+++ b/types/three/three-effectcomposer.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { WebGLRenderTarget, WebGLRenderer } from "./three-core";
 import { ShaderPass } from "./three-shaderpass";

--- a/types/three/three-examples.d.ts
+++ b/types/three/three-examples.d.ts
@@ -1,3 +1,4 @@
+// Definitions by: Edmund Fokschaner <https://github.com/efokschaner>
 // Things from three.js/examples/ that do not (yet) have their own file
 
 import { Shader } from "./three-core";

--- a/types/three/three-examples.d.ts
+++ b/types/three/three-examples.d.ts
@@ -1,4 +1,5 @@
 // Definitions by: Edmund Fokschaner <https://github.com/efokschaner>
+
 // Things from three.js/examples/ that do not (yet) have their own file
 
 import { Shader } from "./three-core";

--- a/types/three/three-maskpass.d.ts
+++ b/types/three/three-maskpass.d.ts
@@ -1,3 +1,5 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
 import { Camera, Scene, WebGLRenderTarget, WebGLRenderer } from "./three-core";
 
 export class MaskPass {

--- a/types/three/three-maskpass.d.ts
+++ b/types/three/three-maskpass.d.ts
@@ -1,5 +1,5 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Camera, Scene, WebGLRenderTarget, WebGLRenderer } from "./three-core";
 
 export class MaskPass {

--- a/types/three/three-octree.d.ts
+++ b/types/three/three-octree.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: HouChunlei <https://github.com/omni360>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Vector3 } from "./three-core";
 
 export class Octree {

--- a/types/three/three-octree.d.ts
+++ b/types/three/three-octree.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: HouChunlei <https://github.com/omni360>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: HouChunlei <https://github.com/omni360>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Vector3 } from "./three-core";
 

--- a/types/three/three-orbitcontrols.d.ts
+++ b/types/three/three-orbitcontrols.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Camera, MOUSE, Object3D, Vector3 } from "./three-core";
 

--- a/types/three/three-orbitcontrols.d.ts
+++ b/types/three/three-orbitcontrols.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Camera, MOUSE, Object3D, Vector3 } from "./three-core";
 
 export class OrbitControls {

--- a/types/three/three-orthographictrackballcontrols.d.ts
+++ b/types/three/three-orthographictrackballcontrols.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Stefan Profanter <https://github.com/Pro>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Camera, EventDispatcher, Vector3 } from "./three-core";
 
 export class OrthographicTrackballControls extends EventDispatcher {

--- a/types/three/three-orthographictrackballcontrols.d.ts
+++ b/types/three/three-orthographictrackballcontrols.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Stefan Profanter <https://github.com/Pro>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Camera, EventDispatcher, Vector3 } from "./three-core";
 

--- a/types/three/three-projector.d.ts
+++ b/types/three/three-projector.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import {
     Camera,
     Color,

--- a/types/three/three-projector.d.ts
+++ b/types/three/three-projector.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import {
     Camera,

--- a/types/three/three-renderpass.d.ts
+++ b/types/three/three-renderpass.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import {
     Camera,
     Color,

--- a/types/three/three-renderpass.d.ts
+++ b/types/three/three-renderpass.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import {
     Camera,

--- a/types/three/three-shaderpass.d.ts
+++ b/types/three/three-shaderpass.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import {
     Camera,
     Mesh,

--- a/types/three/three-shaderpass.d.ts
+++ b/types/three/three-shaderpass.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import {
     Camera,

--- a/types/three/three-trackballcontrols.d.ts
+++ b/types/three/three-trackballcontrols.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Satoru Kimura <https://github.com/gyohk>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Satoru Kimura <https://github.com/gyohk>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Camera, EventDispatcher, Vector3 } from "./three-core";
 

--- a/types/three/three-trackballcontrols.d.ts
+++ b/types/three/three-trackballcontrols.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Satoru Kimura <https://github.com/gyohk>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Camera, EventDispatcher, Vector3 } from "./three-core";
 
 export class TrackballControls extends EventDispatcher {

--- a/types/three/three-transformcontrols.d.ts
+++ b/types/three/three-transformcontrols.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Stefan Profanter <https://github.com/Pro>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 import { Camera, Object3D } from "./three-core";
 
 export class TransformControls extends Object3D {

--- a/types/three/three-transformcontrols.d.ts
+++ b/types/three/three-transformcontrols.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Stefan Profanter <https://github.com/Pro>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>
 
 import { Camera, Object3D } from "./three-core";
 

--- a/types/three/three-vrcontrols.d.ts
+++ b/types/three/three-vrcontrols.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Toshiya Nakakura <https://github.com/nakakura>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Toshiya Nakakura <https://github.com/nakakura>, Edmund Fokschaner <https://github.com/efokschaner>
 
 /// <reference types="webvr-api" />
 

--- a/types/three/three-vrcontrols.d.ts
+++ b/types/three/three-vrcontrols.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Toshiya Nakakura <https://github.com/nakakura>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 /// <reference types="webvr-api" />
 
 import { Camera } from "./three-core";

--- a/types/three/three-vreffect.d.ts
+++ b/types/three/three-vreffect.d.ts
@@ -1,5 +1,4 @@
-// Definitions by: Toshiya Nakakura <https://github.com/nakakura>
-//                 Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Toshiya Nakakura <https://github.com/nakakura>, Edmund Fokschaner <https://github.com/efokschaner>
 
 /// <reference types="webvr-api" />
 

--- a/types/three/three-vreffect.d.ts
+++ b/types/three/three-vreffect.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: Toshiya Nakakura <https://github.com/nakakura>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+
 /// <reference types="webvr-api" />
 
 import { Camera, Matrix4, Renderer, Scene } from "./three-core";


### PR DESCRIPTION
These are definition header changes only.

This needs review by someone who can advise on good usage of the `Definitions by:` metadata, more so than from another maintainer of these definitions.

Originally in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15861 I moved all the metadata comment sections to `index.d.ts` to reduce maintenance, I notice this harmed the effectiveness of the dt-bot as it only looks at the modified files' headers for auto-mentions.

This change restores the per-file attributions. I left myself on all of them as I'm active and happy to review any files' changes.