### PR TITLE
[Node] console.dir() options

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -17,7 +17,7 @@
 interface Console {
     Console: NodeJS.ConsoleConstructor;
     assert(value: any, message?: string, ...optionalParams: any[]): void;
-    dir(obj: any, options?: {showHidden?: boolean, depth?: number, colors?: boolean}): void;
+    dir(obj: any, options?: NodeJS.InspectOptions): void;
     error(message?: any, ...optionalParams: any[]): void;
     info(message?: any, ...optionalParams: any[]): void;
     log(message?: any, ...optionalParams: any[]): void;
@@ -262,6 +262,16 @@ declare var Buffer: {
 *                                               *
 ************************************************/
 declare namespace NodeJS {
+    export interface InspectOptions {
+        showHidden?: boolean;
+        depth?: number | null;
+        colors?: boolean;
+        customInspect?: boolean;
+        showProxy?: boolean;
+        maxArrayLength?: number | null;
+        breakLength?: number;
+    }
+
     export interface ConsoleConstructor {
         prototype: Console;
         new(stdout: WritableStream, stderr?: WritableStream): Console;
@@ -3779,16 +3789,7 @@ declare module "stream" {
 }
 
 declare module "util" {
-    export interface InspectOptions {
-        showHidden?: boolean;
-        depth?: number | null;
-        colors?: boolean;
-        customInspect?: boolean;
-        showProxy?: boolean;
-        maxArrayLength?: number | null;
-        breakLength?: number;
-    }
-
+    export interface InspectOptions extends NodeJS.InspectOptions {}
     export function format(format: any, ...param: any[]): string;
     export function debug(string: string): void;
     export function error(...param: any[]): void;

--- a/types/node/v0/index.d.ts
+++ b/types/node/v0/index.d.ts
@@ -9,6 +9,24 @@
 *                                               *
 ************************************************/
 
+interface Console {
+    Console: {
+        prototype: Console,
+        new(stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream): Console;
+    };
+    assert(value: any, message?: string, ...optionalParams: any[]): void;
+    dir(obj: any, options?: NodeJS.InspectOptions): void;
+    error(message?: any, ...optionalParams: any[]): void;
+    info(message?: any, ...optionalParams: any[]): void;
+    log(message?: any, ...optionalParams: any[]): void;
+    time(label: string): void;
+    timeEnd(label: string): void;
+    trace(message?: any, ...optionalParams: any[]): void;
+    warn(message?: any, ...optionalParams: any[]): void;
+}
+
+declare var console: Console;
+
 interface Error {
     stack?: string;
 }
@@ -159,6 +177,13 @@ declare var Buffer: {
 *                                               *
 ************************************************/
 declare namespace NodeJS {
+    export interface InspectOptions {
+        showHidden?: boolean;
+        depth?: number | null;
+        colors?: boolean;
+        customInspect?: boolean;
+    }
+
     export interface ErrnoException extends Error {
         errno?: number;
         code?: string;
@@ -1791,13 +1816,7 @@ declare module "stream" {
 }
 
 declare module "util" {
-    export interface InspectOptions {
-        showHidden?: boolean;
-        depth?: number | null;
-        colors?: boolean;
-        customInspect?: boolean;
-    }
-
+    export interface InspectOptions extends NodeJS.InspectOptions {}
     export function format(format: any, ...param: any[]): string;
     export function debug(string: string): void;
     export function error(...param: any[]): void;

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -16,7 +16,7 @@ interface Console {
         new(stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream): Console;
     };
     assert(value: any, message?: string, ...optionalParams: any[]): void;
-    dir(obj: any, options?: {showHidden?: boolean, depth?: number, colors?: boolean}): void;
+    dir(obj: any, options?: NodeJS.InspectOptions): void;
     error(message?: any, ...optionalParams: any[]): void;
     info(message?: any, ...optionalParams: any[]): void;
     log(message?: any, ...optionalParams: any[]): void;
@@ -228,6 +228,13 @@ declare var Buffer: {
 *                                               *
 ************************************************/
 declare namespace NodeJS {
+    export interface InspectOptions {
+        showHidden?: boolean;
+        depth?: number | null;
+        colors?: boolean;
+        customInspect?: boolean;
+    }
+
     export interface ErrnoException extends Error {
         errno?: number;
         code?: string;
@@ -2237,13 +2244,8 @@ declare module "stream" {
 }
 
 declare module "util" {
-    export interface InspectOptions {
-        showHidden?: boolean;
-        depth?: number | null;
-        colors?: boolean;
-        customInspect?: boolean;
-    }
 
+    export interface InspectOptions extends NodeJS.InspectOptions {}
     export function format(format: any, ...param: any[]): string;
     export function debug(string: string): void;
     export function error(...param: any[]): void;

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -13,7 +13,7 @@
 interface Console {
     Console: typeof NodeJS.Console;
     assert(value: any, message?: string, ...optionalParams: any[]): void;
-    dir(obj: any, options?: {showHidden?: boolean, depth?: number, colors?: boolean}): void;
+    dir(obj: any, options?: NodeJS.InspectOptions): void;
     error(message?: any, ...optionalParams: any[]): void;
     info(message?: any, ...optionalParams: any[]): void;
     log(message?: any, ...optionalParams: any[]): void;
@@ -247,6 +247,16 @@ declare var Buffer: {
 *                                               *
 ************************************************/
 declare namespace NodeJS {
+    export interface InspectOptions {
+        showHidden?: boolean;
+        depth?: number | null;
+        colors?: boolean;
+        customInspect?: boolean;
+        showProxy?: boolean;
+        maxArrayLength?: number | null;
+        breakLength?: number;
+    }
+
     export var Console: {
         prototype: Console;
         new(stdout: WritableStream, stderr?: WritableStream): Console;
@@ -3632,16 +3642,7 @@ declare module "stream" {
 }
 
 declare module "util" {
-    export interface InspectOptions {
-        showHidden?: boolean;
-        depth?: number | null;
-        colors?: boolean;
-        customInspect?: boolean;
-        showProxy?: boolean;
-        maxArrayLength?: number | null;
-        breakLength?: number;
-    }
-
+    export interface InspectOptions extends NodeJS.InspectOptions {}
     export function format(format: any, ...param: any[]): string;
     export function debug(string: string): void;
     export function error(...param: any[]): void;


### PR DESCRIPTION
According to source code the ``console.dir()`` method [takes the same options][latestsrcdir] that ``util.inspect()`` does: 
```js
Console.prototype.dir = function dir(object, options) {
  options = Object.assign({customInspect: false}, options);
  write(this._ignoreErrors,
        this._stdout,
        `${util.inspect(object, options)}\n`, // <--- attention here 
        this._stdoutErrorHandler);
};

```
The ``options`` object from above is left intact and passed down to the ``inspect()`` call hence leading to idea that the options interfaces of both methods ``console.dir()`` and ``inspect()`` are the same and have to be unified.  This unification is done by this PR.

Here some links on source code and docs of ``console.dir()`` to be sure:

- [``console.dir()``][v012srcdir]	  of NodeJS **v0.x**
- [``console.dir()``][v4srcdir]     of NodeJS **v4.x**
- [``console.dir()``][v6srcdir]     of NodeJS **v6.x**
- [``console.dir()``][latestsrcdir] and [docs][latestDocsDir] of NodeJS **v8.x**

## Changes
### Node v8x, v6x, v4x, v0
The same fixes were done across all nodejs declaration versions to ensure consistency.
-  Moves up ``InspectOptions`` from ``util`` module to ``NodeJS`` namespace
- Leaves mocking interface ``InspectOptions`` inside ``util``

### Node v0
- Resurrect missing ``console`` declaration 
(seems like somebody forgot or intentionally left it undeclared :neutral_face: )


[v012srcdir]: https://github.com/nodejs/node/blob/v0.12.0-release/lib/console.js#L71
[v4srcdir]: https://github.com/nodejs/node/blob/v4.x/lib/console.js#L55
[v6srcdir]: https://github.com/nodejs/node/blob/v6.x/lib/console.js#L60
[latestsrcdir]: https://github.com/nodejs/node/blob/0d8021e5a4cf0a6aa3a700a361f6d42c2894f2ba/lib/console.js#L129
[latestDocsDir]: https://nodejs.org/dist/latest-v8.x/docs/api/console.html#console_console_dir_obj_options

<details>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
Source code of [``console.dir()``][latestsrcdir] and its [docs][latestDocsDir]

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
</details>

<hr>
@sandersn @ikokostya @endel @Flarna @aozgaa @andy-ms @trustedtomato @kadler15 @RyanCavanaugh @RobDesideri @parambirs @gurisko @lochbrunner @mjbvz @leonard-thieu @JoshGlazebrook @blakeembrey @DanielRosenwasser @tellnes @bcherny @Loghorn @aksharpatel47