### PR TITLE
add: node v8 has standardized stream "destroy"

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -319,6 +319,7 @@ declare namespace NodeJS {
         unshift(chunk: string): void;
         unshift(chunk: Buffer): void;
         wrap(oldStream: ReadableStream): ReadableStream;
+        destroy(err?: Error): void;
     }
 
     export interface WritableStream extends EventEmitter {
@@ -329,6 +330,7 @@ declare namespace NodeJS {
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
+        destroy(err?: Error): void;
     }
 
     export interface ReadWriteStream extends ReadableStream, WritableStream { }
@@ -893,7 +895,6 @@ declare module "http" {
          */
         statusMessage?: string;
         socket: net.Socket;
-        destroy(error?: Error): void;
     }
     /**
      * @deprecated Use IncomingMessage
@@ -2231,7 +2232,6 @@ declare module "net" {
         bufferSize: number;
         setEncoding(encoding?: string): this;
         write(data: any, encoding?: string, callback?: Function): void;
-        destroy(err?: any): void;
         pause(): this;
         resume(): this;
         setTimeout(timeout: number, callback?: Function): void;
@@ -2571,7 +2571,6 @@ declare module "fs" {
 
     export interface ReadStream extends stream.Readable {
         close(): void;
-        destroy(): void;
         bytesRead: number;
         path: string | Buffer;
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -3765,6 +3765,7 @@ declare module "stream" {
             unshift(chunk: any): void;
             wrap(oldStream: NodeJS.ReadableStream): Readable;
             push(chunk: any, encoding?: string): boolean;
+            destroy(err?: Error): void;            
 
             /**
              * Event emitter
@@ -3846,6 +3847,7 @@ declare module "stream" {
             end(chunk: any, encoding?: string, cb?: Function): void;
             cork(): void;
             uncork(): void;
+            destroy(err?: Error): void;
 
             /**
              * Event emitter
@@ -3933,6 +3935,7 @@ declare module "stream" {
             end(chunk: any, encoding?: string, cb?: Function): void;
             cork(): void;
             uncork(): void;
+            destroy(err?: Error): void;            
         }
 
         export interface TransformOptions extends DuplexOptions {


### PR DESCRIPTION
Add `destroy(err?: Error): void;` to `ReadableStream`, and `WritableStream` from which everything else is derived from. 
Also cleaned up other higher level `destroy` that's no longer needed.