### PR TITLE
react-bootstrap: bsClass attribute missing for Table and Badge components

### DIFF
--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -847,6 +847,7 @@ declare namespace ReactBootstrap {
 
     // <Badge />
     interface BadgeProps extends React.HTMLProps<Badge> {
+        bsClass?: string;
         pullRight?: boolean;
     }
     type Badge = React.ClassicComponent<BadgeProps>;
@@ -908,6 +909,7 @@ declare namespace ReactBootstrap {
         responsive?: boolean;
         striped?: boolean;
         fill?: boolean;
+        bsClass?: string;
     }
     type Table = React.ClassicComponent<TableProps>;
     var Table: React.ClassicComponentClass<TableProps>;


### PR DESCRIPTION
Attribute bsClass was added to components Table and Badge as described here https://react-bootstrap.github.io/components.html#table-props and here https://react-bootstrap.github.io/components.html#badges-props

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-bootstrap.github.io/components.html#table-props
https://react-bootstrap.github.io/components.html#badges-props
