### PR TITLE
Add mongodb return type WriteOpResult to Collection.replaceOne(...) 

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for MongoDB v2.2
 // Project: https://github.com/mongodb/node-mongodb-native/tree/2.2
 // Definitions by: Federico Caselli <https://github.com/CaselIT>
+//                 Alan Marcell <https://github.com/alanmarcell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -585,9 +586,9 @@ export interface Collection<TSchema = Default> {
     rename(newName: string, callback: MongoCallback<Collection<TSchema>>): void;
     rename(newName: string, options?: { dropTarget?: boolean }): Promise<Collection<TSchema>>;
     rename(newName: string, options: { dropTarget?: boolean }, callback: MongoCallback<Collection<TSchema>>): void;
-    //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#replaceOne
+    //http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#replaceOne
     replaceOne(filter: Object, doc: Object, callback: MongoCallback<UpdateWriteOpResult>): void;
-    replaceOne(filter: Object, doc: Object, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult>;
+    replaceOne(filter: Object, doc: Object, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult> | Promise<WriteOpResult>;
     replaceOne(filter: Object, doc: Object, options: ReplaceOneOptions, callback: MongoCallback<UpdateWriteOpResult>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#save
     /** @deprecated Use insertOne, insertMany, updateOne or updateMany */

--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -587,9 +587,9 @@ export interface Collection<TSchema = Default> {
     rename(newName: string, options?: { dropTarget?: boolean }): Promise<Collection<TSchema>>;
     rename(newName: string, options: { dropTarget?: boolean }, callback: MongoCallback<Collection<TSchema>>): void;
     //http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#replaceOne
-    replaceOne(filter: Object, doc: Object, callback: MongoCallback<UpdateWriteOpResult>): void;
-    replaceOne(filter: Object, doc: Object, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult> | Promise<WriteOpResult>;
-    replaceOne(filter: Object, doc: Object, options: ReplaceOneOptions, callback: MongoCallback<UpdateWriteOpResult>): void;
+    replaceOne(filter: Object, doc: Object, callback: MongoCallback<UpdateWriteOpResult & { ops: Array<any> }>): void;
+    replaceOne(filter: Object, doc: Object, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult & { ops: Array<any> }>;
+    replaceOne(filter: Object, doc: Object, options: ReplaceOneOptions, callback: MongoCallback<UpdateWriteOpResult & { ops: Array<any> }>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#save
     /** @deprecated Use insertOne, insertMany, updateOne or updateMany */
     save(doc: Object, callback: MongoCallback<WriteOpResult>): void;


### PR DESCRIPTION
In case of Collection.replaceOne(..., {upsert:true}) the return type is an WriteOpResult

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#replaceOne>
