### PR TITLE
[request] Allow Url object in optional request API

### DIFF
--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -131,8 +131,8 @@ declare namespace request {
     export type RequiredUriUrl = UriOptions | UrlOptions;
 
     interface OptionalUriUrl {
-        uri?: string;
-        url?: string;
+        uri?: string | Url;
+        url?: string | Url;
     }
 
     export type OptionsWithUri = UriOptions & CoreOptions;


### PR DESCRIPTION
Fixes #17171.

The request types fail on TypeScript 2.4 or above because type checking got better -- because the types of `OptionalUriUrl` were lacking `Url` (which is supported, see ttps://github.com/request/request#requestoptions-callback). 