### PR TITLE
redux-mock-store export MockStore

### DIFF
--- a/types/redux-mock-store/index.d.ts
+++ b/types/redux-mock-store/index.d.ts
@@ -8,14 +8,16 @@
 declare module 'redux-mock-store' {
     import * as Redux from 'redux';
 
-    function createMockStore<T>(middlewares?: Redux.Middleware[]): mockStore<T>;
-
-    interface MockStore<T> extends Redux.Store<T> {
+    export interface MockStore<T> extends Redux.Store<T> {
         getActions(): any[];
         clearActions(): void;
     }
 
-    export type mockStore<T> = (state?: T) => MockStore<T>;
+    export interface MockStoreCreator<T> {
+        (state?: T): MockStore<T>;
+    }
+
+    function createMockStore<T>(middlewares?: Redux.Middleware[]): MockStoreCreator<T>;
 
     export default createMockStore;
 }

--- a/types/redux-mock-store/redux-mock-store-tests.ts
+++ b/types/redux-mock-store/redux-mock-store-tests.ts
@@ -1,5 +1,5 @@
 import * as Redux from 'redux';
-import configureStore from 'redux-mock-store';
+import configureStore, { MockStore, MockStoreCreator } from 'redux-mock-store';
 
 // Redux store API tests
 // The following test are taken from ../redux/redux-tests.ts
@@ -24,10 +24,10 @@ function loggingMiddleware() {
     };
 }
 
-const storeMock = configureStore<number>([loggingMiddleware]);
+const mockStoreCreator: MockStoreCreator<number> = configureStore<number>([loggingMiddleware]);
 const initialState = 0
 
-const store = storeMock(initialState);
+const store: MockStore<number> = mockStoreCreator(initialState);
 
 store.subscribe(() => {
     // ...


### PR DESCRIPTION
Using this library as-is doesn't allow declaring a variable for the actual store.

```
const mockStore = createMockStore<State>([thunk]);
let store: MockStore<State>;

beforeEach(() => {
    store = mockStore(initialState);
});
```
This should be possible imo.