### PR TITLE
express-session: req.session is not optional

### DIFF
--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -12,7 +12,7 @@ import node = require('events');
 declare global {
   namespace Express {
     interface Request {
-      session?: Session;
+      session: Session;
       sessionID?: string;
     }
 


### PR DESCRIPTION
When using `strictNullChecks` with these typings, you have to guard access to `req.session`, checking for existence. This should not be necessary as `req.session` is always defined.

--

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/expressjs/session#reqsession
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

/cc @jacobbogers