### PR TITLE
[DefinitelyTyped] Increase nProcesses from 1 to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "compile-scripts": "tsc -p scripts",
     "not-needed": "node scripts/not-needed.js",
-    "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --nProcesses 1",
+    "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --nProcesses 4",
     "lint": "dtslint types"
   },
   "devDependencies": {


### PR DESCRIPTION
Some builds can take a particularly long time. Most of the time is spent running `npm test` where the test script is:
```json
"test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --nProcesses 1"
```

I ran benchmarks with `--nProcesses 4` and it seems to give a substantial speed up.

| Run | [--nProcesses 1](https://github.com/leonard-thieu/DefinitelyTyped/pull/8) | [--nProcesses 4](https://github.com/leonard-thieu/DefinitelyTyped/pull/9) |
| --- | --- | --- |
| 1 | 43 min 59 sec | 16 min 29 sec |
| 2 | 42 min 44 sec | 16 min 5 sec |
| 3 | 46 min 38 sec | 15 min 52 sec |
| 4 | 41 min 58 sec | 16 min 57 sec |
| 5 | 42 min 24 sec | 15 min 38 sec |
| **Avg** | 43 min 33 sec | 16 min 12 sec |

<sub>`master` was at https://github.com/leonard-thieu/DefinitelyTyped/commit/f2c8b617014491a302a9d7a01d83bbde3366dc0d when these tests were run</sub>

Is there any pitfalls from bumping up `--nProcesses`?