### PR TITLE
react-sortable-tree: Made TreeItem.children prop optional

### DIFF
--- a/types/react-measure/index.d.ts
+++ b/types/react-measure/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-measure 0.4.0
+// Type definitions for react-measure 0.4
 // Project: https://github.com/souporserious/react-measure
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -19,7 +19,7 @@ declare module "react-measure" {
             left?: number;
         }
 
-        type MeasureChildren = React.ReactElement<any> | { (dimension: Dimensions): React.ReactElement<any> };
+        type MeasureChildren = React.ReactNode | React.ReactElement<any> | ((dimension: Dimensions) => React.ReactElement<any>);
 
         interface MeasureProps {
             /**
@@ -43,7 +43,7 @@ declare module "react-measure" {
             /**
              * Callback when the component has been mutated. Receives dimensions, mutations, and anything passed to shouldMeasure.
              */
-            onMeasure?: (dimensions: Dimensions) => void;
+            onMeasure?(dimensions: Dimensions): void;
             /**
              * Children, ordinary JSX element or function. Leaving it for reference here
              */
@@ -51,5 +51,4 @@ declare module "react-measure" {
         }
     }
     export = Measure;
-
 }

--- a/types/react-measure/react-measure-tests.tsx
+++ b/types/react-measure/react-measure-tests.tsx
@@ -34,3 +34,20 @@ class Test2 extends React.Component {
         );
     }
 }
+
+function testHocComponent<T>(Component: React.ComponentClass<T>): React.ComponentClass<T> {
+    return class extends React.Component<T> {
+        render(): JSX.Element {
+            return (
+                <Measure onMeasure={this.handleDimensionChange}>
+                    <Component {...this.props} />;
+                </Measure>
+            );
+        }
+
+        private handleDimensionChange = (dimensions: Measure.Dimensions) => {
+            dimensions.width;
+            dimensions.height;
+        }
+    };
+}

--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -15,7 +15,7 @@ export interface TreeItem {
     title?: string;
     subtitle?: string;
     expanded?: boolean;
-    children: TreeItem[];
+    children?: TreeItem[];
     [x: string]: any;
 }
 

--- a/types/react-sortable-tree/react-sortable-tree-tests.tsx
+++ b/types/react-sortable-tree/react-sortable-tree-tests.tsx
@@ -21,7 +21,7 @@ class Test extends React.Component {
             {
                 title: "Title", subtitle: "Subtitle", children: [
                     {title: "Child 1", subtitle: "Subtitle", children: []},
-                    {title: "Child 2", subtitle: "Subtitle", children: []}
+                    {title: "Child 2", subtitle: "Subtitle"}
                 ]
             }
         ];

--- a/types/react-sortable-tree/tsconfig.json
+++ b/types/react-sortable-tree/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
- Made the TreeItem.children prop optional since the library allows this and prevents verboseness/unneeded empty arrays (see example here: https://github.com/fritz-c/react-sortable-tree)
- Added 'dom' lib in tsconfig to fix dom errors from definition dependencies when running `tsc`

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
