### PR TITLE
[React-router v4] Make Route component extensible

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -71,7 +71,7 @@ export interface RouteProps {
   exact?: boolean;
   strict?: boolean;
 }
-export class Route extends React.Component<RouteProps> { }
+export class Route<T extends RouteProps = RouteProps> extends React.Component<T> { }
 
 export interface RouterProps {
   history: any;

--- a/types/react-router/test/InheritingRoute.tsx
+++ b/types/react-router/test/InheritingRoute.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Route, RouteProps } from 'react-router';
+
+interface CustomRouteInterface extends RouteProps {
+  aProperty: string;
+  anotherOne: boolean;
+  willItEnd?: number;
+}
+
+// React advocates composition over inheritance, but doesn't prevent us from using it
+export default class CustomRoute extends Route<CustomRouteInterface> {
+  render() {
+    const maybeElement = super.render();
+    return maybeElement && <div className="meaningfulClass">{React.cloneElement(maybeElement, this.props)}</div>;
+  }
+}

--- a/types/react-router/tsconfig.json
+++ b/types/react-router/tsconfig.json
@@ -33,6 +33,7 @@
     "test/NavigateWithContext.tsx",
     "test/MemoryRouter.tsx",
     "test/Switch.tsx",
+    "test/InheritingRoute.tsx",
     "test/WithRouter.tsx"
   ]
 }


### PR DESCRIPTION
Transparent change thanks to default generics (Shouldn't affect existing codebase at all)

Allow this
```typescript
interface ICustomRoute extends RouteProps {}
class CustomRoute extends Route<ICustomRoute> {
  ...
}
```
