### PR TITLE
express header methods can return undefined

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -197,11 +197,11 @@ interface Request extends http.IncomingMessage, Express.Request {
         *
         * @param name
         */
-    get(name: string): string;
+    get(name: string): string | undefined;
 
-    header(name: string): string;
+    header(name: string): string | undefined;
 
-    headers: { [key: string]: string; };
+    headers: { [key: string]: string | undefined; };
 
     /**
         * Check if the given `type(s)` is acceptable, returning

--- a/types/express-serve-static-core/tsconfig.json
+++ b/types/express-serve-static-core/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -71,6 +71,15 @@ namespace express_tests {
         language = req.acceptsLanguages(['en', 'ja']);
         language = req.acceptsLanguages('en', 'ja');
 
+        let existingHeader1 = req.get('existingHeader') as string;
+        let nonExistingHeader1 = req.get('nonExistingHeader') as undefined;
+
+        let existingHeader2 = req.header('existingHeader') as string;
+        let nonExistingHeader2 = req.header('nonExistingHeader') as undefined;
+
+        let existingHeader3 = req.headers.existingHeader as string;
+        let nonExistingHeader3 = req.headers.nonExistingHeader as undefined;
+
         res.send(req.query['token']);
     });
 

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://expressjs.com
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /* =================== USAGE ===================
 

--- a/types/express/tsconfig.json
+++ b/types/express/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Didn't provide docs, note that these methods can return undefined is on line 193 of `types/express-serve-static-core/index.d.ts`