### PR TITLE
react-virtualized-select: add second type to extends PureComponent line

### DIFF
--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -30,5 +30,5 @@ export interface VirtualizedSelectProps extends ReactSelectProps {
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 
-declare class VirtualizedSelect extends React.PureComponent<VirtualizedSelectProps> {}
+declare class VirtualizedSelect extends React.PureComponent<VirtualizedSelectProps, any> {}
 export default VirtualizedSelect;


### PR DESCRIPTION
When trying to use `<VirtualizedSelect>` with TS2.3.x, I receive the following error from tsc:
```
TS2604: JSX element type 'VirtualizedSelect' does not have any construct or call signatures.
```
Adding the second type argument (`any`) seems to resolve the issue, as it's listed in the declaration doc for React.PureComponent here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L263

I tested this locally by making this change in `node_modules/@types/react-virtualized-select` and re-running `tsc`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [-] Increase the version number in the header if appropriate.
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
