### PR TITLE
graphqljs: get[Mutation|Subscription]Type() are nullable

### DIFF
--- a/types/graphql/type/schema.d.ts
+++ b/types/graphql/type/schema.d.ts
@@ -49,8 +49,8 @@ export class GraphQLSchema {
     constructor(config: GraphQLSchemaConfig)
 
     getQueryType(): GraphQLObjectType;
-    getMutationType(): GraphQLObjectType;
-    getSubscriptionType(): GraphQLObjectType;
+    getMutationType(): GraphQLObjectType|undefined;
+    getSubscriptionType(): GraphQLObjectType|undefined;
     getTypeMap(): { [typeName: string]: GraphQLNamedType };
     getType(name: string): GraphQLType;
     getPossibleTypes(abstractType: GraphQLAbstractType): Array<GraphQLObjectType>;

--- a/types/graphql/type/schema.d.ts
+++ b/types/graphql/type/schema.d.ts
@@ -49,8 +49,8 @@ export class GraphQLSchema {
     constructor(config: GraphQLSchemaConfig)
 
     getQueryType(): GraphQLObjectType;
-    getMutationType(): GraphQLObjectType|undefined;
-    getSubscriptionType(): GraphQLObjectType|undefined;
+    getMutationType(): GraphQLObjectType|null|undefined;
+    getSubscriptionType(): GraphQLObjectType|null|undefined;
     getTypeMap(): { [typeName: string]: GraphQLNamedType };
     getType(name: string): GraphQLType;
     getPossibleTypes(abstractType: GraphQLAbstractType): Array<GraphQLObjectType>;


### PR DESCRIPTION
According to [`schema.js`](https://github.com/graphql/graphql-js/blob/master/src/type/schema.js#L160), `GraphQLSchema.getMutationType()` and `getSubscriptionType()` may return `undefined`, so the types should reflect that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/graphql/graphql-js/blob/master/src/type/schema.js#L160>>
- [ ] Increase the version number in the header if appropriate.