### PR TITLE
Revert "Make render optional in react-loadable"

### DIFF
--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -67,7 +67,7 @@ export interface OptionsWithRender<Props, Exports extends object> extends Common
      * });
      * ```
      */
-    render?(loaded: Exports, props: Props): React.ReactNode;
+    render(loaded: Exports, props: Props): React.ReactNode;
 }
 
 export interface OptionsWithMap<Props, Exports extends { [key: string]: any }> extends CommonOptions {


### PR DESCRIPTION
This reverts commit 668fb871aeeb385ba5ce2be31540309d527e32b5.

`render` is _already_ optional due to the declaration of `OptionsWithoutRender`. Making it optional here allows all sorts of invalid code as the only requirement for the `loader` function then becomes that its result `extends object`.

However, there is a confusing error message should the `loading` key not be provided -- the compiler will try to use the `OptionsWithoutRender` overload instead, and complain that `render` is missing, even if the `type Options` definition is reordered. No idea how to help with that.