### PR TITLE
[node] Adds type definition for process.env.

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -413,7 +413,7 @@ declare namespace NodeJS {
         chdir(directory: string): void;
         cwd(): string;
         emitWarning(warning: string | Error, name?: string, ctor?: Function): void;
-        env: any;
+        env: { [variable: string]: string };
         exit(code?: number): never;
         exitCode: number;
         getgid(): number;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1260,17 +1260,14 @@ namespace path_tests {
     //        ['foo', 'bar', 'baz']
 
     console.log(process.env.PATH)
+    console.log(process.env["PATH"])
     // '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin'
-
-    process.env.PATH.split(path.delimiter)
-    // returns
-    //        ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin']
-
-    console.log(process.env.PATH)
     // 'C:\Windows\system32;C:\Windows;C:\Program Files\nodejs\'
 
     process.env.PATH.split(path.delimiter)
+    process.env["PATH"].split(path.delimiter)
     // returns
+    //        ['/usr/bin', '/bin', '/usr/sbin', '/sbin', '/usr/local/bin']
     //        ['C:\Windows\system32', 'C:\Windows', 'C:\Program Files\nodejs\']
 
     path.parse('/home/user/dir/file.txt')


### PR DESCRIPTION
Fixes #11615

This should work in TypeScript 2.2+ (see TypeScript issue [#12596](https://github.com/Microsoft/TypeScript/issues/12596))