### PR TITLE
[convict] Fix header

### DIFF
--- a/types/convict/index.d.ts
+++ b/types/convict/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for node-convict v3.0.0
+// Type definitions for convict 3.0
 // Project: https://github.com/mozilla/node-convict
 // Definitions by: Wim Looman <https://github.com/Nemo157>, Vesa Poikajärvi <https://github.com/vesse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
The DefinitelyTyped header needs to have the name of the library as it is published on npm and must not have a patch number in the version.

The types-publisher package determines the name of the library a type definition describes [by calling `parseHeaderOrFail`][publisher-extract], which is provided by [the definitelytyped-header-parser library][header-parser]. Looking at its source, one can see that it gets the library name [by parsing the `Type definitions for` comment line][call parselabel]. As [a comment in the code describes][parselabel], it parses the line in reverse, first finding the version number and then assuming that the rest is the name of the library. Unfortunately, in the case of convict, the name was incorrect. While, [unlike with bunyan][bunyan], it appears to have published automatically, there is no guarantee that that will continue to function.

Additionally, when the header is parsed in strict mode, [the version number must be bare (i.e. not prefixed by `v`) and only have major and minor version numbers][version]. Patch numbers are not allowed.

See also #17045.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see above

[bunyan]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17045
[publisher-extract]: https://github.com/Microsoft/types-publisher/blob/aba4e1579bfcc26d5cc01b0db94cf97a571caeec/src/lib/definition-parser.ts#L90-L91
[header-parser]: https://github.com/Microsoft/definitelytyped-header-parser
[call parselabel]: https://github.com/Microsoft/definitelytyped-header-parser/blob/1fd60d367b95045e27608fd9feb0f2e65a733bc3/index.ts#L109-L110
[parselabel]: https://github.com/Microsoft/definitelytyped-header-parser/blob/1fd60d367b95045e27608fd9feb0f2e65a733bc3/index.ts#L170-L171
[version]: https://github.com/Microsoft/definitelytyped-header-parser/blob/1fd60d367b95045e27608fd9feb0f2e65a733bc3/index.ts#L183-L198