### PR TITLE
[pouchdb-core] Added missing parameter on RemoveAttachmentResponse

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -452,6 +452,7 @@ declare namespace PouchDB {
         }
 
         interface RemoveAttachmentResponse extends BasicResponse {
+            id: Core.DocumentId;
             rev: Core.RevisionId;
         }
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
http://docs.couchdb.org/en/2.0.0/api/document/attachments.html#delete--db-docid-attname
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
