### PR TITLE
react-dropzone: Use namespace for importing

### DIFF
--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -7,38 +7,43 @@
 /// <reference types="react"/>
 
 declare module "react-dropzone" {
-    interface DropzoneProps {
-        // Drop behavior
-        onDrop?: (accepted: File[], rejected: File[]) => any;
-        onDropAccepted?: (accepted: File[]) => any;
-        onDropRejected?: (rejected: File[]) => any;
 
-        // Drag behavior
-        onDragStart?: Function;
-        onDragEnter?: Function;
-        onDragLeave?: Function;
+    import * as React from "react";
 
-        style?: React.CSSProperties; // CSS styles to apply
-        activeStyle?: React.CSSProperties; // CSS styles to apply when drop will be accepted
-        rejectStyle?: React.CSSProperties; // CSS styles to apply when drop will be rejected
-        className?: string; // Optional className
-        activeClassName?: string; // className for accepted state
-        rejectClassName?: string; // className for rejected state
+    namespace Dropzone {
+        interface DropzoneProps {
+            // Drop behavior
+            onDrop?: (accepted: File[], rejected: File[]) => any;
+            onDropAccepted?: (accepted: File[]) => any;
+            onDropRejected?: (rejected: File[]) => any;
 
-        disablePreview?: boolean; // Enable/disable preview generation
-        disableClick?: boolean; // Disallow clicking on the dropzone container to open file dialog
+            // Drag behavior
+            onDragStart?: Function;
+            onDragEnter?: Function;
+            onDragLeave?: Function;
 
-        inputProps?: React.ChangeTargetHTMLProps<HTMLInputElement>; // Pass additional attributes to the <input type="file"/> tag
-        multiple?: boolean; // Allow dropping multiple files
-        accept?: string; // Allow specific types of files. See https://github.com/okonet/attr-accept for more information
-        name?: string; // name attribute for the input tag
-        maxSize?: number;
-        minSize?: number;
+            style?: React.CSSProperties; // CSS styles to apply
+            activeStyle?: React.CSSProperties; // CSS styles to apply when drop will be accepted
+            rejectStyle?: React.CSSProperties; // CSS styles to apply when drop will be rejected
+            className?: string; // Optional className
+            activeClassName?: string; // className for accepted state
+            rejectClassName?: string; // className for rejected state
 
-        onFileDialogCancel?: () => void;
+            disablePreview?: boolean; // Enable/disable preview generation
+            disableClick?: boolean; // Disallow clicking on the dropzone container to open file dialog
+
+            inputProps?: React.ChangeTargetHTMLProps<HTMLInputElement>; // Pass additional attributes to the <input type="file"/> tag
+            multiple?: boolean; // Allow dropping multiple files
+            accept?: string; // Allow specific types of files. See https://github.com/okonet/attr-accept for more information
+            name?: string; // name attribute for the input tag
+            maxSize?: number;
+            minSize?: number;
+
+            onFileDialogCancel?: () => void;
+        }
     }
 
-    class Dropzone extends React.Component<DropzoneProps, never> {
+    class Dropzone extends React.Component<Dropzone.DropzoneProps, never> {
         open(): void;
     }
 

--- a/types/react-dropzone/react-dropzone-tests.tsx
+++ b/types/react-dropzone/react-dropzone-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Dropzone = require('react-dropzone');
+import * as Dropzone from 'react-dropzone';
 
 class Test extends React.Component {
   constructor(props: any) {


### PR DESCRIPTION
Fixes `error TS2497: Module '"react-dropzone"' resolves to a non-module entity and cannot be imported using this construct.` when using:

```
import * as Dropzone from 'react-dropzone';
```