### PR TITLE
route-parser: Restricting boolean types to just false.

### DIFF
--- a/types/route-parser/index.d.ts
+++ b/types/route-parser/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for route-parser 0.0
+// Type definitions for route-parser 0.1
 // Project: https://github.com/rcs/route-parser
-// Definitions by: Ian Ker-Seymer <https://github.com/ianks>
+// Definitions by: Ian Ker-Seymer <https://github.com/ianks>, Bob Buehler <https://github.com/bobbuehler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare class Route {
@@ -23,7 +23,7 @@ declare class Route {
      * var route = new Route('/:one/:two')
      * route.match('/foo/bar/') // -> {one: 'foo', two: 'bar'}
      */
-    match(pathname: string): { [i: string]: string } | boolean;
+    match(pathname: string): { [i: string]: string } | false;
 
     /**
      * Reverse a route specification to a path, returning false if it can't be
@@ -32,7 +32,7 @@ declare class Route {
      * var route = new Route('/:one/:two')
      * route.reverse({one: 'foo', two: 'bar'}) -> '/foo/bar'
      */
-    reverse(params: { [i: string]: any } ): string | boolean;
+    reverse(params: { [i: string]: any } ): string | false;
 }
 
 declare namespace Route {}


### PR DESCRIPTION
These two functions never return true.

Here is the return false for match:
https://github.com/rcs/route-parser/blob/master/lib/route.js#L55

And all the handlers here return a string for false:
https://github.com/rcs/route-parser/blob/master/lib/route/visitors/reverse.js