### PR TITLE
performance.hints in webpack can't be true

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -504,7 +504,7 @@ declare namespace webpack {
              * Turns hints on/off. In addition, tells webpack to throw either an error or a warning when hints are
              * found. This property is set to "warning" by default.
              */
-            hints?: 'warning' | 'error' | boolean;
+            hints?: 'warning' | 'error' | false;
             /**
              * An asset is any emitted file from webpack. This option controls when webpack emits a performance hint
              * based on individual asset size. The default value is 250000 (bytes).


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [see source code](https://github.com/webpack/webpack/blob/3e3b7489b4414c8c43d605ef8a36fecd91f9ca21/schemas/webpackOptionsSchema.json#L905)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Passing `true` throws [here](https://github.com/webpack/webpack/blob/3e3b7489b4414c8c43d605ef8a36fecd91f9ca21/schemas/webpackOptionsSchema.json#L905). Only `false` is valid.

I also created a PR to update the webpack docs as they are wrong, too. https://github.com/webpack/webpack.js.org/pull/1342