### PR TITLE
add patch method definition for fetch.io package

### DIFF
--- a/types/fetch.io/fetch.io-tests.ts
+++ b/types/fetch.io/fetch.io-tests.ts
@@ -24,6 +24,10 @@ request
   .json();
 
 request
+  .patch('')
+  .json();
+
+request
   .config('key', 'value')
   .json();
 

--- a/types/fetch.io/index.d.ts
+++ b/types/fetch.io/index.d.ts
@@ -63,7 +63,6 @@ export class Request {
    */
   put: (url: TUrl) => this;
 
-
   /**
    * HTTP patch method
    */

--- a/types/fetch.io/index.d.ts
+++ b/types/fetch.io/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for fetch.io 4.0
+// Type definitions for fetch.io 4.1
 // Project: https://github.com/haoxins/fetch.io
 // Definitions by: newraina <https://github.com/newraina>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -63,6 +63,12 @@ export class Request {
    */
   put: (url: TUrl) => this;
 
+
+  /**
+   * HTTP patch method
+   */
+  patch: (url: TUrl) => this;
+
   /**
    * Set Options
    */
@@ -93,7 +99,7 @@ export class Request {
   send(data: {[key: string]: any}): this;
 
   /**
-   * ppend formData
+   * append formData
    */
   append(key: string, value: any): this;
 


### PR DESCRIPTION
Changes because of this PR: [haoxins/fetch.io](https://github.com/haoxins/fetch.io/pull/46)
fetch.io support patch method now.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


