### PR TITLE
Correct ua-parser-js's export

### DIFF
--- a/types/ua-parser-js/index.d.ts
+++ b/types/ua-parser-js/index.d.ts
@@ -139,7 +139,7 @@ declare namespace IUAParser {
 }
 
 declare module "ua-parser-js" {
-    export class UAParser {
+    class UAParser {
         static VERSION: string;
         static BROWSER: IUAParser.BROWSER;
         static CPU: IUAParser.CPU;
@@ -192,5 +192,6 @@ declare module "ua-parser-js" {
          */
         getResult(): IUAParser.IResult;
     }
+    const exported: typeof UAParser & { UAParser: UAParser };
+    export = exported
 }
-

--- a/types/ua-parser-js/index.d.ts
+++ b/types/ua-parser-js/index.d.ts
@@ -192,6 +192,6 @@ declare module "ua-parser-js" {
          */
         getResult(): IUAParser.IResult;
     }
-    const exported: typeof UAParser & { UAParser: UAParser };
+    const exported: typeof UAParser & { UAParser: typeof UAParser };
     export = exported
 }

--- a/types/ua-parser-js/ua-parser-js-tests.ts
+++ b/types/ua-parser-js/ua-parser-js-tests.ts
@@ -1,4 +1,4 @@
-import {UAParser} from 'ua-parser-js';
+import UAParser = require('ua-parser-js');
 
 function test_parser() {
     var ua = 'Mozilla/5.0 (Windows NT 6.2) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1090.0 Safari/536.6';


### PR DESCRIPTION
ua-parser-js is _not_ an ES module; it is a handwritten AMD module.

It exports itself both by setting the UAParser class as the export and adding a self-reference with the same name, which is why the current definition happens to work with the current commonjs emit.

See https://github.com/faisalman/ua-parser-js/blob/fd46c4d2/src/ua-parser.js#L915-L920