### PR TITLE
Update archiver to 2.0 and define options argument

### DIFF
--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -1,6 +1,26 @@
 import * as Archiver from 'archiver';
 import * as fs from 'fs';
 
+const options: Archiver.ArchiverOptions = {
+    statConcurrency: 1,
+    allowHalfOpen: true,
+    readableObjectMode: true,
+    writeableObjectMode: true,
+    decodeStrings: true,
+    encoding: 'test',
+    highWaterMark: 1,
+    objectmode: true,
+    comment: 'test',
+    forceLocalTime: true,
+    forceZip64: true,
+    store: true,
+    zlib: {},
+    gzip: true,
+    gzipOptions: {},
+};
+
+Archiver('zip', options);
+
 const archiver = Archiver.create('zip');
 
 const writeStream = fs.createWriteStream('./archiver.d.ts');
@@ -13,8 +33,6 @@ archiver.append(readStream, { name: 'archiver.d.ts' });
 
 archiver.append(readStream, {name: 'archiver.d.ts'})
 .append(readStream, {name: 'archiver.d.ts'});
-
-archiver.bulk({ mappaing: {} });
 
 archiver.directory('./path', './someOtherPath');
 archiver.directory('./path', { name: "testName" });
@@ -38,4 +56,6 @@ archiver.setModule(() => {});
 archiver.pointer();
 archiver.use(() => {});
 
-archiver.finalize();
+archiver.finalize().then();
+
+archiver.symlink('./path', './target');

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -1,22 +1,11 @@
-// Type definitions for archiver 1.3
+// Type definitions for archiver 2.0
 // Project: https://github.com/archiverjs/node-archiver
-// Definitions by: Esri <https://github.com/archiverjs/node-archiver>, Dolan Miu <https://github.com/dolanmiu>
+// Definitions by: Esri <https://github.com/archiverjs/node-archiver>, Dolan Miu <https://github.com/dolanmiu>, Crevil <https://github.com/crevil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-/* =================== USAGE ===================
-
-    import Archiver = require('archiver);
-    var archiver = Archiver.create('zip');
-    archiver.pipe(fs.createWriteStream('xxx'));
-    archiver.append(fs.createReadStream('xxx'));
-    archiver.finalize();
-
- =============================================== */
-
-/// <reference types="node" />
 
 import * as stream from 'stream';
 import * as glob from 'glob';
+import { ZlibOptions } from 'zlib';
 
 declare function archiver(format: archiver.Format, options?: archiver.ArchiverOptions): archiver.Archiver;
 
@@ -36,27 +25,48 @@ declare namespace archiver {
         abort(): this;
         append(source: stream.Readable | Buffer | string, name?: EntryData): this;
 
-        bulk(mappings: any): this;
-
         directory(dirpath: string, options: EntryData | string, data?: EntryData): this;
 
         file(filename: string, data: EntryData): this;
         glob(pattern: string, options?: glob.IOptions, data?: EntryData): this;
-        finalize(): this;
+        finalize(): Promise<void>;
 
         setFormat(format: string): this;
         setModule(module: Function): this;
 
         pointer(): number;
         use(plugin: Function): this;
+
+        symlink(filepath: string, target: string): this;
     }
 
-    interface ArchiverOptions {
+    type ArchiverOptions = CoreOptions & TransformOptions & ZipOptions & TarOptions;
+
+    interface CoreOptions {
+        statConcurrency?: number;
+    }
+
+    interface TransformOptions {
+        allowHalfOpen?: boolean;
+        readableObjectMode?: boolean;
+        writeableObjectMode?: boolean;
+        decodeStrings?: boolean;
+        encoding?: string;
+        highWaterMark?: number;
+        objectmode?: boolean;
+    }
+
+    interface ZipOptions {
+        comment?: string;
+        forceLocalTime?: boolean;
+        forceZip64?: boolean;
         store?: boolean;
+        zlib?: ZlibOptions;
+    }
+
+    interface TarOptions {
         gzip?: boolean;
-        gzipOptions?: {
-            level: number,
-        };
+        gzipOptions?: ZlibOptions;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/archiverjs/node-archiver/blob/2.0.0/CHANGELOG.md#changelog
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
