### PR TITLE
fix: `node` in module `readline`, `cursorTo` should allow only x coordinate

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1731,7 +1731,7 @@ declare module "readline" {
     export function createInterface(input: NodeJS.ReadableStream, output?: NodeJS.WritableStream, completer?: Completer | AsyncCompleter, terminal?: boolean): ReadLine;
     export function createInterface(options: ReadLineOptions): ReadLine;
 
-    export function cursorTo(stream: NodeJS.WritableStream, x: number, y: number): void;
+    export function cursorTo(stream: NodeJS.WritableStream, x: number, y?: number): void;
     export function moveCursor(stream: NodeJS.WritableStream, dx: number | string, dy: number | string): void;
     export function clearLine(stream: NodeJS.WritableStream, dir: number): void;
     export function clearScreenDown(stream: NodeJS.WritableStream): void;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1410,6 +1410,7 @@ namespace readline_tests {
         let x: number;
         let y: number;
 
+        readline.cursorTo(stream, x);
         readline.cursorTo(stream, x, y);
     }
 


### PR DESCRIPTION
fix: `node` in module `readline`, `cursorTo` should allow only x coordinate

Like this we are easily able to move in the current line with absolute x-axis coordinate.

This is unfortunately not described in the `readline` documentation (https://nodejs.org/api/readline.html), but this is used in the `readline` source code:
- https://github.com/nodejs/node/blob/master/lib/readline.js#L346
- https://github.com/nodejs/node/blob/master/lib/readline.js#L359
And we can see that a normal behaviour is made when `y` is `undefined`: 
https://github.com/nodejs/node/blob/master/lib/readline.js#L1071

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
