### PR TITLE
Add ember-testing lib helpers.

### DIFF
--- a/types/ember-testing-helpers/ember-testing-helpers-tests.ts
+++ b/types/ember-testing-helpers/ember-testing-helpers-tests.ts
@@ -1,0 +1,79 @@
+function testAndThen() {
+    const result: RSVP.Promise<string> = andThen(() => "some string");
+    result.then(s => s.length);
+}
+
+function testClick() {
+    const result: RSVP.Promise<void> = click('someString');
+    result.then(() => {});
+}
+
+function testCurrentPath() {
+    const path = currentPath();
+    const chars = path.split('');
+}
+
+function testCurrentRouteName() {
+    const routeName = currentRouteName();
+    const isIndex = routeName === 'index';
+}
+
+function testCurrentURL() {
+    const url = currentURL();
+    const isIndex = url.match(/^\/$/);
+}
+
+function testFillIn() {
+    const textResult = fillIn('.foo', 'waffles');
+    textResult.then(() => true);
+    const contextResult = fillIn('.bar', { }, 'pancakes');
+    contextResult.catch(reason => false);
+}
+
+function testFind() {
+    const found = find('#quux');
+    found.addClass('has-ducks');
+
+    const foundInAContext = find('#baz', {});
+    foundInAContext.removeClass('can-cluck');
+}
+
+function testFindWithAssert() {
+    const found = findWithAssert('#quux');
+    found.addClass('has-ducks');
+
+    const foundInAContext = findWithAssert('#baz', {});
+    foundInAContext.removeClass('can-cluck');
+}
+
+function testKeyEvent() {
+    keyEvent('.some-button', 'keydown', 11).then(() => 11);
+    keyEvent('.some-button', 'keypress', 101).then(() => 101);
+    keyEvent('.some-button', 'keyup', 1001).then(() => 1001);
+}
+
+function testPauseTest() {
+    pauseTest().finally(() => {
+        const foo = 'fighters';
+    })
+}
+
+function testResumeTest() {
+    resumeTest();
+}
+
+function testTriggerEvent() {
+    triggerEvent('.something', {}, 'click', {}).then(() => 'yay');
+    triggerEvent('.something', 'mousedown').then(() => 'no');
+    triggerEvent('.something', {}, 'fetch').then(() => 'huzzah');
+    triggerEvent('.something', 'keydown').then(() => 'whomp whomp');
+}
+
+function testVisit() {
+    visit('some/url').then(() => {})
+}
+
+function testWait() {
+    const waited = wait('whatever');
+    waited.then((s: string) => s.length);
+}

--- a/types/ember-testing-helpers/index.d.ts
+++ b/types/ember-testing-helpers/index.d.ts
@@ -2,8 +2,8 @@
 // Project: Ember.js Testing Helpers: https://github.com/emberjs/ember.js/tree/master/packages/ember-testing/lib/helpers
 // Definitions by: Chris Krycho <github.com/chriskrycho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript version: 2.3
-//
+// TypeScript Version: 2.3
+
 // Note that these are distributed separately because they represent a discrete
 // set of functionality, and as globally-injected items (as of Ember 2.13), are
 // not easily or straightforwardly exported from the Ember type definitions.

--- a/types/ember-testing-helpers/index.d.ts
+++ b/types/ember-testing-helpers/index.d.ts
@@ -1,0 +1,63 @@
+// Type definitions for ember-testing/lib/helpers
+// Project: Ember.js Testing Helpers: https://github.com/emberjs/ember.js/tree/master/packages/ember-testing/lib/helpers
+// Definitions by: Chris Krycho <github.com/chriskrycho>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript version: 2.3
+//
+// Note that these are distributed separately because they represent a discrete
+// set of functionality, and as globally-injected items (as of Ember 2.13), are
+// not easily or straightforwardly exported from the Ember type definitions.
+
+/// <reference types="jquery" />
+/// <reference types="rsvp" />
+
+type KeyEventType = 'keydown' | 'keyup' | 'keypress';
+type VoidWaitResult = RSVP.Promise<void>;
+
+declare global {
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/and_then.js
+  function andThen<T>(callback: <T>(...args: any[]) => T): RSVP.Promise<T>;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/click.js
+  function click(selector: string, context?: Object): VoidWaitResult;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/current_path.js
+  function currentPath(): string;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/current_route_name.js
+  function currentRouteName(): string;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/current_url.js
+  function currentURL(): string;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/fill_in.js
+  function fillIn(selector: string, context: Object, text: string): VoidWaitResult;
+  function fillIn(selector: string, text: string): VoidWaitResult;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/find.js
+  function find(selector: string, context?: Object): JQuery<Node>;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/find_with_assert.js
+  function findWithAssert(selector: string, context?: Object): JQuery<Node>;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/key_event.js
+  function keyEvent(selector: string, type: KeyEventType, keyCode: number): VoidWaitResult;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/pause_test.js
+  function pauseTest(): RSVP.Promise<{}>;
+  function resumeTest(): void;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/trigger_event.js
+  function triggerEvent(selector: string, context: Object, type: string, options: Object): VoidWaitResult;
+  function triggerEvent(selector: string, context: Object, type: string): VoidWaitResult;
+  function triggerEvent(selector: string, type: string, options: Object): VoidWaitResult;
+  function triggerEvent(selector: string, type: string): VoidWaitResult;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/visit.js
+  function visit<T>(route: string): VoidWaitResult;
+
+  // https://github.com/emberjs/ember.js/blob/master/packages/ember-testing/lib/helpers/wait.js
+  function wait<T>(value: T): RSVP.Promise<T>;
+}
+
+export {};

--- a/types/ember-testing-helpers/tsconfig.json
+++ b/types/ember-testing-helpers/tsconfig.json
@@ -5,7 +5,9 @@
             "es6",
             "dom"
         ],
-        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/ember-testing-helpers/tsconfig.json
+++ b/types/ember-testing-helpers/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "strict": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ember-testing-helpers-tests.ts"
+    ]
+}


### PR DESCRIPTION
[Documentation](https://emberjs.com/api/classes/Ember.Test.html)

One other note: I'm not actually *sure* what the correct naming convention is here: this is a lib which *will* be exported on its own in the future, as I understand the plan for Ember's module breakdown. If it's currently a better fit to add this to the Ember type declarations, I can do that.