### PR TITLE
NodeCache: get() will return undefined on miss, key can be string or number

### DIFF
--- a/types/node-cache/index.d.ts
+++ b/types/node-cache/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for node-cache v3.0.0
 // Project: https://github.com/tcs-de/nodecache
 // Definitions by: Ilya Mochalov <https://github.com/chrootsu>
+//                 Daniel Thunell <https://github.com/dthunell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -25,7 +26,7 @@ declare namespace NodeCache {
 		get<T>(
 			key: string,
 			cb?: Callback<T>
-		): T;
+		): T | undefined;
 
 		/**
 		 * get multiple cached keys at once and change the stats
@@ -35,8 +36,8 @@ declare namespace NodeCache {
 		 */
 		mget<T>(
 			keys: string[],
-			cb?: Callback<{[key: string]: T}>
-		): {[key: string]: T};
+			cb?: Callback<{ [key: string]: T }>
+		): { [key: string]: T };
 
 		/**
 		 * set a cached key and change the stats
@@ -50,7 +51,7 @@ declare namespace NodeCache {
 		set<T>(
 			key: string,
 			value: T,
-			ttl: number|string,
+			ttl: number | string,
 			cb?: Callback<boolean>
 		): boolean;
 
@@ -67,7 +68,7 @@ declare namespace NodeCache {
 		 * @returns Number of deleted keys
 		 */
 		del(
-			keys: string|string[],
+			keys: string | string[],
 			cb?: Callback<number>
 		): number;
 
@@ -183,8 +184,8 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	 */
 	mget<T>(
 		keys: string[],
-		cb?: Callback<{[key: string]: T}>
-	): {[key: string]: T};
+		cb?: Callback<{ [key: string]: T }>
+	): { [key: string]: T };
 
 	/**
 	 * set a cached key and change the stats
@@ -198,7 +199,7 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	set<T>(
 		key: string,
 		value: T,
-		ttl: number|string,
+		ttl: number | string,
 		cb?: Callback<boolean>
 	): boolean;
 
@@ -215,7 +216,7 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	 * @returns Number of deleted keys
 	 */
 	del(
-		keys: string|string[],
+		keys: string | string[],
 		cb?: Callback<number>
 	): number;
 

--- a/types/node-cache/index.d.ts
+++ b/types/node-cache/index.d.ts
@@ -1,10 +1,16 @@
-// Type definitions for node-cache v3.0.0
+// Type definitions for node-cache 4.1
 // Project: https://github.com/tcs-de/nodecache
 // Definitions by: Ilya Mochalov <https://github.com/chrootsu>
 //                 Daniel Thunell <https://github.com/dthunell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
+
+/**
+ * Since 4.1.0: Key-validation: The keys can be given as either string or number,
+ * but are casted to a string internally anyway.
+ */
+type Key = string | number;
 
 declare namespace NodeCache {
 	interface NodeCache {
@@ -24,7 +30,7 @@ declare namespace NodeCache {
 		 * @param cb Callback function
 		 */
 		get<T>(
-			key: string,
+			key: Key,
 			cb?: Callback<T>
 		): T | undefined;
 
@@ -35,7 +41,7 @@ declare namespace NodeCache {
 		 * @param cb Callback function
 		 */
 		mget<T>(
-			keys: string[],
+			keys: Key[],
 			cb?: Callback<{ [key: string]: T }>
 		): { [key: string]: T };
 
@@ -49,14 +55,14 @@ declare namespace NodeCache {
 		 * @param cb Callback function
 		 */
 		set<T>(
-			key: string,
+			key: Key,
 			value: T,
 			ttl: number | string,
 			cb?: Callback<boolean>
 		): boolean;
 
 		set<T>(
-			key: string,
+			key: Key,
 			value: T,
 			cb?: Callback<boolean>
 		): boolean;
@@ -68,7 +74,7 @@ declare namespace NodeCache {
 		 * @returns Number of deleted keys
 		 */
 		del(
-			keys: string | string[],
+			keys: Key | Key[],
 			cb?: Callback<number>
 		): number;
 
@@ -76,13 +82,13 @@ declare namespace NodeCache {
 		 * reset or redefine the ttl of a key. If `ttl` is not passed or set to 0 it's similar to `.del()`
 		 */
 		ttl(
-			key: string,
+			key: Key,
 			ttl: number,
 			cb?: Callback<boolean>
 		): boolean;
 
 		ttl(
-			key: string,
+			key: Key,
 			cb?: Callback<boolean>,
 			ttl?: number
 		): boolean;
@@ -141,9 +147,7 @@ declare namespace NodeCache {
 		v: T;
 	}
 
-	interface Callback<T> {
-		(err: any, data: T): void;
-	}
+	type Callback<T> = (err: any, data: T | undefined) => void;
 }
 
 import events = require("events");
@@ -172,9 +176,9 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	 * @param cb Callback function
 	 */
 	get<T>(
-		key: string,
+		key: Key,
 		cb?: Callback<T>
-	): T;
+	): T | undefined;
 
 	/**
 	 * get multiple cached keys at once and change the stats
@@ -183,7 +187,7 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	 * @param cb Callback function
 	 */
 	mget<T>(
-		keys: string[],
+		keys: Key[],
 		cb?: Callback<{ [key: string]: T }>
 	): { [key: string]: T };
 
@@ -197,14 +201,14 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	 * @param cb Callback function
 	 */
 	set<T>(
-		key: string,
+		key: Key,
 		value: T,
 		ttl: number | string,
 		cb?: Callback<boolean>
 	): boolean;
 
 	set<T>(
-		key: string,
+		key: Key,
 		value: T,
 		cb?: Callback<boolean>
 	): boolean;
@@ -216,7 +220,7 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	 * @returns Number of deleted keys
 	 */
 	del(
-		keys: string | string[],
+		keys: Key | Key[],
 		cb?: Callback<number>
 	): number;
 
@@ -224,13 +228,13 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 	 * reset or redefine the ttl of a key. If `ttl` is not passed or set to 0 it's similar to `.del()`
 	 */
 	ttl(
-		key: string,
+		key: Key,
 		ttl: number,
 		cb?: Callback<boolean>
 	): boolean;
 
 	ttl(
-		key: string,
+		key: Key,
 		cb?: Callback<boolean>,
 		ttl?: number
 	): boolean;
@@ -261,4 +265,3 @@ declare class NodeCache extends events.EventEmitter implements NodeCache.NodeCac
 }
 
 export = NodeCache;
-

--- a/types/node-cache/node-cache-tests.ts
+++ b/types/node-cache/node-cache-tests.ts
@@ -1,5 +1,3 @@
-
-
 import NodeCache = require('node-cache');
 
 import Options = NodeCache.Options;
@@ -23,7 +21,7 @@ interface TypeSample {
 	let cache: NodeCache;
 	let key: string;
 	let cb: Callback<TypeSample>;
-	let result: TypeSample;
+	let result: TypeSample | undefined;
 	result = cache.get<TypeSample>(key);
 	result = cache.get<TypeSample>(key, cb);
 }
@@ -31,8 +29,8 @@ interface TypeSample {
 {
 	let cache: NodeCache;
 	let keys: string[];
-	let cb: Callback<{[key: string]: TypeSample}>;
-	let result: {[key: string]: TypeSample};
+	let cb: Callback<{ [key: string]: TypeSample }>;
+	let result: { [key: string]: TypeSample };
 	result = cache.mget<TypeSample>(keys);
 	result = cache.mget<TypeSample>(keys, cb);
 }
@@ -41,7 +39,7 @@ interface TypeSample {
 	let cache: NodeCache;
 	let key: string;
 	let value: TypeSample;
-	let ttl: number|string;
+	let ttl: number | string;
 	let cb: Callback<boolean>;
 	let result: boolean;
 	result = cache.set<TypeSample>(key, value);
@@ -52,7 +50,7 @@ interface TypeSample {
 
 {
 	let cache: NodeCache;
-	let keys: string|string[];
+	let keys: string | string[];
 	let cb: Callback<number>;
 	let result: number;
 	result = cache.del(keys);
@@ -85,6 +83,7 @@ interface TypeSample {
 	result = cache.getStats();
 }
 
+/* tslint:disable void-return */
 {
 	let cache: NodeCache;
 	let result: void;
@@ -96,3 +95,4 @@ interface TypeSample {
 	let result: void;
 	result = cache.close();
 }
+/* tslint:enable void-return */

--- a/types/node-cache/tslint.json
+++ b/types/node-cache/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
-- get() returns undefined : https://github.com/mpneuried/nodecache/blob/master/_src/lib/node_cache.coffee#L101
-- key is string or number : https://github.com/mpneuried/nodecache/commit/992ad63acb3203f3d81a65db0bbcadb34b9c3292
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
