### PR TITLE
Refactoring: use React.ComponentType

### DIFF
--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -14,7 +14,7 @@ export interface RouteConfigComponentProps<T> extends RouteComponentProps<T> {
 
 export interface RouteConfig {
     location?: Location;
-    component?: React.SFC<RouteConfigComponentProps<any> | void> | React.ComponentClass<RouteConfigComponentProps<any> | void>;
+    component?: React.ComponentType<RouteConfigComponentProps<any> | void>;
     path?: string;
     exact?: boolean;
     strict?: boolean;

--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -14,7 +14,7 @@ export interface RouteConfigComponentProps<T> extends RouteComponentProps<T> {
 
 export interface RouteConfig {
     location?: Location;
-    component?: React.ComponentType<RouteConfigComponentProps<any> | void>;
+    component?: React.ComponentType<RouteConfigComponentProps<any> | {}>;
     path?: string;
     exact?: boolean;
     strict?: boolean;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -64,7 +64,7 @@ export interface RouteComponentProps<P> {
 
 export interface RouteProps {
   location?: H.Location;
-  component?: React.ComponentType<RouteComponentProps<any> | undefined>;
+  component?: React.ComponentType<RouteComponentProps<any> | {}>;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -64,7 +64,7 @@ export interface RouteComponentProps<P> {
 
 export interface RouteProps {
   location?: H.Location;
-  component?: React.SFC<RouteComponentProps<any> | undefined> | React.ComponentClass<RouteComponentProps<any> | undefined>;
+  component?: React.ComponentType<RouteComponentProps<any> | undefined>;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;
@@ -99,4 +99,4 @@ export interface match<P> {
 }
 
 export function matchPath<P>(pathname: string, props: RouteProps): match<P> | null;
-export function withRouter<P>(component: React.SFC<RouteComponentProps<any> & P> | React.ComponentClass<RouteComponentProps<any> & P>): React.ComponentClass<P>;
+export function withRouter<P>(component: React.ComponentType<RouteComponentProps<any> & P>): React.ComponentClass<P>;

--- a/types/react-router/test/examples-from-react-router-website/PreventingTransitions.tsx
+++ b/types/react-router/test/examples-from-react-router-website/PreventingTransitions.tsx
@@ -22,7 +22,7 @@ const PreventingTransitionsExample = () => (
   </Router>
 );
 
-class Form extends React.Component<undefined, {isBlocking: boolean}> {
+class Form extends React.Component<{}, {isBlocking: boolean}> {
   state = {
     isBlocking: false
   };

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -35,7 +35,7 @@ declare namespace React {
     // ----------------------------------------------------------------------
 
     type ReactType = string | ComponentType<any>;
-    type ComponentType<P> = ComponentClass<P> | StatelessComponent<P>;
+    type ComponentType<P = {}> = ComponentClass<P> | StatelessComponent<P>;
 
     type Key = string | number;
     type Ref<T> = string | ((instance: T | null) => any);

--- a/types/rrc/index.d.ts
+++ b/types/rrc/index.d.ts
@@ -24,8 +24,8 @@ export interface WithScrollOptions {
 
 export type ComponentConstructor<Props> = React.ComponentType<Props>;
 
-export function withScroll(component: ComponentConstructor<RouteComponentProps<any> | undefined>, options?: WithScrollOptions)
-    : ComponentConstructor<RouteComponentProps<any> | undefined>;
+export function withScroll(component: ComponentConstructor<RouteComponentProps<any> | {}>, options?: WithScrollOptions)
+    : ComponentConstructor<RouteComponentProps<any> | {}>;
 
 export type RouteConfiguration = RouteProps & { inject?: { [key: string]: any } };
 

--- a/types/rrc/index.d.ts
+++ b/types/rrc/index.d.ts
@@ -22,7 +22,7 @@ export interface WithScrollOptions {
     alignToTop?: boolean;
 }
 
-export type ComponentConstructor<Props> = React.ComponentClass<Props> | React.SFC<Props>;
+export type ComponentConstructor<Props> = React.ComponentType<Props>;
 
 export function withScroll(component: ComponentConstructor<RouteComponentProps<any> | undefined>, options?: WithScrollOptions)
     : ComponentConstructor<RouteComponentProps<any> | undefined>;


### PR DESCRIPTION
Instead of writing `React.SFC<...> | React.ComponentClass<...>` we can write simply `React.ComponentType<...>` as it is already defined inside react/index.d.ts

Also default props should be `{}` instead of `undefined` or `void` (see "Should it be" section from #17288 for more details).
