### PR TITLE
jquery: Add null as a possible return value on val()

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2329,7 +2329,7 @@ interface JQuery<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/val/}
      * @since 1.0
      */
-    val(): string | number | string[] | undefined;
+    val(): string | number | string[] | null | undefined;
     /**
      * Set the CSS width of each element in the set of matched elements.
      *

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -3025,7 +3025,7 @@ function JQuery() {
                 return 'myVal';
             });
 
-            // $ExpectType string | number | string[] | undefined
+            // $ExpectType string | number | string[] | null | undefined
             $('p').val();
         }
     }


### PR DESCRIPTION
Handles a corner case when a multiple-option select has no options selected.

```ts
$(`<select multiple>
  <option>A</option>
  <option>B</option>
</select>`).val() === null
```

The current return type already requires an `Array.isArray` check in any case, though.