### PR TITLE
[react-spinkit]: update to 3.0.0

### DIFF
--- a/types/react-spinkit/index.d.ts
+++ b/types/react-spinkit/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-spinkit 3.0.0
 // Project: https://github.com/KyleAMathews/react-spinkit
-// Definitions by: Qubo <https://github.com/tkqubo>, Mleko <https://github.com/mleko>, Tom Crockett <https://github.com/pelotom>
+// Definitions by: Qubo <https://github.com/tkqubo>, Mleko <https://github.com/mleko>, Tom Crockett <https://github.com/pelotom>, zzanol <https://github.com/zzanol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/react-spinkit/index.d.ts
+++ b/types/react-spinkit/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-spinkit 1.1.4
+// Type definitions for react-spinkit 3.0.0
 // Project: https://github.com/KyleAMathews/react-spinkit
 // Definitions by: Qubo <https://github.com/tkqubo>, Mleko <https://github.com/mleko>, Tom Crockett <https://github.com/pelotom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,7 +11,7 @@ declare namespace spinner {
         /**
          * Specify spinner to use.
          */
-        spinnerName?: 'three-bounce' | 'double-bounce' | 'rotating-plane' | 'folding-cube' | 'wave' | 'wandering-cubes' | 'pulse' | 'chasing-dots' | 'circle' | 'cube-grid' | 'wordpress';
+        name?: 'three-bounce' | 'double-bounce' | 'rotating-plane' | 'folding-cube' | 'wave' | 'wandering-cubes' | 'pulse' | 'chasing-dots' | 'circle' | 'cube-grid' | 'wordpress';
         /**
          * Disable the initial fade-in of the spinner.
          */

--- a/types/react-spinkit/react-spinkit-tests.tsx
+++ b/types/react-spinkit/react-spinkit-tests.tsx
@@ -4,20 +4,20 @@ import * as React from 'react';
 // Examples taken from http://kyleamathews.github.io/react-spinkit/
 const spinners = [
     // Basic spinners
-    <Spinner spinnerName="three-bounce" />,
-    <Spinner spinnerName="double-bounce" />,
-    <Spinner spinnerName="rotating-plane" />,
-    <Spinner spinnerName="folding-cube" />,
-    <Spinner spinnerName="wave" />,
-    <Spinner spinnerName="wandering-cubes" />,
-    <Spinner spinnerName="pulse" />,
-    <Spinner spinnerName="chasing-dots" />,
-    <Spinner spinnerName="circle" />,
-    <Spinner spinnerName="cube-grid" />,
-    <Spinner spinnerName="wordpress" />,
+    <Spinner name="three-bounce" />,
+    <Spinner name="double-bounce" />,
+    <Spinner name="rotating-plane" />,
+    <Spinner name="folding-cube" />,
+    <Spinner name="wave" />,
+    <Spinner name="wandering-cubes" />,
+    <Spinner name="pulse" />,
+    <Spinner name="chasing-dots" />,
+    <Spinner name="circle" />,
+    <Spinner name="cube-grid" />,
+    <Spinner name="wordpress" />,
 
     // Spinner options
-    <Spinner spinnerName="wordpress" noFadeIn />,
-    <Spinner spinnerName="wordpress" overrideSpinnerClassName="my-class-to-override" />,
-    <Spinner spinnerName="wordpress" className="my-class" />,
+    <Spinner name="wordpress" noFadeIn />,
+    <Spinner name="wordpress" overrideSpinnerClassName="my-class-to-override" />,
+    <Spinner name="wordpress" className="my-class" />,
 ];

--- a/types/react-spinkit/v1/index.d.ts
+++ b/types/react-spinkit/v1/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for react-spinkit 1.1.4
+// Project: https://github.com/KyleAMathews/react-spinkit
+// Definitions by: Qubo <https://github.com/tkqubo>, Mleko <https://github.com/mleko>, Tom Crockett <https://github.com/pelotom>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/// <reference types="react" />
+
+declare namespace spinner {
+	export interface SpinnerProps {
+        /**
+         * Specify spinner to use.
+         */
+        spinnerName?: 'three-bounce' | 'double-bounce' | 'rotating-plane' | 'folding-cube' | 'wave' | 'wandering-cubes' | 'pulse' | 'chasing-dots' | 'circle' | 'cube-grid' | 'wordpress';
+        /**
+         * Disable the initial fade-in of the spinner.
+         */
+        noFadeIn?: boolean;
+        /**
+         * Change the default "spinner" className.
+         */
+        overrideSpinnerClassName?: string;
+        /**
+         * Component className.
+         */
+        className?: string;
+	}
+
+	export interface Spinner extends React.ComponentClass<SpinnerProps> {
+	}
+}
+
+declare const spinner: spinner.Spinner;
+export = spinner;

--- a/types/react-spinkit/v1/react-spinkit-tests.tsx
+++ b/types/react-spinkit/v1/react-spinkit-tests.tsx
@@ -1,0 +1,23 @@
+import * as Spinner from 'react-spinkit';
+import * as React from 'react';
+
+// Examples taken from http://kyleamathews.github.io/react-spinkit/
+const spinners = [
+    // Basic spinners
+    <Spinner spinnerName="three-bounce" />,
+    <Spinner spinnerName="double-bounce" />,
+    <Spinner spinnerName="rotating-plane" />,
+    <Spinner spinnerName="folding-cube" />,
+    <Spinner spinnerName="wave" />,
+    <Spinner spinnerName="wandering-cubes" />,
+    <Spinner spinnerName="pulse" />,
+    <Spinner spinnerName="chasing-dots" />,
+    <Spinner spinnerName="circle" />,
+    <Spinner spinnerName="cube-grid" />,
+    <Spinner spinnerName="wordpress" />,
+
+    // Spinner options
+    <Spinner spinnerName="wordpress" noFadeIn />,
+    <Spinner spinnerName="wordpress" overrideSpinnerClassName="my-class-to-override" />,
+    <Spinner spinnerName="wordpress" className="my-class" />,
+];

--- a/types/react-spinkit/v1/tsconfig.json
+++ b/types/react-spinkit/v1/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../../",
+        "jsx": "react",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "paths": {
+            "react-spinkit": ["react-spinkit/v1"],
+            "react-spinkit/*": ["react-spinkit/v1/*"]
+        },
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-spinkit-tests.tsx"
+    ]
+}


### PR DESCRIPTION
Prop 'spinnerName' was changed to 'name' in 3.0.0.

https://github.com/KyleAMathews/react-spinkit/commit/60af1a334e4ffe841b23384b970223f58e0a3503
