### PR TITLE
add more options to html-to-text

### DIFF
--- a/types/html-to-text/index.d.ts
+++ b/types/html-to-text/index.d.ts
@@ -75,6 +75,29 @@ interface HtmlToTextOptions {
      *  Ignore all document images if true.
      */
     ignoreImage?: boolean;
+    
+    /**
+     *  Dont print brackets around the link if true
+     */
+    noLinkBrackets?: boolean;
+    
+    /**
+     *  By default, any newlines \n in a block of text will be removed.
+     *  If true, these newlines will not be removed.
+     */
+    preserveNewlines?: boolean;
+    
+    /**
+     *  By default, headings (<h1>, <h2>, etc) are uppercased.
+     *  Set to false to leave headings as they are.
+     */
+    uppercaseHeadings?: boolean;
+    
+    /**
+     *  By default, paragraphs are converted with two newlines (\n\n).
+     *  Set to true to convert to a single newline.
+     */
+    singleNewLineParagraphs?: boolean;
 }
 
 declare module "html-to-text" {


### PR DESCRIPTION
add 4 more optional properties to HtmlToTextOptions interface
noLinkBrackets, preserveNewlines, uppercaseHeadings and singleNewLineParagraphs

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/werk85/node-html-to-text#options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
