### PR TITLE
[sequelize] Added missing type to sequelize.DefineIndexesOptions.fields

### DIFF
--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Sequelize 3.4.1
 // Project: http://sequelizejs.com
-// Definitions by: samuelneff <https://github.com/samuelneff>, Peter Harris <https://github.com/codeanimal>, Ivan Drinchev <https://github.com/drinchev>
+// Definitions by: samuelneff <https://github.com/samuelneff>, Peter Harris <https://github.com/codeanimal>, Ivan Drinchev <https://github.com/drinchev>, Nick Mueller <https://github.com/morpheusxaut>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -4755,7 +4755,7 @@ declare namespace sequelize {
          * (field name), `length` (create a prefix index of length chars), `order` (the direction the column
          * should be sorted in), `collate` (the collation (sort order) for the column)
          */
-        fields?: Array<string | { attribute: string, length: number, order: string, collate: string }>;
+        fields?: Array<string | fn | { attribute: string, length: number, order: string, collate: string }>;
 
         /**
          * Condition for partioal index

--- a/types/sequelize/v3/sequelize-tests.ts
+++ b/types/sequelize/v3/sequelize-tests.ts
@@ -1545,6 +1545,40 @@ s.define( 'TriggerTest', {
     hasTrigger : true
 } );
 
+s.define('DefineOptionsIndexesTest', {
+    id: {
+        type: Sequelize.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        validate: {
+            min: 1
+        }
+    },
+    email: {
+        allowNull: false,
+        type: Sequelize.STRING(255),
+        set: function (val) {
+            if (typeof val === "string") {
+                val = val.toLowerCase();
+            } else {
+                throw new Error("email must be a string");
+            }
+            this.setDataValue("email", val);
+        }
+    }
+}, {
+        timestamps: false,
+        indexes: [
+            {
+                name: "DefineOptionsIndexesTest_lower_email",
+                unique: true,
+                fields: [
+                    Sequelize.fn("LOWER", Sequelize.col("email"))
+                ]
+            }
+        ]
+} );
+
 //
 //  Transaction
 // ~~~~~~~~~~~~~


### PR DESCRIPTION
The v3 typings of sequelize lack do not allow for sequelize.fn to be used in the `DefineIndexesOptions.fields` array when defining a new model. The documentation of the field even states that `sequelize.fn` can be used, but it has been omitted from the union type.

Optionally, the PR could also change the typing to allow for an `Object` to be passed, thus allowing for other sequelize objects/types to be used as well, or a `SequelizeObject` type defined (creating a union of all allowed sequelize types).


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
[DefineIndexesOptions.fields documentation](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/sequelize/v3/index.d.ts#L4754), [sequelize.define documentation](https://github.com/sequelize/sequelize/blob/v3.4.1/lib/sequelize.js#L494),
 [sequelize QueryGenerator.addIndexQuery](https://github.com/sequelize/sequelize/blob/v3.4.1/lib/dialects/abstract/query-generator.js#L568)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.