### PR TITLE
Update @types/vis index.d.ts - rollingMode option from boolean to object.

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -179,7 +179,7 @@ export interface TimelineOptions {
   onRemoveGroup?(): void; // TODO
   order?(): void; // TODO
   orientation?: TimelineOptionsOrientationType;
-  rollingMode?: boolean;
+  rollingMode?: any;
   selectable?: boolean;
   showCurrentTime?: boolean;
   showMajorLabels?: boolean;


### PR DESCRIPTION
Timeline implements rolling mode with an object configuration instead boolean type.

This is the doc for configuration options: 

http://visjs.org/docs/timeline/#Configuration_Options