### PR TITLE
[d3-selection] Allow a child selector to return a parent element

### DIFF
--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -4,11 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 1.1
+// TypeScript Version: 2.3
 
 // --------------------------------------------------------------------------
 // Shared Type Definitions and Interfaces
 // --------------------------------------------------------------------------
-// TypeScript Version: 2.3
 
 /**
  * BaseType serves as an alias for the 'minimal' data type which can be selected

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -14,7 +14,7 @@
  * without 'd3-selection' trying to use properties internally which would otherwise not
  * be supported.
  */
-export type BaseType = Element | EnterElement | Document | Window | null;
+export type BaseType = Element | EnterElement | Document | Window | ShadowRoot | null;
 
 /**
  * A helper interface which covers arguments like NodeListOf<T> or HTMLCollectionOf<T>

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -2,9 +2,9 @@
 // Project: https://github.com/d3/d3-selection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.1
-// TypeScript Version: 2.3
 
 // --------------------------------------------------------------------------
 // Shared Type Definitions and Interfaces

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -2,13 +2,13 @@
 // Project: https://github.com/d3/d3-selection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.1
 
 // --------------------------------------------------------------------------
 // Shared Type Definitions and Interfaces
 // --------------------------------------------------------------------------
+// TypeScript Version: 2.3
 
 /**
  * BaseType serves as an alias for the 'minimal' data type which can be selected

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/d3/d3-selection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 // Last module patch version validated against: 1.1
 

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -176,7 +176,7 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
      *
      * @param selector CSS selector string
      */
-    select<DescElement extends BaseType>(selector: string): Selection<DescElement, Datum, PElement, PDatum>;
+    select<DescElement extends BaseType>(selector: string): Selection<DescElement, Datum, PElement | HTMLElement, PDatum | any>;
     /**
      * Create an empty sub-selection. Selection.select does not affect grouping: it preserves the existing group
      * structure and indexes.


### PR DESCRIPTION
The current type definition does not allow for the following:

```javascript
const mySelection = d3.select(myParentNode).select('mySelector');
mySelection.attr('...')

```
...because `mySelection` doesn't have a parent or pdatum, even though d3-selection allows for such chaining. This change adds the flexibility that the JS already allows.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  https://github.com/d3/d3-selection/blob/master/README.md#select
  and the comment from the author explaining the flexibility:
  https://github.com/d3/d3-selection/pull/133#issuecomment-312347299
- [ ] Increase the version number in the header if appropriate. (not applicable)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (not applicable)