### PR TITLE
[send] fix for typescript 2.4.1

### DIFF
--- a/types/send/index.d.ts
+++ b/types/send/index.d.ts
@@ -197,7 +197,7 @@ declare namespace send {
         /**
          * Pipe to `res`.
          */
-        pipe(res: stream.Writable): stream.Writable;
+        pipe<T extends NodeJS.WritableStream>(res: T): T;
 
         /**
          * Transfer `path`.


### PR DESCRIPTION
I get this error with Typescript 2.4.1
```
node_modules/@types/send/index.d.ts(94,15): error TS2430: Interface 'SendStream' incorrectly extends interface 'Stream'.
  Types of property 'pipe' are incompatible.
    Type '(res: Writable) => Writable' is not assignable to type '<T extends WritableStream>(destination: T, options?: { end?: boolean | undefined; } | undefined) ...'.
      Types of parameters 'res' and 'destination' are incompatible.
        Type 'T' is not assignable to type 'Writable'.
          Type 'WritableStream' is not assignable to type 'Writable'.
            Property '_write' is missing in type 'WritableStream'.
```
This should fix it.