### PR TITLE
React-Burger-Menu: Compatibility with older versions of React

### DIFF
--- a/types/react-burger-menu/index.d.ts
+++ b/types/react-burger-menu/index.d.ts
@@ -41,7 +41,7 @@ export interface Props {
     width?: number | string;
 }
 
-export class ReactBurgerMenu extends React.Component<Props> { }
+export class ReactBurgerMenu extends React.Component<Props, {}> { }
 
 export class slide extends ReactBurgerMenu { }
 export class stack extends ReactBurgerMenu { }


### PR DESCRIPTION
Removing the state of ReactBurgerMenu isn't compatible with older versions of React. I know that this request is a bit regressive, but explicitly defining the state would be more practical for those of us who can't easily upgrade React.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-burger-menu/index.d.ts
