### PR TITLE
@storybook/react: fix type definition error

### DIFF
--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @storybook/react 3.0
+// Type definitions for @storybook/react 3.1
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -14,7 +14,7 @@
 declare module '@storybook/react' {
     import * as React from 'react';
 
-    type Renderable = React.StatelessComponent<any> | React.Component<any> | JSX.Element;
+    type Renderable = React.StatelessComponent<any> | React.Component<any, any> | JSX.Element;
     type RenderFunction = () => Renderable;
 
     type StoryDecorator = (story: RenderFunction, context: { kind: string, story: string }) => Renderable | null;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L192
- [x] Increase the version number in the header if appropriate.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~ already exists.


Fixes:
```
ERROR in /web/node_modules/@types/storybook__react/index.d.ts
(17,55): error TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).
```