### PR TITLE
[convict] Config.get() doesn't require a parameter

### DIFF
--- a/types/convict/convict-tests.ts
+++ b/types/convict/convict-tests.ts
@@ -129,6 +129,7 @@ if (conf.has('key')) {
   });
 }
 
+conf.get();
 conf.getSchema();
 conf.getProperties();
 conf.getSchemaString();

--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -53,7 +53,7 @@ declare namespace convict {
          * @returns the current value of the name property. name can use dot
          * notation to reference nested values
          */
-        get(name: string): any;
+        get(name?: string): any;
         /**
          * @returns the default value of the name property. name can use dot
          * notation to reference nested values


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see below)

Justification for this change:

`Config.get()` [passes its parameter through unmodified to `walk()`][get], which is an internal function used to walk down nested objects. `walk()` predicates any actual object walking on [`path` having a value][walk]. As such, calling `Config.get()` is equivalent to calling `Config.get("")`, which returns an object representation of the config state.

[get]: https://github.com/mozilla/node-convict/blob/v3.0.0/lib/convict.js#L424
[walk]: https://github.com/mozilla/node-convict/blob/v3.0.0/lib/convict.js#L372