### PR TITLE
Create express-enforces-ssl typings.

### DIFF
--- a/types/express-enforces-ssl/express-enforces-ssl-tests.ts
+++ b/types/express-enforces-ssl/express-enforces-ssl-tests.ts
@@ -1,0 +1,6 @@
+import express = require('express');
+import expressEnforcesSsl = require('express-enforces-ssl');
+
+let app: express.Express = express();
+
+app.use(expressEnforcesSsl());

--- a/types/express-enforces-ssl/index.d.ts
+++ b/types/express-enforces-ssl/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for express-enforces-ssl 1.1
+// Project: https://github.com/aredo/express-enforces-ssl
+// Definitions by: Kevin Stubbs <https://github.com/kevinstubbs>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Enforces HTTPS connections on any incoming requests.
+ */
+declare function enforceHTTPS(): (req: Request, res: Response, next: NextFunction) => void;
+
+declare namespace enforceHTTPS {
+}
+
+export = enforceHTTPS;

--- a/types/express-enforces-ssl/index.d.ts
+++ b/types/express-enforces-ssl/index.d.ts
@@ -10,7 +10,4 @@ import { Request, Response, NextFunction } from 'express';
  */
 declare function enforceHTTPS(): (req: Request, res: Response, next: NextFunction) => void;
 
-declare namespace enforceHTTPS {
-}
-
 export = enforceHTTPS;

--- a/types/express-enforces-ssl/tsconfig.json
+++ b/types/express-enforces-ssl/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-enforces-ssl-tests.ts"
+    ]
+}

--- a/types/express-enforces-ssl/tslint.json
+++ b/types/express-enforces-ssl/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Creating definitions for the express-enforces-ssl module.
https://www.npmjs.com/package/express-enforces-ssl

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
