### PR TITLE
Add a string-fallback overload to React.createElement

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -144,6 +144,10 @@ declare namespace React {
         type: keyof ReactSVG,
         props?: ClassAttributes<T> & P,
         ...children: ReactNode[]): ReactSVGElement;
+    function createElement<P extends DOMAttributes<T>, T extends Element>(
+        type: string,
+        props?: ClassAttributes<T> & P,
+        ...children: ReactNode[]): DOMElement<P, T>;
     function createElement<P>(
         type: SFC<P>,
         props?: Attributes & P,

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -190,8 +190,12 @@ var classicElement: React.ClassicElement<Props> =
     React.createElement(ClassicComponent, props);
 var domElement: React.ReactHTMLElement<HTMLDivElement> =
     React.createElement("div");
-var htmlElement = React.createElement("input", { type: "text" });
-var svgElement = React.createElement("svg", { accentHeight: 12 });
+var literalHtmlElement = React.createElement("input", { type: "text" });
+var literalSvgElement = React.createElement("svg", { accentHeight: 12 });
+
+declare let cardhtml: React.HTMLProps<HTMLElement>;
+declare let accessKey: string;
+var nonLiteralElement = React.createElement(accessKey, cardhtml);
 
 // React.cloneElement
 var clonedElement: React.CElement<Props, ModernComponent> =


### PR DESCRIPTION
The types aren't quite as nice as when providing a string literal like "div" or "input", but it works as well as it did before the string-literal-overload change in #17507.

Fixes the bug pointed out by @AlgusDark in the discussion of #17507.