### PR TITLE
[material-ui] Added missing Props to DropDownMenu and ListItem

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1088,7 +1088,7 @@ declare namespace __MaterialUI {
             autoGenerateNestedIndicator?: boolean;
             disableKeyboardFocus?: boolean;
             disabled?: boolean;
-            hoverColor? string;
+            hoverColor?: string;
             initiallyOpen?: boolean;
             innerDivStyle?: React.CSSProperties;
             insetChildren?: boolean;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for material-ui v0.17.51
 // Project: https://github.com/callemall/material-ui
-// Definitions by: Nathan Brown <https://github.com/ngbrown>, Igor Belagorudsky <https://github.com/theigor>, Ali Taheri Moghaddar <https://github.com/alitaheri>, Oliver Herrmann <https://github.com/herrmanno>, Daniel Roth <https://github.com/DaIgeb>, Aurelién Allienne <https://github.com/allienna>
+// Definitions by: Nathan Brown <https://github.com/ngbrown>, Igor Beagorudsky <https://github.com/theigor>, Ali Taheri Moghaddar <https://github.com/alitaheri>, Oliver Herrmann <https://github.com/herrmanno>, Daniel Roth <https://github.com/DaIgeb>, Aurelién Allienne <https://github.com/allienna>, Matthias Schlesinger <https://github.com/schlesingermatthias>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -1088,6 +1088,7 @@ declare namespace __MaterialUI {
             autoGenerateNestedIndicator?: boolean;
             disableKeyboardFocus?: boolean;
             disabled?: boolean;
+            hoverColor? string;
             initiallyOpen?: boolean;
             innerDivStyle?: React.CSSProperties;
             insetChildren?: boolean;
@@ -1223,6 +1224,7 @@ declare namespace __MaterialUI {
             maxHeight?: number;
             menuStyle?: React.CSSProperties;
             onChange?: (e: TouchTapEvent, index: number, menuItemValue: any) => void;
+            onClose?: (e: TouchTapEvent) => void;
             openImmediately?: boolean;
             style?: React.CSSProperties;
             underlineStyle?: React.CSSProperties;


### PR DESCRIPTION
Adding property "onClose" to component DropDownMenu according to the documentation [here](http://www.material-ui.com/#/components/dropdown-menu)

Adding property "hoverColor" to component ListItem according to the documentation [here](http://www.material-ui.com/#/components/list)