### PR TITLE
Add optional message param to sinon.match overload that takes a callback

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -421,7 +421,7 @@ declare namespace Sinon {
         (value: string): SinonMatcher;
         (expr: RegExp): SinonMatcher;
         (obj: any): SinonMatcher;
-        (callback: (value: any) => boolean): SinonMatcher;
+        (callback: (value: any) => boolean, message?: string): SinonMatcher;
         any: SinonMatcher;
         defined: SinonMatcher;
         truthy: SinonMatcher;

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -119,6 +119,14 @@ function testPromises() {
     rejectsStub2 = sinon.stub().rejects("TypeError");
 }
 
+function testMatchInvoke() {
+    let stub = sinon.stub();
+    stub(123);
+    stub.calledWithMatch(sinon.match(123));
+    stub.calledWithMatch(sinon.match((value: any) => value === 123));
+    stub.calledWithMatch(sinon.match((value: any) => value === 123, "Must be 123"));
+}
+
 function testSymbolMatch() {
     let stub = sinon.stub();
     stub(Symbol('TestSymbol'));


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: http://sinonjs.org/releases/v2.3.5/matchers/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
