### PR TITLE
Update @types/auth0-js index.d.ts  connection added to AuthorizeOption and every field of AuthorizeOption is now optional

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -650,8 +650,9 @@ interface RenewAuthOptions {
 interface AuthorizeOptions {
     domain?: string;
     clientID?: string;
-    redirectUri: string;
-    responseType: string;
+    connection?:string;
+    redirectUri?: string;
+    responseType?: string;
     responseMode?: string;
     state?: string;
     nonce?: string;


### PR DESCRIPTION
added connection to authorizeOptions, and made every field of AuthorizeOption optional


If changing an existing definition:
- [ X ] Provide a URL to documentation or source code which provides context for the suggested changes: 

This is the doc on authorize. In index.ts authorize() takes in AuthorizeOption as parameter.

https://auth0.com/docs/libraries/auth0js/v8#webauth-authorize-

