### PR TITLE
[@types/debug] added overloaded definition for string[]

### DIFF
--- a/types/debug/debug-tests.ts
+++ b/types/debug/debug-tests.ts
@@ -14,6 +14,9 @@ log("Formatted %s (%d args)", "test", 2);
 log("Enabled?: %s", debug.enabled("DefinitelyTyped:log"));
 log("Namespace: %s", log.namespace);
 
+var listOStrings: string[] = ['It', 'is', 'allowed', 'to', 'write', 'more', 'then', 'one', 'string']
+log(...listOStrings)
+
 var error:debug.IDebugger = debug("DefinitelyTyped:error");
 error.log = console.error.bind(console);
 error("This should be printed to stderr");

--- a/types/debug/index.d.ts
+++ b/types/debug/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for debug
 // Project: https://github.com/visionmedia/debug
-// Definitions by: Seon-Wook Park <https://github.com/swook>, Gal Talmor <https://github.com/galtalmor>
+// Definitions by: Seon-Wook Park <https://github.com/swook>
+//                 Gal Talmor <https://github.com/galtalmor>
+//                 Tobias Kopelke <https://github.com/raynode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var debug: debug.IDebug;
@@ -28,6 +30,7 @@ declare namespace debug {
 
     export interface IDebugger {
         (formatter: any, ...args: any[]): void;
+        (...args: string[]): void;
 
         enabled: boolean;
         log: Function;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
There is no real url I can add, I just ran into the problem that debug would not accept this code:
```
const messages: string[] = ['Some', 'Message']
debug(...messages)
```

It fails as the definition was `debug(formatter: any, ...args: any[])` which is incompatible with `debug(...args: string[])`
