### PR TITLE
[README] Fix only major version of TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ First, [fork](https://guides.github.com/activities/forking/) this repository, in
   //                 Steve <https://github.com/steve>
   //                 John <https://github.com/john>
   ```
-* `npm install -g typescript@2.0` and run `tsc`.
+* `npm install -g typescript@2` and run `tsc`.
 
 When you make a PR to edit an existing package, `dt-bot` should @-mention previous authors.
 If it doesn't, you can do so yourself in the comment associated with the PR.


### PR DESCRIPTION
Some packages is already using features from TypeScript later than version 2.0. For example, the package `gapi` uses [generic parameter defaults](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#generic-parameter-defaults) (available since 2.3) in [this line](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0d2095987dd858594715962f088f241f60836fae/types/gapi/index.d.ts#L243); running `tsc` in these package gives error with TypeScript 2.0.