### PR TITLE
react-fa IconStack children prop typing fix

### DIFF
--- a/types/react-fa/index.d.ts
+++ b/types/react-fa/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Component, ComponentClass, HTMLProps, StatelessComponent } from "react";
+import { Component, ComponentClass, HTMLProps, StatelessComponent, ReactElement } from "react";
 
 // fake intermediate interface to remove typing on size, as the typing
 // is overrided by react-fa
@@ -37,15 +37,7 @@ export const Icon: ComponentClass<IconProps>;
 
 export interface IconStackProps extends SizeOverrideHTMLProps<IconStack> {
     size?: IconSize;
-
-    // Does not work with TypeScript 2.3:
-    // Type '{ size: "lg"; children: Element[]; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<IconStackProps, ComponentState>> & Reado...'.
-    //   Type '{ size: "lg"; children: Element[]; }' is not assignable to type 'Readonly<IconStackProps>'.
-    //     Types of property 'children' are incompatible.
-    //       Type 'Element[]' is not assignable to type 'IconProps[]'.
-    //         Type 'Element' is not assignable to type 'IconProps'.
-    //           Property 'name' is missing in type 'Element'.
-    // children?: IconProps[];
+    children?: ReactElement<IconProps> | Array<ReactElement<IconProps>>;
 }
 
 export type IconStack = Component<IconStackProps>;

--- a/types/react-fa/react-fa-tests.tsx
+++ b/types/react-fa/react-fa-tests.tsx
@@ -23,7 +23,7 @@ export class ReactFATest extends React.Component {
 
                 <DefaultIcon { ...defaultProps } />
 
-                <IconStack size='lg'>
+                <IconStack size='lg' className='fa-circle-flask'>
                     <Icon name='circle' stack='2x' />
                     <Icon name='flask' stack='1x' inverse />
                 </IconStack>


### PR DESCRIPTION
this fixes the previously commented out and broken children props on `react-fa`'s `IconStack` component.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
