### PR TITLE
react-router-redux v4: lockdown history version

### DIFF
--- a/types/react-router-redux/v4/package.json
+++ b/types/react-router-redux/v4/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "@types/history": "^2.0.0"
   }
 }

--- a/types/react-router-redux/v4/package.json
+++ b/types/react-router-redux/v4/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "redux": "^3.6.0",
-    "@types/history": "^2.0.0"
+    "redux": "^3.6.0"
   }
 }

--- a/types/react-router-redux/v4/tsconfig.json
+++ b/types/react-router-redux/v4/tsconfig.json
@@ -13,8 +13,8 @@
           "../../"
         ],
         "paths": {
-            "history": ["history/v3"],
-            "history/*": ["history/v3/*"],
+            "history": ["history/v2"],
+            "history/*": ["history/v2/*"],
             "react-router-redux": ["react-router-redux/v4"]
         },
         "types": [],


### PR DESCRIPTION
This updates the react-router-redux v4 typings to match the version specified in the package: https://github.com/reactjs/react-router-redux/blob/988c2210dd2528e4a1babe1048da11425e8ea8d1/package.json#L59

Currently I am getting types for history v3:

```
├─┬ @types/react-router-redux@4.0.46
│ ├── @types/history@3.2.1
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
