### PR TITLE
fix(cordova-plugin-inappbrowser): add missing entry of InAppBrowser to Cordova interface

### DIFF
--- a/types/cordova-plugin-inappbrowser/cordova-plugin-inappbrowser-tests.ts
+++ b/types/cordova-plugin-inappbrowser/cordova-plugin-inappbrowser-tests.ts
@@ -1,10 +1,10 @@
 // InAppBrowser plugin
-//----------------------------------------------------------------------
+// ----------------------------------------------------------------------
 
 // signature of window.open() added by InAppBrowser plugin
 // is similar to native window.open signature, so the compiler can's
 // select proper overload, but we cast result to InAppBrowser manually.
-var iab = <InAppBrowser>window.open('google.com', '_self');
+const iab = <InAppBrowser> window.open('google.com', '_self');
 
 iab.addEventListener('loadstart', (ev: InAppBrowserEvent) => { console.log('Start opening ' + ev.url); });
 iab.addEventListener('loadstart', (ev) => { console.log('loadstart' + ev.url); });
@@ -30,5 +30,5 @@ iab.removeEventListener('exit', inAppBrowserCallBack);
 iab.show();
 iab.executeScript(
     { code: "console.log('Injected script in action')" },
-    ()=> { console.log('Script is executed'); }
+    () => { console.log('Script is executed'); }
 );

--- a/types/cordova-plugin-inappbrowser/index.d.ts
+++ b/types/cordova-plugin-inappbrowser/index.d.ts
@@ -6,7 +6,6 @@
 // Copyright (c) Microsoft Open Technologies Inc
 // Licensed under the MIT license.
 // TypeScript Version: 2.3
-type target = "_self" | "_blank" | "_system";
 type channel = "loadstart" | "loadstop" | "loaderror" | "exit";
 
 interface Window {
@@ -18,7 +17,7 @@ interface Window {
      *                 The options string must not contain any blank space, and each feature's
      *                 name/value pairs must be separated by a comma. Feature names are case insensitive.
      */
-    open(url: string, target?: target | string, options?: string, replace?: boolean): InAppBrowser;
+    open(url: string, target?: string, options?: string, replace?: boolean): InAppBrowser;
 }
 
 /**

--- a/types/cordova-plugin-inappbrowser/index.d.ts
+++ b/types/cordova-plugin-inappbrowser/index.d.ts
@@ -1,11 +1,13 @@
-// Type definitions for Apache Cordova InAppBrowser plugin
+// Type definitions for Apache Cordova InAppBrowser plugin 1.7
 // Project: https://github.com/apache/cordova-plugin-inappbrowser
 // Definitions by: Microsoft Open Technologies Inc <http://msopentech.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// 
+//
 // Copyright (c) Microsoft Open Technologies Inc
 // Licensed under the MIT license.
 // TypeScript Version: 2.3
+type target = "_self" | "_blank" | "_system";
+type channel = "loadstart" | "loadstop" | "loaderror" | "exit";
 
 interface Window {
     /**
@@ -16,34 +18,7 @@ interface Window {
      *                 The options string must not contain any blank space, and each feature's
      *                 name/value pairs must be separated by a comma. Feature names are case insensitive.
      */
-    open(url: string, target?: "_self", options?: string): InAppBrowser;
-    /**
-     * Opens a URL in a new InAppBrowser instance, the current browser instance, or the system browser.
-     * @param  url     The URL to load.
-     * @param  target  The target in which to load the URL, an optional parameter that defaults to _self.
-     * @param  options Options for the InAppBrowser. Optional, defaulting to: location=yes.
-     *                 The options string must not contain any blank space, and each feature's
-     *                 name/value pairs must be separated by a comma. Feature names are case insensitive.
-     */
-    open(url: string, target?: "_blank", options?: string): InAppBrowser;
-    /**
-     * Opens a URL in a new InAppBrowser instance, the current browser instance, or the system browser.
-     * @param  url     The URL to load.
-     * @param  target  The target in which to load the URL, an optional parameter that defaults to _self.
-     * @param  options Options for the InAppBrowser. Optional, defaulting to: location=yes.
-     *                 The options string must not contain any blank space, and each feature's
-     *                 name/value pairs must be separated by a comma. Feature names are case insensitive.
-     */
-    open(url: string, target?: "_system", options?: string): InAppBrowser;
-    /**
-     * Opens a URL in a new InAppBrowser instance, the current browser instance, or the system browser.
-     * @param  url     The URL to load.
-     * @param  target  The target in which to load the URL, an optional parameter that defaults to _self.
-     * @param  options Options for the InAppBrowser. Optional, defaulting to: location=yes.
-     *                 The options string must not contain any blank space, and each feature's
-     *                 name/value pairs must be separated by a comma. Feature names are case insensitive.
-     */
-    open(url: string, target?: string, options?: string, replace?: boolean): InAppBrowser;
+    open(url: string, target?: target | string, options?: string, replace?: boolean): InAppBrowser;
 }
 
 /**
@@ -51,10 +26,10 @@ interface Window {
  * NOTE: The InAppBrowser window behaves like a standard web browser, and can't access Cordova APIs.
  */
 interface InAppBrowser extends Window {
-    onloadstart: (type: InAppBrowserEvent) => void;
-    onloadstop: (type: InAppBrowserEvent) => void;
-    onloaderror: (type: InAppBrowserEvent) => void;
-    onexit: (type: InAppBrowserEvent) => void;
+    onloadstart(type: InAppBrowserEvent): void;
+    onloadstop(type: InAppBrowserEvent): void;
+    onloaderror(type: InAppBrowserEvent): void;
+    onexit(type: InAppBrowserEvent): void;
     // addEventListener overloads
     /**
      * Adds a listener for an event from the InAppBrowser.
@@ -65,7 +40,7 @@ interface InAppBrowser extends Window {
      * @param callback  the function that executes when the event fires. The function is
      *                  passed an InAppBrowserEvent object as a parameter.
      */
-    addEventListener(type: "loadstart" | "loadstop" | "loaderror" | "exit", callback: (event: InAppBrowserEvent) => void): void;
+    addEventListener(type: channel, callback: (event: InAppBrowserEvent) => void): void;
     // removeEventListener overloads
     /**
      * Removes a listener for an event from the InAppBrowser.
@@ -77,7 +52,7 @@ interface InAppBrowser extends Window {
      * @param callback  the function that executes when the event fires. The function is
      *                  passed an InAppBrowserEvent object as a parameter.
      */
-    removeEventListener(type: "loadstart" | "loadstop" | "loaderror" | "exit", callback: (event: InAppBrowserEvent) => void): void;
+    removeEventListener(type: channel, callback: (event: InAppBrowserEvent) => void): void;
     /** Closes the InAppBrowser window. */
     close(): void;
     /** Hides the InAppBrowser window. Calling this has no effect if the InAppBrowser was already hidden. */
@@ -96,29 +71,13 @@ interface InAppBrowser extends Window {
      *                  For multi-line scripts, this is the return value of the last statement,
      *                  or the last expression evaluated.
      */
-    executeScript(script: { code: string }, callback: (result: any) => void): void;
-    /**
-     * Injects JavaScript code into the InAppBrowser window.
-     * @param script    Details of the script to run, specifying either a file or code key.
-     * @param callback  The function that executes after the JavaScript code is injected.
-     *                  If the injected script is of type code, the callback executes with
-     *                  a single parameter, which is the return value of the script, wrapped in an Array.
-     *                  For multi-line scripts, this is the return value of the last statement,
-     *                  or the last expression evaluated.
-     */
-    executeScript(script: { file: string }, callback: (result: any) => void): void;
+    executeScript(script: { code: string } | { file: string }, callback: (result: any) => void): void;
     /**
      * Injects CSS into the InAppBrowser window.
      * @param css       Details of the script to run, specifying either a file or code key.
      * @param callback  The function that executes after the CSS is injected.
      */
-    insertCSS(css: { code: string }, callback: () => void): void;
-    /**
-     * Injects CSS into the InAppBrowser window.
-     * @param css       Details of the script to run, specifying either a file or code key.
-     * @param callback  The function that executes after the CSS is injected.
-     */
-    insertCSS(css: { file: string }, callback: () => void): void;
+    insertCSS(css: { code: string } | { file: string }, callback: () => void): void;
 }
 
 interface InAppBrowserEvent extends Event {
@@ -130,4 +89,8 @@ interface InAppBrowserEvent extends Event {
     code: number;
     /** the error message, only in the case of loaderror. */
     message: string;
+}
+
+interface Cordova {
+    InAppBrowser: InAppBrowser;
 }

--- a/types/cordova-plugin-inappbrowser/tslint.json
+++ b/types/cordova-plugin-inappbrowser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR adds the missing interface entry of `InAppBrowser` to `Cordova` in order to fix `Property 'InAppBrowser' does not exist on type 'Cordova'.`
Besides that it enables linting of the types and fixes the reported errors.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apache/cordova-plugin-inappbrowser#cordovainappbrowseropen
- [x] There is an open issue on StackOverflow for the missing entry: https://stackoverflow.com/q/42095516/1902598
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
