### PR TITLE
jquery: Make JQueryStatic's context optional

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2470,11 +2470,10 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/jQuery/}
      * @since 1.0
      */
-    (selector: JQuery.Selector, context?: Element | Document | JQuery): JQuery<TElement>;
+    (selector: JQuery.Selector, context: Element | Document | JQuery | undefined): JQuery<TElement>;
     // HACK: This is the factory function returned when importing jQuery without a DOM. Declaring it separately breaks using the type parameter on JQueryStatic.
     // HACK: The discriminator parameter handles the edge case of passing a Window object to JQueryStatic. It doesn't actually exist on the factory function.
     <FElement extends Node = HTMLElement>(window: Window, discriminator: boolean): JQueryStatic<FElement>;
-
     /**
      * Creates DOM elements on the fly from the provided string of raw HTML.
      *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2446,7 +2446,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/jQuery/}
      * @since 1.0
      */
-    (selector: JQuery.Selector, context: Element | Document | JQuery): JQuery<TElement>;
+    (selector: JQuery.Selector, context?: Element | Document | JQuery): JQuery<TElement>;
     /**
      * Creates DOM elements on the fly from the provided string of raw HTML.
      *


### PR DESCRIPTION
Not having this prevents calling JQueryStatic with a potentially-`undefined` second argument, which would still be validly processed by jquery.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jquery/jquery/blob/36389288/src/core.js#L30 (just forwards to internal function, always with 2 arguments)
