### PR TITLE
update ws types for ws v3.0.0 (breaking changes) 

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for ws
 // Project: https://github.com/einaros/ws
 // Definitions by: Paul Loyd <https://github.com/loyd>
+//                 Onur Yıldırım <https://github.com/onury>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -22,7 +23,6 @@ declare class WebSocket extends events.EventEmitter {
     protocolVersion: string;
     url: string;
     supports: any;
-    upgradeReq: http.IncomingMessage;
     protocol: string;
     bufferedAmount: number;
     binaryType: string;
@@ -64,17 +64,17 @@ declare class WebSocket extends events.EventEmitter {
     // Events
     on(event: 'error', cb: (err: Error) => void): this;
     on(event: 'close', cb: (code: number, message: string) => void): this;
-    on(event: 'message', cb: (data: any, flags: { binary: boolean }) => void): this;
-    on(event: 'ping', cb: (data: any, flags: { binary: boolean }) => void): this;
-    on(event: 'pong', cb: (data: any, flags: { binary: boolean }) => void): this;
+    on(event: 'message', cb: (data: any) => void): this;
+    on(event: 'ping', cb: (data: any) => void): this;
+    on(event: 'pong', cb: (data: any) => void): this;
     on(event: 'open', cb: () => void): this;
     on(event: string, listener: () => void): this;
 
     addListener(event: 'error', cb: (err: Error) => void): this;
     addListener(event: 'close', cb: (code: number, message: string) => void): this;
-    addListener(event: 'message', cb: (data: any, flags: { binary: boolean }) => void): this;
-    addListener(event: 'ping', cb: (data: any, flags: { binary: boolean }) => void): this;
-    addListener(event: 'pong', cb: (data: any, flags: { binary: boolean }) => void): this;
+    addListener(event: 'message', cb: (data: any) => void): this;
+    addListener(event: 'ping', cb: (data: any) => void): this;
+    addListener(event: 'pong', cb: (data: any) => void): this;
     addListener(event: 'open', cb: () => void): this;
     addListener(event: string, listener: () => void): this;
 }
@@ -138,7 +138,7 @@ declare namespace WebSocket {
         // Events
         on(event: 'error', cb: (err: Error) => void): this;
         on(event: 'headers', cb: (headers: string[]) => void): this;
-        on(event: 'connection', cb: (client: WebSocket) => void): this;
+        on(event: 'connection', cb: (client: WebSocket, req: http.IncomingMessage) => void): this;
         on(event: string, listener: () => void): this;
 
         addListener(event: 'error', cb: (err: Error) => void): this;

--- a/types/ws/ws-tests.ts
+++ b/types/ws/ws-tests.ts
@@ -8,7 +8,7 @@ var WebSocketServer = WebSocket.Server;
 {
     var ws = new WebSocket('ws://www.host.com/path');
     ws.on('open', () => ws.send('something'));
-    ws.on('message', (data, flags) => {});
+    ws.on('message', (data) => {});
 }
 
 {
@@ -22,7 +22,8 @@ var WebSocketServer = WebSocket.Server;
 
 {
     var wss = new WebSocketServer({port: 8080});
-    wss.on('connection', (ws) => {
+    wss.on('connection', (ws, req) => {
+        console.log('url: %s', req.url);
         ws.on('message', (message) => console.log('received: %s', message));
         ws.send('something');
     });
@@ -46,8 +47,8 @@ var WebSocketServer = WebSocket.Server;
     wsc.on('open',  () => wsc.send(Date.now().toString(), {mask: true}));
     wsc.on('close', () => console.log('disconnected'));
 
-    wsc.on('message', (data, flags) => {
-        console.log('Roundtrip time: ' + (Date.now() - parseInt(data)) + 'ms', flags);
+    wsc.on('message', (data) => {
+        console.log('Roundtrip time: ' + (Date.now() - parseInt(data)) + 'ms');
         setTimeout(() => {
             wsc.send(Date.now().toString(), {mask: true});
         }, 500);
@@ -71,13 +72,14 @@ var WebSocketServer = WebSocket.Server;
     ): void {
         callback(true)
     }
-    
+
     var wsv = new WebSocketServer({
         verifyClient
     })
-    
-    wsv.on('connection', function connection(ws) {
-        console.log(ws.protocol)
+
+    wsv.on('connection', function connection(ws, req) {
+        console.log('protocol:', ws.protocol);
+        console.log('url:', req.url);
     })
 }
 


### PR DESCRIPTION
Applied (breaking) changes to types.
See https://github.com/websockets/ws/releases/tag/3.0.0

- Removed the upgradeReq property.
- Removed the flags argument from the 'message', 'ping', and 'pong' events.
- Added req argument to connection event.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/releases/tag/3.0.0
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
