### PR TITLE
@types/mapbox-gl: allow StyleFunction for circle-color

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mapbox GL JS v0.39.0
+// Type definitions for Mapbox GL JS v0.39.1
 // Project: https://github.com/mapbox/mapbox-gl-js
 // Definitions by: Dominik Bruderer <https://github.com/dobrud>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -706,7 +706,7 @@ declare namespace mapboxgl {
 		angleWidth(p: Point): number;
 
 		angleWithSep(x: number, y: number): number;
-		
+
 		convert(a: Array<number> | Point): Point;
 	}
 
@@ -1045,7 +1045,7 @@ declare namespace mapboxgl {
 	export interface CirclePaint {
 		"circle-radius"?: number | StyleFunction;
 		"circle-radius-transition"?: Transition;
-		"circle-color"?: string;
+		"circle-color"?: string | StyleFunction;
 		"circle-blur"?: number | StyleFunction;
 		"circle-opacity"?: number | StyleFunction;
 		"circle-translate"?: number[];


### PR DESCRIPTION
Fix regression in CirclePaint definition (StyleFunction was incorrectly removed from circle-color type set) [See reference documentation](https://www.mapbox.com/mapbox-gl-js/style-spec/#types-function)

@dobrud