### PR TITLE
Fix d3-scale TS2304: Cannot find name 'Range'

### DIFF
--- a/types/d3-scale/d3-scale-tests.ts
+++ b/types/d3-scale/d3-scale-tests.ts
@@ -382,7 +382,7 @@ const copiedLogScale: d3Scale.ScaleLogarithmic<number, string> = logScaleNumStri
 
 // scaleIdentity -----------------------------------------------------------------
 
-let identityScale: d3Scale.ScaleIdentity<number>;
+let identityScale: d3Scale.ScaleIdentity;
 
 identityScale = d3Scale.scaleIdentity();
 
@@ -427,7 +427,7 @@ outputNumber = identityScale(10);
 
 // copy(...) -----------------------------------------------------------------
 
-const copiedIdentityScale: d3Scale.ScaleIdentity<number> = identityScale.copy();
+const copiedIdentityScale: d3Scale.ScaleIdentity = identityScale.copy();
 
 // -------------------------------------------------------------------------------
 // Time Scale Factories

--- a/types/d3-scale/d3-scale-tests.ts
+++ b/types/d3-scale/d3-scale-tests.ts
@@ -382,7 +382,7 @@ const copiedLogScale: d3Scale.ScaleLogarithmic<number, string> = logScaleNumStri
 
 // scaleIdentity -----------------------------------------------------------------
 
-let identityScale: d3Scale.ScaleIdentity;
+let identityScale: d3Scale.ScaleIdentity<number>;
 
 identityScale = d3Scale.scaleIdentity();
 
@@ -427,7 +427,7 @@ outputNumber = identityScale(10);
 
 // copy(...) -----------------------------------------------------------------
 
-const copiedIdentityScale: d3Scale.ScaleIdentity = identityScale.copy();
+const copiedIdentityScale: d3Scale.ScaleIdentity<number> = identityScale.copy();
 
 // -------------------------------------------------------------------------------
 // Time Scale Factories

--- a/types/d3-scale/index.d.ts
+++ b/types/d3-scale/index.d.ts
@@ -569,7 +569,7 @@ export function scaleLog<Range, Output>(): ScaleLogarithmic<Range, Output>;
  * Identity scales are a special case of linear scales where the domain and range are identical; the scale and its invert method are thus the identity function.
  * These scales are occasionally useful when working with pixel coordinates, say in conjunction with an axis or brush.
  */
-export interface ScaleIdentity {
+export interface ScaleIdentity<Range> {
     /**
      * Given a value from the domain, returns the corresponding value from the range, subject to interpolation, if any.
      *
@@ -671,13 +671,13 @@ export interface ScaleIdentity {
     /**
      * Returns an exact copy of this scale. Changes to this scale will not affect the returned scale, and vice versa.
      */
-    copy(): ScaleIdentity;
+    copy(): ScaleIdentity<Range>;
 }
 
 /**
  * Constructs a new identity scale with the unit domain [0, 1] and the unit range [0, 1].
  */
-export function scaleIdentity(): ScaleIdentity;
+export function scaleIdentity<Range>(): ScaleIdentity<Range>;
 
 // -------------------------------------------------------------------------------
 // Time Scale Factories
@@ -1297,7 +1297,7 @@ export interface ScaleQuantile<Range> {
      *
      * @param domain Array of domain values.
      */
-    domain(domain: Array<number | { valueOf(): number } | null | undefined>): this;
+    domain(domain: Array<number | { valueOf(): number } | null | undefined >): this;
 
     /**
      * Returns the current range.

--- a/types/d3-scale/index.d.ts
+++ b/types/d3-scale/index.d.ts
@@ -569,7 +569,7 @@ export function scaleLog<Range, Output>(): ScaleLogarithmic<Range, Output>;
  * Identity scales are a special case of linear scales where the domain and range are identical; the scale and its invert method are thus the identity function.
  * These scales are occasionally useful when working with pixel coordinates, say in conjunction with an axis or brush.
  */
-export interface ScaleIdentity<Range> {
+export interface ScaleIdentity {
     /**
      * Given a value from the domain, returns the corresponding value from the range, subject to interpolation, if any.
      *
@@ -626,7 +626,7 @@ export interface ScaleIdentity<Range> {
      *
      * @param range Array of range values.
      */
-    range(range: Array<Range | { valueOf(): number }>): this;
+    range(range: Array<number | { valueOf(): number }>): this;
 
     /**
      * Returns approximately count representative values from the scale’s domain.
@@ -671,13 +671,13 @@ export interface ScaleIdentity<Range> {
     /**
      * Returns an exact copy of this scale. Changes to this scale will not affect the returned scale, and vice versa.
      */
-    copy(): ScaleIdentity<Range>;
+    copy(): ScaleIdentity;
 }
 
 /**
  * Constructs a new identity scale with the unit domain [0, 1] and the unit range [0, 1].
  */
-export function scaleIdentity<Range>(): ScaleIdentity<Range>;
+export function scaleIdentity(): ScaleIdentity;
 
 // -------------------------------------------------------------------------------
 // Time Scale Factories


### PR DESCRIPTION
- fix `range` function in `ScaleIdentity` use generic Range but not declared

fix #16814 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
