### PR TITLE
Add types for passport-unique-token

### DIFF
--- a/types/passport-unique-token/index.d.ts
+++ b/types/passport-unique-token/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for passport-unique-token 1.0
+// Project: https://github.com/Lughino/passport-unique-token
+// Definitions by: briman0094 <https://github.com/briman0094>
+//                 Maxime LUCE <https://github.com/SomaticIT>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import passport = require('passport');
+import express = require('express');
+
+export interface StrategyOptions {
+    tokenField?: string;
+    tokenQuery?: string;
+    tokenParams?: string;
+    tokenHeader?: string;
+    failedOnMissing?: boolean;
+    passReqToCallback?: false;
+}
+
+export interface StrategyOptionsWithRequest {
+    tokenField?: string;
+    tokenQuery?: string;
+    tokenParams?: string;
+    tokenHeader?: string;
+    failedOnMissing?: boolean;
+    passReqToCallback: true;
+}
+
+export interface VerifyOptions {
+    message: string;
+}
+
+export type VerifyFunctionWithRequest = (req: express.Request, token: string, done: (error: any, user?: any, options?: VerifyOptions) => void) => void;
+export type VerifyFunction = (token: string, done: (error: any, user?: any, options?: VerifyOptions) => void) => void;
+
+export class Strategy implements passport.Strategy {
+    constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
+    constructor(options: StrategyOptions, verify: VerifyFunction);
+    constructor(verify: VerifyFunction);
+
+    name: string;
+    authenticate: (req: express.Request, options?: object) => void;
+}

--- a/types/passport-unique-token/passport-unique-token-tests.ts
+++ b/types/passport-unique-token/passport-unique-token-tests.ts
@@ -1,0 +1,89 @@
+/**
+ * Created by briman0094 <https://github.com/briman0094>.
+ * Based on passport-local tests by Maxime LUCE <https://github.com/SomaticIT>.
+ */
+
+import express = require("express");
+import passport = require("passport");
+import uniqueToken = require("passport-unique-token");
+
+//#region Test Models
+interface BaseUser {
+    uniqueToken: string;
+}
+
+class User implements BaseUser {
+    uniqueToken: string;
+
+    static findOne(user: BaseUser & any, callback: (err: Error | null, user: User) => void): void {
+        callback(null, new User());
+    }
+
+    verifyPassword(password: string): boolean {
+        return true;
+    }
+}
+//#endregion
+
+// Sample from https://github.com/Lughino/passport-unique-token
+passport.use(new uniqueToken.Strategy((token: string, done: any) => {
+    User.findOne({
+        uniqueToken: token,
+        expireToken: {
+            $gt: Date.now()
+        }
+    }, (err, user) => {
+        if (err) {
+            return done(err);
+        }
+
+        if (!user) {
+            return done(null, false);
+        }
+
+        return done(null, user);
+    });
+}));
+
+passport.use(new uniqueToken.Strategy({
+    tokenField: "q",
+    passReqToCallback: true
+}, (req: express.Request, token: string, done: any) => {
+    User.findOne({
+        uniqueToken: token
+    }, (err, user) => {
+        if (err) {
+            return done(err);
+        }
+
+        if (!user) {
+            return done(null, false);
+        }
+
+        return done(null, user);
+    });
+}));
+
+// Sample from https://github.com/Lughino/passport-unique-token#authenticate
+let app = express();
+
+app.post('/login', authenticate, (req, res) => {
+    res.redirect('/');
+});
+
+function authenticate(req: express.Request, res: express.Response, next: express.NextFunction) {
+    passport.authenticate('token', (err: any, user: any, info: any) => {
+        if (err) {
+            return next(err);
+        }
+
+        if (!user) {
+            res.status(401).json({
+                message: "Incorrect token credentials"
+            });
+        }
+
+        req.user = user;
+        next();
+    });
+}

--- a/types/passport-unique-token/tsconfig.json
+++ b/types/passport-unique-token/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "passport-unique-token-tests.ts"
+    ]
+}

--- a/types/passport-unique-token/tslint.json
+++ b/types/passport-unique-token/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
(Take 2 after fixing lint issues)

- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

Because of the similarity of the two packages, these typings were somewhat based off of the already defined `passport-local` types in this repository. Types have been tested in my own project and work correctly.