### PR TITLE
Replaced self-implemented definition for history with actual definition

### DIFF
--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -11,6 +11,7 @@ import {
     Middleware,
     GenericStoreEnhancer
 } from 'redux';
+import { History } from 'history';
 
 export type Nullable<T> = T | null | undefined;
 
@@ -103,23 +104,6 @@ export interface HistoryLocation {
 export type HistoryAction = string;
 
 export type Listener = (location: HistoryLocation, action: HistoryAction) => void;
-
-export interface History {
-    listen(listener: Listener): void;
-    push(pathname: string): void;
-    replace(pathname: string): void;
-    goBack(): void;
-    goForward(): void;
-    go(n: number): void;
-    canGo(n: number): boolean;
-
-    entries: Array<{ pathname: string }>;
-    index: number;
-    length: number;
-    location: {
-        pathname: string;
-    };
-}
 
 export type ScrollBehavior = object;
 

--- a/types/redux-first-router/package.json
+++ b/types/redux-first-router/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "redux": "^3.7.0"
+    "redux": "^3.7.0",
+    "history": "^4.6.2"
   }
 }

--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -1,4 +1,4 @@
-import { connectRoutes, History, LocationState, RoutesMap } from 'redux-first-router';
+import { connectRoutes, LocationState, RoutesMap } from 'redux-first-router';
 import {
   createStore,
   applyMiddleware,
@@ -11,6 +11,7 @@ import {
   GenericStoreEnhancer,
   StoreEnhancerStoreCreator
 } from 'redux';
+import { History } from 'history';
 
 declare var console: any;
 declare var history: History;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/faceyspacey/redux-first-router/blob/master/package.json#L67 (The APIs used by `redux-first-router` should actually match those if its peer dependency `history`)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
