### PR TITLE
Implement dom-inputevent

### DIFF
--- a/types/dom-inputevent/dom-inputevent-tests.ts
+++ b/types/dom-inputevent/dom-inputevent-tests.ts
@@ -1,0 +1,10 @@
+const input = document.createElement('input');
+input.addEventListener('input', (event: InputEvent) => {
+    return event.data === 'foo' && event.isComposing === true;
+});
+
+const foo = new InputEvent('input');
+const bar = new InputEvent('beforeinput', {
+    data: 'bar',
+    isComposing: true,
+});

--- a/types/dom-inputevent/index.d.ts
+++ b/types/dom-inputevent/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for UI Events W3C Working Draft — Input Events — Interface InputEvent 1.0
+// Project: https://w3c.github.io/uievents/#interface-inputevent
+// Definitions by: Steven Sinatra <https://github.com/diagramatics>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface InputEventInit extends UIEventInit {
+    data?: string;
+    isComposing: boolean;
+}
+interface InputEvent extends UIEvent {
+    readonly data: string;
+    readonly isComposing: boolean;
+}
+
+declare class InputEvent {
+    constructor(typeArg: 'input' | 'beforeinput', inputEventInit?: InputEventInit);
+}

--- a/types/dom-inputevent/tsconfig.json
+++ b/types/dom-inputevent/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "dom-inputevent-tests.ts"
+    ]
+}

--- a/types/dom-inputevent/tslint.json
+++ b/types/dom-inputevent/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is my first foray into TypeScript definitions, so sorry if this is all messed up.

This is an implementation of [DOM InputEvent](https://w3c.github.io/uievents/#interface-inputevent), which is usable as the event types returned by the `beforeinput` and `input` events as well as  `EventEmitter<InputEvent>` for Angular code when using `@Output('click')`. It's still a Working Draft unfortunately.

I'm not sure if I can just implement a subset of the UI Events spec or do I need to have a type package that implements (or should implement) all of the ones that have changed, so I named it as `dom-inputevent` for now.