### PR TITLE
[jquery.notify] new typings for https://github.com/ehynds/jquery-notify

### DIFF
--- a/types/jquery.notify/index.d.ts
+++ b/types/jquery.notify/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for jQuery Notify UI Widget 1.5 by Eric Hynds
+// Project: https://github.com/ehynds/jquery-notify
+// Definitions by: Sergei Dorogin <https://github.com/evil-shrike>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="jquery"/>
+
+interface JQueryNotifyOptions {
+	close?: () => void;
+	open?: () => void;
+	custom?: boolean;
+	disabled?: boolean;
+	expires?: number;
+	queue?: boolean;
+	speed?: number;
+	stack?: "below" | "above";
+}
+interface JQuery {
+	notify (options?: JQueryNotifyOptions): JQueryNotifyWidget;
+	notify (method: string, template: number, params?: Object, opts?: JQueryNotifyOptions): JQueryNotifyInstance;
+	notify (method: string, params?: Object, opts?: JQueryNotifyOptions): JQueryNotifyInstance;
+}
+interface JQueryNotifyInstance extends JQuery {
+	element: JQuery;
+	isOpen: boolean;
+	options: JQueryNotifyOptions;
+	close (): void;
+	open (): void;
+}
+interface JQueryNotifyWidget extends JQuery  {
+}

--- a/types/jquery.notify/index.d.ts
+++ b/types/jquery.notify/index.d.ts
@@ -1,5 +1,5 @@
-// Type definitions for jQuery Notify UI Widget 1.5 by Eric Hynds
-// Project: https://github.com/ehynds/jquery-notify
+// Type definitions for jquery.notify 1.5
+// Project: https://github.com/ehynds/jquery-notify (jQuery Notify UI Widget by Eric Hynds)
 // Definitions by: Sergei Dorogin <https://github.com/evil-shrike>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
@@ -17,16 +17,16 @@ interface JQueryNotifyOptions {
 	stack?: "below" | "above";
 }
 interface JQuery {
-	notify (options?: JQueryNotifyOptions): JQueryNotifyWidget;
-	notify (method: string, template: number, params?: Object, opts?: JQueryNotifyOptions): JQueryNotifyInstance;
-	notify (method: string, params?: Object, opts?: JQueryNotifyOptions): JQueryNotifyInstance;
+	notify(options?: JQueryNotifyOptions): JQueryNotifyWidget;
+	notify(method: string, template: number, params?: object, opts?: JQueryNotifyOptions): JQueryNotifyInstance;
+	notify(method: string, params?: object, opts?: JQueryNotifyOptions): JQueryNotifyInstance;
 }
 interface JQueryNotifyInstance extends JQuery {
 	element: JQuery;
 	isOpen: boolean;
 	options: JQueryNotifyOptions;
-	close (): void;
-	open (): void;
+	close(): void;
+	open(): void;
 }
 interface JQueryNotifyWidget extends JQuery  {
 }

--- a/types/jquery.notify/index.d.ts
+++ b/types/jquery.notify/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/ehynds/jquery-notify
 // Definitions by: Sergei Dorogin <https://github.com/evil-shrike>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="jquery"/>
 

--- a/types/jquery.notify/index.d.ts
+++ b/types/jquery.notify/index.d.ts
@@ -21,7 +21,7 @@ interface JQuery {
 	notify(method: string, template: number, params?: object, opts?: JQueryNotifyOptions): JQueryNotifyInstance;
 	notify(method: string, params?: object, opts?: JQueryNotifyOptions): JQueryNotifyInstance;
 }
-interface JQueryNotifyInstance extends JQuery {
+interface JQueryNotifyInstance {
 	element: JQuery;
 	isOpen: boolean;
 	options: JQueryNotifyOptions;

--- a/types/jquery.notify/jquery.notify-tests.ts
+++ b/types/jquery.notify/jquery.notify-tests.ts
@@ -1,0 +1,21 @@
+let $container: JQueryNotifyWidget = $("<div style='display:none' class='noprint'><div></div></div>").appendTo(document.body).notify();
+
+let notification: JQueryNotifyInstance = $container.notify(
+	"create",
+	{}, // empty parameters
+	{
+		close: () => {
+			console.log("closed");
+		},
+		open: () => {
+			console.log("opened");
+		},
+		expires: 1000,
+		speed: 100
+	}
+);
+notification.element.html("<strong>text</strong>");
+
+notification.element.click(() => {
+	notification.close();
+});

--- a/types/jquery.notify/tsconfig.json
+++ b/types/jquery.notify/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": false,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery.notify-tests.ts"
+    ]
+}

--- a/types/jquery.notify/tsconfig.json
+++ b/types/jquery.notify/tsconfig.json
@@ -5,9 +5,9 @@
             "es6",
             "dom"
         ],
-        "noImplicitAny": false,
+        "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/jquery.notify/tslint.json
+++ b/types/jquery.notify/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-empty-interface": false,
+        "prefer-method-signature": false
+    }
+}


### PR DESCRIPTION
Type definitions for jQuery Notify UI Widget 1.5 by Eric Hynds (https://github.com/ehynds/jquery-notify).

Unfortunately the lib doesn't have documentation (it was on author's blog but now disappear).

- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with dts-gen --dt, not by basing it on an existing project.
- [x] tslint.json should be present, and tsconfig.json should have noImplicitAny, noImplicitThis, and strictNullChecks set to true.