### PR TITLE
Leaflet: restructured into UMD with satellite modules as augmentations

### DIFF
--- a/types/leaflet-curve/index.d.ts
+++ b/types/leaflet-curve/index.d.ts
@@ -1,13 +1,16 @@
-// Type definitions for leaflet-curve 0.0.1
+// Type definitions for leaflet-curve 0.1
 // Project: https://github.com/onikiienko/Leaflet.curve
 // Definitions by: Onikiienko <https://github.com/onikiienko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
+import L = require('leaflet');
 
-declare namespace L {
-	/**
-	 * Drawing Bezier curves and other complex shapes.
-	 */
-	function  curve(path: any[], options?: L.PathOptions): Path;
+export as namespace L;
+
+declare module 'leaflet' {
+    /**
+     * Drawing Bezier curves and other complex shapes.
+     */
+    function curve(path: any[], options?: L.PathOptions): L.Path;
+
 }

--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -1,340 +1,343 @@
-// Type definitions for leaflet-draw 0.4
+// Type definitions for leaflet-draw 0.5
 // Project: https://github.com/Leaflet/Leaflet.draw
 // Definitions by: Matt Guest <https://github.com/matt-guest>, Ryan Blace <https://github.com/reblace>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
+import L = require('leaflet');
 
-declare namespace L {
-	interface MapOptions {
-		drawControl?: boolean;
-	}
+export as namespace L;
 
-	namespace Control {
-		interface DrawConstructorOptions {
+declare module 'leaflet' {
+
+    interface MapOptions {
+        drawControl?: boolean;
+    }
+
+    namespace Control {
+        interface DrawConstructorOptions {
 			/**
 			 * The initial position of the control (one of the map corners).
 			 *
 			 * Default value: 'topleft'
 			 */
-			position?: string;
+            position?: string;
 
 			/**
 			 * The options used to configure the draw toolbar.
 			 *
 			 * Default value: {}
 			 */
-			draw?: DrawOptions;
+            draw?: DrawOptions;
 
 			/**
 			 * 	The options used to configure the edit toolbar.
 			 *
 			 *  Default value: false
 			 */
-			edit?: EditOptions;
-		}
+            edit?: EditOptions;
+        }
 
-		interface DrawOptions {
+        interface DrawOptions {
 			/**
 			 * Polyline draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			polyline?: DrawOptions.PolylineOptions;
+            polyline?: DrawOptions.PolylineOptions;
 
 			/**
 			 * Polygon draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			polygon?: DrawOptions.PolygonOptions;
+            polygon?: DrawOptions.PolygonOptions;
 
 			/**
 			 * Rectangle draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			rectangle?: DrawOptions.RectangleOptions;
+            rectangle?: DrawOptions.RectangleOptions;
 
 			/**
 			 * Circle draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			circle?: DrawOptions.CircleOptions;
+            circle?: DrawOptions.CircleOptions;
 
 			/**
 			 * Marker draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			marker?: DrawOptions.MarkerOptions;
-		}
+            marker?: DrawOptions.MarkerOptions;
+        }
 
-		interface EditOptions {
+        interface EditOptions {
 			/**
 			 * This is the FeatureGroup that stores all editable shapes.
 			 * THIS IS REQUIRED FOR THE EDIT TOOLBAR TO WORK
 			 *
 			 * Default value: null
 			 */
-			featureGroup: FeatureGroup;
+            featureGroup: FeatureGroup;
 
 			/**
 			 * Edit handler options. Set to false to disable handler.
 			 *
 			 * Default value: null
 			 */
-			edit?: DrawOptions.EditHandlerOptions;
+            edit?: DrawOptions.EditHandlerOptions;
 
 			/**
 			 * Delete handler options. Set to false to disable handler.
 			 *
 			 * Default value: null
 			 */
-			remove?: DrawOptions.DeleteHandlerOptions;
-		}
+            remove?: DrawOptions.DeleteHandlerOptions;
+        }
 
-		interface Draw extends Control {
-			setDrawingOptions(options: DrawOptions): void;
-		}
+        interface Draw extends Control {
+            setDrawingOptions(options: DrawOptions): void;
+        }
 
-		class Draw {
-			constructor(options?: DrawConstructorOptions);
-		}
-	}
+        class Draw {
+            constructor(options?: DrawConstructorOptions);
+        }
+    }
 
-	namespace DrawOptions {
-		interface PolylineOptions {
+    namespace DrawOptions {
+        interface PolylineOptions {
 			/**
 			 * Determines if line segments can cross.
 			 *
 			 * Default value: true
 			 */
-			allowIntersection?: boolean;
+            allowIntersection?: boolean;
 
 			/**
 			 * Configuration options for the error that displays if an intersection is detected.
 			 *
 			 * Default value: See code
 			 */
-			drawError?: any;
+            drawError?: any;
 
 			/**
 			 * Distance in pixels between each guide dash.
 			 *
 			 * Default value: 20
 			 */
-			guidelineDistance?: number;
+            guidelineDistance?: number;
 
 			/**
 			 * The options used when drawing the polyline/polygon on the map.
 			 *
 			 * Default value: See code
 			 */
-			shapeOptions?: L.PolylineOptions;
+            shapeOptions?: L.PolylineOptions;
 
 			/**
 			 * Determines which measurement system (metric or imperial) is used.
 			 *
 			 * Default value: true
 			 */
-			metric?: boolean;
+            metric?: boolean;
 
 			/**
 			 * 	This should be a high number to ensure that you can draw over all other layers on the map.
 			 *
 			 * Default value: 2000
 			 */
-			zIndexOffset?: number;
+            zIndexOffset?: number;
 
 			/**
 			 * Determines if the draw tool remains enabled after drawing a shape.
 			 *
 			 * Default value: false
 			 */
-			repeatMode?: boolean;
-		}
+            repeatMode?: boolean;
+        }
 
-		interface PolygonOptions extends PolylineOptions {
+        interface PolygonOptions extends PolylineOptions {
 			/**
 			 * Show the area of the drawn polygon in m², ha or km².
 			 * The area is only approximate and become less accurate the larger the polygon is.
 			 *
 			 * Default value: false
 			 */
-			showArea?: boolean;
-		}
+            showArea?: boolean;
+        }
 
-		interface RectangleOptions {
+        interface RectangleOptions {
 			/**
 			 * The options used when drawing the rectangle on the map.
 			 *
 			 * Default value: See code
 			 */
-			shapeOptions?: L.PathOptions;
+            shapeOptions?: L.PathOptions;
 
 			/**
 			 * Determines if the draw tool remains enabled after drawing a shape.
 			 *
 			 * Default value: false
 			 */
-			repeatMode?: boolean;
-		}
+            repeatMode?: boolean;
+        }
 
-		interface CircleOptions {
+        interface CircleOptions {
 			/**
 			 * The options used when drawing the circle on the map.
 			 *
 			 * Default value: See code
 			 */
-			shapeOptions?: L.PathOptions;
+            shapeOptions?: L.PathOptions;
 
 			/**
 			 * Determines if the draw tool remains enabled after drawing a shape.
 			 *
 			 * Default value: false
 			 */
-			repeatMode?: boolean;
-		}
+            repeatMode?: boolean;
+        }
 
-		interface MarkerOptions {
+        interface MarkerOptions {
 			/**
 			 * TThe icon displayed when drawing a marker.
 			 *
 			 * Default value: L.Icon.Default()
 			 */
-			icon?: L.Icon;
+            icon?: L.Icon;
 
 			/**
 			 * This should be a high number to ensure that you can draw over all other layers on the map.
 			 *
 			 * Default value: 2000
 			 */
-			zIndexOffset?: number;
+            zIndexOffset?: number;
 
 			/**
 			 * Determines if the draw tool remains enabled after drawing a shape.
 			 *
 			 * Default value: false
 			 */
-			repeatMode?: boolean;
-		}
+            repeatMode?: boolean;
+        }
 
-		interface EditHandlerOptions {
+        interface EditHandlerOptions {
 			/**
 			 * The path options for how the layers will look while in edit mode.
 			 * If this is set to null the editable path options will not be set.
 			 *
 			 * Default value: See code
 			 */
-			selectedPathOptions?: L.PathOptions;
-		}
+            selectedPathOptions?: L.PathOptions;
+        }
 
-		interface DeleteHandlerOptions {
-		}
-	}
+        interface DeleteHandlerOptions {
+        }
+    }
 
-	namespace Draw {
-		namespace Event {
-			const CREATED: string;
-			const EDITED: string;
-			const DELETED: string;
-			const DRAWSTART: string;
-			const DRAWSTOP: string;
-			const DRAWVERTEX: string;
-			const EDITSTART: string;
-			const EDITMOVE: string;
-			const EDITRESIZE: string;
-			const EDITVERTEX: string;
-			const EDITSTOP: string;
-			const DELETESTART: string;
-			const DELETESTOP: string;
-		}
-	}
+    namespace Draw {
+        namespace Event {
+            const CREATED: string;
+            const EDITED: string;
+            const DELETED: string;
+            const DRAWSTART: string;
+            const DRAWSTOP: string;
+            const DRAWVERTEX: string;
+            const EDITSTART: string;
+            const EDITMOVE: string;
+            const EDITRESIZE: string;
+            const EDITVERTEX: string;
+            const EDITSTOP: string;
+            const DELETESTART: string;
+            const DELETESTOP: string;
+        }
+    }
 
-	namespace DrawEvents {
-		interface Created extends L.Event {
+    namespace DrawEvents {
+        interface Created extends L.Event {
 			/**
 			 * Layer that was just created.
 			 */
-			layer: Layer;
+            layer: Layer;
 
 			/**
 			 * The type of layer this is. One of: polyline, polygon, rectangle, circle, marker.
 			 */
-			layerType: string;
-		}
+            layerType: string;
+        }
 
-		interface Edited extends L.Event {
+        interface Edited extends L.Event {
 			/**
 			 * List of all layers just edited on the map.
 			 */
-			layers: LayerGroup;
-		}
+            layers: LayerGroup;
+        }
 
 		/**
 		 * Triggered when layers have been removed (and saved) from the FeatureGroup.
 		 */
-		interface Deleted extends L.Event {
+        interface Deleted extends L.Event {
 			/**
 			 * List of all layers just removed from the map.
 			 */
-			layers: LayerGroup;
-		}
+            layers: LayerGroup;
+        }
 
-		interface DrawStart extends L.Event {
+        interface DrawStart extends L.Event {
 			/**
 			 * The type of layer this is. One of: polyline, polygon, rectangle, circle, marker
 			 */
-			layerType: string;
-		}
+            layerType: string;
+        }
 
-		interface DrawStop extends L.Event {
+        interface DrawStop extends L.Event {
 			/**
 			 * The type of layer this is. One of: polyline, polygon, rectangle, circle, marker
 			 */
-			layerType: string;
-		}
+            layerType: string;
+        }
 
-		interface EditStart extends L.Event {
+        interface EditStart extends L.Event {
 			/**
 			 * The type of edit this is. One of: edit
 			 */
-			handler: string;
-		}
+            handler: string;
+        }
 
-		interface EditStop extends L.Event {
+        interface EditStop extends L.Event {
 			/**
 			 * The type of edit this is. One of: edit
 			 */
-			handler: string;
-		}
+            handler: string;
+        }
 
-		interface DeleteStart extends L.Event {
+        interface DeleteStart extends L.Event {
 			/**
 			 * The type of edit this is. One of: remove
 			 */
-			handler: string;
-		}
+            handler: string;
+        }
 
-		interface DeleteStop extends L.Event {
+        interface DeleteStop extends L.Event {
 			/**
 			 * The type of edit this is. One of: remove
 			 */
-			handler: string;
-		}
-	}
+            handler: string;
+        }
+    }
 
-	namespace GeometryUtil {
+    namespace GeometryUtil {
 		/**
 		 * Returns the area of a polygon drawn with leaflet.draw
 		 */
-		function geodesicArea(coordinates: L.LatLngLiteral[]): number;
+        function geodesicArea(coordinates: L.LatLngLiteral[]): number;
 
 		/**
 		 * Returns a readable area string in yards or metric
 		 */
-		function readableArea(area: number, isMetric: boolean): string;
-	}
+        function readableArea(area: number, isMetric: boolean): string;
+    }
 }

--- a/types/leaflet-fullscreen/index.d.ts
+++ b/types/leaflet-fullscreen/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for leaflet-fullscreen 1.0
+// Type definitions for leaflet-fullscreen 1.1
 // Project: https://github.com/Leaflet/Leaflet.fullscreen
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
+import L = require('leaflet');
 
-declare namespace L {
+declare module 'leaflet' {
     interface MapOptions {
         fullscreenControl?: true | {pseudoFullscreen: boolean};
     }

--- a/types/leaflet-imageoverlay-rotated/index.d.ts
+++ b/types/leaflet-imageoverlay-rotated/index.d.ts
@@ -1,11 +1,11 @@
-// Type definitions for leaflet-imageoverlay-rotated 0.1
+// Type definitions for leaflet-imageoverlay-rotated 0.2
 // Project: https://github.com/IvanSanchez/Leaflet.ImageOverlay.Rotated
 // Definitions by: Thomas Kleinke <https://github.com/tkleinke>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
+import L = require('leaflet');
 
-declare namespace L {
+declare module 'leaflet' {
     namespace ImageOverlay {
         interface Rotated extends L.ImageOverlay {
             reposition(

--- a/types/leaflet-polylinedecorator/index.d.ts
+++ b/types/leaflet-polylinedecorator/index.d.ts
@@ -1,15 +1,15 @@
-// Type definitions for leaflet-polylinedecorator 1.1
+// Type definitions for leaflet-polylinedecorator 1.2
 // Project: https://github.com/bbecquet/Leaflet.PolylineDecorator#readme
 // Definitions by: Viktor Soucek <https://github.com/soucekv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
+import L = require('leaflet');
 
-declare namespace L {
+declare module 'leaflet' {
     namespace Symbol {
         interface DashOptions {
             pixelSize?: number;
-            pathOptions?: PathOptions;
+            pathOptions?: L.PathOptions;
         }
 
         class Dash {
@@ -22,7 +22,7 @@ declare namespace L {
             polygon?: boolean;
             pixelSize?: number;
             headAngle?: number;
-            pathOptions?: PathOptions;
+            pathOptions?: L.PathOptions;
         }
 
         class ArrowHead {
@@ -54,9 +54,9 @@ declare namespace L {
         patterns: Pattern[];
     }
 
-    class PolylineDecorator extends FeatureGroup {
-        constructor(paths: Polyline | Polygon | LatLngExpression[] | Polyline[] | Polygon[] | LatLngExpression[][], options?: PolylineDecoratorOptions);
+    class PolylineDecorator extends L.FeatureGroup {
+        constructor(paths: L.Polyline | L.Polygon | L.LatLngExpression[] | L.Polyline[] | L.Polygon[] | L.LatLngExpression[][], options?: PolylineDecoratorOptions);
     }
 
-    function polylineDecorator(paths: Polyline | Polyline[], options?: PolylineDecoratorOptions): PolylineDecorator;
+    function polylineDecorator(paths: L.Polyline | L.Polyline[], options?: PolylineDecoratorOptions): PolylineDecorator;
 }

--- a/types/leaflet.awesome-markers/index.d.ts
+++ b/types/leaflet.awesome-markers/index.d.ts
@@ -1,22 +1,22 @@
-// Type definitions for Leaflet.awesome-markers plugin v2.0
+// Type definitions for Leaflet.awesome-markers plugin 2.1
 // Project: https://github.com/sigma-geosistemas/Leaflet.awesome-markers#properties
 // Definitions by: Marcel Sebek <https://github.com/sebek64>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as Leaflet from "leaflet";
+import L = require('leaflet');
 
-declare global { namespace L {
-    module AwesomeMarkers {
+declare module 'leaflet' {
+    namespace AwesomeMarkers {
         var version: string;
 
         function icon(options: AwesomeMarkers.IconOptions): AwesomeMarkers.Icon;
 
-        class Icon extends Leaflet.BaseIcon {
+        class Icon extends L.BaseIcon {
             constructor(options?: AwesomeMarkers.IconOptions);
             options: AwesomeMarkers.IconOptions;
         }
 
-        interface IconOptions extends Leaflet.BaseIconOptions {
+        interface IconOptions extends L.BaseIconOptions {
             /**
             * Name of the icon. See glyphicons or font-awesome.
             */
@@ -48,4 +48,4 @@ declare global { namespace L {
             extraClasses?: string;
         }
     }
-} }
+}

--- a/types/leaflet.fullscreen/index.d.ts
+++ b/types/leaflet.fullscreen/index.d.ts
@@ -3,33 +3,33 @@
 // Definitions by: William Comartin <https://github.com/wcomartin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
+import L = require('leaflet');
 
-declare namespace L {
+declare module 'leaflet' {
 
-  namespace Control {
+    namespace Control {
 
-    export class Fullscreen extends L.Control {
-      constructor(options?: Control.FullscreenOptions);
-      options: FullscreenOptions;
+        export class Fullscreen extends L.Control {
+            constructor(options?: Control.FullscreenOptions);
+            options: FullscreenOptions;
+        }
+        export interface FullscreenOptions {
+            content?: string,
+            position?: L.ControlPosition,
+            title?: string,
+            titleCancel?: string,
+            forceSeparateButton?: boolean,
+            forcePseudoFullscreen?: boolean,
+            pseudoFullscreen?: boolean
+        }
     }
-    export interface FullscreenOptions {
-      content?: string,
-      position?: L.ControlPosition,
-      title?: string,
-      titleCancel?: string,
-      forceSeparateButton?: boolean,
-      forcePseudoFullscreen?: boolean,
-      pseudoFullscreen?:boolean
+
+    namespace control {
+
+        /**
+         * Creates a fullscreen control.
+         */
+        export function fullscreen(options?: Control.FullscreenOptions): L.Control.Fullscreen;
+
     }
-  }
-
-  namespace control {
-
-    /**
-     * Creates a fullscreen control.
-     */
-    export function fullscreen(options?: Control.FullscreenOptions): L.Control.Fullscreen;
-
-  }
 }

--- a/types/leaflet.gridlayer.googlemutant/index.d.ts
+++ b/types/leaflet.gridlayer.googlemutant/index.d.ts
@@ -1,77 +1,79 @@
-// Type definitions for leaflet.gridlayer.googlemutant 0.4
+// Type definitions for leaflet.gridlayer.googlemutant 0.5
 // Project: https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant#README
 // Definitions by: Ernest Rhinozeros <https://github.com/ernest-rhinozeros>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
+import L = require('leaflet');
 
-declare namespace L.gridLayer {
-    interface GoogleMutant extends L.GridLayer {
-        setElementSize(e: HTMLElement, size: L.Point): void ;
+declare module 'leaflet' {
+    namespace gridLayer {
+        interface GoogleMutant extends L.GridLayer {
+            setElementSize(e: HTMLElement, size: L.Point): void;
+        }
+
+        type GoogleMutantType = 'roadmap' | 'satellite' | 'terrain' | 'hybrid';
+
+        interface GoogleMutantStyler {
+            hue?: string;
+            lightness?: number;
+            saturation?: number;
+            gamma?: number;
+            invert_lightness?: boolean;
+            visibility?: string;
+            color?: string;
+            weight?: number;
+        }
+
+        /**
+         * Google's map style.
+         *
+         * https://developers.google.com/maps/documentation/javascript/style-reference
+         */
+        interface GoogleMutantStyle {
+            /**
+             * https://developers.google.com/maps/documentation/javascript/style-reference#style-features
+             */
+            featureType?: string;
+
+            /**
+             * https://developers.google.com/maps/documentation/javascript/style-reference#style-elements
+             */
+            elementType?: string;
+
+            /**
+             * https://developers.google.com/maps/documentation/javascript/style-reference#stylers
+             */
+            stylers?: GoogleMutantStyler[];
+        }
+
+        interface GoogleMutantOptions extends L.TileLayerOptions {
+            minZoom?: number;
+            maxZoom?: number;
+            maxNativeZoom?: number;
+            tileSize?: number | Point;
+            subdomains?: string | string[];
+            errorTileUrl?: string;
+
+            /**
+             * The mutant container will add its own attribution anyways.
+             */
+            attribution?: string;
+
+            opacity?: number;
+            continuousWorld?: boolean;
+            noWrap?: boolean;
+
+            /**
+             * Google's map type. 'hybrid' is not really supported.
+             */
+            type?: GoogleMutantType;
+
+            /**
+             * Google's map styles.
+             */
+            styles?: GoogleMutantStyle[];
+        }
+
+        function googleMutant(options?: GoogleMutantOptions): GoogleMutant;
     }
-
-    type GoogleMutantType = 'roadmap' | 'satellite' | 'terrain' | 'hybrid';
-
-    interface GoogleMutantStyler {
-        hue?: string;
-        lightness?: number;
-        saturation?: number;
-        gamma?: number;
-        invert_lightness?: boolean;
-        visibility?: string;
-        color?: string;
-        weight?: number;
-    }
-
-    /**
-     * Google's map style.
-     *
-     * https://developers.google.com/maps/documentation/javascript/style-reference
-     */
-    interface GoogleMutantStyle {
-        /**
-         * https://developers.google.com/maps/documentation/javascript/style-reference#style-features
-         */
-        featureType?: string;
-
-        /**
-         * https://developers.google.com/maps/documentation/javascript/style-reference#style-elements
-         */
-        elementType?: string;
-
-        /**
-         * https://developers.google.com/maps/documentation/javascript/style-reference#stylers
-         */
-        stylers?: GoogleMutantStyler[];
-    }
-
-    interface GoogleMutantOptions extends L.TileLayerOptions {
-        minZoom?: number;
-        maxZoom?: number;
-        maxNativeZoom?: number;
-        tileSize?: number | Point;
-        subdomains?: string | string[];
-        errorTileUrl?: string;
-
-        /**
-         * The mutant container will add its own attribution anyways.
-         */
-        attribution?: string;
-
-        opacity?: number;
-        continuousWorld?: boolean;
-        noWrap?: boolean;
-
-        /**
-         * Google's map type. 'hybrid' is not really supported.
-         */
-        type?: GoogleMutantType;
-
-        /**
-         * Google's map styles.
-         */
-        styles?: GoogleMutantStyle[];
-    }
-
-    function googleMutant(options?: GoogleMutantOptions): GoogleMutant;
 }

--- a/types/leaflet.locatecontrol/index.d.ts
+++ b/types/leaflet.locatecontrol/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
+import L = require('leaflet');
 
-declare namespace L {
+declare module 'leaflet' {
     namespace Control {
         interface LocateOptions {
             position?: string;

--- a/types/leaflet.markercluster/index.d.ts
+++ b/types/leaflet.markercluster/index.d.ts
@@ -1,13 +1,11 @@
-// Type definitions for Leaflet.markercluster 1.0
+// Type definitions for Leaflet.markercluster 1.1
 // Project: https://github.com/Leaflet/Leaflet.markercluster
 // Definitions by: Robert Imig <https://github.com/rimig>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as Leaflet from "leaflet";
+import L = require('leaflet');
 
-export = Leaflet;
-
-declare global { namespace L {
+declare module 'leaflet' {
     interface MarkerCluster extends Marker {
         /*
         * Recursively retrieve all child markers of this cluster.
@@ -105,7 +103,7 @@ declare global { namespace L {
         /*
         * Function used to create the cluster icon
         */
-        iconCreateFunction?: ((cluster: MarkerCluster) => Icon | DivIcon);
+        iconCreateFunction?: (cluster: MarkerCluster) => L.Icon | L.DivIcon;
 
         /*
         * Boolean to split the addLayers processing in to small intervals so that the page does not freeze.
@@ -118,13 +116,13 @@ declare global { namespace L {
         chunkDelay?: number;
     }
 
-    interface MarkerClusterGroup extends FeatureGroup {
+    interface MarkerClusterGroup extends L.FeatureGroup {
         /*
         * Bulk methods for adding and removing markers and should be favoured over the
         * single versions when doing bulk addition/removal of markers.
         */
-        addLayers(layers: Layer[]): this;
-        removeLayers(layers: Layer[]): this;
+        addLayers(layers: L.Layer[]): this;
+        removeLayers(layers: L.Layer[]): this;
 
         clearLayers(): this;
 
@@ -132,13 +130,13 @@ declare global { namespace L {
         * If you have a marker in your MarkerClusterGroup and you want to get the visible
         * parent of it
         */
-        getVisibleParent(marker: Marker): Marker;
+        getVisibleParent(marker: L.Marker): L.Marker;
 
         /*
         * If you have customized the clusters icon to use some data from the contained markers,
         * and later that data changes, use this method to force a refresh of the cluster icons.
         */
-        refreshClusters(clusters?: Marker | Marker[] | LayerGroup | {[index: string]: Layer}): this;
+        refreshClusters(clusters?: L.Marker | L.Marker[] | L.LayerGroup | {[index: string]: L.Layer}): this;
 
         /*
         * Returns the total number of markers contained within that cluster.
@@ -148,22 +146,22 @@ declare global { namespace L {
         /*
         * Returns the array of total markers contained within that cluster.
         */
-        getAllChildMarkers(): Marker[];
+        getAllChildMarkers(): L.Marker[];
 
         /*
         * Returns true if the given layer (marker) is in the cluster.
         */
-        hasLayer(layer: Layer): boolean;
+        hasLayer(layer: L.Layer): boolean;
 
         /*
         * Zooms to show the given marker (spiderfying if required),
         * calls the callback when the marker is visible on the map.
         */
-        zoomToShowLayer(layer: Layer, callback?: () => void): void;
+        zoomToShowLayer(layer: L.Layer, callback?: () => void): void;
     }
 
     /*
     * Create a marker cluster group, optionally given marker cluster group options.
     */
     function markerClusterGroup(options?: MarkerClusterGroupOptions): MarkerClusterGroup;
-} }
+}

--- a/types/leaflet.pm/index.d.ts
+++ b/types/leaflet.pm/index.d.ts
@@ -3,9 +3,10 @@
 // Definitions by: Thomas Kleinke <https://github.com/tkleinke>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="leaflet" />
 
-declare namespace L {
+import L = require('leaflet');
+
+declare module 'leaflet' {
     interface Map {
         pm: PM.Map;
     }

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -1,25 +1,29 @@
-// Type definitions for Leaflet.js 1.0
+// Type definitions for Leaflet.js 1.1
 // Project: https://github.com/Leaflet/Leaflet
 // Definitions by: Alejandro Sánchez <https://github.com/alejo90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="geojson" />
+// Alias imports to avoid conflicts with the GeoJSON classes of leaflet
+import {
+    GeoJsonObject as GeoJSONGeoJsonObject,
+    Feature as GeoJSONFeature,
+    FeatureCollection as GeoJSONFeatureCollection,
+    LineString as GeoJSONLineString,
+    MultiLineString as GeoJSONMultiLineString,
+    Polygon as GeoJSONPolygon,
+    MultiPolygon as GeoJSONMultiPolygon,
+    GeometryObject as GeoJSONGeometryObject,
+    GeometryCollection as GeoJSONGeometryCollection,
+    Point as GeoJSONPoint,
+    MultiPoint as GeoJSONMultiPoint
+} from 'geojson';
 
+// Alias DOM types to avoid conflicts their wrapping events
 type NativeMouseEvent = MouseEvent;
 type NativeKeyboardEvent = KeyboardEvent;
 
-// Import to avoid conflicts with the GeoJSON class of leaflet
-import GeoJSONFeature = GeoJSON.Feature;
-import GeoJSONLineString = GeoJSON.LineString;
-import GeoJSONMultiLineString = GeoJSON.MultiLineString;
-import GeoJSONPolygon = GeoJSON.Polygon;
-import GeoJSONMultiPolygon = GeoJSON.MultiPolygon;
-import GeoJSONFeatureCollection = GeoJSON.FeatureCollection;
-import GeoJSONGeometryObject = GeoJSON.GeometryObject;
-import GeoJSONGeometryCollection = GeoJSON.GeometryCollection;
-import GeoJSONPoint = GeoJSON.Point;
-import GeoJSONMultiPoint = GeoJSON.MultiPoint;
-import GeoJSONGeoJsonObject = GeoJSON.GeoJsonObject;
+export = L;
+export as namespace L;
 
 declare namespace L {
     class Class {
@@ -1544,8 +1548,6 @@ declare namespace L {
         let lastId: number;
         let emptyImageUrl: string;
     }
-}
 
-declare module 'leaflet' {
-    export = L;
+
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I'm not 100% sure if this is the correct way to model the dependencies between Leaflet and the many surrounding packages that enrich it. 
There are a number of issues with how Leaflet is currently represented.
It is an ambient external module.
It depends on a global but that is not necessary
In the process of trying to change these, it soon became clear that adjusting ~11 other packages would be necessary.

I am curious to see the feedback on this PR, especially as there are many longstanding libraries, like jQuery, that still have not migrated to the UMD declaration format, it will be interesting to see if this is deemed practical.

I am also keen to learn if there is a better approach to take here.

Thanks!