### PR TITLE
Declare memory-fs module

### DIFF
--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -80,4 +80,6 @@ declare class MemoryFileSystem {
     readFile(path: string, optArg: {}, callback: (err?: Error, result?: any) => any): void;
 }
 
-export = MemoryFileSystem;
+declare module "memory-fs" {
+    export = MemoryFileSystem;
+}


### PR DESCRIPTION
Not sure if this is the fix but I'm getting error doing this:

```ts
import * as MemoryFileSystem from 'memory-fs';
```

#### Error

```
"memory-fs" resolves to a non-module entity and cannot be imported using this construct
```

This doesn't happen with tsc but happens in VSCode

```js
// tsconfig
{
    "compilerOptions": {
        "target": "es5",
        "module": "commonjs",
        "jsx": "react",
        "sourceMap": true,
        "outDir": "dist",
        "strict": true,
        "types": [
            "node",
            "webpack-env"
        ]
    }
}

```
