### PR TITLE
expose default export for react-onclickoutside

### DIFF
--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-onclickoutside 5.7
+// Type definitions for react-onclickoutside 6.0.0
 // Project: https://github.com/Pomax/react-onclickoutside
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -35,4 +35,4 @@ declare function OnClickOut<P>(
         | ClickOutComponentClass<P & OnClickOut.InjectedOnClickOutProps>
 ): React.ComponentClass<P & OnClickOut.OnClickOutProps>;
 
-export = OnClickOut;
+export = { default: OnClickOut };

--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-onclickoutside 6.0.0
+// Type definitions for react-onclickoutside 6.0
 // Project: https://github.com/Pomax/react-onclickoutside
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-onclickoutside/react-onclickoutside-tests.tsx
+++ b/types/react-onclickoutside/react-onclickoutside-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Component, MouseEvent, StatelessComponent } from 'react';
 import { render } from 'react-dom';
-import * as onClickOutside from 'react-onclickoutside';
+import onClickOutside from 'react-onclickoutside';
 
 function TestStateless(props: { handleClickOutside(): void; }) {
     return (


### PR DESCRIPTION
From v6.0.0 onwards, this libarary has changed to use a ES6-style default export instead of exporting a function as the main export commonjs-style. Updated the type definitions to match.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Pomax/react-onclickoutside/pull/169
- [x] Increase the version number in the header if appropriate.
