### PR TITLE
[heremaps] improve definition of H.service.ServiceResult, add missing parameters to callbacks

### DIFF
--- a/types/heremaps/heremaps-tests.ts
+++ b/types/heremaps/heremaps-tests.ts
@@ -44,7 +44,7 @@ let map = new H.Map(mapContainer, defaultLayers.normal.map, {
     // initial center and zoom level of the map
     zoom: 16,
     // Champs-Elysees
-    center: {lat: 48.869145, lng: 2.314298}
+    center: { lat: 48.869145, lng: 2.314298 }
 });
 
 // Step 3: make the map interactive
@@ -85,3 +85,78 @@ let polyline = new H.map.Polyline(new H.geo.Strip());
 // tslint:disable-next-line:array-type
 let clipArr: Array<Array<number>>;
 clipArr = polyline.clip(new H.geo.Rect(5, 5, 5, 5));
+
+let router = platform.getRoutingService();
+let calculateRouteParams = {
+    waypoint0: 'geo!52.5,13.4',
+    waypoint1: 'geo!52.5,13.45',
+    mode: 'fastest;car;traffic:disabled'
+};
+router.calculateRoute(
+    calculateRouteParams,
+    (result) => {
+        console.log(result.response.route[0]);
+    },
+    (error) => {
+        console.log(error);
+    }
+);
+
+let places = platform.getPlacesService();
+let entryPoint = H.service.PlacesService.EntryPoint;
+places.request(
+    entryPoint.SEARCH,
+    {
+        at: '52.5044,13.3909',
+        q: 'pizza'
+    },
+    (response) => {
+        console.log(response);
+        let items = response.results.items;
+        places.follow(
+            items[0].href,
+            (resp) => {
+                console.log(resp);
+            },
+            (resp) => {
+                console.log('ERROR: ' + resp);
+            }
+        );
+    },
+    (error) => {
+        console.log('ERROR: ' + error);
+    }
+);
+
+let geocoder = platform.getGeocodingService();
+let geocodingParams: H.service.ServiceParameters = {
+    searchText: '425 W Randolph Street, Chicago'
+};
+geocoder.geocode(
+    geocodingParams,
+    (result) => {
+        console.log(result);
+        console.log(result.Response.View[0].Result[0].Location.DisplayPosition);
+    },
+    (error) => {
+        console.log(error);
+    }
+);
+
+// deprecated but w/e
+let enterprieseRouter = platform.getEnterpriseRoutingService();
+let calculateIsoline: H.service.ServiceParameters = {
+    start: 'geo!52.5,13.4',
+    distance: '1000,2000',
+    mode: 'fastest;car;traffic:disabled'
+};
+enterprieseRouter.calculateIsoline(
+    calculateIsoline,
+    (result) => {
+        console.log(result);
+        console.log(result.Response.isolines[0]);
+    },
+    (error) => {
+        console.log(error);
+    }
+);

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -4301,14 +4301,15 @@ declare namespace H {
 
             /**
              * This is generic method to query places RestAPI.
-             * @param entryPoint {string} - can be one of available entry points H.service.PlacesService.EntryPoint i.e value of H.service.PlacesService.EntryPoint.SEARCH
+             * @param entryPoint {H.service.PlacesService.EntryPoint} - can be one of available entry points H.service.PlacesService.EntryPoint i.e value of H.service.PlacesService.EntryPoint.SEARCH
              * @param entryPointParams {Object} - parameter map key value pairs will be transformed into the url key=value parametes. For entry point parameters description please refer to places
              * restful api documentation documentation for available parameters for chose entry point
              * @param onResult {Function} - callback which is called when result is returned
              * @param onError {Function} - callback which is called when error occured (i.e request timeout)
              * @returns {H.service.JsonpRequestHandle} - jsonp request handle
              */
-            request(entryPoint: string, entryPointParams: {}, onResult: () => void, onError: () => void): H.service.JsonpRequestHandle;
+            request(entryPoint: H.service.PlacesService.EntryPoint, entryPointParams: {}, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void):
+                H.service.JsonpRequestHandle;
 
             /**
              * Function triggers places api 'search' entry point. Please refer to documentation for parameter specification and response handling.
@@ -4317,7 +4318,7 @@ declare namespace H {
              * @param onError {Function}
              * @returns {H.service.JsonpRequestHandle} - jsonp request handle
              */
-            search(searchParams: H.service.ServiceParameters, onResult: () => void, onError: () => void): H.service.JsonpRequestHandle;
+            search(searchParams: H.service.ServiceParameters, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void): H.service.JsonpRequestHandle;
 
             /**
              * Function triggers places api 'suggestions' entry point. Please refer to documentation for parameter specification and response handling.
@@ -4326,7 +4327,7 @@ declare namespace H {
              * @param onError {Function}
              * @returns {H.service.JsonpRequestHandle} - jsonp request handle
              */
-            suggest(suggestParams: H.service.ServiceParameters, onResult: () => void, onError: () => void): H.service.JsonpRequestHandle;
+            suggest(suggestParams: H.service.ServiceParameters, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void): H.service.JsonpRequestHandle;
 
             /**
              * Function triggers places api 'explore' entry point. Please refer to documentation for parameter specification and response handling.
@@ -4335,7 +4336,7 @@ declare namespace H {
              * @param onError {Function}
              * @returns {H.service.JsonpRequestHandle} - jsonp request handle
              */
-            explore(exploreParams: H.service.ServiceParameters, onResult: () => void, onError: () => void): H.service.JsonpRequestHandle;
+            explore(exploreParams: H.service.ServiceParameters, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void): H.service.JsonpRequestHandle;
 
             /**
              * Function triggers places api 'around' entry point. Please refer to documentation for parameter specification and response handling.
@@ -4344,7 +4345,7 @@ declare namespace H {
              * @param onError {Function}
              * @returns {H.service.JsonpRequestHandle} - jsonp request handle
              */
-            around(aroundParams: H.service.ServiceParameters, onResult: () => void, onError: () => void): H.service.JsonpRequestHandle;
+            around(aroundParams: H.service.ServiceParameters, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void): H.service.JsonpRequestHandle;
 
             /**
              * Function triggers places api 'here' entry point. Please refer to documentation for parameter specification and response handling.
@@ -4353,7 +4354,7 @@ declare namespace H {
              * @param onError {Function}
              * @returns {H.service.JsonpRequestHandle} - jsonp request handle
              */
-            here(hereParams: H.service.ServiceParameters, onResult: () => void, onError: () => void): H.service.JsonpRequestHandle;
+            here(hereParams: H.service.ServiceParameters, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void): H.service.JsonpRequestHandle;
 
             /**
              * Function triggers places api 'categories' entry point. Please refer to documentation for parameter specification and response handling.
@@ -4362,7 +4363,7 @@ declare namespace H {
              * @param onError {Function}
              * @returns {H.service.JsonpRequestHandle} - jsonp request handle
              */
-            categories(categoriesParams: H.service.ServiceParameters, onResult: () => void, onError: () => void): H.service.JsonpRequestHandle;
+            categories(categoriesParams: H.service.ServiceParameters, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void): H.service.JsonpRequestHandle;
 
             /**
              * This method should be used to follow hyperlinks available in results returned by dicovery queries.
@@ -4372,7 +4373,7 @@ declare namespace H {
              * @param opt_additionalParameters {Object=} - additional parameters to send with request
              * @returns {H.service.JsonpRequestHandle} - jsonp resquest handle
              */
-            follow(hyperlink: string, onResult: () => void, onError: () => void, opt_additionalParameters?: {}): H.service.JsonpRequestHandle;
+            follow(hyperlink: string, onResult: (result: H.service.ServiceResult) => void, onError: (error: Error) => void, opt_additionalParameters?: {}): H.service.JsonpRequestHandle;
         }
 
         namespace PlacesService {
@@ -4603,11 +4604,142 @@ declare namespace H {
 
         /**
          * This type encapsulates a response object provider by a HERE platform service.
-         * In most cases the HERE Maps API for JavaScript communicates with the HERE REST APIs, using the JSON-P protocol. The resulting JSON response is parsed and provided to a callback function.
-         * The structure of a service response object is specific to each service.
          */
         interface ServiceResult {
             [key: string]: any;
+            response?: {
+                language?: string,
+                route?: Array<{
+                    leg: Array<{
+                        maneuver: Array<{
+                            id: string,
+                            instruction: string,
+                            length: number,
+                            note: string[],
+                            position: {
+                                latitude: number,
+                                longitude: number
+                            },
+                            shape: string[],
+                            travelTime: number,
+                            _type: string
+                        }>
+                    }>,
+                    mode: {
+                        feature: any[],
+                        trafficMode: string,
+                        transportModes: string[],
+                        type: string
+                    }
+                    shape: string[],
+                    summary: {
+                        baseTime: number,
+                        distance: number,
+                        flags: string[],
+                        text: string,
+                        trafficTime: number,
+                        travelTime: number
+                    }
+                    waypoint: Array<{
+                        label: string,
+                        linkId: string,
+                        mappedPosition: {
+                            latitude: number,
+                            longitude: number
+                        },
+                        mappedRoadName: string,
+                        originalPosition: {
+                            latitude: number,
+                            longitude: number
+                        },
+                        shapeIndex: number,
+                        sideOfStreet: string,
+                        spot: number,
+                        type: string
+                    }>
+                }>,
+                metaInfo: {}
+            };
+            results?: {
+                items?: any[],
+                next?: string
+            };
+            search?: {
+                context: {
+                    href: string,
+                    location: {
+                        address: {
+                            city: string,
+                            country: string,
+                            countryCode: string,
+                            county: string,
+                            district: string,
+                            house: string,
+                            postalCode: string,
+                            stateCode: string,
+                            street: string,
+                            text: string
+                        },
+                        position: number[]
+                    },
+                    type: string
+                }
+            };
+            Response?: {
+                MetaInfo: {
+                    Timestamp: string
+                },
+                View: Array<{
+                    Result: Array<{
+                        Location: {
+                            Address: {
+                                AdditionalData: Array<{
+                                    key: string,
+                                    value: string
+                                }>,
+                                City: string,
+                                Country: string,
+                                County: string,
+                                District: string,
+                                HouseNumber: string,
+                                Label: string,
+                                PostalCode: string,
+                                State: string,
+                                Street: string
+                            },
+                            DisplayPosition: {
+                                Latitude: number,
+                                Longitude: number
+                            },
+                            LocationId: string,
+                            LocationType: string,
+                            MapView: {
+                                BottomRight: {
+                                    Latitude: number,
+                                    Longitude: number
+                                },
+                                TopLeft: {
+                                    Latitude: number,
+                                    Longitude: number
+                                }
+                            },
+                            NavigationPosition: Array<{
+                                Latitude: number,
+                                Longitude: number
+                            }>
+                        },
+                        MatchLevel: string,
+                        MatchQuality: {
+                            City: number,
+                            HouseNumber: number,
+                            Street: number[]
+                        },
+                        MatchType: string,
+                        Relevance: number
+                    }>
+                }>,
+                isolines: any[]
+            };
         }
 
         /**
@@ -4636,7 +4768,7 @@ declare namespace H {
              * @param onError {function()}
              * @returns {H.service.JsonpRequestHandle}
              */
-            requestIncidents(serviceParams: H.service.ServiceParameters, onResponse: (result: H.service.ServiceResult) => void, onError: () => void): H.service.JsonpRequestHandle;
+            requestIncidents(serviceParams: H.service.ServiceParameters, onResponse: (result: H.service.ServiceResult) => void, onError: (error: Error) => void): H.service.JsonpRequestHandle;
 
             /**
              * This method requests traffic incident information by tile coordinates
@@ -4648,8 +4780,8 @@ declare namespace H {
              * @param opt_serviceParams {H.service.ServiceParameters=} - optional service parameters to be added to the request
              * @returns {H.service.JsonpRequestHandle}
              */
-            requestIncidentsByTile(x: number, y: number, z: number, onResponse: (result: H.service.ServiceResult) => void, onError: () => void, opt_serviceParams?: H.service.ServiceParameters):
-                H.service.JsonpRequestHandle;
+            requestIncidentsByTile(x: number, y: number, z: number, onResponse: (result: H.service.ServiceResult) => void, onError: (error: Error) => void,
+                                   opt_serviceParams?: H.service.ServiceParameters): H.service.JsonpRequestHandle;
         }
 
         namespace TrafficIncidentsService {

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -4603,9 +4603,11 @@ declare namespace H {
 
         /**
          * This type encapsulates a response object provider by a HERE platform service.
+         * In most cases the HERE Maps API for JavaScript communicates with the HERE REST APIs, using the JSON-P protocol. The resulting JSON response is parsed and provided to a callback function.
+         * The structure of a service response object is specific to each service.
          */
         interface ServiceResult {
-            [key: string]: string;
+            [key: string]: any;
         }
 
         /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See the example <https://developer.here.com/javascript-apis/documentation/v3/maps/topics_api/h-service-routingservice.html>, <https://developer.here.com/javascript-apis/documentation/v3/maps/topics_api/h-service-geocodingservice.html>, <https://developer.here.com/javascript-apis/documentation/v3/maps/topics_api/h-service-trafficincidentsservice.html>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Note:
Besides adding parameters with types to a bunch of `onResult` and `onError` callbacks this PR primarily defines the interface of `H.service.ServiceResult` by looking at the actual return values when using `H.service.TrafficIncidentsService`, `H.service.GeocodingService` and `H.service.RoutingService`. There is no proper documentation for that interface but it's used universally: <https://developer.here.com/javascript-apis/documentation/v3/maps/topics_api/h-service-serviceresult.html>
