### PR TITLE
Allow false as a result of React render()

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -185,7 +185,7 @@ declare namespace React {
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
         setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
         forceUpdate(callBack?: () => any): void;
-        render(): JSX.Element | null;
+        render(): JSX.Element | null | false;
 
         // React.Props<T> is now deprecated, which means that the `children`
         // property is not available on `P` by default, even though you can
@@ -2728,7 +2728,7 @@ declare global {
     namespace JSX {
         interface Element extends React.ReactElement<any> { }
         interface ElementClass extends React.Component<any, any> {
-            render(): JSX.Element | null;
+            render(): JSX.Element | null | false;
         }
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }


### PR DESCRIPTION
`false` is treated the same as `null` when returned from `render()` in react but it wasn't allowed in the typings.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Didn't manage to build the tests as tsc fails on them in master currently with :

```
test/index.ts(201,24): error TS2345: Argument of type 'ComponentElement<Props, ModernComponent>' is not assignable to parameter of type 'ReactElement<ClassAttributes<ModernComponent>>'.
  Types of property 'type' are incompatible.
    Type 'ComponentClass<Props>' is not assignable to type 'string | StatelessComponent<ClassAttributes<ModernComponent>> | ComponentClass<ClassAttributes<Mo...'.
      Type 'ComponentClass<Props>' is not assignable to type 'ComponentClass<ClassAttributes<ModernComponent>>'.
        Type 'Props' has no properties in common with type 'ClassAttributes<ModernComponent>'.
```

Building the `.d.ts` only succeed

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react/docs/react-component.html#render
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.