### PR TITLE
Update node-auth0 typings for client credential grants

### DIFF
--- a/types/auth0/auth0-tests.ts
+++ b/types/auth0/auth0-tests.ts
@@ -7,7 +7,8 @@ const management = new auth0.ManagementClient({
 
 const auth = new auth0.AuthenticationClient({
   domain: '{YOUR_ACCOUNT}.auth0.com',
-  clientId: '{OPTIONAL_CLIENT_ID}'
+  clientId: '{OPTIONAL_CLIENT_ID}',
+  clientSecret: '{OPTIONAL_CLIENT_SECRET}'
 });
 
 // Using a callback.

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -83,6 +83,7 @@ export interface Identity {
 
 export interface AuthenticationClientOptions {
   clientId?: string;
+  clientSecret?: string;
   domain: string;
 }
 
@@ -129,6 +130,16 @@ export interface ResetPasswordOptions {
 export interface ResetPasswordEmailOptions {
   email: string;
   connection: string;
+}
+
+export interface ClientCredentialsGrantOptions {
+  audience: string;
+}
+
+export interface PasswordGrantOptions {
+  username: string;
+  password: string;
+  realm?: string;
 }
 
 export interface ObjectWithId {
@@ -254,8 +265,11 @@ export class AuthenticationClient {
   getProfile(accessToken: string): Promise<any>;
   getProfile(accessToken: string, cb: (err: Error, message: string) => void): void;
 
-  getCredentialsGrant(scope: string): Promise<any>;
-  getCredentialsGrant(scope: string, cb: (err: Error, message: string) => void): void;
+  clientCredentialsGrant(options: ClientCredentialsGrantOptions): Promise<any>;
+  clientCredentialsGrant(options: ClientCredentialsGrantOptions, cb: (err: Error, response: any) => void): void;
+
+  passwordGrant(options: PasswordGrantOptions): Promise<any>;
+  passwordGrant(options: PasswordGrantOptions, cb: (err: Error, response: any) => void): void;
 
 }
 

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for auth0 3.0
+// Type definitions for auth0 4.0
 // Project: https://github.com/auth0/node-auth0
 // Definitions by: Wilson Hobbs <https://github.com/wbhob>, Seth Westphal <https://github.com/westy92>, Amiram Korach <https://github.com/amiram>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -198,7 +198,8 @@ export interface UnlinkAccountsResponse {
 
 export interface LinkAccountsData {
   user_id: string;
-  connection_id: string;
+  connection_id?: string;
+  provider?: string;
 }
 
 export interface Token {

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for auth0 4.0
+// Type definitions for auth0 2.3
 // Project: https://github.com/auth0/node-auth0
 // Definitions by: Wilson Hobbs <https://github.com/wbhob>, Seth Westphal <https://github.com/westy92>, Amiram Korach <https://github.com/amiram>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/node-auth0/blob/master/src/auth/index.js#L482

* Adds the optional `clientSecret` parameter to `AuthenticationClientOptions`,
* Removes `getCredentialsGrant` as it no longer exists, and adds `clientCredentialsGrant` and `passwordGrant`,
* The `connection_id` parameter on the `LinkAccountsData` object is optional, but there is also a `provider` parameter that must be provided in some circumstances according to the [Management API documentation](https://auth0.com/docs/api/management/v2#!/Users/post_identities).