### PR TITLE
history: Update PathUtils for 4.6.2

### DIFF
--- a/types/history/PathUtils.d.ts
+++ b/types/history/PathUtils.d.ts
@@ -2,6 +2,8 @@ import { Path, Location, LocationDescriptorObject } from './index';
 
 export function addLeadingSlash(path: Path): Path;
 export function stripLeadingSlash(path: Path): Path;
-export function stripPrefix(path: Path, prefix: string): Path;
+export function hasBasename(path: Path): boolean;
+export function stripBasename(path: Path, prefix: string): Path;
+export function stripTrailingSlash(path: Path): Path;
 export function parsePath(path: Path): Location;
 export function createPath(location: LocationDescriptorObject): Path;

--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -109,7 +109,7 @@ let input = { value: "" };
 
 {
     let path = PathUtils.createPath({ pathname: '/a/path', hash: '#hash' });
-    let strippedPath = PathUtils.stripPrefix(path, '/a/');
+    let strippedPath = PathUtils.stripBasename(path, '/a/');
     let location = PathUtils.parsePath(strippedPath);
 }
 

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for history 4.5
+// Type definitions for history 4.6.2
 // Project: https://github.com/mjackson/history
 // Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>, Nathan Brown <https://github.com/ngbrown>, Young Rok Kim <https://github.com/rokoroku>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/history/pull/459
- [x] Increase the version number in the header if appropriate.

---

Yeah, it is a breaking change for people that were using PathUtils directly. I believe it is not supposed to be public API, though.