### PR TITLE
[request-promise-native] expose request-promise-native as a promise

### DIFF
--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -8,8 +8,7 @@ declare module 'request-promise-native' {
     import http = require('http');
 
     namespace requestPromise {
-        type RequestAndPromise<T> = request.Request & Promise<T>
-        interface RequestPromise extends RequestAndPromise<any> {
+        interface RequestPromise extends request.Request, Promise<any> {
             promise(): Promise<any>;
         }
 

--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -8,11 +8,9 @@ declare module 'request-promise-native' {
     import http = require('http');
 
     namespace requestPromise {
-        interface RequestPromise extends request.Request {
-            then<TResult>(onfulfilled?: (value: any) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult> | void): Promise<TResult>;
-            catch(onrejected?: (reason: any) => any | PromiseLike<any> | void): Promise<any>;
+        type RequestAndPromise<T> = request.Request & Promise<T>
+        interface RequestPromise extends RequestAndPromise<any> {
             promise(): Promise<any>;
-            cancel(): void;
         }
 
         interface RequestPromiseOptions extends request.CoreOptions {


### PR DESCRIPTION
Because request-promise-native exposes native Promise methods on top of a Request, we should just mixin those signatures to prevent any clashes of types.

This fixes breakages for this typing on Typescript 2.4.1.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/request/request-promise-native/blob/master/lib/rp.js#L17
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
