### PR TITLE
[material-ui] Add missing properties for GridTile and RefreshIndicator component props

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -8,6 +8,7 @@
 //                 Aurelién Allienne <https://github.com/allienna>
 //                 Matthias Schlesinger <https://github.com/schlesingermatthias>
 //                 Jonathon Kelly <https://github.com/InsidersByte>
+//                 Artyom Stukans <https://github.com/artyomsv>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -1057,6 +1058,7 @@ declare namespace __MaterialUI {
             title?: React.ReactNode;
             titleBackground?: string;
             titlePosition?: "top" | "bottom";
+            titleStyle?: React.CSSProperties;
             onTouchTap?: TouchTapEventHandler;
         }
         export class GridTile extends React.Component<GridTileProps> {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/callemall/material-ui/blob/master/src/GridList/GridTile.js> 125 line
