### PR TITLE
mixpanel: declare module as published on npm

### DIFF
--- a/types/mixpanel/index.d.ts
+++ b/types/mixpanel/index.d.ts
@@ -72,3 +72,7 @@ declare namespace Mixpanel
 }
 
 declare var mixpanel:Mixpanel;
+
+declare module 'mixpanel-browser' {
+    export = mixpanel;
+}


### PR DESCRIPTION
The Mixpanel js library is published on npm as `mixpanel-browser`: https://www.npmjs.com/package/mixpanel-browser
This allows importing the library from js, instead of using a var declaration.




Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/mixpanel-browser
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.