### PR TITLE
[jquery] factory() is not a global.

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -25,14 +25,16 @@
 // TypeScript Version: 2.3
 
 declare module 'jquery' {
+    function factory(window: Window, noGlobal?: boolean): JQueryStatic;
+
     export = factory;
 }
 
 declare module 'jquery/dist/jquery.slim' {
+    function factory(window: Window, noGlobal?: boolean): JQueryStatic;
+
     export = factory;
 }
-
-declare function factory(window: Window, noGlobal?: boolean): JQueryStatic;
 
 declare const jQuery: JQueryStatic;
 declare const $: JQueryStatic;

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2224,7 +2224,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.4.3
      * @deprecated 3.0
      */
-    unbind(event: string, handler: JQuery.EventHandler<TElement> | false | false): this;
+    unbind(event: string, handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Remove a previously-attached event handler from the elements.
      *


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

`Event` is still being exposed as `JQuery.Event` and shouldn't be. I couldn't figure out a decent way to fix it.