### PR TITLE
react-redux: remove implicit dispatch<any> from props

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -54,7 +54,7 @@ export declare function connect(): ComponentDecoratorInfer<DispatchProp<any>>;
 
 export declare function connect<TStateProps, no_dispatch, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>
-): ComponentDecorator<DispatchProp<any> & TStateProps, TOwnProps>;
+): ComponentDecorator<TStateProps, TOwnProps>;
 
 export declare function connect<no_state, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,


### PR DESCRIPTION
In __connect__ function that does not have a __mapDispatchToProps__ function as an argument, we don't want to implicitly inject dispatch props into the component. The component may only need to get the data from store. If __dispatch__ is needed, we can pass in __mapDispatchToProps__  function.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
  __Prior version broken already, tsc cannot compile. However, tested with my own component__
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17829>>
 <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/6237>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.