### PR TITLE
[types/paper] Added hex string option to Color constructor

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -3514,6 +3514,12 @@ declare module 'paper' {
          * @param highlight [optional] -
          */
         constructor(color: Gradient, origin: Point, destination: Point, highlight?: Point);
+        
+        /**
+         * Creates a RGB Color object.
+         * @param hex - the RGB color in hex, i.e. #000000
+         */
+        constructor(hex: string);
 
         /**
          * The type of the color as a string.


### PR DESCRIPTION
Passing a string into Color worked prior to Typescript 2.4

Requires @clark-stevenson approval.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [PaperJS Docs](http://paperjs.org/reference/global/) [clark-stevenson repo](https://github.com/clark-stevenson/paper.d.ts)
- [x] Increase the version number in the header if appropriate.
