### PR TITLE
Improve type of HandlebarsTemplateDelegate

### DIFF
--- a/types/handlebars/handlebars-tests.ts
+++ b/types/handlebars/handlebars-tests.ts
@@ -36,7 +36,7 @@ var post = { url: '/hello-world', body: 'Hello World!' };
 var context2 = { posts: [post] };
 var source2 = '<ul>{{#posts}}<li>{{{link_to this}}}</li>{{/posts}}</ul>';
 
-var template2 = Handlebars.compile(source2);
+var template2: HandlebarsTemplateDelegate<{ posts: { url: string, body: string }[] }> = Handlebars.compile(source2);
 template2(context2);
 
 Handlebars.registerHelper('link_to', (title: string, context: typeof post) => {

--- a/types/handlebars/handlebars-tests.ts
+++ b/types/handlebars/handlebars-tests.ts
@@ -45,14 +45,14 @@ Handlebars.registerHelper('link_to', (title: string, context: typeof post) => {
 
 var context3 = { posts: [{url: '/hello-world', body: 'Hello World!'}] };
 var source3 = '<ul>{{#posts}}<li>{{{link_to "Post" this}}}</li>{{/posts}}</ul>';
-var template3 = Handlebars.compile(source3);
+var template3 = Handlebars.compile<typeof context3>(source3);
 template3(context3);
 
 var source4 = '<ul>{{#people}}<li>{{#link}}{{name}}{{/link}}</li>{{/people}}</ul>';
 Handlebars.registerHelper('link', function(context: any) {
     return '<a href="/people/' + this.id + '">' + context.fn(this) + '</a>';
 });
-var template4 = Handlebars.compile(source4);
+var template4 = Handlebars.compile<{ people: { name: string, id: number }[] }>(source4);
 var data2 = { 'people': [
     { 'name': 'Alan', 'id': 1 },
     { 'name': 'Yehuda', 'id': 2 }

--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -19,9 +19,9 @@ declare namespace Handlebars {
     export function Exception(message: string): void;
     export function log(level: number, obj: any): void;
     export function parse(input: string): hbs.AST.Program;
-    export function compile(input: any, options?: CompileOptions): HandlebarsTemplateDelegate;
+    export function compile<T = any>(input: any, options?: CompileOptions): HandlebarsTemplateDelegate<T>;
     export function precompile(input: any, options?: PrecompileOptions): TemplateSpecification;
-    export function template(precompilation: TemplateSpecification): HandlebarsTemplateDelegate;
+    export function template<T = any>(precompilation: TemplateSpecification): HandlebarsTemplateDelegate<T>;
 
     export function create(): typeof Handlebars;
 

--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://handlebarsjs.com/
 // Definitions by: Boris Yankov <https://github.com/borisyankov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 
 declare namespace Handlebars {

--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -4,7 +4,6 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-
 declare namespace Handlebars {
     export function registerHelper(name: string, fn: Function, inverse?: boolean): void;
     export function registerHelper(name: Object): void;

--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -96,8 +96,8 @@ interface HandlebarsTemplatable {
     template: HandlebarsTemplateDelegate;
 }
 
-interface HandlebarsTemplateDelegate {
-    (context: any, options?: any): string;
+interface HandlebarsTemplateDelegate<T = any> {
+    (context: T, options?: RuntimeOptions): string;
 }
 
 interface HandlebarsTemplates {
@@ -106,6 +106,14 @@ interface HandlebarsTemplates {
 
 interface TemplateSpecification {
 
+}
+
+interface RuntimeOptions {
+    partial?: boolean;
+    depths?: any[];
+    helpers?: { [name: string]: Function }
+    partials?: { [name: string]: HandlebarsTemplateDelegate }
+    decorators?: { [name: string]: Function }
 }
 
 interface CompileOptions {

--- a/types/koa-hbs/index.d.ts
+++ b/types/koa-hbs/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/gilt/koa-hbs
 // Definitions by: Jacob Malone <https://github.com/jcbmln/>, Mudkip <https://github.com/mudkipme>
 // Definitions: https://github.com/jcbmln/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/swag/index.d.ts
+++ b/types/swag/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/elving/swag
 // Definitions by: Shogo Iwano <https://github.com/shiwano>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 /// <reference types="handlebars" />
 


### PR DESCRIPTION
Adds an optional type argument that should be useful for .hbs.d.ts files.

The RuntimeOptions were specified by looking at https://github.com/wycats/handlebars.js/blob/680ec96/lib/handlebars/runtime.js#L131-L171 -- these don't seem to be documented anywhere.

It may be better to just not specify a second argument, as I believe the second argument is intended to be internal.