### PR TITLE
@types/ws: binary flag is gone on ping and pong which reduces the options object to the mask boolean

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -43,8 +43,8 @@ declare class WebSocket extends events.EventEmitter {
     close(code?: number, data?: any): void;
     pause(): void;
     resume(): void;
-    ping(data?: any, options?: { mask?: boolean; binary?: boolean }, dontFail?: boolean): void;
-    pong(data?: any, options?: { mask?: boolean; binary?: boolean }, dontFail?: boolean): void;
+    ping(data?: any, mask?: boolean, dontFail?: boolean): void;
+    pong(data?: any, mask?: boolean, dontFail?: boolean): void;
     send(data: any, cb?: (err: Error) => void): void;
     send(data: any, options: { mask?: boolean; binary?: boolean }, cb?: (err: Error) => void): void;
     stream(options: { mask?: boolean; binary?: boolean }, cb?: (err: Error, final: boolean) => void): void;
@@ -76,8 +76,8 @@ declare class WebSocket extends events.EventEmitter {
     addListener(event: 'close', cb: (code: number, message: string) => void): this;
     addListener(event: 'headers', cb: (headers: {}, request: http.IncomingMessage) => void): this;
     addListener(event: 'message', cb: (data: WebSocket.Data, flags: { binary: boolean }) => void): this;
-    addListener(event: 'ping', cb: (data: Buffer, flags: { binary: boolean }) => void): this;
-    addListener(event: 'pong', cb: (data: Buffer, flags: { binary: boolean }) => void): this;
+    addListener(event: 'ping', cb: (data: Buffer) => void): this;
+    addListener(event: 'pong', cb: (data: Buffer) => void): this;
     addListener(event: 'open', cb: () => void): this;
     addListener(event: 'unexpected-response', cb: (request: http.ClientRequest, response: http.IncomingMessage) => void): this;
     addListener(event: string, listener: () => void): this;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/websockets/ws/blob/master/doc/ws.md#websocketpingdata-mask-failsilently
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This is my first PR. I'm not sure if it's done correct. Readme says just doing a fork which I've done, then I've pushed my changes to the master branch of my fork and made a PR to the master branch of DefinitelyTyped. Running tsc gave no errors with current version of TS, so I guess this was testing enough?
