### PR TITLE
[react-datepicker] Export the ReactDatePickerProps interface

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -9,7 +9,7 @@
 import * as React from "react";
 import * as moment from "moment";
 
-interface ReactDatePickerProps {
+export interface ReactDatePickerProps {
 	autoComplete?: string;
 	autoFocus?: boolean;
 	calendarClassName?: string;


### PR DESCRIPTION
This is useful when wrapping the date picker in a custom component so that the props of the custom component can extend ReactDatePickerProps.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:

> _No docs that I could find. This change allows devs to import the ReactDatePickerProps interface in order to extend their own interface, e.g. `interface MyComponentProps extends ReactDatePickerProps {}`_

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.