### PR TITLE
Swiper: Added missing/new callbacks from 3.4.2 and `wrapper` + `virtualSize` properties

### DIFF
--- a/types/swiper/index.d.ts
+++ b/types/swiper/index.d.ts
@@ -241,6 +241,7 @@ declare class Swiper {
     height: number;
     params: any;
     positions: any;
+    virtualSize: number;
 
     // Feature detection
     support: {

--- a/types/swiper/index.d.ts
+++ b/types/swiper/index.d.ts
@@ -193,6 +193,10 @@ interface SwiperOptions {
     onLazyImageLoad?(swiper: Swiper, slide: any, image: any): void;
     onLazyImageReady?(swiper: Swiper, slide: any, image: any): void;
     onPaginationRendered?(swiper: Swiper, paginationContainer: any): void;
+    onScroll?(swiper: Swiper, event: Event): void;
+    onBeforeResize?(swiper: Swiper): void;
+    onAfterResize?(swiper: Swiper): void;
+    onKeyPress?(swiper: Swiper, kc: any): void;
 
     // Namespace
     slideClass?: string;

--- a/types/swiper/index.d.ts
+++ b/types/swiper/index.d.ts
@@ -241,6 +241,7 @@ declare class Swiper {
     height: number;
     params: any;
     positions: any;
+    wrapper: any;
     virtualSize: number;
 
     // Feature detection


### PR DESCRIPTION
Added new callbacks from 3.4.2: `onBeforeReize`, `onAfterResize` and `onKeyPress` 
see https://github.com/nolimits4web/Swiper/blob/master/CHANGELOG.md

Also added missing callback `onScroll` and `wrapper` + `virtualSize` properties.