### PR TITLE
[Boom, Hapi] Add default generic type to all error creation functions

### DIFF
--- a/types/boom/boom-tests.ts
+++ b/types/boom/boom-tests.ts
@@ -165,41 +165,16 @@ interface CustomPayload extends Boom.Payload {
 (error.output.payload as CustomPayload).custom = 'abc_123';
 
 /**
- * Test custom data
+ * Test assignment of custom error data:
  */
-
-// If the concrete functions do not default their generic parameter to null, this assignment fails:
-const error2: Boom.BoomError = Boom.badImplementation('message');
-
-// If the interface defaults its generic parameter to null, you cannot pass it as a parameter to existing continuation functions:
-const handleError: Hapi.ContinuationValueFunction = (err?: Boom.BoomError | null) => {
-    if (!err || !err.data.isCustom === true) {
-        return;
-    }
-
-    // assignment is possible due to default generic Data = any
-    const customError: Boom.BoomError<CustomData> = err;
-
-    // Discriminated union type works:
-    switch (customError.data.customType) {
-        case 'Custom1':
-            customError.data.custom1;
-            break;
-        case 'Custom2':
-            customError.data.custom2;
-            break;
-    }
-};
-handleError(Boom.badData());
-
-
-// Also errors with custom data can only be passed to existing continuation functions if the Data type defaults to any
 const errorWithData = Boom.badImplementation('', { custom1: 'test', customType: <'Custom1'>'Custom1', isCustom: <true>true });
-handleError(errorWithData);
+const errorWithNoExplicitDataType: Boom.BoomError = errorWithData; // can assign to error without explicit data type
+const errorWithExplicitType: Boom.BoomError<CustomData> = errorWithData; // can assign to union data type
+const errorWithConcreteCustomData: Boom.BoomError<CustomData1> = errorWithData; // can assign to concrete data type
+// assignment to CustomData2 would not be possible
+// const errorWithConcreteCustomData2: Boom.BoomError<CustomData2> = errorWithData;
 
-const errorWithExplicitType: Boom.BoomError<CustomData> = errorWithData;
-const errorWithConcreteCustomData: Boom.BoomError<CustomData1> = errorWithData; // assignment to CustomData2 would not be possible
-
+// Some complex error data types for testing purposes:
 interface CustomDataBase {
     isCustom: true;
 }

--- a/types/boom/boom-tests.ts
+++ b/types/boom/boom-tests.ts
@@ -5,6 +5,7 @@ import * as Hapi from 'hapi';
 
 const badRequestError = Boom.badRequest('message', {some: 'data'});
 badRequestError.data.some;
+const badRequestError2: Boom.BoomError = Boom.badImplementation('message');
 
 const unauthorizedError1 = Boom.unauthorized('message', 'scheme', {some: 'attribute'});
 unauthorizedError1.output.payload.attributes === { some: 'attribute', error: 'message' };
@@ -24,89 +25,116 @@ unauthorizedError4.output.headers === { 'WWW-Authenticate': 'scheme some="attrib
 
 const paymentRequiredError = Boom.paymentRequired('message', {some: 'data'});
 paymentRequiredError.data.some;
+const paymentRequiredError2: Boom.BoomError = Boom.paymentRequired('message');
 
 const forbiddenError = Boom.forbidden('message', {some: 'data'});
 forbiddenError.data.some;
+const forbiddenError2: Boom.BoomError = Boom.forbidden('message');
 
 const notFoundError = Boom.notFound('message', {some: 'data'});
 notFoundError.data.some;
+const notFoundError2: Boom.BoomError = Boom.notFound('message');
 
 const methodNotAllowedError = Boom.methodNotAllowed('message', {some: 'data'});
 methodNotAllowedError.data.some;
+const methodNotAllowedError2: Boom.BoomError = Boom.methodNotAllowed('message');
 
 const notAcceptableError = Boom.notAcceptable('message', {some: 'data'});
 notAcceptableError.data.some;
+const notAcceptableError2: Boom.BoomError = Boom.notAcceptable('message');
 
 const proxyAuthRequiredError = Boom.proxyAuthRequired('message', {some: 'data'});
 proxyAuthRequiredError.data.some;
+const proxyAuthRequiredError2: Boom.BoomError = Boom.proxyAuthRequired('message');
 
 const clientTimeoutError = Boom.clientTimeout('message', {some: 'data'});
 clientTimeoutError.data.some;
+const clientTimeoutError2: Boom.BoomError = Boom.clientTimeout('message');
 
 const conflictError = Boom.conflict('message', {some: 'data'});
 conflictError.data.some;
 
 const resourceGoneError = Boom.resourceGone('message', {some: 'data'});
 resourceGoneError.data.some;
+const resourceGoneError2: Boom.BoomError = Boom.resourceGone('message');
 
 const lengthRequiredError = Boom.lengthRequired('message', {some: 'data'});
 lengthRequiredError.data.some;
+const lengthRequiredError2: Boom.BoomError = Boom.lengthRequired('message');
 
 const preconditionFailedError = Boom.preconditionFailed('message', {some: 'data'});
 preconditionFailedError.data.some;
+const preconditionFailedError2: Boom.BoomError = Boom.preconditionFailed('message');
 
 const entityTooLargeError = Boom.entityTooLarge('message', {some: 'data'});
 entityTooLargeError.data.some;
+const entityTooLargeError2: Boom.BoomError = Boom.lengthRequired('message');
 
 const uriTooLongError = Boom.uriTooLong('message', {some: 'data'});
 uriTooLongError.data.some;
+const uriTooLongError2: Boom.BoomError = Boom.uriTooLong('message');
 
 const unsupportedMediaTypeError = Boom.unsupportedMediaType('message', {some: 'data'});
 unsupportedMediaTypeError.data.some;
+const unsupportedMediaTypeError2: Boom.BoomError = Boom.unsupportedMediaType('message');
 
 const rangeNotSatisfiableError = Boom.rangeNotSatisfiable('message', {some: 'data'});
 rangeNotSatisfiableError.data.some;
+const rangeNotSatisfiableError2: Boom.BoomError = Boom.rangeNotSatisfiable('message');
 
 const expectationFailedError = Boom.expectationFailed('message', {some: 'data'});
 expectationFailedError.data.some;
+const expectationFailedError2: Boom.BoomError = Boom.expectationFailed('message');
 
 const teapotError = Boom.teapot('message', {some: 'data'});
 teapotError.data.some;
+const teapotError2: Boom.BoomError = Boom.teapot('message');
 
 const badDataError = Boom.badData('message', {some: 'data'});
 badDataError.data.some;
+const badDataError2: Boom.BoomError = Boom.badData('message');
 
 const lockedError = Boom.locked('message', {some: 'data'});
 lockedError.data.some;
+const lockedError2: Boom.BoomError = Boom.locked('message');
 
 const preconditionRequiredError = Boom.preconditionRequired('message', {some: 'data'});
 preconditionRequiredError.data.some;
+const preconditionRequiredError2: Boom.BoomError = Boom.preconditionRequired('message');
 
 const tooManyRequestsError = Boom.tooManyRequests('message', {some: 'data'});
 tooManyRequestsError.data.some;
+const tooManyRequestsError2: Boom.BoomError = Boom.tooManyRequests('message');
 
 const illegalError = Boom.illegal('message', {some: 'data'});
 illegalError.data.some;
+const illegalError2: Boom.BoomError = Boom.illegal('message');
 
 // 5xx and data type
 
 const badImplementationError = Boom.badImplementation('message', {some: 'data'});
 badImplementationError.data.some;
+const badImplementationError2: Boom.BoomError = Boom.badImplementation('message');
 
 const internalError = Boom.internal('message', {some: 'data'});
 internalError.data.some;
+const internalError2: Boom.BoomError = Boom.internal('message');
 
 const notImplementedError = Boom.notImplemented('message', {some: 'data'});
 notImplementedError.data.some;
+const notImplementedError2: Boom.BoomError = Boom.notImplemented('message');
 
 const badGatewayError = Boom.badGateway('message', {some: 'data'});
 badGatewayError.data.some;
+const badGatewayError2: Boom.BoomError = Boom.badGateway('message');
 
 const serverUnavailableError = Boom.serverUnavailable('message', {some: 'data'});
 serverUnavailableError.data.some;
+const serverUnavailableError2: Boom.BoomError = Boom.serverUnavailable('message');
 
 const gatewayTimeoutError = Boom.gatewayTimeout('message', {some: 'data'});
 gatewayTimeoutError.data.some;
+const gatewayTimeoutError2: Boom.BoomError = Boom.gatewayTimeout('message');
 
 // wrap and create
 
@@ -114,6 +142,7 @@ const wrappedError = Boom.wrap(new Error('test'), 400, 'some message');
 
 const error1 = Boom.create(500, 'Internal server error', { timestamp: Date.now() });
 error1.data.timestamp;
+const error2: Boom.BoomError = Boom.create(500, 'Internal server error');
 
 // type widen asserting
 

--- a/types/boom/boom-tests.ts
+++ b/types/boom/boom-tests.ts
@@ -144,7 +144,7 @@ const error2: Boom.BoomError = Boom.badImplementation('message');
 
 // If the interface defaults its generic parameter to null, you cannot pass it as a parameter to existing continuation functions:
 const handleError: Hapi.ContinuationValueFunction = (err?: Boom.BoomError | null) => {
-    if (!err || !err.data.isCustom === true) {
+    if (!err || !err.data.isCustom) {
         return;
     }
 
@@ -163,9 +163,8 @@ const handleError: Hapi.ContinuationValueFunction = (err?: Boom.BoomError | null
 };
 handleError(Boom.badData());
 
-
 // Also errors with custom data can only be passed to existing continuation functions if the Data type defaults to any
-const errorWithData = Boom.badImplementation('', { custom1: 'test', customType: <'Custom1'>'Custom1', isCustom: <true>true });
+const errorWithData = Boom.badImplementation('', { custom1: 'test', customType: 'Custom1', isCustom: true } as CustomData1);
 handleError(errorWithData);
 
 const errorWithExplicitType: Boom.BoomError<CustomData> = errorWithData;

--- a/types/boom/boom-tests.ts
+++ b/types/boom/boom-tests.ts
@@ -1,4 +1,5 @@
 import Boom = require('boom');
+import * as Hapi from 'hapi';
 
 // 4xx and data type
 
@@ -133,3 +134,19 @@ interface CustomPayload extends Boom.Payload {
 }
 
 (error.output.payload as CustomPayload).custom = 'abc_123';
+
+/**
+ * Test additional data
+ */
+
+// If the concrete functions do not default their generic parameter to null, too, this fails:
+const error2: Boom.BoomError = Boom.badImplementation('really bad');
+
+// And this too:
+const next = <Hapi.ContinuationValueFunction>(() => { });
+next(Boom.badData());
+
+interface CustomData {
+    custom: string;
+}
+const errorWithData: Boom.BoomError<CustomData> = Boom.badImplementation('', { custom: 'test' });

--- a/types/boom/index.d.ts
+++ b/types/boom/index.d.ts
@@ -25,7 +25,7 @@ declare namespace Boom {
         reformat: () => string;
         /** "If message is unset, the 'error' segment of the header will not be present and isMissing will be true on the error object." mentioned in @see {@link https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes} */
         isMissing?: boolean;
-        /** https://github.com/hapijs/boom#createstatuscode-message-data */
+        /** https://github.com/hapijs/boom#createstatuscode-message-data and https://github.com/hapijs/boom/blob/v4.3.0/lib/index.js#L99 */
         data: Data;
     }
 
@@ -70,7 +70,7 @@ declare namespace Boom {
      * @param data additional error data set to error.data property.
      * @see {@link https://github.com/hapijs/boom#createstatuscode-message-data}
      */
-    export function create<Data>(statusCode: number, message?: string, data?: Data): BoomError<Data>;
+    export function create<Data = null>(statusCode: number, message?: string, data?: Data): BoomError<Data>;
 
     // 4xx
     /**
@@ -79,7 +79,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boombadrequestmessage-data}
      */
-    export function badRequest<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function badRequest<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 401 Unauthorized error
@@ -101,7 +101,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boompaymentrequiredmessage-data}
      */
-    export function paymentRequired<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function paymentRequired<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 403 Forbidden error
@@ -109,7 +109,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomforbiddenmessage-data}
      */
-    export function forbidden<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function forbidden<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 404 Not Found error
@@ -117,7 +117,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomnotfoundmessage-data}
      */
-    export function notFound<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function notFound<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 405 Method Not Allowed error
@@ -126,7 +126,7 @@ declare namespace Boom {
      * @param allow optional string or array of strings (to be combined and separated by ', ') which is set to the 'Allow' header.
      * @see {@link https://github.com/hapijs/boom#boommethodnotallowedmessage-data-allow}
      */
-    export function methodNotAllowed<Data>(message?: string, data?: Data, allow?: string | string[]): BoomError<Data>;
+    export function methodNotAllowed<Data = null>(message?: string, data?: Data, allow?: string | string[]): BoomError<Data>;
 
     /**
      * Returns a 406 Not Acceptable error
@@ -134,7 +134,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomnotacceptablemessage-data}
      */
-    export function notAcceptable<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function notAcceptable<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 407 Proxy Authentication Required error
@@ -142,7 +142,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomproxyauthrequiredmessage-data}
      */
-    export function proxyAuthRequired<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function proxyAuthRequired<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 408 Request Time-out error
@@ -150,7 +150,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomclienttimeoutmessage-data}
      */
-    export function clientTimeout<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function clientTimeout<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 409 Conflict error
@@ -158,7 +158,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomconflictmessage-data}
      */
-    export function conflict<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function conflict<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 410 Gone error
@@ -166,7 +166,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomresourcegonemessage-data}
      */
-    export function resourceGone<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function resourceGone<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 411 Length Required error
@@ -174,7 +174,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomlengthrequiredmessage-data}
      */
-    export function lengthRequired<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function lengthRequired<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 412 Precondition Failed error
@@ -182,7 +182,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boompreconditionfailedmessage-data}
      */
-    export function preconditionFailed<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function preconditionFailed<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 413 Request Entity Too Large error
@@ -190,7 +190,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomentitytoolargemessage-data}
      */
-    export function entityTooLarge<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function entityTooLarge<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 414 Request-URI Too Large error
@@ -198,7 +198,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomuritoolongmessage-data}
      */
-    export function uriTooLong<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function uriTooLong<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 415 Unsupported Media Type error
@@ -206,7 +206,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomunsupportedmediatypemessage-data}
      */
-    export function unsupportedMediaType<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function unsupportedMediaType<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 416 Requested Range Not Satisfiable error
@@ -214,7 +214,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomrangenotsatisfiablemessage-data}
      */
-    export function rangeNotSatisfiable<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function rangeNotSatisfiable<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 417 Expectation Failed error
@@ -222,7 +222,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomexpectationfailedmessage-data}
      */
-    export function expectationFailed<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function expectationFailed<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 418 I'm a Teapot error
@@ -230,7 +230,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomteapotmessage-data}
      */
-    export function teapot<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function teapot<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 422 Unprocessable Entity error
@@ -238,7 +238,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boombaddatamessage-data}
      */
-    export function badData<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function badData<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 423 Locked error
@@ -246,7 +246,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomlockedmessage-data}
      */
-    export function locked<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function locked<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 428 Precondition Required error
@@ -254,7 +254,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boompreconditionrequiredmessage-data}
      */
-    export function preconditionRequired<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function preconditionRequired<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 429 Too Many Requests error
@@ -262,7 +262,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomtoomanyrequestsmessage-data}
      */
-    export function tooManyRequests<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function tooManyRequests<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 451 Unavailable For Legal Reasons error
@@ -270,7 +270,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomillegalmessage-data}
      */
-    export function illegal<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function illegal<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     // 5xx
     /**
@@ -280,7 +280,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boombadimplementationmessage-data---alias-internal}
      */
-    export function badImplementation<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function badImplementation<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 500 Internal Server Error error
@@ -289,7 +289,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boombadimplementationmessage-data---alias-internal}
      */
-    export function internal<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function internal<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 501 Not Implemented error with your error message to the user
@@ -297,7 +297,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomnotimplementedmessage-data}
      */
-    export function notImplemented<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function notImplemented<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 502 Bad Gateway error with your error message to the user
@@ -305,7 +305,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boombadgatewaymessage-data}
      */
-    export function badGateway<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function badGateway<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 503 Service Unavailable error with your error message to the user
@@ -313,7 +313,7 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomserverunavailablemessage-data}
      */
-    export function serverUnavailable<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function serverUnavailable<Data = null>(message?: string, data?: Data): BoomError<Data>;
 
     /**
      * Returns a 504 Gateway Time-out error with your error message to the user
@@ -321,5 +321,5 @@ declare namespace Boom {
      * @param data optional additional error data.
      * @see {@link https://github.com/hapijs/boom#boomgatewaytimeoutmessage-data}
      */
-    export function gatewayTimeout<Data>(message?: string, data?: Data): BoomError<Data>;
+    export function gatewayTimeout<Data = null>(message?: string, data?: Data): BoomError<Data>;
 }

--- a/types/boom/index.d.ts
+++ b/types/boom/index.d.ts
@@ -61,7 +61,7 @@ declare namespace Boom {
      * @param message optional message string. If the error already has a message, it adds the message as a prefix. Defaults to no message.
      * @see {@link https://github.com/hapijs/boom#wraperror-statuscode-message}
      */
-    export function wrap(error: Error, statusCode?: number, message?: string): BoomError;
+    export function wrap(error: Error, statusCode?: number, message?: string): BoomError<null>;
 
     /**
      * Generates an Error object with the boom decorations
@@ -90,10 +90,10 @@ declare namespace Boom {
      * @param attributes an object of values to use while setting the 'WWW-Authenticate' header. This value is only used when scheme is a string, otherwise it is ignored. Every key/value pair will be included in the 'WWW-Authenticate' in the format of 'key="value"' as well as in the response payload under the attributes key. Alternatively value can be a string which is use to set the value of the scheme, for example setting the token value for negotiate header. If string is used message parameter must be null. null and undefined will be replaced with an empty string. If attributes is set, message will be used as the 'error' segment of the 'WWW-Authenticate' header. If message is unset, the 'error' segment of the header will not be present and isMissing will be true on the error object.
      * @see {@link https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes}
      */
-    export function unauthorized(message?: string, scheme?: string, attributes?: {[index: string]: string}): BoomError;
-    export function unauthorized(message?: string, scheme?: string[]): BoomError;
-    export function unauthorized(message?: null, scheme?: string, attributes?: {[index: string]: string} | string): BoomError;
-    export function unauthorized(message?: null, scheme?: string[]): BoomError;
+    export function unauthorized(message?: string, scheme?: string, attributes?: {[index: string]: string}): BoomError<null>;
+    export function unauthorized(message?: string, scheme?: string[]): BoomError<null>;
+    export function unauthorized(message?: null, scheme?: string, attributes?: {[index: string]: string} | string): BoomError<null>;
+    export function unauthorized(message?: null, scheme?: string[]): BoomError<null>;
 
     /**
      * Returns a 402 Payment Required error

--- a/types/boom/index.d.ts
+++ b/types/boom/index.d.ts
@@ -12,7 +12,7 @@ declare namespace Boom {
      * boom provides a set of utilities for returning HTTP errors. Each utility returns a Boom error response object (instance of Error) which includes the following properties:
      * @see {@link https://github.com/hapijs/boom#boom}
      */
-    export interface BoomError<Data = null> extends Error {
+    export interface BoomError<Data = any> extends Error {
         /** isBoom - if true, indicates this is a Boom object instance. */
         isBoom: boolean;
         /** isServer - convenience bool indicating status code >= 500. */

--- a/types/hapi/test/continuation/errors.ts
+++ b/types/hapi/test/continuation/errors.ts
@@ -1,0 +1,57 @@
+
+import * as Hapi from 'hapi';
+import * as Boom from 'boom';
+
+// Assignment of a typical function to ContinuationValueFunction is possible
+const handleError: Hapi.ContinuationValueFunction = (err?: Boom.BoomError | null, value?: any) => {
+    if (!err || !err.data.isCustom === true) {
+        return;
+    }
+
+    // assignment is possible due to default generic Data = any
+    const customError: Boom.BoomError<CustomData> = err;
+
+    // Discriminated union type works:
+    switch (customError.data.customType) {
+        case 'Custom1':
+            customError.data.custom1;
+            break;
+        case 'Custom2':
+            customError.data.custom2;
+            break;
+    }
+};
+
+// Accepts a simple Boom error
+handleError(Boom.badData());
+
+// Accepts an error with custom data
+const errorWithData = Boom.badImplementation('', { custom1: 'test', customType: <'Custom1'>'Custom1', isCustom: <true>true });
+handleError(errorWithData);
+
+// Accepts an error with a more explicit type
+const errorWithExplicitType: Boom.BoomError<CustomData> = errorWithData;
+handleError(errorWithExplicitType);
+
+// Accepts an error with an even more explicit type
+const errorWithConcreteCustomData: Boom.BoomError<CustomData1> = errorWithData; // assignment to CustomData2 would not be possible
+handleError(errorWithConcreteCustomData);
+
+/**
+ * Some complex error data types:
+ */
+interface CustomDataBase {
+    isCustom: true;
+}
+
+interface CustomData1 extends CustomDataBase {
+    customType: 'Custom1';
+    custom1: string;
+}
+
+interface CustomData2 extends CustomDataBase {
+    customType: 'Custom2';
+    custom2: string;
+}
+
+type CustomData = CustomData1 | CustomData2;

--- a/types/hapi/tsconfig.json
+++ b/types/hapi/tsconfig.json
@@ -18,6 +18,7 @@
     "files": [
         "index.d.ts",
         "test/connection/table.ts",
+        "test/continuation/errors.ts",
         "test/getting-started/01-creating-a-server.ts",
         "test/getting-started/02-adding-routes.ts",
         "test/getting-started/03-serving-static-content.ts",


### PR DESCRIPTION
Hi again,

after the latest changes to both Hapi and Boom types, I ran into some problems when passing new Boom errors into continuation functions.

Have a look at the added test cases to see what I mean. Providing a default for the generic parameter  `Data` solves these issues for me.


---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
