### PR TITLE
Updated RedisStoreOptions interface in @types/connect-redis

### DIFF
--- a/types/connect-redis/connect-redis-tests.ts
+++ b/types/connect-redis/connect-redis-tests.ts
@@ -2,3 +2,9 @@ import * as connectRedis from "connect-redis";
 import * as session from "express-session";
 
 let RedisStore = connectRedis(session);
+const store = new RedisStore({
+    host: 'localhost',
+    port: 6379,
+    logErrors: error => console.warn(error),
+    scanCount: 80,
+});

--- a/types/connect-redis/index.d.ts
+++ b/types/connect-redis/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for connect-redis
 // Project: https://npmjs.com/package/connect-redis
 // Definitions by: Xavier Stouder <https://github.com/xstoudi>
+//                 Albert Kurniawan <https://github.com/morcerf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="express" />
@@ -32,6 +33,8 @@ declare module "connect-redis" {
             prefix?: string;
             unref?: boolean;
             serializer?: Serializer | JSON;
+            logErrors?: boolean | ((error: string) => void);
+            scanCount?: number;
         }
         interface Serializer {
             stringify: Function;


### PR DESCRIPTION
Added 2 missing properties of the `RedisStoreOptions` interface in `@types/connect-redis`. The missing properties are `logErrors` and `scanCount`, as described [here](https://github.com/tj/connect-redis#options)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/tj/connect-redis#options>
- [x] ~~Increase the version number in the header if appropriate.~~ Not appropriate
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~ Change not substantial
