### PR TITLE
passport-local-mongoose: new optional parameters in the js lib

### DIFF
--- a/types/passport-local-mongoose/index.d.ts
+++ b/types/passport-local-mongoose/index.d.ts
@@ -19,8 +19,8 @@ declare module 'mongoose' {
   // statics
   interface PassportLocalModel<T extends Document> extends Model<T> {
     authenticate(): (username: string, password: string, cb: (err: any, res: T, error: any) => void) => void;
-    serializeUser(): (user: PassportLocalModel<T>, cb: (err: any) => void) => void;
-    deserializeUser(): (username: string, cb: (err: any) => void) => void;
+    serializeUser(): (user: PassportLocalModel<T>, cb: (err: any, id?: any) => void) => void;
+    deserializeUser(): (username: string, cb: (err: any, user?: any) => void) => void;
     register(user: T, password: string, cb: (err: any, account: any) => void): void;
     findByUsername(username: string, selectHashSaltFields: boolean, cb: (err: any, account: any) => void): any;
     createStrategy(): passportLocal.Strategy;


### PR DESCRIPTION
Adding (new) optional parameters to the serializeUser and deserialize following the changes in passport js lib. 

This package plugs into https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/passport/index.d.ts. The methods serializeUser and deserializeUser have a new optional parameter into their callback param. This is causing a warning during typescript compiling.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/passport/index.d.ts
