### PR TITLE
[react-sortable-hoc] Use HTMLElement instead of React.ReactNode for node type

### DIFF
--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -12,7 +12,7 @@ declare module 'react-sortable-hoc' {
     export type Offset = number | string;
 
     export interface SortStart {
-        node: React.ReactNode;
+        node: HTMLElement;
         index: number;
         collection: Offset;
     }

--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -12,7 +12,7 @@ declare module 'react-sortable-hoc' {
     export type Offset = number | string;
 
     export interface SortStart {
-        node: HTMLElement;
+        node: Element;
         index: number;
         collection: Offset;
     }


### PR DESCRIPTION
From source usage, looks like `node` is actually a `HTMLElement`:
  - [`node` is set to result of `findDOMNode` call](https://github.com/clauderic/react-sortable-hoc/blob/3245c5eb44204ca3a7f30b17eea231f84805f029/src/SortableElement/index.js#L59)
  - [`HTMLElement` properties are accessed in the default implementation for `getHelperDimensions`](https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableContainer/index.js#L58)

-------
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [`node` is set to result of `findDOMNode` call](https://github.com/clauderic/react-sortable-hoc/blob/3245c5eb44204ca3a7f30b17eea231f84805f029/src/SortableElement/index.js#L59)
  - [`HTMLElement` properties are accessed in the default implementation for `getHelperDimensions`.](https://github.com/clauderic/react-sortable-hoc/blob/master/src/SortableContainer/index.js#L58
)
- [ ] ~Increase the version number in the header if appropriate.~
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.