### PR TITLE
flux-standard-action: fix typos, declare assertions

### DIFF
--- a/types/flux-standard-action/flux-standard-action-tests.ts
+++ b/types/flux-standard-action/flux-standard-action-tests.ts
@@ -23,3 +23,17 @@ var result1: boolean = isError(sample1);
 var result2: boolean = isFSA(sample1);
 var result3: boolean = isError(sample2);
 var result4: boolean = isFSA(sample2);
+
+declare function alert (message: string): void
+
+function unwrapAction(action: { type: string }) {
+    if (isFSA(action)) {
+        if (isError(action)) {
+            alert(action.payload!.message)
+        }
+        return action.payload
+    }
+}
+
+var result5: TextPayload = unwrapAction(sample1)
+var result6: Error = unwrapAction(sample2)

--- a/types/flux-standard-action/index.d.ts
+++ b/types/flux-standard-action/index.d.ts
@@ -5,7 +5,7 @@
 
 
 export interface ErrorAction extends Action<Error> {
-    error: boolean;
+    error: true;
 }
 
 export interface Action<T> {
@@ -14,16 +14,16 @@ export interface Action<T> {
     error?: boolean;
 }
 
-// Usage: var action: Action<sring> & AnyMeta;
+/** Usage: `var action: Action<string> & AnyMeta;` */
 export interface AnyMeta {
     meta: any
 }
 
-// Usage: var action: Action<sring> & TypedMeta<string>;
+/** Usage: `var action: Action<string> & TypedMeta<string>;` */
 export interface TypedMeta<T> {
     meta: T
 }
 
-export declare function isFSA(action: any): boolean;
+export declare function isFSA(action: any): action is Action<any>;
 
-export declare function isError(action: any): boolean;
+export declare function isError(action: any): action is ErrorAction;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).

The `isFSA` and `isError` checks are assertions, so they should declare their return value as an assertion.

However, one thing I wonder about the `ErrorAction` type is, `isError` makes _no guarantees_ that the `payload` is an `Error`. The spec even says that it SHOULD be an Error, but as it is analogous to a Promise rejection value, it can be anything.

I could change it to `extend Action<any>`, or change it to `ErrorAction<T = any> extends Action<T>` but that would be as-assertion-like, as the compiler would have to take the generic argument at face value.