### PR TITLE
[gm]: allows subclasses to process non-string argument types as image source

### DIFF
--- a/types/gm/gm-tests.ts
+++ b/types/gm/gm-tests.ts
@@ -346,3 +346,13 @@ var imageMagick = gm.subClass({ imageMagick: true });
 var readStream = imageMagick(src)
 	.adjoin()
 	.stream();
+
+var passStream = imageMagick(readStream).stream();
+
+var buffers: Buffer[] = [];
+var buffer: Buffer;
+passStream.on('data', (chunk) => buffers.push(chunk as Buffer)).on('close', () => {
+	buffer = Buffer.concat(buffers);
+	var readstream = imageMagick(buffer).stream();
+})
+

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -615,9 +615,9 @@ declare namespace m {
 
     export interface SubClass {
         (image: string): State;
-        (stream: NodeJS.ReadableStream, image?: string): State
-        (buffer: Buffer, image?: string): State
-        (width: number, height: number, color?: string): State
+        (stream: NodeJS.ReadableStream, image?: string): State;
+        (buffer: Buffer, image?: string): State;
+        (width: number, height: number, color?: string): State;
     }
 
     export function compare(filename1: string, filename2: string, callback: CompareCallback): void;

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -615,6 +615,9 @@ declare namespace m {
 
     export interface SubClass {
         (image: string): State;
+        (stream: NodeJS.ReadableStream, image?: string): State
+        (buffer: Buffer, image?: string): State
+        (width: number, height: number, color?: string): State
     }
 
     export function compare(filename1: string, filename2: string, callback: CompareCallback): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [gm documentation: https://github.com/aheckmann/gm/blob/master/index.js](https://github.com/aheckmann/gm/blob/master/index.js#L91-L106)
Lines 91-106 shows that the subclass created by passing through an option (e.g. `const im = require('gm').subClass({imageMagick: true})`) returns an instance of the "parent" class, thus should also have the same interface for handling different argument types. 
[Issue #16784](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16784)

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
