### PR TITLE
[material-ui] Add missing methods for opening date picker dialog

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -942,6 +942,8 @@ declare namespace __MaterialUI {
             utils?: propTypes.utils;
         }
         export class DatePicker extends React.Component<DatePickerProps> {
+            focus(): void;
+            openDialog(): void;
         }
 
         interface DatePickerDialogProps {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/callemall/material-ui/blob/master/src/DatePicker/DatePicker.js#L194
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I copied the definition from TimePicker