### PR TITLE
[react-responsive] Adds 'any' state interface to Media Query to avoid TypeScript compiler errors

### DIFF
--- a/types/react-responsive/index.d.ts
+++ b/types/react-responsive/index.d.ts
@@ -59,7 +59,7 @@ declare module "react-responsive" {
         }
     }
 
-    class MediaQuery extends React.Component<MediaQuery.MediaQueryProps> { }
+    class MediaQuery extends React.Component<MediaQuery.MediaQueryProps, any> { }
     export = MediaQuery;
 
 }


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


This line:
`    class MediaQuery extends React.Component<MediaQuery.MediaQueryProps> { }`
was causing this error:
`[ts] Generic type 'Component<P, S>' requires 2 type argument(s).`



When I tried to use the MediaQuery:
```
import MediaQuery from 'react-responsive';
...

const Routes = (props) => (
<MediaQuery minWidth={600}>
    width greater than 600
</MediaQuery>
);
```
ts generated this error:
`[ts] JSX element type 'MediaQuery' does not have any construct or call signatures.`

Adding `any` as the state interface fixed these issues.

For now I am using `let MediaQuery = require("react-responsive");` to avoid type checking.


