### PR TITLE
Added .withCredentials to CoreOptions in .d.ts file

### DIFF
--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -143,6 +143,7 @@ declare namespace request {
         gzip?: boolean;
         preambleCRLF?: boolean;
         postambleCRLF?: boolean;
+        withCredentials?: boolean;
         key?: Buffer;
         cert?: Buffer;
         passphrase?: string;


### PR DESCRIPTION
Although not specified on the main page, as per 

https://github.com/request/request/blob/b12a6245d9acdb1e13c6486d427801e123fdafae/tests/browser/test.js we can see that this is part of the request module. 

More practically: local testing shows adding the {withCredentials:false} option allows us to create a request that accepts an "*" value for the Access-Control-Allow-Origin header.
