### PR TITLE
@types/sockjs-client export interfaces

### DIFF
--- a/types/sockjs-client/index.d.ts
+++ b/types/sockjs-client/index.d.ts
@@ -33,8 +33,7 @@
     CONNECTING = 0, OPEN, CLOSING, CLOSED
   }
 
-  export class SockJS{
-    constructor(url: string, _reserved?: any, options?: Options);
+  export interface SockJSClass extends EventTarget {
     readyState: State;
     protocol: string;
     url: string;
@@ -44,5 +43,16 @@
     send(data: any): void;
     close(code?: number, reason?: string): void;
   }
+
+
+  export const SockJS: {
+    new(url: string, _reserved?: any, options?: Options): SockJSClass;
+    (url: string, _reserved?: any, options?: Options): SockJSClass;
+    prototype: SockJSClass;
+    CONNECTING: State;
+    OPEN: State;
+    CLOSING: State;
+    CLOSED: State;
+  };
 
 

--- a/types/sockjs-client/index.d.ts
+++ b/types/sockjs-client/index.d.ts
@@ -33,7 +33,8 @@
     CONNECTING = 0, OPEN, CLOSING, CLOSED
   }
 
-  export interface SockJSClass extends EventTarget {
+  export class SockJS{
+    constructor(url: string, _reserved?: any, options?: Options);
     readyState: State;
     protocol: string;
     url: string;
@@ -43,14 +44,5 @@
     send(data: any): void;
     close(code?: number, reason?: string): void;
   }
-
-export interface SockJS{
-  new(url: string, _reserved?: any, options?: Options): SockJSClass;
-  prototype: SockJSClass;
-  CONNECTING: State;
-  OPEN: State;
-  CLOSING: State;
-  CLOSED: State;
-}
 
 

--- a/types/sockjs-client/index.d.ts
+++ b/types/sockjs-client/index.d.ts
@@ -3,38 +3,37 @@
 // Definitions by: Emil Ivanov <https://github.com/vladev>, Alexander Rusakov <https://github.com/arusakov/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace __SockJSClient {
-  interface BaseEvent extends Event {
+  export interface BaseEvent extends Event {
     type: string;
   }
 
-  interface OpenEvent extends BaseEvent {}
+  export interface OpenEvent extends BaseEvent {}
 
-  interface CloseEvent extends BaseEvent {
+  export interface CloseEvent extends BaseEvent {
     code: number;
     reason: string;
     wasClean: boolean;
   }
 
-  interface MessageEvent extends BaseEvent {
+  export interface MessageEvent extends BaseEvent {
     data: string;
   }
 
-  interface SessionGenerator {
+  export interface SessionGenerator {
     (): string;
   }
 
-  interface Options {
+  export interface Options {
     server?: string;
     sessionId?: number | SessionGenerator;
     transports?: string | string[]
   }
 
-  enum State {
+  export enum State {
     CONNECTING = 0, OPEN, CLOSING, CLOSED
   }
 
-  interface SockJSClass extends EventTarget {
+  export interface SockJSClass extends EventTarget {
     readyState: State;
     protocol: string;
     url: string;
@@ -44,22 +43,14 @@ declare namespace __SockJSClient {
     send(data: any): void;
     close(code?: number, reason?: string): void;
   }
-}
 
-import SockJSClass = __SockJSClient.SockJSClass;
-import Options = __SockJSClient.Options;
-import State = __SockJSClient.State;
-
-declare var SockJS: {
+export interface SockJS{
   new(url: string, _reserved?: any, options?: Options): SockJSClass;
-  (url: string, _reserved?: any, options?: Options): SockJSClass;
   prototype: SockJSClass;
   CONNECTING: State;
   OPEN: State;
   CLOSING: State;
   CLOSED: State;
-};
+}
 
-export = SockJS;
-export as namespace SockJS;
 

--- a/types/sockjs-client/sockjs-client-tests.ts
+++ b/types/sockjs-client/sockjs-client-tests.ts
@@ -1,5 +1,3 @@
-
-
 import * as SockJS from 'sockjs-client';
 
 let sockJs: any;

--- a/types/sockjs-client/sockjs-client-tests.ts
+++ b/types/sockjs-client/sockjs-client-tests.ts
@@ -1,6 +1,6 @@
-import * as SockJS from 'sockjs-client';
+import { SockJS, SockJSClass } from 'sockjs-client';
 
-let sockJs: any;
+let sockJs: SockJSClass;
 
 sockJs = new SockJS('url');
 sockJs = SockJS('url');


### PR DESCRIPTION
exported interfaces of `@types/sockjs-client` since it was unusable. 