### PR TITLE
[request-promise] expose request_promise as a promise

### DIFF
--- a/types/request-promise/index.d.ts
+++ b/types/request-promise/index.d.ts
@@ -13,7 +13,6 @@ declare namespace requestPromise {
     type RequestAndPromise<T> = request.Request & Promise<T>;
     interface RequestPromise extends RequestAndPromise<any> {
         promise(): Promise<any>;
-        cancel(): void;
     }
 
     interface RequestPromiseOptions extends request.CoreOptions {

--- a/types/request-promise/index.d.ts
+++ b/types/request-promise/index.d.ts
@@ -10,8 +10,7 @@ import errors = require('request-promise/errors');
 import Promise = require('bluebird');
 
 declare namespace requestPromise {
-    type RequestAndPromise<T> = request.Request & Promise<T>;
-    interface RequestPromise extends RequestAndPromise<any> {
+    interface RequestPromise extends request.Request, Promise<any> {
         promise(): Promise<any>;
     }
 

--- a/types/request-promise/index.d.ts
+++ b/types/request-promise/index.d.ts
@@ -10,13 +10,8 @@ import errors = require('request-promise/errors');
 import Promise = require('bluebird');
 
 declare namespace requestPromise {
-    interface RequestPromise extends request.Request {
-        then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void | TResult | PromiseLike<TResult>): Promise<TResult>;
-        catch(onrejected?: (reason: any) => any | PromiseLike<any>): Promise<any>;
-        catch(type: errors.RequestErrorConstructor, onrejected?: (reason: errors.RequestError) => void): Promise<any>;
-        catch(type: errors.StatusCodeErrorConstructor, onrejected?: (reason: errors.StatusCodeError) => void): Promise<any>;
-        catch(type: errors.TransformErrorConstructor, onrejected?: (reason: errors.TransformError) => void): Promise<any>;
-        finally<TResult>(handler: () => TResult | PromiseLike<TResult>): Promise<any>;
+    type RequestAndPromise<T> = request.Request & Promise<T>;
+    interface RequestPromise extends RequestAndPromise<any> {
         promise(): Promise<any>;
         cancel(): void;
     }


### PR DESCRIPTION
Because request-promise exposes Bluebird methods on top of a Request, we should just mixin those signatures to prevent any clashes of types.

This fixes breakages for this typing on Typescript 2.4.1.


Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/request/request-promise/blob/master/lib/rp.js#L31
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.