### PR TITLE
[jquery] jqXHR.fail(failCallback) refers to wrong 'this'

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -3632,8 +3632,8 @@ declare namespace JQuery {
          * @see {@link https://api.jquery.com/deferred.fail/}
          * @since 1.5
          */
-        fail(failCallback: TypeOrArray<jqXHR.FailCallback>,
-             ...failCallbacks: Array<TypeOrArray<jqXHR.FailCallback>>): this;
+        fail(failCallback: TypeOrArray<jqXHR.FailCallback<this>>,
+             ...failCallbacks: Array<TypeOrArray<jqXHR.FailCallback<this>>>): this;
         /**
          * Utility method to filter and/or chain Deferreds.
          *
@@ -3699,8 +3699,8 @@ declare namespace JQuery {
             (data: TResolve, textStatus: Ajax.SuccessTextStatus, jqXHR: jqXHR<TResolve>): void;
         }
 
-        interface FailCallback {
-            (jqXHR: this, textStatus: Ajax.ErrorTextStatus | null, errorThrown: string): void;
+        interface FailCallback<TResolve> {
+            (jqXHR: TResolve, textStatus: Ajax.ErrorTextStatus | null, errorThrown: string): void;
         }
 
         interface AlwaysCallback<TResolve = any> {

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -179,4 +179,15 @@ function jqXHR() {
             value;
         });
     }
+
+    function fail() {
+        $.ajax('/echo').fail((jqXHR, textStatus, errorThrown) => {
+            // $ExpectType jqXHR<any>
+            jqXHR;
+            // $ExpectType "abort" | "timeout" | "error" | "parsererror" | null
+            textStatus;
+            // $ExpectType string
+            errorThrown;
+        });
+    }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17239#issuecomment-309000880
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~