### PR TITLE
@types/rison Added a necessary exporting to rison

### DIFF
--- a/types/rison/index.d.ts
+++ b/types/rison/index.d.ts
@@ -2,7 +2,8 @@
 // Project: https://github.com/Nanonid/rison
 // Definitions by: Andrei Kurosh <https://github.com/impworks>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-
+export = rison;
+export as namespace rison;
 declare var rison: IRison;
 
 interface IRison {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


**Added a necessary exporting to rison**
```
export = rison;
export as namespace rison;
declare var rison: IRison;
```

Instead of just:

`declare var rison: IRison;`

Without this addition, programmers were unable to use the definitions of rison.js from DefinitelyTyped.
The way to use rison now is:
  
`import * as rison from '@types/rison';`

