### PR TITLE
@types/mongodb: change Default to any

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -994,7 +994,7 @@ export interface WriteOpResult {
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html#~resultCallback
 export type CursorResult = any | void | boolean;
 
-type Default = { [key: string]: any };
+type Default = any;
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Cursor.html
 export class Cursor<T = Default> extends Readable {

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -85,7 +85,7 @@ let options = {
     let cursor: mongodb.Cursor<bag> = collection.find<bag>({color: 'black'})
         cursor.toArray(function (err,r) { r[0].cost} );
         cursor.forEach(function (bag  ) { bag.color }, () => {});
-        collection.findOne({ color: 'white' }).then(() => { })
+        collection.findOne({ color: 'white' }).then(b => { let _b:bag = b; })
         collection.findOne<bag>({ color: 'white' }).then(b => { b.cost; })
     }
     {


### PR DESCRIPTION
change type of `Default` to `any`

**TypeScript Version**
2.4.0

previous it is:
```ts
type Default = any;
```

it may result in code below to be error: 

```ts
import {Db} from 'mongodb';

interface Format{
    a:string;
    b:number;
}

declare let db:Db;
db.collection('Test').find({}).next().then(doc=>{
    let a:Format = doc;
})
```

Make this PR is because there are too many files to modified as `.collection<any>` after update `@types/mongodb`
So for better backward compatibility, maybe `Default` is better to be `any`.

