### PR TITLE
react-router: Add union to component properties

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -13,6 +13,7 @@
 //                 Huy Nguyen <https://github.com/huy-nguyen>
 //                 Jérémy Fauvel <https://github.com/grmiade>
 //                 Daniel Roth <https://github.com/DaIgeb>
+//                 Steve Buzonas <https://github.com/sbuzonas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -62,9 +63,11 @@ export interface RouteComponentProps<P> {
   staticContext?: any;
 }
 
-export interface RouteProps {
+export type RouteComponentPropsUnion<P> = Partial<RouteComponentProps<any>> & P;
+
+export interface RouteProps<P = {}> {
   location?: H.Location;
-  component?: React.ComponentType<RouteComponentProps<any> | {}>;
+  component?: React.ComponentType<RouteComponentPropsUnion<P> | {}>;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -63,11 +63,11 @@ export interface RouteComponentProps<P> {
   staticContext?: any;
 }
 
-export type RouteComponentPropsUnion<P> = Partial<RouteComponentProps<any>> & P;
+export type RouteComponentPropsUnion<P> = RouteComponentProps<any> & P;
 
 export interface RouteProps<P = {}> {
   location?: H.Location;
-  component?: React.ComponentType<RouteComponentPropsUnion<P> | {}>;
+  component?: React.ComponentType<RouteComponentPropsUnion<P> | P>;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;


### PR DESCRIPTION
This is a different approach to #17086 it solves the issue in #13689

All components that are children of Route are passed the RouteComponentProps, this is typed
as a partial because not all components are router aware, and do not declare/use the props.

Components also extend a generic class that takes properties and state types, these changes
allow for inclusion of the user defined types with a union of the RouteComponentProps provided
by the react-router library.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ReactTraining/react-router/blob/v4.1.1/packages/react-router/modules/Route.js#L101-L110>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
