### PR TITLE
[jquery] Add example to create plugin

### DIFF
--- a/types/jquery/README.md
+++ b/types/jquery/README.md
@@ -32,7 +32,7 @@ Note that while the factory function ignores the second parameter, it is require
 - [test/longdesc-tests.ts](test/longdesc-tests.ts)
     - Tests generated from non-example snippets in jQuery documentation.
 - [test/learn-tests.ts](test/learn-tests.ts)
-    - Tests imported from in [jQuery Learning Center](https://learn.jquery.com/).
+    - Tests imported from examples in [jQuery Learning Center](https://learn.jquery.com).
 - [test/jquery-window-module-tests.ts](test/jquery-window-module-tests.ts)<br>
   [test/jquery-slim-window-module-tests.ts](test/jquery-slim-window-module-tests.ts)
     - Tests importing jQuery with a DOM available

--- a/types/jquery/README.md
+++ b/types/jquery/README.md
@@ -31,6 +31,8 @@ Note that while the factory function ignores the second parameter, it is require
     - Tests generated from examples in jQuery documentation.
 - [test/longdesc-tests.ts](test/longdesc-tests.ts)
     - Tests generated from non-example snippets in jQuery documentation.
+- [test/learn-tests.ts](test/learn-tests.ts)
+    - Tests imported from in [jQuery Learning Center](https://learn.jquery.com/).
 - [test/jquery-window-module-tests.ts](test/jquery-window-module-tests.ts)<br>
   [test/jquery-slim-window-module-tests.ts](test/jquery-slim-window-module-tests.ts)
     - Tests importing jQuery with a DOM available

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2422,7 +2422,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @since 1.4.3
      */
     cssNumber: JQuery.PlainObject<boolean>;
-    readonly fn: JQuery<TElement>;
+    fn: JQuery<TElement>;
     fx: {
         /**
          * The rate (in milliseconds) at which animations fire.

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -2422,7 +2422,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @since 1.4.3
      */
     cssNumber: JQuery.PlainObject<boolean>;
-    fn: JQuery<TElement>;
+    readonly fn: JQuery<TElement>;
     fx: {
         /**
          * The rate (in milliseconds) at which animations fire.

--- a/types/jquery/test/learn-tests.ts
+++ b/types/jquery/test/learn-tests.ts
@@ -1,6 +1,3 @@
-import jQueryFactory = require('jquery');
-const jQuery = jQueryFactory(window, true);
-
 # From https://learn.jquery.com/plugins/basic-plugin-creation/
 
 ## Basic Plugin Authoring

--- a/types/jquery/test/learn-tests.ts
+++ b/types/jquery/test/learn-tests.ts
@@ -1,6 +1,6 @@
-# From https://learn.jquery.com/plugins/basic-plugin-creation/
+// From https://learn.jquery.com/plugins/basic-plugin-creation/
 
-## Basic Plugin Authoring
+// Basic Plugin Authoring
 
 interface JQuery {
     greenify: GreenifyPlugin;

--- a/types/jquery/test/learn-tests.ts
+++ b/types/jquery/test/learn-tests.ts
@@ -1,0 +1,20 @@
+import jQueryFactory = require('jquery');
+const jQuery = jQueryFactory(window, true);
+
+# From https://learn.jquery.com/plugins/basic-plugin-creation/
+
+## Basic Plugin Authoring
+
+interface JQuery {
+    greenify: GreenifyPlugin;
+}
+
+interface GreenifyPlugin {
+   (this: JQuery): void;
+}
+
+jQuery.fn.greenify = function() {
+    this.css( "color", "green" );
+};
+
+jQuery( "a" ).greenify(); // Makes all the links green.

--- a/types/jquery/tsconfig.json
+++ b/types/jquery/tsconfig.json
@@ -22,6 +22,7 @@
         "jquery-tests.ts",
         "test/example-tests.ts",
         "test/longdesc-tests.ts",
+        "test/learn-tests.ts",
         "test/jquery-no-window-module-tests.ts",
         "test/jquery-window-module-tests.ts",
         "test/jquery-slim-no-window-module-tests.ts",


### PR DESCRIPTION
Modifying jQuery property `$.fn` is required to create a jQuery plugin.

So me should remove `readonly` keyword from its TypeScript definition.

Reference: https://learn.jquery.com/plugins/basic-plugin-creation/#basic-plugin-authoring
