### PR TITLE
Fixes CodeMirror's show-hint module to use the Editor object instead of the Doc object in most parameters

### DIFF
--- a/types/codemirror/codemirror-showhint.d.ts
+++ b/types/codemirror/codemirror-showhint.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for CodeMirror
 // Project: https://github.com/marijnh/CodeMirror
-// Definitions by: jacqt <https://github.com/jacqt>, basarat <https://github.com/basarat>
+// Definitions by: jacqt <https://github.com/jacqt>, basarat <https://github.com/basarat>, mbilsing <https://github.com/mbilsing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // See docs https://codemirror.net/doc/manual.html#addon_show-hint
@@ -16,7 +16,7 @@ declare module "codemirror" {
     and return a {list, from, to} object, where list is an array of strings or objects (the completions), and
     from and to give the start and end of the token that is being completed as {line, ch} objects. An optional
     selectedHint property (an integer) can be added to the completion object to control the initially selected hint. */
-    function showHint(cm: CodeMirror.Doc, hinter?: HintFunction, options?: ShowHintOptions): void;
+    function showHint(cm: CodeMirror.Editor, hinter?: HintFunction, options?: ShowHintOptions): void;
 
     interface Hints {
         from: Position;
@@ -32,7 +32,7 @@ declare module "codemirror" {
         displayText?: string;
         from?: Position;
         /** Called if a completion is picked. If provided *you* are responsible for applying the completion */
-        hint?: (cm: any, data: Hints, cur: Hint) => void;
+        hint?: (cm: CodeMirror.Editor, data: Hints, cur: Hint) => void;
         render?: (element: HTMLLIElement, data: Hints, cur: Hint) => void;
         to?: Position;
     }
@@ -41,18 +41,15 @@ declare module "codemirror" {
         /** An extension of the existing CodeMirror typings for the Editor.on("keyup", func) syntax */
         on(eventName: string, handler: (doc: CodeMirror.Doc, event: any) => void): void;
         off(eventName: string, handler: (doc: CodeMirror.Doc, event: any) => void): void;
-    }
-
-    interface Doc {
         showHint: (options: ShowHintOptions) => void;
     }
 
     interface HintFunction {
-        (doc: CodeMirror.Doc): Hints;
+        (cm: CodeMirror.Editor): Hints;
     }
 
     interface AsyncHintFunction {
-        (doc: CodeMirror.Doc, callback: (hints: Hints) => any): any;
+        (cm: CodeMirror.Editor, callback: (hints: Hints) => any): any;
         async?: boolean;
     }
 

--- a/types/codemirror/codemirror-showhint.d.ts
+++ b/types/codemirror/codemirror-showhint.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for CodeMirror
 // Project: https://github.com/marijnh/CodeMirror
-// Definitions by: jacqt <https://github.com/jacqt>, basarat <https://github.com/basarat>, mbilsing <https://github.com/mbilsing>
+// Definitions by: jacqt <https://github.com/jacqt>
+//                 basarat <https://github.com/basarat>
+//                 mbilsing <https://github.com/mbilsing>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // See docs https://codemirror.net/doc/manual.html#addon_show-hint

--- a/types/codemirror/test/showhint.ts
+++ b/types/codemirror/test/showhint.ts
@@ -1,16 +1,16 @@
 
 
-var doc = new CodeMirror.Doc('text');
+var cm = CodeMirror(document.body, {value: 'text'});
 var pos = new CodeMirror.Pos(2, 3);
-CodeMirror.showHint(doc);
-CodeMirror.showHint(doc, function (cm) {
+CodeMirror.showHint(cm);
+CodeMirror.showHint(cm, function (cm) {
     return {
         from: pos,
         list: ["one", "two"],
         to: pos
     };
 });
-CodeMirror.showHint(doc, function (cm) {
+CodeMirror.showHint(cm, function (cm) {
     return {
         from: pos,
         list: [
@@ -32,7 +32,7 @@ CodeMirror.showHint(doc, function (cm) {
     };
 });
 var asyncHintFunc : CodeMirror.AsyncHintFunction =
-    (doc: CodeMirror.Doc, callback: (hints: CodeMirror.Hints) => any) => {
+    (cm: CodeMirror.Editor, callback: (hints: CodeMirror.Hints) => any) => {
         callback({
             from: pos,
             list: ["one", "two"],
@@ -41,7 +41,7 @@ var asyncHintFunc : CodeMirror.AsyncHintFunction =
     };
 asyncHintFunc.async = true;
 
-doc.showHint({
+cm.showHint({
     completeSingle: false,
     hint: asyncHintFunc
 })


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/codemirror/CodeMirror/blob/master/addon/hint/show-hint.js#L27
