### PR TITLE
gulp-watch - Extend options with vinyl-fs src options

### DIFF
--- a/types/gulp-watch/gulp-watch-tests.ts
+++ b/types/gulp-watch/gulp-watch-tests.ts
@@ -25,3 +25,15 @@ gulp.task('build', () => {
     gulp.src(files, { base: '..' })
         .pipe(watch(files, { base: '..' }));
 });
+
+gulp.task('build', () => {
+    var files = [
+        'app/**/*.ts',
+        'lib/**/*.ts',
+        'components/**/*.ts',
+    ];
+
+    gulp.src(files, { cwd: '..' })
+        .pipe(watch(files, { base: '..' }));
+});
+

--- a/types/gulp-watch/index.d.ts
+++ b/types/gulp-watch/index.d.ts
@@ -5,8 +5,9 @@
 
 /// <reference types="node" />
 
+import {SrcOptions} from "vinyl-fs";
 
-interface IOptions {
+interface IOptions extends SrcOptions {
     ignoreInitial?: boolean;
     events?: Array<string>;
     base?: string;


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/floatdrop/gulp-watch#options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
