### PR TITLE
[expect.js] Fix the exports

### DIFF
--- a/types/expect.js/index.d.ts
+++ b/types/expect.js/index.d.ts
@@ -221,7 +221,7 @@ declare namespace Expect {
 }
 
 declare module "expect.js" {
-
+    function expect(target?: any): Expect.Root;
+    namespace expect {}
     export = expect;
-
 }


### PR DESCRIPTION
Resolve tsc error:
> error TS2497: Module '"expect.js"' resolves to a non-module entity and cannot be imported using this construct.

https://github.com/Microsoft/TypeScript/issues/5073

