### PR TITLE
fix error TS2314 in @types/react-native-scrollable-tab-view

### DIFF
--- a/types/react-native-scrollable-tab-view/index.d.ts
+++ b/types/react-native-scrollable-tab-view/index.d.ts
@@ -103,5 +103,5 @@ export interface ScrollableTabViewProperties extends React.Props<ScrollableTabVi
   prerenderingSiblingsNumber?: number;
 }
 
-export default class ScrollableTabView extends React.Component<ScrollableTabViewProperties> {
+export default class ScrollableTabView extends React.Component<ScrollableTabViewProperties, {}> {
 }


### PR DESCRIPTION
fixes error TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - this is the exact same issue as #17896 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.