### PR TITLE
[d3-selection] Export Selection as a class to specify our own element & parent elements

### DIFF
--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -54,6 +54,10 @@ interface CircleDatumAlternative {
 // Tests of Top-Level Selection Functions
 // ---------------------------------------------------------------------------------------
 
+// Test the constructor function. --------------------------------------------------------
+
+const selection: d3Selection.Selection<HTMLElement, any, HTMLElement, any> = new d3Selection.Selection([[new HTMLElement()]], [new HTMLElement()]);
+
 // test top-level .selection() -----------------------------------------------------------
 
 const topSelection: d3Selection.Selection<HTMLElement, any, null, undefined> = d3Selection.selection();

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -159,9 +159,16 @@ export function selectAll<GElement extends BaseType, OldDatum>(nodes: ArrayLike<
  * The third generic "PElement" refers to the type of the parent element(s) in the D3 selection.
  * The fourth generic "PDatum" refers to the type of the datum of the parent element(s).
  */
-export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
+export class Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
     // Sub-selection -------------------------
 
+    /**
+     * Creates a new Selection object from a group of elements, and its parent elements
+     *
+     * @param groups An array of array of elements that comprise this collection.
+     * @param parents An array of elements that comprise this selection's ancestors. Usually document.documentElement.
+     */
+    constructor(groups: GElement[][], parents: PElement[]);
     /**
      * For each selected element, select the first descendant element that matches the specified selector string.
      * If no element matches the specified selector for the current element, the element at the current index will


### PR DESCRIPTION
The current types don't support creating our own selections with our own parents. This prevents us from using d3 in browsers with web components (i.e. Polymer) where the standard "document.querySelector" doesn't find elements in shadow DOM.

This is already solved in d3 v4 ( see https://github.com/d3/d3-selection/blob/master/src/selection/index.js#L33 ) by exporting the constructor function.

This commit adds support to the existing function so what we can use it in web-components.

Please fill in this template.

- [d3 ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes:  https://github.com/d3/d3-selection/blob/master/src/selection/index.js#L33 
- [ - ] Increase the version number in the header if appropriate. 
- [ - ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.