### PR TITLE
[postmark] Add initial types for Postmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "devDependencies": {
     "dtslint": "Microsoft/dtslint#production",
     "types-publisher": "Microsoft/types-publisher#production"
+  },
+  "dependencies": {
+    "typescript": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
   "devDependencies": {
     "dtslint": "Microsoft/dtslint#production",
     "types-publisher": "Microsoft/types-publisher#production"
-  },
-  "dependencies": {
-    "typescript": "^2.4.1"
   }
 }

--- a/types/postmark/index.d.ts
+++ b/types/postmark/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://wildbit.github.io/postmark.js
 // Definitions by: Ben Bayard <https://github.com/benbayard>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 interface PostmarkError {
     status: number;

--- a/types/postmark/index.d.ts
+++ b/types/postmark/index.d.ts
@@ -1,0 +1,215 @@
+// Type definitions for postmark 1.3
+// Project: http://wildbit.github.io/postmark.js
+// Definitions by: Ben Bayard <https://github.com/benbayard>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface PostmarkError {
+    status: number;
+    message: string;
+    code: number;
+}
+
+interface PostmarkMessageHeader {
+    Name: string;
+    Value: string;
+}
+
+interface PostmarkAttachment {
+    Content: string;
+    Name: string;
+    ContentType: string;
+}
+
+interface Filter {
+    count: number;
+    offset: number;
+}
+
+interface PostmarkMessageWithTemplate {
+    To: string;
+    From: string;
+    Cc?: string;
+    Bcc?: string;
+    ReplyTo?: string;
+    TemplateId?: string;
+    TemplateModel?: any;
+    Tag?: string;
+    Subject?: string;
+    TrackOpens?: boolean;
+    TrackLinks?: string;
+    Headers?: PostmarkMessageHeader[];
+}
+
+interface PostmarkMessage {
+    To: string;
+    From: string;
+    Cc?: string;
+    Bcc?: string;
+    ReplyTo?: string;
+    Tag?: string;
+    Subject?: string;
+    HTMLBody?: string;
+    TextBody?: string;
+    TrackOpens?: boolean;
+    TrackLinks?: string;
+    Headers?: PostmarkMessageHeader[];
+    Attachments?: PostmarkAttachment[];
+}
+
+interface Sender {
+    Color: string;
+    RawEmailEnabled: boolean;
+    SmtpApiActivated: boolean;
+    DeliveryHookUrl: string;
+    InboundHookUrl: string;
+    BounceHookUrl: boolean;
+    IncludeBounceContentInHook: boolean;
+    OpenHookUrl: boolean;
+    PostFirstOpenOnly: boolean;
+    TrackOpens: boolean;
+    TrackLinks: string;
+    InboundDomain: string;
+    InboundSpamThreshold: number;
+}
+
+interface TemplateValidator<T extends object> {
+    Subject: string;
+    HtmlBody: string;
+    TextBody: string;
+    TestRenderModel?: T;
+    InlineCssForHtmlTestRender?: boolean;
+}
+
+type PostmarkCallback<T extends object = any> = ((e: PostmarkError, ret: T) => void) | undefined;
+
+interface SimpleOptions {
+    ssl: boolean;
+    requestHost: string;
+}
+
+interface Options extends SimpleOptions {
+    requestFactory(
+        options: SimpleOptions
+    ): (
+        path?: string,
+        type?: string,
+        content?: PostmarkMessage,
+        callback?: PostmarkCallback
+    ) => any;
+}
+
+declare class Client {
+    constructor(serverKey: string, options: Partial<Options>);
+    send(message: PostmarkMessage, callback: PostmarkCallback): void;
+    sendEmailWithTemplate(
+        message: PostmarkMessageWithTemplate,
+        callback: PostmarkCallback
+    ): void;
+    batch(message: PostmarkMessage[], callback: PostmarkCallback): void;
+    sendEmail(message: PostmarkMessage, callback: PostmarkCallback): void;
+    sendEmailBatch(message: PostmarkMessage[], callback: PostmarkCallback): void;
+    getDeliveryStatistics(callback: PostmarkCallback): void;
+    getBounces(filter: Partial<Filter>, callback: PostmarkCallback): void;
+    getBounce(id: number, callback: PostmarkCallback): void;
+    getBounceDump(id: number, callback: PostmarkCallback): void;
+    activateBounce(id: number, callback: PostmarkCallback): void;
+    getBounceTags(callback: PostmarkCallback): void;
+    getServer(callback: PostmarkCallback): void;
+    editServer<T extends keyof Sender>(options: Pick<Sender, T>, callback: PostmarkCallback): void;
+    getOutboundMessages(filter: Partial<Filter>, callback: PostmarkCallback): void;
+    getOutboundMessageDetails(id: number, callback: PostmarkCallback): void;
+    getMessageOpens(filter: Partial<Filter>, callback: PostmarkCallback): void;
+    getMessageOpensForSingleMessage(id: number, filter: Partial<Filter>, callback: PostmarkCallback): void;
+    getInboundMessages(filter: Partial<Filter>, callback: PostmarkCallback): void;
+    getInboundMessageDetails(id: number, callback: PostmarkCallback): void;
+    bypassBlockedInboundMessage(id: number, callback: PostmarkCallback): void;
+    retryInboundHookForMessage(id: number, callback: PostmarkCallback): void;
+    getOuboundOverview(filter: Partial<Filter>, callback: PostmarkCallback): void;
+    validateTemplate<T extends object>(templateObject: TemplateValidator<T>, callback: PostmarkCallback): void;
+}
+
+interface CreateSignature {
+    FromEmail: string;
+    Name: string;
+    ReplyToEmail?: string;
+    ReturnPathDomain?: string;
+}
+
+interface CreateServer {
+    Name: string;
+    Color?: string;
+    RawEmailEnabled?: boolean;
+    SmtpApiActivated?: boolean;
+    DeliveryHookUrl?: string;
+    InboundHookUrl?: string;
+    BounceHookUrl?: string;
+    IncludeBounceContentInHook?: boolean;
+    OpenHookUrl?: string;
+    PostFirstOpenOnly?: boolean;
+    TrackOpens?: boolean;
+    TrackLinks?: string;
+    InboundDomain?: string;
+    InboundSpamThreshold?: number;
+}
+
+interface CreateDomain {
+    Name: string;
+    ReturnPathDomain?: string;
+}
+
+declare class AdminClient {
+    constructor(apiKey: string, options: Partial<Options>);
+    listSenderSignatures(query: Partial<Filter>, callback: PostmarkCallback): void;
+    createSenderSignature(options: CreateSignature, callback: PostmarkCallback): void;
+    editSenderSignature<T extends keyof CreateSignature>(
+        id: number,
+        options: Partial<Pick<CreateSignature, T>>,
+        callback: PostmarkCallback
+    ): void;
+    deleteSenderSignature(id: number, callback: PostmarkCallback): void;
+    resendSenderSignatureConfirmation(id: number, callback: PostmarkCallback): void;
+    verifySenderSignatureSPF(id: number, callback: PostmarkCallback): void;
+    requestNewDKIMForSenderSignature(id: number, callback: PostmarkCallback): void;
+    getServer(id: number, callback: PostmarkCallback): void;
+    createServer(options: CreateServer, callback: PostmarkCallback): void;
+    editServer<T extends keyof CreateServer>(
+        id: number,
+        options: Pick<CreateServer, T>,
+        callback: PostmarkCallback
+    ): void;
+    deleteServer(id: number, callback: PostmarkCallback): void;
+    listServers(query: Partial<Filter>, callback: PostmarkCallback): void;
+    listDomains(query: Partial<Filter>, callback: PostmarkCallback): void;
+    getDomain(id: number, callback: PostmarkCallback): void;
+    createDomain(
+        options: CreateDomain,
+        callback: PostmarkCallback
+    ): void;
+    editDomain<T extends keyof CreateDomain>(
+        id: number,
+        options: Pick<CreateDomain, T>,
+        callback: PostmarkCallback
+    ): void;
+    deleteDomain(id: number, callback: PostmarkCallback): void;
+    verifyDomainSPF(id: number, callback: PostmarkCallback): void;
+    rotateDKIMForDomain(id: number, callback: PostmarkCallback): void;
+}
+
+interface ClientClass {
+    new(serverKey: string, options: Partial<Options>): Client;
+}
+
+interface AdminClientClass {
+    new(apiKey: string, options: Partial<Options>): AdminClient;
+}
+
+interface Postmark {
+    (apiKey: string, options: Partial<Options>): void;
+    defaults: Options;
+    Client: ClientClass;
+    AdminClient: AdminClientClass;
+}
+
+declare var postmark: Postmark;
+
+export = postmark;

--- a/types/postmark/postmark-tests.ts
+++ b/types/postmark/postmark-tests.ts
@@ -1,0 +1,61 @@
+import postmark = require('postmark');
+
+declare var options: typeof postmark.defaults;
+const message = { To: 'me', From: 'you' };
+const templateMessage = {...message, TemplateId: '1'};
+const filter = { offset: 0 };
+const editSender = { Color: 'black' };
+const templateValidator = {
+  Subject: '123',
+  HtmlBody: '123345',
+  TextBody: '123535',
+};
+
+declare function callback(err: any, data: any): void;
+
+const client = new postmark.Client('124345', options);
+const adminClient = new postmark.AdminClient('1123235', options);
+
+client.send(message, callback);
+client.sendEmailWithTemplate(templateMessage, callback);
+client.batch([message, message], callback);
+client.sendEmail(message, callback);
+client.sendEmailBatch([message, message], callback);
+client.getDeliveryStatistics(callback);
+client.getBounces(filter, callback);
+client.getBounce(1, callback);
+client.getBounceDump(1, callback);
+client.activateBounce(1, callback);
+client.getBounceTags(callback);
+client.getServer(callback);
+client.editServer(editSender, callback);
+client.getOutboundMessages(filter, callback);
+client.getOutboundMessageDetails(1, callback);
+client.getMessageOpens(filter, callback);
+client.getMessageOpensForSingleMessage(1, filter, callback);
+client.getInboundMessages(filter, callback);
+client.getInboundMessageDetails(1, callback);
+client.bypassBlockedInboundMessage(1, callback);
+client.retryInboundHookForMessage(1, callback);
+client.getOuboundOverview(filter, callback);
+client.validateTemplate(templateValidator, callback);
+
+adminClient.listSenderSignatures(filter, callback);
+adminClient.createSenderSignature({FromEmail: '', Name: ''}, callback);
+adminClient.editSenderSignature(0, {ReplyToEmail: '123'}, callback);
+adminClient.deleteSenderSignature(0, callback);
+adminClient.resendSenderSignatureConfirmation(0, callback);
+adminClient.verifySenderSignatureSPF(0, callback);
+adminClient.requestNewDKIMForSenderSignature(0, callback);
+adminClient.getServer(0, callback);
+adminClient.createServer({Name: '123'}, callback);
+adminClient.editServer(0, {Color: 'black'}, callback);
+adminClient.deleteServer(0, callback);
+adminClient.listServers(filter, callback);
+adminClient.listDomains(filter, callback);
+adminClient.getDomain(0, callback);
+adminClient.createDomain({Name: '1234'}, callback);
+adminClient.editDomain(0, {ReturnPathDomain: '/'}, callback);
+adminClient.deleteDomain(0, callback);
+adminClient.verifyDomainSPF(0, callback);
+adminClient.rotateDKIMForDomain(0, callback);

--- a/types/postmark/tsconfig.json
+++ b/types/postmark/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "postmark-tests.ts"
+    ]
+}

--- a/types/postmark/tslint.json
+++ b/types/postmark/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Postmark Developer docs: http://developer.postmarkapp.com/developer-api-overview.html
PostmarkJS Typedefs: https://github.com/wildbit/postmark.js/blob/master/lib/postmark/documentationTypeDefs.js

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.