### PR TITLE
[simplemde] Tweak ShortcutsArray definition

### DIFF
--- a/types/simplemde/index.d.ts
+++ b/types/simplemde/index.d.ts
@@ -35,7 +35,7 @@ declare namespace SimpleMDE {
     }
 
     interface ShortcutsArray {
-        [action: string]: string;
+        [action: string]: string|undefined;
         toggleBlockquote?: string;
         toggleBold?: string;
         cleanBlock?: string;

--- a/types/simplemde/simplemde-tests.ts
+++ b/types/simplemde/simplemde-tests.ts
@@ -57,7 +57,8 @@ function testSimplemde() {
                 codeSyntaxHighlighting: true
             },
             shortcuts: {
-                drawTable: "Cmd-Alt-T"
+                drawTable: "Cmd-Alt-T",
+                toggleCodeBlock: null
             },
             showIcons: ["code", "table"],
             spellChecker: false,


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sparksuite/simplemde-markdown-editor#keyboard-shortcuts
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Rationale:
When using `simplemde` in my project it complains about the ShortcutsArray properties with the following error:
`Property 'toggleCodeBlock' of type 'string | undefined' is not assignable to string index type 'string'.`
I get similar errors on the other ShortcutsArray properties.

Changing the indexer to also allow `undefined` values fixes this.
