### PR TITLE
react-dropzone enable importing as es6 module

### DIFF
--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -42,5 +42,8 @@ declare module "react-dropzone" {
         open(): void;
     }
 
+    /* This enables 'import * as Dropzone' syntax when compiling to es2015 */
+    namespace Dropzone { }
+
     export = Dropzone;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Importing as an ES6 module works using version 0.0.32 but was broken by this change: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/d1a4134e773639eadfa6c2e3ee73283029045f02
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.