### PR TITLE
Add missing triangle prop to react-color GitHub

### DIFF
--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-color 2.11
 // Project: https://github.com/casesandberg/react-color/
-// Definitions by: Karol Janyst <https://github.com/LKay>
+// Definitions by: Karol Janyst <https://github.com/LKay>, Marks Polakovs <https://github.com/markspolakovs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/react-color/lib/components/github/Github.d.ts
+++ b/types/react-color/lib/components/github/Github.d.ts
@@ -4,6 +4,7 @@ import { ColorPickerProps } from "react-color";
 export interface GithubPickerProps extends ColorPickerProps<GithubPicker> {
     colors?: string[];
     width?: string;
+    triangle?: 'hide' | 'top-left' | 'top-right';
 }
 
 export default class GithubPicker extends Component<GithubPickerProps, any> {}


### PR DESCRIPTION
GithubPicker has the "triangle" prop. From the docs:

> triangle - String, Either hide, top-left or top-right. Default top-left

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://casesandberg.github.io/react-color/#api-individual>
- [x] Increase the version number in the header if appropriate. **N/A (at least I don't think it is)**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **N/A**

