### PR TITLE
Fix incorrect definitions for transducers-js

### DIFF
--- a/types/transducers-js/index.d.ts
+++ b/types/transducers-js/index.d.ts
@@ -47,7 +47,7 @@ export function comp(...args: Array<(x: any) => any>): (x: any) => any;
 /**
  * Take a predicate function and return its complement.
  */
-export function complement(f: Function): Function;
+export function complement<T>(f: (x: T) => boolean): (x: T) => boolean;
 
 /**
  * Identity function.

--- a/types/transducers-js/index.d.ts
+++ b/types/transducers-js/index.d.ts
@@ -34,7 +34,10 @@ export function isReduced(x: any): boolean;
 /**
  * Function composition. Take N function and return their composition.
  */
-export function comp<T>(...args: T[]): T;
+// Infers correct return type when all arguments have same type.
+export function comp<T extends (x: any) => any>(...args: T[]): T;
+// Falls back to (any => any) when argument types differ.
+export function comp(...args: Array<(x: any) => any>): (x: any) => any;
 
 /**
  * Take a predicate function and return its complement.
@@ -323,8 +326,8 @@ export function into<TInput, TOutput>(
  */
 export function toFn<TResult, TInput, TOutput>(
   xf: Transducer<TInput, TOutput>,
-  builder: Reducer<TResult, TInput> | Transformer<TResult, TInput>
-): Reducer<TResult, TInput>;
+  builder: Reducer<TResult, TOutput> | Transformer<TResult, TOutput>
+): Reducer<TResult, TOutput>;
 
 /**
  * A transformer which simply returns the first input.

--- a/types/transducers-js/index.d.ts
+++ b/types/transducers-js/index.d.ts
@@ -11,7 +11,12 @@ export interface Reduced<TResult> {
 
 export type Reducer<TResult, TInput> = (result: TResult, input: TInput) => TResult;
 
-export type Transducer<TInput, TOutput> = <TResult>(xf: Transformer<TResult, TOutput>) => Transformer<TResult, TInput>;
+// Common case: Transducer<TInput, TOutput> =
+//   Transformer<TResult, TOutput> => Transformer<TResult, TInput>.
+export type Transducer<TInput, TOutput> =
+    <TResult, TCompleteResult>(
+        xf: CompletingTransformer<TResult, TCompleteResult, TOutput>
+    ) => CompletingTransformer<TResult, TCompleteResult, TInput>;
 
 export interface CompletingTransformer <TResult, TCompleteResult, TInput> {
   ['@@transducer/init'](): TResult | void;

--- a/types/transducers-js/index.d.ts
+++ b/types/transducers-js/index.d.ts
@@ -1,18 +1,8 @@
 // Type definitions for transducers-js 0.4
 // Project: https://github.com/cognitect-labs/transducers-js
 // Definitions by: Colin Kahn <https://github.com/colinkahn>
+//                 David Philipson <https://github.com/dphilipson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-export interface IteratorResult<T> {
-  done: boolean;
-  value?: T;
-}
-
-export interface Iterator<T> {
-  next(value?: any): IteratorResult<T>;
-  return?(value?: any): IteratorResult<T>;
-  throw?(e?: any): IteratorResult<T>;
-}
 
 export interface Reduced<TResult> {
   ['@@transducer/reduced']: boolean;
@@ -21,7 +11,7 @@ export interface Reduced<TResult> {
 
 export type Reducer<TResult, TInput> = (result: TResult, input: TInput) => TResult;
 
-export type Transducer<TResult, TInput, TOutput> = (xf: Transformer<TResult, TOutput>) => Transformer<TResult, TInput>;
+export type Transducer<TInput, TOutput> = <TResult>(xf: Transformer<TResult, TOutput>) => Transformer<TResult, TInput>;
 
 export interface CompletingTransformer <TResult, TCompleteResult, TInput> {
   ['@@transducer/init'](): TResult | void;
@@ -66,7 +56,7 @@ export class Map<TResult, TInput, TOutput> implements Transformer<TResult, TInpu
 /**
  * Mapping transducer constructor
  */
-export function map<TResult, TInput, TOutput>(f: (x: TInput) => TOutput): Transducer<TResult, TInput, TOutput>;
+export function map<TInput, TOutput>(f: (x: TInput) => TOutput): Transducer<TInput, TOutput>;
 
 export class Filter<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(pred: (x: TInput) => boolean, xf: Transformer<TResult, TInput>);
@@ -78,13 +68,13 @@ export class Filter<TResult, TInput> implements Transformer<TResult, TInput> {
 /**
  * Filtering transducer constructor
  */
-export function filter<TResult, TInput>(pred: (x: TInput) => boolean): Transducer<TResult, TInput, TInput>;
+export function filter<TInput>(pred: (x: TInput) => boolean): Transducer<TInput, TInput>;
 
 /**
  * Similar to filter except the predicate is used to
  * eliminate values.
  */
-export function remove<TResult, TInput>(pred: (x: TInput) => boolean): Transducer<TResult, TInput, TInput>;
+export function remove<TInput>(pred: (x: TInput) => boolean): Transducer<TInput, TInput>;
 
 export class Keep<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(f: (x: TInput) => any, xf: Transformer<TResult, TInput>);
@@ -97,7 +87,7 @@ export class Keep<TResult, TInput> implements Transformer<TResult, TInput> {
  * A keeping transducer. Keep inputs as long as the provided
  * function does not return null or undefined.
  */
-export function keep<TResult, TInput>(f: (x: TInput) => any): Transducer<TResult, TInput, TInput>;
+export function keep<TInput>(f: (x: TInput) => any): Transducer<TInput, TInput>;
 
 export class KeepIndexed<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(f: (i: number, x: TInput) => any, xf: Transformer<TResult, TInput>);
@@ -110,7 +100,7 @@ export class KeepIndexed<TResult, TInput> implements Transformer<TResult, TInput
  * Like keep but the provided function will be passed the
  * index as the fist argument.
  */
-export function keepIndexed<TResult, TInput>(f: (i: number, x: TInput) => any): Transducer<TResult, TInput, TInput>;
+export function keepIndexed<TInput>(f: (i: number, x: TInput) => any): Transducer<TInput, TInput>;
 
 export class Take<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(n: number, xf: Transformer<TResult, TInput>);
@@ -123,7 +113,7 @@ export class Take<TResult, TInput> implements Transformer<TResult, TInput> {
  * A take transducer constructor. Will take n values before
  * returning a reduced result.
  */
-export function take<TResult, TInput>(n: number): Transducer<TResult, TInput, TInput>;
+export function take<TInput>(n: number): Transducer<TInput, TInput>;
 
 export class TakeWhile<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(pred: (n: TInput) => boolean, xf: Transformer<TResult, TInput>);
@@ -136,7 +126,7 @@ export class TakeWhile<TResult, TInput> implements Transformer<TResult, TInput> 
  * Like the take transducer except takes as long as the pred
  * return true for inputs.
  */
-export function takeWhile<TResult, TInput>(pred: (n: TInput) => boolean): Transducer<TResult, TInput, TInput>;
+export function takeWhile<TInput>(pred: (n: TInput) => boolean): Transducer<TInput, TInput>;
 
 export class TakeNth<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(n: number, xf: Transformer<TResult, TInput>);
@@ -148,7 +138,7 @@ export class TakeNth<TResult, TInput> implements Transformer<TResult, TInput> {
 /**
  * A transducer that takes every Nth input
  */
-export function takeNth<TResult, TInput>(n: number): Transducer<TResult, TInput, TInput>;
+export function takeNth<TInput>(n: number): Transducer<TInput, TInput>;
 
 export class Drop<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(n: number, xf: Transformer<TResult, TInput>);
@@ -160,7 +150,7 @@ export class Drop<TResult, TInput> implements Transformer<TResult, TInput> {
 /**
  * A dropping transducer constructor
  */
-export function drop<TResult, TInput>(n: number): Transducer<TResult, TInput, TInput>;
+export function drop<TInput>(n: number): Transducer<TInput, TInput>;
 
 export class DropWhile<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(pred: (input: TInput) => boolean, xf: Transformer<TResult, TInput>);
@@ -173,7 +163,7 @@ export class DropWhile<TResult, TInput> implements Transformer<TResult, TInput> 
  * A dropping transducer that drop inputs as long as
  * pred is true.
  */
-export function dropWhile<TResult, TInput>(pred: (input: TInput) => boolean): Transducer<TResult, TInput, TInput>;
+export function dropWhile<TInput>(pred: (input: TInput) => boolean): Transducer<TInput, TInput>;
 
 export class PartitionBy<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(f: (input: TInput) => any, xf: Transformer<TResult, TInput[]>);
@@ -187,7 +177,7 @@ export class PartitionBy<TResult, TInput> implements Transformer<TResult, TInput
  * arrays as long as predicate remains true for contiguous
  * inputs.
  */
-export function partitionBy<TResult, TInput>(f: (input: TInput) => any): Transducer<TResult, TInput, TInput[]>;
+export function partitionBy<TInput>(f: (input: TInput) => any): Transducer<TInput, TInput[]>;
 
 export class PartitionAll<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(n: number, xf: Transformer<TResult, TInput[]>);
@@ -200,7 +190,7 @@ export class PartitionAll<TResult, TInput> implements Transformer<TResult, TInpu
  * A partitioning transducer. Collects inputs into
  * arrays of size N.
  */
-export function partitionAll<TResult, TInput>(n: number): Transducer<TResult, TInput, TInput[]>;
+export function partitionAll<TResult, TInput>(n: number): Transducer<TInput, TInput[]>;
 
 export class Completing<TResult, TCompleteResult, TInput> implements CompletingTransformer<TResult, TCompleteResult, TInput> {
   constructor(cf: (result: TResult) => TCompleteResult, xf: Transformer<TResult, TInput>);
@@ -213,7 +203,9 @@ export class Completing<TResult, TCompleteResult, TInput> implements CompletingT
  * A completing transducer constructor. Useful to provide cleanup
  * logic at the end of a reduction/transduction.
  */
-export function completing<TResult, TCompleteResult, TInput>(cf: (result: TResult) => TCompleteResult): CompletingTransformer<TResult, TCompleteResult, TInput>;
+export function completing<TResult, TCompleteResult, TInput>(
+    xf: Transformer<TResult, TInput> | Reducer<TResult, TInput>,
+    cf: (result: TResult) => TCompleteResult): CompletingTransformer<TResult, TCompleteResult, TInput>;
 
 export class Wrap<TResult, TInput> implements Transformer<TResult, TInput> {
   constructor(stepFn: Reducer<TResult, TInput>, xf: Transformer<TResult, TInput>);
@@ -227,44 +219,102 @@ export class Wrap<TResult, TInput> implements Transformer<TResult, TInput> {
  * accumluation and the second argument is the next input and convert
  * it into a transducer transformer object.
  */
-export function wrap<TResult, TInput>(stepFn: Reducer<TResult, TInput>): Transducer<TResult, TInput, TInput>;
+export function wrap<TResult, TInput>(stepFn: Reducer<TResult, TInput>): Transformer<TResult, TInput>;
 
 /**
  * Given a transformer return a concatenating transformer
  */
-export function cat<TResult, TInput>(xf: Transformer<TResult, TInput>): Transformer<TResult, TInput> ;
+export function cat<TResult, TInput>(xf: Transformer<TResult, TInput>): Transformer<TResult, Iterable<TInput>>;
 
 /**
  * A mapping concatenating transformer
  */
-export function mapcat<TResult, TInput, TOutput>(f: (arr: TInput[]) => TOutput[]): Transducer<TResult, TInput[], TOutput>;
+export function mapcat<TResult, TInput, TOutput>(f: (arr: TInput) => Iterable<TOutput>): Transducer<TInput, TOutput>;
 
 /**
  * Given a transducer, a builder function, an initial value
  * and a iterable collection - returns the reduction.
  */
 export function transduce<TResult, TInput, TOutput>(
-  xf: Transducer<TResult, TInput, TOutput>,
-  f: Transformer<TResult, TInput> | Reducer<TResult, TInput>,
+  xf: Transducer<TInput, TOutput>,
+  f: Reducer<TResult, TOutput>,
   init: TResult,
-  coll: TInput[] | Iterator<TInput> | string | Object): TResult;
+  coll: Iterable<TInput>): TResult;
+export function transduce<TResult, TCompleteResult, TInput, TOutput>(
+  xf: Transducer<TInput, TOutput>,
+  f: CompletingTransformer<TResult, TCompleteResult, TOutput>,
+  init: TResult,
+  coll: Iterable<TInput>): TCompleteResult;
+export function transduce<TResult, TCompleteResult, TInput, TOutput>(
+  xf: Transducer<TInput, TOutput>,
+  f: CompletingTransformer<TResult, TCompleteResult, TOutput>,
+  coll: Iterable<TInput>): TCompleteResult;
+// Overloads for object iteration.
+export function transduce<TResult, TInput, TOutput>(
+  xf: Transducer<[string, TInput], TOutput>,
+  f: Reducer<TResult, TOutput>,
+  init: TResult,
+  coll: { [key: string]: TInput }): TResult;
+export function transduce<TResult, TCompleteResult, TInput, TOutput>(
+  xf: Transducer<[string, TInput], TOutput>,
+  f: CompletingTransformer<TResult, TCompleteResult, TOutput>,
+  init: TResult,
+  coll: { [key: string]: TInput }): TCompleteResult;
+export function transduce<TResult, TCompleteResult, TInput, TOutput>(
+  xf: Transducer<[string, TInput], TOutput>,
+  f: CompletingTransformer<TResult, TCompleteResult, TOutput>,
+  coll: { [key: string]: TInput }): TCompleteResult;
 
 /**
  * Given a transducer, an intial value and a
  * collection - returns the reduction.
  */
-export function reduce<TResult, TInput, TOutput>(
-  xf: Transducer<TResult, TInput, TOutput>,
+export function reduce<TResult, TInput>(
+  xf: Transformer<TResult, TInput> | Reducer<TResult, TInput>,
   init: TResult,
-  coll: TInput[] | Iterator<TInput> | string | Object): TResult;
+  coll: Iterable<TInput>): TResult;
+export function reduce<TResult, TCompleteResult, TInput>(
+  xf: CompletingTransformer<TResult, TCompleteResult, TInput>,
+  init: TResult,
+  coll: Iterable<TInput>): TCompleteResult;
+// Overloads for object iteration.
+export function reduce<TResult, TInput>(
+  xf: Transformer<TResult, [string, TInput]> | Reducer<TResult, [string, TInput]>,
+  init: TResult,
+  coll: { [key: string]: TInput }): TResult;
+export function reduce<TResult, TCompleteResult, TInput>(
+  xf: CompletingTransformer<TResult, TCompleteResult, [string, TInput]>,
+  init: TResult,
+  coll: { [key: string]: TInput }): TCompleteResult;
 
 /**
  * Reduce a value into the given empty value using a transducer.
  */
-export function into<TResult, TInput, TOutput>(
-  empty: TResult,
-  xf: Transducer<TResult, TInput, TOutput>,
-  coll: TInput[] | Iterator<TInput> | string | Object): TResult;
+export function into<TInput, TOutput>(
+  empty: TOutput[],
+  xf: Transducer<TInput, TOutput>,
+  coll: Iterable<TInput>): TOutput[];
+export function into<TInput>(
+  empty: string,
+  xf: Transducer<TInput, string>,
+  coll: Iterable<TInput>): string;
+export function into<TInput, TOutput>(
+  empty: { [key: string]: TOutput },
+  xf: Transducer<TInput, [string, TOutput]>,
+  coll: Iterable<TInput>): { [key: string]: TOutput };
+// Overloads for object iteration.
+export function into<TInput, TOutput>(
+  empty: TOutput[],
+  xf: Transducer<[string, TInput], TOutput>,
+  coll: { [key: string]: TInput }): TOutput[];
+export function into<TInput>(
+  empty: string,
+  xf: Transducer<[string, TInput], string>,
+  coll: { [key: string]: TInput }): string;
+export function into<TInput, TOutput>(
+  empty: { [key: string]: TOutput },
+  xf: Transducer<[string, TInput], [string, TOutput]>,
+  coll: { [key: string]: TInput }): { [key: string]: TOutput };
 
 /**
  * Convert a transducer transformer object into a function so
@@ -272,7 +322,7 @@ export function into<TResult, TInput, TOutput>(
  * Underscore, lodash
  */
 export function toFn<TResult, TInput, TOutput>(
-  xf: Transducer<TResult, TInput, TOutput>,
+  xf: Transducer<TInput, TOutput>,
   builder: Reducer<TResult, TInput> | Transformer<TResult, TInput>
 ): Reducer<TResult, TInput>;
 

--- a/types/transducers-js/index.d.ts
+++ b/types/transducers-js/index.d.ts
@@ -211,7 +211,7 @@ export function completing<TResult, TCompleteResult, TInput>(
     cf: (result: TResult) => TCompleteResult): CompletingTransformer<TResult, TCompleteResult, TInput>;
 
 export class Wrap<TResult, TInput> implements Transformer<TResult, TInput> {
-  constructor(stepFn: Reducer<TResult, TInput>, xf: Transformer<TResult, TInput>);
+  constructor(stepFn: Reducer<TResult, TInput>);
   ['@@transducer/init'](): TResult;
   ['@@transducer/step'](result: TResult, input: TInput): TResult;
   ['@@transducer/result'](result: TResult): TResult;

--- a/types/transducers-js/transducers-js-tests.ts
+++ b/types/transducers-js/transducers-js-tests.ts
@@ -124,3 +124,51 @@ function mapcatExample() {
   const xf = t.mapcat(reverse);
   t.into([], xf, [[3, 2, 1], [6, 5, 4]]); // [1, 2, 3, 4, 5, 6]
 }
+
+// Original tests
+
+function transduceExample() {
+    const { completing, transduce, wrap } = t;
+    const stringAppendFn = (acc: string, x: number) => acc + x;
+    const stringAppendTransformer = wrap(stringAppendFn);
+    const stringAppendThenLengthTransformer = completing(
+        stringAppendFn,
+        s => s.length,
+    );
+    const lengthsString1: string = transduce(
+        t.map((s: string) => s.length),
+        stringAppendFn,
+        "",
+        ["a", "b"],
+    );
+    const lengthsString2: string = transduce(
+        t.map((s: string) => s.length),
+        stringAppendTransformer,
+        "",
+        ["a", "b"],
+    );
+    const lengthsStringLength: number = transduce(
+        t.map((s: string) => s.length),
+        stringAppendThenLengthTransformer,
+        "",
+        ["a", "b"],
+    );
+}
+
+function advancedIntoExample() {
+    const array: number[] = into([], t.map((s: string) => s.length), [
+        "a",
+        "b",
+    ]);
+    const string: string = into("", t.map((s: string) => s + s), ["a", "b"]);
+    const object1: { [key: string]: number } = into(
+        {},
+        t.map((s: string) => [s, s.length]),
+        ["a", "b"],
+    );
+    const object2: { [key: string]: boolean } = into(
+        {},
+        t.map((kv: [string, number]) => [kv[0], true]),
+        { a: 1, b: 2 }
+    );
+}

--- a/types/transducers-js/transducers-js-tests.ts
+++ b/types/transducers-js/transducers-js-tests.ts
@@ -172,3 +172,11 @@ function advancedIntoExample() {
         { a: 1, b: 2 }
     );
 }
+
+function compExample() {
+    const fn1: t.Transducer<number, number> = comp(map(inc), filter(isEven));
+    const fn2: t.Transducer<number, string> = comp(
+        filter(isEven),
+        map((x: number) => "" + x),
+    );
+}


### PR DESCRIPTION
Changes are as follows:

* Remove unnecessary type parameters
* Update transduce() and reduce() to accept CompletingTransformers
* Fix incorrect definition of transduce()
* Fix incorrect definition of reduce()
* Fix incorrect definition of completing()
* Fix incorrect definition of wrap()
* Fix incorrect definition of cat()
* Fix incorrect definition of toFn()
* Fix overly strict definition of mapcat()
* Tweak definition of comp() to make it both stricter and looser
* Make into() definition precise with overloads

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cognitect-labs/transducers-js/blob/master/src/com/cognitect/transducers.js
- [ ] ~~Increase the version number in the header if appropriate.~~ Not appropriate
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~