### PR TITLE
added missing DataGroup.nestedGroups

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -79,6 +79,7 @@ export interface DataGroup {
   style?: string;
   subgroupOrder?: string | (() => void);
   title?: string;
+  nestedGroups?: number[];
 }
 
 export interface DataGroupOptions {


### PR DESCRIPTION
added missing DataGroup.nestedGroups according this example: http://visjs.org/examples/timeline/groups/nestedGroups.html

Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: http://visjs.org/examples/timeline/groups/nestedGroups.html
