### PR TITLE
[Dragula] add the declaration of 'ignoreInputTextSelection' for its 'DragulaOptions'

### DIFF
--- a/types/dragula/dragula-tests.ts
+++ b/types/dragula/dragula-tests.ts
@@ -20,7 +20,8 @@ var d2 = dragula({
     revertOnSpill: false,
     removeOnSpill: false,
     delay: false,
-    mirrorContainer: document.body
+    mirrorContainer: document.body,
+    ignoreInputTextSelection: true
 });
 
 var d3 = dragula();

--- a/types/dragula/index.d.ts
+++ b/types/dragula/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for dragula v2.1.2
 // Project: http://bevacqua.github.io/dragula/
 // Definitions by: Paul Welter <https://github.com/pwelter34/>
+//                 Yang He <https://github.com/abruzzihraig/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var dragula: dragula.Dragula;
@@ -21,6 +22,7 @@ declare namespace dragula {
         removeOnSpill?: boolean;
         delay?: boolean | number;
         mirrorContainer?: Element;
+        ignoreInputTextSelection?: boolean;
     }
 
     interface Drake {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/bevacqua/dragula/blame/00ff5f9fa4ff62f09c5d16509dc290699344bec0/readme.markdown#L110>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

No need to change its version number. The project Dragula it already has the option 'ignoreInputTextSelection' in its document, but its type declaration doesn't have such option. Everything is fine until using TypeScript 2.4.1. If you use the option in TypeScript 2.4.1, there would be an error occur that the option 'ignoreInputTextSelection' doesn't exist in the declaration of 'DragulaOptions'.
