### PR TITLE
Fix Ramda for 2.4: evolve and functor map

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -55,14 +55,14 @@ declare namespace R {
         push(x: string): void;
     }
 
-    interface Nested<U> {
-        [index: string]: Nested<U> | (<U>(value: any) => U);
-    }
-
     interface Lens {
         <T, U>(obj: T): U;
         set<T, U>(str: string, obj: T): U;
     }
+
+    type Evolver<T> =
+        | ((x: T) => T)
+        | { [K in keyof T]?: Evolver<T[K]> }
 
     // @see https://gist.github.com/donnut/fd56232da58d25ceecf1, comment by @albrow
     interface CurriedTypeGuard2<T1, T2, R extends T2> {
@@ -567,8 +567,9 @@ declare namespace R {
         /**
          * Creates a new object by evolving a shallow copy of object, according to the transformation functions.
          */
-        evolve<V>(transformations: Nested<V>, obj: V): Nested<V>;
-        evolve<V>(transformations: Nested<V>): <V>(obj: V) => Nested<V>;
+        evolve<V>(transformations: Evolver<V>, obj: V): V;
+        evolve<V>(transformations: Evolver<V>): <W extends V>(obj: W) => W;
+
         /*
          * A function that always returns false. Any passed in parameters are ignored.
          */

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -62,7 +62,7 @@ declare namespace R {
 
     type Evolver<T> =
         | ((x: T) => T)
-        | { [K in keyof T]?: Evolver<T[K]> }
+        | { [K in keyof T]?: Evolver<T[K]> };
 
     // @see https://gist.github.com/donnut/fd56232da58d25ceecf1, comment by @albrow
     interface CurriedTypeGuard2<T1, T2, R extends T2> {

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -744,13 +744,13 @@ interface Obj {
     R.map(double, [1, 2, 3]); // => [2, 4, 6]
 
     // functor
-    const stringFunctor = {
-        map: (fn: (c: number) => number) => {
+    const numberFunctor = {
+        map: <U>(fn: (c: number) => U) => {
             let chars = "Ifmmp!Xpsme".split("");
-            return chars.map((char) => String.fromCharCode(fn(char.charCodeAt(0)))).join("") as any;
+            return chars.map(char => fn(char.charCodeAt(0)));
         }
     };
-    R.map((x: number) => x - 1, stringFunctor); // => "Hello World"
+    R.map((x: number) => x - 1, numberFunctor); // => "Hello World"
 };
 
 () => {
@@ -2199,10 +2199,3 @@ class Why {
     R.intersperse(0, [1, 2]); // => [1, 0, 2]
     R.intersperse(0, [1]); // => [1]
 };
-
-{
-    const functor = {
-        map: (fn: (x: string) => string) => functor
-    };
-    R.map(x => x.trim(), functor);
-}


### PR DESCRIPTION
1. Evolve now uses mapped type to more accurately reflect the resulting type.
2. 2.4's contravariance checking of callbacks caught some incorrect code. I fixed one instance that was nearly-correct and deleted one instance that was non-sensical. It created an infinite functor by returning itself.