### PR TITLE
[swagger-tools] Swagger UI 2.0 does not require options

### DIFF
--- a/types/swagger-tools/index.d.ts
+++ b/types/swagger-tools/index.d.ts
@@ -58,7 +58,7 @@ export interface Middleware12 extends Middleware {
 }
 
 export interface Middleware20 extends Middleware {
-    swaggerUi(options: SwaggerUiOptions): NextHandleFunction;
+    swaggerUi(options?: SwaggerUiOptions): NextHandleFunction;
 }
 
 export type InitializeMiddlewareCallback12 = (middleware: Middleware12) => void;

--- a/types/swagger-tools/swagger-tools-tests.ts
+++ b/types/swagger-tools/swagger-tools-tests.ts
@@ -36,6 +36,7 @@ swaggerTools.initializeMiddleware(swaggerDoc20, middleware => {
 
     // Serve the Swagger documents and Swagger UI
     app.use(middleware.swaggerUi(swaggerUiOptions));
+    app.use(middleware.swaggerUi());
 
     // Start the server
     createServer(app).listen(serverPort, () => {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I made a small error in the original version of this, in that I required `options` for the 2.0 Swagger UI. This is not actually required.