### PR TITLE
[three] fix of FontLoader callback parameter type from string to Font

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -2100,7 +2100,7 @@ export class FontLoader {
 
     manager: LoadingManager;
 
-    load(url: string, onLoad?: (responseText: string) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): void;
+    load(url: string, onLoad?: (responseFont: Font) => void, onProgress?: (event: ProgressEvent) => void, onError?: (event: ErrorEvent) => void): void;
     parse(json: string): Font;
 }
 


### PR DESCRIPTION
This is a small fix of FontLoader method in the three.js package.
There was a bug suggesting that the load response is string, but it is a Font object already.
I just did not want to loose this fix and I hope I am doing the pull request right. Feel free to ignore my input if I missed some obligatory step.
I am confident that the fix is correct/compiles/works.