### PR TITLE
add destroy() to keypress typing

### DIFF
--- a/types/keypress/index.d.ts
+++ b/types/keypress/index.d.ts
@@ -46,6 +46,7 @@ declare namespace Keypress {
         unregister_many(combos: Combo[]): void;
         unregister_many(keys: string[]): void;
         get_registered_combos(): Combo[];
+        destroy(): void;
         reset(): void;
         listen(): void;
         stop_listening(): void;


### PR DESCRIPTION
this function exist in the api mentioned in https://dmauro.github.io/Keypress/