### PR TITLE
hapi: fix incorrect connection.table() result type

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -1256,13 +1256,14 @@ export interface RoutingTableEntry {
 
 /**
  * [See docs](https://hapijs.com/api/16.1.1#servertablehost) > return value
+ * For source [See source](https://github.com/hapijs/hapi/blob/v16.1.1/lib/route.js#L71)
  */
 export interface Route {
     /**
      * the route config with defaults applied.
      * TODO check type of RouteConfiguration here is correct
      */
-    settings: RouteConfiguration;
+    settings: RouteAdditionalConfigurationOptions;
     /**
      * the HTTP method in lower case.
      * TODO, check if it can contain 'head' or not.
@@ -1270,6 +1271,18 @@ export interface Route {
     method: HTTP_METHODS_PARTIAL_lowercase;
     /** the route path. */
     path: string;
+
+    params: string[];
+
+    connection: ServerConnection;
+
+    fingerprint: string;
+
+    plugin?: any;
+
+    public: RoutePublicInterface;
+
+    server: Server;
 }
 
 /**
@@ -1618,8 +1631,8 @@ export interface ServerConnection {
     /** Described in server.inject [See docs](https://hapijs.com/api/16.1.1#serverinjectoptions-callback) */
     inject(options: string | InjectedRequestOptions, callback: (res: InjectedResponseObject) => void): void;
     inject(options: string | InjectedRequestOptions, ): Promise<InjectedResponseObject>;
-    /** Described in server.table [See docs](https://hapijs.com/api/16.1.1#servertablehost) */
-    table(host?: string): RoutingTableEntry;
+    /** Mentioned but not documented under server.connections [See docs](https://hapijs.com/api/16.1.1#serverconnections) */
+    table(host?: string): Route[];
     /** Described in server.table [See docs](https://hapijs.com/api/16.1.1#serverlookupid) */
     lookup(id: string): RoutePublicInterface | null;
     /** Described in server.table [See docs](https://hapijs.com/api/16.1.1#servermatchmethod-path-host) */

--- a/types/hapi/test/connection/table.ts
+++ b/types/hapi/test/connection/table.ts
@@ -18,3 +18,5 @@ const table = connection.table();
         }
     ]
 */
+
+table.map(({method, path, settings: {description}}) => { });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - fixes #17005
  - call returns its previously received hapi route [here](https://github.com/hapijs/call/blob/master/lib/index.js#L346)
  - hapi defines its route [here](https://github.com/hapijs/hapi/blob/v16.1.1/lib/route.js#L23)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The change basically extends type information of a hapi route (see screenshot in #17005 for example structure) and sets the correct return type for hapi/call `table()` result.
It also changes the type of settings to `RouteAdditionalConfigurationOptions` because, as seen in the screenshot, `settings` contains the whole configuration options and not only `RouteConfiguration`.

![20170608-200641](https://user-images.githubusercontent.com/1205444/26946905-1eb434d2-4c91-11e7-9ed5-85a4c332ade5.png)

