### PR TITLE
[archiver] defer to Readable.pipe instead of our own pipe

### DIFF
--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -44,8 +44,6 @@ declare namespace archiver {
         glob(pattern: string, options?: glob.IOptions, data?: EntryData): this;
         finalize(): this;
 
-        pipe(stream: stream.Writable): void;
-
         setFormat(format: string): this;
         setModule(module: Function): this;
 


### PR DESCRIPTION
Because archiver inherits from `stream.Transform`, which in turn inherits from `stream.Readable`, and because archiver doesn't overwrite the implementation of `pipe`,  we should use the definition of `pipe` provided by the parent types.

This fixes compilation errors with typescript 2.4.1, where typescript sees `Writable` as a more restrictive form of `T extends WritableStream`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/archiverjs/node-archiver/blob/master/lib/core.js#L70]
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
