### PR TITLE
Additional optional properties for React Breadcrumb to work.

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -63,6 +63,10 @@ export interface RouteComponentProps<P> {
 }
 
 export interface RouteProps {
+  /* Start React Breadcrumb  */
+  name?: string;
+  staticName?: boolean;
+  /* Start React Breadcrumb */
   location?: H.Location;
   component?: React.SFC<RouteComponentProps<any> | undefined> | React.ComponentClass<RouteComponentProps<any> | undefined>;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);


### PR DESCRIPTION
'Route' needs properties 'name' and 'staticName' for this to work.
https://github.com/svenanders/react-breadcrumbs