### PR TITLE
Numeral.js - add missing argument to `format` method

### DIFF
--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -22,6 +22,7 @@ interface NumeralJSLocale {
 	};
 }
 
+type RoundingFunction = (value: number) => number;
 
 // http://numeraljs.com/#custom-formats
 interface NumeralJsFormat {
@@ -29,13 +30,11 @@ interface NumeralJsFormat {
 		format: RegExp,
 		unformat: RegExp,
 	},
-	format: (value: any, format: string, roundingFunction: Function) => string,
+	format: (value: any, format: string, roundingFunction: RoundingFunction) => string,
 	unformat: (value: string) => number
 }
 
 type RegisterType = 'format' | 'locale';
-
-type RoundingFunction = (value: number) => number;
 
 // http://numeraljs.com/#use-it
 interface Numeral {

--- a/types/numeral/index.d.ts
+++ b/types/numeral/index.d.ts
@@ -35,6 +35,8 @@ interface NumeralJsFormat {
 
 type RegisterType = 'format' | 'locale';
 
+type RoundingFunction = (value: number) => number;
+
 // http://numeraljs.com/#use-it
 interface Numeral {
 	(value?: any): Numeral;
@@ -60,7 +62,7 @@ interface Numeral {
 	nullFormat(format: string): void;
 	defaultFormat(format: string): void;
 	clone(): Numeral;
-	format(inputString?: string): string;
+	format(inputString?: string, roundingFunction?: RoundingFunction): string;
 	formatCurrency(inputString?: string): string;
 	unformat(inputString: string): number;
 	value(): number;

--- a/types/numeral/numeral-tests.ts
+++ b/types/numeral/numeral-tests.ts
@@ -6,6 +6,9 @@ var valueFormat: string = numeral(1000).format('0,0');
 var valueUnformat: number = numeral().unformat('($10,000.00)');
 // '-10000'
 
+var valueFormatFloor: string = numeral(1.357).format('0.00', Math.floor);
+// '1.35'
+
 var value3: Numeral = numeral(1000);
 var added: Numeral = value3.add(10);
 // 1010


### PR DESCRIPTION
Numeral.js
- Create new type RoundingFunction
- Add missing second optional argument to `format` method in Numeral interface for defining a custom rounding function.
- Replace the format method's roundingFunction argument type in existing NumeralJsFormat interface with new RoundingFunction type
<hr>

- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/adamwdraper/Numeral-js/blob/master/src/numeral.js#L576>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.