### PR TITLE
Make SnapSVG accessible from WebPack

### DIFF
--- a/types/mina/index.d.ts
+++ b/types/mina/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for mina Snap-SVG 0.4.1
+// Project: https://github.com/adobe-webplatform/Snap.svg
+// Definitions by: Lars Klein <https://github.com/lhk>, Mattanja Kern <https://github.com/mattanja>, Andrey Kurdyumov <https://github.com/kant2002>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function mina(a:number, A:number, b:number, B:number, get:Function, set:Function, easing?:(num:number)=>number):mina.AnimationDescriptor;
+declare namespace mina {
+    export interface MinaAnimation {
+        id: string;
+        duration: Function;
+        easing: Function;
+        speed: Function;
+        status: Function;
+        stop: Function;
+    }
+
+    export interface AnimationDescriptor {
+        id: string;
+        start: number;
+        end: number;
+        b: number;
+        s: number;
+        dur: number;
+        spd: number;
+        get(): number;
+        set(slave: number): number;
+        easing(input: number): number;
+        status(): number;
+        status(newStatus: number): void;
+        speed(): number;
+        speed(newSpeed: number): void;
+        duration(): number;
+        duration(newDuration: number): void;
+        stop(): void;
+        pause(): void;
+        resume(): void;
+        update(): void;
+    }
+
+    export function backin(n:number):number;
+    export function backout(n:number):number;
+    export function bounce(n:number):number;
+    export function easein(n:number):number;
+    export function easeinout(n:number):number;
+    export function easeout(n:number):number;
+    export function elastic(n:number):number;
+    export function getById(id:string):AnimationDescriptor;
+    export function linear(n:number):number;
+    export function time():number;
+}

--- a/types/mina/index.d.ts
+++ b/types/mina/index.d.ts
@@ -1,20 +1,20 @@
-// Type definitions for mina Snap-SVG 0.4.1
+// Type definitions for mina Snap-SVG 0.4
 // Project: https://github.com/adobe-webplatform/Snap.svg
 // Definitions by: Lars Klein <https://github.com/lhk>, Mattanja Kern <https://github.com/mattanja>, Andrey Kurdyumov <https://github.com/kant2002>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function mina(a:number, A:number, b:number, B:number, get:Function, set:Function, easing?:(num:number)=>number):mina.AnimationDescriptor;
+declare function mina(a: number, A: number, b: number, B: number, get: () => number, set: (time: number) => void, easing?: (num: number) => number): mina.AnimationDescriptor;
 declare namespace mina {
-    export interface MinaAnimation {
+    interface MinaAnimation {
         id: string;
-        duration: Function;
-        easing: Function;
-        speed: Function;
-        status: Function;
-        stop: Function;
+        duration(): number;
+        easing(): number;
+        speed(): number;
+        status(): number;
+        stop(): void;
     }
 
-    export interface AnimationDescriptor {
+    interface AnimationDescriptor {
         id: string;
         start: number;
         end: number;
@@ -37,14 +37,14 @@ declare namespace mina {
         update(): void;
     }
 
-    export function backin(n:number):number;
-    export function backout(n:number):number;
-    export function bounce(n:number):number;
-    export function easein(n:number):number;
-    export function easeinout(n:number):number;
-    export function easeout(n:number):number;
-    export function elastic(n:number):number;
-    export function getById(id:string):AnimationDescriptor;
-    export function linear(n:number):number;
-    export function time():number;
+    function backin(n: number): number;
+    function backout(n: number): number;
+    function bounce(n: number): number;
+    function easein(n: number): number;
+    function easeinout(n: number): number;
+    function easeout(n: number): number;
+    function elastic(n: number): number;
+    function getById(id: string): AnimationDescriptor;
+    function linear(n: number): number;
+    function time(): number;
 }

--- a/types/mina/tsconfig.json
+++ b/types/mina/tsconfig.json
@@ -2,12 +2,11 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
@@ -17,9 +16,6 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts",
-        "test/1.ts",
-        "test/2.ts",
-        "test/3.ts"
+        "index.d.ts"
     ]
 }

--- a/types/mina/tslint.json
+++ b/types/mina/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -1,53 +1,11 @@
 // Type definitions for Snap-SVG 0.4.1
 // Project: https://github.com/adobe-webplatform/Snap.svg
-// Definitions by: Lars Klein <https://github.com/lhk>, Mattanja Kern <https://github.com/mattanja>
+// Definitions by: Lars Klein <https://github.com/lhk>, Mattanja Kern <https://github.com/mattanja>, Andrey Kurdyumov <https://github.com/kant2002>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+/// <reference types="mina" />
 
-declare function mina(a:number, A:number, b:number, B:number, get:Function, set:Function, easing?:(num:number)=>number):mina.AnimationDescriptor;
-declare namespace mina {
-    export interface MinaAnimation {
-        id: string;
-        duration: Function;
-        easing: Function;
-        speed: Function;
-        status: Function;
-        stop: Function;
-    }
-
-    export interface AnimationDescriptor {
-        id: string;
-        start: number;
-        end: number;
-        b: number;
-        s: number;
-        dur: number;
-        spd: number;
-        get(): number;
-        set(slave: number): number;
-        easing(input: number): number;
-        status(): number;
-        status(newStatus: number): void;
-        speed(): number;
-        speed(newSpeed: number): void;
-        duration(): number;
-        duration(newDuration: number): void;
-        stop(): void;
-        pause(): void;
-        resume(): void;
-        update(): void;
-    }
-
-    export function backin(n:number):number;
-    export function backout(n:number):number;
-    export function bounce(n:number):number;
-    export function easein(n:number):number;
-    export function easeinout(n:number):number;
-    export function easeout(n:number):number;
-    export function elastic(n:number):number;
-    export function getById(id:string):AnimationDescriptor;
-    export function linear(n:number):number;
-    export function time():number;
-}
+export = Snap;
+export as namespace Snap;
 
 declare function Snap(width:number|string,height:number|string):Snap.Paper;
 declare function Snap(query:string):Snap.Paper;


### PR DESCRIPTION
I have to add export = Snap to make project accessible from projects which using webpack, mina object was not accessibly now, but in runtime it was still perfectly fine to have it in the code. Thus I extract mina package as separate global dependency. For code which use SnapSVG as global dependency this will work as earlier, but for those who want to use SnapSVG with WebPack it will reflect how mina available after importing SnapSVG.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://snapsvg.io/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.