### PR TITLE
[jquery] Module should export factory or JQueryStatic

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -659,18 +659,12 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * Reduce the set of matched elements to the one at the specified index.
      *
      * @param index An integer indicating the 0-based position of the element.
+     *              An integer indicating the position of the element, counting backwards from the last element in the set.
      * @see {@link https://api.jquery.com/eq/}
      * @since 1.1.2
-     */
-    eq(index: number): this;
-    /**
-     * Reduce the set of matched elements to the one at the specified index.
-     *
-     * @param indexFromEnd An integer indicating the position of the element, counting backwards from the last element in the set.
-     * @see {@link https://api.jquery.com/eq/}
      * @since 1.4
      */
-    eq(indexFromEnd: number): this;
+    eq(index: number): this;
     /**
      * Merge the contents of an object onto the jQuery prototype to provide new jQuery instance methods.
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -25,14 +25,16 @@
 // TypeScript Version: 2.3
 
 declare module 'jquery' {
+    function factory(window: Window, noGlobal?: boolean): JQueryStatic;
+
     export = factory;
 }
 
 declare module 'jquery/dist/jquery.slim' {
+    function factory(window: Window, noGlobal?: boolean): JQueryStatic;
+
     export = factory;
 }
-
-declare function factory(window: Window, noGlobal?: boolean): JQueryStatic;
 
 declare const jQuery: JQueryStatic;
 declare const $: JQueryStatic;

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -25,15 +25,17 @@
 // TypeScript Version: 2.3
 
 declare module 'jquery' {
-    function factory(window: Window, noGlobal?: boolean): JQueryStatic;
+    function factory(window: Window): JQueryStatic;
 
-    export = factory;
+    const factoryOrJQuery: typeof factory & JQueryStatic;
+    export = factoryOrJQuery;
 }
 
 declare module 'jquery/dist/jquery.slim' {
-    function factory(window: Window, noGlobal?: boolean): JQueryStatic;
+    function factory(window: Window): JQueryStatic;
 
-    export = factory;
+    const factoryOrJQuery: typeof factory & JQueryStatic;
+    export = factoryOrJQuery;
 }
 
 declare const jQuery: JQueryStatic;
@@ -3641,7 +3643,6 @@ declare namespace JQuery {
          *
          * @param doneFilter An optional function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
-         * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see {@link https://api.jquery.com/deferred.pipe/}
          * @since 1.6
          * @since 1.7
@@ -3687,7 +3688,6 @@ declare namespace JQuery {
          *
          * @param doneFilter A function that is called when the Deferred is resolved.
          * @param failFilter An optional function that is called when the Deferred is rejected.
-         * @param progressFilter An optional function that is called when progress notifications are sent to the Deferred.
          * @see {@link https://api.jquery.com/deferred.then/}
          * @since 1.8
          */

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2224,7 +2224,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.4.3
      * @deprecated 3.0
      */
-    unbind(event: string, handler: JQuery.EventHandler<TElement> | false | false): this;
+    unbind(event: string, handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Remove a previously-attached event handler from the elements.
      *


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17239#issuecomment-309241804
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

jQuery can export `JQueryStatic` if `global.document` is available.
```javascript
module.exports = global.document ?
    factory( global, true ) :
    function( w ) {
        if ( !w.document ) {
            throw new Error( "jQuery requires a window with a document" );
        }
        return factory( w );
    };
```
This also corrects the `factory` signature and makes the import form `import * as $ from 'jquery';` possible.