### PR TITLE
[redux-immutable] Fix definitions for 'redux-immutable', missing getDefaultState second param on combineReducers()

### DIFF
--- a/types/redux-immutable/index.d.ts
+++ b/types/redux-immutable/index.d.ts
@@ -1,8 +1,12 @@
-// Type definitions for redux-immutable v3.0.10
+// Type definitions for redux-immutable v3.0.33
 // Project: https://github.com/gajus/redux-immutable
-// Definitions by: Pedro Pereira <https://github.com/oizie>, Sebastian Sebald <https://github.com/sebald/>
+// Definitions by: Pedro Pereira <https://github.com/oizie>
+//                 Sebastian Sebald <https://github.com/sebald/>
+//                 Gavin Gregory <https://github.com/gavingregory>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as Redux from 'redux';
+import { Collection } from 'immutable';
 
-export declare function combineReducers<S>(reducers: Redux.ReducersMapObject): Redux.Reducer<S>;
+export declare function combineReducers<S, T>(reducers: Redux.ReducersMapObject, getDefaultState?: () => Collection.Keyed<T, S>): Redux.Reducer<S>;
+export declare function combineReducers<S>(reducers: Redux.ReducersMapObject, getDefaultState?: () => Collection.Indexed<S>): Redux.Reducer<S>;

--- a/types/redux-immutable/package.json
+++ b/types/redux-immutable/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "immutable": "^3.8.1"
   }
 }

--- a/types/redux-immutable/redux-immutable-tests.ts
+++ b/types/redux-immutable/redux-immutable-tests.ts
@@ -1,5 +1,22 @@
 
 import { combineReducers } from 'redux-immutable';
+import { Map, List } from 'immutable';
 
-combineReducers({
-});
+// Dummy State interface
+interface State { };
+
+/**
+ * Combine reducers should work with only one argument (a reducers object).
+ */
+combineReducers({});
+combineReducers<State>({});
+
+/**
+ * Combine reducers should accepts a function (getDefaultState()) as a second parameter, that returns an immutable Collection.Keyed collection.
+ */
+combineReducers<State, string>({}, () => { return Map<string, State>(); });
+combineReducers<State, number>({}, () => { return Map<number, State>(); });
+/**
+ * Combine reducers should accepts a function (getDefaultState()) as a second parameter, that returns an immutable Collection.Indexed collection.
+ */
+combineReducers<State>({}, () => { return List<State>(); });


### PR DESCRIPTION
 'redux-immutable' combineReducers(...) accepts an optional second param (a function that returns the default state) which was not accounted for in the typescript definitions, see code 
[here](https://github.com/gajus/redux-immutable/blob/master/src/combineReducers.js) and usage [here](https://github.com/gajus/redux-immutable).
*exerpt from Usage:*
> "By default, if state is undefined, rootReducer(state, action) is called with state = Immutable.Map(). A different default function can be provided as the second parameter to combineReducers(reducers, getDefaultState), for example:"

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [src](https://github.com/gajus/redux-immutable/blob/master/src/combineReducers.js)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
