### PR TITLE
[react] Add example of default state being null.

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -196,7 +196,7 @@ declare namespace React {
     type ReactInstance = Component<any> | Element;
 
     // Base component for plain JS classes
-    interface Component<P = {}, S = {}> extends ComponentLifecycle<P, S> { }
+    interface Component<P = {}, S = null> extends ComponentLifecycle<P, S> { }
     class Component<P, S> {
         constructor(props?: P, context?: any);
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -53,6 +53,10 @@ class ComponentWithPropsAndState extends React.Component<Props, State> {
 <ComponentWithPropsAndState hello="TypeScript" />
 
 class ComponentWithoutState extends React.Component<Props> {
+    render() {
+        const result: null = this.state
+        return result
+    }
 }
 <ComponentWithoutState hello="TypeScript" />
 


### PR DESCRIPTION
The React default for the `state` property of a component class is `null`. There aren’t any docs I could find that specifically mention this, nor was I able to easily pinpoint the location that `state` gets set to `null`, but by testing at runtime I can empirically say that it is the case.

E.g. here’s an example from using React 15.6.1 on [the React site](https://facebook.github.io/react/):

<img width="949" alt="screen shot 2017-07-03 at 12 10 37" src="https://user-images.githubusercontent.com/2320/27790860-b57b505c-5ff2-11e7-8fb2-9feb57b5852e.png">

I tried to start on a full PR, but it quickly developed into a rabbit hole, so in the end I backed out and figured I’d open a PR that adds a test and very naively shows what needs to be changed, hoping that it would be enough for the maintainers to know exactly how to full implement this.

/cc @pspeter3 @vsiao @johnnyreilly @bbenezech @pzavolinsky @digiguru @ericanderson @morcerf @tkrotoff