### PR TITLE
Update ramda find functions to reflect returning undefined

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -587,8 +587,8 @@ declare namespace R {
          * Returns the first element of the list which matches the predicate, or `undefined` if no
          * element matches.
          */
-        find<T>(fn: (a: T) => boolean, list: T[]): T;
-        find<T>(fn: (a: T) => boolean): (list: T[]) => T;
+        find<T>(fn: (a: T) => boolean, list: T[]): T | undefined;
+        find<T>(fn: (a: T) => boolean): (list: T[]) => T | undefined;
 
 
         /**
@@ -602,8 +602,8 @@ declare namespace R {
          * Returns the last element of the list which matches the predicate, or `undefined` if no
          * element matches.
          */
-        findLast<T>(fn: (a: T) => boolean, list: T[]): T;
-        findLast<T>(fn: (a: T) => boolean): (list: T[]) => T;
+        findLast<T>(fn: (a: T) => boolean, list: T[]): T | undefined;
+        findLast<T>(fn: (a: T) => boolean): (list: T[]) => T | undefined;
 
         /**
          * Returns the index of the last element of the list which matches the predicate, or


### PR DESCRIPTION
The find & findLast functions can both return undefined when the predicate matches nothing. The types don't reflect that.

http://ramdajs.com/docs/#find

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://ramdajs.com/docs/#find
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
