### PR TITLE
[react-dropzone] Use new typescript definition for exported classes

### DIFF
--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -38,7 +38,9 @@ declare module "react-dropzone" {
         onFileDialogCancel?: () => void;
     }
 
-    class Dropzone extends React.Component<DropzoneProps, never> {}
+    class Dropzone extends React.Component<DropzoneProps, never> {
+        open(): void;
+    }
 
     export = Dropzone;
 }

--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-dropzone
 // Project: https://github.com/okonet/react-dropzone
-// Definitions by: Mathieu Larouche Dube <https://github.com/matdube>, Ivo Jesus <https://github.com/LynxEyes>, Luís Rodrigues <https://github.com/goblindegook>
+// Definitions by: Mathieu Larouche Dube <https://github.com/matdube>, Ivo Jesus <https://github.com/LynxEyes>, Luís Rodrigues <https://github.com/goblindegook>, Ben Bayard <https://github.com/benbayard>
+
 // Definitions: https://github.com/Vooban/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -41,7 +41,6 @@ declare module "react-dropzone" {
 
     export declare class Dropzone extends React.Component<DropzoneProps, never> {
         open(): void;
-        render(): JSX.Element;
     }
     export = Dropzone;
 }

--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for react-dropzone
 // Project: https://github.com/okonet/react-dropzone
 // Definitions by: Mathieu Larouche Dube <https://github.com/matdube>, Ivo Jesus <https://github.com/LynxEyes>, Luís Rodrigues <https://github.com/goblindegook>, Ben Bayard <https://github.com/benbayard>
-
 // Definitions: https://github.com/Vooban/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -10,37 +9,36 @@
 declare module "react-dropzone" {
     interface DropzoneProps {
         // Drop behavior
-        onDrop?: Function,
-        onDropAccepted?: Function,
-        onDropRejected?: Function,
+        onDrop?: (accepted: File[], rejected: File[]) => any;
+        onDropAccepted?: (accepted: File[]) => any;
+        onDropRejected?: (rejected: File[]) => any;
 
         // Drag behavior
-        onDragStart?: Function,
-        onDragEnter?: Function,
-        onDragLeave?: Function,
+        onDragStart?: Function;
+        onDragEnter?: Function;
+        onDragLeave?: Function;
 
-        style?: Object, // CSS styles to apply
-        activeStyle?: Object, // CSS styles to apply when drop will be accepted
-        rejectStyle?: Object, // CSS styles to apply when drop will be rejected
-        className?: string, // Optional className
-        activeClassName?: string, // className for accepted state
-        rejectClassName?: string, // className for rejected state
+        style?: React.CSSProperties; // CSS styles to apply
+        activeStyle?: React.CSSProperties; // CSS styles to apply when drop will be accepted
+        rejectStyle?: React.CSSProperties; // CSS styles to apply when drop will be rejected
+        className?: string; // Optional className
+        activeClassName?: string; // className for accepted state
+        rejectClassName?: string; // className for rejected state
 
-        disablePreview?: boolean, // Enable/disable preview generation
-        disableClick?: boolean, // Disallow clicking on the dropzone container to open file dialog
+        disablePreview?: boolean; // Enable/disable preview generation
+        disableClick?: boolean; // Disallow clicking on the dropzone container to open file dialog
 
-        inputProps?: Object, // Pass additional attributes to the <input type="file"/> tag
-        multiple?: boolean, // Allow dropping multiple files
-        accept?: string, // Allow specific types of files. See https://github.com/okonet/attr-accept for more information
-        name?: string, // name attribute for the input tag
-        maxSize?: number,
-        minSize?: number
+        inputProps?: React.ChangeTargetHTMLProps<HTMLInputElement>; // Pass additional attributes to the <input type="file"/> tag
+        multiple?: boolean; // Allow dropping multiple files
+        accept?: string; // Allow specific types of files. See https://github.com/okonet/attr-accept for more information
+        name?: string; // name attribute for the input tag
+        maxSize?: number;
+        minSize?: number;
 
         onFileDialogCancel?: () => void;
     }
 
-    export declare class Dropzone extends React.Component<DropzoneProps, never> {
-        open(): void;
-    }
+    class Dropzone extends React.Component<DropzoneProps, never> {}
+
     export = Dropzone;
 }

--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -38,6 +38,9 @@ declare module "react-dropzone" {
         onFileDialogCancel?: () => void;
     }
 
-    let Dropzone: React.ClassicComponentClass<DropzoneProps>;
+    export declare class Dropzone extends React.Component<DropzoneProps, never> {
+        open(): void;
+        render(): JSX.Element;
+    }
     export = Dropzone;
 }

--- a/types/react-dropzone/react-dropzone-tests.tsx
+++ b/types/react-dropzone/react-dropzone-tests.tsx
@@ -1,36 +1,41 @@
 import * as React from 'react';
-import * as Dropzone from 'react-dropzone';
+import Dropzone = require('react-dropzone');
 
 class Test extends React.Component {
   constructor(props: any) {
     super(props);
   }
 
+  dz: Dropzone;
+
   render() {
-    return (<div>
-      <Dropzone
-        onDrop={(e: any) => { e.preventDefault(); } }
-        onDropAccepted={(e: any) => { e.preventDefault(); } }
-        onDropRejected={(e: any) => { e.preventDefault(); } }
-        onDragStart={(e: any) => { e.preventDefault(); } }
-        onDragEnter={(e: any) => { e.preventDefault(); } }
-        onDragLeave={(e: any) => { e.preventDefault(); } }
-        style={{ borderStyle: "dashed" }}
-        activeStyle={{ borderStyle: "dotted" }}
-        rejectStyle={{ borderStyle: "dotted" }}
-        className="regular"
-        activeClassName="active"
-        rejectClassName="reject"
-        minSize={2000}
-        maxSize={Infinity}
-        disablePreview={true}
-        disableClick={true}
-        multiple={false}
-        accept="*.png"
-        name="dropzone"
-        inputProps={{ id: "dropzone" }}
+    return (
+      <div>
+        <Dropzone
+          ref={(node) => { this.dz = node } }
+          onDrop={(e: any) => { e.preventDefault(); } }
+          onDropAccepted={(e: any) => { e.preventDefault(); } }
+          onDropRejected={(e: any) => { e.preventDefault(); } }
+          onDragStart={(e: any) => { e.preventDefault(); } }
+          onDragEnter={(e: any) => { e.preventDefault(); } }
+          onDragLeave={(e: any) => { e.preventDefault(); } }
+          style={{ borderStyle: "dashed" }}
+          activeStyle={{ borderStyle: "dotted" }}
+          rejectStyle={{ borderStyle: "dotted" }}
+          className="regular"
+          activeClassName="active"
+          rejectClassName="reject"
+          minSize={2000}
+          maxSize={Infinity}
+          disablePreview={true}
+          disableClick={true}
+          multiple={false}
+          accept="*.png"
+          name="dropzone"
+          inputProps={{ id: "dropzone" }}
         />
-      </div>);
+      </div>
+    );
   }
 }
 

--- a/types/react-dropzone/react-dropzone-tests.tsx
+++ b/types/react-dropzone/react-dropzone-tests.tsx
@@ -8,6 +8,10 @@ class Test extends React.Component {
 
   dz: Dropzone;
 
+  open() {
+    this.dz.open();
+  }
+
   render() {
     return (
       <div>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

This code:
```
import * as React from 'react';

export class Dropzone extends React.Component<{}, {}> { }
```

Emits a declaration of
```
/// <reference types="react" />
import * as React from 'react';
export declare class Dropzone extends React.Component<{}, {}> {
}
```

The problem is that `react-dropzone` really needs the `export = <>` syntax to match the behavior expected by the library.

Included is the updated syntax for exports as well as a test for ensuring you can call the open method on a referenced `dropzone`. 