### PR TITLE
Update types/react-input-mask/index.d.ts to export default

### DIFF
--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -41,4 +41,4 @@ declare namespace reactInputMask {
     }
 }
 declare var ReactInputMask: typeof reactInputMask.ReactInputMask;
-export = ReactInputMask;
+export default ReactInputMask;

--- a/types/react-input-mask/react-input-mask-tests.tsx
+++ b/types/react-input-mask/react-input-mask-tests.tsx
@@ -1,4 +1,4 @@
-import * as ReactInputMask from 'react-input-mask';
+import ReactInputMask from 'react-input-mask';
 import * as React from 'react';
 
 <div>


### PR DESCRIPTION
ReactInputMask should be exported as default to be proper used.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/sanniassin/react-input-mask/blob/master/src/index.js>> <<https://github.com/sanniassin/react-input-mask>>
