### PR TITLE
[recompose] Flesh out Subscribable type to better match ES Observable spec

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -17,8 +17,17 @@ declare module 'recompose' {
     type predicate<T> = mapper<T, boolean>;
     type predicateDiff<T> = (current: T, next: T) => boolean
 
+    interface Observer<T>{
+        next(props: T): void;
+        complete(): void;
+    }
+
+    interface Subscription{
+        unsubscribe(): void
+    }
+
     interface Subscribable<T> {
-        subscribe(observer: any):any;
+        subscribe(observer: Observer<T>): Subscription;
     }
 
     interface ComponentEnhancer<TInner, TOutter> {

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -16,8 +16,18 @@ declare module 'recompose' {
     type mapper<TInner, TOutter> = (input: TInner) => TOutter;
     type predicate<T> = mapper<T, boolean>;
     type predicateDiff<T> = (current: T, next: T) => boolean
+    interface Observer<T> {
+        next(value: T): void;
+        error(err: any): void;
+        complete(): void;
+    }
+
+    interface Subscription {
+        unsubscribe(): void;
+        closed: boolean;
+    }
     interface Subscribable<T> {
-        subscribe: Function;
+        subscribe(observer: Observer<T>):Subscription;
     }
 
     interface ComponentEnhancer<TInner, TOutter> {

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -15,7 +15,7 @@ declare module 'recompose' {
     type Component<P> = ComponentClass<P> | StatelessComponent<P>;
     type mapper<TInner, TOutter> = (input: TInner) => TOutter;
     type predicate<T> = mapper<T, boolean>;
-    type predicateDiff<T> = (current: T, next: T) => boolean}
+    type predicateDiff<T> = (current: T, next: T) => boolean
 
     interface Subscribable<T> {
         subscribe(observer: any):any;

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -15,19 +15,10 @@ declare module 'recompose' {
     type Component<P> = ComponentClass<P> | StatelessComponent<P>;
     type mapper<TInner, TOutter> = (input: TInner) => TOutter;
     type predicate<T> = mapper<T, boolean>;
-    type predicateDiff<T> = (current: T, next: T) => boolean
-    interface Observer<T> {
-        next(value: T): void;
-        error(err: any): void;
-        complete(): void;
-    }
+    type predicateDiff<T> = (current: T, next: T) => boolean}
 
-    interface Subscription {
-        unsubscribe(): void;
-        closed: boolean;
-    }
     interface Subscribable<T> {
-        subscribe(observer: Observer<T>):Subscription;
+        subscribe(observer: any):any;
     }
 
     interface ComponentEnhancer<TInner, TOutter> {


### PR DESCRIPTION
This PR extends the Subscribable type to better match the [ES Observable spec](https://github.com/tc39/proposal-observable)

Currently, if you try to write code like this in TS 2.4 (with no config):
```
componentFromStream(props$ => {
  const rxjsProps$ = Rx.Observable.from(props$);
  
  // Rest of code here
}
```
You will get type mismatch errors between Recompose's ```subscribe: Function``` and the more fleshed out definition in ```rxjs```.

To fix this, I added methods and interfaces from the ES Observable spec to pass the failing type checks. This has fixed the issues I was having with RxJS 5. My understanding is so long as the fix adheres to the spec, this should not cause issues with other libraries, but I have not yet tested this.