### PR TITLE
Rangy: fix the exports so that everything is cleanly exported.

### DIFF
--- a/types/rangy/index.d.ts
+++ b/types/rangy/index.d.ts
@@ -3,69 +3,71 @@
 // Definitions by: Rudolph Gottesheim <http://www.midnight-design.at/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface RangyRange extends Range {
-    setStartAndEnd(startNode:Node, startOffset:number, endNode?:Node, endOffset?:number):any;
-    setStartAndEnd(startNode:Node, startOffset:number, endOffset:number):any;
-    canSurroundContents():boolean;
-    isValid():boolean;
-    toHtml():string;
-    compareNode(node:Node):any;
-    intersectsOrTouchesRange(range:RangyRange):boolean;
-    intersectsRange(range:RangyRange):boolean;
-    intersection(range:RangyRange):RangyRange;
-    union(range:RangyRange):RangyRange;
-    containsNode(node:Node, partial:boolean):boolean;
-    containsNodeContents(node:Node):boolean;
-    containsNodeText(node:Node):boolean;
-    containsRange(range:RangyRange):boolean;
-    splitBoundaries():any;
-    normalizeBoundaries():any;
-    collapseToPoint(node:Node, offset:number):any;
-    collapseBefore(node:Node):any;
-    collapseAfter(node:Node):any;
-    getNodes(nodeTypes?:any[], filter?:(node:Node) => boolean):Node[];
-    getBookmark(containerNode?:Node):{start:number, end:number};
-    moveToBookmark(bookmark:Object):any;
-    getDocument():Document;
-    inspect():string;
-    equals(range:RangyRange):boolean;
-    refresh():any;
-    select():any;
+declare namespace rangy {
+    interface RangyRange extends Range {
+        setStartAndEnd(startNode:Node, startOffset:number, endNode?:Node, endOffset?:number):any;
+        setStartAndEnd(startNode:Node, startOffset:number, endOffset:number):any;
+        canSurroundContents():boolean;
+        isValid():boolean;
+        toHtml():string;
+        compareNode(node:Node):any;
+        intersectsOrTouchesRange(range:RangyRange):boolean;
+        intersectsRange(range:RangyRange):boolean;
+        intersection(range:RangyRange):RangyRange;
+        union(range:RangyRange):RangyRange;
+        containsNode(node:Node, partial:boolean):boolean;
+        containsNodeContents(node:Node):boolean;
+        containsNodeText(node:Node):boolean;
+        containsRange(range:RangyRange):boolean;
+        splitBoundaries():any;
+        normalizeBoundaries():any;
+        collapseToPoint(node:Node, offset:number):any;
+        collapseBefore(node:Node):any;
+        collapseAfter(node:Node):any;
+        getNodes(nodeTypes?:any[], filter?:(node:Node) => boolean):Node[];
+        getBookmark(containerNode?:Node):{start:number, end:number};
+        moveToBookmark(bookmark:Object):any;
+        getDocument():Document;
+        inspect():string;
+        equals(range:RangyRange):boolean;
+        refresh():any;
+        select():any;
+    }
+
+    interface RangySelection extends Selection {
+        nativeSelection:Selection;
+        isBackwards():boolean;
+        refresh(checkForChanges?:boolean):any;
+        toHtml():string;
+        getAllRanges():RangyRange[];
+        getRangeAt(idx:number):RangyRange;
+        getNativeTextRange():any;
+        setSingleRange(range:RangyRange):any;
+        setRanges(ranges:RangyRange[]):any;
+        getBookmark(containerNode:Node):any;
+        moveToBookmark(bookmark:Object):any;
+        saveRanges():Object;
+        restoreRanges(saved:Object):any;
+        saveCharacterRanges(containerNode:Node):Object;
+        restoreCharacterRanges(containerNode:Node, characterRanges:Object):any;
+        detach():any;
+        inspect():string;
+    }
+
+    interface RangyStatic {
+        createNativeRange(doc?:Document|Window|HTMLIFrameElement):Range;
+        createRange(doc?:Document|Window|HTMLIFrameElement):RangyRange;
+        createRangyRange(doc?:Document|Window|HTMLIFrameElement):RangyRange;
+        getNativeSelection(win?:Window):Selection;
+        getSelection():RangySelection;
+        addInitListener(listener:(rangy:RangyStatic) => void):any;
+        shim():any;
+        createMissingNativeApi():any;
+        initialized:boolean;
+        supported:boolean;
+    }
 }
 
-interface RangySelection extends Selection {
-    nativeSelection:Selection;
-    isBackwards():boolean;
-    refresh(checkForChanges?:boolean):any;
-    toHtml():string;
-    getAllRanges():RangyRange[];
-    getRangeAt(idx:number):RangyRange;
-    getNativeTextRange():any;
-    setSingleRange(range:RangyRange):any;
-    setRanges(ranges:RangyRange[]):any;
-    getBookmark(containerNode:Node):any;
-    moveToBookmark(bookmark:Object):any;
-    saveRanges():Object;
-    restoreRanges(saved:Object):any;
-    saveCharacterRanges(containerNode:Node):Object;
-    restoreCharacterRanges(containerNode:Node, characterRanges:Object):any;
-    detach():any;
-    inspect():string;
-}
-
-interface RangyStatic {
-    createNativeRange(doc?:Document|Window|HTMLIFrameElement):Range;
-    createRange(doc?:Document|Window|HTMLIFrameElement):RangyRange;
-    createRangyRange(doc?:Document|Window|HTMLIFrameElement):RangyRange;
-    getNativeSelection(win?:Window):Selection;
-    getSelection():RangySelection;
-    addInitListener(listener:(rangy:RangyStatic) => void):any;
-    shim():any;
-    createMissingNativeApi():any;
-    initialized:boolean;
-    supported:boolean;
-}
-declare module 'rangy' {
-    export = rangy;
-}
-declare var rangy:RangyStatic;
+declare var rangy:rangy.RangyStatic;
+export as namespace rangy;
+export = rangy;

--- a/types/rangy/rangy-module-tests.ts
+++ b/types/rangy/rangy-module-tests.ts
@@ -1,0 +1,14 @@
+// This test file is meant to only test that we get sensible values
+// when Rangy is loaded as a module. That is, both calls to the
+// libraries functions **and** the types declared should be accessible
+// to the symbol used with the import.
+
+// We purposely import with a name other than "rangy" because using
+// the name "rangy" for the import could mask issues.
+import * as moo from "./index";
+
+// Functions are accessible through `rangy`.
+moo.getSelection();
+
+// Types are also accessible through `rangy`.
+function foo(a:moo.RangyRange):void {}

--- a/types/rangy/rangy-tests.ts
+++ b/types/rangy/rangy-tests.ts
@@ -3,13 +3,13 @@
 declare function assertAny(a:any):any;
 declare function assertBoolean(b:boolean):any;
 declare function assertString(s:string):any;
-declare function assertRangyRange(r:RangyRange):any;
-declare function getRangyRange():RangyRange;
+declare function assertRangyRange(r:rangy.RangyRange):any;
+declare function getRangyRange():rangy.RangyRange;
 
 type TextRange = any; // ?
 
 function testRangyStatic() {
-    rangy.addInitListener((rangy:RangyStatic) => {
+    rangy.addInitListener((rangy:rangy.RangyStatic) => {
     });
 
     rangy.createMissingNativeApi();
@@ -20,7 +20,7 @@ function testRangyStatic() {
     nativeRange = rangy.createNativeRange(new HTMLIFrameElement);
     nativeRange = rangy.createNativeRange();
 
-    let rangyRange:RangyRange = rangy.createRange(document);
+    let rangyRange:rangy.RangyRange = rangy.createRange(document);
     rangyRange = rangy.createRange(window);
     rangyRange = rangy.createRange(new HTMLIFrameElement);
     rangyRange = rangy.createRange();
@@ -33,14 +33,14 @@ function testRangyStatic() {
     let nativeSelection:Selection = rangy.getNativeSelection(window);
     nativeSelection = rangy.getNativeSelection();
 
-    let rangySelection:RangySelection = rangy.getSelection();
+    let rangySelection:rangy.RangySelection = rangy.getSelection();
 
     let initialized:boolean = rangy.initialized;
     let supported:boolean = rangy.supported;
 }
 
 function testRangyRange() {
-    let rangyRange:RangyRange = rangy.createRange();
+    let rangyRange:rangy.RangyRange = rangy.createRange();
 
     assertBoolean(rangyRange.canSurroundContents());
     rangyRange.collapseAfter(new Node);
@@ -77,11 +77,11 @@ function testRangyRange() {
 }
 
 function testSelection() {
-    let selection:RangySelection = rangy.getSelection();
+    let selection:rangy.RangySelection = rangy.getSelection();
 
     selection.detach();
-    let ranges:RangyRange[] = selection.getAllRanges();
-    let range:RangyRange = selection.getRangeAt(0);
+    let ranges:rangy.RangyRange[] = selection.getAllRanges();
+    let range:rangy.RangyRange = selection.getRangeAt(0);
     selection.getBookmark(new Node);
     let nativeTextRange:TextRange = selection.getNativeTextRange();
     assertString(selection.inspect());

--- a/types/rangy/tsconfig.json
+++ b/types/rangy/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
-        "rangy-tests.ts"
+        "rangy-tests.ts",
+        "rangy-module-tests.ts"
     ]
 }


### PR DESCRIPTION
### `@types/rangy` 0.0.27

It used to be that the file installed with `@types/rangy` would dump everything into the global space. You'd have to do:

```
import "rangy";

rangy.getSelection();

function foo(range: RangyRange): void {}
```

If you wanted to import "rangy" as some other symbol, you're out of luck. `import * as moo from "rangy"` would not work. 

### `@types/rangy` 0.0.28

The change in #16686 improved things a bit, but there are still problems:

```
import * as moo from "rangy";

// Yay! I can access rangy's functions through a symbol of my
// choosing.
moo.getSelection();

// Where does this come from?? Oh, the `rangy` symbol is still dumped
// into the global space.
rangy.getSelection();

function foo(range: RangyRange): void {}

// This does not compile, because RangyRange is still dumped into the
// global space.
//
// function foo2(range: moo.RangyRange): void {}
```

The pollution of the global space, is, well, global. The following file (let's call it `other.ts`) will not show any errors if used in combination with the previous one, even though it does not import the "rangy" module:

```
rangy.getSelection();

export function blah(range: RangyRange): void {}
```

### Changes in this PR

```
import * as moo from "rangy";

// Still works.
moo.getSelection();

// This is no longer valid. I don't get an unwanted symbol dumped into
// the global space.
//
// rangy.getSelection();

// No longer valid either.
// function foo(range: RangyRange): void {}

// Yep, types are now accessible through the same symbol as the one that
// holds rangy's functions.
function foo2(range: moo.RangyRange): void {}
```

And the `other.ts` file I've shown above now has, as one would expect, errors on both statements because `rangy` is no longer accessible globally in modules. Modules cannot access "rangy" without importing it.

Check list:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [N/A] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I have N/A for one of the items above because this change concerns purely how we consume the types on the TypeScript side. Since the Rangy project completely ignores TypeScript there's nothing there to support one position or the other.