### PR TITLE
replace params 'any' type with index types

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -440,7 +440,10 @@ interface Request extends http.IncomingMessage, Express.Request {
 
     method: string;
 
-    params: any;
+    params: {
+        [namedParameter: string]: string;
+        [captureGroup: number]: string;
+    };
 
     /**
         * Clear cookie `name`.

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -83,7 +83,7 @@ namespace express_tests {
     });
 
     router.get('/user/:id', function(req, res, next) {
-    if (req.params.id == 0) next('route');
+    if (req.params.id == "0") next('route');
     else next();
     }, function(req, res, next) {
     res.render('regular');

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://expressjs.com
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 


### PR DESCRIPTION
Params have [well-defined values](https://expressjs.com/en/guide/routing.html#route-parameters), so they're not `any`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://expressjs.com/en/guide/routing.html#route-parameters

