### PR TITLE
[redux-form] Fixed definitions to handle FieldArray errors.

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -19,12 +19,12 @@ export interface DataShape {
 }
 
 export type FormErrors<FormData extends DataShape> = {
-    [P in keyof FormData]?: ReactElement<any> | string;
-} & { _error?: string };
+    [P in keyof FormData]?: ReactElement<any> | string | { _error?: string };
+};
 
 export type FormWarnings<FormData extends DataShape> = {
-    [P in keyof FormData]?: ReactElement<any> | string;
-} & { _warning?: string };
+    [P in keyof FormData]?: ReactElement<any> | string | { _warning?: string };
+};
 
 /**
  * A component class or stateless function component.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

> The FieldArray example at <http://redux-form.com/6.8.0/examples/fieldArrays/> sets an error message for the entire array like this: `errors.members = { _error: 'At least one member must be entered' }`. The change proposed to the typing file support setting an error message this way.

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.