### PR TITLE
[request] fix for Typescript 2.4

### DIFF
--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -131,8 +131,8 @@ declare namespace request {
     export type RequiredUriUrl = UriOptions | UrlOptions;
 
     interface OptionalUriUrl {
-        uri?: string;
-        url?: string;
+        uri?: string | Url;
+        url?: string | Url;
     }
 
     export type OptionsWithUri = UriOptions & CoreOptions;

--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -68,13 +68,42 @@ declare namespace request {
         TUriUrlOptions> extends RequestAPI<TRequest, TOptions, TUriUrlOptions> {
 
         defaults(options: TOptions): DefaultUriUrlRequestApi<TRequest, TOptions, OptionalUriUrl>;
-        (): TRequest;
-        get(): TRequest;
-        post(): TRequest;
-        put(): TRequest;
-        head(): TRequest;
-        patch(): TRequest;
-        del(): TRequest;
+        (callback?: RequestCallback): TRequest;
+
+        get(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+        get(uri: string, callback?: RequestCallback): TRequest;
+        get(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+        get(callback?: RequestCallback): TRequest;
+
+        post(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+        post(uri: string, callback?: RequestCallback): TRequest;
+        post(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+        post(callback?: RequestCallback): TRequest;
+
+        put(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+        put(uri: string, callback?: RequestCallback): TRequest;
+        put(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+        put(callback?: RequestCallback): TRequest;
+
+        head(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+        head(uri: string, callback?: RequestCallback): TRequest;
+        head(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+        head(callback?: RequestCallback): TRequest;
+
+        patch(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+        patch(uri: string, callback?: RequestCallback): TRequest;
+        patch(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+        patch(callback?: RequestCallback): TRequest;
+
+        del(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+        del(uri: string, callback?: RequestCallback): TRequest;
+        del(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+        del(callback?: RequestCallback): TRequest;
+
+        delete(uri: string, options?: TOptions, callback?: RequestCallback): TRequest;
+        delete(uri: string, callback?: RequestCallback): TRequest;
+        delete(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
+        delete(callback?: RequestCallback): TRequest;
     }
 
     interface CoreOptions {
@@ -130,10 +159,7 @@ declare namespace request {
     }
     export type RequiredUriUrl = UriOptions | UrlOptions;
 
-    interface OptionalUriUrl {
-        uri?: string | Url;
-        url?: string | Url;
-    }
+    export type OptionalUriUrl = RequiredUriUrl | {};
 
     export type OptionsWithUri = UriOptions & CoreOptions;
     export type OptionsWithUrl = UrlOptions & CoreOptions;

--- a/types/request/request-tests.ts
+++ b/types/request/request-tests.ts
@@ -693,3 +693,45 @@ request.get({
 request.get({
   uri: urlModule.parse('http://example.com')
 });
+
+var requestWithOptionalUri = request.defaults({ uri: 'http://example.com' });
+
+requestWithOptionalUri();
+
+requestWithOptionalUri({});
+
+requestWithOptionalUri({ uri: 'http://example.com' });
+
+requestWithOptionalUri({ uri: urlModule.parse('http://example.com') });
+
+requestWithOptionalUri({ url: 'http://example.com' });
+
+requestWithOptionalUri({ url: urlModule.parse('http://example.com') });
+
+requestWithOptionalUri('http://example.com');
+
+requestWithOptionalUri(function() {});
+
+requestWithOptionalUri.get();
+
+requestWithOptionalUri.get(function() {});
+
+requestWithOptionalUri.get('http://example.com');
+
+requestWithOptionalUri.get({});
+
+requestWithOptionalUri.get({
+  url: 'http://example.com'
+});
+
+requestWithOptionalUri.get({
+  uri: 'http://example.com'
+});
+
+requestWithOptionalUri.get({
+  url: urlModule.parse('http://example.com')
+});
+
+requestWithOptionalUri.get({
+  uri: urlModule.parse('http://example.com')
+});


### PR DESCRIPTION
I get this error with typescript 2.4
```
node_modules/@types/request/index.d.ts(66,15): error TS2430: Interface 'DefaultUriUrlRequestApi<TRequest, TOptions, TUriUrlOptions>' incorrectly extends interface 'RequestAPI<TRequest, TOptions, TUriUrlOptions>'.
  Types of property 'defaults' are incompatible.
    Type '(options: TOptions) => DefaultUriUrlRequestApi<TRequest, TOptions, OptionalUriUrl>' is not assignable to type '{ (options: TOptions): RequestAPI<TRequest, TOptions, RequiredUriUrl>; (options: (UriOptions & T
O...'.
      Type 'DefaultUriUrlRequestApi<TRequest, TOptions, OptionalUriUrl>' is not assignable to type 'RequestAPI<TRequest, TOptions, RequiredUriUrl>'.
        Types of property 'delete' are incompatible.
          Type '{ (uri: string, options?: TOptions | undefined, callback?: request.RequestCallback | undefined): ...' is not assignable to type '{ (uri: string, options?: TOptions | undefined, callback?: request.Reque
stCallback | undefined): ...'. Two different types with this name exist, but they are unrelated.
            Types of parameters 'options' and 'options' are incompatible.
              Type '(UriOptions & TOptions) | (UrlOptions & TOptions)' is not assignable to type 'OptionalUriUrl & TOptions'.
                Type 'UriOptions & TOptions' is not assignable to type 'OptionalUriUrl & TOptions'.
                  Type 'UriOptions & TOptions' is not assignable to type 'OptionalUriUrl'.
                    Types of property 'uri' are incompatible.
                      Type 'string | Url' is not assignable to type 'string | undefined'.
                        Type 'Url' is not assignable to type 'string | undefined'.
                          Type 'Url' is not assignable to type 'string'.
```
This pull request should fix this error.