### PR TITLE
FIX type definition for JSDom

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -12,17 +12,17 @@ import * as tough from 'tough-cookie';
 import { Script } from 'vm';
 
 export class JSDOM {
-    static fromURL(url: string | Buffer | jsdom.BinaryData, options?: jsdom.FromUrlOptions | object): Promise<JSDOM>;
+    static fromURL(url: string | Buffer | BinaryData, options?: FromUrlOptions | object): Promise<JSDOM>;
 
-    static fromFile(url: string | Buffer | jsdom.BinaryData, options?: jsdom.Options | object): Promise<JSDOM>;
+    static fromFile(url: string | Buffer | BinaryData, options?: Options | object): Promise<JSDOM>;
 
     static fragment(html: string): DocumentFragment;
 
-    constructor(html?: string | Buffer | jsdom.BinaryData, options?: jsdom.Options | object);
+    constructor(html?: string | Buffer | BinaryData, options?: Options | object);
 
-    readonly window: jsdom.Window;
-    readonly virtualConsole: jsdom.VirtualConsole;
-    readonly cookieJar: jsdom.CookieJar;
+    readonly window: DOMWindow;
+    readonly virtualConsole: VirtualConsole;
+    readonly cookieJar: CookieJar;
 
     /**
      * The serialize() method will return the HTML serialization of the document, including the doctype.
@@ -42,97 +42,92 @@ export class JSDOM {
      */
     runVMScript(script: Script): void;
 
-    reconfigure(settings: jsdom.ReconfigureSettings | object): void;
+    reconfigure(settings: ReconfigureSettings | object): void;
 }
 
-// Alias DOM Window so we can extend from it and still name the type Window
-// tslint:disable-next-line strict-export-declare-modifiers
-type DOMWindow = Window;
+export interface FromUrlOptions extends Pick<FromUrlOptions._Impl, keyof FromUrlOptions._Impl> { }
 
-export namespace jsdom {
-    interface FromUrlOptions extends Pick<FromUrlOptions._Impl, keyof FromUrlOptions._Impl> { }
+export namespace FromUrlOptions {
+    interface _Impl {
+        /**
+         * referrer just affects the value read from document.referrer.
+         * It defaults to no referrer (which reflects as the empty string).
+         */
+        referrer: string;
+        /**
+         * userAgent affects the value read from navigator.userAgent, as well as the User-Agent header sent while fetching subresources.
+         * It defaults to `Mozilla/5.0 (${process.platform}) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/${jsdomVersion}`.
+         */
+        userAgent: string;
+        /**
+         * includeNodeLocations preserves the location info produced by the HTML parser,
+         * allowing you to retrieve it with the nodeLocation() method (described below).
+         * It defaults to false to give the best performance,
+         * and cannot be used with an XML content type since our XML parser does not support location info.
+         */
+        includeNodeLocations: boolean;
+        runScripts: 'dangerously' | 'outside-only';
+        resources: 'usable';
+        virtualConsole: VirtualConsole;
+        cookieJar: CookieJar;
+        beforeParse(window: DOMWindow): void;
+    }
+}
 
-    namespace FromUrlOptions {
+interface Options extends Pick<Options._Impl, keyof Options._Impl> { }
+
+export namespace Options {
+    interface _Impl extends FromUrlOptions._Impl {
+        /**
+         * url sets the value returned by window.location, document.URL, and document.documentURI,
+         * and affects things like resolution of relative URLs within the document
+         * and the same-origin restrictions and referrer used while fetching subresources.
+         * It defaults to "about:blank".
+         */
+        url: string;
+        /**
+         * contentType affects the value read from document.contentType, and how the document is parsed: as HTML or as XML.
+         * Values that are not "text/html" or an XML mime type will throw. It defaults to "text/html".
+         */
+        contentType: string;
+    }
+}
+
+interface DOMWindow extends Window {
+    ran: number;
+
+    eval(script: string): void;
+}
+export {DOMWindow as Window};
+
+export type BinaryData = ArrayBuffer | DataView | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
+
+export class VirtualConsole extends EventEmitter {
+    on<K extends keyof Console>(method: K, callback: Console[K]): this;
+    on(event: 'jsdomError', callback: (e: Error) => void): this;
+
+    sendTo(console: Console, options?: VirtualConsole.SendToOptions | object): this;
+}
+
+export namespace VirtualConsole {
+    interface SendToOptions extends Pick<SendToOptions._Impl, keyof SendToOptions._Impl> { }
+
+    namespace SendToOptions {
         interface _Impl {
-            /**
-             * referrer just affects the value read from document.referrer.
-             * It defaults to no referrer (which reflects as the empty string).
-             */
-            referrer: string;
-            /**
-             * userAgent affects the value read from navigator.userAgent, as well as the User-Agent header sent while fetching subresources.
-             * It defaults to `Mozilla/5.0 (${process.platform}) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/${jsdomVersion}`.
-             */
-            userAgent: string;
-            /**
-             * includeNodeLocations preserves the location info produced by the HTML parser,
-             * allowing you to retrieve it with the nodeLocation() method (described below).
-             * It defaults to false to give the best performance,
-             * and cannot be used with an XML content type since our XML parser does not support location info.
-             */
-            includeNodeLocations: boolean;
-            runScripts: 'dangerously' | 'outside-only';
-            resources: 'usable';
-            virtualConsole: VirtualConsole;
-            cookieJar: CookieJar;
-            beforeParse(window: jsdom.Window): void;
+            omitJSDOMErrors: boolean;
         }
     }
+}
 
-    interface Options extends Pick<Options._Impl, keyof Options._Impl> { }
+export class CookieJar extends tough.CookieJar { }
 
-    namespace Options {
-        interface _Impl extends FromUrlOptions._Impl {
-            /**
-             * url sets the value returned by window.location, document.URL, and document.documentURI,
-             * and affects things like resolution of relative URLs within the document
-             * and the same-origin restrictions and referrer used while fetching subresources.
-             * It defaults to "about:blank".
-             */
-            url: string;
-            /**
-             * contentType affects the value read from document.contentType, and how the document is parsed: as HTML or as XML.
-             * Values that are not "text/html" or an XML mime type will throw. It defaults to "text/html".
-             */
-            contentType: string;
-        }
-    }
+export const toughCookie: typeof tough;
 
-    interface Window extends DOMWindow {
-        ran: number;
+export interface ReconfigureSettings extends Pick<ReconfigureSettings._Impl, keyof ReconfigureSettings._Impl> { }
 
-        eval(script: string): void;
-    }
-
-    type BinaryData = ArrayBuffer | DataView | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
-
-    class VirtualConsole extends EventEmitter {
-        on<K extends keyof Console>(method: K, callback: Console[K]): this;
-        on(event: 'jsdomError', callback: (e: Error) => void): this;
-
-        sendTo(console: Console, options?: VirtualConsole.SendToOptions | object): this;
-    }
-
-    namespace VirtualConsole {
-        interface SendToOptions extends Pick<SendToOptions._Impl, keyof SendToOptions._Impl> { }
-
-        namespace SendToOptions {
-            interface _Impl {
-                omitJSDOMErrors: boolean;
-            }
-        }
-    }
-
-    class CookieJar extends tough.CookieJar { }
-
-    const toughCookie: typeof tough;
-
-    interface ReconfigureSettings extends Pick<ReconfigureSettings._Impl, keyof ReconfigureSettings._Impl> { }
-
-    namespace ReconfigureSettings {
-        interface _Impl {
-            windowTop: DOMWindow;
-            url: string;
-        }
+export namespace ReconfigureSettings {
+    interface _Impl {
+        WindowTop: DOMWindow;
+        url: string;
     }
 }

--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -74,7 +74,7 @@ export namespace FromUrlOptions {
     }
 }
 
-interface Options extends Pick<Options._Impl, keyof Options._Impl> { }
+export interface Options extends Pick<Options._Impl, keyof Options._Impl> { }
 
 export namespace Options {
     interface _Impl extends FromUrlOptions._Impl {
@@ -93,7 +93,7 @@ export namespace Options {
     }
 }
 
-interface DOMWindow extends Window {
+export interface DOMWindow extends Window {
     ran: number;
 
     eval(script: string): void;

--- a/types/jsdom/jsdom-tests.ts
+++ b/types/jsdom/jsdom-tests.ts
@@ -1,4 +1,4 @@
-import { jsdom, JSDOM } from 'jsdom';
+import { CookieJar, FromUrlOptions, JSDOM, Options, VirtualConsole } from 'jsdom';
 import { CookieJar, MemoryCookieStore } from 'tough-cookie';
 import { Script } from 'vm';
 
@@ -37,7 +37,7 @@ function test_executing_scripts3() {
 }
 
 function test_virtualConsole() {
-    const virtualConsole = new jsdom.VirtualConsole();
+    const virtualConsole = new VirtualConsole();
     const dom = new JSDOM(``, { virtualConsole });
 
     virtualConsole.on('error', () => { });
@@ -56,7 +56,7 @@ function test_cookieJar() {
     const store = {} as MemoryCookieStore;
     const options = {} as CookieJar.Options;
 
-    const cookieJar = new jsdom.CookieJar(store, options);
+    const cookieJar = new CookieJar(store, options);
     const dom = new JSDOM(``, { cookieJar });
 }
 
@@ -129,7 +129,7 @@ function test_reconfigure() {
 }
 
 function test_fromURL() {
-    const options = {} as jsdom.FromUrlOptions;
+    const options = {} as FromUrlOptions;
 
     JSDOM.fromURL('https://example.com/', options).then(dom => {
         console.log(dom.serialize());
@@ -137,7 +137,7 @@ function test_fromURL() {
 }
 
 function test_fromFile() {
-    const options = {} as jsdom.Options;
+    const options = {} as Options;
 
     JSDOM.fromFile('stuff.html', options).then(dom => {
         console.log(dom.serialize());


### PR DESCRIPTION
The objects like CookieJar etc. are direct named exports, but the current definition forces you to treat them as if they were under an extra `jsdom` namespace.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tmpvar/jsdom
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
