### PR TITLE
[koa-morgan] Wrapper passes IncomingMessage instead of Koa.Request

### DIFF
--- a/types/koa-morgan/index.d.ts
+++ b/types/koa-morgan/index.d.ts
@@ -4,19 +4,20 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
+import { IncomingMessage, ServerResponse } from 'http';
 import * as Koa from 'koa';
 import * as originalMorgan from 'morgan';
 
 declare namespace morgan {
     interface FormatFn {
-        (tokens: TokenIndexer, req: Koa.Request, res: Koa.Response): string;
+        (tokens: TokenIndexer, req: IncomingMessage, res: ServerResponse): string;
     }
 
     interface TokenCallbackFn {
-        (req: Koa.Request, res: Koa.Response, arg?: string | number | boolean): string;
+        (req: IncomingMessage, res: ServerResponse, arg?: string | number | boolean): string;
     }
 
-    interface TokenIndexer extends originalMorgan.TokenIndexer {}
+    type TokenIndexer = originalMorgan.TokenIndexer;
 
     /**
      * Public interface of morgan logger
@@ -121,7 +122,7 @@ declare namespace morgan {
      */
     function compile(format: string): FormatFn;
 
-    interface StreamOptions extends originalMorgan.StreamOptions {}
+    type StreamOptions = originalMorgan.StreamOptions;
 
     /***
      * Morgan accepts these properties in the options object.
@@ -141,7 +142,7 @@ declare namespace morgan {
         /***
          * Function to determine if logging is skipped, defaults to false. This function will be called as skip(req, res).
          */
-        skip?: (req: Koa.Request, res: Koa.Response) => boolean;
+        skip?: (req: IncomingMessage, res: ServerResponse) => boolean;
 
         /***
          * Output stream for writing log lines, defaults to process.stdout.
@@ -206,6 +207,6 @@ declare function morgan(format: 'tiny', options?: morgan.Options): Koa.Middlewar
  * @param format
  * @param options
  */
-declare function morgan(custom: (req: Koa.Request, res: Koa.Response) => string): Koa.Middleware;
+declare function morgan(custom: (req: IncomingMessage, res: ServerResponse) => string): Koa.Middleware;
 
 export = morgan;

--- a/types/koa-morgan/koa-morgan-tests.ts
+++ b/types/koa-morgan/koa-morgan-tests.ts
@@ -1,3 +1,4 @@
+import { IncomingMessage, ServerResponse } from 'http';
 import * as Koa from 'koa';
 import * as morgan from 'koa-morgan';
 
@@ -10,6 +11,20 @@ app.use(morgan('short'));
 app.use(morgan('tiny'));
 app.use(morgan(':remote-addr :method :url'));
 
+const tokenCallback: morgan.TokenCallbackFn = (req: IncomingMessage, res: ServerResponse): string => {
+    if (req.headers['request-id']) {
+        if (Array.isArray(req.headers['request-id'])) {
+            return (req.headers['request-id'] as string[]).join(';');
+        } else {
+            return req.headers['request-id'] as string;
+        }
+    } else {
+        return '-';
+    }
+};
+
+morgan.token('id', tokenCallback);
+
 const stream: morgan.StreamOptions = {
     write: (str: string) => {
         console.log(str);
@@ -19,7 +34,7 @@ const stream: morgan.StreamOptions = {
 app.use(morgan('combined', {
     buffer: true,
     immediate: true,
-    skip: (req: Koa.Request, res: Koa.Response) => res.status < 400,
+    skip: (req: IncomingMessage, res: ServerResponse) => res.statusCode < 400,
     stream
 }));
 
@@ -41,10 +56,10 @@ interface ExtendedFormatFn extends morgan.FormatFn {
     memoizer?: FormatFnIndexer;
 }
 
-const developmentExtendedFormatLine: ExtendedFormatFn = (tokens, req: Koa.Request, res: Koa.Response): string => {
+const developmentExtendedFormatLine: ExtendedFormatFn = (tokens, req: IncomingMessage, res: ServerResponse): string => {
     // get the status code if response written
-    const status = res.status
-        ? res.status
+    const status = res.statusCode
+        ? res.statusCode
         : undefined;
 
     // get status color


### PR DESCRIPTION
The wrapper function passes ctx.req and ctx.res to original morgan.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Where ctx.req and ctx.res are passed: https://github.com/koa-modules/morgan/blob/v1.0.1/index.js#L33
  - ctx type definition: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/354cec620daccfa0ad167ba046651fb5fef69e8a/types/koa/index.d.ts#L648-L649
- [X] Increase the version number in the header if appropriate.
  - Not needed
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
