### PR TITLE
feat(connect-history-api-fallback): add typings for connect-history-api-fallback

### DIFF
--- a/types/connect-history-api-fallback/connect-history-api-fallback-tests.ts
+++ b/types/connect-history-api-fallback/connect-history-api-fallback-tests.ts
@@ -1,0 +1,64 @@
+import * as historyApiFallback from 'connect-history-api-fallback';
+
+import * as express from "express";
+
+const app = express();
+app.use(historyApiFallback());
+
+historyApiFallback({
+    verbose: true
+});
+
+historyApiFallback({
+    logger: console.log.bind(console)
+});
+
+historyApiFallback({
+    rewrites: [
+        { from: /\/soccer/, to: '/soccer.html' }
+    ]
+});
+
+historyApiFallback({
+    index: 'default.html'
+});
+
+historyApiFallback({
+    htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
+});
+
+historyApiFallback({
+    rewrites: [
+        {
+            from: /^\/libs\/(.*)$/,
+            to(context) {
+                return './bower_components' + context.parsedUrl.pathname;
+            }
+        }
+    ]
+});
+
+historyApiFallback({
+    rewrites: [
+        {
+            from: /\/app\/login/,
+            to: function onMatch(ctx) {
+                if (ctx.parsedUrl.path && ctx.parsedUrl.path.indexOf('.js')) {
+                    return ctx.parsedUrl.href || '';
+                }
+                return '/app/login/index.html';
+            }
+        }
+    ]
+});
+
+historyApiFallback({
+    rewrites: [
+        {
+            from: /^\/libs\/(.*)$/,
+            to(context) {
+                return '/' + context.match[2] + '/' + context.match[3];
+            }
+        }
+    ]
+});

--- a/types/connect-history-api-fallback/index.d.ts
+++ b/types/connect-history-api-fallback/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for connect-history-api-fallback 1.3
+// Project: https://github.com/bripkens/connect-history-api-fallback#readme
+// Definitions by: Douglas Duteil <https://github.com/douglasduteil>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Url } from 'url';
+
+import * as core from "express-serve-static-core";
+
+declare function historyApiFallback(options?: Options): core.RequestHandler;
+declare namespace historyApiFallback {}
+export = historyApiFallback;
+
+interface Options {
+    disableDotRule?: true;
+    htmlAcceptHeaders?: string[];
+    index?: string;
+    logger?: typeof console.log;
+    rewrites?: Rewrite[];
+    verbose?: boolean;
+}
+
+interface Context {
+    match: RegExpMatchArray;
+    parsedUrl: Url;
+}
+type RewriteTo = (context: Context) => string;
+
+interface Rewrite {
+    from: RegExp;
+    to: string | RegExp | RewriteTo;
+}

--- a/types/connect-history-api-fallback/tsconfig.json
+++ b/types/connect-history-api-fallback/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "connect-history-api-fallback-tests.ts"
+    ]
+}

--- a/types/connect-history-api-fallback/tslint.json
+++ b/types/connect-history-api-fallback/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Overview 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

New definition:

- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
