### PR TITLE
update rollup Option.entry type

### DIFF
--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -86,7 +86,7 @@ export interface Bundle {
 
 export interface Options {
 	/** The bundle's entry point (e.g. your `main.js` or `app.js` or `index.js`) */
-	entry: string
+	entry: string | string[]
 	/** A previous bundle. Use it to speed up subsequent bundles :) */
 	cache?: Bundle
 	/**


### PR DESCRIPTION
[rollup-plugin-multi-entry](https://github.com/rollup/rollup-plugin-multi-entry) lets you define entry among others as `string[]`