### PR TITLE
[stripe-node] cvc must be a string, as it may have leading zeros

### DIFF
--- a/types/stripe-node/index.d.ts
+++ b/types/stripe-node/index.d.ts
@@ -3959,7 +3959,7 @@ declare namespace StripeNode {
              * Australia, Canada, or the United States. Highly recommended to always
              * include this value.
              */
-            cvc?: number;
+            cvc?: string;
 
             /**
              * Cardholder's full name.


### PR DESCRIPTION
I believe the type currently assigned to the `cvc` field on `ISourceCreationOptions` is incorrect. At the moment, it is a `number` which means that if your cvc number is `012`, stripe will fail the payment because there will not be a leading zero on `12`. Instead, it must be sent as a string so that the leading zeros are retained. I have verified the error occurs as described here, and that changing the type fixes the error and allows stripe to process the charge.

The Stripe API docs online are unusually vague when discussing the `cvc` (https://stripe.com/docs/api/node#create_charge). They do not say what the type is, nor do they have any example code that demonstrates a charge with a card source. The full text at the moment is:

> Card security code. Highly recommended to always include this value, but it's only required for accounts based in European countries.

The best proof that this is a valid change is, I think, to look at stripe's own librarys for other languages which are typed. For example, here are links to the `cvc` definition in the `go` and `dotnet` libs:

https://github.com/stripe/stripe-go/blob/master/card.go#L33
https://github.com/stripe/stripe-dotnet/blob/master/src/Stripe.net/Services/_sources/SourceCard.cs#L22

- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
