### PR TITLE
Add maxTileCacheSize to map object on mapbox-gl

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mapbox GL JS v0.38.0
+// Type definitions for Mapbox GL JS v0.39.0
 // Project: https://github.com/mapbox/mapbox-gl-js
 // Definitions by: Dominik Bruderer <https://github.com/dobrud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -254,6 +254,9 @@ declare namespace mapboxgl {
 
 		/** Initial zoom level */
 		zoom?: number;
+
+		/** Maximum tile cache size for each layer. */
+		maxTileCacheSize?: number;
 	}
 
 	export interface PaddingOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/mapbox-gl-js/pull/4778
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

[Pull request 4778](https://github.com/mapbox/mapbox-gl-js/pull/4778) on mapbox-gl-js adds a new configuration to map object, `maxTileCacheSize`. This pull request simply adds that single map configuration option.