### PR TITLE
websocket: Use correct type for incoming message

### DIFF
--- a/types/websocket/index.d.ts
+++ b/types/websocket/index.d.ts
@@ -181,7 +181,7 @@ export interface IExtension {
 
 export declare class request extends events.EventEmitter {
     /** A reference to the original Node HTTP request object */
-    httpRequest: http.ClientRequest;
+    httpRequest: http.IncomingMessage;
     /** This will include the port number if a non-standard port is used */
     host: string;
     /** A string containing the path that was requested by the client */
@@ -222,7 +222,7 @@ export declare class request extends events.EventEmitter {
     requestedProtocols: string[];
     protocolFullCaseMap: { [key: string]: string };
 
-    constructor(socket: net.Socket, httpRequest: http.ClientRequest, config: IServerConfig);
+    constructor(socket: net.Socket, httpRequest: http.IncomingMessage, config: IServerConfig);
 
     /**
      * After inspecting the `request` properties, call this function on the
@@ -580,7 +580,7 @@ declare class client extends events.EventEmitter {
 declare class routerRequest extends events.EventEmitter {
 
     /** A reference to the original Node HTTP request object */
-    httpRequest: http.ClientRequest;
+    httpRequest: http.IncomingMessage;
     /** A string containing the path that was requested by the client */
     resource: string;
     /** Parsed resource, including the query string parameters */


### PR DESCRIPTION
Use the correct type of `IncomingMessage` for the node http request. At runtime, the type of these requests is `IncomingMessage`. Further, the 1ClientRequest1 type is for an outgoing http request to an external server, and thus is not appropriate for a web socket server.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
