### PR TITLE
Makes typedefinitions for Cypress match documentation

### DIFF
--- a/types/cypress/cypress-tests.ts
+++ b/types/cypress/cypress-tests.ts
@@ -11,3 +11,28 @@ cy
   .contains('ul', 'oranges').should('have.class', 'query-list')
   .get('.query-button')
   .contains('Save Form').should('have.class', 'btn');
+
+cy
+  .get('form')
+  .find('input')
+  .then($input => $input.click());
+
+cy
+  .wrap({ sum: (a: number, b: number, c: number) => a + b + c })
+  .invoke('sum', 2, 4, 6);
+
+cy
+  .get('ul>li')
+  .each(($el, index, $list) => {
+      // $el is wrapped jquery element
+      if ($el.someMethod() === "something") {
+        // wrap this element so we can
+        // use cypress commands on it
+        cy.wrap($el).click();
+      } else {
+        // do something else
+      }
+    })
+    .spread((x , y, z) => {
+        x + y + z;
+    });

--- a/types/cypress/index.d.ts
+++ b/types/cypress/index.d.ts
@@ -32,9 +32,9 @@ declare namespace Cypress {
     /**
      * @see https://on.cypress.io/api/commands
      */
-    addChildCommand(name: string, fn: (args: any[]) => void): void;
-    addDualCommand(name: string, fn: (args: any[]) => void): void;
-    addParentCommand(name: string, fn: (args: any[]) => void): void;
+    addChildCommand(name: string, fn: (...args: any[]) => void): void;
+    addDualCommand(name: string, fn: (...args: any[]) => void): void;
+    addParentCommand(name: string, fn: (...args: any[]) => void): void;
 
     _: any;
     $: any;
@@ -42,6 +42,7 @@ declare namespace Cypress {
     moment: any;
     Blob: any;
     Promise: any;
+    Log: any;
 
     /**
      * @see https://on.cypress.io/api/cookies
@@ -73,7 +74,7 @@ declare namespace Cypress {
      */
     and(chainers: string, value?: any): Chainable;
     and(chainers: string, method: string, value: any): Chainable;
-    and(fn: (args: any[]) => void): Chainable;
+    and(fn: (currentSubject?: any) => void): Chainable;
 
     /**
      * @see https://on.cypress.io/api/as
@@ -155,7 +156,7 @@ declare namespace Cypress {
     /**
      * @see https://on.cypress.io/api/each
      */
-    each(fn: (args: any[]) => void): Chainable;
+    each(fn: (element?: any, index?: number, $list?: any) => void): Chainable;
 
     /**
      * @see https://on.cypress.io/api/end
@@ -232,7 +233,7 @@ declare namespace Cypress {
     /**
      * @see https://on.cypress.io/api/invoke
      */
-    invoke(functionName: string, args: any[]): Chainable;
+    invoke(functionName: string, ...args: any[]): Chainable;
 
     /**
      * @see https://on.cypress.io/api/its
@@ -317,7 +318,7 @@ declare namespace Cypress {
      */
     route(url: string, response?: any): Chainable;
     route(method: string, url: string, response?: any): Chainable;
-    route(fn: (args: any[]) => void | RouteOptions): Chainable;
+    route(fn: () => RouteOptions | RouteOptions): Chainable;
 
     /**
      * @see https://on.cypress.io/api/screenshot
@@ -346,7 +347,7 @@ declare namespace Cypress {
      */
     should(chainers: string, value?: any): Chainable;
     should(chainers: string, method: string, value: any): Chainable;
-    should(fn: (args: any[]) => void): Chainable;
+    should(fn: (currentSubject?: any) => void): Chainable;
 
     /**
      * @see https://on.cypress.io/api/siblings
@@ -357,7 +358,7 @@ declare namespace Cypress {
     /**
      * @see https://on.cypress.io/api/spread
      */
-    spread(fn: (args: any[]) => void): Chainable;
+    spread(fn: (...args: any[]) => any): Chainable;
 
     /**
      * @see https://on.cypress.io/api/submit
@@ -367,7 +368,7 @@ declare namespace Cypress {
     /**
      * @see https://on.cypress.io/api/then
      */
-    then(fn: (args: any[]) => void): Chainable;
+    then(fn: (currentSubject: any) => any): Chainable;
 
     /**
      * @see https://on.cypress.io/api/title
@@ -415,8 +416,8 @@ declare namespace Cypress {
     /**
      * @see https://on.cypress.io/api/within
      */
-    within(fn: (args: any[]) => void): Chainable;
-    within(options: Loggable, fn: (args: any[]) => void): Chainable; // inconsistent argument order
+    within(fn: (currentSubject?: any) => void): Chainable;
+    within(options: Loggable, fn: (currentSubject?: any) => void): Chainable; // inconsistent argument order
 
     /**
      * @see https://on.cypress.io/api/wrap
@@ -435,7 +436,7 @@ declare namespace Cypress {
   }
 
   interface CookieDefaults {
-    whitelist?: string | string[] | RegExp | ((args: any[]) => void);
+    whitelist?: string | string[] | RegExp | ((cookie: any) => boolean);
   }
 
   interface Loggable {
@@ -494,9 +495,9 @@ declare namespace Cypress {
     delay?: number;
     headers?: object;
     force404?: boolean;
-    onRequest?(args: any[]): void;
-    onResponse?(args: any[]): void;
-    onAbort?(args: any[]): void;
+    onRequest?(...args: any[]): void;
+    onResponse?(...args: any[]): void;
+    onAbort?(...args: any[]): void;
   }
 
   interface SelectOptions extends Loggable, Timeoutable {
@@ -510,13 +511,13 @@ declare namespace Cypress {
     status?: number;
     headers?: object;
     response?: any;
-    onRequest?(args: any[]): void;
-    onResponse?(args: any[]): void;
-    onAbort?(args: any[]): void;
+    onRequest?(...args: any[]): void;
+    onResponse?(...args: any[]): void;
+    onAbort?(...args: any[]): void;
     enable?: boolean;
     force404?: boolean;
     urlMatchingOptions?: object;
-    whitelist?(args: any[]): void;
+    whitelist?(...args: any[]): void;
   }
 
   interface SetCookieOptions extends Loggable, Timeoutable {


### PR DESCRIPTION
URL to documentation or source code which provides context for the suggested changes: https://docs.cypress.io/v1.0/docs

The initial typings were working, but I made them more specific