### PR TITLE
Make Mithril component use more strict.

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -44,6 +44,8 @@ declare namespace Mithril {
 		onbeforeupdate?(this: State, vnode: Vnode<Attrs, State>, old: VnodeDOM<Attrs, State>): boolean | void;
 		/** The onremove hook is called before a DOM element is removed from the document. */
 		onupdate?(this: State, vnode: VnodeDOM<Attrs, State>): any;
+		/** WORKAROUND: TypeScript 2.4 does not allow extending an interface with all-optional properties. */
+		[_: number]: any;
 	}
 
 	interface Hyperscript {

--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -44,7 +44,6 @@ declare namespace Mithril {
 		onbeforeupdate?(this: State, vnode: Vnode<Attrs, State>, old: VnodeDOM<Attrs, State>): boolean | void;
 		/** The onremove hook is called before a DOM element is removed from the document. */
 		onupdate?(this: State, vnode: VnodeDOM<Attrs, State>): any;
-		[s: string]: any;
 	}
 
 	interface Hyperscript {

--- a/types/mithril/test/test-component.ts
+++ b/types/mithril/test/test-component.ts
@@ -1,5 +1,6 @@
 import * as m from 'mithril';
-import {Component, Comp} from 'mithril';
+
+import {Comp, Component} from 'mithril';
 
 ///////////////////////////////////////////////////////////
 // 0.
@@ -44,6 +45,32 @@ const comp2: Component<Comp2Attrs, {}> = {
 		return [m('h2', title), m('p', description)];
 	}
 };
+
+// Correct use
+m(comp2, {title: '', description: ''});
+
+// Correct use with lifecycle method
+m(comp2, {title: '', description: '', oncreate: (v) => v.attrs.title + '\n' + v.attrs.description});
+
+// Properties missing
+// $ExpectError
+m(comp2, {});
+
+// Property 'description' is missing in type '{ title: string; }'.
+// $ExpectError
+m(comp2, {title: ''});
+
+// Property 'title' is missing in type '{ description: string; }'.
+// $ExpectError
+m(comp2, {description: ''});
+
+// Type 'boolean' is not assignable to type 'string'.
+// $ExpectError
+m(comp2, {title: '', description: true});
+
+// Object literal may only specify known properties, and 'foo' does not exist in type 'Comp2Attrs & Lifecycle<Comp2Attrs, {}> & { key?: string | number | undefined; }'.
+// $ExpectError
+m(comp2, {title: '', description: '', foo: ''});
 
 ///////////////////////////////////////////////////////////
 // 3.


### PR DESCRIPTION
* Removed ‘[s: string]: any’ from Lifecycle.
* Added tests for component use. ‘Object literal may only specify known properties’ is the important piece.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: _Not relevant_
- [x] Increase the version number in the header if appropriate. _Not appropriate_
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. _Not substantial_
