### PR TITLE
adding nested keyword for chai v4

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -490,20 +490,20 @@ function property() {
     ({ foo: { bar: 'baz' } }).should.have.property('foo.bar');
 }
 
-function deepProperty() {
+function nestedProperty() {
     expect({ 'foo.bar': 'baz' })
-        .to.not.have.deep.property('foo.bar');
+        .to.not.have.nested.property('foo.bar');
     ({ 'foo.bar': 'baz' }).should
-        .not.have.deep.property('foo.bar');
+        .not.have.nested.property('foo.bar');
     expect({ foo: { bar: 'baz' } })
-        .to.have.deep.property('foo.bar');
+        .to.have.nested.property('foo.bar');
     ({ foo: { bar: 'baz' } }).should
-        .have.deep.property('foo.bar');
+        .have.nested.property('foo.bar');
 
     expect({ 'foo.bar': 'baz' })
-        .to.have.deep.property('foo.bar');
+        .to.have.nested.property('foo.bar');
     ({ 'foo.bar': 'baz' }).should
-        .have.deep.property('foo.bar');
+        .have.nested.property('foo.bar');
 }
 
 function property2() {
@@ -525,24 +525,24 @@ function property2() {
     'asd'.should.have.property('constructor', Number, 'blah');
 }
 
-function deepProperty2() {
+function nestedProperty2() {
     expect({ foo: { bar: 'baz' } })
-        .to.have.deep.property('foo.bar', 'baz');
+        .to.have.nested.property('foo.bar', 'baz');
     ({ foo: { bar: 'baz' } }).should
-        .have.deep.property('foo.bar', 'baz');
+        .have.nested.property('foo.bar', 'baz');
 
     expect({ foo: { bar: 'baz' } })
-        .to.have.deep.property('foo.bar', 'quux', 'blah');
+        .to.have.nested.property('foo.bar', 'quux', 'blah');
     ({ foo: { bar: 'baz' } }).should
-        .have.deep.property('foo.bar', 'quux', 'blah');
+        .have.nested.property('foo.bar', 'quux', 'blah');
     expect({ foo: { bar: 'baz' } })
-        .to.not.have.deep.property('foo.bar', 'baz', 'blah');
+        .to.not.have.nested.property('foo.bar', 'baz', 'blah');
     ({ foo: { bar: 'baz' } }).should
-        .not.have.deep.property('foo.bar', 'baz', 'blah');
+        .not.have.nested.property('foo.bar', 'baz', 'blah');
     expect({ foo: 5 })
-        .to.not.have.deep.property('foo.bar', 'baz', 'blah');
+        .to.not.have.nested.property('foo.bar', 'baz', 'blah');
     ({ foo: 5 }).should
-        .not.have.deep.property('foo.bar', 'baz', 'blah');
+        .not.have.nested.property('foo.bar', 'baz', 'blah');
 }
 
 function ownProperty() {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -61,6 +61,7 @@ declare namespace Chai {
     interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
         not: Assertion;
         deep: Deep;
+        nested: Nested;
         any: KeyFilter;
         all: KeyFilter;
         a: TypeComparison;
@@ -167,6 +168,12 @@ declare namespace Chai {
         (expected: number, delta: number, message?: string): Assertion;
     }
 
+    interface Nested {
+      include: Include;
+      property: Property;
+      members: Members;
+    }
+
     interface Deep {
         equal: Equal;
         equals: Equal;
@@ -256,7 +263,7 @@ declare namespace Chai {
 
         /**
          * Throws a failure.
-         * 
+         *
          * @type T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
@@ -268,7 +275,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is truthy.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
@@ -277,7 +284,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is truthy.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
@@ -286,7 +293,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is falsy.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
@@ -295,7 +302,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is falsy.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Object to test.
          * @param message    Message to display on error.
@@ -304,7 +311,7 @@ declare namespace Chai {
 
         /**
          * Asserts non-strict equality (==) of actual and expected.
-         * 
+         *
          * @type T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
@@ -314,7 +321,7 @@ declare namespace Chai {
 
         /**
          * Asserts non-strict inequality (==) of actual and expected.
-         * 
+         *
          * @type T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
@@ -324,7 +331,7 @@ declare namespace Chai {
 
         /**
          * Asserts strict equality (===) of actual and expected.
-         * 
+         *
          * @type T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
@@ -334,7 +341,7 @@ declare namespace Chai {
 
         /**
          * Asserts strict inequality (==) of actual and expected.
-         * 
+         *
          * @type T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
@@ -344,7 +351,7 @@ declare namespace Chai {
 
         /**
          * Asserts that actual is deeply equal to expected.
-         * 
+         *
          * @type T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
@@ -354,7 +361,7 @@ declare namespace Chai {
 
         /**
          * Asserts that actual is not deeply equal to expected.
-         * 
+         *
          * @type T   Type of the objects.
          * @param actual   Actual value.
          * @param expected   Potential expected value.
@@ -364,7 +371,7 @@ declare namespace Chai {
 
         /**
          * Asserts valueToCheck is strictly greater than (>) valueToBeAbove.
-         * 
+         *
          * @param valueToCheck   Actual value.
          * @param valueToBeAbove   Minimum Potential expected value.
          * @param message   Message to display on error.
@@ -373,7 +380,7 @@ declare namespace Chai {
 
         /**
          * Asserts valueToCheck is greater than or equal to (>=) valueToBeAtLeast.
-         * 
+         *
          * @param valueToCheck   Actual value.
          * @param valueToBeAtLeast   Minimum Potential expected value.
          * @param message   Message to display on error.
@@ -382,7 +389,7 @@ declare namespace Chai {
 
         /**
          * Asserts valueToCheck is strictly less than (<) valueToBeBelow.
-         * 
+         *
          * @param valueToCheck   Actual value.
          * @param valueToBeBelow   Minimum Potential expected value.
          * @param message   Message to display on error.
@@ -391,7 +398,7 @@ declare namespace Chai {
 
         /**
          * Asserts valueToCheck is greater than or equal to (>=) valueToBeAtMost.
-         * 
+         *
          * @param valueToCheck   Actual value.
          * @param valueToBeAtMost   Minimum Potential expected value.
          * @param message   Message to display on error.
@@ -400,7 +407,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is true.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -409,7 +416,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is false.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -418,7 +425,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not true.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -427,7 +434,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not false.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -436,7 +443,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is null.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -445,7 +452,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not null.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -454,7 +461,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not null.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -463,7 +470,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not null.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -472,7 +479,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is undefined.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -481,7 +488,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not undefined.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -490,7 +497,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is a function.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -499,7 +506,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not a function.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -509,7 +516,7 @@ declare namespace Chai {
         /**
          * Asserts that value is an object of type 'Object'
          * (as revealed by Object.prototype.toString).
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -520,7 +527,7 @@ declare namespace Chai {
         /**
          * Asserts that value is not an object of type 'Object'
          * (as revealed by Object.prototype.toString).
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -529,7 +536,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is an array.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -538,7 +545,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not an array.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -547,7 +554,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is a string.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -556,7 +563,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not a string.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -565,7 +572,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is a number.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -574,7 +581,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not a number.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -583,7 +590,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is a boolean.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -592,7 +599,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not a boolean.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param message   Message to display on error.
@@ -601,7 +608,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value's type is name, as determined by Object.prototype.toString.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param name   Potential expected type name of value.
@@ -611,7 +618,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value's type is not name, as determined by Object.prototype.toString.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param name   Potential expected type name of value.
@@ -621,7 +628,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is an instance of constructor.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param constructor   Potential expected contructor of value.
@@ -631,7 +638,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value is not an instance of constructor.
-         * 
+         *
          * @type T   Type of value.
          * @param value   Actual value.
          * @param constructor   Potential expected contructor of value.
@@ -641,7 +648,7 @@ declare namespace Chai {
 
         /**
          * Asserts that haystack includes needle.
-         * 
+         *
          * @param haystack   Container string.
          * @param needle   Potential expected substring of haystack.
          * @param message   Message to display on error.
@@ -650,7 +657,7 @@ declare namespace Chai {
 
         /**
          * Asserts that haystack includes needle.
-         * 
+         *
          * @type T   Type of values in haystack.
          * @param haystack   Container array.
          * @param needle   Potential value contained in haystack.
@@ -660,7 +667,7 @@ declare namespace Chai {
 
         /**
          * Asserts that haystack does not include needle.
-         * 
+         *
          * @param haystack   Container string.
          * @param needle   Potential expected substring of haystack.
          * @param message   Message to display on error.
@@ -669,7 +676,7 @@ declare namespace Chai {
 
         /**
          * Asserts that haystack does not include needle.
-         * 
+         *
          * @type T   Type of values in haystack.
          * @param haystack   Container array.
          * @param needle   Potential value contained in haystack.
@@ -679,7 +686,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value matches the regular expression regexp.
-         * 
+         *
          * @param value   Actual value.
          * @param regexp   Potential match of value.
          * @param message   Message to display on error.
@@ -688,7 +695,7 @@ declare namespace Chai {
 
         /**
          * Asserts that value does not match the regular expression regexp.
-         * 
+         *
          * @param value   Actual value.
          * @param regexp   Potential match of value.
          * @param message   Message to display on error.
@@ -697,7 +704,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object has a property named by property.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Container object.
          * @param property   Potential contained property of object.
@@ -707,7 +714,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object has a property named by property.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Container object.
          * @param property   Potential contained property of object.
@@ -718,7 +725,7 @@ declare namespace Chai {
         /**
          * Asserts that object has a property named by property, which can be a string
          * using dot- and bracket-notation for deep reference.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Container object.
          * @param property   Potential contained property of object.
@@ -729,7 +736,7 @@ declare namespace Chai {
         /**
          * Asserts that object does not have a property named by property, which can be a
          * string using dot- and bracket-notation for deep reference.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Container object.
          * @param property   Potential contained property of object.
@@ -739,7 +746,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object has a property named by property with value given by value.
-         * 
+         *
          * @type T   Type of object.
          * @type V   Type of value.
          * @param object   Container object.
@@ -751,7 +758,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object has a property named by property with value given by value.
-         * 
+         *
          * @type T   Type of object.
          * @type V   Type of value.
          * @param object   Container object.
@@ -764,7 +771,7 @@ declare namespace Chai {
         /**
          * Asserts that object has a property named by property, which can be a string
          * using dot- and bracket-notation for deep reference.
-         * 
+         *
          * @type T   Type of object.
          * @type V   Type of value.
          * @param object   Container object.
@@ -777,7 +784,7 @@ declare namespace Chai {
         /**
          * Asserts that object does not have a property named by property, which can be a
          * string using dot- and bracket-notation for deep reference.
-         * 
+         *
          * @type T   Type of object.
          * @type V   Type of value.
          * @param object   Container object.
@@ -789,7 +796,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object has a length property with the expected value.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Container object.
          * @param length   Potential expected length of object.
@@ -799,7 +806,7 @@ declare namespace Chai {
 
         /**
          * Asserts that fn will throw an error.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param message   Message to display on error.
          */
@@ -807,7 +814,7 @@ declare namespace Chai {
 
         /**
          * Asserts that function will throw an error with message matching regexp.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param regExp   Potential expected message match.
          * @param message   Message to display on error.
@@ -816,7 +823,7 @@ declare namespace Chai {
 
         /**
          * Asserts that function will throw an error that is an instance of constructor.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
@@ -826,7 +833,7 @@ declare namespace Chai {
         /**
          * Asserts that function will throw an error that is an instance of constructor
          * and an error with message matching regexp.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
@@ -835,7 +842,7 @@ declare namespace Chai {
 
         /**
          * Asserts that fn will throw an error.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param message   Message to display on error.
          */
@@ -843,7 +850,7 @@ declare namespace Chai {
 
         /**
          * Asserts that function will throw an error with message matching regexp.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param regExp   Potential expected message match.
          * @param message   Message to display on error.
@@ -852,7 +859,7 @@ declare namespace Chai {
 
         /**
          * Asserts that function will throw an error that is an instance of constructor.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
@@ -862,7 +869,7 @@ declare namespace Chai {
         /**
          * Asserts that function will throw an error that is an instance of constructor
          * and an error with message matching regexp.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
@@ -871,7 +878,7 @@ declare namespace Chai {
 
         /**
          * Asserts that fn will throw an error.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param message   Message to display on error.
          */
@@ -879,7 +886,7 @@ declare namespace Chai {
 
         /**
          * Asserts that function will throw an error with message matching regexp.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param regExp   Potential expected message match.
          * @param message   Message to display on error.
@@ -888,7 +895,7 @@ declare namespace Chai {
 
         /**
          * Asserts that function will throw an error that is an instance of constructor.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
@@ -898,7 +905,7 @@ declare namespace Chai {
         /**
          * Asserts that function will throw an error that is an instance of constructor
          * and an error with message matching regexp.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
@@ -907,7 +914,7 @@ declare namespace Chai {
 
         /**
          * Asserts that fn will not throw an error.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param message   Message to display on error.
          */
@@ -915,7 +922,7 @@ declare namespace Chai {
 
         /**
          * Asserts that function will throw an error with message matching regexp.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param regExp   Potential expected message match.
          * @param message   Message to display on error.
@@ -924,7 +931,7 @@ declare namespace Chai {
 
         /**
          * Asserts that function will throw an error that is an instance of constructor.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
@@ -934,7 +941,7 @@ declare namespace Chai {
         /**
          * Asserts that function will throw an error that is an instance of constructor
          * and an error with message matching regexp.
-         * 
+         *
          * @param fn   Function that may throw.
          * @param constructor   Potential expected error constructor.
          * @param message   Message to display on error.
@@ -943,7 +950,7 @@ declare namespace Chai {
 
         /**
          * Compares two values using operator.
-         * 
+         *
          * @param val1   Left value during comparison.
          * @param operator   Comparison operator.
          * @param val2   Right value during comparison.
@@ -953,7 +960,7 @@ declare namespace Chai {
 
         /**
          * Asserts that the target is equal to expected, to within a +/- delta range.
-         * 
+         *
          * @param actual   Actual value
          * @param expected   Potential expected value.
          * @param delta   Maximum differenced between values.
@@ -963,7 +970,7 @@ declare namespace Chai {
 
         /**
          * Asserts that the target is equal to expected, to within a +/- delta range.
-         * 
+         *
          * @param actual   Actual value
          * @param expected   Potential expected value.
          * @param delta   Maximum differenced between values.
@@ -973,7 +980,7 @@ declare namespace Chai {
 
         /**
          * Asserts that set1 and set2 have the same members. Order is not take into account.
-         * 
+         *
          * @type T   Type of set values.
          * @param set1   Actual set of values.
          * @param set2   Potential expected set of values.
@@ -984,7 +991,7 @@ declare namespace Chai {
         /**
          * Asserts that set1 and set2 have the same members using deep equality checking.
          * Order is not take into account.
-         * 
+         *
          * @type T   Type of set values.
          * @param set1   Actual set of values.
          * @param set2   Potential expected set of values.
@@ -994,7 +1001,7 @@ declare namespace Chai {
 
         /**
          * Asserts that subset is included in superset. Order is not take into account.
-         * 
+         *
          * @type T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential contained set of values.
@@ -1005,7 +1012,7 @@ declare namespace Chai {
         /**
          * Asserts that subset is included in superset using deep equality checking.
          * Order is not take into account.
-         * 
+         *
          * @type T   Type of set values.
          * @param superset   Actual set of values.
          * @param subset   Potential contained set of values.
@@ -1015,7 +1022,7 @@ declare namespace Chai {
 
         /**
          * Asserts that non-object, non-array value inList appears in the flat array list.
-         * 
+         *
          * @type T   Type of list values.
          * @param inList   Value expected to be in the list.
          * @param list   List of values.
@@ -1025,7 +1032,7 @@ declare namespace Chai {
 
         /**
          * Asserts that a function changes the value of a property.
-         * 
+         *
          * @type T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
@@ -1036,7 +1043,7 @@ declare namespace Chai {
 
         /**
          * Asserts that a function does not change the value of a property.
-         * 
+         *
          * @type T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
@@ -1047,7 +1054,7 @@ declare namespace Chai {
 
         /**
          * Asserts that a function increases an object property.
-         * 
+         *
          * @type T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
@@ -1058,7 +1065,7 @@ declare namespace Chai {
 
         /**
          * Asserts that a function does not increase an object property.
-         * 
+         *
          * @type T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
@@ -1069,7 +1076,7 @@ declare namespace Chai {
 
         /**
          * Asserts that a function decreases an object property.
-         * 
+         *
          * @type T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
@@ -1080,7 +1087,7 @@ declare namespace Chai {
 
         /**
          * Asserts that a function does not decrease an object property.
-         * 
+         *
          * @type T   Type of object.
          * @param modifier   Function to run.
          * @param object   Container object.
@@ -1091,7 +1098,7 @@ declare namespace Chai {
 
         /**
          * Asserts if value is not a false value, and throws if it is a true value.
-         * 
+         *
          * @type T   Type of object.
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1102,7 +1109,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is extensible (can have new properties added to it).
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1111,7 +1118,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is extensible (can have new properties added to it).
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1120,7 +1127,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is not extensible.
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1129,7 +1136,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is not extensible.
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1139,7 +1146,7 @@ declare namespace Chai {
         /**
          * Asserts that object is sealed (can have new properties added to it
          * and its existing properties cannot be removed).
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1149,7 +1156,7 @@ declare namespace Chai {
         /**
          * Asserts that object is sealed (can have new properties added to it
          * and its existing properties cannot be removed).
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1158,7 +1165,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is not sealed.
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1167,7 +1174,7 @@ declare namespace Chai {
 
         /**
          * Asserts that object is not sealed.
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1177,7 +1184,7 @@ declare namespace Chai {
         /**
          * Asserts that object is frozen (cannot have new properties added to it
          * and its existing properties cannot be removed).
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1187,7 +1194,7 @@ declare namespace Chai {
         /**
          * Asserts that object is frozen (cannot have new properties added to it
          * and its existing properties cannot be removed).
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1197,7 +1204,7 @@ declare namespace Chai {
         /**
          * Asserts that object is not frozen (cannot have new properties added to it
          * and its existing properties cannot be removed).
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.
@@ -1207,7 +1214,7 @@ declare namespace Chai {
         /**
          * Asserts that object is not frozen (cannot have new properties added to it
          * and its existing properties cannot be removed).
-         * 
+         *
          * @type T   Type of object
          * @param object   Actual value.
          * @param message   Message to display on error.

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for chai 3.5.0
+// Type definitions for chai 4.0.0
 // Project: http://chaijs.com/
 // Definitions by: Jed Mao <https://github.com/jedmao/>,
 //                 Bart van der Schoor <https://github.com/Bartvds>,


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run ~`npm run lint package-name`~ (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chaijs/chai/releases/tag/4.0.0
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The new version of Chai has moved nested properties from syntax like

```
const v = { a: { b: 'potato' } };
expect(v).to.have.deep.property('a.b', 'potato');
```

to

```
const v = { a: { b: 'potato' } };
expect(v).to.have.nested.property('a.b', 'potato');
```

to disambiguate the meaning of 'deep' into `deep` === 'deep equality' and `nested` === 'deep property name'.

Note that I just took a stab at adding the .nested selector for 4.0 (this is what I'm using for the time being at least), because I didn't want to break backwards compatibility on the types library for 3.5 users. 