### PR TITLE
[@types/angular-resource] fix resource interceptor for typescript > = 2.4

### DIFF
--- a/types/angular-resource/index.d.ts
+++ b/types/angular-resource/index.d.ts
@@ -55,6 +55,20 @@ declare module 'angular' {
         interface IActionHash {
             [action: string]: IActionDescriptor
         }
+        
+        interface IResourceResponse {
+            config: any;
+            data: any;
+            headers: any;
+            resource: any;
+            status: number;
+            statusText: string
+        }
+
+        interface IResourceInterceptor {
+            response?(response: IResourceResponse): any;
+            responseError?(rejection: any): any;
+        }
 
         // Just a reference to facilitate describing new actions
         interface IActionDescriptor {
@@ -75,7 +89,7 @@ declare module 'angular' {
             cancellable?: boolean;
             withCredentials?: boolean;
             responseType?: string;
-            interceptor?: angular.IHttpInterceptor;
+            interceptor?: IResourceInterceptor;
         }
 
         // Allow specify more resource methods


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

As according to documentation https://docs.angularjs.org/api/ngResource/service/$resource
and the way interceptor working in $resource(is not actually angular.IHttpInterceptor), old realization need to be fixed for typescript >= 2.4.x 
links for detailed information
https://github.com/angular/angular.js/issues/11201