### PR TITLE
reopen: parse: generic queries & relations

### DIFF
--- a/types/parse-mockdb/index.d.ts
+++ b/types/parse-mockdb/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for parse-mockdb v0.1.13
+// Type definitions for parse-mockdb v0.1.14
 // Project: https://github.com/HustleInc/parse-mockdb
 // Definitions by: David Poetzsch-Heffter <https://github.com/dpoetzsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="parse" />
 

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -267,22 +267,22 @@ declare namespace Parse {
      * A class that is used to access all of the children of a many-to-many relationship.
      * Each instance of Parse.Relation is associated with a particular parent object and key.
      */
-    class Relation extends BaseObject {
+    class Relation<S extends Object, T extends Object> extends BaseObject {
 
-        parent: Object;
+        parent: S;
         key: string;
         targetClassName: string;
 
-        constructor(parent?: Object, key?: string);
+        constructor(parent?: S, key?: string);
 
         //Adds a Parse.Object or an array of Parse.Objects to the relation.
-        add(object: Object): void;
+        add(object: T): void;
 
         // Returns a Parse.Query that is limited to objects in this relation.
-        query(): Query;
+        query(): Query<T>;
 
         // Removes a Parse.Object or an array of Parse.Objects from this relation.
-        remove(object: Object): void;
+        remove(object: T): void;
     }
 
     /**
@@ -355,7 +355,7 @@ declare namespace Parse {
         op(attr: string): any;
         previous(attr: string): any;
         previousAttributes(): any;
-        relation(attr: string): Relation;
+        relation(attr: string): Relation<this, Object>;
         remove(attr: string, item: any): any;
         save(attrs?: { [key: string]: any } | null, options?: Object.SaveOptions): Promise<this>;
         save(key: string, value: any, options?: Object.SaveOptions): Promise<this>;
@@ -429,7 +429,7 @@ declare namespace Parse {
 
         model: Object;
         models: Object[];
-        query: Query;
+        query: Query<Object>;
         comparator: (object: Object) => any;
 
         constructor(models?: Object[], options?: Collection.Options);
@@ -454,7 +454,7 @@ declare namespace Parse {
     namespace Collection {
         interface Options {
             model?: Object;
-            query?: Query;
+            query?: Query<Object>;
             comparator?: string;
         }
 
@@ -571,59 +571,59 @@ declare namespace Parse {
      *   }
      * });</pre></p>
      */
-    class Query extends BaseObject {
+    class Query<T extends Object> extends BaseObject {
 
         objectClass: any;
         className: string;
 
         constructor(objectClass: string);
-        constructor(objectClass: new(...args: any[]) => Object);
+        constructor(objectClass: new(...args: any[]) => T);
 
-        static or<U extends Object>(...var_args: Query[]): Query;
+        static or<U extends Object>(...var_args: Query<U>[]): Query<U>;
 
-        addAscending(key: string): Query;
-        addAscending(key: string[]): Query;
-        addDescending(key: string): Query;
-        addDescending(key: string[]): Query;
-        ascending(key: string): Query;
-        ascending(key: string[]): Query;
+        addAscending(key: string): Query<T>;
+        addAscending(key: string[]): Query<T>;
+        addDescending(key: string): Query<T>;
+        addDescending(key: string[]): Query<T>;
+        ascending(key: string): Query<T>;
+        ascending(key: string[]): Query<T>;
         collection(items?: Object[], options?: Collection.Options): Collection<Object>;
-        containedIn(key: string, values: any[]): Query;
-        contains(key: string, substring: string): Query;
-        containsAll(key: string, values: any[]): Query;
+        containedIn(key: string, values: any[]): Query<T>;
+        contains(key: string, substring: string): Query<T>;
+        containsAll(key: string, values: any[]): Query<T>;
         count(options?: Query.CountOptions): Promise<number>;
-        descending(key: string): Query;
-        descending(key: string[]): Query;
-        doesNotExist(key: string): Query;
-        doesNotMatchKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query): Query;
-        doesNotMatchQuery<U extends Object>(key: string, query: Query): Query;
+        descending(key: string): Query<T>;
+        descending(key: string[]): Query<T>;
+        doesNotExist(key: string): Query<T>;
+        doesNotMatchKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query<U>): Query<T>;
+        doesNotMatchQuery<U extends Object>(key: string, query: Query<U>): Query<T>;
         each(callback: Function, options?: Query.EachOptions): Promise<void>;
-        endsWith(key: string, suffix: string): Query;
-        equalTo(key: string, value: any): Query;
-        exists(key: string): Query;
-        find(options?: Query.FindOptions): Promise<Object[]>;
-        first(options?: Query.FirstOptions): Promise<Object | undefined>;
-        get(objectId: string, options?: Query.GetOptions): Promise<Object>;
-        greaterThan(key: string, value: any): Query;
-        greaterThanOrEqualTo(key: string, value: any): Query;
-        include(key: string): Query;
-        include(keys: string[]): Query;
-        lessThan(key: string, value: any): Query;
-        lessThanOrEqualTo(key: string, value: any): Query;
-        limit(n: number): Query;
-        matches(key: string, regex: RegExp, modifiers: any): Query;
-        matchesKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query): Query;
-        matchesQuery<U extends Object>(key: string, query: Query): Query;
-        near(key: string, point: GeoPoint): Query;
-        notContainedIn(key: string, values: any[]): Query;
-        notEqualTo(key: string, value: any): Query;
-        select(...keys: string[]): Query;
-        skip(n: number): Query;
-        startsWith(key: string, prefix: string): Query;
-        withinGeoBox(key: string, southwest: GeoPoint, northeast: GeoPoint): Query;
-        withinKilometers(key: string, point: GeoPoint, maxDistance: number): Query;
-        withinMiles(key: string, point: GeoPoint, maxDistance: number): Query;
-        withinRadians(key: string, point: GeoPoint, maxDistance: number): Query;
+        endsWith(key: string, suffix: string): Query<T>;
+        equalTo(key: string, value: any): Query<T>;
+        exists(key: string): Query<T>;
+        find(options?: Query.FindOptions): Promise<T[]>;
+        first(options?: Query.FirstOptions): Promise<T | undefined>;
+        get(objectId: string, options?: Query.GetOptions): Promise<T>;
+        greaterThan(key: string, value: any): Query<T>;
+        greaterThanOrEqualTo(key: string, value: any): Query<T>;
+        include(key: string): Query<T>;
+        include(keys: string[]): Query<T>;
+        lessThan(key: string, value: any): Query<T>;
+        lessThanOrEqualTo(key: string, value: any): Query<T>;
+        limit(n: number): Query<T>;
+        matches(key: string, regex: RegExp, modifiers: any): Query<T>;
+        matchesKeyInQuery<U extends Object>(key: string, queryKey: string, query: Query<U>): Query<T>;
+        matchesQuery<U extends Object>(key: string, query: Query<U>): Query<T>;
+        near(key: string, point: GeoPoint): Query<T>;
+        notContainedIn(key: string, values: any[]): Query<T>;
+        notEqualTo(key: string, value: any): Query<T>;
+        select(...keys: string[]): Query<T>;
+        skip(n: number): Query<T>;
+        startsWith(key: string, prefix: string): Query<T>;
+        withinGeoBox(key: string, southwest: GeoPoint, northeast: GeoPoint): Query<T>;
+        withinKilometers(key: string, point: GeoPoint, maxDistance: number): Query<T>;
+        withinMiles(key: string, point: GeoPoint, maxDistance: number): Query<T>;
+        withinRadians(key: string, point: GeoPoint, maxDistance: number): Query<T>;
     }
 
     namespace Query {
@@ -651,8 +651,8 @@ declare namespace Parse {
 
         constructor(name: string, acl: ACL);
 
-        getRoles(): Relation;
-        getUsers(): Relation;
+        getRoles(): Relation<Role, Role>;
+        getUsers(): Relation<Role, User>;
         getName(): string;
         setName(name: string, options?: SuccessFailureOptions): any;
     }
@@ -1068,7 +1068,7 @@ declare namespace Parse {
             push_time?: Date;
             expiration_time?: Date;
             expiration_interval?: number;
-            where?: Query;
+            where?: Query<Object>;
             data?: any;
             alert?: string;
             badge?: string;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1068,7 +1068,7 @@ declare namespace Parse {
             push_time?: Date;
             expiration_time?: Date;
             expiration_interval?: number;
-            where?: Query<Object>;
+            where?: Query<Installation>;
             data?: any;
             alert?: string;
             badge?: string;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://parse.com/
 // Definitions by: Ullisen Media Group <http://ullisenmedia.com>, David Poetzsch-Heffter <https://github.com/dpoetzsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 /// <reference types="jquery" />
@@ -267,7 +268,7 @@ declare namespace Parse {
      * A class that is used to access all of the children of a many-to-many relationship.
      * Each instance of Parse.Relation is associated with a particular parent object and key.
      */
-    class Relation<S extends Object, T extends Object> extends BaseObject {
+    class Relation<S extends Object = Object, T extends Object = Object> extends BaseObject {
 
         parent: S;
         key: string;
@@ -571,7 +572,7 @@ declare namespace Parse {
      *   }
      * });</pre></p>
      */
-    class Query<T extends Object> extends BaseObject {
+    class Query<T extends Object = Object> extends BaseObject {
 
         objectClass: any;
         className: string;

--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for parse v1.9.2
+// Type definitions for parse 1.9
 // Project: https://parse.com/
 // Definitions by: Ullisen Media Group <http://ullisenmedia.com>, David Poetzsch-Heffter <https://github.com/dpoetzsch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -127,6 +127,14 @@ class TestCollection extends Parse.Collection<Object> {
     }
 }
 
+function return_a_generic_query(): Parse.Query<Game> {
+    return new Parse.Query(Game);
+}
+
+function return_a_query(): Parse.Query {
+    return new Parse.Query(Game);
+}
+
 function test_collections() {
 
     var collection = new TestCollection();


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.parseplatform.org/js/guide/#queries
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dslint/dt.json" }`. (My node version 6.10 is not compatible with DefinitelyTyped's tooling)

This PR introduces a generic `Parse.Query` and `Parse.Relation` (similar to parse's android lib for example). If no explicit typing information is used the type parameters should be inferred automatically and lead to better typed promises with less explicit type annotations required.

However, to make the change backwards compatible and convenient to use it uses default generic parameters which will soon be introduced with typescript 2.3. Thus, I flagged this as typescript-2.3-only in the header.

This is a re-opening of pull request #15921 because back then typescript 2.3 was not yet available.