### PR TITLE
Support Leaflet-draw explicit false options

### DIFF
--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -40,35 +40,35 @@ declare namespace L {
 			 *
 			 *  Default value: {}
 			 */
-			polyline?: DrawOptions.PolylineOptions;
+			polyline?: DrawOptions.PolylineOptions | false;
 
 			/**
 			 * Polygon draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			polygon?: DrawOptions.PolygonOptions;
+			polygon?: DrawOptions.PolygonOptions | false;
 
 			/**
 			 * Rectangle draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			rectangle?: DrawOptions.RectangleOptions;
+			rectangle?: DrawOptions.RectangleOptions | false;
 
 			/**
 			 * Circle draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			circle?: DrawOptions.CircleOptions;
+			circle?: DrawOptions.CircleOptions | false;
 
 			/**
 			 * Marker draw handler options. Set to false to disable handler.
 			 *
 			 *  Default value: {}
 			 */
-			marker?: DrawOptions.MarkerOptions;
+			marker?: DrawOptions.MarkerOptions | false;
 		}
 
 		interface EditOptions {
@@ -85,14 +85,14 @@ declare namespace L {
 			 *
 			 * Default value: null
 			 */
-			edit?: DrawOptions.EditHandlerOptions;
+			edit?: DrawOptions.EditHandlerOptions | false;
 
 			/**
 			 * Delete handler options. Set to false to disable handler.
 			 *
 			 * Default value: null
 			 */
-			remove?: DrawOptions.DeleteHandlerOptions;
+			remove?: DrawOptions.DeleteHandlerOptions | false;
 		}
 
 		interface Draw extends Control {

--- a/types/leaflet-draw/leaflet-draw-tests.ts
+++ b/types/leaflet-draw/leaflet-draw-tests.ts
@@ -45,3 +45,27 @@ map.on(L.Draw.Event.CREATED, (e: L.DrawEvents.Created) => {
 let examplePolygon: L.LatLngLiteral[] = [{lng: 0, lat: 0}, {lng: 10, lat: 0}, {lng: 10, lat: 10}, {lng: 0, lat: 10}, {lng: 0, lat: 0}];
 let examplePolygonArea: number = L.GeometryUtil.geodesicArea(examplePolygon);
 L.GeometryUtil.readableArea(examplePolygonArea, true);
+
+function testBooleanControlOptions() {
+    const drawControl = new L.Control.Draw({
+        position: 'topleft' ,
+        draw: {
+            polygon: {
+                allowIntersection: false,
+                drawError: {
+                    color: '#b00b00',
+                    timeout: 1000
+                },
+                shapeOptions: {
+                    color: '#bada55'
+                },
+                showArea: true
+            },
+            polyline: {},
+            circle: false
+        },
+        edit: {
+            featureGroup: drawnItems
+        }
+    });
+}


### PR DESCRIPTION
This matches the documentation better where most of the Leaflet Draw documentation encourages to use explicit false options (rather than null), as seen in the type comments already in the typing file.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#options
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

