### PR TITLE
[synaptic] Fix typo in Network definition

### DIFF
--- a/types/synaptic/index.d.ts
+++ b/types/synaptic/index.d.ts
@@ -291,7 +291,7 @@ export namespace Network {
  * Networks are basically an array of layers. They have an input layer, a number of hidden layers, and an output layer.
  */
 export class Network {
-    layer: Network.Options;
+    layers: Network.Options;
 
     optimized: Network.Optimized;
 

--- a/types/synaptic/index.d.ts
+++ b/types/synaptic/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for synaptic 1.0.8
+// Type definitions for synaptic 1.0.9
 // Project: https://github.com/cazala/synaptic
 // Definitions by: Markus Peloso <https://github.com/ToastHawaii/>
+//                 Austin Cummings <https://github.com/austincummings>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as Synaptic from "synaptic"; // Need this to refer to Synaptic from within the `declare global`


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cazala/synaptic/blob/master/src/network.js#L15
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
