### PR TITLE
Fix AppContainer for react-hot-loader 3.0.0-beta.7

### DIFF
--- a/types/react-hot-loader/index.d.ts
+++ b/types/react-hot-loader/index.d.ts
@@ -15,4 +15,4 @@ export interface AppContainerProps {
   errorReporter?: React.ComponentClass<ErrorReporterProps> | React.StatelessComponent<ErrorReporterProps>
 }
 
-export class AppContainer extends React.Component<AppContainerProps> {}
+export class AppContainer extends React.Component<AppContainerProps, React.ComponentState> {}


### PR DESCRIPTION
Fixes error when using AppContainer in a TypeScript project:

ERROR in [at-loader] ./node_modules/@types/react-hot-loader/index.d.ts:18:35 
    TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: (only a bug fix, see ts compile error above)
- [ ] Increase the version number in the header if appropriate. (it fixes the current definition, no reason to increase the header)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (minor change)
