### PR TITLE
cryptiles: add initial typing for 3.1

### DIFF
--- a/types/cryptiles/cryptiles-tests.ts
+++ b/types/cryptiles/cryptiles-tests.ts
@@ -1,0 +1,5 @@
+import * as cryptiles from "cryptiles";
+
+cryptiles.randomString(0); // $ExpectType string
+cryptiles.randomDigits(0); // $ExpectType string
+cryptiles.fixedTimeComparison("", ""); // $ExpectTpe boolean

--- a/types/cryptiles/index.d.ts
+++ b/types/cryptiles/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for cryptiles 3.1
+// Project: https://github.com/hapijs/cryptiles
+// Definitions by: Alex Wendland <https://github.com/awendland>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Returns a cryptographically strong pseudo-random data string. Takes a size argument for the length of the string.
+ */
+export function randomString(size: number): string;
+
+/**
+ * Returns a cryptographically strong pseudo-random data string consisting of only numerical digits (0-9).
+ * Takes a size argument for the length of the string.
+ */
+export function randomDigits(size: number): string;
+
+/**
+ * Compare two strings using fixed time algorithm (to prevent time-based analysis of MAC digest match).
+ * Returns true if the strings match, false if they differ.
+ */
+export function fixedTimeComparison(a: string, b: string): boolean;

--- a/types/cryptiles/tsconfig.json
+++ b/types/cryptiles/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cryptiles-tests.ts"
+    ]
+}

--- a/types/cryptiles/tslint.json
+++ b/types/cryptiles/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adding type information for `hapijs/cryptiles`. This brings it inline with the type setup for `hapijs/hapi`.

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.