### PR TITLE
feat(execa): add typings for `execa`

### DIFF
--- a/types/execa/execa-tests.ts
+++ b/types/execa/execa-tests.ts
@@ -1,0 +1,124 @@
+import * as assert from 'assert';
+import * as execa from 'execa';
+import { PassThrough } from "stream";
+
+execa('unicorns')
+    .then(result => {
+        assert(result.cmd === 'unicorns');
+        assert(result.code === 0);
+        assert(result.failed === false);
+        assert(result.killed === false);
+        assert(result.signal === null);
+        assert(result.stderr === 'bad unicorns');
+        assert(result.stdout === 'good unicorns');
+        assert(result.timedOut === false);
+    });
+
+execa('foo')
+    .catch(error => {
+        assert(error.cmd === 'foo');
+        assert(error.code === 128);
+        assert(error.failed === true);
+        assert(error.killed === false);
+        assert(error.signal === 'SIGINT');
+        assert(error.stderr === 'stderr');
+        assert(error.stdout === 'stdout');
+        assert(error.timedOut === false);
+    });
+
+execa('noop', ['foo'])
+    .then(result => result.stderr.toLocaleLowerCase());
+
+execa.stdout('unicorns')
+    .then(stdout => stdout.toLocaleLowerCase());
+execa.stdout('echo', ['unicorns'])
+    .then(stdout => stdout.toLocaleLowerCase());
+
+execa.stderr('unicorns')
+    .then(stderr => stderr.toLocaleLowerCase());
+execa.stderr('echo', ['unicorns'])
+    .then(stderr => stderr.toLocaleLowerCase());
+
+execa.shell('echo unicorns')
+    .then(result => result.stdout.toLocaleLowerCase());
+
+{
+    let result: string;
+    result = execa.shellSync('foo').stderr;
+    result = execa.shellSync('noop', ['foo']).stdout;
+
+    result = execa.shellSync('foo').stderr;
+    result = execa.shellSync('noop foo').stdout;
+}
+
+execa('echo', ['unicorns']).stdout.pipe(process.stdout);
+execa('echo', ['unicorns']).stderr.pipe(process.stderr);
+
+async () => {
+    const { stdout } = await execa('noop', ['foo'], { stripEof: false });
+    assert(stdout === 'foo\n');
+};
+
+async () => {
+    const { stdout } = await execa('foo', { preferLocal: false });
+    assert(stdout === 'global foo');
+};
+
+async () => {
+    const { stdout } = await execa('stdin', { input: 'foobar' });
+    assert(stdout === 'foobar');
+};
+
+async () => {
+    const { stdout } = await execa('stdin', { input: new Buffer('foobar') });
+    assert(stdout === 'foobar');
+};
+
+async () => {
+    const s = new PassThrough();
+    s.write('howdy');
+    s.end();
+    const { stdout } = await execa('stdin', { input: s });
+    assert(stdout === 'foobar');
+};
+
+async () => {
+    const child = execa('stdin');
+    child.stdin.end('unicorns');
+    const { stdout } = await child;
+    assert(stdout === 'unicorns');
+};
+
+async () => {
+    const { stdout } = await execa('stdin', {
+        input: 'hello',
+        stdio: [null, 'ignore', null]
+    });
+    assert(stdout === null);
+};
+
+{
+    const child = execa('stdin', {
+        input: 'hello',
+        stdio: [null, 'ignore', null]
+    });
+
+    child.stdout.setEncoding('utf8');
+
+    assert(child.pid === 0);
+    child.kill();
+}
+
+async () => {
+    const { timedOut, code } = await execa('delay', ['3000', '22'], { timeout: 9000 });
+    assert(timedOut === true);
+    assert(code === 22);
+};
+
+async () => {
+    const { stdout } = await execa.shell('noop foo', {
+        shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash'
+    });
+
+    assert(stdout === 'foo');
+};

--- a/types/execa/index.d.ts
+++ b/types/execa/index.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for execa 0.6
+// Project: https://github.com/sindresorhus/execa#readme
+// Definitions by: Douglas Duteil <https://github.com/douglasduteil>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node" />
+
+import { ExecOptions, SpawnOptions, SpawnSyncOptions, SpawnSyncReturns, ChildProcess } from "child_process";
+import { Stream } from 'stream';
+
+interface ExecaOptions {
+    input: string | Buffer | Stream;
+    preferLocal: boolean;
+    stripEof: boolean;
+}
+
+type Options = SpawnOptions & ExecaOptions & ExecOptions;
+
+interface ExecaReturns {
+    cmd: string;
+    code: number;
+    failed: boolean;
+    killed: boolean;
+    signal: string | null;
+    stderr: string;
+    stdout: string;
+    timedOut: boolean;
+}
+
+type ExecaError = Error & ExecaReturns;
+
+interface ExecaChildPromise {
+    catch<TResult = never>(onrejected?: ((reason: ExecaError) => TResult | PromiseLike<TResult>) | undefined | null): Promise<ExecaReturns | TResult>;
+}
+type ExecaChildProcess = ChildProcess & ExecaChildPromise & Promise<ExecaReturns>;
+
+declare function execa(file: string, options?: Partial<Options>): ExecaChildProcess;
+declare function execa(file: string, args?: string[], options?: Partial<Options>): ExecaChildProcess;
+declare namespace execa {
+    function stdout(file: string, options?: Partial<Options>): Promise<string>;
+    function stdout(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
+    function stderr(file: string, options?: Partial<Options>): Promise<string>;
+    function stderr(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
+    function shell(command: string, options?: SpawnOptions): ExecaChildProcess;
+    function sync<T = string>(file: string, options?: SpawnSyncOptions): ExecaReturns;
+    function sync<T = string>(file: string, args?: string[], options?: SpawnSyncOptions): ExecaReturns;
+    function shellSync(command: string, options?: SpawnOptions): ExecaReturns;
+}
+
+export = execa;

--- a/types/execa/tsconfig.json
+++ b/types/execa/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "execa-tests.ts"
+    ]
+}

--- a/types/execa/tslint.json
+++ b/types/execa/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Overview 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

New definition

- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
