### PR TITLE
deep-freeze: Fixed bug that resulted in `any` inference

### DIFF
--- a/types/deep-freeze/index.d.ts
+++ b/types/deep-freeze/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for deep-freeze 0.1
 // Project: https://github.com/substack/deep-freeze
-// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Aluan Haddad <https://github.com/aluanhaddad>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -11,5 +11,7 @@ declare function deepFreeze<T extends Function>(f: T): T;
 declare function deepFreeze<T>(o: T): deepFreeze.DeepReadonly<T>;
 
 declare namespace deepFreeze {
-    type DeepReadonly<T> = Readonly<{ [P in keyof T]: DeepReadonly<T[P]> }>;
+    type DeepReadonly<T> = {
+        readonly [P in keyof T]: DeepReadonly<T[P]>
+    };
 }


### PR DESCRIPTION
Fixed a bug that resulted in `any` being inferred for nested recursive generics.
Formatted type declaration on multiple lines for readability.
Updated maintainers list.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.