### PR TITLE
[angular] Add element indexer to jqLite

### DIFF
--- a/types/angular-animate/index.d.ts
+++ b/types/angular-animate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://angularjs.org
 // Definitions by: Michel Salib <https://github.com/michelsalib>, Adi Dahiya <https://github.com/adidahiya>, Raphael Schweizer <https://github.com/rasch>, Cody Schaaf <https://github.com/codyschaaf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 declare var _: string;
 export = _;

--- a/types/angular/jqlite.d.ts
+++ b/types/angular/jqlite.d.ts
@@ -25,7 +25,7 @@
 
 // Definitions copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0480c5ec87fab41aa23047a02b27f0ea71aaf975/types/jquery/v2/index.d.ts
 
-interface JQuery {
+interface JQuery<TElement extends Node = HTMLElement> {
     /**
      * Adds the specified class(es) to each of the set of matched elements.
      *
@@ -651,6 +651,7 @@ interface JQuery {
 
     // Undocumented
     length: number;
+    [index: number]: TElement;
 
     // TODO: events, how to define?
     // $destroy


### PR DESCRIPTION
This indexer is required in order to access the underlying native
HTML elements behind a jqLite object. Although it's not documented in
either the Angular `element` documentation [1] or the original jQuery
API documentation it is part of the jqLite API. In fact, in the absence
of the `get()` method I believe this is the only means to access the
HTML elements.

The `TElement` type variable is required to ensure that the jqLite
typings continue to compile OK in conjunction with the latest jQuery
definitions. I'd originally used the same definition as in the old
jQuery typings [2] and, while that compiled OK in isolation, it raised a
compile error when the full jQuery typings were available.

[1] https://docs.angularjs.org/api/ng/function/angular.element
[2]
https://github.com/smfeest/DefinitelyTyped/blob/52318fe24f42759f3f41bbf86075b0aff9aab432/types/jquery/index.d.ts#L3378

Please fill in this template.

- [Y] Use a meaningful title for the pull request. Include the name of the package modified.
- [Y] Test the change in your own code. (Compile and run.)
- [Y] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [Y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [Y] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [Y] Provide a URL to documentation or source code which provides context for the suggested changes: https://learn.jquery.com/using-jquery-core/faq/how-do-i-pull-a-native-dom-element-from-a-jquery-object/
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

