### PR TITLE
[jquery] Fix PromiseLike compatibility for Promise3, Promise2, and jqXHR

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -6674,6 +6674,9 @@ declare namespace JQuery {
              progressFilter?: null): Promise3<ARD, AJD, AND,
             BRD, BJD, BND,
             CRD, CJD, CND>;
+        // PromiseLike compatibility
+        then<TResult1 = TR, TResult2 = never>(onfulfilled?: ((value: TR) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+                                              onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): PromiseLike<TResult1 | TResult2>;
 
         /**
          * Add handlers to be called when the Deferred object is rejected.

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -7138,6 +7138,13 @@ function Promise3() {
             return $.ajax('/echo/json');
         });
     }
+
+    // As argument to PromiseLike parameter
+    {
+        Promise.resolve(p).then(a => {
+            a; // $ExpectType string
+        });
+    }
 }
 
 function Promise2(p: JQuery.Promise2<string, Error, number, JQuery, string, boolean>) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

Fixes #17966 

@Kovensky 