### PR TITLE
update `mkdirp` error type

### DIFF
--- a/types/mkdirp/index.d.ts
+++ b/types/mkdirp/index.d.ts
@@ -1,14 +1,14 @@
-// Type definitions for mkdirp 0.3.0
+// Type definitions for mkdirp 0.5.1
 // Project: http://github.com/substack/node-mkdirp
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
 
-
-declare function mkdirp(dir: string, cb: (err: any, made: string) => void): void;
-declare function mkdirp(dir: string, flags: any, cb: (err: any, made: string) => void): void;
+declare function mkdirp(dir: string, cb: (err: NodeJS.ErrnoException, made: string) => void): void;
+declare function mkdirp(dir: string, opts: any, cb: (err: NodeJS.ErrnoException, made: string) => void): void;
 
 declare namespace mkdirp {
-    function sync(dir: string, flags?: any): string;
+    function sync(dir: string, opts?: any): string;
 }
 export = mkdirp;

--- a/types/mkdirp/mkdirp-tests.ts
+++ b/types/mkdirp/mkdirp-tests.ts
@@ -3,8 +3,15 @@ import mkdirp = require('mkdirp');
 
 var str: string;
 var num: number;
+var opts = {
+    mode: num,
+    fs: {}
+};
 
 mkdirp(str, num, (err, made) => {
+	str = made;
+});
+mkdirp(str, opts, (err, made) => {
 	str = made;
 });
 mkdirp(str, (err, made) => {
@@ -12,4 +19,5 @@ mkdirp(str, (err, made) => {
 });
 
 str = mkdirp.sync(str, num);
+str = mkdirp.sync(str, opts);
 str = mkdirp.sync(str);


### PR DESCRIPTION
- `mkdirp` actually returns only `NodeJS.ErrnoException` created by native `fs` module.
- If `err` is `any`, `mkdirp` cannot be used with [denodefy](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/denodeify) that accepts `Error` type as `err`.
----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/substack/node-mkdirp
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.