### PR TITLE
[semantic-ui-api] Add type definitions

### DIFF
--- a/types/semantic-ui-api/global.d.ts
+++ b/types/semantic-ui-api/global.d.ts
@@ -104,13 +104,13 @@ declare namespace SemanticUI {
         (settings?: ApiSettings | object): JQuery;
     }
 
-    interface ApiSettings extends Pick<Api._Settings, keyof Api._Settings> { }
+    /**
+     * @see {@link http://semantic-ui.com/behaviors/api.html#/settings}
+     */
+    interface ApiSettings extends Pick<ApiSettings._Impl, keyof ApiSettings._Impl> { }
 
-    namespace Api {
-        /**
-         * @see {@link http://semantic-ui.com/behaviors/api.html#/settings}
-         */
-        interface _Settings {
+    namespace ApiSettings {
+        interface _Impl {
             // region Behavior
 
             /**
@@ -289,25 +289,25 @@ declare namespace SemanticUI {
             /**
              * Regular expressions used for template matching
              */
-            regExp: RegExpSettings;
+            regExp: Api.RegExpSettings;
             /**
              * Selectors used to find parts of a module
              */
-            selector: SelectorSettings;
+            selector: Api.SelectorSettings;
             /**
              * Class names used to determine element state
              */
-            className: ClassNameSettings;
+            className: Api.ClassNameSettings;
             /**
              * Metadata used to store XHR and response promise
              */
-            metadata: MetadataSettings;
+            metadata: Api.MetadataSettings;
 
             // endregion
 
             // region Debug Settings
 
-            error: ErrorSettings;
+            error: Api.ErrorSettings;
 
             // endregion
 
@@ -349,114 +349,126 @@ declare namespace SemanticUI {
 
             // endregion
         }
+    }
 
-        interface RegExpSettings extends Pick<_RegExpSettings, keyof _RegExpSettings> { }
+    namespace Api {
+        interface RegExpSettings extends Pick<RegExpSettings._Impl, keyof RegExpSettings._Impl> { }
 
-        interface _RegExpSettings {
-            /**
-             * @default /\{\$*[A-z0-9]+\}/g
-             */
-            required: RegExp;
-            /**
-             * @default /\{\/\$*[A-z0-9]+\}/g
-             */
-            optional: RegExp;
+        namespace RegExpSettings {
+            interface _Impl {
+                /**
+                 * @default /\{\$*[A-z0-9]+\}/g
+                 */
+                required: RegExp;
+                /**
+                 * @default /\{\/\$*[A-z0-9]+\}/g
+                 */
+                optional: RegExp;
+            }
         }
 
-        interface SelectorSettings extends Pick<_SelectorSettings, keyof _SelectorSettings> { }
+        interface SelectorSettings extends Pick<SelectorSettings._Impl, keyof SelectorSettings._Impl> { }
 
-        interface _SelectorSettings {
-            /**
-             * @default '.disabled'
-             */
-            disabled: string;
-            /**
-             * @default 'form'
-             */
-            form: string;
+        namespace SelectorSettings {
+            interface _Impl {
+                /**
+                 * @default '.disabled'
+                 */
+                disabled: string;
+                /**
+                 * @default 'form'
+                 */
+                form: string;
+            }
         }
 
-        interface ClassNameSettings extends Pick<_ClassNameSettings, keyof _ClassNameSettings> { }
+        interface ClassNameSettings extends Pick<ClassNameSettings._Impl, keyof ClassNameSettings._Impl> { }
 
-        interface _ClassNameSettings {
-            /**
-             * @default 'loading'
-             */
-            loading: string;
-            /**
-             * @default 'error'
-             */
-            error: string;
+        namespace ClassNameSettings {
+            interface _Impl {
+                /**
+                 * @default 'loading'
+                 */
+                loading: string;
+                /**
+                 * @default 'error'
+                 */
+                error: string;
+            }
         }
 
-        interface MetadataSettings extends Pick<_MetadataSettings, keyof _MetadataSettings> { }
+        interface MetadataSettings extends Pick<MetadataSettings._Impl, keyof MetadataSettings._Impl> { }
 
-        interface _MetadataSettings {
-            /**
-             * @default 'action'
-             */
-            action: string;
-            /**
-             * @default 'url'
-             */
-            url: string;
+        namespace MetadataSettings {
+            interface _Impl {
+                /**
+                 * @default 'action'
+                 */
+                action: string;
+                /**
+                 * @default 'url'
+                 */
+                url: string;
+            }
         }
 
-        interface ErrorSettings extends Pick<_ErrorSettings, keyof _ErrorSettings> { }
+        interface ErrorSettings extends Pick<ErrorSettings._Impl, keyof ErrorSettings._Impl> { }
 
-        interface _ErrorSettings {
-            /**
-             * @default 'The before send function has aborted the request'
-             */
-            beforeSend: string;
-            /**
-             * @default 'There was an error with your request'
-             */
-            error: string;
-            /**
-             * @default 'API Request Aborted. Exit conditions met'
-             */
-            exitConditions: string;
-            /**
-             * @default 'JSON could not be parsed during error handling'
-             */
-            JSONParse: string;
-            /**
-             * @default 'You are using legacy API success callback names'
-             */
-            legacyParameters: string;
-            /**
-             * @default 'API action used but no url was defined'
-             */
-            missingAction: string;
-            /**
-             * @default 'Required dependency jquery-serialize-object missing, using basic serialize'
-             */
-            missingSerialize: string;
-            /**
-             * @default 'No URL specified for API event'
-             */
-            missingURL: string;
-            /**
-             * @default 'The beforeSend callback must return a settings object, beforeSend ignored.'
-             */
-            noReturnedValue: string;
-            /**
-             * @default 'There was an error parsing your request'
-             */
-            parseError: string;
-            /**
-             * @default 'Missing a required URL parameter: '
-             */
-            requiredParameter: string;
-            /**
-             * @default 'Server gave an error: '
-             */
-            statusMessage: string;
-            /**
-             * @default 'Your request timed out'
-             */
-            timeout: string;
+        namespace ErrorSettings {
+            interface _Impl {
+                /**
+                 * @default 'The before send function has aborted the request'
+                 */
+                beforeSend: string;
+                /**
+                 * @default 'There was an error with your request'
+                 */
+                error: string;
+                /**
+                 * @default 'API Request Aborted. Exit conditions met'
+                 */
+                exitConditions: string;
+                /**
+                 * @default 'JSON could not be parsed during error handling'
+                 */
+                JSONParse: string;
+                /**
+                 * @default 'You are using legacy API success callback names'
+                 */
+                legacyParameters: string;
+                /**
+                 * @default 'API action used but no url was defined'
+                 */
+                missingAction: string;
+                /**
+                 * @default 'Required dependency jquery-serialize-object missing, using basic serialize'
+                 */
+                missingSerialize: string;
+                /**
+                 * @default 'No URL specified for API event'
+                 */
+                missingURL: string;
+                /**
+                 * @default 'The beforeSend callback must return a settings object, beforeSend ignored.'
+                 */
+                noReturnedValue: string;
+                /**
+                 * @default 'There was an error parsing your request'
+                 */
+                parseError: string;
+                /**
+                 * @default 'Missing a required URL parameter: '
+                 */
+                requiredParameter: string;
+                /**
+                 * @default 'Server gave an error: '
+                 */
+                statusMessage: string;
+                /**
+                 * @default 'Your request timed out'
+                 */
+                timeout: string;
+            }
         }
     }
 }

--- a/types/semantic-ui-api/global.d.ts
+++ b/types/semantic-ui-api/global.d.ts
@@ -1,0 +1,462 @@
+interface JQueryStatic {
+    api: SemanticUI.Api;
+}
+
+interface JQuery {
+    api: SemanticUI.Api;
+}
+
+declare namespace SemanticUI {
+    interface Api {
+        settings: ApiSettings;
+
+        /**
+         * Execute query using existing API settings
+         */
+        (behavior: 'query'): JQuery;
+        /**
+         * Adds data to existing templated url and returns full url string
+         */
+        (behavior: 'add url data', url: string, data: any): string;
+        /**
+         * Gets promise for current API request
+         */
+        (behavior: 'get request'): JQueryDeferred<any> | false;
+        /**
+         * Aborts current API request
+         */
+        (behavior: 'abort'): JQuery;
+        /**
+         * Removes loading and error state from element
+         */
+        (behavior: 'reset'): JQuery;
+        /**
+         * Returns whether last request was cancelled
+         */
+        (behavior: 'was cancelled'): boolean;
+        /**
+         * Returns whether last request was failure
+         */
+        (behavior: 'was failure'): boolean;
+        /**
+         * Returns whether last request was successful
+         */
+        (behavior: 'was successful'): boolean;
+        /**
+         * Returns whether last request was completed
+         */
+        (behavior: 'was complete'): boolean;
+        /**
+         * Returns whether element is disabled
+         */
+        (behavior: 'is disabled'): boolean;
+        /**
+         * Returns whether element response is mocked
+         */
+        (behavior: 'is mocked'): boolean;
+        /**
+         * Returns whether element is loading
+         */
+        (behavior: 'is loading'): boolean;
+        /**
+         * Sets loading state to element
+         */
+        (behavior: 'set loading'): JQuery;
+        /**
+         * Sets error state to element
+         */
+        (behavior: 'set error'): JQuery;
+        /**
+         * Removes loading state to element
+         */
+        (behavior: 'remove loading'): JQuery;
+        /**
+         * Removes error state to element
+         */
+        (behavior: 'remove error'): JQuery;
+        /**
+         * Gets event that API request will occur on
+         */
+        (behavior: 'get event'): string;
+        /**
+         * Returns encodeURIComponent value only if value passed is not already encoded
+         */
+        (behavior: 'get url encoded value', value: any): string;
+        /**
+         * Reads a locally cached response for a URL
+         */
+        (behavior: 'read cached response', url: string): any;
+        /**
+         * Writes a cached response for a URL
+         */
+        (behavior: 'write cached response', url: string, response: any): JQuery;
+        /**
+         * Creates new cache, removing all locally cached URLs
+         */
+        (behavior: 'create cache'): JQuery;
+        /**
+         * Removes API settings from the page and all events
+         */
+        (behavior: 'destroy'): JQuery;
+        <K extends keyof ApiSettings>(behavior: 'setting', name: K, value?: undefined): ApiSettings[K];
+        <K extends keyof ApiSettings>(behavior: 'setting', name: K, value: ApiSettings[K]): JQuery;
+        (behavior: 'setting', value: ApiSettings | object): JQuery;
+        (settings?: ApiSettings | object): JQuery;
+    }
+
+    interface ApiSettings extends Pick<Api._Settings, keyof Api._Settings> { }
+
+    namespace Api {
+        /**
+         * @see {@link http://semantic-ui.com/behaviors/api.html#/settings}
+         */
+        interface _Settings {
+            // region Behavior
+
+            /**
+             * When API event should occur
+             *
+             * @default 'auto'
+             */
+            on: string;
+            /**
+             * Can be set to 'local' to cache successful returned AJAX responses when using a JSON API.
+             * This helps avoid server round trips when API endpoints will return the same results when accessed repeatedly.
+             * Setting to false, will add cache busting parameters to the URL.
+             *
+             * @default true
+             */
+            cache: 'local' | boolean;
+            /**
+             * UI state will be applied to this element, defaults to triggering element.
+             */
+            stateContext: string | JQuery;
+            /**
+             * Whether to encode parameters with encodeURIComponent before adding into url string
+             *
+             * @default true
+             */
+            encodeParameters: boolean;
+            /**
+             * Whether to automatically include default data like {value} and {text}
+             *
+             * @default true
+             */
+            defaultData: boolean;
+            /**
+             * Whether to serialize closest form and include in request
+             *
+             * @default false
+             */
+            serializeForm: boolean;
+            /**
+             * How long to wait when a request is made before triggering request, useful for rate limiting oninput
+             *
+             * @default 0
+             */
+            throttle: number;
+            /**
+             * When set to false will not delay the first request made, when no others are queued
+             *
+             * @default true
+             */
+            throttleFirstRequest: boolean;
+            /**
+             * Whether an API request can occur while another request is still pending
+             *
+             * @default false
+             */
+            interruptRequests: boolean;
+            /**
+             * Minimum duration to show loading indication
+             *
+             * @default 0
+             */
+            loadingDuration: number;
+            /**
+             * The default auto will automatically remove error state after error duration, unless the element is a form
+             *
+             * @default 'auto'
+             */
+            hideError: 'auto' | boolean;
+            /**
+             * Setting to true, will not remove error.
+             * Setting to a duration in milliseconds to show error state after request error.
+             *
+             * @default 2000
+             */
+            errorDuration: true | number;
+
+            // endregion
+
+            // region Request Settings
+
+            /**
+             * Named API action for query, originally specified in $.fn.settings.api
+             */
+            action: string | false;
+            /**
+             * Templated URL for query, will override specified action
+             */
+            url: string | false;
+            /**
+             * Variables to use for replacement
+             */
+            urlData: any | false;
+            /**
+             * Can be set to a Javascript object which will be returned automatically instead of requesting JSON from server
+             */
+            response: any | false;
+            /**
+             * When specified, this function can be used to retrieve content from a server and return it asynchronously instead of a standard AJAX call.
+             * The callback function should return the server response.
+             *
+             * @default false
+             */
+            responseAsync: ((settings: ApiSettings, callback: (response: any) => void) => void) | false;
+            /**
+             * @see response
+             */
+            mockResponse: any | false;
+            /**
+             * @see responseAsync
+             */
+            mockResponseAsync: ((settings: ApiSettings, callback: (response: any) => void) => void) | false;
+            /**
+             * Method for transmitting request to server
+             */
+            method: 'post' | 'get';
+            /**
+             * Expected data type of response
+             */
+            dataType: 'xml' | 'json' | 'jsonp' | 'script' | 'html' | 'text';
+            /**
+             * POST/GET Data to Send with Request
+             */
+            data: any;
+
+            // endregion
+
+            // region Callbacks
+
+            /**
+             * Allows modifying settings before request, or cancelling request
+             */
+            beforeSend(settings: ApiSettings): any;
+            /**
+             * Allows modifying XHR object for request
+             */
+            beforeXHR(xhrObject: JQueryXHR): any;
+            /**
+             * Callback that occurs when request is made. Receives both the API success promise and the XHR request promise.
+             */
+            onRequest(promise: JQueryDeferred<any>, xhr: JQueryXHR): void;
+            /**
+             * Allows modifying the server's response before parsed by other callbacks to determine API event success
+             */
+            onResponse(response: any): void;
+            /**
+             * Determines whether completed JSON response should be treated as successful
+             *
+             * @see {@link http://semantic-ui.com/behaviors/api.html#determining-json-success}
+             */
+            successTest(response: any): boolean;
+            /**
+             * Callback after successful response, JSON response must pass successTest
+             */
+            onSuccess(response: any, element: JQuery, xhr: JQueryXHR): void;
+            /**
+             * Callback on request complete regardless of conditions
+             */
+            onComplete(response: any, element: JQuery, xhr: JQueryXHR): void;
+            /**
+             * Callback on failed response, or JSON response that fails successTest
+             */
+            onFailure(response: any, element: JQuery): void;
+            /**
+             * Callback on server error from returned status code, or XHR failure.
+             */
+            onError(errorMessage: string, element: JQuery, xhr: JQueryXHR): void;
+            /**
+             * Callback on abort caused by user clicking a link or manually cancelling request.
+             */
+            onAbort(errorMessage: string, element: JQuery, xhr: JQueryXHR): void;
+
+            // endregion
+
+            // region DOM Settings
+
+            /**
+             * Regular expressions used for template matching
+             */
+            regExp: RegExpSettings;
+            /**
+             * Selectors used to find parts of a module
+             */
+            selector: SelectorSettings;
+            /**
+             * Class names used to determine element state
+             */
+            className: ClassNameSettings;
+            /**
+             * Metadata used to store XHR and response promise
+             */
+            metadata: MetadataSettings;
+
+            // endregion
+
+            // region Debug Settings
+
+            error: ErrorSettings;
+
+            // endregion
+
+            // region Component Settings
+
+            // region DOM Settings
+
+            /**
+             * Event namespace. Makes sure module teardown does not effect other events attached to an element.
+             */
+            namespace: string;
+
+            // endregion
+
+            // region Debug Settings
+
+            /**
+             * Name used in log statements
+             */
+            name: string;
+            /**
+             * Silences all console output including error messages, regardless of other debug settings.
+             */
+            silent: boolean;
+            /**
+             * Debug output to console
+             */
+            debug: boolean;
+            /**
+             * Show console.table output with performance metrics
+             */
+            performance: boolean;
+            /**
+             * Debug output includes all internal behaviors
+             */
+            verbose: boolean;
+
+            // endregion
+
+            // endregion
+        }
+
+        interface RegExpSettings extends Pick<_RegExpSettings, keyof _RegExpSettings> { }
+
+        interface _RegExpSettings {
+            /**
+             * @default /\{\$*[A-z0-9]+\}/g
+             */
+            required: RegExp;
+            /**
+             * @default /\{\/\$*[A-z0-9]+\}/g
+             */
+            optional: RegExp;
+        }
+
+        interface SelectorSettings extends Pick<_SelectorSettings, keyof _SelectorSettings> { }
+
+        interface _SelectorSettings {
+            /**
+             * @default '.disabled'
+             */
+            disabled: string;
+            /**
+             * @default 'form'
+             */
+            form: string;
+        }
+
+        interface ClassNameSettings extends Pick<_ClassNameSettings, keyof _ClassNameSettings> { }
+
+        interface _ClassNameSettings {
+            /**
+             * @default 'loading'
+             */
+            loading: string;
+            /**
+             * @default 'error'
+             */
+            error: string;
+        }
+
+        interface MetadataSettings extends Pick<_MetadataSettings, keyof _MetadataSettings> { }
+
+        interface _MetadataSettings {
+            /**
+             * @default 'action'
+             */
+            action: string;
+            /**
+             * @default 'url'
+             */
+            url: string;
+        }
+
+        interface ErrorSettings extends Pick<_ErrorSettings, keyof _ErrorSettings> { }
+
+        interface _ErrorSettings {
+            /**
+             * @default 'The before send function has aborted the request'
+             */
+            beforeSend: string;
+            /**
+             * @default 'There was an error with your request'
+             */
+            error: string;
+            /**
+             * @default 'API Request Aborted. Exit conditions met'
+             */
+            exitConditions: string;
+            /**
+             * @default 'JSON could not be parsed during error handling'
+             */
+            JSONParse: string;
+            /**
+             * @default 'You are using legacy API success callback names'
+             */
+            legacyParameters: string;
+            /**
+             * @default 'API action used but no url was defined'
+             */
+            missingAction: string;
+            /**
+             * @default 'Required dependency jquery-serialize-object missing, using basic serialize'
+             */
+            missingSerialize: string;
+            /**
+             * @default 'No URL specified for API event'
+             */
+            missingURL: string;
+            /**
+             * @default 'The beforeSend callback must return a settings object, beforeSend ignored.'
+             */
+            noReturnedValue: string;
+            /**
+             * @default 'There was an error parsing your request'
+             */
+            parseError: string;
+            /**
+             * @default 'Missing a required URL parameter: '
+             */
+            requiredParameter: string;
+            /**
+             * @default 'Server gave an error: '
+             */
+            statusMessage: string;
+            /**
+             * @default 'Your request timed out'
+             */
+            timeout: string;
+        }
+    }
+}

--- a/types/semantic-ui-api/index.d.ts
+++ b/types/semantic-ui-api/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for semantic-ui-api 2.2
+// Project: http://www.semantic-ui.com
+// Definitions by: Leonard Thieu <https://github.com/leonard-thieu>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="jquery" />
+
+declare const api: SemanticUI.Api;
+export = api;

--- a/types/semantic-ui-api/index.d.ts
+++ b/types/semantic-ui-api/index.d.ts
@@ -5,6 +5,7 @@
 // TypeScript Version: 2.2
 
 /// <reference types="jquery" />
+/// <reference path="global.d.ts" />
 
 declare const api: SemanticUI.Api;
 export = api;

--- a/types/semantic-ui-api/semantic-ui-api-tests.ts
+++ b/types/semantic-ui-api/semantic-ui-api-tests.ts
@@ -1,0 +1,141 @@
+function test_static() {
+    $.api.settings.className.error = 'error';
+    $.api.settings.namespace = 'namespace';
+    $.api.settings.name = 'name';
+    $.api.settings.silent = false;
+    $.api.settings.debug = true;
+    $.api.settings.performance = true;
+    $.api.settings.verbose = true;
+
+    $.fn.api.settings.namespace = 'namespace';
+    $.fn.api.settings.name = 'name';
+    $.fn.api.settings.silent = false;
+    $.fn.api.settings.debug = true;
+    $.fn.api.settings.performance = true;
+    $.fn.api.settings.verbose = true;
+}
+
+function test_api() {
+    const selector = '.ui.api';
+    $(selector).api('destroy') === $();
+    $(selector).api('setting', 'debug', undefined) === false;
+    $(selector).api('setting', 'debug') === false;
+    $(selector).api('setting', 'debug', true) === $();
+    $(selector).api('setting', {
+        namespace: 'namespace',
+        name: 'name',
+        silent: false,
+        debug: true,
+        performance: true,
+        verbose: true
+    }) === $();
+    $(selector).api({
+        on: 'on',
+        cache: true,
+        stateContext: $(),
+        encodeParameters: false,
+        defaultData: true,
+        serializeForm: false,
+        throttle: 10,
+        throttleFirstRequest: true,
+        interruptRequests: false,
+        loadingDuration: 3,
+        hideError: true,
+        errorDuration: 10,
+
+        action: 'action',
+        url: 'url',
+        urlData: false,
+        response: false,
+        responseAsync(settings, callback) {
+            settings === ({} as SemanticUI.ApiSettings);
+            callback === ((response: any) => { });
+        },
+        mockResponse: false,
+        mockResponseAsync(settings, callback) {
+            settings === ({} as SemanticUI.ApiSettings);
+            callback === ((response: any) => { });
+        },
+        method: 'post',
+        dataType: 'xml',
+        data: {},
+        beforeSend(settings) {
+            settings === ({} as SemanticUI.ApiSettings);
+        },
+        beforeXHR(xhrObject) {
+            xhrObject === ({} as JQueryXHR);
+        },
+        onRequest(promise, xhr) {
+            promise === ({} as JQueryDeferred<any>);
+            xhr === ({} as JQueryXHR);
+        },
+        onResponse(response) {
+            response === ({} as any);
+        },
+        successTest(response) {
+            return response === ({} as any);
+        },
+        onSuccess(response, element, xhr) {
+            response === ({} as any);
+            element === $();
+            xhr === ({} as JQueryXHR);
+        },
+        onComplete(response, element, xhr) {
+            response === ({} as any);
+            element === $();
+            xhr === ({} as JQueryXHR);
+        },
+        onFailure(response, element) {
+            response === ({} as any);
+            element === $();
+        },
+        onError(errorMessage, element, xhr) {
+            errorMessage === '';
+            element === $();
+            xhr === ({} as JQueryXHR);
+        },
+        onAbort(errorMessage, element, xhr) {
+            errorMessage === '';
+            element === $();
+            xhr === ({} as JQueryXHR);
+        },
+        regExp: {
+            required: /{\$*[A-z0-9]+}/g,
+            optional: /{\/\$*[A-z0-9]+}/g
+        },
+        selector: {
+            disabled: '.disabled',
+            form: 'form'
+        },
+        className: {
+            loading: 'loading',
+            error: 'error'
+        },
+        metadata: {
+            action: 'action',
+            url: 'url'
+        },
+        error: {
+            beforeSend: 'beforeSend',
+            error: 'error',
+            exitConditions: 'exitConditions',
+            JSONParse: 'JSONParse',
+            legacyParameters: 'legacyParameters',
+            missingAction: 'missingAction',
+            missingSerialize: 'missingSerialize',
+            missingURL: 'missingURL',
+            noReturnedValue: 'noReturnedValue',
+            parseError: 'parseError',
+            requiredParameter: 'requiredParameter',
+            statusMessage: 'statusMessage',
+            timeout: 'timeout'
+        }
+    }) === $();
+    $(selector).api() === $();
+}
+
+import api = require('semantic-ui-api');
+
+function test_module() {
+    $.fn.api = api;
+}

--- a/types/semantic-ui-api/tsconfig.json
+++ b/types/semantic-ui-api/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "global.d.ts",
+        "semantic-ui-api-tests.ts"
+    ]
+}

--- a/types/semantic-ui-api/tslint.json
+++ b/types/semantic-ui-api/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-empty-interface": false,
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

`unified-signatures` is disabled as discussed at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14252.
`no-empty-interface` is disabled for a better debugging experience. Empty interfaces are used to alias a type alias.
- **Type Alias**
`Argument of type 'string' is not assignable to parameter of type 'object | Pick<_Settings, "namespace" | "name" | "silent" | "debug" | "performance" | "verbose" | ...'.`
- **Interface**
`Argument of type 'string' is not assignable to parameter of type 'object | DimmerSettings | undefined'.`