### PR TITLE
Update SelectRow interface type, selected to be either string[] or number[]

### DIFF
--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -157,7 +157,7 @@ export interface SelectRow {
 	Give an array data to perform which rows you want to be selected when table loading.
 	The content of array should be the rowkey which you want to be selected.
 	*/
-    selected?: string[];
+    selected?: string[] | number[];
 	/**
 	if true, the radio/checkbox column will be hide.
 	You can enable this attribute if you enable clickToSelect and you don't want to show the selection column.


### PR DESCRIPTION
In SelectRow interface type add an alternative type of number[] to the selected property. That resolves compiler errors if the key field of the row data is of type number.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.