### PR TITLE
[pg] Pool.end() accepts an optional callback param

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -71,7 +71,7 @@ export declare class Pool extends events.EventEmitter {
     connect(): Promise<Client>;
     connect(callback: (err: Error, client: Client, done: () => void) => void): void;
 
-    end(): Promise<void>;
+    end(callback?: () => void): Promise<void>;
 
     query(queryStream: QueryConfig & stream.Readable): stream.Readable;
     query(queryTextOrConfig: string | QueryConfig): Promise<QueryResult>;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -74,3 +74,8 @@ pool.connect((err, client, done) => {
 pool.on('error', (err, client) => {
   console.error('idle client error', err.message, err.stack)
 })
+
+pool.end();
+pool.end(() => {
+    console.log("pool is closed");
+});


### PR DESCRIPTION
Here is the source code from `pg-pool`. No parameters are passed to callback.
```
Pool.prototype.end = function (cb) {
  this.log('draining pool')
  return this._promise(cb, function (resolve, reject) {
    this.pool.drain(function () {
      this.log('pool drained, calling destroy all now')
      this.pool.destroyAllNow(resolve)
    }.bind(this))
  }.bind(this))
}
```