### PR TITLE
update types for autosize

### DIFF
--- a/types/autosize/autosize-tests.ts
+++ b/types/autosize/autosize-tests.ts
@@ -1,3 +1,5 @@
+import autosize from 'autosize'
+
 // from a NodeList
 autosize(document.querySelectorAll('textarea'));
 

--- a/types/autosize/index.d.ts
+++ b/types/autosize/index.d.ts
@@ -1,20 +1,64 @@
-// Type definitions for jquery.autosize 3.0.7
+// Type definitions for jquery.autosize 3.0.20
 // Project: http://www.jacklmoore.com/autosize/
-// Definitions by: Aaron T. King <https://github.com/kingdango>, keika299 <https://github.com/keika299>
+// Definitions by: Aaron T. King <https://github.com/kingdango>, keika299 <https://github.com/keika299>, NeekSandhu <https://github.com/NeekSandhu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="jquery" />
+
+/**
+ * Attach autosize to NodeList
+ * @param elements 
+ */
+declare function autosize(elements: NodeList): NodeList;
+/**
+ * Attach autosize to Element
+ * @param element
+ */
+declare function autosize(element: Element): Element;
+/**
+ * Attach autosize to JQuery collection
+ * @param collection
+ */
+declare function autosize(collection: JQuery): JQuery;
+
 declare namespace autosize {
-    interface AutosizeStatic {
-        (el: Element): void;
-        (el: NodeList): void;
-        update(el: Element): void;
-        update(el: NodeList): void;
-        destroy(el: Element): void;
-        destroy(el: NodeList): void;
-    }
+    /**
+     * Triggers the height adjustment for an assigned textarea element.
+     * Autosize will automatically adjust the textarea height on keyboard and window resize events. 
+     * There is no efficient way for Autosize to monitor for when another script has changed the textarea value or for changes in layout that impact the textarea element.
+     * @param elements 
+     */
+    function update(elements: NodeList): NodeList;
+    /**
+     * Triggers the height adjustment for an assigned textarea element.
+     * Autosize will automatically adjust the textarea height on keyboard and window resize events. 
+     * There is no efficient way for Autosize to monitor for when another script has changed the textarea value or for changes in layout that impact the textarea element.
+     * @param element
+     */
+    function update(element: Element): Element;
+    /**
+     * Triggers the height adjustment for an assigned textarea element.
+     * Autosize will automatically adjust the textarea height on keyboard and window resize events. 
+     * There is no efficient way for Autosize to monitor for when another script has changed the textarea value or for changes in layout that impact the textarea element.
+     * @param collection 
+     */
+    function update(collection: JQuery): JQuery;
+
+    /**
+     * Removes Autosize and reverts any changes it made to the textarea element.
+     * @param elements 
+     */
+    function destroy(elements: NodeList): NodeList;
+    /**
+     * Removes Autosize and reverts any changes it made to the textarea element.
+     * @param element
+     */
+    function destroy(element: Element): Element;
+    /**
+     * Removes Autosize and reverts any changes it made to the textarea element.
+     * @param collection 
+     */
+    function destroy(collection: JQuery): JQuery;
 }
 
-declare var autosize: autosize.AutosizeStatic;
-
-export = autosize;
-export as namespace autosize;
+export default autosize;

--- a/types/css-modules/css-modules-tests.ts
+++ b/types/css-modules/css-modules-tests.ts
@@ -1,0 +1,21 @@
+import styles from './main.css'
+import * as classNames from 'classnames'
+
+class App {
+    private theme: string
+    constructor(theme: string) {
+        this.theme = theme
+    }
+
+    render() {
+        // as a style tag (using webpack's css-loader)
+        const tpl = `<div style="${styles.toString()}"></div>`
+        // or as scoped unique classes, also latest typescript versions allow prop access using dot like styles.darkUI instead of styles['darkUI']
+        return `
+            <div class="${classNames((this.theme === 'dark')? 
+                styles['darkUI'] : 
+                styles['lightUI'].toString())}">
+            </div>
+        `
+    }
+}

--- a/types/css-modules/index.d.ts
+++ b/types/css-modules/index.d.ts
@@ -1,0 +1,16 @@
+declare module '*.css' {
+    interface Stringifyable {
+        /**
+         * Stringifies the imported stylesheet for use with inline style tags 
+         */
+        toString: () => string
+    }
+    type SelectorNode = {
+        /**
+         * Returns the specific selector from imported stylesheet as string 
+         */
+        [key: string]: string
+    }
+    const styles: SelectorNode & Stringifyable
+    export default styles
+}

--- a/types/css-modules/index.d.ts
+++ b/types/css-modules/index.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for css-modules
+// Project: https://github.com/css-modules/css-modules
+// Definitions by: Neek Sandhu <https://github.com/NeekSandhu>
+// Definitions: https://github.com/ilich/DefinitelyTyped
+
 declare module '*.css' {
     interface Stringifyable {
         /**

--- a/types/css-modules/tsconfig.json
+++ b/types/css-modules/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "css-modules-tests.ts"
+    ]
+}


### PR DESCRIPTION

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.jacklmoore.com/autosize/
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

# Changes
- Add jQuery overloads
- Fixed return values of functions, they now return whatever type is passed in
- Module no longer pollutes global scope, consumers will now require `import autosize from 'autosize'`
- Added function comments (for better intellisense experience)
