### PR TITLE
[@types/webpack-sources] The `originalSource` parameter to the `SourceMapSource` constructor is optional.

### DIFF
--- a/types/webpack-sources/index.d.ts
+++ b/types/webpack-sources/index.d.ts
@@ -186,7 +186,10 @@ export class SourceMapSource extends Source implements SourceAndMapMixin {
     _innerSourceMap: RawSourceMap;
 
     constructor(
-        value: string, name: string, sourceMap: SourceMapGenerator | RawSourceMap, originalSource: string,
+        value: string,
+        name: string,
+        sourceMap: SourceMapGenerator | RawSourceMap,
+        originalSource?: string,
         innerSourceMap?: RawSourceMap
     );
 

--- a/types/webpack-sources/index.d.ts
+++ b/types/webpack-sources/index.d.ts
@@ -1,15 +1,14 @@
-// Type definitions for webpack-sources v0.1.2
+// Type definitions for webpack-sources 0.1
 // Project: https://github.com/webpack/webpack-sources
 // Definitions by: e-cloud <http://github.com/e-cloud>
+//                 Chris Eppstein <http://github.com/chriseppstein>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="source-map" />
-/// <reference types="source-list-map" />
 /// <reference types="node" />
 
-import { Hash } from 'crypto'
-import { SourceNode, RawSourceMap, SourceMapGenerator } from 'source-map'
-import { SourceListMap } from 'source-list-map'
+import { Hash } from 'crypto';
+import { SourceNode, RawSourceMap, SourceMapGenerator } from 'source-map';
+import { SourceListMap } from 'source-list-map';
 
 export abstract class Source {
     size(): number;
@@ -32,7 +31,7 @@ export abstract class Source {
     listMap(options?: any): any;
 }
 
-interface SourceAndMapMixin {
+export interface SourceAndMapMixin {
     map(options: { columns?: boolean }): RawSourceMap;
     sourceAndMap(options: { columns?: boolean }): {
         source: string;
@@ -67,9 +66,9 @@ export class CachedSource {
 }
 
 export class ConcatSource extends Source implements SourceAndMapMixin {
-    children: (string | Source)[];
+    children: Array<(string | Source)>;
 
-    constructor(...args: (string | Source)[]);
+    constructor(...args: Array<(string | Source)>);
 
     add(item: string | Source): void;
 

--- a/types/webpack-sources/tslint.json
+++ b/types/webpack-sources/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-sources/webpack-sources-tests.ts
+++ b/types/webpack-sources/webpack-sources-tests.ts
@@ -7,9 +7,8 @@ import {
     ReplaceSource,
     OriginalSource,
     SourceMapSource,
-
 } from 'webpack-sources';
-import { RawSourceMap } from 'source-map'
+import { RawSourceMap } from 'source-map';
 
 const s1 = new OriginalSource('a', 'b');
 
@@ -19,8 +18,8 @@ const s3 = new ConcatSource('a', 'b', s1);
 
 const s4 = new RawSource('hey');
 
-const a = {} as RawSourceMap
-const b = {} as RawSourceMap
+const a = {} as RawSourceMap;
+const b = {} as RawSourceMap;
 
 const s5 = new LineToLineMappedSource('a', 'v', 'c');
 const s6 = new PrefixSource(s4, s5);


### PR DESCRIPTION
**NOTE:** This PR builds on top of https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17789 which makes no API changes and should land first.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack-sources/blob/v0.1.5/lib/SourceMapSource.js#L36-L53 (As you can see `this._originalSource` is always guarded with an existence check -- this link is to a 0.1.x version of the source which is the same as for this package.)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (this is done in the pull request mentioned above)
