### PR TITLE
Allow 'children' to be an element in react-router.

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -65,7 +65,7 @@ export interface RouteProps {
   location?: H.Location;
   component?: React.SFC<RouteComponentProps<any> | undefined> | React.ComponentClass<RouteComponentProps<any> | undefined>;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
-  children?: ((props: RouteComponentProps<any>) => React.ReactNode | React.ReactNode);
+  children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;
   exact?: boolean;
   strict?: boolean;

--- a/types/react-router/test/Children.tsx
+++ b/types/react-router/test/Children.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { Route } from 'react-router';
+
+function RouteWithFunctionChildrenAttribute() {
+    return <Route path="/" children={() => <div>Hello!</div>} />
+}
+
+function RouteWithFunctionJsxChildren() {
+    return <Route path="/">
+        {() => <div>Hello!</div>}
+    </Route>
+}
+
+function RouteWithElementChildrenAttribute() {
+    return <Route path="/" children={<div>Hello!</div>} />
+}
+
+function RouteWithElementJsxChildren() {
+    return <Route path="/">
+        {<div>Hello!</div>}
+    </Route>
+}

--- a/types/react-router/test/Children.tsx
+++ b/types/react-router/test/Children.tsx
@@ -2,21 +2,21 @@ import * as React from 'react';
 import { Route } from 'react-router';
 
 function RouteWithFunctionChildrenAttribute() {
-    return <Route path="/" children={() => <div>Hello!</div>} />
+    return <Route path="/" children={() => <div>Hello!</div>} />;
 }
 
 function RouteWithFunctionJsxChildren() {
     return <Route path="/">
         {() => <div>Hello!</div>}
-    </Route>
+    </Route>;
 }
 
 function RouteWithElementChildrenAttribute() {
-    return <Route path="/" children={<div>Hello!</div>} />
+    return <Route path="/" children={<div>Hello!</div>} />;
 }
 
 function RouteWithElementJsxChildren() {
     return <Route path="/">
         {<div>Hello!</div>}
-    </Route>
+    </Route>;
 }

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -18,6 +18,7 @@
     "test/Animation.tsx",
     "test/Auth.tsx",
     "test/Basic.tsx",
+    "test/Children.tsx",
     "test/CustomLink.tsx",
     "test/ModalGallery.tsx",
     "test/NavigateWithContext.tsx",


### PR DESCRIPTION
Found in https://stackoverflow.com/questions/44250465/react-router-typescript-type-error

Appropriate resources:

- [The propTypes](https://github.com/ReactTraining/react-router/blob/d64ed0150b41df02b083f090b6682261c819a91e/packages/react-router/modules/Route.js#L17-L20).
- [The runtime check](https://github.com/ReactTraining/react-router/blob/d64ed0150b41df02b083f090b6682261c819a91e/packages/react-router/modules/Route.js#L109-L111)
- [The test](https://github.com/ReactTraining/react-router/blob/d64ed0150b41df02b083f090b6682261c819a91e/packages/react-router/modules/__tests__/Route-test.js#L216-L218)

Note: technically [this isn't documented](https://reacttraining.com/react-router/web/api/Route/children-func) but it is tested and supported in the code itself.