### PR TITLE
react-big-calendar: update to use es6 default export

### DIFF
--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-big-calendar 0.12.3
+// Type definitions for react-big-calendar 0.14.0
 // Project: https://github.com/intljusticemission/react-big-calendar
 // Definitions by: Piotr Witek <http://piotrwitek.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -53,9 +53,5 @@ declare module 'react-big-calendar' {
         static globalizeLocalizer(globalizeInstance: Object): void;
     }
 
-    /* This enables 'import * as BigCalendar' syntax when compiling to es2015 */
-    namespace BigCalendar {}
-
-    /* react-big-calendar is exported as a commonjs module (it uses babel-preset-jason) */
-    export = BigCalendar;
+    export default BigCalendar;
 }

--- a/types/react-big-calendar/react-big-calendar-tests.tsx
+++ b/types/react-big-calendar/react-big-calendar-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as ReactDOMServer from "react-dom/server";
-import BigCalendar = require("react-big-calendar");
+import BigCalendar from "react-big-calendar";
 
 // Don't want to add this as a dependency, because it is only used for tests.
 declare const moment: any;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://unpkg.com/react-big-calendar@0.14.3/lib/index.js (at the bottom ```export default``` is used)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
