### PR TITLE
[react-router] Add state type declaration to components

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/ReactTraining/react-router
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Huy Nguyen <https://github.com/huy-nguyen>
+//                 Luyao Hou <https://github.com/hlycharles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -30,20 +31,20 @@ declare module 'react-router-dom' {
     forceRefresh?: boolean;
     keyLength?: number;
   }
-  class BrowserRouter extends React.Component<BrowserRouterProps> {}
+  class BrowserRouter extends React.Component<BrowserRouterProps, never> {}
 
   interface HashRouterProps {
     basename?: string;
     getUserConfirmation?(): void;
     hashType?: 'slash' | 'noslash' | 'hashbang';
   }
-  class HashRouter extends React.Component<HashRouterProps> {}
+  class HashRouter extends React.Component<HashRouterProps, never> {}
 
   interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to: H.LocationDescriptor;
     replace?: boolean;
   }
-  class Link extends React.Component<LinkProps> {}
+  class Link extends React.Component<LinkProps, never> {}
 
   interface NavLinkProps extends LinkProps {
     activeClassName?: string;
@@ -52,7 +53,7 @@ declare module 'react-router-dom' {
     strict?: boolean;
     isActive?<P>(match: match<P>, location: H.Location): boolean;
   }
-  class NavLink extends React.Component<NavLinkProps> {}
+  class NavLink extends React.Component<NavLinkProps, never> {}
 
   export {
     BrowserRouter,

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -13,6 +13,7 @@
 //                 Huy Nguyen <https://github.com/huy-nguyen>
 //                 Jérémy Fauvel <https://github.com/grmiade>
 //                 Daniel Roth <https://github.com/DaIgeb>
+//                 Luyao Hou <https://github.com/hlycharles>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -37,13 +38,13 @@ export interface MemoryRouterProps {
   keyLength?: number;
 }
 
-export class MemoryRouter extends React.Component<MemoryRouterProps> { }
+export class MemoryRouter extends React.Component<MemoryRouterProps, never> { }
 
 export interface PromptProps {
   message: string | ((location: H.Location) => void);
   when?: boolean;
 }
-export class Prompt extends React.Component<PromptProps> { }
+export class Prompt extends React.Component<PromptProps, never> { }
 
 export interface RedirectProps {
   to: H.LocationDescriptor;
@@ -53,7 +54,7 @@ export interface RedirectProps {
   exact?: boolean;
   strict?: boolean;
 }
-export class Redirect extends React.Component<RedirectProps> { }
+export class Redirect extends React.Component<RedirectProps, never> { }
 
 export interface RouteComponentProps<P> {
   match: match<P>;
@@ -71,12 +72,12 @@ export interface RouteProps {
   exact?: boolean;
   strict?: boolean;
 }
-export class Route<T extends RouteProps = RouteProps> extends React.Component<T> { }
+export class Route<T extends RouteProps = RouteProps> extends React.Component<T, never> { }
 
 export interface RouterProps {
   history: any;
 }
-export class Router extends React.Component<RouterProps> { }
+export class Router extends React.Component<RouterProps, never> { }
 
 export interface StaticRouterProps {
   basename?: string;
@@ -84,12 +85,12 @@ export interface StaticRouterProps {
   context?: object;
 }
 
-export class StaticRouter extends React.Component<StaticRouterProps> { }
+export class StaticRouter extends React.Component<StaticRouterProps, never> { }
 export interface SwitchProps {
   children?: React.ReactNode;
   location?: H.Location;
 }
-export class Switch extends React.Component<SwitchProps> { }
+export class Switch extends React.Component<SwitchProps, never> { }
 
 export interface match<P> {
   params: P;


### PR DESCRIPTION
Part of the changes relates to #17777 but this PR address the issue that _Generic type `Component<P, S>` requires 2 type arguments_.

Similar fix for react-redux: #17896
Reference: https://github.com/Microsoft/TypeScript-React-Starter#creating-a-component

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/Microsoft/TypeScript-React-Starter#creating-a-component>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.