### PR TITLE
Backbone: Fetch method returns JQuery.Promise<any>

### DIFF
--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -138,7 +138,7 @@ declare namespace Backbone {
         constructor(attributes?: any, options?: any);
         initialize(attributes?: any, options?: any): void;
 
-        fetch(options?: ModelFetchOptions): JQueryXHR;
+        fetch(options?: ModelFetchOptions): JQuery.Promise<any>;
 
         /**
         * For strongly-typed access to attributes, use the `get` method only privately in public getter properties.


### PR DESCRIPTION
JQuery 3.2: .then() is no longer compatible with JQueryXHR so the use case for
returning model.fetch().then(...) requires replacing fetch's JQueryXHR type
with JQuery.Promise<any>

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.