### PR TITLE
PouchDB Generics for Heterogeneous Databases

### DIFF
--- a/types/pouch-redux-middleware/index.d.ts
+++ b/types/pouch-redux-middleware/index.d.ts
@@ -1,34 +1,33 @@
-// Type definitions for pouch-redux-middleware 0.5.0
+// Type definitions for pouch-redux-middleware 0.5
 // Project: https://github.com/pgte/pouch-redux-middleware
 // Definitions by: Adam Charron <https://github.com/charrondev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-import { Dispatch, Action, Middleware } from 'redux'
-import * as PouchDB from 'pouchdb'
+import { Dispatch, Action, Middleware } from 'redux';
+import * as PouchDB from 'pouchdb';
 
 export interface Document {
   _id: any;
-  [field: string]: any
+  [field: string]: any;
 }
 
 export interface Path {
-  path: string
-  db: PouchDB.Database<any>
-  scheduleRemove?: (doc: Document) => void
-  scheduleInset?: (doc: Document) => void
-  propagateDelete?: (doc: Document, dispatch: Dispatch<any>) => void
-  propagateInsert?: (doc: Document, dispatch: Dispatch<any>) => void
-  propagateUpdate?: (doc: Document, dispatch: Dispatch<any>) => void
-  handleResponse?: (err: Error, data: any, errorCallback: (err: Error) => void) => void
-  queue?: Function
-  docs?: any
+  path: string;
+  db: PouchDB.Database<any>;
+  scheduleRemove?(doc: Document): void;
+  scheduleInset?(doc: Document): void;
+  propagateDelete?(doc: Document, dispatch: Dispatch<any>): void;
+  propagateInsert?(doc: Document, dispatch: Dispatch<any>): void;
+  propagateUpdate?(doc: Document, dispatch: Dispatch<any>): void;
+  handleResponse?(err: Error, data: any, errorCallback: (err: Error) => void): void;
+  queue?(...args: any[]): any;
+  docs?: any;
   actions: {
-    remove: (doc: Document) => Action
-    update: (doc: Document) => Action
-    insert: (doc: Document) => Action
-  }
+    remove(doc: Document): Action;
+    update(doc: Document): Action;
+    insert(doc: Document): Action;
+  };
 }
 
-export default function PouchMiddlewareFactory(paths?: Path[] | Path): Middleware
-
-
+export default function PouchMiddlewareFactory(paths?: Path[] | Path): Middleware;

--- a/types/pouch-redux-middleware/pouch-redux-middleware-tests.ts
+++ b/types/pouch-redux-middleware/pouch-redux-middleware-tests.ts
@@ -1,22 +1,22 @@
-import * as redux from 'redux'
-import makePouchMiddleware, { Document, Path } from 'pouch-redux-middleware'
+import * as redux from 'redux';
+import makePouchMiddleware, { Document, Path } from 'pouch-redux-middleware';
 import * as PouchDB from 'pouchdb';
 
 const types = {
     DELETE_TODO: 'delete-todo',
     INSERT_TODO: 'insert-todo',
     UPDATE_TODO: 'update-todo'
-}
+};
 
 const path: Path = {
     path: "/test",
     db: new PouchDB('test'),
     actions: {
-        remove: doc => { return { type: types.DELETE_TODO, id: doc._id } },
-        insert: doc => { return { type: types.INSERT_TODO, todo: doc } },
-        update: doc => { return { type: types.UPDATE_TODO, todo: doc } },
+        remove: doc => ({ type: types.DELETE_TODO, id: doc._id }),
+        insert: doc => ({ type: types.INSERT_TODO, todo: doc }),
+        update: doc => ({ type: types.UPDATE_TODO, todo: doc }),
     }
-}
+};
 
-const middleware: redux.Middleware = makePouchMiddleware(path)
-const otherMiddleware: redux.Middleware = makePouchMiddleware([path, path, path])
+const middleware: redux.Middleware = makePouchMiddleware(path);
+const otherMiddleware: redux.Middleware = makePouchMiddleware([path, path, path]);

--- a/types/pouch-redux-middleware/tslint.json
+++ b/types/pouch-redux-middleware/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-adapter-fruitdown/index.d.ts
+++ b/types/pouchdb-adapter-fruitdown/index.d.ts
@@ -1,9 +1,13 @@
-// Type definitions for pouchdb-adapter-fruitdown v6.1.2
+// Type definitions for pouchdb-adapter-fruitdown 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
     namespace FruitDOWNAdapter {
@@ -14,9 +18,9 @@ declare namespace PouchDB {
     }
 
     interface Static {
-        new<Content extends Core.Encodable>(name: string | void,
-            options: FruitDOWNAdapter.FruitDOWNAdapterConfiguration
-            ): Database<Content>;
+        new<Content extends {}>(name: string | null,
+                                options: FruitDOWNAdapter.FruitDOWNAdapterConfiguration
+                               ): Database<Content>;
     }
 }
 

--- a/types/pouchdb-adapter-fruitdown/pouchdb-adapter-fruitdown-tests.ts
+++ b/types/pouchdb-adapter-fruitdown/pouchdb-adapter-fruitdown-tests.ts
@@ -1,5 +1,7 @@
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
     let model: PouchDB.Core.Document<MyModel>;
 
     let db = new PouchDB<MyModel>(null, {

--- a/types/pouchdb-adapter-fruitdown/tslint.json
+++ b/types/pouchdb-adapter-fruitdown/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-adapter-http/index.d.ts
+++ b/types/pouchdb-adapter-http/index.d.ts
@@ -1,9 +1,13 @@
-// Type definitions for pouchdb-http v6.1.2
+// Type definitions for pouchdb-http 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
     namespace HttpAdapter {
@@ -14,9 +18,9 @@ declare namespace PouchDB {
     }
 
     interface Static {
-        new<Content extends Core.Encodable>(name: string | void,
-            options: HttpAdapter.HttpAdapterConfiguration
-            ): Database<Content>;
+        new<Content extends {}>(name: string | null,
+                                options: HttpAdapter.HttpAdapterConfiguration
+                               ): Database<Content>;
     }
 }
 

--- a/types/pouchdb-adapter-http/tslint.json
+++ b/types/pouchdb-adapter-http/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-adapter-idb/index.d.ts
+++ b/types/pouchdb-adapter-idb/index.d.ts
@@ -1,9 +1,13 @@
-// Type definitions for pouchdb-adapter-idb v6.1.2
+// Type definitions for pouchdb-adapter-idb 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
     namespace Core {
@@ -26,9 +30,9 @@ declare namespace PouchDB {
     }
 
     interface Static {
-        new<Content extends Core.Encodable>(name: string | void,
-            options: IdbAdapter.IdbAdapterConfiguration
-            ): Database<Content>;
+        new<Content extends {}>(name: string | null,
+                                options: IdbAdapter.IdbAdapterConfiguration
+                               ): Database<Content>;
     }
 }
 

--- a/types/pouchdb-adapter-idb/tslint.json
+++ b/types/pouchdb-adapter-idb/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-adapter-leveldb/index.d.ts
+++ b/types/pouchdb-adapter-leveldb/index.d.ts
@@ -1,9 +1,13 @@
-// Type definitions for pouchdb-adapter-leveldb v6.1.2
+// Type definitions for pouchdb-adapter-leveldb 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
     namespace LevelDbAdapter {
@@ -13,9 +17,9 @@ declare namespace PouchDB {
     }
 
     interface Static {
-        new<Content extends Core.Encodable>(name: string | void,
-            options: LevelDbAdapter.LevelDbAdapterConfiguration
-            ): Database<Content>;
+        new<Content extends {}>(name: string | null,
+                                options: LevelDbAdapter.LevelDbAdapterConfiguration
+                               ): Database<Content>;
     }
 }
 

--- a/types/pouchdb-adapter-leveldb/pouchdb-adapter-leveldb-tests.ts
+++ b/types/pouchdb-adapter-leveldb/pouchdb-adapter-leveldb-tests.ts
@@ -1,5 +1,7 @@
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
 
     let db = new PouchDB<MyModel>(null, {
         adapter: 'leveldb',
@@ -8,4 +10,3 @@ function testConstructor() {
         adapter: 'leveldb',
     });
 }
-

--- a/types/pouchdb-adapter-leveldb/tslint.json
+++ b/types/pouchdb-adapter-leveldb/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-adapter-localstorage/index.d.ts
+++ b/types/pouchdb-adapter-localstorage/index.d.ts
@@ -1,9 +1,13 @@
-// Type definitions for pouchdb-adapter-localstorage v6.1.2
+// Type definitions for pouchdb-adapter-localstorage 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
     namespace LocalStorageAdapter {
@@ -14,9 +18,9 @@ declare namespace PouchDB {
     }
 
     interface Static {
-        new<Content extends Core.Encodable>(name: string | void,
-            options: LocalStorageAdapter.LocalStorageAdapterConfiguration
-            ): Database<Content>;
+        new<Content extends {}>(name: string | null,
+                                options: LocalStorageAdapter.LocalStorageAdapterConfiguration
+                               ): Database<Content>;
     }
 }
 

--- a/types/pouchdb-adapter-localstorage/pouchdb-adapter-localstorage-tests.ts
+++ b/types/pouchdb-adapter-localstorage/pouchdb-adapter-localstorage-tests.ts
@@ -1,5 +1,7 @@
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
 
     let db = new PouchDB<MyModel>(null, {
         adapter: 'localstorage',

--- a/types/pouchdb-adapter-localstorage/tslint.json
+++ b/types/pouchdb-adapter-localstorage/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-adapter-memory/index.d.ts
+++ b/types/pouchdb-adapter-memory/index.d.ts
@@ -1,9 +1,13 @@
-// Type definitions for pouchdb-adapter-memory v6.1.2
+// Type definitions for pouchdb-adapter-memory 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
     namespace MemoryAdapter {
@@ -14,9 +18,9 @@ declare namespace PouchDB {
     }
 
     interface Static {
-        new<Content extends Core.Encodable>(name: string | void,
-            options: MemoryAdapter.MemoryAdapterConfiguration
-            ): Database<Content>;
+        new<Content extends {}>(name: string | null,
+                                options: MemoryAdapter.MemoryAdapterConfiguration
+                               ): Database<Content>;
     }
 }
 

--- a/types/pouchdb-adapter-memory/pouchdb-adapter-memory-tests.ts
+++ b/types/pouchdb-adapter-memory/pouchdb-adapter-memory-tests.ts
@@ -1,5 +1,7 @@
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
 
     let db = new PouchDB<MyModel>(null, {
         adapter: 'memory',

--- a/types/pouchdb-adapter-memory/tslint.json
+++ b/types/pouchdb-adapter-memory/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-adapter-node-websql/index.d.ts
+++ b/types/pouchdb-adapter-node-websql/index.d.ts
@@ -1,10 +1,14 @@
-// Type definitions for pouchdb-adapter-node-websql v6.1.2
+// Type definitions for pouchdb-adapter-node-websql 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
 /// <reference types="pouchdb-adapter-websql" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare module 'pouchdb-adapter-node-websql' {
     const plugin: PouchDB.Plugin;

--- a/types/pouchdb-adapter-node-websql/pouchdb-adapter-node-websql-tests.ts
+++ b/types/pouchdb-adapter-node-websql/pouchdb-adapter-node-websql-tests.ts
@@ -6,7 +6,9 @@ function isString(someString: string) {
 }
 
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
 
     let db = new PouchDB<MyModel>(null, {
         adapter: 'websql',

--- a/types/pouchdb-adapter-node-websql/tslint.json
+++ b/types/pouchdb-adapter-node-websql/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-adapter-websql/index.d.ts
+++ b/types/pouchdb-adapter-websql/index.d.ts
@@ -1,9 +1,13 @@
-// Type definitions for pouchdb-adapter-websql v6.1.2
+// Type definitions for pouchdb-adapter-websql 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
     namespace Core {
@@ -25,8 +29,8 @@ declare namespace PouchDB {
     }
 
     interface Static {
-        new<Content extends Core.Encodable>(name: string | void,
-            options: AdapterWebSql.Configuration): Database<Content>;
+        new<Content extends {}>(name: string | null,
+                                options: AdapterWebSql.Configuration): Database<Content>;
     }
 }
 

--- a/types/pouchdb-adapter-websql/pouchdb-adapter-websql-tests.ts
+++ b/types/pouchdb-adapter-websql/pouchdb-adapter-websql-tests.ts
@@ -6,8 +6,6 @@ function isString(someString: string) {
 }
 
 function testConstructor() {
-    type MyModel = { numericProperty: number };
-
     let db = new PouchDB('basic');
     db = new PouchDB(null, {
         adapter: 'websql'

--- a/types/pouchdb-adapter-websql/tslint.json
+++ b/types/pouchdb-adapter-websql/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-browser/index.d.ts
+++ b/types/pouchdb-browser/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for pouchdb-browser v6.1.2
+// Type definitions for pouchdb-browser 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
 /// <reference types="pouchdb-adapter-idb" />
@@ -9,6 +10,9 @@
 /// <reference types="pouchdb-adapter-http" />
 /// <reference types="pouchdb-mapreduce" />
 /// <reference types="pouchdb-replication" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare module 'pouchdb-browser' {
     const PouchDb: PouchDB.Static;

--- a/types/pouchdb-browser/pouchdb-browser-tests.ts
+++ b/types/pouchdb-browser/pouchdb-browser-tests.ts
@@ -1,5 +1,7 @@
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
     let model: PouchDB.Core.Document<MyModel>;
 
     let db = new PouchDB<MyModel>(null, {

--- a/types/pouchdb-browser/tslint.json
+++ b/types/pouchdb-browser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Jakub Navratil <https://github.com/trubit>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Typescript Version: 2.3
 
 /// <reference types="node" />
 /// <reference types="debug" />
@@ -19,7 +20,7 @@ declare namespace PouchDB {
         type AttachmentId = string;
         type RevisionId = string;
         type Availability = 'available' | 'compacted' | 'not compacted' | 'missing';
-        type Encodable = { [propertyName: string]: any };
+        type Encodable = {};
         type Attachment = string | Blob | Buffer;
 
         interface Options {
@@ -48,7 +49,7 @@ declare namespace PouchDB {
             update_seq: number | string;
         }
 
-        interface Revision<Content> {
+        interface Revision<Content extends Encodable> {
             ok: Document<Content> & RevisionIdMeta;
         }
         interface RevisionInfo {
@@ -217,10 +218,16 @@ declare namespace PouchDB {
         }
 
         interface BulkGetOptions extends Options {
-            docs: any,
+            docs: Array<{ id: string; rev: RevisionId }>,
             revs?: boolean,
             attachments?: boolean,
             binary?: boolean
+        }
+
+        interface BulkGetResponse<Content extends Encodable> {
+            results: {
+                docs: Array<{ ok: Content & GetMeta } | { error: Error }>;
+            }
         }
 
         interface ChangesMeta {
@@ -458,7 +465,7 @@ declare namespace PouchDB {
 
         debug: debug.IDebug;
 
-        new<Content extends Core.Encodable>(name?: string,
+        new<Content extends Core.Encodable = {}>(name?: string,
             options?: Configuration.DatabaseConfiguration): Database<Content>;
 
         /**
@@ -466,28 +473,28 @@ declare namespace PouchDB {
          * except that whenever you invoke it (e.g. with new), the given options will be passed in by default.
          */
         defaults(options: Configuration.DatabaseConfiguration): {
-            new<Content extends Core.Encodable>(name?: string,
+            new<Content extends Core.Encodable = {}>(name?: string,
                 options?: Configuration.DatabaseConfiguration): Database<Content>;
         }
     }
 
-    interface Database<Content extends Core.Encodable>  {
+    interface Database<Content extends Core.Encodable = {}>  {
 
         /** Fetch all documents matching the given key. */
-        allDocs(options: Core.AllDocsWithKeyOptions):
-            Promise<Core.AllDocsResponse<Content>>;
+        allDocs<Model>(options: Core.AllDocsWithKeyOptions):
+            Promise<Core.AllDocsResponse<Content & Model>>;
 
         /** Fetch all documents matching any of the given keys. */
-        allDocs(options: Core.AllDocsWithKeysOptions):
-            Promise<Core.AllDocsResponse<Content>>;
+        allDocs<Model>(options: Core.AllDocsWithKeysOptions):
+            Promise<Core.AllDocsResponse<Content & Model>>;
 
         /** Fetch all documents matching the given key range. */
-        allDocs(options: Core.AllDocsWithinRangeOptions):
-            Promise<Core.AllDocsResponse<Content>>;
+        allDocs<Model>(options: Core.AllDocsWithinRangeOptions):
+            Promise<Core.AllDocsResponse<Content & Model>>;
 
         /** Fetch all documents. */
-        allDocs(options?: Core.AllDocsOptions):
-            Promise<Core.AllDocsResponse<Content>>;
+        allDocs<Model>(options?: Core.AllDocsOptions):
+            Promise<Core.AllDocsResponse<Content & Model>>;
 
         /**
          * Create, update or delete multiple documents. The docs argument is an array of documents.
@@ -496,9 +503,9 @@ declare namespace PouchDB {
          * which should match the ID and revision of the document on which to base your updates.
          * Finally, to delete a document, include a _deleted parameter with the value true.
          */
-        bulkDocs(docs: Core.PutDocument<Content>[],
-                 options: Core.BulkDocsOptions | null,
-                 callback: Core.Callback<Core.Error, Core.Response[]>): void;
+        bulkDocs<Model>(docs: Core.PutDocument<Content & Model>[],
+                        options: Core.BulkDocsOptions | null,
+                        callback: Core.Callback<Core.Error, Core.Response[]>): void;
 
         /**
          * Create, update or delete multiple documents. The docs argument is an array of documents.
@@ -507,8 +514,8 @@ declare namespace PouchDB {
          * which should match the ID and revision of the document on which to base your updates.
          * Finally, to delete a document, include a _deleted parameter with the value true.
          */
-        bulkDocs(docs: Core.PutDocument<Content>[],
-                 options?: Core.BulkDocsOptions): Promise<Core.Response[]>;
+        bulkDocs<Model>(docs: Core.PutDocument<Content & Model>[],
+                        options?: Core.BulkDocsOptions): Promise<Core.Response[]>;
 
         /** Compact the database */
         compact(options?: Core.CompactOptions): Promise<Core.Response>;
@@ -525,27 +532,27 @@ declare namespace PouchDB {
         destroy(options?: Core.DestroyOptions | void): Promise<void>;
 
         /** Fetch a document */
-        get(docId: Core.DocumentId,
-            options: Core.GetOptions | null,
-            callback: Core.Callback<any, Core.Document<Content> & Core.GetMeta>
-            ): void;
+        get<Model>(docId: Core.DocumentId,
+                   options: Core.GetOptions | null,
+                   callback: Core.Callback<any, Core.Document<Content & Model> & Core.GetMeta>
+                  ): void;
 
         /** Fetch a document */
-        get(docId: Core.DocumentId,
-            options: Core.GetOptions
-            ): Promise<Core.Document<Content> & Core.GetMeta>;
+        get<Model>(docId: Core.DocumentId,
+                   options: Core.GetOptions
+                  ): Promise<Core.Document<Content & Model> & Core.GetMeta>;
 
         /** Fetch a document */
-        get(docId: Core.DocumentId): Promise<Core.Document<Content> & Core.GetMeta>;
+        get<Model>(docId: Core.DocumentId): Promise<Core.Document<Content & Model> & Core.GetMeta>;
 
         /** Fetch document open revs */
-        get(docId: Core.DocumentId,
-            options: Core.GetOpenRevisions,
-            callback: Core.Callback<any, Core.Revision<Content>[]>): void;
+        get<Model>(docId: Core.DocumentId,
+                   options: Core.GetOpenRevisions,
+                   callback: Core.Callback<any, Core.Revision<Content & Model>[]>): void;
 
         /** Fetch document open revs */
-        get(docId: Core.DocumentId,
-            options: Core.GetOpenRevisions): Promise<Core.Revision<Content>[]>;
+        get<Model>(docId: Core.DocumentId,
+                   options: Core.GetOpenRevisions): Promise<Core.Revision<Content & Model>[]>;
 
         /** Create a new document without providing an id.
          *
@@ -555,9 +562,9 @@ declare namespace PouchDB {
          *
          * @see {@link https://pouchdb.com/2014/06/17/12-pro-tips-for-better-code-with-pouchdb.html|PouchDB Pro Tips}
          */
-        post(doc: Core.PostDocument<Content>,
-            options: Core.PostOptions | null,
-            callback: Core.Callback<Core.Error, Core.Response>): void;
+        post<Model>(doc: Core.PostDocument<Content & Model>,
+                    options: Core.PostOptions | null,
+                    callback: Core.Callback<Core.Error, Core.Response>): void;
 
         /** Create a new document without providing an id.
          *
@@ -567,8 +574,8 @@ declare namespace PouchDB {
          *
          * @see {@link https://pouchdb.com/2014/06/17/12-pro-tips-for-better-code-with-pouchdb.html|PouchDB Pro Tips}
          */
-        post(doc: Core.PostDocument<Content>,
-            options?: Core.PostOptions): Promise<Core.Response>;
+        post<Model>(doc: Core.PostDocument<Content & Model>,
+                    options?: Core.PostOptions): Promise<Core.Response>;
 
         /** Create a new document or update an existing document.
          *
@@ -578,9 +585,9 @@ declare namespace PouchDB {
          * If you try to store non-JSON data (for instance Date objects) you may
          * see inconsistent results.
          */
-        put(doc: Core.PutDocument<Content>,
-            options: Core.PutOptions | null,
-            callback: Core.Callback<Core.Error, Core.Response>): void;
+        put<Model>(doc: Core.PutDocument<Content & Model>,
+                   options: Core.PutOptions | null,
+                   callback: Core.Callback<Core.Error, Core.Response>): void;
 
         /** Create a new document or update an existing document.
          *
@@ -590,8 +597,8 @@ declare namespace PouchDB {
          * If you try to store non-JSON data (for instance Date objects) you may
          * see inconsistent results.
          */
-        put(doc: Core.PutDocument<Content>,
-            options?: Core.PutOptions): Promise<Core.Response>;
+        put<Model>(doc: Core.PutDocument<Content & Model>,
+                   options?: Core.PutOptions): Promise<Core.Response>;
 
         /** Remove a doc from the database */
         remove(doc: Core.RemoveDocument,
@@ -627,8 +634,8 @@ declare namespace PouchDB {
          * a 'complete' event when all the changes have been processed, and an 'error' event when an error occurs.
          * Calling cancel() will unsubscribe all event listeners automatically.
          */
-        changes(options: Core.ChangesOptions | null,
-            callback: Core.Callback<any, Core.Changes<Content>>): void;
+        changes<Model>(options: Core.ChangesOptions | null,
+                       callback: Core.Callback<any, Core.Changes<Content & Model>>): void;
 
         /**
          * A list of changes made to documents in the database, in the order they were made.
@@ -638,7 +645,7 @@ declare namespace PouchDB {
          * a 'complete' event when all the changes have been processed, and an 'error' event when an error occurs.
          * Calling cancel() will unsubscribe all event listeners automatically.
          */
-        changes(options?: Core.ChangesOptions): Core.Changes<Content>;
+        changes<Model>(options?: Core.ChangesOptions): Core.Changes<Content & Model>;
 
         /** Close the database */
         close(callback: Core.AnyCallback): void;
@@ -722,11 +729,11 @@ declare namespace PouchDB {
             rev: Core.RevisionId): Promise<Core.RemoveAttachmentResponse>;
 
         /** Given a set of document/revision IDs, returns the document bodies (and, optionally, attachment data) for each ID/revision pair specified. */
-        bulkGet(options: Core.BulkGetOptions,
-            callback: Core.Callback<any, any>): void;
+        bulkGet<Model>(options: Core.BulkGetOptions,
+                       callback: Core.Callback<Core.Error, Core.BulkGetResponse<Content & Model>>): void;
 
         /** Given a set of document/revision IDs, returns the document bodies (and, optionally, attachment data) for each ID/revision pair specified. */
-        bulkGet(options: Core.BulkGetOptions): Promise<any>;
+        bulkGet<Model>(options: Core.BulkGetOptions): Promise<Core.BulkGetResponse<Content & Model>>;
 
         /** Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database */
         revsDiff(diff : Core.RevisionDiffOptions,
@@ -737,6 +744,7 @@ declare namespace PouchDB {
     }
 }
 
+//
 declare module 'pouchdb-core' {
   const PouchDb: PouchDB.Static;
   export = PouchDb;

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -1,26 +1,35 @@
-// Type definitions for pouchdb-core v6.1.2
+// Type definitions for pouchdb-core 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Jakub Navratil <https://github.com/trubit>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Typescript Version: 2.3
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 /// <reference types="debug" />
 
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
+
 declare namespace PouchDB {
     namespace Core {
         interface Error {
+            /**
+             * HTTP Status Code during HTTP or HTTP-like operations
+             */
+            status?: number;
+            name?: string;
+            message?: string;
+            reason?: string;
+            error?: string | boolean;
+            id?: string;
+            rev?: RevisionId;
         }
-        interface Callback<E, R> {
-            (error: E | void, result: R | void): void;
-        }
-        type AnyCallback = Callback<any, any>;
+        type Callback<R> = (error: Error | null, result: R | null) => void;
         type DocumentId = string;
         type DocumentKey = string;
         type AttachmentId = string;
         type RevisionId = string;
         type Availability = 'available' | 'compacted' | 'not compacted' | 'missing';
-        type Encodable = {};
         type Attachment = string | Blob | Buffer;
 
         interface Options {
@@ -49,7 +58,7 @@ declare namespace PouchDB {
             update_seq: number | string;
         }
 
-        interface Revision<Content extends Encodable> {
+        interface Revision<Content extends {}> {
             ok: Document<Content> & RevisionIdMeta;
         }
         interface RevisionInfo {
@@ -57,14 +66,14 @@ declare namespace PouchDB {
             status: Availability;
         }
         interface RevisionDiffOptions {
-            [DocumentId : string]: string[];
+            [DocumentId: string]: string[];
         }
         interface RevisionDiff {
             missing?: string[];
             possible_ancestors?: string[];
         }
         interface RevisionDiffResponse {
-            [DocumentId : string]: RevisionDiff
+            [DocumentId: string]: RevisionDiff;
         }
 
         interface IdMeta {
@@ -86,7 +95,7 @@ declare namespace PouchDB {
             _revisions?: {
                 ids: RevisionId[];
                 start: number;
-            }
+            };
 
             /** Attachments where index is attachmentId */
             _attachments?: Attachments;
@@ -116,15 +125,15 @@ declare namespace PouchDB {
             [attachmentId: string]: AttachmentResponse;
         }
 
-        type NewDocument<Content extends Encodable> = Content;
-        type Document<Content extends Encodable> = Content & IdMeta;
-        type ExistingDocument<Content extends Encodable> =
+        type NewDocument<Content extends {}> = Content;
+        type Document<Content extends {}> = Content & IdMeta;
+        type ExistingDocument<Content extends {}> =
                 Document<Content> & RevisionIdMeta;
 
         /** Existing doc or just object with `_id` and `_rev` */
-        type RemoveDocument = Encodable & IdMeta & RevisionIdMeta;
+        type RemoveDocument = IdMeta & RevisionIdMeta;
 
-        type PostDocument<Content extends Encodable> = NewDocument<Content> & {
+        type PostDocument<Content extends {}> = NewDocument<Content> & {
             filters?: {[filterName: string]: string};
             views?: {[viewName: string]: string};
 
@@ -134,7 +143,7 @@ declare namespace PouchDB {
             _attachments?: {[attachmentId: string]: PutAttachment};
         };
 
-        type PutDocument<Content extends Encodable> = PostDocument<Content> & ChangesMeta & {
+        type PutDocument<Content extends {}> = PostDocument<Content> & ChangesMeta & {
             _id?: DocumentId;
         };
 
@@ -155,11 +164,13 @@ declare namespace PouchDB {
             /** Return attachments as Buffers.
              *
              * Requires `include_docs` to be `true`.
-             * Requires `attachments` to be `true`. */
+             * Requires `attachments` to be `true`.
+             */
             binary?: boolean;
             /** Include conflict information for each document.
              *
-             * Requires `include_docs` to be `true`. */
+             * Requires `include_docs` to be `true`.
+             */
             conflicts?: boolean;
             /** Reverse ordering of results. */
             descending?: boolean;
@@ -169,7 +180,8 @@ declare namespace PouchDB {
             limit?: number;
             /** Number of documents to skip before returning.
              *
-             * Causes poor performance on IndexedDB and LevelDB. */
+             * Causes poor performance on IndexedDB and LevelDB.
+             */
             skip?: number;
         }
         interface AllDocsWithKeyOptions extends AllDocsOptions {
@@ -187,21 +199,21 @@ declare namespace PouchDB {
             endkey: DocumentKey;
             /** Include any documents identified by `endkey`.
              *
-             * Defaults to `true`. */
+             * Defaults to `true`.
+             */
             inclusive_end?: boolean;
         }
         interface AllDocsMeta {
-
             /** Only present if `conflicts` is `true` */
             _conflicts?: RevisionId[];
 
             _attachments?: Attachments;
         }
-        interface AllDocsResponse<Content extends Core.Encodable> {
+        interface AllDocsResponse<Content extends {}> {
             /** The `skip` if provided, or in CouchDB the actual offset */
             offset: number;
             total_rows: number;
-            rows: {
+            rows: Array<{
                 /** Only present if `include_docs` was `true`. */
                 doc?: Document<Content & AllDocsMeta>;
                 id: DocumentId;
@@ -210,24 +222,24 @@ declare namespace PouchDB {
                     rev: RevisionId;
                     deleted?: boolean;
                 }
-            }[];
+            }>;
         }
 
-        interface BulkDocsOptions extends PutOptions {
+        interface BulkDocsOptions extends Options {
             new_edits?: boolean;
         }
 
         interface BulkGetOptions extends Options {
-            docs: Array<{ id: string; rev: RevisionId }>,
-            revs?: boolean,
-            attachments?: boolean,
-            binary?: boolean
+            docs: Array<{ id: string; rev: RevisionId }>;
+            revs?: boolean;
+            attachments?: boolean;
+            binary?: boolean;
         }
 
-        interface BulkGetResponse<Content extends Encodable> {
+        interface BulkGetResponse<Content extends {}> {
             results: {
                 docs: Array<{ ok: Content & GetMeta } | { error: Error }>;
-            }
+            };
         }
 
         interface ChangesMeta {
@@ -283,7 +295,7 @@ declare namespace PouchDB {
              * To use a view function, pass '_view' here and provide a reference to the view function in options.view.
              * See filtered changes for details.
              */
-            filter?: string | {(doc: any, params: any): any};
+            filter?: string | ((doc: any, params: any) => any);
 
             /** Only show changes for docs with these ids (array of strings). */
             doc_ids?: string[];
@@ -303,29 +315,27 @@ declare namespace PouchDB {
             view?: string;
         }
 
-        interface ChangesResponseChange<Content extends Core.Encodable> {
+        interface ChangesResponseChange<Content extends {}> {
             id: string;
             seq: number | string;
-            changes: { rev: string }[];
+            changes: Array<{ rev: string }>;
             deleted?: boolean;
             doc?: ExistingDocument<Content & ChangesMeta>;
         }
 
-        interface ChangesResponse<Content extends Core.Encodable> {
+        interface ChangesResponse<Content extends {}> {
             status: string;
             last_seq: number | string;
-            results: ChangesResponseChange<Content>[];
+            results: Array<ChangesResponseChange<Content>>;
         }
 
-        interface Changes<Content extends Core.Encodable> extends EventEmitter, Promise<ChangesResponse<Content>> {
+        /** @todo: remove nodejs dep. */
+        interface Changes<Content extends {}> extends NodeJS.EventEmitter, Promise<ChangesResponse<Content>> {
             on(event: 'change', listener: (value: ChangesResponseChange<Content>) => any): this;
             on(event: 'complete', listener: (value: ChangesResponse<Content>) => any): this;
             on(event: 'error', listener: (value: any) => any): this;
 
             cancel(): void;
-        }
-
-        interface DestroyOptions extends Options {
         }
 
         interface GetOptions extends Options {
@@ -336,7 +346,8 @@ declare namespace PouchDB {
             /** Include revision history of the document. */
             revs?: boolean;
             /** Include a list of revisions of the document, and their
-             * availability. */
+             * availability.
+             */
             revs_info?: boolean;
 
             /** Include attachment data. */
@@ -352,16 +363,12 @@ declare namespace PouchDB {
         interface GetOpenRevisions extends Options {
             /** Fetch all leaf revisions if open_revs="all" or fetch all leaf
              * revisions specified in open_revs array. Leaves will be returned
-             * in the same order as specified in input array. */
+             * in the same order as specified in input array.
+             */
             open_revs: 'all' | Core.RevisionId[];
 
             /** Include revision history of the document. */
             revs?: boolean;
-        }
-
-        interface PutOptions extends Options {
-        }
-        interface PostOptions extends PutOptions {
         }
 
         interface CompactOptions extends Core.Options {
@@ -376,7 +383,7 @@ declare namespace PouchDB {
     /**
      * Pass this to `PouchDB.plugin()`.
      */
-    export type Plugin = 'This should be passed to PouchDB.plugin()';
+    type Plugin = 'This should be passed to PouchDB.plugin()';
 
     namespace Configuration {
         interface CommonDatabaseConfiguration {
@@ -423,7 +430,7 @@ declare namespace PouchDB {
              */
             headers?: {
                 [name: string]: string;
-            }
+            };
 
             /**
              * Enables transferring cookies and HTTP Authorization information.
@@ -439,7 +446,7 @@ declare namespace PouchDB {
             auth?: {
                 username?: string;
                 password?: string;
-            }
+            };
             /**
              * Disables automatic creation of databases.
              */
@@ -451,49 +458,31 @@ declare namespace PouchDB {
     }
 
     /** @todo: remove nodejs dep. */
-    interface EventEmitter extends NodeJS.EventEmitter {
-
-    }
-
-    interface Static extends EventEmitter {
+    interface Static extends NodeJS.EventEmitter {
         plugin(plugin: Plugin): Static;
 
         version: string;
 
-        on(event: 'created', listener: (dbName: string) => any): this;
-        on(event: 'destroyed', listener: (dbName: string) => any): this;
+        on(event: 'created' | 'destroyed', listener: (dbName: string) => any): this;
 
         debug: debug.IDebug;
 
-        new<Content extends Core.Encodable = {}>(name?: string,
-            options?: Configuration.DatabaseConfiguration): Database<Content>;
+        new<Content extends {} = {}>(name?: string,
+                                     options?: Configuration.DatabaseConfiguration): Database<Content>;
 
         /**
          * The returned object is a constructor function that works the same as PouchDB,
          * except that whenever you invoke it (e.g. with new), the given options will be passed in by default.
          */
         defaults(options: Configuration.DatabaseConfiguration): {
-            new<Content extends Core.Encodable = {}>(name?: string,
-                options?: Configuration.DatabaseConfiguration): Database<Content>;
-        }
+            new<Content extends {} = {}>(name?: string,
+                                         options?: Configuration.DatabaseConfiguration): Database<Content>;
+        };
     }
 
-    interface Database<Content extends Core.Encodable = {}>  {
-
-        /** Fetch all documents matching the given key. */
-        allDocs<Model>(options: Core.AllDocsWithKeyOptions):
-            Promise<Core.AllDocsResponse<Content & Model>>;
-
-        /** Fetch all documents matching any of the given keys. */
-        allDocs<Model>(options: Core.AllDocsWithKeysOptions):
-            Promise<Core.AllDocsResponse<Content & Model>>;
-
-        /** Fetch all documents matching the given key range. */
-        allDocs<Model>(options: Core.AllDocsWithinRangeOptions):
-            Promise<Core.AllDocsResponse<Content & Model>>;
-
-        /** Fetch all documents. */
-        allDocs<Model>(options?: Core.AllDocsOptions):
+    interface Database<Content extends {} = {}>  {
+        /** Fetch all documents matching the given options. */
+        allDocs<Model>(options?: Core.AllDocsWithKeyOptions | Core.AllDocsWithKeysOptions | Core.AllDocsWithinRangeOptions | Core.AllDocsOptions):
             Promise<Core.AllDocsResponse<Content & Model>>;
 
         /**
@@ -503,9 +492,9 @@ declare namespace PouchDB {
          * which should match the ID and revision of the document on which to base your updates.
          * Finally, to delete a document, include a _deleted parameter with the value true.
          */
-        bulkDocs<Model>(docs: Core.PutDocument<Content & Model>[],
+        bulkDocs<Model>(docs: Array<Core.PutDocument<Content & Model>>,
                         options: Core.BulkDocsOptions | null,
-                        callback: Core.Callback<Core.Error, Core.Response[]>): void;
+                        callback: Core.Callback<Core.Response[]>): void;
 
         /**
          * Create, update or delete multiple documents. The docs argument is an array of documents.
@@ -514,7 +503,7 @@ declare namespace PouchDB {
          * which should match the ID and revision of the document on which to base your updates.
          * Finally, to delete a document, include a _deleted parameter with the value true.
          */
-        bulkDocs<Model>(docs: Core.PutDocument<Content & Model>[],
+        bulkDocs<Model>(docs: Array<Core.PutDocument<Content & Model>>,
                         options?: Core.BulkDocsOptions): Promise<Core.Response[]>;
 
         /** Compact the database */
@@ -522,37 +511,37 @@ declare namespace PouchDB {
 
         /** Compact the database */
         compact(options: Core.CompactOptions,
-                callback: Core.Callback<Core.Error, Core.Response>): void;
+                callback: Core.Callback<Core.Response>): void;
 
         /** Destroy the database */
-        destroy(options: Core.DestroyOptions | void,
-            callback: Core.AnyCallback): void;
+        destroy(options: Core.Options | null,
+                callback: Core.Callback<any>): void;
 
         /** Destroy the database */
-        destroy(options?: Core.DestroyOptions | void): Promise<void>;
+        destroy(options?: Core.Options | null): Promise<void>;
 
         /** Fetch a document */
         get<Model>(docId: Core.DocumentId,
-                   options: Core.GetOptions | null,
-                   callback: Core.Callback<any, Core.Document<Content & Model> & Core.GetMeta>
+                   options: Core.GetOptions | Core.GetOpenRevisions | null,
+                   callback: Core.Callback<Core.Document<Content & Model> & Core.GetMeta>
                   ): void;
 
         /** Fetch a document */
         get<Model>(docId: Core.DocumentId,
-                   options: Core.GetOptions
+                   options?: Core.GetOptions | Core.GetOpenRevisions
                   ): Promise<Core.Document<Content & Model> & Core.GetMeta>;
 
-        /** Fetch a document */
-        get<Model>(docId: Core.DocumentId): Promise<Core.Document<Content & Model> & Core.GetMeta>;
-
-        /** Fetch document open revs */
-        get<Model>(docId: Core.DocumentId,
-                   options: Core.GetOpenRevisions,
-                   callback: Core.Callback<any, Core.Revision<Content & Model>[]>): void;
-
-        /** Fetch document open revs */
-        get<Model>(docId: Core.DocumentId,
-                   options: Core.GetOpenRevisions): Promise<Core.Revision<Content & Model>[]>;
+        /** Create a new document without providing an id.
+         *
+         * You should prefer put() to post(), because when you post(), you are
+         * missing an opportunity to use allDocs() to sort documents by _id
+         * (because your _ids are random).
+         *
+         * @see {@link https://pouchdb.com/2014/06/17/12-pro-tips-for-better-code-with-pouchdb.html|PouchDB Pro Tips}
+         */
+        post<Model>(doc: Core.PostDocument<Content & Model>,
+                    options: Core.Options | null,
+                    callback: Core.Callback<Core.Response>): void;
 
         /** Create a new document without providing an id.
          *
@@ -563,19 +552,7 @@ declare namespace PouchDB {
          * @see {@link https://pouchdb.com/2014/06/17/12-pro-tips-for-better-code-with-pouchdb.html|PouchDB Pro Tips}
          */
         post<Model>(doc: Core.PostDocument<Content & Model>,
-                    options: Core.PostOptions | null,
-                    callback: Core.Callback<Core.Error, Core.Response>): void;
-
-        /** Create a new document without providing an id.
-         *
-         * You should prefer put() to post(), because when you post(), you are
-         * missing an opportunity to use allDocs() to sort documents by _id
-         * (because your _ids are random).
-         *
-         * @see {@link https://pouchdb.com/2014/06/17/12-pro-tips-for-better-code-with-pouchdb.html|PouchDB Pro Tips}
-         */
-        post<Model>(doc: Core.PostDocument<Content & Model>,
-                    options?: Core.PostOptions): Promise<Core.Response>;
+                    options?: Core.Options): Promise<Core.Response>;
 
         /** Create a new document or update an existing document.
          *
@@ -586,8 +563,8 @@ declare namespace PouchDB {
          * see inconsistent results.
          */
         put<Model>(doc: Core.PutDocument<Content & Model>,
-                   options: Core.PutOptions | null,
-                   callback: Core.Callback<Core.Error, Core.Response>): void;
+                   options: Core.Options | null,
+                   callback: Core.Callback<Core.Response>): void;
 
         /** Create a new document or update an existing document.
          *
@@ -598,18 +575,18 @@ declare namespace PouchDB {
          * see inconsistent results.
          */
         put<Model>(doc: Core.PutDocument<Content & Model>,
-                   options?: Core.PutOptions): Promise<Core.Response>;
+                   options?: Core.Options): Promise<Core.Response>;
 
         /** Remove a doc from the database */
         remove(doc: Core.RemoveDocument,
                options: Core.Options,
-               callback: Core.Callback<Core.Error, Core.Response>): void;
+               callback: Core.Callback<Core.Response>): void;
 
         /** Remove a doc from the database */
         remove(docId: Core.DocumentId,
                revision: Core.RevisionId,
                options: Core.Options,
-               callback: Core.Callback<Core.Error, Core.Response>): void;
+               callback: Core.Callback<Core.Response>): void;
 
         /** Remove a doc from the database */
         remove(doc: Core.RemoveDocument,
@@ -621,7 +598,7 @@ declare namespace PouchDB {
                options?: Core.Options): Promise<Core.Response>;
 
         /** Get database information */
-        info(callback: Core.Callback<any, Core.DatabaseInfo>): void;
+        info(callback: Core.Callback<Core.DatabaseInfo>): void;
 
         /** Get database information */
         info(): Promise<Core.DatabaseInfo>;
@@ -635,7 +612,7 @@ declare namespace PouchDB {
          * Calling cancel() will unsubscribe all event listeners automatically.
          */
         changes<Model>(options: Core.ChangesOptions | null,
-                       callback: Core.Callback<any, Core.Changes<Content & Model>>): void;
+                       callback: Core.Callback<Core.Changes<Content & Model>>): void;
 
         /**
          * A list of changes made to documents in the database, in the order they were made.
@@ -648,7 +625,7 @@ declare namespace PouchDB {
         changes<Model>(options?: Core.ChangesOptions): Core.Changes<Content & Model>;
 
         /** Close the database */
-        close(callback: Core.AnyCallback): void;
+        close(callback: Core.Callback<any>): void;
 
         /** Close the database */
         close(): Promise<void>;
@@ -659,88 +636,84 @@ declare namespace PouchDB {
          * If the document doesn’t already exist, then this method will create an empty document containing the attachment.
          */
         putAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            rev: Core.RevisionId,
-            attachment: Core.Attachment,
-            type: string,
-            callback: Core.Callback<Core.Error, Core.Response>): void;
+                      attachmentId: Core.AttachmentId,
+                      rev: Core.RevisionId,
+                      attachment: Core.Attachment,
+                      type: string,
+                      callback: Core.Callback<Core.Response>): void;
 
          /**
-         * Attaches a binary object to a document.
-         * This method will update an existing document to add the attachment, so it requires a rev if the document already exists.
-         * If the document doesn’t already exist, then this method will create an empty document containing the attachment.
-         */
+          * Attaches a binary object to a document.
+          * This method will update an existing document to add the attachment, so it requires a rev if the document already exists.
+          * If the document doesn’t already exist, then this method will create an empty document containing the attachment.
+          */
         putAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            rev: Core.RevisionId,
-            attachment: Core.Attachment,
-            type: string): Promise<Core.Response>;
+                      attachmentId: Core.AttachmentId,
+                      rev: Core.RevisionId,
+                      attachment: Core.Attachment,
+                      type: string): Promise<Core.Response>;
 
          /**
-         * Attaches a binary object to a document.
-         * This method will update an existing document to add the attachment, so it requires a rev if the document already exists.
-         * If the document doesn’t already exist, then this method will create an empty document containing the attachment.
-         */
+          * Attaches a binary object to a document.
+          * This method will update an existing document to add the attachment, so it requires a rev if the document already exists.
+          * If the document doesn’t already exist, then this method will create an empty document containing the attachment.
+          */
         putAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            attachment: Core.Attachment,
-            type: string,
-            callback: Core.Callback<Core.Error, Core.Response>): void;
+                      attachmentId: Core.AttachmentId,
+                      attachment: Core.Attachment,
+                      type: string,
+                      callback: Core.Callback<Core.Response>): void;
 
          /**
-         * Attaches a binary object to a document.
-         * This method will update an existing document to add the attachment, so it requires a rev if the document already exists.
-         * If the document doesn’t already exist, then this method will create an empty document containing the attachment.
-         */
+          * Attaches a binary object to a document.
+          * This method will update an existing document to add the attachment, so it requires a rev if the document already exists.
+          * If the document doesn’t already exist, then this method will create an empty document containing the attachment.
+          */
         putAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            attachment: Core.Attachment,
-            type: string): Promise<Core.Response>;
+                      attachmentId: Core.AttachmentId,
+                      attachment: Core.Attachment,
+                      type: string): Promise<Core.Response>;
 
         /** Get attachment data */
         getAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            options: { rev?: Core.RevisionId},
-            callback: Core.Callback<Core.Error, Blob | Buffer>): void;
+                      attachmentId: Core.AttachmentId,
+                      options: { rev?: Core.RevisionId},
+                      callback: Core.Callback<Blob | Buffer>): void;
 
         /** Get attachment data */
         getAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            options: { rev?: Core.RevisionId}): Promise<Blob | Buffer>;
+                      attachmentId: Core.AttachmentId,
+                      options?: { rev?: Core.RevisionId}): Promise<Blob | Buffer>;
 
         /** Get attachment data */
         getAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            callback: Core.Callback<Core.Error, Blob | Buffer>): void;
-
-        /** Get attachment data */
-        getAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId): Promise<Blob | Buffer>;
+                      attachmentId: Core.AttachmentId,
+                      callback: Core.Callback<Blob | Buffer>): void;
 
         /** Delete an attachment from a doc. You must supply the rev of the existing doc. */
         removeAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            rev: Core.RevisionId,
-            callback: Core.Callback<Core.Error, Core.RemoveAttachmentResponse>): void;
+                         attachmentId: Core.AttachmentId,
+                         rev: Core.RevisionId,
+                         callback: Core.Callback<Core.RemoveAttachmentResponse>): void;
 
         /** Delete an attachment from a doc. You must supply the rev of the existing doc. */
         removeAttachment(docId: Core.DocumentId,
-            attachmentId: Core.AttachmentId,
-            rev: Core.RevisionId): Promise<Core.RemoveAttachmentResponse>;
+                         attachmentId: Core.AttachmentId,
+                         rev: Core.RevisionId): Promise<Core.RemoveAttachmentResponse>;
 
         /** Given a set of document/revision IDs, returns the document bodies (and, optionally, attachment data) for each ID/revision pair specified. */
         bulkGet<Model>(options: Core.BulkGetOptions,
-                       callback: Core.Callback<Core.Error, Core.BulkGetResponse<Content & Model>>): void;
+                       callback: Core.Callback<Core.BulkGetResponse<Content & Model>>): void;
 
         /** Given a set of document/revision IDs, returns the document bodies (and, optionally, attachment data) for each ID/revision pair specified. */
         bulkGet<Model>(options: Core.BulkGetOptions): Promise<Core.BulkGetResponse<Content & Model>>;
 
         /** Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database */
-        revsDiff(diff : Core.RevisionDiffOptions,
-            callback: Core.Callback<Core.Error, Core.RevisionDiffResponse>): void;
+        revsDiff(diff: Core.RevisionDiffOptions,
+                 callback: Core.Callback<Core.RevisionDiffResponse>): void;
 
         /** Given a set of document/revision IDs, returns the subset of those that do not correspond to revisions stored in the database */
-        revsDiff(diff : Core.RevisionDiffOptions): Promise<Core.RevisionDiffResponse>;
+        revsDiff(diff: Core.RevisionDiffOptions): Promise<Core.RevisionDiffResponse>;
     }
 }
 

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -534,7 +534,7 @@ declare namespace PouchDB {
 
         /** Fetch a document */
         get<Model>(docId: Core.DocumentId,
-                   options?: Core.GetOptions | Core.GetOpenRevisions
+                   options?: Core.GetOptions
                   ): Promise<Core.Document<Content & Model> & Core.GetMeta>;
 
         /** Fetch a document */

--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -522,14 +522,25 @@ declare namespace PouchDB {
 
         /** Fetch a document */
         get<Model>(docId: Core.DocumentId,
-                   options: Core.GetOptions | Core.GetOpenRevisions | null,
+                   options: Core.GetOptions | null,
                    callback: Core.Callback<Core.Document<Content & Model> & Core.GetMeta>
+                  ): void;
+
+        /** Fetch a document */
+        get<Model>(docId: Core.DocumentId,
+                   options: Core.GetOpenRevisions,
+                   callback: Core.Callback<Array<Core.Revision<Content & Model>>>
                   ): void;
 
         /** Fetch a document */
         get<Model>(docId: Core.DocumentId,
                    options?: Core.GetOptions | Core.GetOpenRevisions
                   ): Promise<Core.Document<Content & Model> & Core.GetMeta>;
+
+        /** Fetch a document */
+        get<Model>(docId: Core.DocumentId,
+                   options: Core.GetOpenRevisions
+                  ): Promise<Array<Core.Revision<Content & Model>>>;
 
         /** Create a new document without providing an id.
          *

--- a/types/pouchdb-core/pouchdb-core-tests.ts
+++ b/types/pouchdb-core/pouchdb-core-tests.ts
@@ -210,3 +210,26 @@ function testRemoteOptions() {
         skip_setup: true
     });
 }
+
+interface Cat {
+    meow: string;
+}
+
+interface Boot {
+    thud: boolean;
+}
+
+async function heterogeneousGenericsDatabase(db: PouchDB.Database) {
+    const cats = await db.allDocs<Cat>({ startkey: 'cat/', endkey: 'cat/\uffff', include_docs: true });
+    for (let row of cats.rows) {
+        if (row.doc) {
+            row.doc.meow; // $ExpectType string
+        }
+    }
+    const boots = await db.allDocs<Boot>({ startkey: 'boot/', endkey: 'boot/\uffff', include_docs: true });
+    for (let row of boots.rows) {
+        if (row.doc) {
+            row.doc.thud; // $ExpectType boolean
+        }
+    }
+}

--- a/types/pouchdb-core/pouchdb-core-tests.ts
+++ b/types/pouchdb-core/pouchdb-core-tests.ts
@@ -17,7 +17,7 @@ function testAllDocs() {
 
             // check document property
             isNumber(doc!.foo);
-        })
+        });
     });
 
     db.allDocs({ startkey: "a", endkey: "b" });
@@ -37,7 +37,9 @@ function testAllDocs() {
 
 function testBulkDocs() {
     const db = new PouchDB<MyModel>();
-    type MyModel = { property: string };
+    interface MyModel {
+        property: string;
+    }
     let model = { property: 'test' };
     let model2 = { property: 'test' };
 
@@ -59,8 +61,8 @@ function testBulkGet() {
 }
 function testRevsDiff() {
     const db = new PouchDB<{}>();
-    db.revsDiff({'a': ['1-a', '2-b']}).then((result) => {});
-    db.revsDiff({'a': ['1-a', '2-b']}, (error, response) => {});
+    db.revsDiff({a: ['1-a', '2-b']}).then((result) => {});
+    db.revsDiff({a: ['1-a', '2-b']}, (error, response) => {});
 }
 
 function testCompact() {
@@ -84,7 +86,9 @@ function testDestroy() {
 }
 
 function testBasics() {
-    type MyModel = { property: string };
+    interface MyModel {
+        property: string;
+    }
     let model = { property: 'test' };
     const id = 'model';
 
@@ -114,7 +118,9 @@ function testBasics() {
 }
 
 function testRemove() {
-    type MyModel = { property: string };
+    interface MyModel {
+        property: string;
+    }
     const id = 'model';
     const rev = 'rev';
     let model = { _id: id, _rev: rev, existingDocProperty: 'any' };
@@ -141,7 +147,9 @@ function testRemove() {
 }
 
 function testChanges() {
-    type MyModel = { foo: string };
+    interface MyModel {
+        foo: string;
+    }
     const db = new PouchDB<MyModel>();
 
     db.changes({
@@ -164,7 +172,7 @@ function testChanges() {
         let _id: string = change.id;
         let _seq: number = change.seq as number;
         let _seq_couch20: string = change.seq as string;
-        let _changes: { rev: string }[] = change.changes;
+        let _changes: Array<{ rev: string }> = change.changes;
         let _foo: string = change.doc!.foo;
         let _deleted: boolean | undefined = change.doc!._deleted;
         let _attachments: PouchDB.Core.Attachments | undefined = change.doc!._attachments;
@@ -178,7 +186,7 @@ function testChanges() {
         let _id: string = change.id;
         let _seq: number = change.seq as number;
         let _seq_couch20: string = change.seq as string;
-        let _changes: { rev: string }[] = change.changes;
+        let _changes: Array<{ rev: string }> = change.changes;
         let _deleted: boolean | undefined = change.doc!._deleted;
         let _attachments: PouchDB.Core.Attachments | undefined = change.doc!._attachments;
     });

--- a/types/pouchdb-core/pouchdb-core-tests.ts
+++ b/types/pouchdb-core/pouchdb-core-tests.ts
@@ -1,3 +1,5 @@
+import * as PouchDB from 'pouchdb-core';
+
 function isString(someString: string) {
 }
 function isNumber(someNumber: number) {
@@ -219,25 +221,29 @@ function testRemoteOptions() {
     });
 }
 
-interface Cat {
-    meow: string;
-}
-
-interface Boot {
-    thud: boolean;
-}
-
-async function heterogeneousGenericsDatabase(db: PouchDB.Database) {
-    const cats = await db.allDocs<Cat>({ startkey: 'cat/', endkey: 'cat/\uffff', include_docs: true });
-    for (let row of cats.rows) {
-        if (row.doc) {
-            row.doc.meow; // $ExpectType string
-        }
+function heterogeneousGenericsDatabase(db: PouchDB.Database) {
+    interface Cat {
+        meow: string;
     }
-    const boots = await db.allDocs<Boot>({ startkey: 'boot/', endkey: 'boot/\uffff', include_docs: true });
-    for (let row of boots.rows) {
-        if (row.doc) {
-            row.doc.thud; // $ExpectType boolean
-        }
+
+    interface Boot {
+        thud: boolean;
     }
+
+    db.allDocs<Cat>({ startkey: 'cat/', endkey: 'cat/\uffff', include_docs: true })
+        .then(cats => {
+            for (let row of cats.rows) {
+                if (row.doc) {
+                    row.doc.meow; // $ExpectType string
+                }
+            }
+        });
+    db.allDocs<Boot>({ startkey: 'boot/', endkey: 'boot/\uffff', include_docs: true })
+        .then(boots => {
+            for (let row of boots.rows) {
+                if (row.doc) {
+                    row.doc.thud; // $ExpectType boolean
+                }
+            }
+        });
 }

--- a/types/pouchdb-core/tslint.json
+++ b/types/pouchdb-core/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-find/index.d.ts
+++ b/types/pouchdb-find/index.d.ts
@@ -1,14 +1,16 @@
-// Type definitions for pouchdb-find v0.10.0
+// Type definitions for pouchdb-find 0.10
 // Project: https://pouchdb.com/
 // Definitions by: Jakub Navratil <https://github.com/trubit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
 
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
+
 declare namespace PouchDB {
-
     namespace Find {
-
         interface ConditionOperators {
             /** Match fields "less than" this one. */
             $lt?: any;
@@ -47,7 +49,7 @@ declare namespace PouchDB {
              * Non-integer values result in a 404 status.
              * Matches documents where (field % Divisor == Remainder) is true, and only when the document field is an integer.
              * [divisor, remainder]
-             * */
+             */
             $mod?: [number, number];
 
             /** A regular expression pattern to match against the document field. Only matches when the field is a string value and matches the supplied regular expression. */
@@ -79,7 +81,7 @@ declare namespace PouchDB {
             _id?: ConditionOperators;
         }
 
-        interface FindRequest<Content extends Core.Encodable> {
+        interface FindRequest<Content extends {}> {
             /** Defines a selector to filter the results. Required */
             selector: Selector;
 
@@ -96,8 +98,8 @@ declare namespace PouchDB {
             skip?: number;
         }
 
-        interface FindResponse<Content extends Core.Encodable> {
-            docs: Core.Document<Content>[];
+        interface FindResponse<Content extends {}> {
+            docs: Array<Core.Document<Content>>;
         }
 
         interface CreateIndexOptions {
@@ -113,10 +115,10 @@ declare namespace PouchDB {
 
                 /** Only supports 'json', and it's also the default */
                 type?: string;
-            }
+            };
         }
 
-        interface CreateIndexResponse<Content extends Core.Encodable> {
+        interface CreateIndexResponse<Content extends {}> {
             result: string;
         }
 
@@ -131,14 +133,14 @@ declare namespace PouchDB {
             type: string;
 
             def: {
-                fields: {
+                fields: Array<{
                     [fieldName: string]: string
-                }[]
-            }
+                }>;
+            };
         }
 
-        interface GetIndexesResponse<Content extends Core.Encodable> {
-            indexes: Index[]
+        interface GetIndexesResponse<Content extends {}> {
+            indexes: Index[];
         }
 
         interface DeleteIndexOptions {
@@ -152,33 +154,30 @@ declare namespace PouchDB {
             type?: string;
         }
 
-        interface DeleteIndexResponse<Content extends Core.Encodable> {
+        interface DeleteIndexResponse<Content extends {}> {
             [propertyName: string]: any;
         }
-
     }
 
-    interface Database<Content extends Core.Encodable> {
-
+    interface Database<Content extends {} = {}> {
         /** Query the API to find some documents. */
         find(request: Find.FindRequest<Content>,
-            callback: Core.Callback<any, Find.FindResponse<Content>>): void;
+             callback: Core.Callback<Find.FindResponse<Content>>): void;
         find(request?: Find.FindRequest<Content>): Promise<Find.FindResponse<Content>>;
 
         /** Create an index if it doesn't exist, or do nothing if it already exists. */
         createIndex(index: Find.CreateIndexOptions,
-            callback: Core.Callback<any, Find.CreateIndexResponse<Content>>): void;
+                    callback: Core.Callback<Find.CreateIndexResponse<Content>>): void;
         createIndex(index?: Find.CreateIndexOptions): Promise<Find.CreateIndexResponse<Content>>;
 
         /** Get a list of all the indexes you've created. Also tells you about the special _all_docs index, i.e. the default index on the _id field. */
-        getIndexes(callback: Core.Callback<any, Find.GetIndexesResponse<Content>>): void;
+        getIndexes(callback: Core.Callback<Find.GetIndexesResponse<Content>>): void;
         getIndexes(): Promise<Find.GetIndexesResponse<Content>>;
 
         /** Delete an index and clean up any leftover data on the disk. */
         deleteIndex(index: Find.DeleteIndexOptions,
-            callback: Core.Callback<any, Find.DeleteIndexResponse<Content>>): void;
+                    callback: Core.Callback<Find.DeleteIndexResponse<Content>>): void;
         deleteIndex(index?: Find.DeleteIndexOptions): Promise<Find.DeleteIndexResponse<Content>>;
-
     }
 }
 

--- a/types/pouchdb-find/pouchdb-find-tests.ts
+++ b/types/pouchdb-find/pouchdb-find-tests.ts
@@ -7,11 +7,11 @@ function testFind() {
         sort: ['fieldName'],
         limit: 1,
         skip: 1
-    })
+    });
 
     db.find({
         selector: {},
-        sort: [{'fieldName': 'asc'}]
+        sort: [{fieldName: 'asc'}]
     });
 
     // test combinations of selectors

--- a/types/pouchdb-find/tslint.json
+++ b/types/pouchdb-find/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-http/index.d.ts
+++ b/types/pouchdb-http/index.d.ts
@@ -1,10 +1,14 @@
-// Type definitions for pouchdb-http v6.1.2
+// Type definitions for pouchdb-http 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
 /// <reference types="pouchdb-adapter-http" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare module 'pouchdb-http' {
     const PouchDb: PouchDB.Static;

--- a/types/pouchdb-http/pouchdb-http-tests.ts
+++ b/types/pouchdb-http/pouchdb-http-tests.ts
@@ -1,5 +1,7 @@
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
     let model: PouchDB.Core.Document<MyModel>;
 
     let db = new PouchDB<MyModel>('myDb', {

--- a/types/pouchdb-http/tslint.json
+++ b/types/pouchdb-http/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -10,6 +10,7 @@
 /* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
+    type BuiltInReducers = '_sum' | '_count' | '_stats';
     type Map<Content extends {}> = (doc: Content) => void;
     /**
      * CouchDB-style Reduction function
@@ -22,13 +23,13 @@ declare namespace PouchDB {
     interface Filter<Content extends {}, Reduction> {
         map: Map<Content>;
         // Assume that Content[] | Reduction[] is enough leverage in most cases to handle intermediate map emits
-        reduce?: Reducer<Content, Reduction> | '_sum' | '_count' | '_stats' | string;
+        reduce?: Reducer<Content, Reduction> | BuiltInReducers | string;
     }
 
     namespace Query {
         interface Options<Content extends {}, Reduction> {
             /** Reduce function, or the string name of a built-in function: '_sum', '_count', or '_stats'. */
-            reduce?: Reducer<Content, Reduction> | '_sum' | '_count' | '_stats' | boolean;
+            reduce?: Reducer<Content, Reduction> | BuiltInReducers | boolean;
             /** Include the document in each row in the doc field. */
             include_docs?: boolean;
             /** Include conflicts in the _conflicts field of a doc. */

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -11,7 +11,12 @@
 
 declare namespace PouchDB {
     type BuiltInReducers = '_sum' | '_count' | '_stats';
-    type Map<Content extends {}> = (doc: Content) => void;
+    /**
+     * CouchDB-style Map function
+     *
+     * @param emit CouchDB does not support emit as an argument and maps defined this way will always run locally
+     */
+    type Map<Content extends {}, Result> = (doc: Content, emit?: (key: any, value: Content | Result) => void) => void;
     /**
      * CouchDB-style Reduction function
      *
@@ -21,8 +26,8 @@ declare namespace PouchDB {
     type Reducer<Content extends {}, Reduction> = (keys: any | null, values: Content[] | Reduction[], rereduce: boolean) => Reduction[] | Reduction;
 
     interface Filter<Content extends {}, Reduction> {
-        map: Map<Content>;
-        // Assume that Content[] | Reduction[] is enough leverage in most cases to handle intermediate map emits
+        // Assume that Content | Reduction is enough leverage in most cases to handle intermediate map emits
+        map: Map<Content, Reduction>;
         reduce?: Reducer<Content, Reduction> | BuiltInReducers | string;
     }
 
@@ -105,17 +110,17 @@ declare namespace PouchDB {
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Result, Model = Content>(fun: string | Map<Model> | Filter<Model, Result>, opts: Query.Options<Model, Result>, callback: Core.Callback<Query.Response<Result>>): void;
+        query<Result, Model = Content>(fun: string | Map<Model, Result> | Filter<Model, Result>, opts: Query.Options<Model, Result>, callback: Core.Callback<Query.Response<Result>>): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Result, Model = Content>(fun: string | Map<Model> | Filter<Model, Result>, callback: Core.Callback<Query.Response<Result>>): void;
+        query<Result, Model = Content>(fun: string | Map<Model, Result> | Filter<Model, Result>, callback: Core.Callback<Query.Response<Result>>): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Result, Model = Content>(fun: string | Map<Model> | Filter<Model, Result>, opts?: Query.Options<Model, Result>): Promise<Query.Response<Result>>;
+        query<Result, Model = Content>(fun: string | Map<Model, Result> | Filter<Model, Result>, opts?: Query.Options<Model, Result>): Promise<Query.Response<Result>>;
     }
 }
 

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -10,15 +10,19 @@
 /* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
+    type Map<Content extends {}> = (doc: Content) => void;
+    // The any below would be the value type from emit(key, value), currently hidden from type information in the Map
+    type Reducer<Content extends {}, Reduction> = (keys: Array<[string, any]> | null, values: Content[] | Reduction[], rereduce: boolean) => Reduction[] | Reduction;
+
     interface Filter<Content extends {}, Reduction> {
-        map(doc: Content): void;
-        reduce?(key: string, value: Content): Reduction;
+        map: Map<Content>;
+        reduce?: Reducer<Content, Reduction> | '_sum' | '_count' | '_stats' | string;
     }
 
     namespace Query {
-        interface Options {
+        interface Options<Content extends {}, Reduction> {
             /** Reduce function, or the string name of a built-in function: '_sum', '_count', or '_stats'. */
-            reduce?: ((...args: any[]) => void) | '_sum' | '_count' | '_stats' | boolean;
+            reduce?: Reducer<Content, Reduction> | '_sum' | '_count' | '_stats' | boolean;
             /** Include the document in each row in the doc field. */
             include_docs?: boolean;
             /** Include conflicts in the _conflicts field of a doc. */
@@ -94,32 +98,17 @@ declare namespace PouchDB {
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model>(fun: string | ((doc: Content & Model) => void), opts: Query.Options, callback: (err: Core.Error, res: Query.Response<Content & Model>) => void): void;
+        query<Model>(fun: string | Map<Content> | Filter<Content, Model>, opts: Query.Options<Content, Model>, callback: Core.Callback<Query.Response<Model>>): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model, Reduction>(fun: Filter<Content & Model, Reduction>, opts: Query.Options, callback: (err: Core.Error, res: Query.Response<Reduction>) => void): void;
+        query<Model>(fun: string | Map<Content> | Filter<Content, Model>, callback: Core.Callback<Query.Response<Model>>): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model>(fun: string | ((doc: Content & Model) => void), callback: (err: Core.Error, res: Query.Response<Content & Model>) => void): void;
-        /**
-         * Invoke a map/reduce function, which allows you to perform more complex queries
-         * on PouchDB than what you get with allDocs().
-         */
-        query<Model, Reduction>(fun: Filter<Content & Model, Reduction>, callback: (err: Core.Error, res: Query.Response<Reduction>) => void): void;
-        /**
-         * Invoke a map/reduce function, which allows you to perform more complex queries
-         * on PouchDB than what you get with allDocs().
-         */
-        query<Model>(fun: string | ((doc: Content & Model) => void), opts?: Query.Options): Promise<Query.Response<Content & Model>>;
-        /**
-         * Invoke a map/reduce function, which allows you to perform more complex queries
-         * on PouchDB than what you get with allDocs().
-         */
-        query<Model, Reduction>(fun: Filter<Content & Model, Reduction>, opts?: Query.Options): Promise<Query.Response<Reduction>>;
+        query<Model>(fun: string | Map<Content> | Filter<Content, Model>, opts?: Query.Options<Content, Model>): Promise<Query.Response<Model>>;
     }
 }
 

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -10,9 +10,9 @@
 /* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
-    interface Filter {
-        map(doc: any): void;
-        reduce?(key: string, value: any): any;
+    interface Filter<Content extends {}, Reduction> {
+        map(doc: Content): void;
+        reduce?(key: string, value: Content): Reduction;
     }
 
     namespace Query {
@@ -94,17 +94,32 @@ declare namespace PouchDB {
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model>(fun: string | Filter | ((doc: any) => void), opts: Query.Options, callback: (err: Core.Error, res: Query.Response<Content & Model>) => void): void;
+        query<Model>(fun: string | ((doc: Content & Model) => void), opts: Query.Options, callback: (err: Core.Error, res: Query.Response<Content & Model>) => void): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model>(fun: string | Filter | ((doc: any) => void), callback: (err: Core.Error, res: Query.Response<Content & Model>) => void): void;
+        query<Model, Reduction>(fun: Filter<Content & Model, Reduction>, opts: Query.Options, callback: (err: Core.Error, res: Query.Response<Reduction>) => void): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model>(fun: string | Filter | ((doc: any) => void), opts?: Query.Options): Promise<Query.Response<Content & Model>>;
+        query<Model>(fun: string | ((doc: Content & Model) => void), callback: (err: Core.Error, res: Query.Response<Content & Model>) => void): void;
+        /**
+         * Invoke a map/reduce function, which allows you to perform more complex queries
+         * on PouchDB than what you get with allDocs().
+         */
+        query<Model, Reduction>(fun: Filter<Content & Model, Reduction>, callback: (err: Core.Error, res: Query.Response<Reduction>) => void): void;
+        /**
+         * Invoke a map/reduce function, which allows you to perform more complex queries
+         * on PouchDB than what you get with allDocs().
+         */
+        query<Model>(fun: string | ((doc: Content & Model) => void), opts?: Query.Options): Promise<Query.Response<Content & Model>>;
+        /**
+         * Invoke a map/reduce function, which allows you to perform more complex queries
+         * on PouchDB than what you get with allDocs().
+         */
+        query<Model, Reduction>(fun: Filter<Content & Model, Reduction>, opts?: Query.Options): Promise<Query.Response<Reduction>>;
     }
 }
 

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -98,17 +98,17 @@ declare namespace PouchDB {
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model>(fun: string | Map<Content> | Filter<Content, Model>, opts: Query.Options<Content, Model>, callback: Core.Callback<Query.Response<Model>>): void;
+        query<Result, Model = Content>(fun: string | Map<Model> | Filter<Model, Result>, opts: Query.Options<Model, Result>, callback: Core.Callback<Query.Response<Result>>): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model>(fun: string | Map<Content> | Filter<Content, Model>, callback: Core.Callback<Query.Response<Model>>): void;
+        query<Result, Model = Content>(fun: string | Map<Model> | Filter<Model, Result>, callback: Core.Callback<Query.Response<Result>>): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query<Model>(fun: string | Map<Content> | Filter<Content, Model>, opts?: Query.Options<Content, Model>): Promise<Query.Response<Model>>;
+        query<Result, Model = Content>(fun: string | Map<Model> | Filter<Model, Result>, opts?: Query.Options<Model, Result>): Promise<Query.Response<Result>>;
     }
 }
 

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -11,11 +11,17 @@
 
 declare namespace PouchDB {
     type Map<Content extends {}> = (doc: Content) => void;
-    // The any below would be the value type from emit(key, value), currently hidden from type information in the Map
-    type Reducer<Content extends {}, Reduction> = (keys: Array<[string, any]> | null, values: Content[] | Reduction[], rereduce: boolean) => Reduction[] | Reduction;
+    /**
+     * CouchDB-style Reduction function
+     *
+     * @param keys From CouchDB documentation: Array of pairs of docid-key for related map function results;
+     *             PouchDB may pass a simple array and also supports complex keys.
+     */
+    type Reducer<Content extends {}, Reduction> = (keys: any | null, values: Content[] | Reduction[], rereduce: boolean) => Reduction[] | Reduction;
 
     interface Filter<Content extends {}, Reduction> {
         map: Map<Content>;
+        // Assume that Content[] | Reduction[] is enough leverage in most cases to handle intermediate map emits
         reduce?: Reducer<Content, Reduction> | '_sum' | '_count' | '_stats' | string;
     }
 

--- a/types/pouchdb-mapreduce/index.d.ts
+++ b/types/pouchdb-mapreduce/index.d.ts
@@ -1,15 +1,18 @@
-// Type definitions for pouchdb-mapreduce v6.1.2
+// Type definitions for pouchdb-mapreduce 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
 
-declare namespace PouchDB {
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
+declare namespace PouchDB {
     interface Filter {
-        map: (doc: any) => void;
-        reduce?: (key: string, value: any) => any;
+        map(doc: any): void;
+        reduce?(key: string, value: any): any;
     }
 
     namespace Query {
@@ -55,19 +58,19 @@ declare namespace PouchDB {
             stale?: 'ok' | 'update_after';
         }
 
-        interface Response<Content extends Core.Encodable> {
+        interface Response<Content extends {}> {
             total_rows: number;
             offset: number;
-            rows: {
+            rows: Array<{
                 id: any;
                 key: any;
                 value: any;
                 doc?: Core.ExistingDocument<Content & Core.AllDocsMeta>;
-            }[]
+            }>;
         }
     }
 
-    export interface Database<Content extends Core.Encodable> {
+    interface Database<Content extends {} = {}> {
         /**
          * Cleans up any stale map/reduce indexes.
          *
@@ -76,7 +79,7 @@ declare namespace PouchDB {
          * to take up space on disk. viewCleanup() removes these unnecessary
          * index files.
          */
-        viewCleanup(callback: PouchDB.Core.Callback<any,Core.BasicResponse>): void;
+        viewCleanup(callback: PouchDB.Core.Callback<Core.BasicResponse>): void;
         /**
          * Cleans up any stale map/reduce indexes.
          *
@@ -91,17 +94,17 @@ declare namespace PouchDB {
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query(fun: string | Filter | Function, opts: Query.Options, callback: (err: Core.Error, res: Query.Response<Content>) => void): void;
+        query<Model>(fun: string | Filter | ((doc: any) => void), opts: Query.Options, callback: (err: Core.Error, res: Query.Response<Content & Model>) => void): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query(fun: string | Filter | Function, callback: (err: Core.Error, res: Query.Response<Content>) => void): void;
+        query<Model>(fun: string | Filter | ((doc: any) => void), callback: (err: Core.Error, res: Query.Response<Content & Model>) => void): void;
         /**
          * Invoke a map/reduce function, which allows you to perform more complex queries
          * on PouchDB than what you get with allDocs().
          */
-        query(fun: string | Filter | Function, opts?: Query.Options): Promise<Query.Response<Content>>;
+        query<Model>(fun: string | Filter | ((doc: any) => void), opts?: Query.Options): Promise<Query.Response<Content & Model>>;
     }
 }
 

--- a/types/pouchdb-mapreduce/pouchdb-mapreduce-tests.ts
+++ b/types/pouchdb-mapreduce/pouchdb-mapreduce-tests.ts
@@ -1,5 +1,7 @@
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
     let model: PouchDB.Core.Document<MyModel>;
 
     let db = new PouchDB<MyModel>('mydb');
@@ -8,14 +10,14 @@ function testConstructor() {
 }
 
 function testQuery() {
-    let pouch = new PouchDB<{}>('mydb');
+    let pouch = new PouchDB('mydb');
     // find pokemon with name === 'Pika pi!'
     pouch.query('my_index/by_name', {
         key          : 'Pika pi!',
         include_docs : true
-    }).then(function (result) {
+    }).then((result) => {
         // handle result
-    }).catch(function (err) {
+    }).catch((err) => {
         // handle errors
     });
 
@@ -25,10 +27,9 @@ function testQuery() {
         endkey       : 'P\uffff',
         limit        : 5,
         include_docs : true
-    }).then(function (result) {
+    }).then((result) => {
         // handle result
-    }).catch(function (err) {
+    }).catch((err) => {
         // handle errors
     });
-
 }

--- a/types/pouchdb-mapreduce/tslint.json
+++ b/types/pouchdb-mapreduce/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-node/index.d.ts
+++ b/types/pouchdb-node/index.d.ts
@@ -1,13 +1,17 @@
-// Type definitions for pouchdb-node v6.1.2
+// Type definitions for pouchdb-node 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Simon Paulger <https://github.com/spaulg>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
 /// <reference types="pouchdb-adapter-leveldb" />
 /// <reference types="pouchdb-adapter-http" />
 /// <reference types="pouchdb-mapreduce" />
 /// <reference types="pouchdb-replication" />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare namespace PouchDB {
     namespace Core {

--- a/types/pouchdb-node/pouchdb-node-tests.ts
+++ b/types/pouchdb-node/pouchdb-node-tests.ts
@@ -1,5 +1,7 @@
 function testConstructor() {
-    type MyModel = { numericProperty: number };
+    interface MyModel {
+        numericProperty: number;
+    }
     let model: PouchDB.Core.Document<MyModel>;
 
     let db = new PouchDB<MyModel>('myDb', {

--- a/types/pouchdb-node/tslint.json
+++ b/types/pouchdb-node/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-replication/index.d.ts
+++ b/types/pouchdb-replication/index.d.ts
@@ -1,14 +1,16 @@
-// Type definitions for pouchdb-replication v6.1.2
+// Type definitions for pouchdb-replication 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Jakub Navratil <https://github.com/trubit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
 
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
+
 declare namespace PouchDB {
-
     namespace Replication {
-
         interface ReplicateOptions {
             /** If true, starts subscribing to future changes in the source database and continue replicating them. */
             live?: boolean;
@@ -25,7 +27,7 @@ declare namespace PouchDB {
              * To use a view function, pass '_view' here and provide a reference to the view function in options.view.
              * See filtered changes for details.
              */
-            filter?: string | {(doc: any, params: any): any};
+            filter?: string | ((doc: any, params: any) => any);
 
             /** Only show changes for docs with these ids (array of strings). */
             doc_ids?: string[];
@@ -76,38 +78,35 @@ declare namespace PouchDB {
              * Defaults to a function that chooses a random backoff between 0 and 2 seconds and doubles every time it fails to connect.
              * The default delay will never exceed 10 minutes.
              */
-            back_off_function?: (delay: number) => number;
+            back_off_function?(delay: number): number;
         }
 
-        interface ReplicationEventEmitter<Content extends Core.Encodable, C, F> extends EventEmitter {
+        interface ReplicationEventEmitter<Content extends {}, C, F> extends NodeJS.EventEmitter {
             on(event: 'change', listener: (info: C) => any): this;
-            on(event: 'paused', listener: (err: {}) => any): this;
+            on(event: 'paused' | 'denied' | 'error', listener: (err: {}) => any): this;
             on(event: 'active', listener: () => any): this;
-            on(event: 'denied', listener: (err: {}) => any): this;
             on(event: 'complete', listener: (info: F) => any): this;
-            on(event: 'error', listener: (err: {}) => any): this;
 
             cancel(): void;
         }
 
-        interface Replication<Content extends Core.Encodable>
+        interface Replication<Content extends {}>
             extends ReplicationEventEmitter<Content, ReplicationResult<Content>, ReplicationResultComplete<Content>>,
                     Promise<ReplicationResultComplete<Content>> {
-
         }
 
-        interface ReplicationResult<Content extends Core.Encodable> {
+        interface ReplicationResult<Content extends {}> {
             doc_write_failures: number;
             docs_read: number;
             docs_written: number;
-            last_seq: number,
-            start_time: Date,
-            ok: boolean,
+            last_seq: number;
+            start_time: Date;
+            ok: boolean;
             errors: any[];
-            docs: Core.ExistingDocument<Content>[];
+            docs: Array<Core.ExistingDocument<Content>>;
         }
 
-        interface ReplicationResultComplete<Content extends Core.Encodable> extends ReplicationResult<Content> {
+        interface ReplicationResultComplete<Content extends {}> extends ReplicationResult<Content> {
             end_time: Date;
             status: string;
         }
@@ -117,26 +116,23 @@ declare namespace PouchDB {
             pull?: ReplicateOptions;
         }
 
-        interface Sync<Content extends Core.Encodable>
+        interface Sync<Content extends {}>
             extends ReplicationEventEmitter<Content, SyncResult<Content>, SyncResultComplete<Content>>,
                     Promise<SyncResultComplete<Content>> {
-
         }
 
-        interface SyncResult<Content extends Core.Encodable> {
+        interface SyncResult<Content extends {}> {
             direction: 'push' | 'pull';
             change: ReplicationResult<Content>;
         }
 
-        interface SyncResultComplete<Content extends Core.Encodable> {
+        interface SyncResultComplete<Content extends {}> {
             push?: ReplicationResultComplete<Content>;
             pull?: ReplicationResultComplete<Content>;
         }
-
     }
 
     interface Static {
-
         /**
          * Replicate data from source to target. Both the source and target can be a PouchDB instance or a string
          * representing a CouchDB database URL or the name of a local PouchDB database. If options.live is true,
@@ -147,7 +143,7 @@ declare namespace PouchDB {
             source: string | Database<Content>,
             target: string | Database<Content>,
             options?: Replication.ReplicateOptions,
-            callback?: Core.Callback<any, Replication.ReplicationResultComplete<Content>>
+            callback?: Core.Callback<Replication.ReplicationResultComplete<Content>>
         ): Replication.Replication<Content>;
 
         /**
@@ -163,13 +159,11 @@ declare namespace PouchDB {
             source: string | Database<Content>,
             target: string | Database<Content>,
             options?: Replication.SyncOptions,
-            callback?: Core.Callback<any, Replication.SyncResultComplete<Content>>
+            callback?: Core.Callback<Replication.SyncResultComplete<Content>>
         ): Replication.Sync<Content>;
-
     }
 
-    interface Database<Content extends Core.Encodable> {
-
+    interface Database<Content extends {} = {}> {
         replicate: {
             /**
              * Replicate data to `target`. Both the source and target can be a PouchDB instance
@@ -180,7 +174,7 @@ declare namespace PouchDB {
             to<Content>(
                 target: string | Database<Content>,
                 options?: Replication.ReplicateOptions,
-                callback?: Core.Callback<any, Replication.ReplicationResultComplete<Content>>
+                callback?: Core.Callback<Replication.ReplicationResultComplete<Content>>
             ): Replication.Replication<Content>;
 
             /**
@@ -192,7 +186,7 @@ declare namespace PouchDB {
             from<Content>(
                 source: string | Database<Content>,
                 options?: Replication.ReplicateOptions,
-                callback?: Core.Callback<any, Replication.ReplicationResultComplete<Content>>
+                callback?: Core.Callback<Replication.ReplicationResultComplete<Content>>
             ): Replication.Replication<Content>;
         };
 
@@ -208,9 +202,8 @@ declare namespace PouchDB {
         sync<Content>(
             remote: string | Database<Content>,
             options?: Replication.SyncOptions,
-            callback?: Core.Callback<any, Replication.SyncResultComplete<Content>>
+            callback?: Core.Callback<Replication.SyncResultComplete<Content>>
         ): Replication.Sync<Content>;
-
     }
 }
 

--- a/types/pouchdb-replication/pouchdb-replication-tests.ts
+++ b/types/pouchdb-replication/pouchdb-replication-tests.ts
@@ -1,13 +1,13 @@
 /** @todo make some real tests */
 function testReplication() {
-    type Model = { foo: number };
+    interface Model {
+        foo: number;
+    }
     const db = new PouchDB<Model>();
 
     db.replicate.to('').then((res: PouchDB.Replication.ReplicationResultComplete<Model>) => {
-
     });
 
     db.replicate.from('').then((res: PouchDB.Replication.ReplicationResultComplete<Model>) => {
-
     });
 }

--- a/types/pouchdb-replication/tslint.json
+++ b/types/pouchdb-replication/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb-upsert/index.d.ts
+++ b/types/pouchdb-upsert/index.d.ts
@@ -1,13 +1,16 @@
-// Type definitions for pouchdb-upsert v2.0.1
+// Type definitions for pouchdb-upsert 2.0
 // Project: https://github.com/pouchdb/upsert
 // Definitions by: Keith D. Moore <https://github.com/keithdmoore>, Andrew Mitchell <https://github.com/hotforfeature>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="pouchdb-core" />
 
-declare namespace PouchDB {
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
-  interface Database<Content extends Core.Encodable> {
+declare namespace PouchDB {
+  interface Database<Content extends {} = {}> {
     /**
      * Perform an upsert (update or insert) operation. Returns a Promise.
      *
@@ -17,7 +20,7 @@ declare namespace PouchDB {
      * If the document does not already exist, then {} will be the input to diffFunc.
      *
      */
-    upsert(docId: Core.DocumentId, diffFun: UpsertDiffCallback<Content>): Promise<Core.Response>;
+    upsert<Model>(docId: Core.DocumentId, diffFun: UpsertDiffCallback<Content & Model>): Promise<Core.Response>;
 
     /**
      * Perform an upsert (update or insert) operation. If a callback is not provided, the Promise based version
@@ -29,8 +32,8 @@ declare namespace PouchDB {
      * If the document does not already exist, then {} will be the input to diffFunc.
      * @param callback - called with the results after operation is completed.
      */
-    upsert(docId: Core.DocumentId, diffFun: UpsertDiffCallback<Content>,
-           callback: Core.Callback<Core.Error, Core.Response>): void;
+    upsert<Model>(docId: Core.DocumentId, diffFun: UpsertDiffCallback<Content & Model>,
+                  callback: Core.Callback<Core.Response>): void;
 
     /**
      * Put a new document with the given docId, if it doesn't already exist. Returns a Promise.
@@ -38,7 +41,7 @@ declare namespace PouchDB {
      * @param doc - the document to insert. Should contain an _id if docId is not specified
      * If the document already exists, then the Promise will just resolve immediately.
      */
-    putIfNotExists(doc: Core.Document<Content>): Promise<Core.Response>;
+    putIfNotExists<Model>(doc: Core.Document<Content & Model>): Promise<Core.Response>;
 
     //
     /**
@@ -51,13 +54,11 @@ declare namespace PouchDB {
      * If you don't specify a callback, then the Promise version of this function will be invoked and it
      * will return a Promise.
      */
-    putIfNotExists(doc: Core.Document<Content>,
-                   callback: Core.Callback<Core.Error, Core.Response>): void;
+    putIfNotExists<Model>(doc: Core.Document<Content & Model>,
+                          callback: Core.Callback<Core.Response>): void;
   }
 
-  interface UpsertDiffCallback<Content extends Core.Encodable> {
-    (doc: Core.Document<Content>): Core.Document<Content>|boolean;
-  }
+  type UpsertDiffCallback<Content extends {}> = (doc: Core.Document<Content>) => Core.Document<Content> | boolean;
 }
 
 declare module 'pouchdb-upsert' {

--- a/types/pouchdb-upsert/pouchdb-upsert-tests.ts
+++ b/types/pouchdb-upsert/pouchdb-upsert-tests.ts
@@ -1,7 +1,10 @@
 import * as pouchdbUpsert from 'pouchdb-upsert';
 PouchDB.plugin(pouchdbUpsert);
 
-type UpsertDocModel = { _id: 'test-doc1', name: 'test' };
+interface UpsertDocModel {
+   _id: 'test-doc1';
+   name: 'test';
+}
 let docToUpsert: PouchDB.Core.Document<UpsertDocModel>;
 const db = new PouchDB<UpsertDocModel>();
 
@@ -14,7 +17,7 @@ function testUpsert_WithPromise_AndReturnDoc() {
 }
 
 function testUpsert_WithPromise_AndReturnBoolean() {
-  db.upsert(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert<UpsertDocModel>(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
     // Make some updates....
     return false;
   }).then((res: PouchDB.Core.Response) => {
@@ -22,7 +25,7 @@ function testUpsert_WithPromise_AndReturnBoolean() {
 }
 
 function testUpsert_WithCallback_AndReturnDoc() {
-  db.upsert(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert<UpsertDocModel>(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
     // Make some updates....
     return doc;
   }, (res: PouchDB.Core.Response) => {});
@@ -30,7 +33,7 @@ function testUpsert_WithCallback_AndReturnDoc() {
 
 function testUpsert_WithCallback_AndReturnBoolean() {
   // callback return boolean
-  db.upsert(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
+  db.upsert<UpsertDocModel>(docToUpsert._id, (doc: PouchDB.Core.Document<UpsertDocModel>) => {
     // Make some updates....
     return false;
   }, (res: PouchDB.Core.Response) => {});

--- a/types/pouchdb-upsert/tslint.json
+++ b/types/pouchdb-upsert/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/pouchdb/index.d.ts
+++ b/types/pouchdb/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for pouchdb v6.1.2
+// Type definitions for pouchdb 6.1
 // Project: https://pouchdb.com/
 // Definitions by: Andy Brown <https://github.com/AGBrown>, Brian Geppert <https://github.com/geppy>, Frederico Galvão <https://github.com/fredgalvao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types='pouchdb-adapter-fruitdown' />
 /// <reference types='pouchdb-adapter-http' />
@@ -17,6 +18,9 @@
 /// <reference types='pouchdb-mapreduce' />
 /// <reference types='pouchdb-node' />
 /// <reference types='pouchdb-replication' />
+
+// TODO: Fixing this lint error will require a large refactor
+/* tslint:disable:no-single-declare-module */
 
 declare module 'pouchdb' {
     const plugin: PouchDB.Static;

--- a/types/pouchdb/pouchdb-tests.ts
+++ b/types/pouchdb/pouchdb-tests.ts
@@ -19,7 +19,7 @@ function testAllDocs() {
 
             // check document property
             isNumber(doc.foo);
-        })
+        });
     });
 
     db.allDocs({ startkey: "a", endkey: "b" });
@@ -48,7 +48,9 @@ function testDestroy() {
 }
 
 function testBasics() {
-    type MyModel = { property: 'someProperty '};
+    interface MyModel {
+        property: 'someProperty ';
+    }
     let model: PouchDB.Core.Document<MyModel>;
     const id = 'model';
 

--- a/types/pouchdb/tslint.json
+++ b/types/pouchdb/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- Add a default to Database's generic parameter allowing easier "bare" usage (requires Typescript 2.3)
- Add a new `<Model>` generic to allow narrowing all calls to specific models at call point. (Generic default not needed here because Typescript already defaults to `{}` or `any` depending on noImplicitAny for all of these sorts of calls.)
- Expand bulkGet to include return type
- Tested and linted the entire family tree in DT

Resolves #17039

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #17039
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

