### PR TITLE
Add preservePath parameter to multer defitition as described https://github.com/expressjs/multer

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -34,6 +34,9 @@ declare namespace multer {
             parts?: number;
             /** For multipart forms, the max number of header key=> value pairs to parse Default: 2000(same as node's http). */
             headerPairs?: number;
+            /** Keep the full path of files instead of just the base name (Default: false) */
+            preservePath?: boolean;
+        
         };
         /** A function to control which files to upload and which to skip. */
         fileFilter?: (req: Express.Request, file: Express.Multer.File, callback: (error: Error, acceptFile: boolean) => void) => void;


### PR DESCRIPTION
Add preservePath parameter as described https://github.com/expressjs/multer

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/multer
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

