### PR TITLE
added more expressive types to jake to better match the actual js code

### DIFF
--- a/types/jake/index.d.ts
+++ b/types/jake/index.d.ts
@@ -38,7 +38,7 @@ declare function fail(...err:any[]): void;
  * @param action The action to perform for this task
  * @param opts Perform this task asynchronously. If you flag a task with this option, you must call the global `complete` method inside the task's action, for execution to proceed to the next task.
  */
-declare function file(name:string, prereqs?:string[], action?:()=>void, opts?:jake.FileTaskOptions): jake.FileTask;
+declare function file(name:string, prereqs?:string[], action?:(this: jake.FileTask)=>void, opts?:jake.FileTaskOptions): jake.FileTask;
 
 /**
  * Creates Jake FileTask from regex patterns
@@ -63,9 +63,9 @@ declare function namespace(name:string, scope:()=>void): void;
  * @param action The action to perform for this task
  * @param opts
  */
-declare function task(name:string, prereqs?:string[], action?:(...params:any[])=>any, opts?:jake.TaskOptions): jake.Task;
-declare function task(name:string, action?:(...params:any[])=>any, opts?:jake.TaskOptions): jake.Task;
-declare function task(name:string, opts?:jake.TaskOptions, action?:(...params:any[])=>any): jake.Task;
+declare function task(name:string, prereqs?:string[], action?:(this: jake.Task, ...params:any[])=>any, opts?:jake.TaskOptions): jake.Task;
+declare function task(name:string, action?:(this: jake.Task, ...params:any[])=>any, opts?:jake.TaskOptions): jake.Task;
+declare function task(name:string, opts?:jake.TaskOptions, action?:(this: jake.Task, ...params:any[])=>any): jake.Task;
 
 /**
  * @param name The name of the NpmPublishTask
@@ -214,7 +214,7 @@ declare namespace jake{
 		 * @param action The action to perform for this task
 		 * @param opts Perform this task asynchronously. If you flag a task with this option, you must call the global `complete` method inside the task's action, for execution to proceed to the next task.
 		 */
-		constructor(name:string, prereqs?:string[], action?:()=>void, opts?:TaskOptions);
+		constructor(name:string, prereqs?:string[], action?:(this: Task)=>void, opts?:TaskOptions);
 
 		/**
 		 * Runs prerequisites, then this task. If the task has already been run, will not run the task again.
@@ -236,10 +236,19 @@ declare namespace jake{
 		listeners(event: string): Function[];
 		emit(event: string, ...args: any[]): boolean;
 		listenerCount(type: string): number;
+		complete(value): void;
 		value: any;
+
+		name?: string;
+		prereqs?: string[];
+		action?: (...params: any[]) => any;
+		taskStatus?: string;
+		async?: boolean;
+		description?: string;
+		fullName: string;
 	}
 
-	export class DirectoryTask{
+	export class DirectoryTask extends FileTask {
 		/**
          * @param name The name of the directory to create.
 		 */
@@ -254,14 +263,14 @@ declare namespace jake{
 		async?: boolean;
 	}
 
-	export class FileTask{
+	export class FileTask extends Task{
 		/**
 		 * @param name The name of the Task
 		 * @param prereqs Prerequisites to be run before this task
 		 * @param action The action to perform to create this file
 		 * @param opts Perform this task asynchronously. If you flag a task with this option, you must call the global `complete` method inside the task's action, for execution to proceed to the next task.
 	     */
-		constructor(name:string, prereqs?:string[], action?:()=>void, opts?:FileTaskOptions);
+		constructor(name:string, prereqs?:string[], action?:(this: FileTask)=>void, opts?:FileTaskOptions);
 	}
 
 	interface FileFilter{

--- a/types/jake/index.d.ts
+++ b/types/jake/index.d.ts
@@ -236,7 +236,7 @@ declare namespace jake{
 		listeners(event: string): Function[];
 		emit(event: string, ...args: any[]): boolean;
 		listenerCount(type: string): number;
-		complete(value): void;
+		complete(value?: any): void;
 		value: any;
 
 		name?: string;


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/jakejs/jake/blob/master/lib/task/file_task.js#L127
https://github.com/jakejs/jake/blob/master/lib/task/directory_task.js#L26
https://github.com/jakejs/jake/blob/master/lib/task/task.js#L68
https://github.com/jakejs/jake/blob/master/lib/task/task.js#L294
https://github.com/jakejs/jake/blob/master/lib/task/task.js#L262

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
