### PR TITLE
Update TS version in swagger-node-runner to trigger republish with new deps versions

### DIFF
--- a/types/swagger-node-runner/index.d.ts
+++ b/types/swagger-node-runner/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/swagger-node-runner
 // Definitions by: Michael Mrowetz <https://github.com/micmro/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---
The types for this rely on `restify` which had an error that prevented compilation in TS 2.4 which is now fixed.
The currently published version of `swagger-node-runner` however still references an old version of `restify` that does not have the fix yet.