### PR TITLE
react-loadable: Only default is a valid key by default

### DIFF
--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -44,7 +44,7 @@ export interface OptionsWithoutRender<Props> extends CommonOptions {
      *
      * Resulting React component receives all the props passed to the generated component.
      */
-    loader(): Promise<React.ComponentType<Props> | { [key: string]: React.ComponentType<Props> }>;
+    loader(): Promise<React.ComponentType<Props> | { default: React.ComponentType<Props> }>;
 }
 
 export interface OptionsWithRender<Props, Exports extends object> extends CommonOptions {

--- a/types/react-loadable/react-loadable-tests.tsx
+++ b/types/react-loadable/react-loadable-tests.tsx
@@ -42,7 +42,7 @@ const Loadable300 = Loadable({
   loading: LoadingComponent,
   delay: false,
   timeout: false,
-  render(loaded, props) {
+  render(loaded, props: ComponentProps) {
     const { Component } = loaded;
     return <Component {...props} />;
   }


### PR DESCRIPTION
Having it be an indexed type prevents use with dynamic import.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/thejameskyle/react-loadable/blob/754266e66/src/index.js#L103

---

I'm not sure how I can make a test that would fail without this change. It accepts an indexed object so providing an inline object will always be valid; the problem is when using the result of dynamic `import()` as that object is not indexable (it's not supposed to be).