### PR TITLE
change bootstrap types: reference to jquery prevents loading

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -3,9 +3,6 @@
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-/// <reference types="jquery"/>
-
 interface ModalOptions {
     backdrop?: boolean|string;
     keyboard?: boolean;


### PR DESCRIPTION
see #14307 - as long as this line is present, the type definition is not being loaded - without the file, everything works just fine.