### PR TITLE
[express] fix accepts return

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -239,9 +239,9 @@ interface Request extends http.IncomingMessage, Express.Request {
         *     // => "json"
         */
     accepts(): string[];
-    accepts(type: string): string | boolean;
-    accepts(type: string[]): string | boolean;
-    accepts(...type: string[]): string | boolean;
+    accepts(type: string): string | false;
+    accepts(type: string[]): string | false;
+    accepts(...type: string[]): string | false;
 
     /**
         * Returns the first accepted charset of the specified character sets,
@@ -252,9 +252,9 @@ interface Request extends http.IncomingMessage, Express.Request {
         * @param charset
         */
     acceptsCharsets(): string[];
-    acceptsCharsets(charset: string): string | boolean;
-    acceptsCharsets(charset: string[]): string | boolean;
-    acceptsCharsets(...charset: string[]): string | boolean;
+    acceptsCharsets(charset: string): string | false;
+    acceptsCharsets(charset: string[]): string | false;
+    acceptsCharsets(...charset: string[]): string | false;
 
     /**
         * Returns the first accepted encoding of the specified encodings,
@@ -265,9 +265,9 @@ interface Request extends http.IncomingMessage, Express.Request {
         * @param encoding
         */
     acceptsEncodings(): string[];
-    acceptsEncodings(encoding: string): string | boolean;
-    acceptsEncodings(encoding: string[]): string | boolean;
-    acceptsEncodings(...encoding: string[]): string | boolean;
+    acceptsEncodings(encoding: string): string | false;
+    acceptsEncodings(encoding: string[]): string | false;
+    acceptsEncodings(...encoding: string[]): string | false;
 
     /**
         * Returns the first accepted language of the specified languages,
@@ -279,9 +279,9 @@ interface Request extends http.IncomingMessage, Express.Request {
         * @param lang
         */
     acceptsLanguages(): string[];
-    acceptsLanguages(lang: string): string | boolean;
-    acceptsLanguages(lang: string[]): string | boolean;
-    acceptsLanguages(...lang: string[]): string | boolean;
+    acceptsLanguages(lang: string): string | false;
+    acceptsLanguages(lang: string[]): string | false;
+    acceptsLanguages(...lang: string[]): string | false;
 
     /**
         * Parse Range header field,

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -51,22 +51,22 @@ namespace express_tests {
     router.route('/users')
     .get((req, res, next) => {
         let types: string[] = req.accepts();
-        let type: string | boolean = req.accepts('json');
+        let type: string | false = req.accepts('json');
         type = req.accepts(['json', 'text']);
         type = req.accepts('json', 'text');
 
         let charsets: string[] = req.acceptsCharsets();
-        let charset: string | boolean = req.acceptsCharsets('utf-8');
+        let charset: string | false = req.acceptsCharsets('utf-8');
         charset = req.acceptsCharsets(['utf-8', 'utf-16']);
         charset = req.acceptsCharsets('utf-8', 'utf-16');
 
         let encodings: string[] = req.acceptsEncodings();
-        let encoding: string | boolean = req.acceptsEncodings('gzip');
+        let encoding: string | false = req.acceptsEncodings('gzip');
         encoding = req.acceptsEncodings(['gzip', 'deflate']);
         encoding = req.acceptsEncodings('gzip', 'deflate');
 
         let languages: string[] = req.acceptsLanguages();
-        let language: string | boolean = req.acceptsLanguages('en');
+        let language: string | false = req.acceptsLanguages('en');
         language = req.acceptsLanguages(['en', 'ja']);
         language = req.acceptsLanguages('en', 'ja');
 


### PR DESCRIPTION
accepts/acceptsCharsets/acceptsEncodings/acceptsLanguages methods return `string | false` and not `string | boolean`
These methods internally use the `accepts` module which already have the right [typing](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/accepts/index.d.ts).