### PR TITLE
graphql: GraphQLFormattedError: locations, path opt'nl

### DIFF
--- a/types/graphql/error/formatError.d.ts
+++ b/types/graphql/error/formatError.d.ts
@@ -8,8 +8,8 @@ export function formatError(error: GraphQLError): GraphQLFormattedError;
 
 export type GraphQLFormattedError = {
     message: string,
-    locations: Array<GraphQLErrorLocation>,
-    path: Array<string | number>
+    locations?: Array<GraphQLErrorLocation>,
+    path?: Array<string | number>
 };
 
 export type GraphQLErrorLocation = {


### PR DESCRIPTION
See e.g. the flow definition in https://github.com/graphql/graphql-js/blob/master/src/error/formatError.js, where they are defined as optional.
I'm no GraphQL expert; caveat emptor.

I'm not sure whether I was supposed to bump the version number somewhere.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

