### PR TITLE
[c3] Added bar.width.max property to ChartConfiguration interface

### DIFF
--- a/types/c3/c3-tests.ts
+++ b/types/c3/c3-tests.ts
@@ -620,7 +620,8 @@ function chart_bar() {
         },
         bar: {
             width: {
-                ratio: 0.5 // this makes bar width 50% of length between ticks
+                ratio: 0.5, // this makes bar width 50% of length between ticks
+                max: 50 // this limits maximum width of bar to 50px
             }
             // or
             //width: 100 // this makes bar width 100px

--- a/types/c3/index.d.ts
+++ b/types/c3/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for C3js v0.4
 // Project: http://c3js.org/
 // Definitions by: Marc Climent <https://github.com/mcliment>
+//                 Gerin Jacob <https://github.com/gerinjacob>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as d3 from "d3";
@@ -161,7 +162,16 @@ declare namespace c3 {
             /**
              * Change the width of bar chart. If ratio is specified, change the width of bar chart by ratio.
              */
-            width?: number | { ratio: number };
+            width?: number | {
+                /**
+                 * Set the width of each bar by ratio
+                 */
+                ratio: number,
+                /**
+                 * Set max width of each bar
+                 */
+                max?: number
+            };
             /**
              * Set if min or max value will be 0 on bar chart.
              */


### PR DESCRIPTION
Added bar.width.max as an optional property to ChartConfiguration interface in c3.
This property lets you limit the maximum width of the bar.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/c3js/c3/blob/master/src/shape.bar.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

