### PR TITLE
sequelize: use type indexing to make find* functions more helpful.

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -10,6 +10,7 @@
 
 
 import * as _ from "lodash";
+import * as Promise from "bluebird";
 
 declare namespace sequelize {
 

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -10,7 +10,6 @@
 
 
 import * as _ from "lodash";
-import * as Promise from "bluebird";
 
 declare namespace sequelize {
 
@@ -259,7 +258,7 @@ declare namespace sequelize {
         /**
          * An optional where clause to limit the associated models.
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * Apply a scope on the related model, or remove its default scope by passing false.
@@ -346,7 +345,7 @@ declare namespace sequelize {
          */
         (
             newAssociations?: Array<TInstance | TInstancePrimaryKey>,
-            options?: HasManySetAssociationsMixinOptions | FindOptions | InstanceUpdateOptions
+            options?: HasManySetAssociationsMixinOptions | AnyFindOptions | InstanceUpdateOptions
         ): Promise<void>;
     }
 
@@ -672,7 +671,7 @@ declare namespace sequelize {
         /**
          * An optional where clause to limit the associated models.
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * Apply a scope on the related model, or remove its default scope by passing false.
@@ -722,7 +721,7 @@ declare namespace sequelize {
         /**
          * An optional where clause to limit the associated models.
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * Apply a scope on the related model, or remove its default scope by passing false.
@@ -809,7 +808,7 @@ declare namespace sequelize {
          */
         (
             newAssociations?: Array<TInstance | TInstancePrimaryKey>,
-            options?: BelongsToManySetAssociationsMixinOptions | FindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | { through: TJoinTableAttributes }
+            options?: BelongsToManySetAssociationsMixinOptions | AnyFindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | { through: TJoinTableAttributes }
         ): Promise<void>;
     }
 
@@ -858,7 +857,7 @@ declare namespace sequelize {
          */
         (
             newAssociations?: Array<TInstance | TInstancePrimaryKey>,
-            options?: BelongsToManyAddAssociationsMixinOptions | FindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | { through: TJoinTableAttributes }
+            options?: BelongsToManyAddAssociationsMixinOptions | AnyFindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | { through: TJoinTableAttributes }
         ): Promise<void>;
     }
 
@@ -907,7 +906,7 @@ declare namespace sequelize {
          */
         (
             newAssociation?: TInstance | TInstancePrimaryKey,
-            options?: BelongsToManyAddAssociationMixinOptions | FindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | { through: TJoinTableAttributes }
+            options?: BelongsToManyAddAssociationMixinOptions | AnyFindOptions | BulkCreateOptions | InstanceUpdateOptions | InstanceDestroyOptions | { through: TJoinTableAttributes }
         ): Promise<void>;
     }
 
@@ -1135,7 +1134,7 @@ declare namespace sequelize {
         /**
          * An optional where clause to limit the associated models.
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * Apply a scope on the related model, or remove its default scope by passing false.
@@ -2613,7 +2612,7 @@ declare namespace sequelize {
         /**
          * A hash of attributes to describe your search. See above for examples.
          */
-        where?: WhereOptions | Array<col | and | or | string>;
+        where?: AnyWhereOptions | Array<col | and | or | string>;
 
     }
 
@@ -2663,7 +2662,7 @@ declare namespace sequelize {
         /**
          * A hash of attributes to describe your search. See above for examples.
          */
-        where?: WhereOptions | Array<col | and | or | string>;
+        where?: AnyWhereOptions | Array<col | and | or | string>;
 
     }
 
@@ -2824,7 +2823,7 @@ declare namespace sequelize {
          * return a new instance. With this method, all references to the Instance are updated with the new data
          * and no new objects are created.
          */
-        reload(options?: FindOptions): Promise<this>;
+        reload(options?: AnyFindOptions): Promise<this>;
 
         /**
          * Validate the attribute of this instance according to validation rules set in the model definition.
@@ -3031,8 +3030,8 @@ declare namespace sequelize {
      * Where Complex nested query
      */
     interface WhereNested {
-        $and: Array<WhereOptions | WhereLogic>;
-        $or: Array<WhereOptions | WhereLogic>;
+        $and: Array<AnyWhereOptions | WhereLogic>;
+        $or: Array<AnyWhereOptions | WhereLogic>;
     }
 
     /**
@@ -3054,10 +3053,10 @@ declare namespace sequelize {
     /**
      * Logic of where statement
      */
-    interface WhereLogic {
+    type WhereLogic = Partial<{
         $ne: string | number | WhereLogic;
         $in: Array<string | number> | literal;
-        $not: boolean | string | number | WhereOptions;
+        $not: boolean | string | number | AnyWhereOptions;
         $notIn: Array<string | number> | literal;
         $gte: number | string | Date;
         $gt: number | string | Date;
@@ -3078,7 +3077,7 @@ declare namespace sequelize {
         "@>": any;
         $contained: any;
         "<@": any;
-    }
+    }>;
 
     /**
      * A hash of attributes to describe your search. See above for examples.
@@ -3086,8 +3085,15 @@ declare namespace sequelize {
      * We did put Object in the end, because there where query might be a JSON Blob. It cripples a bit the
      * typesafety, but there is no way to pass the tests if we just remove it.
      */
-    interface WhereOptions {
-        [field: string]: string | number | WhereLogic | WhereOptions | col | and | or | WhereGeometryOptions | Array<string | number> | Object | null;
+    type WhereOptions<T> = {
+        [P in keyof T]?: string | number | WhereLogic | WhereOptions<T[P]> | col | and | or | WhereGeometryOptions | Array<string | number> | null;
+    };
+
+    /**
+     * A hash of attributes to describe your search, accepting any field names. See `WhereOptions` for details.
+     */
+    interface AnyWhereOptions {
+        [field: string]: WhereOptions<any>[] | Object;
     }
 
     /**
@@ -3098,7 +3104,7 @@ declare namespace sequelize {
         /**
          * Filter on the join model for belongsToMany relations
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * A list of attributes to select from the join model for belongsToMany relations
@@ -3141,7 +3147,7 @@ declare namespace sequelize {
          * Where clauses to apply to the child models. Note that this converts the eager load to an inner join,
          * unless you explicitly set `required: false`
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * A list of attributes to select from the child model
@@ -3183,12 +3189,12 @@ declare namespace sequelize {
 *
 * A hash of options to describe the scope of the search
 */
-    interface FindOptions extends LoggingOptions, SearchPathOptions {
+    interface FindOptions<T> extends LoggingOptions, SearchPathOptions {
 
         /**
          * A hash of attributes to describe your search. See above for examples.
          */
-        where?: WhereOptions | fn | Array<col | and | or | string>;
+        where?: WhereOptions<T> | fn | Array<col | and | or | string>;
 
         /**
          * A list of the attributes that you want to select. To rename an attribute, you can pass an array, with
@@ -3245,7 +3251,7 @@ declare namespace sequelize {
         /**
          * having ?!?
          */
-        having?: WhereOptions;
+        having?: AnyWhereOptions;
 
         /**
          * Group by. It is not mentioned in sequelize's JSDoc, but mentioned in docs.
@@ -3265,6 +3271,8 @@ declare namespace sequelize {
         subQuery?: boolean;
     }
 
+    type AnyFindOptions = FindOptions<any>;
+
     /**
      * Options for Model.count method
      */
@@ -3273,7 +3281,7 @@ declare namespace sequelize {
         /**
          * A hash of search attributes.
          */
-        where?: WhereOptions | string[];
+        where?: AnyWhereOptions | string[];
 
         /**
          * Include options. See `find` for details
@@ -3335,7 +3343,7 @@ declare namespace sequelize {
     /**
      * Options for Model.findOrInitialize method
      */
-    interface FindOrInitializeOptions<TAttributes> extends FindOptions {
+    interface FindOrInitializeOptions<TAttributes> extends AnyFindOptions {
 
         /**
          * Default values to use if building a new instance
@@ -3347,7 +3355,7 @@ declare namespace sequelize {
     /**
      * Options for Model.findOrInitialize method
      */
-    interface FindCreateFindOptions<TAttributes> extends FindOptions {
+    interface FindCreateFindOptions<TAttributes> extends FindOptions<TAttributes> {
 
         /**
          * Default values to use if building a new instance
@@ -3423,7 +3431,7 @@ declare namespace sequelize {
         /**
          * Filter the destroy
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * Run before / after bulk destroy hooks?
@@ -3462,7 +3470,7 @@ declare namespace sequelize {
         /**
          * Filter the restore
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * Run before / after bulk restore hooks?
@@ -3495,7 +3503,7 @@ declare namespace sequelize {
         /**
          * Options to describe the scope of the search.
          */
-        where: WhereOptions;
+        where: AnyWhereOptions;
 
         /**
          * Run before / after bulk update hooks?
@@ -3543,7 +3551,7 @@ declare namespace sequelize {
         /**
          * A hash of search attributes.
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
         /**
          * The type of the result. If `field` is a field in this Model, the default will be the type of that field,
@@ -3634,7 +3642,7 @@ declare namespace sequelize {
          * @param {Object}          [options]
          * @param {Boolean}         [options.override=false]
          */
-        addScope(name: string, scope: FindOptions | Function, options?: AddScopeOptions): void;
+        addScope(name: string, scope: AnyFindOptions | Function, options?: AddScopeOptions): void;
 
         /**
              * Add a new scope to the model. This is especially useful for adding scopes with includes, when the model you want to include is not available at the time this model is defined.
@@ -3646,7 +3654,7 @@ declare namespace sequelize {
              * @param {Object}          [options]
              * @param {Boolean}         [options.override=false]
              */
-        addScope(name: string, scope: FindOptions | Function, options?: AddScopeOptions): void;
+        addScope(name: string, scope: AnyFindOptions | Function, options?: AddScopeOptions): void;
 
         /**
  * Apply a scope created in `define` to the model. First let's look at how to create scopes:
@@ -3695,7 +3703,7 @@ declare namespace sequelize {
  * @return Model A reference to the model, with the scope(s) applied. Calling scope again on the returned
  *     model will clear the previous scope.
  */
-        scope(options?: string | ScopeOptions | WhereOptions | Array<string | ScopeOptions | WhereOptions>): this;
+        scope(options?: string | ScopeOptions | AnyWhereOptions | Array<string | ScopeOptions | AnyWhereOptions>): this;
 
         /**
          * Search for multiple instances.
@@ -3759,22 +3767,22 @@ declare namespace sequelize {
          *
          * @see    {Sequelize#query}
          */
-        findAll(options?: FindOptions): Promise<TInstance[]>;
-        all(optionz?: FindOptions): Promise<TInstance[]>;
+        findAll<TCustomAttributes>(options?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance[]>;
+        all<TCustomAttributes>(optionz?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance[]>;
 
         /**
          * Search for a single instance by its primary key. This applies LIMIT 1, so the listener will
          * always be called with a single instance.
          */
-        findById(identifier?: number | string, options?: FindOptions): Promise<TInstance | null>;
-        findByPrimary(identifier?: number | string, options?: FindOptions): Promise<TInstance | null>;
+        findById<TCustomAttributes>(identifier?: number | string, options?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance | null>;
+        findByPrimary<TCustomAttributes>(identifier?: number | string, options?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance | null>;
 
         /**
          * Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single
          * instance.
          */
-        findOne(options?: FindOptions): Promise<TInstance | null>;
-        find(options?: FindOptions): Promise<TInstance | null>;
+        findOne<TCustomAttributes>(options?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance | null>;
+        find<TCustomAttributes>(options?: FindOptions<TAttributes & TCustomAttributes>): Promise<TInstance | null>;
 
         /**
          * Run an aggregation method on the specified field
@@ -3829,8 +3837,8 @@ declare namespace sequelize {
          * without
          * profiles will be counted
          */
-        findAndCount(options?: FindOptions): Promise<{ rows: TInstance[], count: number }>;
-        findAndCountAll(options?: FindOptions): Promise<{ rows: TInstance[], count: number }>;
+        findAndCount<TCustomAttributes>(options?: FindOptions<TAttributes & TCustomAttributes>): Promise<{ rows: TInstance[], count: number }>;
+        findAndCountAll<TCustomAttributes>(options?: FindOptions<TAttributes & TCustomAttributes>): Promise<{ rows: TInstance[], count: number }>;
 
         /**
          * Find the maximum value of field
@@ -3886,7 +3894,7 @@ declare namespace sequelize {
              * A more performant findOrCreate that will not work under a transaction (at least not in postgres)
              * Will execute a find call, if empty then attempt to create, if unique constraint then attempt to find again
              */
-        findCreateFind(options: FindCreateFindOptions<TAttributes>): Promise<TInstance>;
+        findCreateFind<TCustomAttributes>(options: FindCreateFindOptions<TAttributes & TCustomAttributes>): Promise<TInstance>;
 
         /**
  * Insert or update a single row. An update will be executed if a row which matches the supplied values on
@@ -3994,7 +4002,7 @@ declare namespace sequelize {
     interface AddCheckConstraintOptions {
         type: 'check';
         name?: string;
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
     }
 
     interface AddPrimaryKeyConstraintOptions {
@@ -4850,7 +4858,7 @@ declare namespace sequelize {
         /**
          * Condition for partioal index
          */
-        where?: WhereOptions;
+        where?: AnyWhereOptions;
 
     }
 
@@ -4901,7 +4909,7 @@ declare namespace sequelize {
         /**
          * Name of the scope and it's query
          */
-        [scopeName: string]: FindOptions | Function;
+        [scopeName: string]: AnyFindOptions | Function;
 
     }
 
@@ -4916,7 +4924,7 @@ declare namespace sequelize {
          * Define the default search scope to use for this model. Scopes have the same form as the options passed to
          * find / findAll.
          */
-        defaultScope?: FindOptions;
+        defaultScope?: AnyFindOptions;
 
         /**
          * More scopes, defined in the same way as defaultScope above. See `Model.scope` for more information about

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -983,7 +983,7 @@ User.create( { title : 'Chair', creator : { first_name : 'Matt', last_name : 'Ha
 User.create( { id : 1, title : 'e', Tags : [{ id : 1, name : 'c' }, { id : 2, name : 'd' }] }, { include : [User] } );
 User.create( { id : 'My own ID!' } ).then( ( i ) => i.isNewRecord );
 
-let findOrRetVal: Bluebird<[AnyInstance, boolean]>;
+let findOrRetVal: Promise<[AnyInstance, boolean]>;
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' } } );
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, transaction : t } );
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, defaults : { foo : 'asd' }, transaction : t } );
@@ -1318,7 +1318,7 @@ s.define( 'ProductWithSettersAndGetters1', {
         get : function() {
             return 'answer = ' + this.getDataValue( 'price' );
         },
-        set : function( v ) {
+        set : function( v: number ) {
             return this.setDataValue( 'price', v + 42 );
         }
     }
@@ -1436,6 +1436,37 @@ s.define( 'ScopeMe', {
         }
     }
 } );
+
+// Generic find options
+interface ChairAttributes {
+    id: number;
+    color: string;
+    legs: number;
+}
+interface ChairInstance extends Sequelize.Instance<ChairAttributes> {}
+
+const Chair = s.define<ChairInstance, ChairAttributes>('chair', {});
+
+Chair.findAll({
+    where: {
+        color: 'blue',
+        legs: { $in: [3, 4] },
+    },
+});
+
+// If you want to use a property that isn't explicitly on the model's Attributes
+// use the find-function's generic type parameter.
+Chair.findAll<{ customProperty: number }>({
+    where: {
+        customProperty: 123,
+    }
+});
+Chair.findAll<any>({
+    where: {
+        customProperty1: 123,
+        customProperty2: 456,
+    }
+});
 
 s.define( 'ScopeMe', {
     username : Sequelize.STRING,
@@ -1640,21 +1671,21 @@ s.transaction({
     });
 
 s.transaction( function() {
-    return Bluebird.resolve();
+    return Promise.resolve();
 } );
-s.transaction( { isolationLevel : 'SERIALIZABLE' }, function( t ) { return Bluebird.resolve(); } );
-s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, (t) => Bluebird.resolve() );
-s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, (t) => Bluebird.resolve() );
+s.transaction( { isolationLevel : 'SERIALIZABLE' }, function( t ) { return Promise.resolve(); } );
+s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, (t) => Promise.resolve() );
+s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, (t) => Promise.resolve() );
 
 // transaction types
 new Sequelize( '', { transactionType: 'DEFERRED' } );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.DEFERRED} );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.IMMEDIATE} );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.EXCLUSIVE} );
-s.transaction( { type : 'DEFERRED' }, (t) => Bluebird.resolve() );
-s.transaction( { type : s.Transaction.TYPES.DEFERRED }, (t) => Bluebird.resolve() );
-s.transaction( { type : s.Transaction.TYPES.IMMEDIATE }, (t) => Bluebird.resolve() );
-s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Bluebird.resolve() );
+s.transaction( { type : 'DEFERRED' }, (t) => Promise.resolve() );
+s.transaction( { type : s.Transaction.TYPES.DEFERRED }, (t) => Promise.resolve() );
+s.transaction( { type : s.Transaction.TYPES.IMMEDIATE }, (t) => Promise.resolve() );
+s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Promise.resolve() );
 
 // promise transaction
 s.transaction(async () => {
@@ -1662,11 +1693,16 @@ s.transaction(async () => {
 s.transaction((): Promise<void> => {
     return Promise.resolve();
 });
-s.transaction((): Bluebird<void> => {
-    return Bluebird.resolve();
+s.transaction((): Promise<void> => {
+    return Promise.resolve();
 });
 s.transaction((): Q.Promise<void> => {
     return Q.Promise<void>((resolve) => {
+        resolve(null);
+    });
+});
+s.transaction((): Bluebird<void> => {
+    return new Bluebird<void>((resolve) => {
         resolve(null);
     });
 });

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -983,7 +983,7 @@ User.create( { title : 'Chair', creator : { first_name : 'Matt', last_name : 'Ha
 User.create( { id : 1, title : 'e', Tags : [{ id : 1, name : 'c' }, { id : 2, name : 'd' }] }, { include : [User] } );
 User.create( { id : 'My own ID!' } ).then( ( i ) => i.isNewRecord );
 
-let findOrRetVal: Promise<[AnyInstance, boolean]>;
+let findOrRetVal: Bluebird<[AnyInstance, boolean]>;
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' } } );
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, transaction : t } );
 findOrRetVal = User.findOrInitialize( { where : { username : 'foo' }, defaults : { foo : 'asd' }, transaction : t } );
@@ -1698,11 +1698,6 @@ s.transaction((): Promise<void> => {
 });
 s.transaction((): Q.Promise<void> => {
     return Q.Promise<void>((resolve) => {
-        resolve(null);
-    });
-});
-s.transaction((): Bluebird<void> => {
-    return new Bluebird<void>((resolve) => {
         resolve(null);
     });
 });

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -1671,21 +1671,21 @@ s.transaction({
     });
 
 s.transaction( function() {
-    return Promise.resolve();
+    return Bluebird.resolve();
 } );
-s.transaction( { isolationLevel : 'SERIALIZABLE' }, function( t ) { return Promise.resolve(); } );
-s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, (t) => Promise.resolve() );
-s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, (t) => Promise.resolve() );
+s.transaction( { isolationLevel : 'SERIALIZABLE' }, function( t ) { return Bluebird.resolve(); } );
+s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.SERIALIZABLE }, (t) => Bluebird.resolve() );
+s.transaction( { isolationLevel : s.Transaction.ISOLATION_LEVELS.READ_COMMITTED }, (t) => Bluebird.resolve() );
 
 // transaction types
 new Sequelize( '', { transactionType: 'DEFERRED' } );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.DEFERRED} );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.IMMEDIATE} );
 new Sequelize( '', { transactionType: Sequelize.Transaction.TYPES.EXCLUSIVE} );
-s.transaction( { type : 'DEFERRED' }, (t) => Promise.resolve() );
-s.transaction( { type : s.Transaction.TYPES.DEFERRED }, (t) => Promise.resolve() );
-s.transaction( { type : s.Transaction.TYPES.IMMEDIATE }, (t) => Promise.resolve() );
-s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Promise.resolve() );
+s.transaction( { type : 'DEFERRED' }, (t) => Bluebird.resolve() );
+s.transaction( { type : s.Transaction.TYPES.DEFERRED }, (t) => Bluebird.resolve() );
+s.transaction( { type : s.Transaction.TYPES.IMMEDIATE }, (t) => Bluebird.resolve() );
+s.transaction( { type : s.Transaction.TYPES.EXCLUSIVE }, (t) => Bluebird.resolve() );
 
 // promise transaction
 s.transaction(async () => {
@@ -1693,8 +1693,8 @@ s.transaction(async () => {
 s.transaction((): Promise<void> => {
     return Promise.resolve();
 });
-s.transaction((): Promise<void> => {
-    return Promise.resolve();
+s.transaction((): Bluebird<void> => {
+    return Bluebird.resolve();
 });
 s.transaction((): Q.Promise<void> => {
     return Q.Promise<void>((resolve) => {


### PR DESCRIPTION
This turns WhereOptions and FindOptions into generic types, which can then check that you are using the correct column names, in the find* functions (findOne, findAll etc.). In other places where there is no attributes type available, fall back to the old behaviour of allowing any field names (now with types named AnyWhereOptions and AnyFindOptions).

This allows typescript to catch more errors, e.g.

`User.findOne({ where: { firstName: 'Bob' } });`
vs.
`User.findOne({ where: { first_name: 'Bob' } });`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [findAll documentation, with example of using `where` options with properties of the model attributes](http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-findAll).
- [x] ~Increase the version number in the header if appropriate.~
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
