### PR TITLE
Annotate `react-redux` more explicitly

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -15,12 +15,12 @@ type Store<S> = Redux.Store<S>;
 type Dispatch<S> = Redux.Dispatch<S>;
 type ActionCreator<A> = Redux.ActionCreator<A>;
 
-export interface DispatchProp<T> {
-  dispatch: Dispatch<T>
+export interface DispatchProp<S> {
+  dispatch: Dispatch<S>;
 }
 
-interface ComponentDecorator<TMergedProps> {
-    <TOwnProps>(component: Component<(TOwnProps & TMergedProps) | TOwnProps>): ComponentClass<TOwnProps>;
+interface ComponentDecorator<TMergedProps, TOwnProps> {
+    <T extends TOwnProps>(component: Component<T & TMergedProps>): ComponentClass<T>;
 }
 
 interface ComponentMergeDecorator<TMergedProps, TOwnProps> {
@@ -46,21 +46,21 @@ interface ComponentMergeDecorator<TMergedProps, TOwnProps> {
  * @param mergeProps
  * @param options
  */
-export declare function connect(): ComponentDecorator<DispatchProp<any>>;
+export declare function connect(): ComponentDecorator<DispatchProp<any>, {}>;
 
 export declare function connect<TStateProps, no_dispatch, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
-): ComponentDecorator<DispatchProp<any> & TStateProps>;
+): ComponentDecorator<DispatchProp<any> & TStateProps, TOwnProps>;
 
 export declare function connect<no_state, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-): ComponentDecorator<TDispatchProps & TOwnProps>;
+): ComponentDecorator<TDispatchProps, TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-): ComponentDecorator<TStateProps & TDispatchProps>;
+): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
 export declare function connect<TStateProps, no_dispatch, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
@@ -91,21 +91,21 @@ export declare function connect<TStateProps, no_dispatch, TOwnProps>(
     mapDispatchToProps: null | undefined,
     mergeProps: null | undefined,
     options: Options
-): ComponentDecorator<DispatchProp<any> & TStateProps & TOwnProps>;
+): ComponentDecorator<DispatchProp<any> & TStateProps, TOwnProps>;
 
 export declare function connect<no_state, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
     options: Options
-): ComponentDecorator<TDispatchProps>;
+): ComponentDecorator<TDispatchProps, TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
     options: Options
-): ComponentDecorator<TStateProps & TDispatchProps>;
+): ComponentDecorator<TStateProps & TDispatchProps, TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -108,12 +108,7 @@ declare var store: Store<TodoState>;
 class MyRootComponent extends Component<any, any> {
 
 }
-class TodoApp extends Component<DispatchProp<any>, any> {
-    render (): null {
-        this.props.dispatch({ type: 'test' })
-        return null
-    }
-}
+class TodoApp extends Component<any, any> {}
 interface TodoState {
     todos: string[]|string;
 }
@@ -156,9 +151,10 @@ ReactDOM.render(
 
 // Inject just dispatch and don't listen to store
 
-const WrappedTodoApp = connect()<{}>(TodoApp);
+const AppWrap = (props: DispatchProp<any> & { children?: React.ReactNode }) => <div />
+const WrappedApp = connect()(AppWrap);
 
-<WrappedTodoApp />
+<WrappedApp />
 
 // Inject dispatch and every field in the global state
 
@@ -281,7 +277,7 @@ interface TestState {
     isLoaded: boolean;
     state1: number;
 }
-class TestComponent extends Component<TestProp, TestState> { }
+class TestComponent extends Component<TestProp & DispatchProp<any>, TestState> { }
 const WrappedTestComponent = connect()(TestComponent);
 
 // return value of the connect()(TestComponent) is of the type TestComponent
@@ -290,7 +286,6 @@ ATestComponent = TestComponent;
 ATestComponent = WrappedTestComponent;
 
 let anElement: ReactElement<TestProp>;
-<TestComponent property1={42} />;
 <WrappedTestComponent property1={42} />;
 <ATestComponent property1={42} />;
 
@@ -348,7 +343,7 @@ namespace TestTOwnPropsInference {
         state: string;
     }
 
-    class OwnPropsComponent extends React.Component<OwnProps & StateProps, void> {
+    class OwnPropsComponent extends React.Component<StateProps & OwnProps & DispatchProp<any>, void> {
         render() {
             return <div/>;
         }
@@ -370,13 +365,13 @@ namespace TestTOwnPropsInference {
     // React.createElement(ConnectedWithoutOwnProps, { anything: 'goes!' });
 
     // This compiles, as expected.
-    React.createElement(ConnectedWithOwnProps, { state: 'string', own: 'string' });
+    React.createElement(ConnectedWithOwnProps, { own: 'string' });
 
     // This should not compile, which is good.
     // React.createElement(ConnectedWithOwnProps, { anything: 'goes!' });
 
     // This compiles, as expected.
-    React.createElement(ConnectedWithTypeHint, { state: 'string', own: 'string' });
+    React.createElement(ConnectedWithTypeHint, { own: 'string' });
 
     // This should not compile, which is good.
     // React.createElement(ConnectedWithTypeHint, { anything: 'goes!' });
@@ -437,4 +432,45 @@ namespace TestMergedPropsInference {
             merged: "merged",
         }),
     )(MergedPropsComponent);
+}
+
+namespace Issue16652 {
+    interface PassedProps {
+        commentIds: string[];
+    }
+
+    interface GeneratedStateProps {
+        comments: ({ id: string } | undefined)[];
+    }
+
+    class CommentList extends React.Component<PassedProps & GeneratedStateProps & DispatchProp<any>, void> {}
+
+    const mapStateToProps = (state: any, ownProps: PassedProps): GeneratedStateProps => {
+        return {
+            comments: ownProps.commentIds.map(id => ({ id })),
+        };
+    };
+
+    const ConnectedCommentList = connect<GeneratedStateProps, {}, PassedProps>(mapStateToProps)(
+        CommentList
+    );
+
+    <ConnectedCommentList commentIds={['a', 'b', 'c']} />
+}
+
+namespace Issue15463 {
+    interface ISpinnerProps{
+        showGlobalSpinner: boolean;
+    }
+    class SpinnerClass extends React.Component<ISpinnerProps & DispatchProp<any>, undefined> {
+        render() {
+            return (<div />);
+        }
+    }
+
+    export const Spinner = connect((state: any) => {
+        return { showGlobalSpinner: true };
+    })(SpinnerClass);
+
+    <Spinner />
 }

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -84,7 +84,7 @@ reduxForm({
 
 // adapted from: http://redux-form.com/6.0.0-alpha.4/examples/initializeFromState/
 
-import { connect } from 'react-redux'
+import { connect, DispatchProp } from 'react-redux'
 const { DOM: { input } } = React
 
 interface DataShape {
@@ -125,7 +125,7 @@ const ConnectedDecoratedInitializeFromStateFormFunction = connect(
 
 // React ComponentClass instead of StatelessComponent
 
-class InitializeFromStateFormClass extends React.Component<Props, {}> {
+class InitializeFromStateFormClass extends React.Component<Props & DispatchProp<any>, {}> {
     render() {
         return InitializeFromStateFormFunction(this.props);
     }


### PR DESCRIPTION
Related to https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16652. Doesn't really undo what I did, but pushes it further. I also added the one users example and have it passing.