### PR TITLE
React.createElement splits SVG/HTML props based on type parameter

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -140,7 +140,7 @@ declare namespace React {
         type: keyof ReactHTML,
         props?: ClassAttributes<T> & P,
         ...children: ReactNode[]): ReactHTMLElement<T>;
-    function createElement<P extends SVGAttributes<T>, T extends Element>(
+    function createElement<P extends SVGAttributes<T>, T extends SVGElement>(
         type: keyof ReactSVG,
         props?: ClassAttributes<T> & P,
         ...children: ReactNode[]): ReactSVGElement;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -136,8 +136,12 @@ declare namespace React {
         type: ClassType<P, T, C>): CFactory<P, T>;
     function createFactory<P>(type: ComponentClass<P>): Factory<P>;
 
-    function createElement<P extends DOMAttributes<T>, T extends Element>(
-        type: string,
+    function createElement<P extends HTMLAttributes<T>, T extends Element>(
+        type: keyof ReactHTML,
+        props?: ClassAttributes<T> & P,
+        ...children: ReactNode[]): DOMElement<P, T>;
+    function createElement<P extends SVGAttributes<T>, T extends Element>(
+        type: keyof ReactSVG,
         props?: ClassAttributes<T> & P,
         ...children: ReactNode[]): DOMElement<P, T>;
     function createElement<P>(
@@ -2526,8 +2530,7 @@ declare namespace React {
     // React.DOM
     // ----------------------------------------------------------------------
 
-    interface ReactDOM {
-        // HTML
+    interface ReactHTML {
         a: HTMLFactory<HTMLAnchorElement>;
         abbr: HTMLFactory<HTMLElement>;
         address: HTMLFactory<HTMLElement>;
@@ -2641,8 +2644,9 @@ declare namespace React {
         "var": HTMLFactory<HTMLElement>;
         video: HTMLFactory<HTMLVideoElement>;
         wbr: HTMLFactory<HTMLElement>;
+    }
 
-        // SVG
+    interface ReactSVG {
         svg: SVGFactory;
         animate: SVGFactory;
         circle: SVGFactory;
@@ -2665,6 +2669,8 @@ declare namespace React {
         tspan: SVGFactory;
         use: SVGFactory;
     }
+
+    interface ReactDOM extends ReactHTML, ReactSVG { }
 
     //
     // React.PropTypes

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -136,14 +136,14 @@ declare namespace React {
         type: ClassType<P, T, C>): CFactory<P, T>;
     function createFactory<P>(type: ComponentClass<P>): Factory<P>;
 
-    function createElement<P extends HTMLAttributes<T>, T extends Element>(
+    function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         type: keyof ReactHTML,
         props?: ClassAttributes<T> & P,
-        ...children: ReactNode[]): DOMElement<P, T>;
+        ...children: ReactNode[]): ReactHTMLElement<T>;
     function createElement<P extends SVGAttributes<T>, T extends Element>(
         type: keyof ReactSVG,
         props?: ClassAttributes<T> & P,
-        ...children: ReactNode[]): DOMElement<P, T>;
+        ...children: ReactNode[]): ReactSVGElement;
     function createElement<P>(
         type: SFC<P>,
         props?: Attributes & P,

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -190,6 +190,8 @@ var classicElement: React.ClassicElement<Props> =
     React.createElement(ClassicComponent, props);
 var domElement: React.ReactHTMLElement<HTMLDivElement> =
     React.createElement("div");
+var htmlElement = React.createElement("input", { type: "text" });
+var svgElement = React.createElement("svg", { accentHeight: 12 });
 
 // React.cloneElement
 var clonedElement: React.CElement<Props, ModernComponent> =


### PR DESCRIPTION
This is required for 2.4 to avoid a weak type error since DOMAttributes is a weak type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#typescript-24
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.