### PR TITLE
dockerode: Add missing methods in Node interface

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -145,3 +145,36 @@ secret.remove((err, response) => {
 secret.update((err, response) => {
   // NOOP
 });
+
+const node = docker.getNode('nodeName');
+node.inspect((err, reponse) => {
+  // NOOP
+});
+
+node.inspect().then(response => {
+  // NOOP
+});
+
+node.update({}, (err, response) => {
+  // NOOP
+});
+
+node.update((err, response) => {
+  // NOOP
+});
+
+node.update({}).then(response => {
+  // NOOP;
+});
+
+node.remove({}, (err, response) => {
+  // NOOP
+});
+
+node.remove((err, response) => {
+  // NOOP
+});
+
+node.remove({}).then(response => {
+  // NOOP;
+});

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -170,6 +170,14 @@ declare namespace Dockerode {
     inspect(callback: Callback<any>): void;
     inspect(): Promise<any>;
 
+    update(options: {}, callback: Callback<any>): void;
+    update(callback: Callback<any>): void;
+    update(options?: {}): Promise<any>;
+
+    remove(options: {}, callback: Callback<any>): void;
+    remove(callback: Callback<any>): void;
+    remove(options?: {}): Promise<any>;
+
     modem: any;
     id?: string;
   }


### PR DESCRIPTION
Added `update` and `remove` methods that were missing from the Node interface.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apocas/dockerode/blob/master/lib/node.js#L57 https://github.com/apocas/dockerode/blob/master/lib/node.js#L100
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
