### PR TITLE
[jasmine] Allow CustomEqualityTester to return undefined

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -209,7 +209,7 @@ declare namespace jasmine {
         withMock(func: () => void): void;
     }
 
-    type CustomEqualityTester = (first: any, second: any) => boolean;
+    type CustomEqualityTester = (first: any, second: any) => boolean | void;
 
     interface CustomMatcher {
         compare<T>(actual: T, expected: T): CustomMatcherResult;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -872,7 +872,7 @@ describe("Fail", () => {
 
 // test based on http://jasmine.github.io/2.2/custom_equality.html
 describe("custom equality", () => {
-    var myCustomEquality: jasmine.CustomEqualityTester = function (first: any, second: any): boolean {
+    var myCustomEquality: jasmine.CustomEqualityTester = function (first: any, second: any): boolean | undefined {
         if (typeof first === "string" && typeof second === "string") {
             return first[0] === second[1];
         }

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -872,7 +872,7 @@ describe("Fail", () => {
 
 // test based on http://jasmine.github.io/2.2/custom_equality.html
 describe("custom equality", () => {
-    var myCustomEquality: jasmine.CustomEqualityTester = function (first: any, second: any): boolean | undefined {
+    var myCustomEquality: jasmine.CustomEqualityTester = function (first: any, second: any): boolean | void {
         if (typeof first === "string" && typeof second === "string") {
             return first[0] === second[1];
         }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/2.5/custom_equality.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
