### PR TITLE
[react-redux] Explicitly enable inference with `connect()`

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -20,7 +20,11 @@ export interface DispatchProp<S> {
 }
 
 interface ComponentDecorator<TMergedProps, TOwnProps> {
-    <T extends TOwnProps>(component: Component<T & TMergedProps>): ComponentClass<T>;
+    (component: Component<TOwnProps & TMergedProps>): ComponentClass<TOwnProps>;
+}
+
+interface ComponentDecoratorInfer<TMergedProps> {
+    <T>(component: Component<T & TMergedProps>): ComponentClass<T>;
 }
 
 interface ComponentMergeDecorator<TMergedProps, TOwnProps> {
@@ -46,7 +50,7 @@ interface ComponentMergeDecorator<TMergedProps, TOwnProps> {
  * @param mergeProps
  * @param options
  */
-export declare function connect(): ComponentDecorator<DispatchProp<any>, {}>;
+export declare function connect(): ComponentDecoratorInfer<DispatchProp<any>>;
 
 export declare function connect<TStateProps, no_dispatch, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -2,7 +2,7 @@ import { Component, ReactElement } from 'react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Store, Dispatch, bindActionCreators } from 'redux';
-import { connect, Provider, DispatchProp } from 'react-redux';
+import { connect, Provider, DispatchProp, MapStateToProps } from 'react-redux';
 import objectAssign = require('object-assign');
 
 //
@@ -375,6 +375,26 @@ namespace TestTOwnPropsInference {
 
     // This should not compile, which is good.
     // React.createElement(ConnectedWithTypeHint, { anything: 'goes!' });
+
+    interface AllProps {
+        own: string
+        state: string
+    }
+
+    class AllPropsComponent extends React.Component<AllProps & DispatchProp<any>, void> {
+        render() {
+            return <div/>;
+        }
+    }
+
+    type PickedOwnProps = Pick<AllProps, "own">
+    type PickedStateProps = Pick<AllProps, "state">
+
+    const mapStateToPropsForPicked: MapStateToProps<PickedStateProps, PickedOwnProps> = (state: any): PickedStateProps => {
+        return { state: "string" }
+    }
+    const ConnectedWithPickedOwnProps = connect(mapStateToPropsForPicked)(AllPropsComponent);
+    <ConnectedWithPickedOwnProps own="blah" />
 }
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16021


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16969#discussion_r122075760 and brings it almost full circle (but at least with basic `dispatch()`).