### PR TITLE
[React-Native] Add dark-content as statusbar option

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7273,9 +7273,9 @@ export interface SettingsStatic {
 
 
 /**
- * @enum('default', 'light-content')
+ * @enum('default', 'light-content', 'dark-content')
  */
-export type StatusBarStyle = "default" | "light-content"
+export type StatusBarStyle = "default" | "light-content" | "dark-content"
 
 /**
  * @enum('fade', 'slide')


### PR DESCRIPTION
One statusbar style option is missing

Docs: https://facebook.github.io/react-native/docs/statusbar.html#statusbarstyle
