### PR TITLE
Add definition for AWS Lambda Cognito User Pool event: request.usernameParameter

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -188,6 +188,7 @@ str = cognitoUserPoolEvent.callerContext.clientId;
 str = cognitoUserPoolEvent.request.userAttributes["email"];
 str = cognitoUserPoolEvent.request.validationData["k1"];
 str = cognitoUserPoolEvent.request.codeParameter;
+str = cognitoUserPoolEvent.request.usernameParameter;
 b = cognitoUserPoolEvent.request.newDeviceUsed;
 cognitoUserPoolEvent.request.session[0].challengeName === "CUSTOM_CHALLENGE";
 cognitoUserPoolEvent.request.session[0].challengeName === "PASSWORD_VERIFIER";

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -142,6 +142,7 @@ interface CognitoUserPoolEvent {
         userAttributes: {[key: string]: string};
         validationData?: {[key: string]: string};
         codeParameter?: string;
+        usernameParameter?: string;
         newDeviceUsed?: boolean;
         session?: {
             challengeName: "CUSTOM_CHALLENGE" | "PASSWORD_VERIFIER" | "SMS_MFA" | "DEVICE_SRP_AUTH" | "DEVICE_PASSWORD_VERIFIER" | "ADMIN_NO_SRP_AUTH";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html#cognito-user-pools-lambda-trigger-syntax-custom-message

Sadly it is not actually in the documentation :( 

