### PR TITLE
enable autodetection for number of processes when running test

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "compile-scripts": "tsc -p scripts",
     "not-needed": "node scripts/not-needed.js",
-    "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed --nProcesses 8",
+    "test": "node node_modules/types-publisher/bin/tester/test.js --run-from-definitely-typed",
     "lint": "dtslint types"
   },
   "devDependencies": {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Final step to enable autodetection for number of processes when running test as discussed in Microsoft/types-publisher#358


