### PR TITLE
[jquery] Clean up event-related methods on JQuery and fix issues with importing

### DIFF
--- a/types/jquery/README.md
+++ b/types/jquery/README.md
@@ -1,0 +1,53 @@
+### Usage
+
+#### Global
+
+When jQuery is globally available, you can use `jQuery` and `$` directly.
+
+#### Importing (with a global DOM available)
+
+When you want to import jQuery as a module and have a global DOM available (e.g. browser and browser-like environments):
+
+```typescript
+import * as jQuery from 'jquery';
+```
+
+#### Importing (without a global DOM available)
+
+When you want to import jQuery as a module and do not have a global DOM available (e.g. Node.js environment):
+
+```typescript
+import jQueryFactory = require('jquery');
+const jQuery = jQueryFactory(window, true);
+```
+
+Note that while the factory function ignores the second parameter, it is required to get correct type declarations.
+
+### Authoring type definitions for jQuery plugins
+
+`$.fn` is represented by `JQuery`.
+
+`$` is represented by `JQueryStatic`.
+
+Declare an interface that has the plugin's overloads as call signatures and static members as properties.
+
+```typescript
+interface MyPlugin {
+    settings: MyPluginSettings;
+    
+    (behavior: 'enable'): JQuery;
+    (settings?: MyPluginSettings): JQuery;
+}
+
+interface MyPluginSettings {
+    title?: string;
+}
+```
+
+Then declare a property on `JQuery` with your plugin's type.
+
+```typescript
+interface JQuery {
+    myPlugin: MyPlugin;
+}
+```

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -296,6 +296,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.10
      */
     before(fn: (this: TElement, index: number, html: string) => JQuery.htmlString | JQuery.TypeOrArray<Element | Text> | JQuery): this;
+    // [bind() overloads] https://github.com/jquery/api.jquery.com/issues/1048
     /**
      * Attach a handler to an event for the elements.
      *
@@ -304,43 +305,23 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @param handler A function to execute each time the event is triggered.
      * @see {@link https://api.jquery.com/bind/}
      * @since 1.0
-     * @deprecated 3.0
-     */
-    bind<TData>(eventType: string, eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
-    /**
-     * Attach a handler to an event for the elements.
-     *
-     * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
-     * @param eventData An object containing data that will be passed to the event handler.
-     * @param preventBubble Setting the third argument to false will attach a function that prevents the default action from
-     *                      occurring and stops the event from bubbling. The default is true.
-     * @see {@link https://api.jquery.com/bind/}
      * @since 1.4.3
      * @deprecated 3.0
      */
-    bind(eventType: string, eventData: any, preventBubble: boolean): this;
+    bind<TData>(eventType: string, eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach a handler to an event for the elements.
      *
      * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
      * @param handler A function to execute each time the event is triggered.
+     *                Setting the second argument to false will attach a function that prevents the default action from
+     *                occurring and stops the event from bubbling.
      * @see {@link https://api.jquery.com/bind/}
      * @since 1.0
+     * @since 1.4.3
      * @deprecated 3.0
      */
-    bind(eventType: string, handler: JQuery.EventHandler<TElement> | false): this;
-    /**
-     * Attach a handler to an event for the elements.
-     *
-     * @param eventType A string containing one or more DOM event types, such as "click" or "submit," or custom event names.
-     * @param preventBubble_eventData Setting the third argument to false will attach a function that prevents the default action from
-     *                                occurring and stops the event from bubbling. The default is true.
-     *                                An object containing data that will be passed to the event handler.
-     * @see {@link https://api.jquery.com/bind/}
-     * @since 1.0
-     * @deprecated 3.0
-     */
-    bind(eventType: string, preventBubble_eventData?: boolean | any): this;
+    bind(eventType: string, handler: JQuery.EventHandler<TElement> | false | null | undefined): this;
     /**
      * Attach a handler to an event for the elements.
      *
@@ -358,7 +339,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/blur/}
      * @since 1.4.3
      */
-    blur<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    blur<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "blur" JavaScript event, or trigger that event on an element.
      *
@@ -375,7 +356,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/change/}
      * @since 1.4.3
      */
-    change<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    change<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "change" JavaScript event, or trigger that event on an element.
      *
@@ -408,7 +389,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/click/}
      * @since 1.4.3
      */
-    click<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    click<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "click" JavaScript event, or trigger that event on an element.
      *
@@ -467,7 +448,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/contextmenu/}
      * @since 1.4.3
      */
-    contextmenu<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    contextmenu<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "contextmenu" JavaScript event, or trigger that event on an element.
      *
@@ -566,7 +547,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/dblclick/}
      * @since 1.4.3
      */
-    dblclick<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    dblclick<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "dblclick" JavaScript event, or trigger that event on an element.
      *
@@ -597,7 +578,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.4.2
      * @deprecated 3.0
      */
-    delegate<TData>(selector: string, eventType: string, eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    delegate<TData>(selector: JQuery.Selector, eventType: string, eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach a handler to one or more events for all elements that match the selector, now or in the
      * future, based on a specific set of root elements.
@@ -610,7 +591,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.4.2
      * @deprecated 3.0
      */
-    delegate(selector: string, eventType: string, handler: JQuery.EventHandler<TElement> | false): this;
+    delegate(selector: JQuery.Selector, eventType: string, handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Attach a handler to one or more events for all elements that match the selector, now or in the
      * future, based on a specific set of root elements.
@@ -621,7 +602,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.4.3
      * @deprecated 3.0
      */
-    delegate(selector: string, events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
+    delegate(selector: JQuery.Selector, events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
     /**
      * Execute the next function on the queue for the matched elements.
      *
@@ -846,7 +827,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/focus/}
      * @since 1.4.3
      */
-    focus<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    focus<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "focus" JavaScript event, or trigger that event on an element.
      *
@@ -863,7 +844,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/focusin/}
      * @since 1.4.3
      */
-    focusin<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    focusin<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "focusin" event.
      *
@@ -880,7 +861,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/focusout/}
      * @since 1.4.3
      */
-    focusout<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    focusout<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "focusout" JavaScript event.
      *
@@ -981,8 +962,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.0
      * @since 1.4
      */
-    hover(handlerInOut: (this: TElement, eventObject: JQuery.Event<TElement>) => void | false,
-          handlerOut?: (this: TElement, eventObject: JQuery.Event<TElement>) => void | false): this;
+    hover(handlerInOut: JQuery.EventHandler<TElement> | false, handlerOut?: JQuery.EventHandler<TElement> | false): this;
     /**
      * Set the HTML contents of each element in the set of matched elements.
      *
@@ -1093,7 +1073,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/keydown/}
      * @since 1.4.3
      */
-    keydown<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    keydown<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "keydown" JavaScript event, or trigger that event on an element.
      *
@@ -1110,7 +1090,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/keypress/}
      * @since 1.4.3
      */
-    keypress<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    keypress<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "keypress" JavaScript event, or trigger that event on an element.
      *
@@ -1127,7 +1107,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/keyup/}
      * @since 1.4.3
      */
-    keyup<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    keyup<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "keyup" JavaScript event, or trigger that event on an element.
      *
@@ -1183,7 +1163,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/mousedown/}
      * @since 1.4.3
      */
-    mousedown<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    mousedown<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mousedown" JavaScript event, or trigger that event on an element.
      *
@@ -1200,7 +1180,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/mouseenter/}
      * @since 1.4.3
      */
-    mouseenter<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    mouseenter<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to be fired when the mouse enters an element, or trigger that handler on an element.
      *
@@ -1217,7 +1197,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/mouseleave/}
      * @since 1.4.3
      */
-    mouseleave<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    mouseleave<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to be fired when the mouse leaves an element, or trigger that handler on an element.
      *
@@ -1234,7 +1214,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/mousemove/}
      * @since 1.4.3
      */
-    mousemove<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    mousemove<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mousemove" JavaScript event, or trigger that event on an element.
      *
@@ -1251,7 +1231,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/mouseout/}
      * @since 1.4.3
      */
-    mouseout<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    mouseout<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mouseout" JavaScript event, or trigger that event on an element.
      *
@@ -1268,7 +1248,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/mouseover/}
      * @since 1.4.3
      */
-    mouseover<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    mouseover<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mouseover" JavaScript event, or trigger that event on an element.
      *
@@ -1285,7 +1265,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/mouseup/}
      * @since 1.4.3
      */
-    mouseup<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    mouseup<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "mouseup" JavaScript event, or trigger that event on an element.
      *
@@ -1346,17 +1326,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/off/}
      * @since 1.7
      */
-    off(events: string, selector: string, handler: JQuery.EventHandler<TElement> | false): this;
-    /**
-     * Remove an event handler.
-     *
-     * @param events An object where the string keys represent one or more space-separated event types and optional
-     *               namespaces, and the values represent handler functions previously attached for the event(s).
-     * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
-     * @see {@link https://api.jquery.com/off/}
-     * @since 1.7
-     */
-    off(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>, selector: string): this;
+    off(events: string, selector: JQuery.Selector, handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Remove an event handler.
      *
@@ -1367,17 +1337,25 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/off/}
      * @since 1.7
      */
-    off(events: string, selector_handler?: string | JQuery.EventHandler<TElement> | false): this;
+    off(events: string, selector_handler?: JQuery.Selector | JQuery.EventHandler<TElement> | false): this;
     /**
      * Remove an event handler.
      *
-     * @param events A jQuery.Event object.
-     *               An object where the string keys represent one or more space-separated event types and optional
+     * @param events An object where the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent handler functions previously attached for the event(s).
+     * @param selector A selector which should match the one originally passed to .on() when attaching event handlers.
      * @see {@link https://api.jquery.com/off/}
      * @since 1.7
      */
-    off(events?: JQuery.Event<TElement> | JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
+    off(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>, selector?: JQuery.Selector): this;
+    /**
+     * Remove an event handler.
+     *
+     * @param event A jQuery.Event object.
+     * @see {@link https://api.jquery.com/off/}
+     * @since 1.7
+     */
+    off(event?: JQuery.Event<TElement>): this;
     /**
      * Set the current coordinates of every element in the set of matched elements, relative to the document.
      *
@@ -1411,37 +1389,33 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
-     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
-     *                for a function that simply does return false.
+     * @param handler A function to execute when the event is triggered.
      * @see {@link https://api.jquery.com/on/}
      * @since 1.7
      */
-    on<TData>(events: string, selector: string | null, data: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
-    /**
-     * Attach an event handler function for one or more events to the selected elements.
-     *
-     * @param events An object in which the string keys represent one or more space-separated event types and optional
-     *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
-     *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
-     * @param data Data to be passed to the handler in event.data when an event occurs.
-     * @see {@link https://api.jquery.com/on/}
-     * @since 1.7
-     */
-    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>, selector: string | null, data: TData): this;
+    on<TData>(events: string, selector: JQuery.Selector | null, data: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param selector_data A selector string to filter the descendants of the selected elements that trigger the event. If the
-     *                      selector is null or omitted, the event is always triggered when it reaches the selected element.
-     *                      Data to be passed to the handler in event.data when an event is triggered.
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the
+     *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
      * @see {@link https://api.jquery.com/on/}
      * @since 1.7
      */
-    on<TData>(events: string, selector_data: string | null | TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    on(events: string, selector: JQuery.Selector | null, handler: JQuery.EventHandler<TElement> | false): this;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered.
+     * @see {@link https://api.jquery.com/on/}
+     * @since 1.7
+     */
+    on<TData>(events: string, data: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach an event handler function for one or more events to the selected elements.
      *
@@ -1457,13 +1431,43 @@ interface JQuery<TElement extends Node = HTMLElement> {
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @param selector_data A selector string to filter the descendants of the selected elements that will call the handler. If
-     *                      the selector is null or omitted, the handler is always called when it reaches the selected element.
-     *                      Data to be passed to the handler in event.data when an event occurs.
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
+     *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event occurs.
      * @see {@link https://api.jquery.com/on/}
      * @since 1.7
      */
-    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>, selector_data?: string | null | TData): this;
+    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>, selector: JQuery.Selector | null, data: TData): this;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional
+     *               namespaces, and the values represent a handler function to be called for the event(s).
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
+     *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @see {@link https://api.jquery.com/on/}
+     * @since 1.7
+     */
+    on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>, selector: JQuery.Selector): this; // tslint:disable-line:unified-signatures
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional
+     *               namespaces, and the values represent a handler function to be called for the event(s).
+     * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @see {@link https://api.jquery.com/on/}
+     * @since 1.7
+     */
+    on<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>, data: TData): this;
+    /**
+     * Attach an event handler function for one or more events to the selected elements.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional
+     *               namespaces, and the values represent a handler function to be called for the event(s).
+     * @see {@link https://api.jquery.com/on/}
+     * @since 1.7
+     */
+    on(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
@@ -1471,37 +1475,33 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the
      *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param data Data to be passed to the handler in event.data when an event is triggered.
-     * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
-     *                for a function that simply does return false.
+     * @param handler A function to execute when the event is triggered.
      * @see {@link https://api.jquery.com/one/}
      * @since 1.7
      */
-    one<TData>(events: string, selector: string | null, data: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    one<TData>(events: string, selector: JQuery.Selector | null, data: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
      * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
-     * @param selector_data A selector string to filter the descendants of the selected elements that trigger the event. If the
-     *                      selector is null or omitted, the event is always triggered when it reaches the selected element.
-     *                      Data to be passed to the handler in event.data when an event is triggered.
+     * @param selector A selector string to filter the descendants of the selected elements that trigger the event. If the
+     *                 selector is null or omitted, the event is always triggered when it reaches the selected element.
      * @param handler A function to execute when the event is triggered. The value false is also allowed as a shorthand
      *                for a function that simply does return false.
      * @see {@link https://api.jquery.com/one/}
      * @since 1.7
      */
-    one<TData>(events: string, selector_data: string | null | TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    one(events: string, selector: JQuery.Selector | null, handler: JQuery.EventHandler<TElement> | false): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
-     * @param events An object in which the string keys represent one or more space-separated event types and optional
-     *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
-     *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
-     * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @param events One or more space-separated event types and optional namespaces, such as "click" or "keydown.myPlugin".
+     * @param data Data to be passed to the handler in event.data when an event is triggered.
+     * @param handler A function to execute when the event is triggered.
      * @see {@link https://api.jquery.com/one/}
      * @since 1.7
      */
-    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>, selector: string | null, data: TData): this;
+    one<TData>(events: string, data: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
      *
@@ -1517,13 +1517,43 @@ interface JQuery<TElement extends Node = HTMLElement> {
      *
      * @param events An object in which the string keys represent one or more space-separated event types and optional
      *               namespaces, and the values represent a handler function to be called for the event(s).
-     * @param selector_data A selector string to filter the descendants of the selected elements that will call the handler. If
-     *                      the selector is null or omitted, the handler is always called when it reaches the selected element.
-     *                      Data to be passed to the handler in event.data when an event occurs.
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
+     *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @param data Data to be passed to the handler in event.data when an event occurs.
      * @see {@link https://api.jquery.com/one/}
      * @since 1.7
      */
-    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>, selector_data?: string | null | TData): this;
+    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>, selector: JQuery.Selector | null, data: TData): this;
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional
+     *               namespaces, and the values represent a handler function to be called for the event(s).
+     * @param selector A selector string to filter the descendants of the selected elements that will call the handler. If
+     *                 the selector is null or omitted, the handler is always called when it reaches the selected element.
+     * @see {@link https://api.jquery.com/one/}
+     * @since 1.7
+     */
+    one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>, selector: JQuery.Selector): this; // tslint:disable-line:unified-signatures
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional
+     *               namespaces, and the values represent a handler function to be called for the event(s).
+     * @param data Data to be passed to the handler in event.data when an event occurs.
+     * @see {@link https://api.jquery.com/one/}
+     * @since 1.7
+     */
+    one<TData>(events: JQuery.PlainObject<JQuery.EventHandler<TElement, TData> | false>, data: TData): this;
+    /**
+     * Attach a handler to an event for the elements. The handler is executed at most once per element per event type.
+     *
+     * @param events An object in which the string keys represent one or more space-separated event types and optional
+     *               namespaces, and the values represent a handler function to be called for the event(s).
+     * @see {@link https://api.jquery.com/one/}
+     * @since 1.7
+     */
+    one(events: JQuery.PlainObject<JQuery.EventHandler<TElement> | false>): this;
     /**
      * Set the CSS outer height of each element in the set of matched elements.
      *
@@ -1770,7 +1800,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/ready/}
      * @since 1.0
      */
-    ready(handler: ($: JQueryStatic) => void): this;
+    ready(handler: ($: JQueryStatic<TElement>) => void): this;
     /**
      * Remove the set of matched elements from the DOM.
      *
@@ -1843,7 +1873,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/resize/}
      * @since 1.4.3
      */
-    resize<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    resize<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "resize" JavaScript event, or trigger that event on an element.
      *
@@ -1860,7 +1890,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/scroll/}
      * @since 1.4.3
      */
-    scroll<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    scroll<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "scroll" JavaScript event, or trigger that event on an element.
      *
@@ -1908,7 +1938,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/select/}
      * @since 1.4.3
      */
-    select<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    select<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "select" JavaScript event, or trigger that event on an element.
      *
@@ -2107,7 +2137,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/submit/}
      * @since 1.4.3
      */
-    submit<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData> | false): this;
+    submit<TData>(eventData: TData, handler: JQuery.EventHandler<TElement, TData>): this;
     /**
      * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
      *
@@ -2208,7 +2238,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.0
      * @since 1.3
      */
-    trigger(eventType: string | JQuery.Event<TElement>, extraParameters?: any[] | JQuery.PlainObject): this;
+    trigger(eventType: string | JQuery.Event<TElement>, extraParameters?: any[] | JQuery.PlainObject | string | number): this;
     /**
      * Execute all handlers attached to an element for an event.
      *
@@ -2219,7 +2249,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @since 1.2
      * @since 1.3
      */
-    triggerHandler(eventType: string | JQuery.Event<TElement>, extraParameters?: any[] | JQuery.PlainObject): undefined | any;
+    triggerHandler(eventType: string | JQuery.Event<TElement>, extraParameters?: any[] | JQuery.PlainObject | string | number): undefined | any;
     /**
      * Remove a previously-attached event handler from the elements.
      *
@@ -4152,7 +4182,8 @@ declare namespace JQuery {
 
     // region Events
 
-    class Event<TTarget = EventTarget, TData = null> {
+    // This should be a class but doesn't work correctly under the JQuery namespace. Event should be an inner class of jQuery.
+    interface Event<TTarget = EventTarget, TData = null> {
         /**
          * The current DOM element within the event bubbling phase.
          *

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -25,17 +25,11 @@
 // TypeScript Version: 2.3
 
 declare module 'jquery' {
-    function factory(window: Window): JQueryStatic & JQuery;
-
-    const factoryOrJQuery: typeof factory & JQueryStatic;
-    export = factoryOrJQuery;
+    export = jQuery;
 }
 
 declare module 'jquery/dist/jquery.slim' {
-    function factory(window: Window): JQueryStatic & JQuery;
-
-    const factoryOrJQuery: typeof factory & JQueryStatic;
-    export = factoryOrJQuery;
+    export = jQuery;
 }
 
 declare const jQuery: JQueryStatic;
@@ -2477,6 +2471,9 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @since 1.0
      */
     (selector: JQuery.Selector, context: Element | Document | JQuery): JQuery<TElement>;
+    // HACK: This is the factory function returned when importing jQuery without a DOM. Declaring it separately breaks using the type parameter on JQueryStatic.
+    // HACK: The discriminator parameter handles the edge case of passing a Window object to JQueryStatic. It doesn't actually exist on the factory function.
+    <FElement extends Node = HTMLElement>(window: Window, discriminator: boolean): JQueryStatic<FElement>;
     /**
      * Creates DOM elements on the fly from the provided string of raw HTML.
      *

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -1376,14 +1376,1025 @@ function JQuery() {
         }
     }
 
-    function on() {
-        function false_handler_shorthand() {
-            $().on('events', false);
+    function events() {
+        // [bind() overloads] https://github.com/jquery/api.jquery.com/issues/1048
+        function bind() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').bind('myEvent', 'myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').bind('myEvent', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').bind('myEvent', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').bind({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                },
+                myEvent2: false
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').bind('myEvent', null);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').bind('myEvent', undefined);
         }
 
-        function typed_event_data() {
-            $('#myElement').on('custom', 45, (event, data) => {
-                event.data === 23;
+        function delegate() {
+            // $ExpectType JQuery<HTMLElement>
+            $('table').delegate('td', 'myEvent', 'myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').delegate('td', 'myEvent', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').delegate('td', 'myEvent', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').delegate('td', {
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, null>
+                    event;
+                },
+                myEvent2: false
+            });
+        }
+
+        function off() {
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off('myEvent', 'td', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off('myEvent', 'td', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off('myEvent', 'td');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off('myEvent', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off('myEvent', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off('myEvent');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, null>
+                    event;
+                },
+                myEvent2: false
+            }, 'td');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, null>
+                    event;
+                },
+                myEvent2: false
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off($.Event('myEvent'));
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').off();
+        }
+
+        function on() {
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', 'td', 'myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', null, 'myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', 'td', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', 'td', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', 3, function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, number>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on('myEvent', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, string>
+                    event;
+                },
+                myEvent2: false
+            }, 'td', 'myData');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, string>
+                    event;
+                },
+                myEvent2: false
+            }, null, 'myData');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, null>
+                    event;
+                },
+                myEvent2: false
+            }, 'td');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, number>
+                    event;
+                },
+                myEvent2: false
+            }, 3);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').on({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, null>
+                    event;
+                },
+                myEvent2: false
+            });
+        }
+
+        function one() {
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one('myEvent', 'td', 'myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one('myEvent', null, 'myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one('myEvent', 'td', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one('myEvent', 'td', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one('myEvent', 3, function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, number>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one('myEvent', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one('myEvent', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, string>
+                    event;
+                },
+                myEvent2: false
+            }, 'td', 'myData');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, string>
+                    event;
+                },
+                myEvent2: false
+            }, null, 'myData');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, null>
+                    event;
+                },
+                myEvent2: false
+            }, 'td');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, number>
+                    event;
+                },
+                myEvent2: false
+            }, 3);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').one({
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, null>
+                    event;
+                },
+                myEvent2: false
+            });
+        }
+
+        function trigger() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').trigger('myEvent', ['Custom', 'Event']);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').trigger('myEvent', { myData: 'myData' });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').trigger('myEvent', 'Custom');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').trigger('myEvent', 3);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').trigger($.Event('myEvent'), ['Custom', 'Event']);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').trigger($.Event('myEvent'), { myData: 'myData' });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').trigger($.Event('myEvent'), 'Custom');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').trigger($.Event('myEvent'), 3);
+        }
+
+        function triggerHandler() {
+            // $ExpectType any
+            $('p').triggerHandler('myEvent', ['Custom', 'Event']);
+
+            // $ExpectType any
+            $('p').triggerHandler('myEvent', { myData: 'myData' });
+
+            // $ExpectType any
+            $('p').triggerHandler('myEvent', 'Custom');
+
+            // $ExpectType any
+            $('p').triggerHandler('myEvent', 3);
+
+            // $ExpectType any
+            $('p').triggerHandler($.Event('myEvent'), ['Custom', 'Event']);
+
+            // $ExpectType any
+            $('p').triggerHandler($.Event('myEvent'), { myData: 'myData' });
+
+            // $ExpectType any
+            $('p').triggerHandler($.Event('myEvent'), 'Custom');
+
+            // $ExpectType any
+            $('p').triggerHandler($.Event('myEvent'), 3);
+        }
+
+        function unbind() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').unbind('myEvent', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').unbind('myEvent', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').unbind('myEvent');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').unbind($.Event('myEvent'));
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').unbind();
+        }
+
+        function undelegate() {
+            // $ExpectType JQuery<HTMLElement>
+            $('table').undelegate('td', 'click', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').undelegate('td', 'click', false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').undelegate('td', 'click');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').undelegate('td', {
+                myEvent1(event) {
+                    // $ExpectType HTMLElement
+                    this;
+                    // $ExpectType Event<HTMLElement, null>
+                    event;
+                },
+                myEvent2: false
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').undelegate('.tt');
+
+            // $ExpectType JQuery<HTMLElement>
+            $('table').undelegate();
+        }
+
+        function blur() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').blur('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').blur(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').blur(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').blur();
+        }
+
+        function change() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').change('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').change(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').change(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').change();
+        }
+
+        function click() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').click('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').click(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').click(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').click();
+        }
+
+        function contextmenu() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').contextmenu('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').contextmenu(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').contextmenu(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').contextmenu();
+        }
+
+        function dblclick() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').dblclick('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').dblclick(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').dblclick(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').dblclick();
+        }
+
+        function focus() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focus('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focus(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focus(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focus();
+        }
+
+        function focusin() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focusin('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focusin(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focusin(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focusin();
+        }
+
+        function focusout() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focusout('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focusout(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focusout(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').focusout();
+        }
+
+        function keydown() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keydown('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keydown(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keydown(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keydown();
+        }
+
+        function keypress() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keypress('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keypress(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keypress(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keypress();
+        }
+
+        function keyup() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keyup('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keyup(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keyup(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').keyup();
+        }
+
+        function mousedown() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mousedown('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mousedown(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mousedown(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mousedown();
+        }
+
+        function mouseenter() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseenter('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseenter(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseenter(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseenter();
+        }
+
+        function mouseleave() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseleave('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseleave(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseleave(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseleave();
+        }
+
+        function mousemove() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mousemove('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mousemove(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mousemove(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mousemove();
+        }
+
+        function mouseout() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseout('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseout(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseout(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseout();
+        }
+
+        function mouseover() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseover('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseover(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseover(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseover();
+        }
+
+        function mouseup() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseup('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseup(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseup(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').mouseup();
+        }
+
+        function resize() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').resize('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').resize(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').resize(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').resize();
+        }
+
+        function scroll() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').scroll('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').scroll(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').scroll(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').scroll();
+        }
+
+        function select() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').select('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').select(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').select(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').select();
+        }
+
+        function submit() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').submit('myData', function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, string>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').submit(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').submit(false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').submit();
+        }
+
+        function hover() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').hover(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            }, function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').hover(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            }, false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').hover(false, function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').hover(false, false);
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').hover(function(event) {
+                // $ExpectType HTMLElement
+                this;
+                // $ExpectType Event<HTMLElement, null>
+                event;
+            });
+
+            // $ExpectType JQuery<HTMLElement>
+            $('p').hover(false);
+        }
+
+        function ready() {
+            // $ExpectType JQuery<HTMLElement>
+            $('p').ready(($) => {
+                // $ExpectType JQueryStatic<HTMLElement>
+                $;
             });
         }
     }
@@ -1563,12 +2574,6 @@ function EffectsOptions() {
 }
 
 function JQuery_Event() {
-    function type_guard(e: object) {
-        if (e instanceof JQuery.Event) {
-            e.isDefaultPrevented() === true;
-        }
-    }
-
     function mixin() {
         const e = $.Event('keydown', {
             mySpecialKeyCode: JQuery.Key.CapsLock,

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -1,4 +1,9 @@
 function JQuery() {
+    function type_assertion() {
+        const $el = $(document.createElement('canvas'));
+        const $canvas = $el as JQuery<HTMLCanvasElement>;
+    }
+
     function iterable() {
         for (const a of $('div')) {
             a.textContent = 'myDiv';
@@ -2401,6 +2406,10 @@ function JQuery() {
 }
 
 function JQueryStatic() {
+    function type_assertion() {
+        const $Canvas = $ as JQueryStatic<HTMLCanvasElement>;
+    }
+
     function type_annotation() {
         const jq: JQueryStatic = $;
     }

--- a/types/jquery/test/jquery-no-window-module-tests.ts
+++ b/types/jquery/test/jquery-no-window-module-tests.ts
@@ -1,8 +1,5 @@
 import jQueryFactory = require('jquery');
 
-const jq = jQueryFactory(window);
-// ExpectType will report 'jq' as 'JQueryStatic<HTMLElement> & JQuery<HTMLElement>' even though the compiler seems to know that 'jq' is 'JQueryStatic<HTMLElement>'
-// // $ExpectType JQueryStatic<HTMLElement>
-// jq;
-// jq === jQuery();
-jq === jQuery;
+const jq = jQueryFactory(window, true);
+// $ExpectType JQueryStatic<HTMLElement>
+jq;

--- a/types/jquery/test/jquery-slim-no-window-module-tests.ts
+++ b/types/jquery/test/jquery-slim-no-window-module-tests.ts
@@ -1,8 +1,5 @@
 import jQueryFactory = require('jquery/dist/jquery.slim');
 
-const jq = jQueryFactory(window);
-// ExpectType will report 'jq' as 'JQueryStatic<HTMLElement> & JQuery<HTMLElement>' even though the compiler seems to know that 'jq' is 'JQueryStatic<HTMLElement>'
-// // $ExpectType JQueryStatic<HTMLElement>
-// jq;
-// jq === jQuery();
-jq === jQuery;
+const jq = jQueryFactory(window, true);
+// $ExpectType JQueryStatic<HTMLElement>
+jq;

--- a/types/jquery/test/jquery-slim-window-module-tests.ts
+++ b/types/jquery/test/jquery-slim-window-module-tests.ts
@@ -1,8 +1,5 @@
 import * as jq from 'jquery/dist/jquery.slim';
 
 const $window = jq(window);
-// ExpectType will report 'jq' as 'JQueryStatic<HTMLElement> & JQuery<HTMLElement>' even though the compiler seems to know that 'jq' is 'JQuery<HTMLElement>'
-// // $ExpectType JQuery<HTMLElement>
-// $window;
-// $window === jq;
-$window === jq();
+// $ExpectType JQuery<HTMLElement>
+$window;

--- a/types/jquery/test/jquery-window-module-tests.ts
+++ b/types/jquery/test/jquery-window-module-tests.ts
@@ -1,8 +1,18 @@
 import * as jq from 'jquery';
 
 const $window = jq(window);
-// ExpectType will report 'jq' as 'JQueryStatic<HTMLElement> & JQuery<HTMLElement>' even though the compiler seems to know that 'jq' is 'JQuery<HTMLElement>'
-// // $ExpectType JQuery<HTMLElement>
-// $window;
-// $window === jq;
-$window === jq();
+// $ExpectType JQuery<HTMLElement>
+$window;
+
+class CanvasLayersDirective {
+    private readonly $renderingCanvas: JQuery<HTMLCanvasElement>;
+    private readonly $offscreenCanvas: JQuery<HTMLCanvasElement>;
+
+    constructor(elementRef: { nativeElement: any; }) {
+        // This type assertion results in an error when exporting 'typeof factory & JQueryStatic' where
+        // 'factory' is jQuery's factory function.
+        const $Canvas = $ as JQueryStatic<HTMLCanvasElement>;
+        this.$renderingCanvas = $Canvas(elementRef.nativeElement);
+        this.$offscreenCanvas = $Canvas(document.createElement('canvas'));
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

**Summary of changes**
- Add README describing usage and guidance for authoring jQuery plugin typedefs
- Importing
  - The factory function is now declared on `JQueryStatic` with an extraneous `discriminator` parameter
    - Exporting `typeof factory & JQueryStatic` results in type assertions not working on the imported `JQueryStatic` object 
(related: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/844920fa549d0c74b5ac2d2d14858a3674952383#commitcomment-22681634)
    - The `discriminator` parameter is needed to differentiate between `factory(Window)` and `JQueryStatic(Window)`. It does not actually exist on `factory`.
    - I'd much prefer a cleaner, less hackier solution
- Events
  - Overloads that accepted event data **and** `false` for `handler` were removed
  - `bind(eventType, handler)` now accepts `null` and `undefined` since jQuery accepts those values for compatibility reasons
  - Fix `on()` and `one()` overloads to reflect that passing `string` as data does not work
  - Fix `trigger()` and `triggerHandler()` to allow `string` and `number` to be passed to `extraParameters`
  - Change `Event` from a `class` to an `interface`
    - This was incorrectly declaring a value at `JQuery.Event` (should be `jQuery.Event`)
    - This probably requires declaring `JQuery` as a class in order to correctly declare `Event` as an inner class
  - [minor] Methods that accept a selector now specify `JQuery.Selector` as the type instead of `string`
  - [minor] `hover()` now uses the virtual equivalent `JQuery.EventHandler` for its callbacks
  - [minor] Reordered and grouped `off()` overloads to be easier to read (should still be equivalent to what they were before)

---
Would really appreciate some reviews before merging.