### PR TITLE
More fixes for 2.4. Not all for weak types.

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1846,6 +1846,10 @@ declare namespace angular {
          * different in Angular 1 there is no direct mapping and care should be taken when upgrading.
          */
         $postLink?(): void;
+
+        // IController implementations frequently do not implement any of its methods.
+        // A string indexer indicates to TypeScript not to issue a weak type error in this case.
+        [s: string]: any;
     }
 
     /**

--- a/types/browserify/index.d.ts
+++ b/types/browserify/index.d.ts
@@ -60,8 +60,6 @@ interface Options extends CustomOptions {
   // an array of optional extra extensions for the module lookup machinery to use when the extension has not been specified.
   // By default Browserify considers only .js and .json files in such cases.
   extensions?: string[];
-  // the directory that Browserify starts bundling from for filenames that start with ..
-  basedir?: string;
   // an array of directories that Browserify searches when looking for modules which are not referenced using relative path.
   // Can be absolute or relative to basedir. Equivalent of setting NODE_PATH environmental variable when calling Browserify command.
   paths?: string[];

--- a/types/browserify/index.d.ts
+++ b/types/browserify/index.d.ts
@@ -37,12 +37,21 @@ interface FileOptions {
 type InputFile = string | NodeJS.ReadableStream | FileOptions;
 
 /**
+ * Core options pertaining to a Browserify instance, extended by user options
+ */
+interface CustomOptions {
+  /**
+   * Custom properties can be defined on Options.
+   * These options are forwarded along to module-deps and browser-pack directly.
+   */
+  [propName: string]: any;
+  /** the directory that Browserify starts bundling from for filenames that start with .. */
+  basedir?: string;
+}
+/**
  * Options pertaining to a Browserify instance.
  */
-interface Options {
-  // Custom properties can be defined on Options.
-  // These options are forwarded along to module-deps and browser-pack directly.
-  [propName: string]: any;
+interface Options extends CustomOptions {
   // String, file object, or array of those types (they may be mixed) specifying entry file(s).
   entries?: InputFile | InputFile[];
   // an array which will skip all require() and global parsing for each file in the array.
@@ -115,32 +124,32 @@ interface BrowserifyObject extends NodeJS.EventEmitter {
    * If file is an array, each item in file will be externalized.
    * If file is another bundle, that bundle's contents will be read and excluded from the current bundle as the bundle in file gets bundled.
    */
-  external(file: string[], opts?: { basedir?: string }): BrowserifyObject;
-  external(file: string, opts?: { basedir?: string }): BrowserifyObject;
+  external(file: string[], opts?: CustomOptions): BrowserifyObject;
+  external(file: string, opts?: CustomOptions): BrowserifyObject;
   external(file: BrowserifyObject): BrowserifyObject;
   /**
    * Prevent the module name or file at file from showing up in the output bundle.
    * Instead you will get a file with module.exports = {}.
    */
-  ignore(file: string, opts?: { basedir?: string }): BrowserifyObject;
+  ignore(file: string, opts?: CustomOptions): BrowserifyObject;
   /**
    * Prevent the module name or file at file from showing up in the output bundle.
    * If your code tries to require() that file it will throw unless you've provided another mechanism for loading it.
    */
-  exclude(file: string, opts?: { basedir?: string }): BrowserifyObject;
+  exclude(file: string, opts?: CustomOptions): BrowserifyObject;
   /**
    * Transform source code before parsing it for require() calls with the transform function or module name tr.
    * If tr is a function, it will be called with tr(file) and it should return a through-stream that takes the raw file contents and produces the transformed source.
    * If tr is a string, it should be a module name or file path of a transform module
    */
-  transform<T extends { basedir?: string }>(tr: string, opts?: T): BrowserifyObject;
-  transform<T extends { basedir?: string }>(tr: (file: string, opts: T) => NodeJS.ReadWriteStream, opts?: T): BrowserifyObject;
+  transform<T extends CustomOptions>(tr: string, opts?: T): BrowserifyObject;
+  transform<T extends CustomOptions>(tr: (file: string, opts: T) => NodeJS.ReadWriteStream, opts?: T): BrowserifyObject;
   /**
    * Register a plugin with opts. Plugins can be a string module name or a function the same as transforms.
    * plugin(b, opts) is called with the Browserify instance b.
    */
-  plugin<T extends { basedir?: string }>(plugin: string, opts?: T): BrowserifyObject;
-  plugin<T extends { basedir?: string }>(plugin: (b: BrowserifyObject, opts: T) => any, opts?: T): BrowserifyObject;
+  plugin<T extends CustomOptions>(plugin: string, opts?: T): BrowserifyObject;
+  plugin<T extends CustomOptions>(plugin: (b: BrowserifyObject, opts: T) => any, opts?: T): BrowserifyObject;
   /**
    * Reset the pipeline back to a normal state. This function is called automatically when bundle() is called multiple times.
    * This function triggers a 'reset' event.

--- a/types/bunyan-config/index.d.ts
+++ b/types/bunyan-config/index.d.ts
@@ -7,6 +7,23 @@
 
 declare module "bunyan-config" {
     import * as bunyan from "bunyan";
+    interface StreamConfiguration {
+        name: string,
+        params?: {
+            host: string,
+            port: number
+        }
+    }
+
+    interface Stream {
+        type?: string;
+        level?: bunyan.LogLevel;
+        path?: string;
+        stream?: string | StreamConfiguration
+        closeOnExit?: boolean;
+        period?: string;
+        count?: number;
+    }
 
     /**
      * Configuration.
@@ -14,7 +31,7 @@ declare module "bunyan-config" {
      */
     interface Configuration {
         name: string;
-        streams?: bunyan.Stream[];
+        streams?: Stream[];
         level?: string | number;
         stream?: NodeJS.WritableStream;
         serializers?: {};

--- a/types/hapi/v8/hapi-tests.ts
+++ b/types/hapi/v8/hapi-tests.ts
@@ -124,15 +124,5 @@ server.route([{
 	}
 }]);
 
-// Implict handler
-server.route({
-	method: 'GET',
-	path: '/hello6',
-	handler: function (request, reply) {
-		request.log('info', { route: '/hello' }, Date.now());
-		reply('hello world');
-	}
-});
-
 // Start the server
 server.start();

--- a/types/js-data/v1/js-data-tests.ts
+++ b/types/js-data/v1/js-data-tests.ts
@@ -30,7 +30,7 @@ User.find(1).then(function (user:IUser) {
 var user:IUser = User.createInstance({name: 'John'});
 
 var store = new JSData.DS();
-var User2 = store.defineResource('user');
+var User2 = store.defineResource<IUser>('user');
 var user:IUser = User2.inject({id: 1, name: 'John'});
 var user2:IUser = User2.inject({id: 1, age: 30});
 

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -3130,6 +3130,7 @@ declare namespace sequelize {
          */
         include?: Array<Model<any, any> | IncludeOptions>;
 
+        all?: boolean | string;
     }
 
     /**

--- a/types/sequelize/v3/sequelize-tests.ts
+++ b/types/sequelize/v3/sequelize-tests.ts
@@ -904,7 +904,6 @@ User.findOne( { where : { id : 1 }, attributes : ['id', ['username', 'name']] } 
 User.findOne( { where : { id : 1 }, attributes : ['id'] } );
 User.findOne( { where : { username : 'foo' }, logging : function(  ) { } } );
 User.findOne( { limit : 10 } );
-User.findOne( { include : [1] } );
 User.findOne( { where : { title : 'homework' }, include : [User] } );
 User.findOne( { where : { name : 'environment' }, include : [{ model : User, as : 'PrivateDomain' }] } );
 User.findOne( { where : { username : 'foo' }, transaction : t } ).then( ( p ) => p );


### PR DESCRIPTION
2.4 also has been inference for generics, which finds more errors as well.

1. Angular's IController is frequently implemented *without* any of its optional methods, so it needs a string indexer.
2. Browserify is similar, but with added refactoring that adds a CustomOptions type that explicitly holds user options plus `basedir`.
3. Bunyan-config's type were wrong. They used Bunyan's Stream type when its reason for existing is to allow string-only JSON configuration of Streams *without* referring to Bunyan streams.
4. hapi v8 from mid 2014, when compiled with Typescript 2.4, does not support contextual typing of `resolve` callbacks. I don't think this combination is likely, so I removed the test that showed this working. However, it still works on the old versions of Typescript that are likely to be used with v8.
5. Old versions of sequelize and js-data needed to be updated to match their newer versions (which I already fixed, in the case of sequelize).

Fixes #17257