### PR TITLE
Updated elementType and featureType of MapTypeStyles

### DIFF
--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -1,3 +1,5 @@
+/// <reference path="index.d.ts" />
+
 // Test file for Google Maps JavaScript API Definition file
 
 let mapOptions: google.maps.MapOptions = {

--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -1,5 +1,3 @@
-/// <reference path="index.d.ts" />
-
 // Test file for Google Maps JavaScript API Definition file
 
 let mapOptions: google.maps.MapOptions = {

--- a/types/googlemaps/googlemaps-tests.ts
+++ b/types/googlemaps/googlemaps-tests.ts
@@ -1,8 +1,6 @@
 // Test file for Google Maps JavaScript API Definition file
 
-/***** Create map *****/
-let map = new google.maps.Map(
-    document.getElementById('map'), {
+let mapOptions: google.maps.MapOptions = {
     backgroundColor: "#fff",
     center: { lat: -25.363, lng: 131.044 },
     clickableIcons: true,
@@ -13,8 +11,34 @@ let map = new google.maps.Map(
     },
     gestureHandling: "cooperative",
     scrollwheel: true,
+    styles: [
+        {
+            elementType: 'geometry',
+            featureType: 'water',
+            stylers: [
+                {
+                    color: '#00bdbd'
+                }
+            ]
+        },
+        {
+            elementType: 'geometry',
+            featureType: 'landscape.man_made',
+            stylers: [
+                {
+                    color: '#f7f1df'
+                }
+            ]
+        }
+    ],
     zoom: 4
-});
+};
+
+/***** Create map *****/
+let map: google.maps.Map = new google.maps.Map(
+    document.getElementById('map'),
+    mapOptions
+);
 
 
 /***** Data *****/

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1058,7 +1058,7 @@ declare namespace google.maps {
         clickable?: boolean;
         /** If set to true, the user can drag this circle over the map. Defaults to false. */
         draggable?: boolean;
-        /** 
+        /**
          * If set to true, the user can edit this circle by dragging the control points shown at the center and around
          * the circumference of the circle. Defaults to false.
          */
@@ -1719,64 +1719,51 @@ declare namespace google.maps {
         stylers?: MapTypeStyler[];
     }
 
-    export interface MapTypeStyleFeatureType {
-        administrative?: {
-            country?: string;
-            land_parcel?: string;
-            locality?: string;
-            neighborhood?: string;
-            province?: string;
-        };
-        all?: string;
-        landscape?: {
-            man_made?: string;
-            natural?: {
-              landcover?: string;
-              terrain?: string;
-            };
-        };
-        poi?: {
-            attraction?: string;
-            business?: string;
-            government?: string;
-            medical?: string;
-            park?: string;
-            place_of_worship?: string;
-            school?: string;
-            sports_complex?: string;
-        };
-        road?: {
-            arterial?: string;
-            highway?: {
-                controlled_access?: string;
-            };
-            local?: string;
-        };
-        transit?: {
-            line?: string;
-            station?: {
-                airport?: string;
-                bus?: string;
-                rail?: string;
-            };
-        };
-        water?: string;
-    }
+    export type MapTypeStyleFeatureType =
+      'all' |
+      'administrative' |
+      'administrative.country' |
+      'administrative.land_parcel' |
+      'administrative.locality' |
+      'administrative.neighborhood' |
+      'administrative.province' |
+      'landscape' |
+      'landscape.man_made' |
+      'landscape.natural' |
+      'landscape.natural.landcover' |
+      'landscape.natural.terrain' |
+      'poi' |
+      'poi.attraction' |
+      'poi.business' |
+      'poi.government' |
+      'poi.medical' |
+      'poi.park' |
+      'poi.place_of_worship' |
+      'poi.school' |
+      'poi.sports_complex' |
+      'road' |
+      'road.arterial' |
+      'road.highway' |
+      'road.highway.controlled_access' |
+      'road.local' |
+      'transit' |
+      'transit.line' |
+      'transit.station' |
+      'transit.station.airport' |
+      'transit.station.bus' |
+      'transit.station.rail' |
+      'water';
 
-    export interface MapTypeStyleElementType {
-        all?: string;
-        geometry?: {
-            fill?: string;
-            stroke?: string;
-        };
-        labels?: {
-            icon?: string;
-            text?: {
-                fill?: string;
-                stroke?: string;
-            }
-        };
-    }
+    export type MapTypeStyleElementType =
+      'all' |
+      'geometry' |
+      'geometry.fill' |
+      'geometry.stroke' |
+      'labels' |
+      'labels.icon' |
+      'labels.text' |
+      'labels.text.fill' |
+      'labels.text.stroke';
 
     export interface MapTypeStyler {
         color?: string;
@@ -2132,7 +2119,7 @@ declare namespace google.maps {
     }
 
     /**
-     * This object is returned from various mouse events on the map and overlays, 
+     * This object is returned from various mouse events on the map and overlays,
      * and contains all the fields shown below.
      */
     export interface MouseEvent {
@@ -2233,7 +2220,7 @@ declare namespace google.maps {
         /** Converts to string. */
         toString(): string;
         /**
-         * Returns a string of the form "lat_lo,lng_lo,lat_hi,lng_hi" for this bounds, where "lo" corresponds to the 
+         * Returns a string of the form "lat_lo,lng_lo,lat_hi,lng_hi" for this bounds, where "lo" corresponds to the
          * southwest corner of the bounding box, while "hi" corresponds to the northeast corner of that box.
          */
         toUrlValue(precision?: number): string;
@@ -2718,7 +2705,7 @@ declare namespace google.maps {
              * and the map property of a new polygon is always set to the DrawingManager's map.
              */
             polygonOptions?: PolygonOptions;
-            /** 
+            /**
              * Options to apply to any new polylines created with this DrawingManager. The path property is ignored,
              * and the map property of a new polyline is always set to the DrawingManager's map.
              */
@@ -2749,7 +2736,7 @@ declare namespace google.maps {
          */
         export enum OverlayType {
             /**
-             * Specifies that the DrawingManager creates circles, and that the overlay given in the overlaycomplete 
+             * Specifies that the DrawingManager creates circles, and that the overlay given in the overlaycomplete
              * event is a circle.
              */
             CIRCLE,


### PR DESCRIPTION
Closes #17732

Updated elementType and featureType of MapTypeStyles which breaks after typescript@2.4.1.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/googlemaps/index.d.ts
