### PR TITLE
[babel-traverse] Add missing `Scope` visitor type.

### DIFF
--- a/types/babel-traverse/babel-traverse-tests.ts
+++ b/types/babel-traverse/babel-traverse-tests.ts
@@ -120,3 +120,15 @@ const BindingKindTest: Visitor  = {
         // kind === 'anythingElse';
     },
 };
+
+// https://github.com/babel/babel/blob/d33d02359474296402b1577ef53f20d94e9085c4/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/exec/scope-bindings.js#L15-L25
+const vScope: Visitor = {
+    Scope: {
+        enter(path) {
+            console.log(`Entering scope: ${path.node.type}`);
+        },
+        exit(path) {
+            console.log(`Exiting scope: ${path.node.type}`);
+        }
+    }
+};

--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -305,6 +305,7 @@ export interface Visitor extends VisitNodeObject<Node> {
     FlowBaseAnnotation?: VisitNode<t.FlowBaseAnnotation>;
     FlowDeclaration?: VisitNode<t.FlowDeclaration>;
     JSX?: VisitNode<t.JSX>;
+    Scope?: VisitNode<t.Scopable>;
 }
 
 export type VisitNode<T> = VisitNodeFunction<T> | VisitNodeObject<T>;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [babel-traverse `Scope` example usage](https://github.com/babel/babel/blob/d33d02359474296402b1577ef53f20d94e9085c4/packages/babel-plugin-transform-es2015-block-scoping/test/fixtures/exec/scope-bindings.js#L15-L25)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.