### PR TITLE
adding optional 'jsonCompatibleStrings' property to 'GeneratorOptions' interface

### DIFF
--- a/types/babel-generator/babel-generator-tests.ts
+++ b/types/babel-generator/babel-generator-tests.ts
@@ -1,7 +1,3 @@
-/// <reference types="babylon" />
-
-
-
 // Example from https://github.com/babel/babel/tree/master/packages/babel-generator
 import {parse} from 'babylon';
 import generate from 'babel-generator';
@@ -14,13 +10,13 @@ ast.loc.start;
 
 const output = generate(ast, { /* options */ }, code);
 
-
 // Example from https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-generator
 let result = generate(ast, {
     retainLines: false,
     compact: "auto",
     concise: false,
     quotes: "double",
+    jsonCompatibleStrings: true,
     // ...
 }, code);
 result.code;

--- a/types/babel-generator/index.d.ts
+++ b/types/babel-generator/index.d.ts
@@ -1,12 +1,10 @@
-// Type definitions for babel-generator v6.7
+// Type definitions for babel-generator 6.25
 // Project: https://github.com/babel/babel/tree/master/packages/babel-generator
 // Definitions by: Troy Gerwien <https://github.com/yortus>
+//                 Johnny Estilles <https://github.com/johnnyestilles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="babel-types" />
-
 import * as t from 'babel-types';
-type Node = t.Node;
 
 /**
  * Turns an AST into code, maintaining sourcemaps, user preferences, and valid output.
@@ -15,18 +13,17 @@ type Node = t.Node;
  * @param code - the original source code, used for source maps.
  * @returns - an object containing the output code and source map.
  */
-export default function generate(ast: Node, opts?: GeneratorOptions, code?: string | {[filename: string]: string}): GeneratorResult;
+export default function generate(ast: t.Node, opts?: GeneratorOptions, code?: string | {[filename: string]: string}): GeneratorResult;
 
 export interface GeneratorOptions {
-
     /**
      * Optional string to add as a block comment at the start of the output file.
-    */
+     */
     auxiliaryCommentBefore?: string;
 
     /**
      * Optional string to add as a block comment at the end of the output file.
-    */
+     */
     auxiliaryCommentAfter?: string;
 
     /**
@@ -34,7 +31,7 @@ export interface GeneratorOptions {
      * By default, comments are included if `opts.comments` is `true` or if `opts.minifed` is `false` and the comment
      * contains `@preserve` or `@license`.
      */
-    shouldPrintComment?: (comment: string) => boolean;
+    shouldPrintComment?(comment: string): boolean;
 
     /**
      * Attempt to use the same line numbers in the output code as in the source code (helps preserve stack traces).
@@ -60,7 +57,7 @@ export interface GeneratorOptions {
     /**
      * Set to true to reduce whitespace (but not as much as opts.compact). Defaults to `false`.
      */
-    concise?: boolean;        
+    concise?: boolean;
 
     /**
      * The type of quote to use in the output. If omitted, autodetects based on `ast.tokens`.
@@ -70,7 +67,7 @@ export interface GeneratorOptions {
     /**
      * Used in warning messages
      */
-    filename?: string;        
+    filename?: string;
 
     /**
      * Enable generating source maps. Defaults to `false`.
@@ -92,10 +89,14 @@ export interface GeneratorOptions {
      * This will only be used if `code` is a string.
      */
     sourceFileName?: string;
+
+    /**
+     * Set to true to run jsesc with "json": true to print "\u00A9" vs. "©";
+     */
+    jsonCompatibleStrings?: boolean;
 }
 
 export interface GeneratorResult {
-    map: Object;
+    map: {};
     code: string;
 }
-

--- a/types/babel-generator/tslint.json
+++ b/types/babel-generator/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Type definitions appear to be outdated. They were missing the `jsonCompatibleStrings` property to `GeneratorOptions` interface, which was added via babel/babel#4827.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/tree/master/packages/babel-generator
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
