### PR TITLE
Updated react-big-calendar to work with TypeScript 2.3 and "noImplicitThis": true

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -42,7 +42,7 @@ declare module 'react-big-calendar' {
         elementProps?: React.HTMLAttributes<HTMLElement>;
     }
 
-    class BigCalendar extends React.Component<BigCalendarProps> {
+    export class BigCalendar extends React.Component<BigCalendarProps, void> {
         /**
          * Setup the localizer by providing the moment Object
          */
@@ -51,11 +51,7 @@ declare module 'react-big-calendar' {
          * Setup the localizer by providing the globalize Object
          */
         static globalizeLocalizer(globalizeInstance: Object): void;
-    }
+	}
 
-    /* This enables 'import * as BigCalendar' syntax when compiling to es2015 */
-    namespace BigCalendar {}
-
-    /* react-big-calendar is exported as a commonjs module (it uses babel-preset-jason) */
-    export = BigCalendar;
+	export default BigCalendar;
 }

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactDOMServer from "react-dom/server";
-import BigCalendar = require("react-big-calendar");
+import BigCalendar from "react-big-calendar";
 
 // Don't want to add this as a dependency, because it is only used for tests.
 declare const moment: any;
@@ -17,7 +17,6 @@ const BasicExample = React.createClass({
     render() {
         return (
             <BigCalendar
-                {...this.props}
                 events={getEvents()}
             />
         );
@@ -33,7 +32,6 @@ const FullAPIExample = React.createClass({
     render() {
         return (
             <BigCalendar
-                {...this.props}
                 date={new Date()}
                 view={'string'}
                 events={getEvents()}

--- a/types/react-big-calendar/tsconfig.json
+++ b/types/react-big-calendar/tsconfig.json
@@ -6,7 +6,7 @@
             "dom"
         ],
         "noImplicitAny": true,
-        "noImplicitThis": false,
+        "noImplicitThis": true,
         "strictNullChecks": false,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Had a few errors when using this component, TS2314: Generic type 'Component<P, S>' requires 2 type argument(s) and import errors. Updated and works well now.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.