### PR TITLE
passport-jwt : Change secretOrKey option to use string or Buffer type

### DIFF
--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for passport-jwt 2.0
 // Project: https://github.com/themikenicholson/passport-jwt
 // Definitions by: TANAKA Koichi <https://github.com/mugeso/>
+//                 Alex Young <https://github.com/alsiola/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import {Strategy as PassportStrategy} from 'passport-strategy';
@@ -12,7 +13,7 @@ export declare class Strategy extends PassportStrategy {
 }
 
 export interface StrategyOptions {
-    secretOrKey: string;
+    secretOrKey: string | Buffer;
     jwtFromRequest: JwtFromRequestFunction;
     issuer?: string;
     audience?: string;

--- a/types/passport-jwt/passport-jwt-tests.ts
+++ b/types/passport-jwt/passport-jwt-tests.ts
@@ -33,5 +33,6 @@ opts.jwtFromRequest = ExtractJwt.fromUrlQueryParameter('param_name');
 opts.jwtFromRequest = ExtractJwt.fromAuthHeaderWithScheme('param_name');
 opts.jwtFromRequest = ExtractJwt.fromExtractors([ExtractJwt.fromHeader('x-api-key'), ExtractJwt.fromBodyField('field_name'), ExtractJwt.fromUrlQueryParameter('param_name')]);
 opts.jwtFromRequest = (req: Request) => { return req.query.token; };
+opts.secretOrKey = new Buffer('secret');
 
 declare function findUser(condition: {id: string}, callback: (error: any, user :any) => void): void;


### PR DESCRIPTION
The prior types only permitted the use of a `string` for `StrategyOptions.secretOrKey`, but as per the [passport-jwt documentation](https://www.npmjs.com/package/passport-jwt#configure-strategy), either a `string` or `Buffer` is acceptable.
