### PR TITLE
[bootstrap.v3.datetimepicker] fixed JQuery plugin declaration

### DIFF
--- a/types/bootstrap.v3.datetimepicker/index.d.ts
+++ b/types/bootstrap.v3.datetimepicker/index.d.ts
@@ -2,8 +2,8 @@
 // Project: http://eonasdan.github.io/bootstrap-datetimepicker
 // Definitions by: Katona Péter <https://github.com/katonap>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// based on the previous version created by Jesica N. Fera <https://github.com/bayitajesi>
 // TypeScript Version: 2.3
+// based on the previous version created by Jesica N. Fera <https://github.com/bayitajesi>
 
 /**
  * bootstrap-datetimepicker.js 4.17.45 Copyright (c) 2015 Jonathan Peterson

--- a/types/bootstrap.v3.datetimepicker/index.d.ts
+++ b/types/bootstrap.v3.datetimepicker/index.d.ts
@@ -2,8 +2,8 @@
 // Project: http://eonasdan.github.io/bootstrap-datetimepicker
 // Definitions by: Katona Péter <https://github.com/katonap>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 // based on the previous version created by Jesica N. Fera <https://github.com/bayitajesi>
+// TypeScript Version: 2.3
 
 /**
  * bootstrap-datetimepicker.js 4.17.45 Copyright (c) 2015 Jonathan Peterson
@@ -328,6 +328,18 @@ export interface Datetimepicker {
 	 * Usually you should not override those options unless you have a special need in your layout.
 	 */
 	widgetPositioning(value: WidgetPositioningOptions): void;
+
+	/**
+	 * JQuery plugin function.
+	 * @param {DatetimepickerOptions} options
+	 */
+	(options?: DatetimepickerOptions): JQuery;
+
+	/**
+	 * Default options that will be used for all instances.
+	 * To change: `$.fn.datetimepicker.defaults`
+	 */
+	defaults: DatetimepickerOptions;
 }
 
 export interface DatetimepickerOptions {
@@ -581,7 +593,7 @@ export type EventName = "dp.show" | "dp.hide" | "dp.error";
 
 declare global {
 	interface JQuery {
-	    datetimepicker(options?: DatetimepickerOptions): JQuery;
+		datetimepicker: Datetimepicker;
 
 	    data(key: "DateTimePicker"): Datetimepicker;
 


### PR DESCRIPTION
* fixed JQuery plugin declaration to more standard approach (see #12685)
* added `$.fn.datetimepicker.defaults` field typing
