### PR TITLE
[moxios] Export as `export = moxios` to match the moxios package export.

### DIFF
--- a/types/moxios/index.d.ts
+++ b/types/moxios/index.d.ts
@@ -189,4 +189,4 @@ declare let moxios: {
     wait(fn: () => void, delay?: number): void;
 };
 
-export default moxios;
+export = moxios;

--- a/types/moxios/moxios-tests.ts
+++ b/types/moxios/moxios-tests.ts
@@ -1,7 +1,7 @@
 // from https://github.com/mzabriskie/moxios/blob/master/test.js
 import {equal, notEqual, deepEqual} from 'power-assert'; // compatible with 'assert';
 import axios from 'axios';
-import moxios from 'moxios';
+import * as moxios from 'moxios';
 
 declare const sinon: any;
 declare const describe: any;


### PR DESCRIPTION
Currently, @types/moxios sets `exports.default = moxios` when [moxios assigns to exports](https://github.com/mzabriskie/moxios/blob/62101e4a7c49fbf5b639ed5d36587f2b4941c6a2/dist/moxios.js#L3).