### PR TITLE
knockout: Make it possible to extend interfaces for subscribables and observables

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -5,19 +5,26 @@
 
 
 interface KnockoutSubscribableFunctions<T> {
-    [key: string]: KnockoutBindingHandler | undefined;
-
 	notifySubscribers(valueToWrite?: T, event?: string): void;
 }
 
+interface KnockoutSubscribableExtensionFunctions<T> extends KnockoutSubscribableFunctions<T> {
+    [key: string]: KnockoutBindingHandler | undefined;
+}
+
 interface KnockoutComputedFunctions<T> {
+}
+
+interface KnockoutComputedExtensionFunctions<T> extends KnockoutComputedFunctions<T> {
     [key: string]: KnockoutBindingHandler | undefined;
 }
 
 interface KnockoutObservableFunctions<T> {
-    [key: string]: KnockoutBindingHandler | undefined;
-
 	equalityComparer(a: any, b: any): boolean;
+}
+
+interface KnockoutObservableExtensionFunctions<T> extends KnockoutObservableFunctions<T> {
+    [key: string]: KnockoutBindingHandler | undefined;
 }
 
 interface KnockoutObservableArrayFunctions<T> {
@@ -35,8 +42,6 @@ interface KnockoutObservableArrayFunctions<T> {
     sort(compareFunction: (left: T, right: T) => number): KnockoutObservableArray<T>;
 
     // Ko specific
-    [key: string]: KnockoutBindingHandler | undefined;
-
     replace(oldItem: T, newItem: T): void;
 
     remove(item: T): T[];
@@ -50,8 +55,12 @@ interface KnockoutObservableArrayFunctions<T> {
     destroyAll(): void;
 }
 
+interface KnockoutObservableArrayExtensionFunctions<T> extends KnockoutObservableArrayFunctions<T> {
+    [key: string]: KnockoutBindingHandler | undefined;
+}
+
 interface KnockoutSubscribableStatic {
-    fn: KnockoutSubscribableFunctions<any>;
+    fn: KnockoutSubscribableExtensionFunctions<any>;
 
     new <T>(): KnockoutSubscribable<T>;
 }
@@ -70,7 +79,7 @@ interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions<T> {
 }
 
 interface KnockoutComputedStatic {
-    fn: KnockoutComputedFunctions<any>;
+    fn: KnockoutComputedExtensionFunctions<any>;
 
     <T>(): KnockoutComputed<T>;
     <T>(func: () => T, context?: any, options?: any): KnockoutComputed<T>;
@@ -78,7 +87,7 @@ interface KnockoutComputedStatic {
 }
 
 interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFunctions<T> {
-	fn: KnockoutComputedFunctions<any>;
+	fn: KnockoutComputedExtensionFunctions<any>;
 
 	dispose(): void;
 	isActive(): boolean;
@@ -87,7 +96,7 @@ interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFun
 }
 
 interface KnockoutObservableArrayStatic {
-    fn: KnockoutObservableArrayFunctions<any>;
+    fn: KnockoutObservableArrayExtensionFunctions<any>;
 
     <T>(value?: T[] | null): KnockoutObservableArray<T>;
 }
@@ -102,7 +111,7 @@ interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutOb
 }
 
 interface KnockoutObservableStatic {
-    fn: KnockoutObservableFunctions<any>;
+    fn: KnockoutObservableExtensionFunctions<any>;
 
     <T>(value?: T | null): KnockoutObservable<T>;
 }

--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -5,7 +5,7 @@
 
 
 interface KnockoutSubscribableFunctions<T> {
-	notifySubscribers(valueToWrite?: T, event?: string): void;
+    notifySubscribers(valueToWrite?: T, event?: string): void;
 }
 
 interface KnockoutSubscribableExtensionFunctions<T> extends KnockoutSubscribableFunctions<T> {
@@ -20,7 +20,7 @@ interface KnockoutComputedExtensionFunctions<T> extends KnockoutComputedFunction
 }
 
 interface KnockoutObservableFunctions<T> {
-	equalityComparer(a: any, b: any): boolean;
+    equalityComparer(a: any, b: any): boolean;
 }
 
 interface KnockoutObservableExtensionFunctions<T> extends KnockoutObservableFunctions<T> {
@@ -66,16 +66,16 @@ interface KnockoutSubscribableStatic {
 }
 
 interface KnockoutSubscription {
-	dispose(): void;
+    dispose(): void;
 }
 
 interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions<T> {
     subscribe(callback: (newValue: T) => void, target: any, event: "beforeChange"): KnockoutSubscription;
-	subscribe(callback: (newValue: T) => void, target?: any, event?: "change"): KnockoutSubscription;
-	subscribe<TEvent>(callback: (newValue: TEvent) => void, target: any, event: string): KnockoutSubscription;
+    subscribe(callback: (newValue: T) => void, target?: any, event?: "change"): KnockoutSubscription;
+    subscribe<TEvent>(callback: (newValue: TEvent) => void, target: any, event: string): KnockoutSubscription;
 
-	extend(requestedExtenders: { [key: string]: any; }): KnockoutSubscribable<T>;
-	getSubscriptionsCount(): number;
+    extend(requestedExtenders: { [key: string]: any; }): KnockoutSubscribable<T>;
+    getSubscriptionsCount(): number;
 }
 
 interface KnockoutComputedStatic {
@@ -87,11 +87,11 @@ interface KnockoutComputedStatic {
 }
 
 interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFunctions<T> {
-	fn: KnockoutComputedExtensionFunctions<any>;
+    fn: KnockoutComputedExtensionFunctions<any>;
 
-	dispose(): void;
-	isActive(): boolean;
-	getDependenciesCount(): number;
+    dispose(): void;
+    isActive(): boolean;
+    getDependenciesCount(): number;
     extend(requestedExtenders: { [key: string]: any; }): KnockoutComputed<T>;
 }
 
@@ -117,23 +117,23 @@ interface KnockoutObservableStatic {
 }
 
 interface KnockoutObservable<T> extends KnockoutSubscribable<T>, KnockoutObservableFunctions<T> {
-	(): T;
-	(value: T | null): void;
+    (): T;
+    (value: T | null): void;
 
-	peek(): T;
-	valueHasMutated?:{(): void;};
-	valueWillMutate?:{(): void;};
+    peek(): T;
+    valueHasMutated?:{(): void;};
+    valueWillMutate?:{(): void;};
     extend(requestedExtenders: { [key: string]: any; }): KnockoutObservable<T>;
 }
 
 interface KnockoutComputedDefine<T> {
-	read(): T;
-	write? (value: T): void;
-	disposeWhenNodeIsRemoved?: Node;
-	disposeWhen? (): boolean;
-	owner?: any;
-	deferEvaluation?: boolean;
-	pure?: boolean;
+    read(): T;
+    write? (value: T): void;
+    disposeWhenNodeIsRemoved?: Node;
+    disposeWhen? (): boolean;
+    owner?: any;
+    deferEvaluation?: boolean;
+    pure?: boolean;
 }
 
 interface KnockoutBindingContext {
@@ -198,10 +198,10 @@ interface KnockoutBindingHandlers {
     uniqueName: KnockoutBindingHandler;
 
     // Rendering templates
-	template: KnockoutBindingHandler;
+    template: KnockoutBindingHandler;
 
-	// Components (new for v3.2)
-	component: KnockoutBindingHandler;
+    // Components (new for v3.2)
+    component: KnockoutBindingHandler;
 }
 
 interface KnockoutMemoization {
@@ -226,12 +226,12 @@ interface KnockoutVirtualElements {
 
 interface KnockoutExtenders {
     throttle(target: any, timeout: number): KnockoutComputed<any>;
-	notify(target: any, notifyWhen: string): any;
+    notify(target: any, notifyWhen: string): any;
 
-	rateLimit(target: any, timeout: number): any;
-	rateLimit(target: any, options: { timeout: number; method?: string; }): any;
+    rateLimit(target: any, timeout: number): any;
+    rateLimit(target: any, options: { timeout: number; method?: string; }): any;
 
-	trackArrayChanges(target: any): any;
+    trackArrayChanges(target: any): any;
 }
 
 //
@@ -361,20 +361,20 @@ interface KnockoutTemplateSourcesDomElement {
 }
 
 interface KnockoutTemplateAnonymous extends KnockoutTemplateSourcesDomElement {
-	nodes(): any;
-	nodes(value: any): void;
+    nodes(): any;
+    nodes(value: any): void;
 }
 
 interface KnockoutTemplateSources {
 
     domElement: {
-	    prototype: KnockoutTemplateSourcesDomElement
-	    new (element: Element): KnockoutTemplateSourcesDomElement
+        prototype: KnockoutTemplateSourcesDomElement
+        new (element: Element): KnockoutTemplateSourcesDomElement
     };
 
     anonymousTemplate: {
-		prototype: KnockoutTemplateAnonymous;
-		new (element: Element): KnockoutTemplateAnonymous;
+        prototype: KnockoutTemplateAnonymous;
+        new (element: Element): KnockoutTemplateAnonymous;
     };
 }
 
@@ -421,26 +421,26 @@ interface KnockoutStatic {
     utils: KnockoutUtils;
     memoization: KnockoutMemoization;
 
-	bindingHandlers: KnockoutBindingHandlers;
-	getBindingHandler(handler: string): KnockoutBindingHandler;
+    bindingHandlers: KnockoutBindingHandlers;
+    getBindingHandler(handler: string): KnockoutBindingHandler;
 
     virtualElements: KnockoutVirtualElements;
     extenders: KnockoutExtenders;
 
     applyBindings(viewModelOrBindingContext?: any, rootNode?: any): void;
-	applyBindingsToDescendants(viewModelOrBindingContext: any, rootNode: any): void;
-	applyBindingAccessorsToNode(node: Node, bindings: (bindingContext: KnockoutBindingContext, node: Node) => {}, bindingContext: KnockoutBindingContext): void;
-	applyBindingAccessorsToNode(node: Node, bindings: {}, bindingContext: KnockoutBindingContext): void;
-	applyBindingAccessorsToNode(node: Node, bindings: (bindingContext: KnockoutBindingContext, node: Node) => {}, viewModel: any): void;
-	applyBindingAccessorsToNode(node: Node, bindings: {}, viewModel: any): void;
+    applyBindingsToDescendants(viewModelOrBindingContext: any, rootNode: any): void;
+    applyBindingAccessorsToNode(node: Node, bindings: (bindingContext: KnockoutBindingContext, node: Node) => {}, bindingContext: KnockoutBindingContext): void;
+    applyBindingAccessorsToNode(node: Node, bindings: {}, bindingContext: KnockoutBindingContext): void;
+    applyBindingAccessorsToNode(node: Node, bindings: (bindingContext: KnockoutBindingContext, node: Node) => {}, viewModel: any): void;
+    applyBindingAccessorsToNode(node: Node, bindings: {}, viewModel: any): void;
     applyBindingsToNode(node: Node, bindings: any, viewModelOrBindingContext?: any): any;
 
     subscribable: KnockoutSubscribableStatic;
     observable: KnockoutObservableStatic;
 
-	computed: KnockoutComputedStatic;
-	pureComputed<T>(evaluatorFunction: () => T, context?: any): KnockoutComputed<T>;
-	pureComputed<T>(options: KnockoutComputedDefine<T>, context?: any): KnockoutComputed<T>;
+    computed: KnockoutComputedStatic;
+    pureComputed<T>(evaluatorFunction: () => T, context?: any): KnockoutComputed<T>;
+    pureComputed<T>(options: KnockoutComputedDefine<T>, context?: any): KnockoutComputed<T>;
 
     observableArray: KnockoutObservableArrayStatic;
 
@@ -456,9 +456,9 @@ interface KnockoutStatic {
     cleanNode(node: Element): Element;
     renderTemplate(template: Function, viewModel: any, options?: any, target?: any, renderMode?: any): any;
     renderTemplate(template: string, viewModel: any, options?: any, target?: any, renderMode?: any): any;
-	unwrap<T>(value: KnockoutObservable<T> | T): T;
+    unwrap<T>(value: KnockoutObservable<T> | T): T;
 
-	computedContext: KnockoutComputedContext;
+    computedContext: KnockoutComputedContext;
 
     //////////////////////////////////
     // templateSources.js
@@ -566,10 +566,10 @@ interface KnockoutStatic {
 
     /////////////////////////////////
 
-	bindingProvider: {
-		instance: KnockoutBindingProvider;
-		new (): KnockoutBindingProvider;
-	}
+    bindingProvider: {
+        instance: KnockoutBindingProvider;
+        new (): KnockoutBindingProvider;
+    }
 
     /////////////////////////////////
     // selectExtensions.js
@@ -608,15 +608,15 @@ interface KnockoutStatic {
 }
 
 interface KnockoutBindingProvider {
-	nodeHasBindings(node: Node): boolean;
-	getBindings(node: Node, bindingContext: KnockoutBindingContext): {};
-	getBindingAccessors?(node: Node, bindingContext: KnockoutBindingContext): { [key: string]: string; };
+    nodeHasBindings(node: Node): boolean;
+    getBindings(node: Node, bindingContext: KnockoutBindingContext): {};
+    getBindingAccessors?(node: Node, bindingContext: KnockoutBindingContext): { [key: string]: string; };
 }
 
 interface KnockoutComputedContext {
-	getDependenciesCount(): number;
-	isInitial: () => boolean;
-	isSleeping: boolean;
+    getDependenciesCount(): number;
+    isInitial: () => boolean;
+    isSleeping: boolean;
 }
 
 //
@@ -697,5 +697,5 @@ interface KnockoutComponents {
 declare var ko: KnockoutStatic;
 
 declare module "knockout" {
-	export = ko;
+    export = ko;
 }

--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -4,28 +4,23 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
+interface KnockoutExtensionFunctions {
+    [key: string]: KnockoutBindingHandler | undefined;
+}
+
 interface KnockoutSubscribableFunctions<T> {
     notifySubscribers(valueToWrite?: T, event?: string): void;
 }
-
-interface KnockoutSubscribableExtensionFunctions<T> extends KnockoutSubscribableFunctions<T> {
-    [key: string]: KnockoutBindingHandler | undefined;
-}
+type KnockoutSubscribableExtensionFunctions<T> = KnockoutSubscribableFunctions<T> & KnockoutExtensionFunctions;
 
 interface KnockoutComputedFunctions<T> {
 }
-
-interface KnockoutComputedExtensionFunctions<T> extends KnockoutComputedFunctions<T> {
-    [key: string]: KnockoutBindingHandler | undefined;
-}
+type KnockoutComputedExtensionFunctions<T> = KnockoutComputedFunctions<T> & KnockoutExtensionFunctions;
 
 interface KnockoutObservableFunctions<T> {
     equalityComparer(a: any, b: any): boolean;
 }
-
-interface KnockoutObservableExtensionFunctions<T> extends KnockoutObservableFunctions<T> {
-    [key: string]: KnockoutBindingHandler | undefined;
-}
+type KnockoutObservableExtensionFunctions<T> = KnockoutObservableFunctions<T> & KnockoutExtensionFunctions;
 
 interface KnockoutObservableArrayFunctions<T> {
     // General Array functions
@@ -54,10 +49,7 @@ interface KnockoutObservableArrayFunctions<T> {
     destroyAll(items: T[]): void;
     destroyAll(): void;
 }
-
-interface KnockoutObservableArrayExtensionFunctions<T> extends KnockoutObservableArrayFunctions<T> {
-    [key: string]: KnockoutBindingHandler | undefined;
-}
+type KnockoutObservableArrayExtensionFunctions<T> = KnockoutObservableArrayFunctions<T> & KnockoutExtensionFunctions;
 
 interface KnockoutSubscribableStatic {
     fn: KnockoutSubscribableExtensionFunctions<any>;

--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -5,24 +5,21 @@
 
 
 interface KnockoutExtensionFunctions {
-    [key: string]: KnockoutBindingHandler | undefined;
+    [key: string]: any;
 }
 
-interface KnockoutSubscribableFunctions<T> {
+interface KnockoutSubscribableFunctions<T> extends KnockoutExtensionFunctions {
     notifySubscribers(valueToWrite?: T, event?: string): void;
 }
-type KnockoutSubscribableExtensionFunctions<T> = KnockoutSubscribableFunctions<T> & KnockoutExtensionFunctions;
 
-interface KnockoutComputedFunctions<T> {
+interface KnockoutComputedFunctions<T> extends KnockoutExtensionFunctions {
 }
-type KnockoutComputedExtensionFunctions<T> = KnockoutComputedFunctions<T> & KnockoutExtensionFunctions;
 
-interface KnockoutObservableFunctions<T> {
+interface KnockoutObservableFunctions<T> extends KnockoutExtensionFunctions {
     equalityComparer(a: any, b: any): boolean;
 }
-type KnockoutObservableExtensionFunctions<T> = KnockoutObservableFunctions<T> & KnockoutExtensionFunctions;
 
-interface KnockoutObservableArrayFunctions<T> {
+interface KnockoutObservableArrayFunctions<T> extends KnockoutExtensionFunctions {
     // General Array functions
     indexOf(searchElement: T, fromIndex?: number): number;
     slice(start: number, end?: number): T[];
@@ -49,10 +46,9 @@ interface KnockoutObservableArrayFunctions<T> {
     destroyAll(items: T[]): void;
     destroyAll(): void;
 }
-type KnockoutObservableArrayExtensionFunctions<T> = KnockoutObservableArrayFunctions<T> & KnockoutExtensionFunctions;
 
 interface KnockoutSubscribableStatic {
-    fn: KnockoutSubscribableExtensionFunctions<any>;
+    fn: KnockoutSubscribableFunctions<any>;
 
     new <T>(): KnockoutSubscribable<T>;
 }
@@ -71,7 +67,7 @@ interface KnockoutSubscribable<T> extends KnockoutSubscribableFunctions<T> {
 }
 
 interface KnockoutComputedStatic {
-    fn: KnockoutComputedExtensionFunctions<any>;
+    fn: KnockoutComputedFunctions<any>;
 
     <T>(): KnockoutComputed<T>;
     <T>(func: () => T, context?: any, options?: any): KnockoutComputed<T>;
@@ -79,7 +75,7 @@ interface KnockoutComputedStatic {
 }
 
 interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFunctions<T> {
-    fn: KnockoutComputedExtensionFunctions<any>;
+    fn: KnockoutComputedFunctions<any>;
 
     dispose(): void;
     isActive(): boolean;
@@ -88,7 +84,7 @@ interface KnockoutComputed<T> extends KnockoutObservable<T>, KnockoutComputedFun
 }
 
 interface KnockoutObservableArrayStatic {
-    fn: KnockoutObservableArrayExtensionFunctions<any>;
+    fn: KnockoutObservableArrayFunctions<any>;
 
     <T>(value?: T[] | null): KnockoutObservableArray<T>;
 }
@@ -103,7 +99,7 @@ interface KnockoutObservableArray<T> extends KnockoutObservable<T[]>, KnockoutOb
 }
 
 interface KnockoutObservableStatic {
-    fn: KnockoutObservableExtensionFunctions<any>;
+    fn: KnockoutObservableFunctions<any>;
 
     <T>(value?: T | null): KnockoutObservable<T>;
 }

--- a/types/knockout/test/index.ts
+++ b/types/knockout/test/index.ts
@@ -1,4 +1,4 @@
-
+/// <reference types="knockout.postbox" />
 /// <reference types="knockout.mapping" />
 
 declare var $;

--- a/types/knockout/test/index.ts
+++ b/types/knockout/test/index.ts
@@ -724,3 +724,19 @@ function observableArrayEventsTests() {
         });
     }, null, "arrayChange");
 }
+
+interface MySubscribable extends KnockoutSubscribable<any> {
+    isBeautiful?: boolean;
+}
+
+interface MyObservable extends KnockoutObservable<any> {
+    isBeautiful?: boolean;
+}
+
+interface MyObservableArray extends KnockoutObservableArray<any> {
+    isBeautiful?: boolean;
+}
+
+interface MyComputed extends KnockoutComputed<any> {
+    isBeautiful?: boolean;
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/MortenHoustonLudvigsen/knockout-typings-demo
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

With the existing typings for knockout, it is not possible to extend any of the subscribable and observable interfaces. This PR fixes that.
