### PR TITLE
Fix hls.js

### DIFF
--- a/types/hls.js/hls.js-tests.ts
+++ b/types/hls.js/hls.js-tests.ts
@@ -1,8 +1,31 @@
 import * as Hls from 'hls.js';
 
+function process(playlist: string) {
+  return playlist;
+}
+
+class pLoader extends Hls.DefaultConfig.loader {
+  constructor(config: Hls.LoaderConfig) {
+    super(config);
+    const load = this.load.bind(this);
+    this.load = (context: Hls.LoaderContext, cfg: Hls.LoaderConfig, callbacks: Hls.LoaderCallbacks) => {
+      if (context.type === 'manifest') {
+        const onSuccess = callbacks.onSuccess;
+        callbacks.onSuccess = (response: Hls.LoaderResponse, stats: Hls.LoaderStats, context: Hls.LoaderContext) => {
+          response.data = process(response.data as string);
+          onSuccess(response, stats, context);
+        }
+      }
+      load(context, config, callbacks);
+    }
+  }
+}
+
 if (Hls.isSupported()) {
-  const video = <HTMLVideoElement> document.getElementById('video');
-  const hls = new Hls();
+  const video = <HTMLVideoElement>document.getElementById('video');
+  const hls = new Hls({
+    pLoader: pLoader
+  });
   const version: string = Hls.version;
   hls.loadSource('http://www.streambox.fr/playlists/test_001/stream.m3u8');
   hls.attachMedia(video);
@@ -10,3 +33,4 @@ if (Hls.isSupported()) {
     video.play();
   });
 }
+

--- a/types/hls.js/hls.js-tests.ts
+++ b/types/hls.js/hls.js-tests.ts
@@ -14,18 +14,16 @@ class pLoader extends Hls.DefaultConfig.loader {
         callbacks.onSuccess = (response: Hls.LoaderResponse, stats: Hls.LoaderStats, context: Hls.LoaderContext) => {
           response.data = process(response.data as string);
           onSuccess(response, stats, context);
-        }
+        };
       }
       load(context, config, callbacks);
-    }
+    };
   }
 }
 
 if (Hls.isSupported()) {
-  const video = <HTMLVideoElement>document.getElementById('video');
-  const hls = new Hls({
-    pLoader: pLoader
-  });
+  const video = <HTMLVideoElement> document.getElementById('video');
+  const hls = new Hls({ pLoader });
   const version: string = Hls.version;
   hls.loadSource('http://www.streambox.fr/playlists/test_001/stream.m3u8');
   hls.attachMedia(video);
@@ -33,4 +31,3 @@ if (Hls.isSupported()) {
     video.play();
   });
 }
-

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -2,6 +2,23 @@
 // Project: https://github.com/video-dev/hls.js
 // Definitions by: John G. Gainfort, Jr. <https://github.com/jgainfort>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+declare class Loader {
+  constructor(config: Hls.LoaderConfig)
+  /**
+   * Start retrieving content located at given URL (HTTP GET).
+   */
+  load(context: Hls.LoaderContext, config: Hls.LoaderConfig, callbacks: Hls.LoaderCallbacks): void;
+  /**
+   * Abort any loading in progress.
+   */
+  abort(): void;
+  /**
+   * Destroy loading context.
+   */
+  destroy(): void;
+}
 
 declare namespace Hls {
   /**
@@ -646,19 +663,19 @@ declare namespace Hls {
      * Use this, if you want to overwrite both the fragment and the playlist loader.
      * Note: If fLoader or pLoader are used, they overwrite loader!
      */
-    loader: Loader;
+    loader: typeof Loader;
     /**
      * (default: undefined)
      * This enables the manipulation of the fragment loader.
      * Note: This will overwrite the default loader, as well as your own loader function.
      */
-    fLoader?: Loader;
+    fLoader?: typeof Loader;
     /**
      * (default: undefined)
      * This enables the manipulation of the playlist loader.
      * Note: This will overwrite the default loader, as well as your own loader function.
      */
-    pLoader?: Loader;
+    pLoader?: typeof Loader;
     /**
      * (default: undefined)
      * XMLHttpRequest customization callback for default XHR based loader.
@@ -1050,19 +1067,19 @@ declare namespace Hls {
      * Use this, if you want to overwrite both the fragment and the playlist loader.
      * Note: If fLoader or pLoader are used, they overwrite loader!
      */
-    loader?: Loader;
+    loader?: typeof Loader;
     /**
      * (default: undefined)
      * This enables the manipulation of the fragment loader.
      * Note: This will overwrite the default loader, as well as your own loader function.
      */
-    fLoader?: Loader;
+    fLoader?: typeof Loader;
     /**
      * (default: undefined)
      * This enables the manipulation of the playlist loader.
      * Note: This will overwrite the default loader, as well as your own loader function.
      */
-    pLoader?: Loader;
+    pLoader?: typeof Loader;
     /**
      * (default: undefined)
      * XMLHttpRequest customization callback for default XHR based loader.
@@ -1522,22 +1539,6 @@ declare namespace Hls {
     mtime: number;
     tbuffered?: number;
     length?: number;
-  }
-
-  interface Loader {
-    new (config: LoaderConfig): Loader;
-    /**
-     * Start retrieving content located at given URL (HTTP GET).
-     */
-    load(context: LoaderContext, config: LoaderConfig, callbacks: LoaderCallbacks): void;
-    /**
-     * Abort any loading in progress.
-     */
-    abort(): void;
-    /**
-     * Destroy loading context.
-     */
-    destroy(): void;
   }
 
   interface LoaderContext {

--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/video-dev/hls.js
 // Definitions by: John G. Gainfort, Jr. <https://github.com/jgainfort>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 declare namespace Hls {
   /**
@@ -390,6 +389,410 @@ declare namespace Hls {
      * if set to true, start level playlist and first fragments will be loaded automatically, after triggering of Hls.Events.MANIFEST_PARSED event
      * if set to false, an explicit API call (hls.startLoad(startPosition=-1)) will be needed to start quality level/fragment loading.
      */
+    autoStartLoad: boolean;
+    /**
+     * (default -1)
+     * if set to -1, playback will start from initialTime=0 for VoD and according to liveSyncDuration/liveSyncDurationCount config params for Live
+     * otherwise, playback will start from predefined value. (unless stated otherwise in autoStartLoad=false mode : in that case startPosition can be overrided using hls.startLoad(startPosition)).
+     */
+    startPosition: number;
+    /**
+     * (default: false)
+     * if set to true, the adaptive algorithm with limit levels usable in auto-quality by the HTML video element dimensions (width and height)
+     * if set to false, levels will not be limited. All available levels could be used in auto-quality mode taking only bandwidth into consideration.
+     */
+    capLevelToPlayerSize: boolean;
+    /**
+     * (default: false)
+     * setting config.debug = true; will turn on debug logs on JS console.
+     * a logger object could also be provided for custom logging: config.debug = customLogger;
+     */
+    debug: boolean;
+    /**
+     * (default: undefined)
+     * if audio codec is not signaled in variant manifest, or if only a stream manifest is provided, hls.js tries to guess audio codec by parsing audio sampling rate in ADTS header.
+     * If sampling rate is less or equal than 22050 Hz, then hls.js assumes it is HE-AAC, otherwise it assumes it is AAC-LC.
+     * This could result in bad guess, leading to audio decode error, ending up in media error.
+     * It is possible to hint default audiocodec to hls.js by configuring this value as below:
+     * mp4a.40.2 (AAC-LC) or
+     * mp4a.40.5 (HE-AAC) or
+     * undefined (guess based on sampling rate)
+     */
+    defaultAudioCodec: string;
+    /**
+     * (default: 1)
+     * number of segments needed to start a playback of Live stream.
+     */
+    initialLiveManifestSize: number;
+    /**
+     * (default: 30 seconds)
+     * Maximum buffer length in seconds. If buffer length is/become less than this value, a new fragment will be loaded.
+     * This is the guaranteed buffer length hls.js will try to reach, regardless of maxBufferSize.
+     */
+    maxBufferLength: number;
+    /**
+     * (default 600s)
+     * Maximum buffer length in seconds. Hls.js will never exceed this value, even if maxBufferSize is not reached yet.
+     * hls.js tries to buffer up to a maximum number of bytes (60 MB by default) rather than to buffer up to a maximum nb of seconds.
+     * This is to mimic the browser behaviour (the buffer eviction algorithm is starting after the browser detects that video buffer size reaches a limit in bytes)
+     * maxBufferLength is the minimum guaranteed buffer length that hls.js will try to achieve, even if that value exceeds the amount of bytes 60 MB of memory.
+     * maxMaxBufferLength acts as a capping value, as if bitrate is really low, you could need more than one hour of buffer to fill 60 MB.
+     */
+    maxMaxBufferLength: number;
+    /**
+     * (default: 60 MB)
+     * 'Minimum' maximum buffer size in bytes. If buffer size upfront is bigger than this value, no fragment will be loaded
+     */
+    maxBufferSize: number;
+    /**
+     * (default: 0.5 seconds)
+     * 'Maximum' inter-fragment buffer hole tolerance that hls.js can cope with when searching for the next fragment to load. When switching between quality level,
+     * fragments might not be perfectly aligned.
+     * This could result in small overlapping or hole in media buffer. This tolerance factor helps cope with this.
+     */
+    maxBufferHole: number;
+    /**
+     * (default: 4s)
+     *
+     * ABR algorithm will always try to choose a quality level that should avoid rebuffering. In case no quality level with this criteria can
+     * be found (lets say for example that buffer length is 1s, but fetching a fragment at lowest quality is predicted to take around 2s ...
+     * ie we can forecast around 1s of rebuffering ...) then ABR algorithm will try to find a level that should guarantee less than
+     * maxStarvationDelay of buffering.
+     */
+    maxStarvationDelay: number;
+    /**
+     * (default: 2s)
+     * In case playback is stalled, and a buffered range is available upfront, less than maxSeekHole seconds from current media position,
+     * hls.js will jump over this buffer hole to reach the beginning of this following buffered range.
+     * maxSeekHole allows to configure this jumpable threshold.
+     */
+    maxSeekHole: number;
+    /**
+     * (default: 0.5s)
+     * media element is expected to play and if currentTime has not moved for more than lowBufferWatchdogPeriod and if there are less than maxBufferHole seconds buffered upfront,
+     * hls.js will try to nudge playhead to recover playback
+     */
+    lowBufferWatchdogPeriod: number;
+    /**
+     * (default: 3s)
+     * if media element is expected to play and if currentTime has not moved for more than highBufferWatchdogPeriod and if there are more than maxBufferHole seconds buffered upfront,
+     * hls.js will try to nudge playhead to recover playback
+     */
+    highBufferWatchdogPeriod: number;
+    /**
+     * (default: 0.1s)
+     * In case playback continues to stall after first playhead nudging, currentTime will be nudged evenmore following nudgeOffset to try to restore playback.
+     * media.currentTime += (nb nudge retry -1)*nudgeOffset
+     */
+    nudgeOffset: number;
+    /**
+     * (default: 3s)
+     * In case playback continues to stall after first playhead nudging, currentTime will be nudged evenmore following nudgeOffset to try to restore playback.
+     * media.currentTime += (nb nudge retry -1)*nudgeOffset
+     */
+    nudgeMaxRetry: number;
+    /**
+     * (default 0.2s)
+     * This tolerance factor is used during fragment lookup.
+     * Instead of checking whether buffered.end is located within [start, end] range, frag lookup will be done by checking within [start-maxFragLookUpTolerance, end-maxFragLookUpTolerance] range.
+     * This tolerance factor is used to cope with situations like:
+     *      buffered.end = 9.991
+     *      frag[0] : [0,10]
+     *      frag[1] : [10,20]
+     *      buffered.end is within frag[0] range, but as we are close to frag[1], frag[1] should be choosen instead
+     * If maxFragLookUpTolerance = 0.2, this lookup will be adjusted to
+     *      frag[0] : [-0.2,9.8]
+     *      frag[1] : [9.8,19.8]
+     *  This time, buffered.end is within frag[1] range, and frag[1] will be the next fragment to be loaded, as expected
+     */
+    maxLoadingDelay: number;
+    /**
+     * (default 4s)
+     *
+     * max video loading delay used in automatic start level selection : in that mode ABR controller will ensure that video loading time (ie
+     * the time to fetch the first fragment at lowest quality level + the time to fetch the fragment at the appropriate quality level is less
+     * than maxLoadingDelay )
+     */
+    maxFragLookUpTolerance: number;
+    /**
+     * (default: 3)
+     * edge of live delay, expressed in multiple of EXT-X-TARGETDURATION. if set to 3, playback will start from fragment N-3, N being the last fragment of the live playlist.
+     * Decreasing this value is likely to cause playback stalls.
+     */
+    liveSyncDurationCount: number;
+    /**
+     * (default: undefined)
+     * Alternative parameter to liveSyncDurationCount, expressed in seconds vs number of segments.
+     * If defined in the configuration object, liveSyncDuration will take precedence over the default liveSyncDurationCount.
+     * You can't define this parameter and either liveSyncDurationCount or liveMaxLatencyDurationCount in your configuration object at the same time.
+     * A value too low (inferior to ~3 segment durations) is likely to cause playback stalls.
+     */
+    liveSyncDuration: number;
+    /**
+     * (default: Infinity)
+     * maximum delay allowed from edge of live, expressed in multiple of EXT-X-TARGETDURATION.
+     * If set to 10, the player will seek back to liveSyncDurationCount whenever the next fragment to be loaded is older than N-10, N being the last fragment of the live playlist.
+     * If set, this value must be stricly superior to liveSyncDurationCount a value too close from liveSyncDurationCount is likely to cause playback stalls.
+     */
+    liveMaxLatencyDurationCount: number;
+    /**
+     * (default: undefined)
+     * Alternative parameter to liveMaxLatencyDurationCount, expressed in seconds vs number of segments.
+     * If defined in the configuration object, liveMaxLatencyDuration will take precedence over the default liveMaxLatencyDurationCount.
+     * If set, this value must be stricly superior to liveSyncDuration which must be defined as well.
+     * You can't define this parameter and either liveSyncDurationCount or liveMaxLatencyDurationCount in your configuration object at the same time.
+     * A value too close from liveSyncDuration is likely to cause playback stalls.
+     */
+    liveMaxLatencyDuration: number;
+    /**
+     * (default: true)
+     * Enable WebWorker (if available on browser) for TS demuxing/MP4 remuxing, to improve performance and avoid lag/frame drops.
+     */
+    enableWorker: boolean;
+    /**
+     * (default: true)
+     * Enable to use JavaScript version AES decryption for fallback of WebCrypto API.
+     */
+    enableSoftwareAES: boolean;
+    /**
+     * (default: undefined)
+     * When set, use this level as the default hls.startLevel. Keep in mind that the startLevel set with the API takes precedence over
+     * config.startLevel configuration parameter.
+     */
+    startLevel: number;
+    /**
+     * (default: 10000ms for level and manifest)
+     * URL Loader timeout. A timeout callback will be triggered if loading duration exceeds this timeout. no further action will be done : the load operation will not be cancelled/aborted.
+     * It is up to the application to catch this event and treat it as needed.
+     */
+    manifestLoadingTimeOut: number;
+    /**
+     * (default: 3)
+     * Max number of load retries.
+     */
+    manifestLoadingMaxRetry: number;
+    /**
+     * (default: 1000 ms)
+     * Initial delay between XMLHttpRequest error and first load retry (in ms).
+     * Any I/O error will trigger retries every 500ms,1s,2s,4s,8s, ... capped to fragLoadingMaxRetryTimeout / manifestLoadingMaxRetryTimeout / levelLoadingMaxRetryTimeout value (exponential backoff).
+     * Prefetch start fragment although media not attached.
+     */
+    manifestLoadingRetryDelay: number;
+    /**
+     * (default: 64000 ms)
+     * Maximum frag/manifest/key retry timeout (in milliseconds) in case I/O errors are met.
+     */
+    manifestLoadingMaxRetryTimeout: number;
+    /**
+     * (default: 60000ms for fragment)
+     * URL Loader timeout. A timeout callback will be triggered if loading duration exceeds this timeout. no further action will be done : the load operation will not be cancelled/aborted.
+     * It is up to the application to catch this event and treat it as needed.
+     */
+    levelLoadingTimeOut: number;
+    /**
+     * (default: 3)
+     * Max number of load retries.
+     */
+    levelLoadingMaxRetry: number;
+    /**
+     * (default: 1000 ms)
+     * Initial delay between XMLHttpRequest error and first load retry (in ms).
+     * Any I/O error will trigger retries every 500ms,1s,2s,4s,8s, ... capped to fragLoadingMaxRetryTimeout / manifestLoadingMaxRetryTimeout / levelLoadingMaxRetryTimeout value (exponential backoff).
+     * Prefetch start fragment although media not attached.
+     */
+    levelLoadingRetryDelay: number;
+    /**
+     * (default: 64000 ms)
+     * Maximum frag/manifest/key retry timeout (in milliseconds) in case I/O errors are met.
+     */
+    levelLoadingMaxRetryTimeout: number;
+    /**
+     * (default: 60000ms for fragment)
+     * URL Loader timeout. A timeout callback will be triggered if loading duration exceeds this timeout. no further action will be done : the load operation will not be cancelled/aborted.
+     * It is up to the application to catch this event and treat it as needed.
+     */
+    fragLoadingTimeOut: number;
+    /**
+     * (default: 3)
+     * Max number of load retries.
+     */
+    fragLoadingMaxRetry: number;
+    /**
+     * (default: 1000 ms)
+     * Initial delay between XMLHttpRequest error and first load retry (in ms).
+     * Any I/O error will trigger retries every 500ms,1s,2s,4s,8s, ... capped to fragLoadingMaxRetryTimeout / manifestLoadingMaxRetryTimeout / levelLoadingMaxRetryTimeout value (exponential backoff).
+     * Prefetch start fragment although media not attached.
+     */
+    fragLoadingRetryDelay: number;
+    /**
+     * (default: 64000 ms)
+     * Maximum frag/manifest/key retry timeout (in milliseconds) in case I/O errors are met.
+     */
+    fragLoadingMaxRetryDelay: number;
+    /**
+     * (default: false)
+     * Start prefetching start fragment although media not attached yet. Max number of append retries.
+     */
+    startFragPrefech: boolean;
+    /**
+     * (default: 3)
+     * Max number of sourceBuffer.appendBuffer() retry upon error. Such error could happen in loop with UHD streams, when internal buffer is full. (Quota Exceeding Error will be triggered).
+     * In that case we need to wait for the browser to evict some data before being able to append buffer correctly.
+     */
+    appendErrorMaxRetry: number;
+    /**
+     * (default: standard XMLHttpRequest-based URL loader)
+     * Override standard URL loader by a custom one. Could be useful for P2P or stubbing (testing).
+     * Use this, if you want to overwrite both the fragment and the playlist loader.
+     * Note: If fLoader or pLoader are used, they overwrite loader!
+     */
+    loader: Loader;
+    /**
+     * (default: undefined)
+     * This enables the manipulation of the fragment loader.
+     * Note: This will overwrite the default loader, as well as your own loader function.
+     */
+    fLoader?: Loader;
+    /**
+     * (default: undefined)
+     * This enables the manipulation of the playlist loader.
+     * Note: This will overwrite the default loader, as well as your own loader function.
+     */
+    pLoader?: Loader;
+    /**
+     * (default: undefined)
+     * XMLHttpRequest customization callback for default XHR based loader.
+     * Parameter should be a function with two arguments (xhr: XMLHttpRequest, url: string).
+     * If xhrSetup is specified, default loader will invoke it before calling xhr.send(). This allows user to easily modify/setup XHR.
+     */
+    xhrSetup?(xhr: XMLHttpRequest, url: string): void;
+    /**
+     * (default: undefined)
+     * Fetch customization callback for Fetch based loader.
+     * Parameter should be a function with two arguments (context and Request Init Params).
+     * If fetchSetup is specified and Fetch loader is used, fetchSetup will be triggered to instantiate Request Object. This allows user to easily tweak Fetch loader.
+     */
+    fetchSetup?(context: any, initParams: any): Request;
+    /**
+     * (default: internal ABR controller)
+     * Customized Adaptive Bitrate Streaming Controller.
+     * Parameter should be a class providing 2 getters, 2 setters and a destroy() method:
+     * get/set nextAutoLevel: return next auto-quality level/force next auto-quality level that should be returned (currently used for emergency switch down)
+     * get/set autoLevelCapping: capping/max level value that could be used by ABR Controller
+     * destroy(): should clean-up all used resources
+     */
+    abrController: AbrController;
+    /**
+     * (default: internal track timeline controller)
+     * Customized text track syncronization controller.
+     * Parameter should be a class with a destroy() method:
+     * destroy() : should clean-up all used resources
+     */
+    timelineController: TimelineController;
+    /**
+     * (default: true)
+     * whether or not to enable CEA-708 captions
+     */
+    enableCEA708Captions: boolean;
+    /**
+     * (default: English)
+     * Label for the text track generated for CEA-708 captions track 1. This is how it will appear in the browser's native menu for subtitles and captions.
+     */
+    captionsTextTrack1Label: string;
+    /**
+     * (default: en)
+     * RFC 3066 language code for the text track generated for CEA-708 captions track 1.
+     */
+    captionsTextTrack1LanguagedCode: string;
+    /**
+     * (default: Spanish)
+     * Label for the text track generated for CEA-708 captions track 2. This is how it will appear in the browser's native menu for subtitles and captions.
+     */
+    captionsTextTrack2Label: string;
+    /**
+     * (default: es)
+     * RFC 3066 language code for the text track generated for CEA-708 captions track 2.
+     */
+    captionsTextTrack2LanguageCode: string;
+    /**
+     * (default: false)
+     * If a segment's video track is shorter than its audio track by > min(maxSeekHole, maxBufferHole), extend the final video frame's duration to match the audio track's duration.
+     * This helps playback continue in certain cases that might otherwise get stuck.
+     */
+    stretchShortVideoTrack: boolean;
+    /**
+     * (default: true)
+     * Whether or not to force having a key frame in the first AVC sample after a discontinuity.
+     * If set to true, after a discontinuity, the AVC samples without any key frame will be dropped until finding one that contains a key frame.
+     * If set to false, all AVC samples will be kept, which can help avoid holes in the stream. Setting this parameter to false can also generate decoding weirdness when switching level or seeking.
+     */
+    forceKeyFrameOnDiscontinuity: boolean;
+    /**
+     * (default: 5.0)
+     * Fast bitrate Exponential moving average half-life, used to compute average bitrate for Live streams.
+     * Half of the estimate is based on the last abrEwmaFastLive seconds of sample history. Each of the sample is weighted by the fragment loading duration.
+     * parameter should be a float greater than 0
+     */
+    abrEwmaFastLive: number;
+    /**
+     * (default: 9.0)
+     * Slow bitrate Exponential moving average half-life, used to compute average bitrate for Live streams.
+     * Half of the estimate is based on the last abrEwmaSlowLive seconds of sample history. Each of the sample is weighted by the fragment loading duration.
+     * parameter should be a float greater than abrEwmaFastLive
+     */
+    arbEwmaSlowLive: number;
+    /**
+     * (default: 4.0)
+     * Fast bitrate Exponential moving average half-life, used to compute average bitrate for VoD streams.
+     * Half of the estimate is based on the last abrEwmaFastVoD seconds of sample history. Each of the sample is weighted by the fragment loading duration.
+     * parameter should be a float greater than 0
+     */
+    arbEwmaFastVod: number;
+    /**
+     * (default: 15.0)
+     * Slow bitrate Exponential moving average half-life, used to compute average bitrate for VoD streams.
+     * Half of the estimate is based on the last abrEwmaSlowVoD seconds of sample history. Each of the sample is weighted by the fragment loading duration.
+     * parameter should be a float greater than abrEwmaFastVoD
+     */
+    arbEwmaSlowVod: number;
+    /**
+     * (default: 500000)
+     * Default bandwidth estimate in bits/second prior to collecting fragment bandwidth samples.
+     * parameter should be a float
+     */
+    arbEwmaDefaultEstimate: number;
+    /**
+     * (default: 0.8)
+     * Scale factor to be applied against measured bandwidth average, to determine whether we can stay on current or lower quality level.
+     * If abrBandWidthFactor * bandwidth average < level.bitrate then ABR can switch to that level providing that it is equal or less than current level.
+     */
+    arbBandWidthFactor: number;
+    /**
+     * (default: 0.7)
+     * Scale factor to be applied against measured bandwidth average, to determine whether we can switch up to a higher quality level.
+     * If abrBandWidthUpFactor * bandwidth average < level.bitrate then ABR can switch up to that quality level.
+     */
+    arbBandWidthUpFactor: number;
+    /**
+     * (default: false)
+     * max bitrate used in ABR by avg measured bitrate i.e. if bitrate signaled in variant manifest for a given level is 2Mb/s but average bitrate measured on this level is 2.5Mb/s,
+     * then if config value is set to true, ABR will use 2.5 Mb/s for this quality level.
+     */
+    abrMaxWithRealBitrate: boolean;
+    /**
+     * (default: 0)
+     * Return the capping/min bandwidth value that could be used by automatic level selection algorithm.
+     * Useful when browser or tab of the browser is not in the focus and bandwidth drops
+     */
+    minAutoBitrate: number;
+  }
+
+  interface OptionalConfig {
+    /**
+     * (default: true)
+     * if set to true, start level playlist and first fragments will be loaded automatically, after triggering of Hls.Events.MANIFEST_PARSED event
+     * if set to false, an explicit API call (hls.startLoad(startPosition=-1)) will be needed to start quality level/fragment loading.
+     */
     autoStartLoad?: boolean;
     /**
      * (default -1)
@@ -647,19 +1050,19 @@ declare namespace Hls {
      * Use this, if you want to overwrite both the fragment and the playlist loader.
      * Note: If fLoader or pLoader are used, they overwrite loader!
      */
-    loader?: any;
+    loader?: Loader;
     /**
      * (default: undefined)
      * This enables the manipulation of the fragment loader.
      * Note: This will overwrite the default loader, as well as your own loader function.
      */
-    fLoader?: any;
+    fLoader?: Loader;
     /**
      * (default: undefined)
      * This enables the manipulation of the playlist loader.
      * Note: This will overwrite the default loader, as well as your own loader function.
      */
-    pLoader?: any;
+    pLoader?: Loader;
     /**
      * (default: undefined)
      * XMLHttpRequest customization callback for default XHR based loader.
@@ -1122,6 +1525,10 @@ declare namespace Hls {
   }
 
   interface Loader {
+    new (config: LoaderConfig): Loader;
+    /**
+     * Start retrieving content located at given URL (HTTP GET).
+     */
     load(context: LoaderContext, config: LoaderConfig, callbacks: LoaderCallbacks): void;
     /**
      * Abort any loading in progress.
@@ -1200,7 +1607,7 @@ declare class Hls {
   /**
    * Constructor. Can be provided an HlsConfig object as default properties and or overrides
    */
-  constructor(config?: Hls.Config)
+  constructor(config?: Hls.OptionalConfig)
   /**
    * return array of available quality levels
    */

--- a/types/hls.js/tsconfig.json
+++ b/types/hls.js/tsconfig.json
@@ -1,23 +1,23 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "lib": [
-      "dom",
-      "es6"
-    ],
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "baseUrl": "../",
-    "typeRoots": [
-      "../"
-    ],
-    "types": [],
-    "noEmit": true,
-    "forceConsistentCasingInFileNames": true
-  },
-  "files": [
-    "index.d.ts",
-    "hls.js-tests.ts"
-  ]
+    "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+        "dom",
+        "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "baseUrl": "../",
+      "typeRoots": [
+        "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+      "index.d.ts",
+      "hls.js-tests.ts"
+    ]
 }

--- a/types/hls.js/tsconfig.json
+++ b/types/hls.js/tsconfig.json
@@ -1,23 +1,23 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
-        "types": [],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "index.d.ts",
-        "hls.js-tests.ts"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "dom",
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "hls.js-tests.ts"
+  ]
 }

--- a/types/hls.js/tsconfig.json
+++ b/types/hls.js/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-
         "module": "commonjs",
         "lib": [
             "es6",

--- a/types/hls.js/tsconfig.json
+++ b/types/hls.js/tsconfig.json
@@ -1,9 +1,10 @@
 {
     "compilerOptions": {
+
         "module": "commonjs",
         "lib": [
-          "dom",
-          "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
@@ -15,9 +16,9 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
-      },
-      "files": [
-          "index.d.ts",
-          "hls.js-tests.ts"
-      ]
+    },
+    "files": [
+        "index.d.ts",
+        "hls.js-tests.ts"
+    ]
 }

--- a/types/hls.js/tsconfig.json
+++ b/types/hls.js/tsconfig.json
@@ -1,23 +1,23 @@
 {
     "compilerOptions": {
-      "module": "commonjs",
-      "lib": [
-        "dom",
-        "es6"
-      ],
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "strictNullChecks": true,
-      "baseUrl": "../",
-      "typeRoots": [
-        "../"
-      ],
-      "types": [],
-      "noEmit": true,
-      "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-      "index.d.ts",
-      "hls.js-tests.ts"
-    ]
+        "module": "commonjs",
+        "lib": [
+          "dom",
+          "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+      },
+      "files": [
+          "index.d.ts",
+          "hls.js-tests.ts"
+      ]
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/video-dev/hls.js/blob/master/doc/API.md#ploader>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Found that I was unable to extend the Hls.DefaultConfig.loader class like the example provided above. Added in fix.

My only concern now is having to duplicate the Hls.Config and Hls.OptionalConfig object.

Found that having optional properties on the config object would throw an error when trying

`class pLoader extends Hls.DefaultConfig.loader { ... }`

with 

> Type 'typeof Loader | undefined' is not a constructor function type.

And then when instantiating the Hls class with the optional config object and the DefaultConfig object didn't have all of its properties optional it would throw an error saying the config object was missing properties. 

`const hls = new Hls({optionalProperty});`

Is there a better way than having to duplicate the entire object to have one with optional properties?