### PR TITLE
[SharePoint] add _spFriendlyUrlPageContextInfo

### DIFF
--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -179,6 +179,13 @@ declare class _spPageContextInfo {
     static webUIVersion: number; // 15
 }
 
+declare class _spFriendlyUrlPageContextInfo {
+    static termId: string;
+    static termSetId: string;
+    static termStoreId: string;
+    static title: string;
+}
+
 declare function STSHtmlEncode(value: string): string;
 declare function STSHtmlDecode(value: string): string;
 


### PR DESCRIPTION
Add the _spFriendlyUrlPageContextInfo class, which is on SharePoint if using Friendly Urls.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: No documentation, but mentioned on several stack Overflow Questions https://sharepoint.stackexchange.com/questions/94371/get-navigation-term-for-current-page-in-csom-javascript
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
