### PR TITLE
react-lazyload missing export forceCheck function.

### DIFF
--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -24,3 +24,5 @@ export default class LazyLoad extends Component<LazyLoadProps> {
 }
 
 export  function lazyload(option: {}): LazyLoad;
+
+export function forceCheck(): void;

--- a/types/react-lazyload/react-lazyload-tests.tsx
+++ b/types/react-lazyload/react-lazyload-tests.tsx
@@ -14,7 +14,7 @@ class Normal extends React.Component<{}, State> {
         }
         this.state = { arr };
     }
-    
+
     componentDidMount() {
         forceCheck();
     }

--- a/types/react-lazyload/react-lazyload-tests.tsx
+++ b/types/react-lazyload/react-lazyload-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import LazyLoad from "react-lazyload";
+import LazyLoad, { forceCheck } from "react-lazyload";
 
 interface State {
     arr: string[];
@@ -14,6 +14,11 @@ class Normal extends React.Component<{}, State> {
         }
         this.state = { arr };
     }
+    
+    componentDidMount() {
+        forceCheck();
+    }
+
     render() {
         return (
             <div>


### PR DESCRIPTION
The react-lazyload have export a `forceCheck` function, but declaration is missing.
see the [README](https://github.com/jasonslyvia/react-lazyload/blob/master/README.md) and [Source Code](https://github.com/jasonslyvia/react-lazyload/blob/master/src/index.jsx#L321)