### PR TITLE
Fix koa-router to avoid koa.Context shadowing.

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for koa-router v7.x
 // Project: https://github.com/alexmingoia/koa-router/
-// Definitions by: Jerry Chin <https://github.com/hellopao/>, Pavel Ivanov <https://github.com/schfkt/>
+// Definitions by: Jerry Chin <https://github.com/hellopao/>
+//                 Pavel Ivanov <https://github.com/schfkt/>
+//                 Bradley Ayers <https://github.com/bradleyayers/>
 // Definitions: https://github.com/hellopao/DefinitelyTyped
 
 /* =================== USAGE ===================
@@ -12,12 +14,6 @@
 
 
 import * as Koa from "koa";
-
-declare module "koa" {
-    interface Context {
-        params: any;
-    }
-}
 
 declare module Layer {
 
@@ -33,7 +29,7 @@ declare module Router {
 
     export interface IRouterOptions {
         /**
-         * Router prefixes 
+         * Router prefixes
          */
         prefix?: string;
         /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR removes the the `declare module "koa"` definition which includes a `Context` interface which ends up shadowing the one defined in `koa`.

Concretely, the following would not work:

```ts
import { Context } from 'koa';

function (ctx: Context) {
  ctx.body = 'Hello world!'; // ERROR: no property `body`
}
```