### PR TITLE
ECharts - Updated visualMap property to match ECharts definition

### DIFF
--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -101,7 +101,7 @@ declare namespace ECharts {
         angleAxis?: Object,
         radar?: Object,
         dataZoom?: Array<Object>,
-        visualMap?: Array<Object>,
+        visualMap?: Object,
         tooltip?: Object,
         toolbox?: Object,
         geo?: Object,


### PR DESCRIPTION
Existing ECharts definition implies EChartOption to be a Array<Object>, whereas documentation states it is an Object.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://ecomfe.github.io/echarts-examples/public/editor.html?c=heatmap-cartesian
