### PR TITLE
[@types/openlayers] Missing function ol.style.Style#clone

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -10583,6 +10583,13 @@ declare module ol {
             constructor(opt_options?: olx.style.StyleOptions);
 
             /**
+             * Clones the style.
+             * @return {ol.style.Style} The cloned style.
+             * @api
+             */
+            clone(): ol.style.Style;
+            
+            /**
              * Get the geometry to be rendered.
              * @return {string|ol.geom.Geometry|ol.StyleGeometryFunction}
              * Feature property or geometry or function that returns the geometry that will


### PR DESCRIPTION
API function clone (introduced in v3.19.0) for ol.style.Style is missing:

`
ol.style.Style.prototype.clone = function() {...};
`
