### PR TITLE
react-motion fix merge

### DIFF
--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -123,7 +123,7 @@ interface TransitionProps {
      */
     willLeave?: (styleThatLeft: TransitionStyle) => Style | void;
 }
-export class TransitionMotion extends Component<any, any> { }
+export class TransitionMotion extends Component<TransitionProps, any> { }
 
 
 interface StaggeredMotionProps {

--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -111,7 +111,7 @@ interface TransitionProps {
      * <StaggeredMotion/>
      */
     styles: Array<TransitionStyle> | InterpolateFunction;
-    children: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement<any>;
+    children?: (interpolatedStyles: Array<TransitionPlainStyle>) => ReactElement<any>;
     /**
      * Triggers when new elements appears
      * @param styleThatEntered


### PR DESCRIPTION
I believe there was an error when merging:
https://github.com/DefinitelyTyped/DefinitelyTyped/commit/b488f3cb5f70ea62c66a3ecaef4e38baadf3727c#diff-3b3fa3639f39b82eca3e15e4ef0f54eeR125

You can see the original PR matches my change:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/9965/files#diff-1ad63a2a56d869f9cc5e998febe8e52eR128

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/chenglou/react-motion#transitionmotion->
