### PR TITLE
noble: add subscribe and unsubscribe methods to peripherals

### DIFF
--- a/types/noble/index.d.ts
+++ b/types/noble/index.d.ts
@@ -4,6 +4,7 @@
 //                 Hans Bakker <https://github.com/wind-rider>
 //                 Shantanu Bhadoria <https://github.com/shantanubhadoria>
 //                 Luke Libraro <https://github.com/lukel99>
+//                 Dan Chao <https://github.com/bioball>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -88,6 +89,8 @@ export declare class Characteristic extends events.EventEmitter {
     notify(notify: boolean, callback?: (error: string) => void): void;
     discoverDescriptors(callback?: (error: string, descriptors: Descriptor[]) => void): void;
     toString(): string;
+    subscribe(callback?: (error: string) => void): void;
+    unsubscribe(callback?: (error: string) => void): void;
 
     on(event: string, listener: Function): this;
     on(event: string, option: boolean, listener: Function): this;

--- a/types/noble/noble-tests.ts
+++ b/types/noble/noble-tests.ts
@@ -87,6 +87,10 @@ characteristic.on("write", true, (error: string): void => {});
 characteristic.on("broadcast", (state: string): void => {});
 characteristic.on("notify", (state: string): void => {});
 characteristic.on("descriptorsDiscover", (descriptors: noble.Descriptor[]): void => {});
+characteristic.subscribe();
+characteristic.subscribe((error: string) => {});
+characteristic.unsubscribe();
+characteristic.unsubscribe((error: string) => {});
 
 var descriptor: noble.Descriptor = new noble.Descriptor();
 descriptor.uuid = "";


### PR DESCRIPTION
Added `subscribe` and `unsubscribe` methods to characteristics.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sandeepmistry/noble/blob/master/lib/characteristic.js#L114
