### PR TITLE
Update index.d.ts for autoprefixer to support browserslist better

### DIFF
--- a/types/autoprefixer/index.d.ts
+++ b/types/autoprefixer/index.d.ts
@@ -7,7 +7,7 @@ import { Plugin, Transformer as PostcssTransformer } from 'postcss';
 
 declare namespace autoprefixer {
     interface Options {
-        browsers?: string[];
+        browsers?: string[] | string;
         env?: string;
         cascade?: boolean;
         add?: boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ai/browserslist/blob/c2f319ef7b5b169cf529102e76d6e9154b61beeb/index.js#L188
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

autoprefixer uses browserslist (see [here](https://github.com/postcss/autoprefixer#browsers)), which accepts an array of strings or a string (concatenated by `", "`). The string is split into an array (see [source code](https://github.com/ai/browserslist/blob/c2f319ef7b5b169cf529102e76d6e9154b61beeb/index.js#L188)) internally.

For its [docs](https://github.com/ai/browserslist#js-api):

> Queries can be a string `"> 5%, last 1 version"` or an array `['> 5%', 'last 1 version']`.

FYI babel-preset-env also works this way and states that it works "like autoprefixer" (see [here](https://github.com/babel/babel-preset-env#support-a-browsers-option-like-autoprefixer)).