### PR TITLE
three: Specify DirectionalLightShadow types to access OrthographicCamera's properties

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -1937,10 +1937,12 @@ export class DirectionalLight extends Light {
      */
     intensity: number;
 
-    shadow: LightShadow;
+    shadow: DirectionalLightShadow;
 }
 
-export class DirectionalLightShadow extends LightShadow {}
+export class DirectionalLightShadow extends LightShadow {
+    camera: OrthographicCamera;
+}
 
 export class HemisphereLight extends Light {
     constructor(skyColorHex?: number|string, groundColorHex?: number|string, intensity?: number);


### PR DESCRIPTION
- DirectionalLight.shadow from LightShadow to DirectionalLightShadow
- DirectionalLightShadow.camera from Camera to OrthographicCamera

Reason: DirectionalLight always uses DirectionalLightShadow with
OrthographicCamera and properties of OrthographicCamera that are not in
Camera need to be available.

____
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://threejs.org/docs/index.html#api/lights/shadows/DirectionalLightShadow
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.