### PR TITLE
[google-map-react] add definition for maxZoom to Option

### DIFF
--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for google-map-react 0.22
+// Type definitions for google-map-react 0.23
 // Project: https://github.com/istarkov/google-map-react
 // Definitions by: Honza Brecka <https://github.com/honzabrecka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -15,6 +15,7 @@ export interface Options {
   mapTypeControl?: boolean;
   minZoomOverride?: boolean;
   minZoom?: number;
+  maxZoom?: number;
   gestureHandling?: string;
 }
 


### PR DESCRIPTION
Adding maxZoom definition to the Option interface.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/caraballofelix88/DefinitelyTyped/blob/master/types/google-map-react/index.d.ts
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.