### PR TITLE
Added 'text' to Response interface, fixed numerous linting errors for chai-http

### DIFF
--- a/types/chai-http/chai-http-tests.ts
+++ b/types/chai-http/chai-http-tests.ts
@@ -1,6 +1,3 @@
-/// <reference types="when" />
-
-
 import fs = require('fs');
 import http = require('http');
 import chai = require('chai');
@@ -16,7 +13,7 @@ if (!global.Promise) {
 	chai.request.addPromises(when.promise);
 }
 
-var app: http.Server;
+let app: http.Server;
 
 chai.request(app).get('/');
 chai.request('http://localhost:8080').get('/');
@@ -58,7 +55,7 @@ chai.request(app)
 	.then((res: ChaiHttp.Response) => chai.expect(res).to.have.status(200))
 	.catch((err: any) => { throw err; });
 
-var agent = chai.request.agent(app);
+let agent = chai.request.agent(app);
 
 agent
 	.post('/session')
@@ -72,7 +69,7 @@ agent
 	});
 
 function test1() {
-	var req = chai.request(app).get('/');
+	let req = chai.request(app).get('/');
 	req.then((res: ChaiHttp.Response) => {
 		chai.expect(res).to.have.status(200);
 		chai.expect(res).to.have.header('content-type', 'text/plain');
@@ -94,6 +91,7 @@ function test1() {
 		chai.expect(res).to.have.cookie('session_id', '1234');
 		chai.expect(res).to.not.have.cookie('PHPSESSID');
 		chai.expect(res.body).to.have.property('version', '4.0.0');
+		chai.expect(res.text).to.equal('<html><body></body></html>');
 	}, (err: any) => {
 		throw err;
 	});

--- a/types/chai-http/index.d.ts
+++ b/types/chai-http/index.d.ts
@@ -1,85 +1,85 @@
-// Type definitions for chai-http
+// Type definitions for chai-http 3.0
 // Project: https://github.com/chaijs/chai-http
 // Definitions by: Wim Looman <https://github.com/Nemo157>
+// 				   Liam Jones <https://github.com/G1itcher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 /// <reference types="chai" />
 
-declare namespace Chai {
+declare global {
+	namespace Chai {
+		interface ChaiStatic {
+			request: ChaiHttpRequest;
+		}
 
-	interface ChaiStatic {
-		request: ChaiHttpRequest;
+		interface ChaiHttpRequest {
+			(server: any): ChaiHttp.Agent;
+			agent(server: any): ChaiHttp.Agent;
+			addPromises(promiseConstructor: any): void;
+		}
+
+		interface Assertion {
+			status(code: number): Assertion;
+			header(key: string, value?: string | RegExp): Assertion;
+			headers: Assertion;
+			json: Assertion;
+			text: Assertion;
+			html: Assertion;
+			redirect: Assertion;
+			redirectTo(location: string): Assertion;
+			param(key: string, value?: string): Assertion;
+			cookie(key: string, value?: string): Assertion;
+		}
+
+		interface TypeComparison {
+			ip: Assertion;
+		}
 	}
 
-	interface ChaiHttpRequest {
-		(server: any): ChaiHttp.Agent;
-		agent(server: any): ChaiHttp.Agent;
-		addPromises(promiseConstructor: any): void;
-	}
+	namespace ChaiHttp {
+		interface Promise<T> {
+			then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => U): Promise<U>;
+		}
 
-	interface Assertion {
-		status(code: number): Assertion;
-		header(key: string, value?: string): Assertion;
-		header(key: string, value?: RegExp): Assertion;
-		headers: Assertion;
-		json: Assertion;
-		text: Assertion;
-		html: Assertion;
-		redirect: Assertion;
-		redirectTo(location: string): Assertion;
-		param(key: string, value?: string): Assertion;
-		cookie(key: string, value?: string): Assertion;
-	}
+		interface Response {
+			body: any;
+			type: string;
+			status: number;
+			text: string;
+		}
 
-	interface TypeComparison {
-		ip: Assertion;
+		interface Request extends FinishedRequest {
+			attach(field: string, file: string|Buffer, filename: string): Request;
+			set(field: string, val: string): Request;
+			query(params: any): Request;
+			send(data: any): Request;
+			auth(user: string, name: string): Request;
+			field(name: string, val: string): Request;
+			buffer(): Request;
+			end(callback?: (err: any, res: Response) => void): FinishedRequest;
+		}
+
+		interface FinishedRequest {
+			then(success?: (res: Response) => void, failure?: (err: any) => void): FinishedRequest;
+			catch(failure?: (err: any) => void): FinishedRequest;
+		}
+
+		interface Agent {
+			get(url: string, callback?: (err: any, res: Response) => void): Request;
+			post(url: string, callback?: (err: any, res: Response) => void): Request;
+			put(url: string, callback?: (err: any, res: Response) => void): Request;
+			head(url: string, callback?: (err: any, res: Response) => void): Request;
+			del(url: string, callback?: (err: any, res: Response) => void): Request;
+			options(url: string, callback?: (err: any, res: Response) => void): Request;
+			patch(url: string, callback?: (err: any, res: Response) => void): Request;
+		}
+
+		interface TypeComparison {
+			ip: any;
+		}
 	}
 }
 
-declare namespace ChaiHttp {
-	interface Promise<T> {
-		then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => U): Promise<U>;
-	}
-
-	interface Response {
-		body: any;
-		type: string;
-		status: number;
-	}
-
-	interface Request extends FinishedRequest {
-		attach(field: string, file: string|Buffer, filename: string): Request;
-		set(field: string, val: string): Request;
-		query(params: Object): Request;
-		send(data: Object): Request;
-		auth(user: string, name: string): Request;
-		field(name: string, val: string): Request;
-		buffer(): Request;
-		end(callback?: (err: any, res: Response) => void): FinishedRequest;
-	}
-
-	interface FinishedRequest {
-		then(success?: (res: Response) => void, failure?: (err: any) => void): FinishedRequest;
-		catch(failure?: (err: any) => void): FinishedRequest;
-	}
-
-	interface Agent {
-		get(url: string, callback?: (err: any, res: Response) => void): Request;
-		post(url: string, callback?: (err: any, res: Response) => void): Request;
-		put(url: string, callback?: (err: any, res: Response) => void): Request;
-		head(url: string, callback?: (err: any, res: Response) => void): Request;
-		del(url: string, callback?: (err: any, res: Response) => void): Request;
-		options(url: string, callback?: (err: any, res: Response) => void): Request;
-		patch(url: string, callback?: (err: any, res: Response) => void): Request;
-	}
-
-	interface TypeComparison {
-		ip: any;
-	}
-}
-
-declare module "chai-http" {
-	function chaiHttp(chai: any, utils: any): void;
-	export = chaiHttp;
-}
+declare function chaiHttp(chai: any, utils: any): void;
+export = chaiHttp;

--- a/types/chai-http/tslint.json
+++ b/types/chai-http/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- Add Version number to header
- Add myself to the 'Definitions by'
- Add 'text' to the 'Respone' interface
- Set the namespace to be declared in global (fixes failing linting)
- Fixed a number of whitespace linting errors
- Fixed a number of 'var' usage linting errors

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/17694>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
