### PR TITLE
Add mutateIn and lookupIn to Couchbase Bucket definition.

### DIFF
--- a/types/couchbase/index.d.ts
+++ b/types/couchbase/index.d.ts
@@ -1013,6 +1013,20 @@ interface Bucket {
      * @param callback The callback function.
      */
     upsert(key: any | Buffer, value: any, options: UpsertOptions, callback: Bucket.OpCallback): void;
+
+    /**
+     * Stores a document to the bucket.
+     * @param key The target document key.
+     * @param options The options object.
+     */
+    mutateIn(key: string, options?: object): any;
+
+    /**
+     * Look up a partial document in the bucket.
+     * @param key The target document key.
+     * @param options The options object.
+     */
+    lookupIn(key: string, options?: object): any;
 }
 
 declare namespace Bucket {


### PR DESCRIPTION
I'm adding these to at _least_ make them available to be used by typescript. There's more work to be done to add the proper return types including a [LookUpInBuilder](https://github.com/couchbase/couchnode/blob/4e61a6390275a8aa1ff94cc05bdfed9a50af6b6d/lib/bucket.js#L2695) and [MutateInBuilder](https://github.com/couchbase/couchnode/blob/4e61a6390275a8aa1ff94cc05bdfed9a50af6b6d/lib/bucket.js#L2825) but I don't have time to put these into play right now. I'll consider adding those later.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/couchbase/couchnode/blob/4e61a6390275a8aa1ff94cc05bdfed9a50af6b6d/lib/bucket.js#L2789
https://github.com/couchbase/couchnode/blob/4e61a6390275a8aa1ff94cc05bdfed9a50af6b6d/lib/bucket.js#L3046
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
