### PR TITLE
Added searchPlaceholder to datatables.net

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -12,6 +12,7 @@ $(document).ready(function () {
         "loadingRecords": "Loading...",
         "processing": "Processing...",
         "search": "Search:",
+        "searchPlaceholder": "Default text",
         "zeroRecords": "No matching records found",
         "paginate": {
             "first": "First",
@@ -413,6 +414,7 @@ $(document).ready(function () {
     var modifier: DataTables.ObjectSelectorModifier = {
         order: "current",
         search: "none",
+        searchPlaceholder: "Default text",
         page: "all",
     };
 

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for JQuery DataTables 1.10.9
 // Project: http://www.datatables.net
-// Definitions by: Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>, Omid Rad <https://github.com/omidkrad>, Armin Sander <https://github.com/pragmatrix/>
+// Definitions by: Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>, Omid Rad <https://github.com/omidkrad>, Armin Sander <https://github.com/pragmatrix/>, Denise Mauldin <https://github.com/denisemauldin/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -144,6 +144,11 @@ declare namespace DataTables {
         * Values: 'none', 'applied', 'removed'
         */
         search?: string;
+
+        /**
+        * The searchPlaceholder modifier provides the ability to provide informational text for an input control when it has no value.
+        */
+        searchPlaceholder?: string;
 
         /**
         * The page modifier allows you to control if the selector should consider all data in the table, regardless of paging, or if only the rows in the currently disabled page should be used.
@@ -1319,6 +1324,11 @@ declare namespace DataTables {
         search?: SearchSettings;
 
         /**
+        * Set placeholder attribute for input type="text" tag elements. Since: 1.10
+        */
+        searchPlaceholder?: SearchSettings;
+
+        /**
         * Define an initial search for individual columns. Since: 1.10
         */
         searchCols?: SearchSettings[];
@@ -1642,6 +1652,11 @@ declare namespace DataTables {
         * Set an initial filtering condition on the table. Since: 1.10
         */
         search?: string;
+
+        /**
+        * Set a placeholder attribute for input type="text" tag elements. Since: 1.10.1
+        */
+        searchPlaceholder?: string;
     }
 
     //#endregion "other-settings"
@@ -1720,6 +1735,7 @@ declare namespace DataTables {
         loadingRecords?: string;
         processing?: string;
         search?: string;
+        searchPlaceholder?: string;
         zeroRecords?: string;
         paginate?: LanguagePaginateSettings;
         aria?: LanguageAriaSettings;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
 
Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatables.net/reference/option/language.searchPlaceholder
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


