### PR TITLE
mongoose-simple-random fix for importing package with ES2015

### DIFF
--- a/types/mongoose-simple-random/index.d.ts
+++ b/types/mongoose-simple-random/index.d.ts
@@ -4,6 +4,12 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 /// <reference types="mongoose" />
 
+declare module 'mongoose-simple-random' {
+  import mongoose = require('mongoose');
+  var _: (schema: mongoose.Schema) => void;
+  export = _;
+}
+
 declare module "mongoose" {
     interface Model<T extends Document> extends NodeJS.EventEmitter, ModelProperties {
         findRandom(conditions: Object, projection?: Object | null, options?: Object | null, callback?: (err: any, res: T[]) => void)

--- a/types/mongoose-simple-random/index.d.ts
+++ b/types/mongoose-simple-random/index.d.ts
@@ -5,7 +5,11 @@
 
 declare module 'mongoose-simple-random' {
   import mongoose = require('mongoose');
-  function plugin(schema: mongoose.Schema): void;
+  // Dummy function allows to avoid hard to kill or fix tslint warning
+  // (exporting pluginFunc will make this a non-importable module)
+  function pluginFunc(schema: mongoose.Schema): void;
+  // Let allows typescript to still use ES2015 style imports
+  let plugin: typeof pluginFunc;
   export = plugin;
 }
 

--- a/types/mongoose-simple-random/index.d.ts
+++ b/types/mongoose-simple-random/index.d.ts
@@ -2,12 +2,11 @@
 // Project: https://github.com/larryprice/mongoose-simple-random
 // Definitions by: My Self <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-/// <reference types="mongoose" />
 
 declare module 'mongoose-simple-random' {
   import mongoose = require('mongoose');
-  var _: (schema: mongoose.Schema) => void;
-  export = _;
+  function plugin(schema: mongoose.Schema): void;
+  export = plugin;
 }
 
 declare module "mongoose" {

--- a/types/mongoose-simple-random/mongoose-simple-random-tests.ts
+++ b/types/mongoose-simple-random/mongoose-simple-random-tests.ts
@@ -1,4 +1,5 @@
 import * as mongoose from 'mongoose';
+import * as mongoose_simple_random from "mongoose-simple-random";
 
 // test compatibility with other libraries - from @types/mongoose
 import * as _ from 'lodash';
@@ -13,3 +14,5 @@ mongoose.Model.findRandom({
 }, {}, { limit: 1 }, (error, data) => {
     if (error) { console.error("Error!"); } else { console.log("Success!"); }
 });
+
+mongoose.plugin(mongoose_simple_random);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: The definition worked while it was ambient in the project, and typescript assumed that mongoose-simple-random was a module. However, after installing the typings which lacked declaration of mongoose-simple-random module, typescript issued an error. (For ES2015 style import). Hence, the fix and a closer to real world example, with a better test.

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
