### PR TITLE
Fix predicate and object types for bluebird catch method

### DIFF
--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -373,6 +373,30 @@ fooProm = fooProm.catch(CustomError, reason => {
 	fooProm = fooProm.catch(CustomError1, CustomError2, CustomError3, error => {});
 	fooProm = fooProm.catch(CustomError1, CustomError2, CustomError3, CustomError4, error => {});
 	fooProm = fooProm.catch(CustomError1, CustomError2, CustomError3, CustomError4, CustomError5, error => {});
+
+	const booPredicate1 = (error: CustomError1) => true;
+	const booPredicate2 = (error: [number]) => true;
+	const booPredicate3 = (error: string) => true;
+	const booPredicate4 = (error: Object) => true;
+	const booPredicate5 = (error: any) => true;
+
+	fooProm = fooProm.catch(booPredicate1, error => {});
+	fooProm = fooProm.catch(booPredicate1, booPredicate2, error => {});
+	fooProm = fooProm.catch(booPredicate1, booPredicate2, booPredicate3, error => {});
+	fooProm = fooProm.catch(booPredicate1, booPredicate2, booPredicate3, booPredicate4, error => {});
+	fooProm = fooProm.catch(booPredicate1, booPredicate2, booPredicate3, booPredicate4, booPredicate5, error => {});
+
+	const booObject1 = new CustomError1();
+	const booObject2 = [400, 500];
+	const booObject3 = "Error";
+	const booObject4 = {code: 400};
+	const booObject5: any = null;
+
+	fooProm = fooProm.catch(booObject1, error => {});
+	fooProm = fooProm.catch(booObject1, booObject2, error => {});
+	fooProm = fooProm.catch(booObject1, booObject2, booObject3, error => {});
+	fooProm = fooProm.catch(booObject1, booObject2, booObject3, booObject4, error => {});
+	fooProm = fooProm.catch(booObject1, booObject2, booObject3, booObject4, booObject5, error => {});
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/types/bluebird/bluebird-tests.ts
+++ b/types/bluebird/bluebird-tests.ts
@@ -388,7 +388,7 @@ fooProm = fooProm.catch(CustomError, reason => {
 
 	const booObject1 = new CustomError1();
 	const booObject2 = [400, 500];
-	const booObject3 = "Error";
+	const booObject3 = ["Error1", "Error2"];
 	const booObject4 = {code: 400};
 	const booObject5: any = null;
 

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -69,247 +69,247 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * TODO: disallow non-objects
    */
   catch<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
-    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
-    filter5: (new (...args: any[]) => E5) | ((error: E5) => boolean) | E5,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
+    filter4: (new (...args: any[]) => E4),
+    filter5: (new (...args: any[]) => E5),
     onReject: (error: E1 | E2 | E3 | E4 | E5) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<E1, E2, E3, E4, E5>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
-    filter4: ((error: E4) => boolean) | E4,
-    filter5: ((error: E5) => boolean) | E5,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
+    filter4: ((error: E4) => boolean) | (E4 & object),
+    filter5: ((error: E5) => boolean) | (E5 & object),
     onReject: (error: E1 | E2 | E3 | E4 | E5) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
-    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
-    filter5: (new (...args: any[]) => E5) | ((error: E5) => boolean) | E5,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
+    filter4: (new (...args: any[]) => E4),
+    filter5: (new (...args: any[]) => E5),
     onReject: (error: E1 | E2 | E3 | E4 | E5) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1, E2, E3, E4, E5>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
-    filter4: ((error: E4) => boolean) | E4,
-    filter5: ((error: E5) => boolean) | E5,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
+    filter4: ((error: E4) => boolean) | (E4 & object),
+    filter5: ((error: E5) => boolean) | (E5 & object),
     onReject: (error: E1 | E2 | E3 | E4 | E5) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
-    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
-    filter5: (new (...args: any[]) => E5) | ((error: E5) => boolean) | E5,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
+    filter4: (new (...args: any[]) => E4),
+    filter5: (new (...args: any[]) => E5),
     onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U> | void | PromiseLike<void>,
   ): Bluebird<U | R>;
   catch<U, E1, E2, E3, E4, E5>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
-    filter4: ((error: E4) => boolean) | E4,
-    filter5: ((error: E5) => boolean) | E5,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
+    filter4: ((error: E4) => boolean) | (E4 & object),
+    filter5: ((error: E5) => boolean) | (E5 & object),
     onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
-    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
-    filter5: (new (...args: any[]) => E5) | ((error: E5) => boolean) | E5,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
+    filter4: (new (...args: any[]) => E4),
+    filter5: (new (...args: any[]) => E5),
     onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1, E2, E3, E4, E5>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
-    filter4: ((error: E4) => boolean) | E4,
-    filter5: ((error: E5) => boolean) | E5,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
+    filter4: ((error: E4) => boolean) | (E4 & object),
+    filter5: ((error: E5) => boolean) | (E5 & object),
     onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 
   catch<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
-    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
+    filter4: (new (...args: any[]) => E4),
     onReject: (error: E1 | E2 | E3 | E4) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<E1, E2, E3, E4>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
-    filter4: ((error: E4) => boolean) | E4,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
+    filter4: ((error: E4) => boolean) | (E4 & object),
     onReject: (error: E1 | E2 | E3 | E4) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
-    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
+    filter4: (new (...args: any[]) => E4),
     onReject: (error: E1 | E2 | E3 | E4) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1, E2, E3, E4>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
-    filter4: ((error: E4) => boolean) | E4,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
+    filter4: ((error: E4) => boolean) | (E4 & object),
     onReject: (error: E1 | E2 | E3 | E4) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
-    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
+    filter4: (new (...args: any[]) => E4),
     onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   catch<U, E1, E2, E3, E4>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
-    filter4: ((error: E4) => boolean) | E4,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
+    filter4: ((error: E4) => boolean) | (E4 & object),
     onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
-    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
+    filter4: (new (...args: any[]) => E4),
     onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1, E2, E3, E4>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
-    filter4: ((error: E4) => boolean) | E4,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
+    filter4: ((error: E4) => boolean) | (E4 & object),
     onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 
   catch<E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
     onReject: (error: E1 | E2 | E3) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<E1, E2, E3>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
     onReject: (error: E1 | E2 | E3) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
     onReject: (error: E1 | E2 | E3) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1, E2, E3>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
     onReject: (error: E1 | E2 | E3) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
     onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   catch<U, E1, E2, E3>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
     onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
-    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
+    filter3: (new (...args: any[]) => E3),
     onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1, E2, E3>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
-    filter3: ((error: E3) => boolean) | E3,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
+    filter3: ((error: E3) => boolean) | (E3 & object),
     onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 
   catch<E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
     onReject: (error: E1 | E2) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<E1, E2>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
     onReject: (error: E1 | E2) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
     onReject: (error: E1 | E2) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1, E2>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
     onReject: (error: E1 | E2) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
     onReject: (error: E1 | E2) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   catch<U, E1, E2>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
     onReject: (error: E1 | E2) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
-    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter1: (new (...args: any[]) => E1),
+    filter2: (new (...args: any[]) => E2),
     onReject: (error: E1 | E2) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1, E2>(
-    filter1: ((error: E1) => boolean) | E1,
-    filter2: ((error: E2) => boolean) | E2,
+    filter1: ((error: E1) => boolean) | (E1 & object),
+    filter2: ((error: E2) => boolean) | (E2 & object),
     onReject: (error: E1 | E2) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 
   catch<E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter1: (new (...args: any[]) => E1),
     onReject: (error: E1) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<E1>(
-    filter1: ((error: E1) => boolean) | E1,
+    filter1: ((error: E1) => boolean) | (E1 & object),
     onReject: (error: E1) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter1: (new (...args: any[]) => E1),
     onReject: (error: E1) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1>(
-    filter1: ((error: E1) => boolean) | E1,
+    filter1: ((error: E1) => boolean) | (E1 & object),
     onReject: (error: E1) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter1: (new (...args: any[]) => E1),
     onReject: (error: E1) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   catch<U, E1>(
-    filter1: ((error: E1) => boolean) | E1,
+    filter1: ((error: E1) => boolean) | (E1 & object),
     onReject: (error: E1) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter1: (new (...args: any[]) => E1),
     onReject: (error: E1) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1>(
-    filter1: ((error: E1) => boolean) | E1,
+    filter1: ((error: E1) => boolean) | (E1 & object),
     onReject: (error: E1) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -69,127 +69,247 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    * TODO: disallow non-objects
    */
   catch<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
-    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    filter5: (new (...args: any[]) => E5) | ((error: E5) => boolean) | E5,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  catch<E1, E2, E3, E4, E5>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
+    filter4: ((error: E4) => boolean) | E4,
+    filter5: ((error: E5) => boolean) | E5,
     onReject: (error: E1 | E2 | E3 | E4 | E5) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
-    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    filter5: (new (...args: any[]) => E5) | ((error: E5) => boolean) | E5,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  caught<E1, E2, E3, E4, E5>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
+    filter4: ((error: E4) => boolean) | E4,
+    filter5: ((error: E5) => boolean) | E5,
     onReject: (error: E1 | E2 | E3 | E4 | E5) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
-    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    filter5: (new (...args: any[]) => E5) | ((error: E5) => boolean) | E5,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U> | void | PromiseLike<void>,
+  ): Bluebird<U | R>;
+  catch<U, E1, E2, E3, E4, E5>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
+    filter4: ((error: E4) => boolean) | E4,
+    filter5: ((error: E5) => boolean) | E5,
     onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
-    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    filter5: (new (...args: any[]) => E5) | ((error: E5) => boolean) | E5,
+    onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1, E2, E3, E4, E5>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
+    filter4: ((error: E4) => boolean) | E4,
+    filter5: ((error: E5) => boolean) | E5,
     onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 
   catch<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    onReject: (error: E1 | E2 | E3 | E4) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  catch<E1, E2, E3, E4>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
+    filter4: ((error: E4) => boolean) | E4,
     onReject: (error: E1 | E2 | E3 | E4) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    onReject: (error: E1 | E2 | E3 | E4) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  caught<E1, E2, E3, E4>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
+    filter4: ((error: E4) => boolean) | E4,
     onReject: (error: E1 | E2 | E3 | E4) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  catch<U, E1, E2, E3, E4>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
+    filter4: ((error: E4) => boolean) | E4,
     onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    filter4: (new (...args: any[]) => E4) | ((error: E4) => boolean) | E4,
+    onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1, E2, E3, E4>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
+    filter4: ((error: E4) => boolean) | E4,
     onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 
   catch<E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    onReject: (error: E1 | E2 | E3) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  catch<E1, E2, E3>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
     onReject: (error: E1 | E2 | E3) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    onReject: (error: E1 | E2 | E3) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  caught<E1, E2, E3>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
     onReject: (error: E1 | E2 | E3) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  catch<U, E1, E2, E3>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
     onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    filter3: (new (...args: any[]) => E3) | ((error: E3) => boolean) | E3,
+    onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1, E2, E3>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
+    filter3: ((error: E3) => boolean) | E3,
     onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 
   catch<E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    onReject: (error: E1 | E2) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  catch<E1, E2>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
     onReject: (error: E1 | E2) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    onReject: (error: E1 | E2) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  caught<E1, E2>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
     onReject: (error: E1 | E2) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    onReject: (error: E1 | E2) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  catch<U, E1, E2>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
     onReject: (error: E1 | E2) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    filter2: (new (...args: any[]) => E2) | ((error: E2) => boolean) | E2,
+    onReject: (error: E1 | E2) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1, E2>(
+    filter1: ((error: E1) => boolean) | E1,
+    filter2: ((error: E2) => boolean) | E2,
     onReject: (error: E1 | E2) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 
   catch<E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    onReject: (error: E1) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  catch<E1>(
+    filter1: ((error: E1) => boolean) | E1,
     onReject: (error: E1) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   caught<E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    onReject: (error: E1) => R | PromiseLike<R> | void | PromiseLike<void>,
+  ): Bluebird<R>;
+  caught<E1>(
+    filter1: ((error: E1) => boolean) | E1,
     onReject: (error: E1) => R | PromiseLike<R> | void | PromiseLike<void>,
   ): Bluebird<R>;
   catch<U, E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    onReject: (error: E1) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  catch<U, E1>(
+    filter1: ((error: E1) => boolean) | E1,
     onReject: (error: E1) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
   caught<U, E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | Object,
+    filter1: (new (...args: any[]) => E1) | ((error: E1) => boolean) | E1,
+    onReject: (error: E1) => U | PromiseLike<U>,
+  ): Bluebird<U | R>;
+  caught<U, E1>(
+    filter1: ((error: E1) => boolean) | E1,
     onReject: (error: E1) => U | PromiseLike<U>,
   ): Bluebird<U | R>;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://bluebirdjs.com/docs/api/catch.html#filtered-catch>>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Description

With the latest change to make `catch` variadic #16737, the definition for `predicates` and `objects` are broken ([see this comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16737#issuecomment-309505678)). The purpose of this PR is to provide an alternative for those cases.

Example using predicates
![image](https://user-images.githubusercontent.com/6817008/27307031-80a1ce14-550d-11e7-8e30-d401de460909.png)

Example using objects
![image](https://user-images.githubusercontent.com/6817008/27307007-6c12307e-550d-11e7-8b7f-ae5728dd5418.png)

Please let me know if I'm missing something.

\cc @lhecker @DanielRosenwasser @juanpaucar @jcready