### PR TITLE
`Highcharts` variable should be available globally (@types/highcharts)

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -6527,7 +6527,7 @@ declare namespace Highcharts {
 }
 
 declare global {
-    declare const Highcharts: Highcharts.Static;
+    const Highcharts: Highcharts.Static;
     interface JQuery {
         highcharts(): Highcharts.ChartObject;
         /**

--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -6527,6 +6527,7 @@ declare namespace Highcharts {
 }
 
 declare global {
+    declare const Highcharts: Highcharts.Static;
     interface JQuery {
         highcharts(): Highcharts.ChartObject;
         /**


### PR DESCRIPTION
According to the source code of Highcharts, there is a global variable named `Highcharts` that should be also available in `@types/highcharts` without any import (https://www.highcharts.com/docs/getting-started/your-first-chart).

Now it requires to write `import * as Highcharts from "highcharts"`, but it cause a problem, when I already have `highcharts.js` imported in my `index.html` file (https://www.highcharts.com/errors/16).