### PR TITLE
[qs] Update typings to 6.4.0

### DIFF
--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -20,7 +20,7 @@ declare namespace QueryString {
         arrayFormat?: 'indices' | 'brackets' | 'repeat';
         indices?: boolean;
         sort?: (a: any, b: any) => number;
-        serializeDate?: (d: Date) => any;
+        serializeDate?: (d: Date) => string;
         format?: 'RFC1738' | 'RFC3986';
         encodeValuesOnly?: boolean;
     }

--- a/types/qs/index.d.ts
+++ b/types/qs/index.d.ts
@@ -1,7 +1,9 @@
-// Type definitions for qs 6.2.0
-// Project: https://github.com/hapijs/qs
-// Definitions by: Roman Korneev <https://github.com/RWander>, Leon Yu <https://github.com/leonyu>,
-//     Belinda Teh <https://github.com/tehbelinda>
+// Type definitions for qs 6.4.0
+// Project: https://github.com/ljharb/qs
+// Definitions by: Roman Korneev <https://github.com/RWander>
+//                 Leon Yu <https://github.com/leonyu>
+//                 Belinda Teh <https://github.com/tehbelinda>
+//                 Melvin Lee <https://github.com/zyml>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = QueryString;
@@ -18,6 +20,9 @@ declare namespace QueryString {
         arrayFormat?: 'indices' | 'brackets' | 'repeat';
         indices?: boolean;
         sort?: (a: any, b: any) => number;
+        serializeDate?: (d: Date) => any;
+        format?: 'RFC1738' | 'RFC3986';
+        encodeValuesOnly?: boolean;
     }
 
     interface IParseOptions {

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -254,3 +254,27 @@ qs.parse('a=b&c=d', { delimiter: '&' });
     var sorted = qs.stringify({ a: 1, c: 3, b: 2 }, { sort: (a, b) => a.localeCompare(b) })
     assert.equal(sorted, 'a=1&b=2&c=3')
 }
+
+() => {
+    var date = new Date(7);
+    assert.equal(
+        qs.stringify({ a: date }, { serializeDate: function (d) { return d.getTime(); } }),
+        'a=7'
+    );
+}
+
+() => {
+    assert.equal(qs.stringify({ a: 'b c' }, { format : 'RFC3986' }), 'a=b%20c');
+}
+
+() => {
+    assert.equal(qs.stringify({ a: 'b c' }, { format : 'RFC1738' }), 'a=b+c');
+}
+
+() => {
+    var encodedValues = qs.stringify(
+        { a: 'b', c: ['d', 'e=f'], f: [['g'], ['h']] },
+        { encodeValuesOnly: true }
+    );
+    assert.equal(encodedValues,'a=b&c[0]=d&c[1]=e%3Df&f[0][0]=g&f[1][0]=h');
+}

--- a/types/qs/qs-tests.ts
+++ b/types/qs/qs-tests.ts
@@ -258,7 +258,7 @@ qs.parse('a=b&c=d', { delimiter: '&' });
 () => {
     var date = new Date(7);
     assert.equal(
-        qs.stringify({ a: date }, { serializeDate: function (d) { return d.getTime(); } }),
+        qs.stringify({ a: date }, { serializeDate: function (d) { return d.getTime().toString(); } }),
         'a=7'
     );
 }

--- a/types/qs/tsconfig.json
+++ b/types/qs/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Includes new options introduced to `stringify` in 6.3.0 and 6.4.0.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ljharb/qs/blob/master/CHANGELOG.md
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
