### PR TITLE
Creating a separate interface for IncomingMessageHeaders in node/index.d.ts

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -804,12 +804,15 @@ declare module "http" {
         end(str: string, encoding?: string, cb?: Function): void;
         end(data?: any, encoding?: string): void;
     }
+    export interface IncomingMessageHeaders {
+        [key: string]: string | string[];
+    }
     export interface IncomingMessage extends stream.Readable {
         httpVersion: string;
         httpVersionMajor: number;
         httpVersionMinor: number;
         connection: net.Socket;
-        headers: { [key: string]: string | string[] };
+        headers: IncomingMessageHeaders;
         rawHeaders: string[];
         trailers: { [key: string]: string };
         rawTrailers: string[];

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -805,7 +805,7 @@ declare module "http" {
         end(data?: any, encoding?: string): void;
     }
     export interface IncomingMessageHeaders {
-        [key: string]: string | string[];
+        [key: string]: string | string[] | undefined;
     }
     export interface IncomingMessage extends stream.Readable {
         httpVersion: string;


### PR DESCRIPTION
This allows for IncomingMessage.headers types to be extensible per project. Suppose a node service expects a fixed set of headers of certain type (say string), that service can specify custom IncomingMessageHeaders with more concrete types defined.
For example

```
interface IncomingMessageHeaders {
    "host": string;
    "set-cookie": string[]
}
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/http.html#http_message_headers

