### PR TITLE
gulp.watch allows the second parameter of string[]

### DIFF
--- a/types/gulp/index.d.ts
+++ b/types/gulp/index.d.ts
@@ -69,8 +69,8 @@ declare namespace GulpClient {
     }
 
     interface WatchMethod {
-        (globs: Globs, fn?: Undertaker.TaskFunction): fs.FSWatcher;
-        (globs: Globs, opts?: WatchOptions, fn?: Undertaker.TaskFunction): fs.FSWatcher;
+        (globs: Globs, fnOrDeps?: Undertaker.TaskFunction | string[]): fs.FSWatcher;
+        (globs: Globs, opts?: WatchOptions, fnOrDeps?: Undertaker.TaskFunction | string[]): fs.FSWatcher;
     }
 
     type SrcMethod = typeof vfs.src;

--- a/types/gulp/test/index.ts
+++ b/types/gulp/test/index.ts
@@ -133,6 +133,8 @@ watcher.on('unlink', (path: string) => {
     console.log('File ' + path + ' was removed');
 });
 
+gulp.watch('js/**/*.js', ['clean', 'one', 'two']);
+
 gulp.task('one', (done) => {
     // do stuff
     done();


### PR DESCRIPTION
This allows specification of tasks the watcher depends on.

See
https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulpwatchglob--opts-tasks-or-gulpwatchglob--opts-cb
