### PR TITLE
make devtoolModuleFilenameTemplate accept a function

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -96,7 +96,7 @@ declare namespace webpack {
         [name: string]: string | string[];
     }
 
-    interface DevtoolModuleTemplateInfo {
+    interface DevtoolModuleFilenameTemplateInfo {
         identifier: string;
         shortIdentifier: string;
         resource: any;
@@ -118,9 +118,9 @@ declare namespace webpack {
         /** The filename of the SourceMaps for the JavaScript files. They are inside the output.path directory. */
         sourceMapFilename?: string;
         /** Filename template string of function for the sources array in a generated SourceMap. */
-        devtoolModuleFilenameTemplate?: string | ((info: DevtoolModuleTemplateInfo) => string);
+        devtoolModuleFilenameTemplate?: string | ((info: DevtoolModuleFilenameTemplateInfo) => string);
         /** Similar to output.devtoolModuleFilenameTemplate, but used in the case of duplicate module identifiers. */
-        devtoolFallbackModuleFilenameTemplate?: string | ((info: DevtoolModuleTemplateInfo) => string);
+        devtoolFallbackModuleFilenameTemplate?: string | ((info: DevtoolModuleFilenameTemplateInfo) => string);
         /**
          * Enable line to line mapped mode for all/specified modules.
          * Line to line mapped mode uses a simple SourceMap where each line of the generated source is mapped to the same line of the original source.

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -95,7 +95,7 @@ declare namespace webpack {
     interface Entry {
         [name: string]: string | string[];
     }
-    
+
     interface DevtoolModuleTemplateInfo {
         identifier: string;
         shortIdentifier: string;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -95,6 +95,18 @@ declare namespace webpack {
     interface Entry {
         [name: string]: string | string[];
     }
+    
+    interface DevtoolModuleTemplateInfo {
+        identifier: string;
+        shortIdentifier: string;
+        resource: any;
+        resourcePath: string;
+        absoluteResourcePath: string;
+        allLoaders: any[];
+        query: string;
+        moduleId: string;
+        hash: string;
+    }
 
     interface Output {
         /** The output directory as absolute path (required). */
@@ -106,9 +118,9 @@ declare namespace webpack {
         /** The filename of the SourceMaps for the JavaScript files. They are inside the output.path directory. */
         sourceMapFilename?: string;
         /** Filename template string of function for the sources array in a generated SourceMap. */
-        devtoolModuleFilenameTemplate?: string | (info: any) => string;
+        devtoolModuleFilenameTemplate?: string | ((info: DevtoolModuleTemplateInfo) => string);
         /** Similar to output.devtoolModuleFilenameTemplate, but used in the case of duplicate module identifiers. */
-        devtoolFallbackModuleFilenameTemplate?: string;
+        devtoolFallbackModuleFilenameTemplate?: string | ((info: DevtoolModuleTemplateInfo) => string);
         /**
          * Enable line to line mapped mode for all/specified modules.
          * Line to line mapped mode uses a simple SourceMap where each line of the generated source is mapped to the same line of the original source.

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -106,7 +106,7 @@ declare namespace webpack {
         /** The filename of the SourceMaps for the JavaScript files. They are inside the output.path directory. */
         sourceMapFilename?: string;
         /** Filename template string of function for the sources array in a generated SourceMap. */
-        devtoolModuleFilenameTemplate?: string;
+        devtoolModuleFilenameTemplate?: string | (info: any) => string;
         /** Similar to output.devtoolModuleFilenameTemplate, but used in the case of duplicate module identifiers. */
         devtoolFallbackModuleFilenameTemplate?: string;
         /**


### PR DESCRIPTION
Reference 
https://github.com/facebookincubator/create-react-app/blob/567d981ee28188a78731b4c45aedaa60b22a03bd/packages/react-scripts/config/webpack.config.dev.js#L81

Not sure about the type of `info`.