### PR TITLE
[angular] Added support for specifying the JSON-P callback parameter name

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1474,6 +1474,12 @@ declare namespace angular {
          * See [XMLHttpRequest.responseType]https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#xmlhttprequest-responsetype
          */
         responseType?: string;
+
+        /**
+         * Name of the parameter added (by AngularJS) to the request to specify the name (in the server response) of the JSON-P callback to invoke.
+         * If unspecified, $http.defaults.jsonpCallbackParam will be used by default. This property is only applicable to JSON-P requests.
+         */
+        jsonpCallbackParam?: string;
     }
 
     /**


### PR DESCRIPTION
Added support for specifying the JSON-P callback parameter name with the angular $http service.

This addresses https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17936

As per https://docs.angularjs.org/api/ng/service/$http#jsonp -

"JSONP requests must specify a callback to be used in the response from the server. This callback is passed as a query parameter in the request. You must specify the name of this parameter by setting the jsonpCallbackParam property on the request config object."

The current typings do not allow this callback to be specified.