### PR TITLE
@types/react: Updated Ref signature to handle null cases

### DIFF
--- a/types/react-smooth-scrollbar/react-smooth-scrollbar-tests.tsx
+++ b/types/react-smooth-scrollbar/react-smooth-scrollbar-tests.tsx
@@ -5,10 +5,12 @@ import * as SmoothScrollbar from "react-smooth-scrollbar";
 <SmoothScrollbar speed={10} overscrollEffect="bounce" />;
 
 class Test extends React.Component<void, void> {
-    ref: SmoothScrollbar;
+    ref: SmoothScrollbar | null;
 
     componentDidMount() {
-        this.ref.scrollbar.scrollTo(0, 500);
+        if (this.ref) {
+            this.ref.scrollbar.scrollTo(0, 500);
+        }
     }
 
     render() {

--- a/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
+++ b/types/react-svg-pan-zoom/react-svg-pan-zoom-tests.tsx
@@ -8,21 +8,29 @@ import {
 } from 'react-svg-pan-zoom';
 
 class Example1 extends React.Component<{}, {}> {
-  Viewer: ReactSVGPanZoom;
+  Viewer: ReactSVGPanZoom | null;
   constructor(props: Props) {
     super(props);
   }
 
   componentDidMount() {
-    this.Viewer.fitToViewer();
+    if (this.Viewer) {
+      this.Viewer.fitToViewer();
+    }
   }
 
   render() {
     return (
       <div>
-        <button onClick={event => this.Viewer.zoomOnViewerCenter(1.1)}>Zoom in</button>
-        <button onClick={event => this.Viewer.fitSelection(40, 40, 200, 200)}>Zoom area 200x200</button>
-        <button onClick={event => this.Viewer.fitToViewer()}>Fit</button>
+        <button onClick={event => this.Viewer && this.Viewer.zoomOnViewerCenter(1.1)}>
+          Zoom in
+        </button>
+        <button onClick={event => this.Viewer && this.Viewer.fitSelection(40, 40, 200, 200)}>
+          Zoom area 200x200
+        </button>
+        <button onClick={event => this.Viewer && this.Viewer.fitToViewer()}>
+          Fit
+        </button>
 
         <hr/>
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for React v15.0
 // Project: http://facebook.github.io/react/
-// Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>, John Reilly <https://github.com/johnnyreilly/>, Benoit Benezech <https://github.com/bbenezech>, Patricio Zavolinsky <https://github.com/pzavolinsky>, Digiguru <https://github.com/digiguru>, Eric Anderson <https://github.com/ericanderson>
+// Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>, John Reilly <https://github.com/johnnyreilly/>, Benoit Benezech <https://github.com/bbenezech>, Patricio Zavolinsky <https://github.com/pzavolinsky>, Digiguru <https://github.com/digiguru>, Eric Anderson <https://github.com/ericanderson>, Albert Kurniawan <https://github.com/morcerf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -29,7 +29,7 @@ declare namespace React {
     type ComponentType<P> = ComponentClass<P> | StatelessComponent<P>;
 
     type Key = string | number;
-    type Ref<T> = string | ((instance: T) => any);
+    type Ref<T> = string | ((instance: T | null) => any);
     type ComponentState = {} | void;
 
     interface Attributes {
@@ -447,7 +447,7 @@ declare namespace React {
      * `createElement` or a factory, use `ClassAttributes<T>`:
      *
      * ```ts
-     * var b: Button;
+     * var b: Button | null;
      * var props: ButtonProps & ClassAttributes<Button> = {
      *     ref: b => button = b, // ok!
      *     label: "I'm a Button"
@@ -2266,7 +2266,7 @@ declare namespace React {
         target?: string;
         type?: string;
         width?: number | string;
-                  
+
         // Other HTML properties supported by SVG elements in browsers
         role?: string;
         tabIndex?: number;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -112,7 +112,7 @@ class ModernComponent extends React.Component<Props, State>
     }
 
     private _myComponent: MyComponent;
-    private _input: HTMLInputElement;
+    private _input: HTMLInputElement | null;
 
     render() {
         return React.DOM.div(null,
@@ -199,7 +199,7 @@ React.cloneElement(element, {}, null);
 var clonedElement2: React.CElement<Props, ModernComponent> =
     // known problem: cloning with key or ref requires cast
     React.cloneElement(element, <React.ClassAttributes<ModernComponent>>{
-        ref: c => c.reset()
+        ref: c => c && c.reset()
     });
 var clonedElement3: React.CElement<Props, ModernComponent> =
     React.cloneElement(element, <{ foo: number } & React.Attributes>{
@@ -288,18 +288,18 @@ class RefComponent extends React.Component<RCProps, {}> {
     }
 }
 
-var componentRef: RefComponent = new RefComponent();
+var componentRef: RefComponent | null = new RefComponent();
 RefComponent.create({ ref: "componentRef" });
 // type of c should be inferred
 RefComponent.create({ ref: c => componentRef = c });
 componentRef.refMethod();
 
-var domNodeRef: Element;
+var domNodeRef: Element | null;
 React.DOM.div({ ref: "domRef" });
 // type of node should be inferred
 React.DOM.div({ ref: node => domNodeRef = node });
 
-var inputNodeRef: HTMLInputElement;
+var inputNodeRef: HTMLInputElement | null;
 React.DOM.input({ ref: node => inputNodeRef = <HTMLInputElement>node });
 
 //

--- a/types/redux-devtools/redux-devtools-tests.tsx
+++ b/types/redux-devtools/redux-devtools-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { compose, createStore, Reducer, Store, StoreEnhancerStoreCreator } from 'redux'
+import { compose, createStore, Reducer, Store, GenericStoreEnhancer } from 'redux'
 import { Provider } from 'react-redux'
 import { createDevTools, persistState } from 'redux-devtools'
 
@@ -12,10 +12,12 @@ const DevTools = createDevTools(
   <DevToolsMonitor />
 )
 
-const finalCreateStore = compose(
+const storeEnhancer = compose(
   DevTools.instrument(),
   persistState('test-session')
-)(createStore)
+) as GenericStoreEnhancer
+
+const finalCreateStore = storeEnhancer(createStore)
 
 const store: Store<any> = finalCreateStore(reducer)
 


### PR DESCRIPTION
This PR should fix incorrect type definition of the `Ref<T>` type.

Ref in React can be `null` if the React / DOM element is unmounted from the DOM. This is as described in this documentation [here](https://facebook.github.io/react/docs/refs-and-the-dom.html). Simple demo can be found [here](https://codepen.io/albertk/pen/pweemW) (continuously click the `click to hide/show` button to see it in action).

Adding the possible null type as the first Ref callback argument ensures the consumer of the instance reference to not use the reference when the element has been unmounted from the DOM  (for example, calling `this.buttonRef.click()` when the button has been unmounted and `this.buttonRef` is null).

Template answers:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://facebook.github.io/react/docs/refs-and-the-dom.html#caveats> and <https://facebook.github.io/react/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element>
- [ ] ~~Increase the version number in the header if appropriate.~~ Not appropriate
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~ Not substantial.