### PR TITLE
[datatables.net] Improve declaration of FunctionColumnRender

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -60,11 +60,34 @@ $(document).ready(function () {
         sort: "asc"
     };
 
-    var colRenderFunc: DataTables.FunctionColumnRender = function (data, type, row, meta) {
+    var colRenderFunc: DataTables.FunctionColumnRender = (data: any, type: 'filter' | 'display' | 'type' | 'sort' | undefined | any, row: any, meta: DataTables.CellMetaSettings): any => {
         meta.col;
         meta.row;
         meta.settings;
+        switch (type) {
+            case undefined:
+                return data.value;
+            case 'filter':
+                return data.filterValue;
+            case 'display':
+                return data.displayValue;
+            case 'type':
+                return data.typeValue;
+            case 'sort':
+                return data.sortValue;
+            default:
+                // Extensibility: the render type can be a custom value, useful for plugins that require custom rendering.
+                // Custom values are declared as any.
+                return data.valueForPlugin;
+        }
     };
+
+    colRenderFunc({}, 'filter', {}, null);
+    colRenderFunc({}, 'display', {}, null);
+    colRenderFunc({}, 'type', {}, null);
+    colRenderFunc({}, 'sort', {}, null);
+    colRenderFunc({}, undefined, {}, null);
+    colRenderFunc({}, 'custom value', {}, null);
 
     var col: DataTables.ColumnSettings =
         {

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1604,7 +1604,7 @@ declare namespace DataTables {
     }
 
     interface FunctionColumnRender {
-        (data: any, t: string, row: any, meta: CellMetaSettings): void;
+        (data: any, type: 'filter' | 'display' | 'type' | 'sort' | undefined | any, row: any, meta: CellMetaSettings): any;
     }
 
     interface CellMetaSettings {


### PR DESCRIPTION
This PR improves the declaration of `FunctionColumnRender` and adds missing overloads as described by the documentation.
https://datatables.net/reference/option/columns.render

Resolves #12687
