### PR TITLE
Fix react-router component was required to receive the router props

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -64,7 +64,7 @@ export interface RouteComponentProps<P> {
 
 export interface RouteProps {
   location?: H.Location;
-  component?: React.SFC<RouteComponentProps<any> | undefined> | React.ComponentClass<RouteComponentProps<any> | undefined>;
+  component?: React.SFC<RouteComponentProps<any> | {} | undefined> | React.ComponentClass<RouteComponentProps<any> | {} | undefined>;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;


### PR DESCRIPTION
A component must be free to ignore the props provided by the router