### PR TITLE
[Express-jwt] Removed optional unless from express-jwt

### DIFF
--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -34,7 +34,7 @@ declare namespace jwt {
         [property: string]: any;
     }
     export interface RequestHandler extends express.RequestHandler {
-        unless?: typeof unless;
+        unless: typeof unless;
     }
 }
 declare global {


### PR DESCRIPTION
There is no reason for the field to be optional, unless will always be available. The current version makes the library unwieldy since you have to check for unless instead of just a one line `app.use`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/express-jwt/blob/master/lib/index.js#L132