### PR TITLE
fix error TS2314 in @types/react-redux

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -176,4 +176,4 @@ export interface ProviderProps {
 /**
  * Makes the Redux store available to the connect() calls in the component hierarchy below.
  */
-export class Provider extends React.Component<ProviderProps> { }
+export class Provider extends React.Component<ProviderProps, {}> { }


### PR DESCRIPTION
Generic type 'Component<P, S>' requires 2 type argument(s).
https://github.com/Microsoft/TypeScript-React-Starter#creating-a-component
