### PR TITLE
Increase nProcesses from 4 to 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "compile-scripts": "tsc -p scripts",
     "not-needed": "node scripts/not-needed.js",
-    "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --nProcesses 4",
+    "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --nProcesses 8",
     "lint": "dtslint types"
   },
   "devDependencies": {


### PR DESCRIPTION
| Run | --nProcesses 4 | --nProcesses 8 |
| --- | --- | --- |
| 1 | 15 min 12 sec | 9 min 53 sec |
| 2 | 14 min 27 sec | 9 min 59 sec |
| 3 | 13 min 29 sec | 11 min 19 sec |
| **Avg** | 14 min 23 sec | 10 min 24 sec |

@andy-ms I'm not sure if https://github.com/Microsoft/types-publisher/pull/358 is going to be able to be pulled in or not. It'd be nice to get the performance benefit from going to 4 processes per core though (especially if we end up [doing more tests](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17626)).