### PR TITLE
Typings for passport-google-oauth2 @ 0.1.6

### DIFF
--- a/types/passport-google-oauth2/index.d.ts
+++ b/types/passport-google-oauth2/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for passport-google-oauth2 0.1.6
+// Project: https://github.com/mstade/passport-google-oauth2
+// Definitions by: Elliot Blackburn <https://github.com/bluehatbrit>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import {Request} from 'express';
+import * as passport from 'passport';
+
+export interface StrategyOptions {
+  clientID: string;
+  clientSecret: string;
+  callbackURL: string;
+  passReqToCallback?: true;
+  scope?: string[];
+}
+
+export interface StrategyOptionsWithRequest {
+  clientID: string;
+  clientSecret: string;
+  callbackURL: string;
+  passReqToCallback: true;
+  scope?: string[];
+}
+
+export interface VerifyOptions {
+  message: string;
+}
+
+export interface VerifyCallback {
+  (error: any, user?: any, options?: VerifyOptions): void;
+}
+
+export interface VerifyFunctionWithRequest {
+  (req: Request, accessToken: string, refreshToken: string, profile: any, done: VerifyCallback): void;
+}
+
+export interface VerifyFunction {
+  (accessToken: string, refreshToken: string, profile: any, done: VerifyCallback): void;
+}
+
+declare class Strategy implements Strategy {
+  public name: string;
+  public authenticate: (req: Request, options?: object) => void;
+
+  constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
+  constructor(options: StrategyOptions, verify: VerifyFunction);
+  constructor(verify: VerifyFunction);
+}

--- a/types/passport-google-oauth2/index.d.ts
+++ b/types/passport-google-oauth2/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/mstade/passport-google-oauth2
 // Definitions by: Elliot Blackburn <https://github.com/bluehatbrit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import {Request} from 'express';
 

--- a/types/passport-google-oauth2/index.d.ts
+++ b/types/passport-google-oauth2/index.d.ts
@@ -1,10 +1,9 @@
-// Type definitions for passport-google-oauth2 0.1.6
+// Type definitions for passport-google-oauth2 0.1
 // Project: https://github.com/mstade/passport-google-oauth2
 // Definitions by: Elliot Blackburn <https://github.com/bluehatbrit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import {Request} from 'express';
-import * as passport from 'passport';
 
 export interface StrategyOptions {
   clientID: string;
@@ -26,21 +25,21 @@ export interface VerifyOptions {
   message: string;
 }
 
-export interface VerifyCallback {
-  (error: any, user?: any, options?: VerifyOptions): void;
-}
+export type VerifyCallback = (error: any, user?: any, options?: VerifyOptions) => void;
 
-export interface VerifyFunctionWithRequest {
-  (req: Request, accessToken: string, refreshToken: string, profile: any, done: VerifyCallback): void;
-}
+export type VerifyFunctionWithRequest = (
+    req: Request,
+    accessToken: string,
+    refreshToken: string,
+    profile: any,
+    done: VerifyCallback
+) => void;
 
-export interface VerifyFunction {
-  (accessToken: string, refreshToken: string, profile: any, done: VerifyCallback): void;
-}
+export type VerifyFunction = (accessToken: string, refreshToken: string, profile: any, done: VerifyCallback) => void;
 
-declare class Strategy implements Strategy {
-  public name: string;
-  public authenticate: (req: Request, options?: object) => void;
+export class Strategy implements Strategy {
+  name: string;
+  authenticate: (req: Request, options?: object) => void;
 
   constructor(options: StrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
   constructor(options: StrategyOptions, verify: VerifyFunction);

--- a/types/passport-google-oauth2/passport-google-oauth2-tests.ts
+++ b/types/passport-google-oauth2/passport-google-oauth2-tests.ts
@@ -1,0 +1,17 @@
+import * as express from 'express';
+import * as PassportGoogle from 'passport-google-oauth2';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth2';
+
+new GoogleStrategy({
+  callbackURL: 'callbackurl',
+  clientID: 'clientid',
+  clientSecret: 'shhh',
+  passReqToCallback: true,
+}, (
+  req: express.Request,
+  accessToken: string,
+  refreshToken: string,
+  profile: any,
+  done: PassportGoogle.VerifyCallback) => {
+  // Some registration / log in logic
+});

--- a/types/passport-google-oauth2/tsconfig.json
+++ b/types/passport-google-oauth2/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "passport-google-oauth2-tests.ts"
+  ]
+}

--- a/types/passport-google-oauth2/tslint.json
+++ b/types/passport-google-oauth2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
## Template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

## Note
There are two similar named libraries on NPM (`passport-google-oauth` and `passport-google-oauth20`), and one of those has a typings directory in this project. It caught me off guard briefly, but these should not be confused.