### PR TITLE
Update to Jquery.foundation method typing

### DIFF
--- a/types/foundation-sites/foundation-sites-tests.ts
+++ b/types/foundation-sites/foundation-sites-tests.ts
@@ -1,6 +1,6 @@
 $(document).foundation();
 $(document).foundation('method5');
-$(document).foundation(['method', 'method2']);
+$(document).foundation('method', 'method2');
 
 Foundation.Abide($('.selector'));
 Foundation.Abide($('.selector'), {});

--- a/types/foundation-sites/index.d.ts
+++ b/types/foundation-sites/index.d.ts
@@ -447,7 +447,7 @@ declare namespace FoundationSites {
 }
 
 interface JQuery {
-    foundation(method?:string|Array<any>) : JQuery;
+    foundation(method?: string, ...args: any[]): JQuery;
 }
 
 declare var Foundation:FoundationSites.FoundationSitesStatic;


### PR DESCRIPTION
As it is, the typing makes it impossible to use big parts of the api. I changed to using spread to define a parameter array of type any to support the entire api. Because the amount and type of parameters may change depending on the first string parameter (method), it is impossible to define the api more strict.
