### PR TITLE
Update SES nodemailer typings to match current implementation

### DIFF
--- a/types/nodemailer-ses-transport/index.d.ts
+++ b/types/nodemailer-ses-transport/index.d.ts
@@ -4,19 +4,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as AWS from "aws-sdk";
-import { HTTPOptions } from "aws-sdk/lib/config";
 import * as nodemailer from "nodemailer";
 
 declare namespace sesTransport {
 	interface SesOptions {
-		ses?: AWS.SES;
-		accessKeyId?: string;
-		secretAccessKey?: string;
-		sessionToken?: string;
-		region?: string;
-		httpOptions?: HTTPOptions;
-		rateLimit?: number;
-		maxConnections?: number;
+		SES?: AWS.SES;
+		component?: string;
+		maxConnections?: string;
+		sendingRate?: string;
 	}
 }
 

--- a/types/nodemailer-ses-transport/index.d.ts
+++ b/types/nodemailer-ses-transport/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for nodemailer-ses-transport 3.1.5
+// Type definitions for nodemailer-ses-transport 3.1
 // Project: https://github.com/andris9/nodemailer-ses-transport
 // Definitions by: Seth Westphal <https://github.com/westy92/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/nodemailer-ses-transport/index.d.ts
+++ b/types/nodemailer-ses-transport/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for nodemailer-ses-transport 1.4
+// Type definitions for nodemailer-ses-transport 3.1.5
 // Project: https://github.com/andris9/nodemailer-ses-transport
 // Definitions by: Seth Westphal <https://github.com/westy92/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -8,10 +8,10 @@ import * as nodemailer from "nodemailer";
 
 declare namespace sesTransport {
 	interface SesOptions {
-		SES?: AWS.SES;
+		SES: AWS.SES;
 		component?: string;
-		maxConnections?: string;
-		sendingRate?: string;
+		maxConnections?: number;
+		sendingRate?: number;
 	}
 }
 

--- a/types/nodemailer-ses-transport/nodemailer-ses-transport-tests.ts
+++ b/types/nodemailer-ses-transport/nodemailer-ses-transport-tests.ts
@@ -1,4 +1,4 @@
-import * as AWS from 'aws-sdk';
+import * as AWS from "aws-sdk"
 import * as nodemailer from "nodemailer";
 import * as sesTransport from 'nodemailer-ses-transport';
 

--- a/types/nodemailer-ses-transport/nodemailer-ses-transport-tests.ts
+++ b/types/nodemailer-ses-transport/nodemailer-ses-transport-tests.ts
@@ -3,9 +3,10 @@ import * as nodemailer from "nodemailer";
 import * as sesTransport from 'nodemailer-ses-transport';
 
 const opts: sesTransport.SesOptions = {
-  ses: new AWS.SES(),
-  rateLimit: 5,
-  maxConnections: 3,
+  SES: new AWS.SES(),
+  component: "string",
+  sendingRate: 5,
+  maxConnections: 3
 };
 
 const transport: nodemailer.Transport = sesTransport(opts);

--- a/types/nodemailer-ses-transport/nodemailer-ses-transport-tests.ts
+++ b/types/nodemailer-ses-transport/nodemailer-ses-transport-tests.ts
@@ -1,4 +1,4 @@
-import * as AWS from "aws-sdk"
+import * as AWS from "aws-sdk";
 import * as nodemailer from "nodemailer";
 import * as sesTransport from 'nodemailer-ses-transport';
 

--- a/types/nodemailer/index.d.ts
+++ b/types/nodemailer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Nodemailer 1.3.2
+// Type definitions for Nodemailer 3.1.5
 // Project: https://github.com/andris9/Nodemailer
 // Definitions by: Rogier Schouten <https://github.com/rogierschouten/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -30,17 +30,6 @@ export interface Transporter {
      * return Promise
      */
     sendMail(mail: SendMailOptions): Promise<SentMessageInfo>;
-
-	/**
-	 * Send mail using a template.
-	 */
-	templateSender(template?: any, defaults?: any): (mailData: any, context: any) => Promise<SentMessageInfo>;
-
-	/**
-	 * Send mail using a template with a callback.
-	 */
-	templateSender(template?: any, defaults?: any, callback?: (error: Error, info: SentMessageInfo) => void): void;
-
 
 	/**
 	 * Attach a plugin. 'compile' and 'stream' plugins can be attached with use(plugin) method

--- a/types/nodemailer/index.d.ts
+++ b/types/nodemailer/index.d.ts
@@ -7,6 +7,7 @@
 
 import directTransport = require("nodemailer-direct-transport");
 import smtpTransport = require("nodemailer-smtp-transport");
+import sesTransport = require("nodemailer-ses-transport")
 
 /**
  * Transporter plugin
@@ -73,6 +74,10 @@ export declare function createTransport(options?: directTransport.DirectOptions,
  * Create an SMTP transporter
  */
 export declare function createTransport(options?: smtpTransport.SmtpOptions, defaults?: Object): Transporter;
+/**
+ * Create an AWS SES transporter
+ */
+export declare function createTransport(options?: sesTransport.SesOptions, defaults?: Object): Transporter
 /**
  * Create a transporter from a given implementation
  */

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -1,5 +1,5 @@
-
 import * as nodemailer from 'nodemailer'
+import * as AWS from 'aws-sdk'
 
 // create reusable transporter object using SMTP transport
 var transporter: nodemailer.Transporter = nodemailer.createTransport({
@@ -9,6 +9,20 @@ var transporter: nodemailer.Transporter = nodemailer.createTransport({
         pass: 'userpass'
     }
 });
+
+// create reusable transporter object using SES transport and set default values for mail options.
+transporter = nodemailer.createTransport({
+    SES: new AWS.SES()
+})
+// create reusable transporter object using SMTP transport and set default values for mail options.
+transporter = nodemailer.createTransport({
+    SES: new AWS.SES()
+}, {
+    from: 'sender@address',
+    headers: {
+        'My-Awesome-Header': '123'
+    }
+})
 
 // create reusable transporter object using SMTP transport and set default values for mail options.
 transporter = nodemailer.createTransport({
@@ -42,20 +56,4 @@ transporter.sendMail(mailOptions, (error: Error, info: nodemailer.SentMessageInf
 transporter
   .sendMail(mailOptions)
   .then(info => info.messageId)
-// create template based sender function
-var sendPwdReset = transporter.templateSender({
-    subject: 'Password reset for {{username}}!',
-    text: 'Hello, {{username}}, Please go here to reset your password: {{ reset }}',
-    html: '<b>Hello, <strong>{{username}}</strong>, Please <a href="{{ reset }}">go here to reset your password</a>: {{ reset }}</p>'
-}, {
-    from: 'sender@example.com',
-});
-
-// use template based sender to send a message
-sendPwdReset({
-    to: 'receiver@example.com'
-}, {
-    username: 'Node Mailer',
-    reset: 'https://www.example.com/reset?token=<unique-single-use-token>'
-})
-.then(info => info.messageId);
+  .catch(err => {})

--- a/types/nodemailer/package.json
+++ b/types/nodemailer/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "aws-sdk": "^2.37.0"
+  }
+}

--- a/types/nodemailer/tsconfig.json
+++ b/types/nodemailer/tsconfig.json
@@ -13,7 +13,7 @@
         ],
         "allowJs": true,
         "types": [],
-        "noEmit": false,
+        "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
     "files": [

--- a/types/nodemailer/tsconfig.json
+++ b/types/nodemailer/tsconfig.json
@@ -11,8 +11,9 @@
         "typeRoots": [
             "../"
         ],
+        "allowJs": true,
         "types": [],
-        "noEmit": true,
+        "noEmit": false,
         "forceConsistentCasingInFileNames": true
     },
     "files": [


### PR DESCRIPTION
Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). - no tslint.json present

Select one of these and delete the others:

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: (see below)
- [ x  ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**Changes**:
* Update SES options typings to match [this version](https://github.com/nodemailer/nodemailer/tree/master/lib/ses-transport)
* Add version of `createTransport` to nodemailer which accepts SES transport as options
* Remove `templateSender` from Transport type since this doesn't seem to exist any more

**Query**:
There seem to be two versions of `nodemailer-ses-transport` around, [one merged in with nodemailer](https://github.com/nodemailer/nodemailer/tree/master/lib/ses-transport) and [one separately](https://github.com/nodemailer/nodemailer-ses-transport). The separate one seems to be what the typings are based on, but the combined one seems to have been updated more recently.

First PR - typescript wasn't working for me with these packages so I thought I would try to fix it for everybody - any advice appreciated.