### PR TITLE
Update react-tabs definitions for version 1.0

### DIFF
--- a/types/react-tabs/index.d.ts
+++ b/types/react-tabs/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for react-tabs 0.5.3
+// Type definitions for react-tabs 1.0.0
 // Project: https://github.com/reactjs/react-tabs/
-// Definitions by: Yuu Igarashi <https://github.com/yu-i9/>
+// Definitions by: Yuu Igarashi <https://github.com/yu-i9/>, Daniel Tschinder <https://github.com/danez>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -11,40 +11,38 @@ export as namespace ReactTabs;
 declare namespace ReactTabs {
 
     interface TabsProps {
-        className?: string;
-        selectedIndex?: number;
-        focus?: boolean;
+        className?: string | Array<string> | { [name: string]: boolean; };
+        defaultFocus?: boolean;
+        defaultIndex?: number;
+        disabledTabClassName?: string;
         forceRenderTabPanel?: boolean;
-        onSelect?: (index: number, last: number) => void;
+        onSelect?: (index: number, last: number, event: Event) => boolean | void;
+        selectedIndex?: number;
+        selectedTabClassName?: string;
+        selectedTabPanelClassName?: string;
     }
 
-    interface Tabs extends React.ComponentClass<TabsProps> {
-        setUseDefaultStyles: (use: boolean) => void;
-    }
+    interface Tabs extends React.ComponentClass<TabsProps> {}
 
     interface TabListProps {
-        className?: string;
-        activeTabClassName?: string;
-        disabledTabClassName?: string;
+        className?: string | Array<string> | { [name: string]: boolean; };
     }
 
     interface TabList extends React.ComponentClass<TabListProps> {}
 
     interface TabProps {
-        className?: string;
-        focus?: boolean;
-        selected?: boolean;
-        id?: string;
-        panelId?: string;
+        className?: string | Array<string> | { [name: string]: boolean; };
+        disabled?: boolean;
+        disabledClassName?: string;
+        selectedClassName?: boolean;
     }
 
     interface Tab extends React.ComponentClass<TabProps> {}
 
     interface TabPanelProps {
-        className?: string;
-        selected?: boolean;
-        id?: string;
-        tabId?: string;
+        className?: string | Array<string> | { [name: string]: boolean; };
+        forceRender?: boolean;
+        selectedClassName?: string;
     }
 
     interface TabPanel extends React.ComponentClass<TabPanelProps> {}
@@ -55,9 +53,12 @@ declare const TabList: ReactTabs.TabList;
 declare const Tab: ReactTabs.Tab;
 declare const TabPanel: ReactTabs.TabPanel;
 
+declare function resetIdCounter(): void;
+
 export {
     Tabs,
     TabList,
     Tab,
-    TabPanel
+    TabPanel,
+    resetIdCounter
 };

--- a/types/react-tabs/react-tabs-tests.ts
+++ b/types/react-tabs/react-tabs-tests.ts
@@ -1,17 +1,20 @@
 import React = require("react");
 import ReactDOM = require("react-dom");
-import { Tabs, TabList, Tab, TabPanel } from "react-tabs";
+import { Tabs, TabList, Tab, TabPanel, resetIdCounter } from "react-tabs";
+
+resetIdCounter();
 
 class TestApp extends React.Component<{}, {}> {
-    onSelect = (index: number, last: number) => {
+    onSelect = (index: number, last: number, event: Event) => {
         console.log("selected tab: " + index.toString());
         console.log("last tab: " + last.toString());
+        console.log("event: " + event.type);
     }
 
     render() {
         return React.createElement(Tabs, {onSelect: this.onSelect, selectedIndex: 1},
                    React.createElement(TabList, {className: "test-class"},
-                       React.createElement(Tab, {}, "Tab1"),
+                       React.createElement(Tab, {disabled: true}, "Tab1"),
                        React.createElement(Tab, {}, "Tab2"),
                        React.createElement(Tab, {}, "Tab3")),
                    React.createElement(TabPanel, {}, React.createElement("h2", {}, "Content1")),

--- a/types/react-tabs/tsconfig.json
+++ b/types/react-tabs/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.) *Sorry I don't use ts*
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-tabs
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fixes reactjs/react-tabs#182

Most of the removed props were always private and should not have been included in the first place.