### PR TITLE
[react-copy-to-clipboard]: fixed typings

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -23,5 +23,5 @@ declare namespace CopyToClipboard {
   }
 }
 
-declare class CopyToClipboard extends React.Component<CopyToClipboard.Props> {
+declare class CopyToClipboard extends React.Component<CopyToClipboard.Props, null> {
 }


### PR DESCRIPTION
React.Component class generic has been missing state parameter which was causing compiler errors.


