### PR TITLE
[SortableJS] Enable non-require imports

### DIFF
--- a/types/sortablejs/index.d.ts
+++ b/types/sortablejs/index.d.ts
@@ -3,9 +3,8 @@
 // Definitions by: Maw-Fox <http://github.com/Maw-Fox>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Sortable = Sortablejs.Sortable;
-export = Sortable;
-export as namespace Sortable;
+export = Sortablejs;
+export as namespace Sortablejs;
 
 declare namespace Sortablejs {
     interface SortableOptions {

--- a/types/sortablejs/sortablejs-tests.ts
+++ b/types/sortablejs/sortablejs-tests.ts
@@ -1,5 +1,5 @@
 // Examples from project repo used for tests.
-import Sortable = require("sortablejs");
+import {Sortable} from "sortablejs"
 
 
 var simpleList = document.getElementById('list');

--- a/types/sortablejs/sortablejs-tests.ts
+++ b/types/sortablejs/sortablejs-tests.ts
@@ -1,5 +1,5 @@
 // Examples from project repo used for tests.
-import {Sortable} from "sortablejs"
+import {Sortable} from "./index"
 
 
 var simpleList = document.getElementById('list');


### PR DESCRIPTION
Sortablejs definition could not be use with ES6 import syntax. Sure it's possible to just use require, but i am not allowed to do so. 

Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.