### PR TITLE
Fix underscore tests for TS 2.4

### DIFF
--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -156,7 +156,7 @@ _.where(listOfPlays, { author: "Shakespeare", year: 1611 });
 
 var odds = _.reject([1, 2, 3, 4, 5, 6], (num) => num % 2 == 0);
 
-_.every([true, 1, null, 'yes'], _.identity);
+_.every([true, 1, null, 'yes'], x => !!_.identity(x));
 
 _.any([null, 0, 'yes', false]);
 


### PR DESCRIPTION
A test in underscore mistakenly used the truthiness of _.identity as a predicate for _.every, even though the predicate is supposed to return boolean. The new code wraps _.identity in an arrow and prefixes a `!!` to coerce truthy values to true.
