### PR TITLE
react-native: Add web as a platform

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5332,7 +5332,7 @@ export interface PixelRatioStatic {
 /**
  * @see https://facebook.github.io/react-native/docs/platform-specific-code.html#content
  */
-export type PlatformOSType = 'ios' | 'android' | 'windows'
+export type PlatformOSType = 'ios' | 'android' | 'windows' | 'web'
 
 interface PlatformStatic {
     OS: PlatformOSType


### PR DESCRIPTION
With the use of the react-native-web library, it is possible to write web applications using react-native primitives, with this type definition, for which the PlatformOS returns 'web'

[https://github.com/necolas/react-native-web/blob/master/docs/apis/Platform.md](https://github.com/necolas/react-native-web/blob/master/docs/apis/Platform.md)

 