### PR TITLE
[react-widgets] Allow custom props on all widgets

### DIFF
--- a/types/react-widgets/lib/CommonProps.d.ts
+++ b/types/react-widgets/lib/CommonProps.d.ts
@@ -19,6 +19,10 @@ interface ReactWidgetsCommonProps<C> extends React.Props<C> {
      * @default false
      */
     isRtl?: boolean;
+    /**
+     * Any other props you wish to pass down to the widgets
+     */
+    [customProp: string]: any;
 }
 
 interface ReactWidgetsCommonDropdownProps<C> extends ReactWidgetsCommonProps<C> {

--- a/types/react-widgets/react-widgets-tests.tsx
+++ b/types/react-widgets/react-widgets-tests.tsx
@@ -54,6 +54,15 @@ class Test extends React.Component<React.Props<{}>, {}> {
                 <NumberPicker disabled readOnly />
                 <SelectList disabled readOnly/>
             </div>
+            <div>
+                <Calendar style={{ width: 400 }} />
+                <Combobox style={{ width: 400 }} />
+                <DateTimePicker style={{ width: 400 }} />
+                <DropdownList style={{ width: 400 }} />
+                <Multiselect style={{ width: 400 }} />
+                <NumberPicker style={{ width: 400 }} />
+                <SelectList style={{ width: 400 }} />
+            </div>
         </div>
         );
     }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
[Source code](https://github.com/jquense/react-widgets/blob/21e3cb1b02e33b2174db3af45811850edd47c841/src/Widget.jsx#L31)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The `Widget` class, which all widgets extend, passes `{...props}` in its `render()` method, therefore TS should allow any custom props of any type.

See [source code](https://github.com/jquense/react-widgets/blob/21e3cb1b02e33b2174db3af45811850edd47c841/src/Widget.jsx#L31)