### PR TITLE
[@types/openlayers] IconOptions.src is optional

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -13572,7 +13572,7 @@ declare module olx {
             rotation?: number;
             size?: ol.Size;
             imgSize?: ol.Size;
-            src: string;
+            src?: string;
         }
 
 


### PR DESCRIPTION
If no icon source will be given, compilation fails though icon source is optional as specified by JSDoc 

`
         *     src: (string|undefined)}}
`