### PR TITLE
[heremaps] fix types for H.map.layer.ObjectLayer() and H.service.Platform.createDefaultLayers()

### DIFF
--- a/types/heremaps/heremaps-tests.ts
+++ b/types/heremaps/heremaps-tests.ts
@@ -160,3 +160,16 @@ enterprieseRouter.calculateIsoline(
         console.log(error);
     }
 );
+
+// Create a clustering provider
+const clusteredDataProvider = new H.clustering.Provider([], {
+clusteringOptions: {
+  // Maximum radius of the neighborhood
+  eps: 64,
+  // minimum weight of points required to form a cluster
+  minWeight: 3
+}
+});
+
+// Create a layer that will consume objects from our clustering provider
+const layer = new H.map.layer.ObjectLayer(clusteredDataProvider);

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -2938,7 +2938,7 @@ declare namespace H {
                  * @param provider {H.map.provider.ObjectProvider} - the ObjectProvider which provides the map objects to this object layer.
                  * @param opt_options {H.map.layer.ObjectLayer.Options=} - The options for this layer
                  */
-                constructor(provider: H.map.provider.ObjectProvider, opt_options?: H.map.layer.ObjectLayer.Options);
+                constructor(provider: H.map.provider.ObjectProvider | H.clustering.Provider, opt_options?: H.map.layer.ObjectLayer.Options);
 
                 /**
                  * This method returns current ObjectLayer's data provider

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -4496,7 +4496,7 @@ declare namespace H {
              */
             createDefaultLayers(opt_tileSize?: (H.service.Platform.DefaultLayersOptions | number), opt_ppi?: number,
                                 opt_lang?: string, opt_secondaryLang?: string, opt_style?: string,
-                                opt_pois?: (string | boolean)): H.service.Platform.MapTypes | H.service.DefaultLayers;
+                                opt_pois?: (string | boolean)): H.service.DefaultLayers;
 
             /**
              * This method returns an instance of H.service.RoutingService to query the Routing API.
@@ -5694,7 +5694,7 @@ declare namespace H {
              * @param opt_locale {(H.ui.i18n.Localization | string)=} - the language to use (or a full localization object).
              * @returns {H.ui.UI} - the UI instance configured with the default controls
              */
-            static createDefault(map: H.Map, mapTypes: H.service.Platform.MapTypes | H.service.MapType | H.service.DefaultLayers, opt_locale?: H.ui.i18n.Localization | string): H.ui.UI;
+            static createDefault(map: H.Map, mapTypes: H.service.Platform.MapTypes | H.service.DefaultLayers, opt_locale?: H.ui.i18n.Localization | string): H.ui.UI;
 
             /**
              * This method is used to capture the element view

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -4018,6 +4018,17 @@ declare namespace H {
         }
 
         /**
+         * This property specifies collection of pre-configured HERE layers
+         */
+        interface DefaultLayers {
+            normal: H.service.MapType;
+            satellite: H.service.MapType;
+            terrain: H.service.MapType;
+            incidents: H.map.layer.MarkerTileLayer;
+            venues: H.map.layer.TileLayer;
+        }
+
+        /**
          * This class encapsulates Enterprise Routing REST API as a service stub. An instance of this class can be retrieved by calling the factory method on a platform instance.
          * H.service.Platform#getEnterpriseRoutingService.
          */
@@ -4473,17 +4484,18 @@ declare namespace H {
             /**
              * This method creates a pre-configured set of HERE tile layers for convenient use with the map.
              * @param opt_tileSize {(H.service.Platform.DefaultLayersOptions | number)=} - When a number – optional tile size to be queried from the HERE Map Tile API, default is 256.
-             * If theparameter is an object, then it represents options and all remaining below parameters should be omitted.
+             * If this parameter is a number, it indicates the tile size to be queried from the HERE Map Tile API (the default value is 256); if this parameter is an object, it represents configuration options for the layer and all the remaining parameters (below) should be omitted
              * @param opt_ppi {number=} - optional 'ppi' parameter to use when querying tiles, default is not specified
              * @param opt_lang {string=} - optional primary language parameter, default is not specified
              * @param opt_secondaryLang {string=} - optional secondary language parameter, default is not specified
              * @param opt_style {string=} - optional 'style' parameter to use when querying map tiles, default is not specified
              * @param opt_pois {(string | boolean)=} - indicates if pois are displayed on the map. Pass true to indicate that all pois should be visible. Alternatively you can specify mask for the
              * POI Categories as described at the Map Tile API documentation POI Categories chapter.
-             * @returns {Object<string, H.service.MapType>} - a set of tile layers ready to use
+             * @returns {H.service.DefaultLayers} - a set of tile layers ready to use
              */
-            createDefaultLayers(opt_tileSize?: (H.service.Platform.DefaultLayersOptions | number), opt_ppi?: number, opt_lang?: string, opt_secondaryLang?: string, opt_style?: string,
-                                opt_pois?: (string | boolean)): H.service.Platform.MapTypes;
+            createDefaultLayers(opt_tileSize?: (H.service.Platform.DefaultLayersOptions | number), opt_ppi?: number, 
+                                opt_lang?: string, opt_secondaryLang?: string, opt_style?: string,
+                                opt_pois?: (string | boolean)): H.service.DefaultLayers;
 
             /**
              * This method returns an instance of H.service.RoutingService to query the Routing API.
@@ -5681,7 +5693,7 @@ declare namespace H {
              * @param opt_locale {(H.ui.i18n.Localization | string)=} - the language to use (or a full localization object).
              * @returns {H.ui.UI} - the UI instance configured with the default controls
              */
-            static createDefault(map: H.Map, mapTypes: H.service.Platform.MapTypes, opt_locale?: H.ui.i18n.Localization | string): UI;
+            static createDefault(map: H.Map, mapTypes: H.service.MapType | H.service.DefaultLayers, opt_locale?: H.ui.i18n.Localization | string): H.ui.UI;
 
             /**
              * This method is used to capture the element view

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -4496,7 +4496,7 @@ declare namespace H {
              */
             createDefaultLayers(opt_tileSize?: (H.service.Platform.DefaultLayersOptions | number), opt_ppi?: number,
                                 opt_lang?: string, opt_secondaryLang?: string, opt_style?: string,
-                                opt_pois?: (string | boolean)): H.service.DefaultLayers;
+                                opt_pois?: (string | boolean)): H.service.Platform.MapTypes | H.service.DefaultLayers;
 
             /**
              * This method returns an instance of H.service.RoutingService to query the Routing API.
@@ -5694,7 +5694,7 @@ declare namespace H {
              * @param opt_locale {(H.ui.i18n.Localization | string)=} - the language to use (or a full localization object).
              * @returns {H.ui.UI} - the UI instance configured with the default controls
              */
-            static createDefault(map: H.Map, mapTypes: H.service.MapType | H.service.DefaultLayers, opt_locale?: H.ui.i18n.Localization | string): H.ui.UI;
+            static createDefault(map: H.Map, mapTypes: H.service.Platform.MapTypes | H.service.MapType | H.service.DefaultLayers, opt_locale?: H.ui.i18n.Localization | string): H.ui.UI;
 
             /**
              * This method is used to capture the element view

--- a/types/heremaps/index.d.ts
+++ b/types/heremaps/index.d.ts
@@ -4484,7 +4484,8 @@ declare namespace H {
             /**
              * This method creates a pre-configured set of HERE tile layers for convenient use with the map.
              * @param opt_tileSize {(H.service.Platform.DefaultLayersOptions | number)=} - When a number – optional tile size to be queried from the HERE Map Tile API, default is 256.
-             * If this parameter is a number, it indicates the tile size to be queried from the HERE Map Tile API (the default value is 256); if this parameter is an object, it represents configuration options for the layer and all the remaining parameters (below) should be omitted
+             * If this parameter is a number, it indicates the tile size to be queried from the HERE Map Tile API (the default value is 256); if this parameter is an object, it represents
+             * configuration options for the layer and all the remaining parameters (below) should be omitted
              * @param opt_ppi {number=} - optional 'ppi' parameter to use when querying tiles, default is not specified
              * @param opt_lang {string=} - optional primary language parameter, default is not specified
              * @param opt_secondaryLang {string=} - optional secondary language parameter, default is not specified
@@ -4493,7 +4494,7 @@ declare namespace H {
              * POI Categories as described at the Map Tile API documentation POI Categories chapter.
              * @returns {H.service.DefaultLayers} - a set of tile layers ready to use
              */
-            createDefaultLayers(opt_tileSize?: (H.service.Platform.DefaultLayersOptions | number), opt_ppi?: number, 
+            createDefaultLayers(opt_tileSize?: (H.service.Platform.DefaultLayersOptions | number), opt_ppi?: number,
                                 opt_lang?: string, opt_secondaryLang?: string, opt_style?: string,
                                 opt_pois?: (string | boolean)): H.service.DefaultLayers;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://developer.here.com/api-explorer/maps-js/v3.0/clustering/custom-cluster-theme>, <https://developer.here.com/javascript-apis/documentation/v3/maps/topics_api/h-service-platform.html#h-service-platform__createdefaultlayers> and <https://developer.here.com/javascript-apis/documentation/v3/maps/topics_api/h-ui-ui.html#h-ui-ui__createdefault-static>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
