### PR TITLE
Fix ckeditor.dialog.getCurrent(), getter is not returning void

### DIFF
--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -1681,7 +1681,7 @@ declare namespace CKEDITOR {
         function addUIElement(typeName: string, builder: Function): void;
         function cancelButton(): void;
         function exists(name: string | number): void; // NOTE: documentation says object, but it's an array accessor, so really a string or number will work
-        function getCurrent(): void;
+        function getCurrent(): CKEDITOR.dialog;
         function isTabEnabled(editor: CKEDITOR.editor, dialogName: string, tabName: string): boolean;
         function okButton(): void;
     }


### PR DESCRIPTION
WIP:  working on this template:

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.ckeditor.com/source/plugin17.html#CKEDITOR-dialog-static-method-getCurrent
  - note the docs on CK are also wrong/incomplete:  http://docs.ckeditor.com/#!/api/CKEDITOR.dialog-static-method-getCurrent
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

