### PR TITLE
Add typings for is-alphanumerical

### DIFF
--- a/is-alphanumerical/index.d.ts
+++ b/is-alphanumerical/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for is-alphanumerical 1.0
+// Project: https://github.com/wooorm/is-alphanumerical/
+// Definitions by: Vu Tran <https://github.com/vutran>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function isAlphanumerical(val: string | boolean | string): boolean;
+export = isAlphanumerical;

--- a/is-alphanumerical/index.d.ts
+++ b/is-alphanumerical/index.d.ts
@@ -3,5 +3,5 @@
 // Definitions by: Vu Tran <https://github.com/vutran>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function isAlphanumerical(val: string | boolean | string): boolean;
+declare function isAlphanumerical(val: string | boolean | number): boolean;
 export = isAlphanumerical;

--- a/is-alphanumerical/is-alphanumerical-tests.ts
+++ b/is-alphanumerical/is-alphanumerical-tests.ts
@@ -1,0 +1,7 @@
+import isAlphanumerical = require('is-alphanumerical');
+
+isAlphanumerical('a');
+isAlphanumerical('z');
+isAlphanumerical('0');
+isAlphanumerical('9');
+isAlphanumerical('💩');

--- a/is-alphanumerical/tsconfig.json
+++ b/is-alphanumerical/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-alphanumerical-tests.ts"
+    ]
+}

--- a/is-alphanumerical/tslint.json
+++ b/is-alphanumerical/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR will add a definition for the npm package [`is-alphanumerical`](https://www.npmjs.com/package/is-alphanumerical).

The author prefers the typings to be sourced in DT rather than the repo itself ([ref](https://github.com/wooorm/is-alphanumerical/pull/7)).