### PR TITLE
extended jasmine-ajax request object by missing error/timeout methods

### DIFF
--- a/types/jasmine-ajax/index.d.ts
+++ b/types/jasmine-ajax/index.d.ts
@@ -24,6 +24,8 @@ interface JasmineAjaxRequest extends XMLHttpRequest {
 	data(): string;
 
 	respondWith(response: JasmineAjaxResponse): void;
+	responseTimeout(): void;
+	responseError(): void;
 }
 
 interface JasmineAjaxRequestTracker {


### PR DESCRIPTION
responseTimeout and responseError methods where missing in JasmineAjaxRequest

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jasmine/jasmine-ajax/blob/master/lib/mock-ajax.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.