### PR TITLE
[hls.js] Changed Hls.version property to return string instead of number

### DIFF
--- a/types/hls.js/hls.js-tests.ts
+++ b/types/hls.js/hls.js-tests.ts
@@ -3,6 +3,7 @@ import * as Hls from 'hls.js';
 if (Hls.isSupported()) {
   const video = <HTMLVideoElement> document.getElementById('video');
   const hls = new Hls();
+  const version: string = Hls.version;
   hls.loadSource('http://www.streambox.fr/playlists/test_001/stream.m3u8');
   hls.attachMedia(video);
   hls.on(Hls.Events.MANIFEST_PARSED, () => {

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -382,7 +382,7 @@ declare namespace Hls {
   /**
    * returns hls.js dist version number
    */
-  const version: number;
+  const version: string;
 
   interface Config {
     /**


### PR DESCRIPTION
Changed Hls.version to return a string instead of a number.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/video-dev/hls.js/blob/master/doc/API.md#version-control
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

/cc @jgainfort 