### PR TITLE
fix(reduxMockStore): mockStore should return intersection of ...

### DIFF
--- a/types/redux-mock-store/index.d.ts
+++ b/types/redux-mock-store/index.d.ts
@@ -10,12 +10,12 @@ declare module 'redux-mock-store' {
 
     function createMockStore<T>(middlewares?: Redux.Middleware[]): mockStore<T>;
 
-    interface MockStore {
+    interface MockStore<T> extends Redux.Store<T> {
         getActions(): any[];
         clearActions(): void;
     }
 
-    export type mockStore<T> = (state?: T) => Redux.Store<T> & MockStore;
+    export type mockStore<T> = (state?: T) => MockStore<T>;
 
     export default createMockStore;
 }

--- a/types/redux-mock-store/index.d.ts
+++ b/types/redux-mock-store/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Redux Mock Store v0.0.6
+// Type definitions for Redux Mock Store v0.0.7
 // Project: https://github.com/arnaudbenard/redux-mock-store
 // Definitions by: Marian Palkus <https://github.com/MarianPalkus>, Cap3 <http://www.cap3.de>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
@@ -6,19 +6,16 @@
 ///<reference types="redux" />
 
 declare module 'redux-mock-store' {
-    import * as Redux from 'redux'
+    import * as Redux from 'redux';
 
     function createMockStore<T>(middlewares?: Redux.Middleware[]): mockStore<T>;
 
-    export type mockStore<T> = (state?: T) => IStore<T>;
-
-    export interface IStore<T> {
-        dispatch(action: any): any;
-        getState(): T;
+    interface MockStore {
         getActions(): any[];
         clearActions(): void;
-        subscribe(listener: Function): Function;
     }
 
-    export default createMockStore
+    export type mockStore<T> = (state?: T) => Redux.Store<T> & MockStore;
+
+    export default createMockStore;
 }

--- a/types/redux-mock-store/package.json
+++ b/types/redux-mock-store/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "redux-mock-store": "^1.2.3"
   }
 }

--- a/types/redux-mock-store/redux-mock-store-tests.ts
+++ b/types/redux-mock-store/redux-mock-store-tests.ts
@@ -1,5 +1,5 @@
 import * as Redux from 'redux';
-import configureStore, {IStore} from 'redux-mock-store';
+import configureStore from 'redux-mock-store';
 
 // Redux store API tests
 // The following test are taken from ../redux/redux-tests.ts
@@ -26,9 +26,8 @@ function loggingMiddleware() {
 
 const storeMock = configureStore<number>([loggingMiddleware]);
 const initialState = 0
-let store: IStore<number>;
 
-store = storeMock(initialState);
+const store = storeMock(initialState);
 
 store.subscribe(() => {
     // ...


### PR DESCRIPTION
Mockstore Interface and `Redux.Store<T>` to be able to use it components e.g: 

```js
// redux-mock-store
const store = configureStore([])(storeState); 

// store does not except IStore Interface, wants that store fullfills Redux.Store<T>
<Component store={store}>  
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.

@KingHenne, @TobiasBales