### PR TITLE
[consolidate] change String wrapper object to primitive

### DIFF
--- a/types/consolidate/consolidate-tests.ts
+++ b/types/consolidate/consolidate-tests.ts
@@ -4,133 +4,136 @@ import cons = require('consolidate');
 var path: string = 'test/path';
 var options = {user: 'tobi'};
 var fn = function(err: Error, html: string) {};
+(async () => {
+  let res: string;
 
-cons.atpl(path);
-cons.atpl(path, options);
-cons.atpl(path, options, fn);
+  res = await cons.atpl(path);
+  res = await cons.atpl(path, options);
+  cons.atpl(path, options, fn);
 
-cons.dot(path);
-cons.dot(path, options);
-cons.dot(path, options, fn);
+  res = await cons.dot(path);
+  res = await cons.dot(path, options);
+  cons.dot(path, options, fn);
 
-cons.dust(path);
-cons.dust(path, options);
-cons.dust(path, options, fn);
+  res = await cons.dust(path);
+  res = await cons.dust(path, options);
+  cons.dust(path, options, fn);
 
-cons.eco(path);
-cons.eco(path, options);
-cons.eco(path, options, fn);
+  res = await cons.eco(path);
+  res = await cons.eco(path, options);
+  cons.eco(path, options, fn);
 
-cons.ect(path);
-cons.ect(path, options);
-cons.ect(path, options, fn);
+  res = await cons.ect(path);
+  res = await cons.ect(path, options);
+  cons.ect(path, options, fn);
 
-cons.ejs(path);
-cons.ejs(path, options);
-cons.ejs(path, options, fn);
+  res = await cons.ejs(path);
+  res = await cons.ejs(path, options);
+  cons.ejs(path, options, fn);
 
-cons.haml(path);
-cons.haml(path, options);
-cons.haml(path, options, fn);
+  res = await cons.haml(path);
+  res = await cons.haml(path, options);
+  cons.haml(path, options, fn);
 
-// TODO figure out how to type haml-coffee
-// cons['haml-coffee'](path, options, fn);
+  // TODO figure out how to type haml-coffee
+  // cons['haml-coffee'](path, options, fn);
 
-cons.hamlet(path);
-cons.hamlet(path, options);
-cons.hamlet(path, options, fn);
+  res = await cons.hamlet(path);
+  res = await cons.hamlet(path, options);
+  cons.hamlet(path, options, fn);
 
-cons.handlebars(path);
-cons.handlebars(path, options);
-cons.handlebars(path, options, fn);
+  res = await cons.handlebars(path);
+  res = await cons.handlebars(path, options);
+  cons.handlebars(path, options, fn);
 
-cons.hogan(path);
-cons.hogan(path, options);
-cons.hogan(path, options, fn);
+  res = await cons.hogan(path);
+  res = await cons.hogan(path, options);
+  cons.hogan(path, options, fn);
 
-cons.htmling(path);
-cons.htmling(path, options);
-cons.htmling(path, options, fn);
+  res = await cons.htmling(path);
+  res = await cons.htmling(path, options);
+  cons.htmling(path, options, fn);
 
-cons.jade(path);
-cons.jade(path, options);
-cons.jade(path, options, fn);
+  res = await cons.jade(path);
+  res = await cons.jade(path, options);
+  cons.jade(path, options, fn);
 
-cons.jazz(path);
-cons.jazz(path, options);
-cons.jazz(path, options, fn);
+  res = await cons.jazz(path);
+  res = await cons.jazz(path, options);
+  cons.jazz(path, options, fn);
 
-cons.jqtpl(path);
-cons.jqtpl(path, options);
-cons.jqtpl(path, options, fn);
+  res = await cons.jqtpl(path);
+  res = await cons.jqtpl(path, options);
+  cons.jqtpl(path, options, fn);
 
-cons.just(path);
-cons.just(path, options);
-cons.just(path, options, fn);
+  res = await cons.just(path);
+  res = await cons.just(path, options);
+  cons.just(path, options, fn);
 
-cons.liquid(path);
-cons.liquid(path, options);
-cons.liquid(path, options, fn);
+  res = await cons.liquid(path);
+  res = await cons.liquid(path, options);
+  cons.liquid(path, options, fn);
 
-cons.liquor(path);
-cons.liquor(path, options);
-cons.liquor(path, options, fn);
+  res = await cons.liquor(path);
+  res = await cons.liquor(path, options);
+  cons.liquor(path, options, fn);
 
-cons.lodash(path);
-cons.lodash(path, options);
-cons.lodash(path, options, fn);
+  res = await cons.lodash(path);
+  res = await cons.lodash(path, options);
+  cons.lodash(path, options, fn);
 
-cons.mote(path);
-cons.mote(path, options);
-cons.mote(path, options, fn);
+  res = await cons.mote(path);
+  res = await cons.mote(path, options);
+  cons.mote(path, options, fn);
 
-cons.mustache(path);
-cons.mustache(path, options);
-cons.mustache(path, options, fn);
+  res = await cons.mustache(path);
+  res = await cons.mustache(path, options);
+  cons.mustache(path, options, fn);
 
-cons.nunjucks(path);
-cons.nunjucks(path, options);
-cons.nunjucks(path, options, fn);
+  res = await cons.nunjucks(path);
+  res = await cons.nunjucks(path, options);
+  cons.nunjucks(path, options, fn);
 
-cons.pug(path);
-cons.pug(path, options);
-cons.pug(path, options, fn);
+  res = await cons.pug(path);
+  res = await cons.pug(path, options);
+  cons.pug(path, options, fn);
 
-cons.qejs(path);
-cons.qejs(path, options);
-cons.qejs(path, options, fn);
+  res = await cons.qejs(path);
+  res = await cons.qejs(path, options);
+  cons.qejs(path, options, fn);
 
-cons.ractive(path);
-cons.ractive(path, options);
-cons.ractive(path, options, fn);
+  res = await cons.ractive(path);
+  res = await cons.ractive(path, options);
+  cons.ractive(path, options, fn);
 
-cons.react(path);
-cons.react(path, options);
-cons.react(path, options, fn);
+  res = await cons.react(path);
+  res = await cons.react(path, options);
+  cons.react(path, options, fn);
 
-cons.swig(path);
-cons.swig(path, options);
-cons.swig(path, options, fn);
+  res = await cons.swig(path);
+  res = await cons.swig(path, options);
+  cons.swig(path, options, fn);
 
-cons.templayed(path);
-cons.templayed(path, options);
-cons.templayed(path, options, fn);
+  res = await cons.templayed(path);
+  res = await cons.templayed(path, options);
+  cons.templayed(path, options, fn);
 
-cons.toffee(path);
-cons.toffee(path, options);
-cons.toffee(path, options, fn);
+  res = await cons.toffee(path);
+  res = await cons.toffee(path, options);
+  cons.toffee(path, options, fn);
 
-cons.underscore(path);
-cons.underscore(path, options);
-cons.underscore(path, options, fn);
+  res = await cons.underscore(path);
+  res = await cons.underscore(path, options);
+  cons.underscore(path, options, fn);
 
-cons.walrus(path);
-cons.walrus(path, options);
-cons.walrus(path, options, fn);
+  res = await cons.walrus(path);
+  res = await cons.walrus(path, options);
+  cons.walrus(path, options, fn);
 
-cons.whiskers(path);
-cons.whiskers(path, options);
-cons.whiskers(path, options, fn);
+  res = await cons.whiskers(path);
+  res = await cons.whiskers(path, options);
+  cons.whiskers(path, options, fn);
+})();
 
 /**
  * Examples from documentation

--- a/types/consolidate/index.d.ts
+++ b/types/consolidate/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for consolidate
 // Project: https://github.com/visionmedia/consolidate.js
-// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>, Theo Sherry <https://github.com/theosherry>
+// Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>, Theo Sherry <https://github.com/theosherry>, Nicolas Henry <https://github.com/nicolashenry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/soywiz/typescript-node-definitions/consolidate.d.ts
@@ -61,15 +61,15 @@ interface Consolidate {
 }
 
 interface RendererInterface {
-    render(path: String, fn: (err: Error, html: String) => any): any;
+    render(path: string, fn: (err: Error, html: string) => any): any;
 
-    render(path: String, options: { cache?: boolean, [otherOptions: string]: any }, fn: (err: Error, html: String) => any): any;
+    render(path: string, options: { cache?: boolean, [otherOptions: string]: any }, fn: (err: Error, html: string) => any): any;
 
-    render(path: String, options?: { cache?: boolean, [otherOptions: string]: any }): Promise<String>;
+    render(path: string, options?: { cache?: boolean, [otherOptions: string]: any }): Promise<string>;
 
-    (path: String, fn: (err: Error, html: String) => any): any;
+    (path: string, fn: (err: Error, html: string) => any): any;
 
-    (path: String, options: { cache?: boolean, [otherOptions: string]: any }, fn: (err: Error, html: String) => any): any;
+    (path: string, options: { cache?: boolean, [otherOptions: string]: any }, fn: (err: Error, html: string) => any): any;
 
-    (path: String, options?: { cache?: boolean, [otherOptions: string]: any }): Promise<String>;
+    (path: string, options?: { cache?: boolean, [otherOptions: string]: any }): Promise<string>;
 }

--- a/types/consolidate/tsconfig.json
+++ b/types/consolidate/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "target": "es6",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
Wrapper object is currently declared which prevent promise use.
"String" wrapper object should not be used so I changed it to "string" primitive.