### PR TITLE
[proj4leaflet] introduce typings

### DIFF
--- a/types/proj4leaflet/index.d.ts
+++ b/types/proj4leaflet/index.d.ts
@@ -1,0 +1,79 @@
+// Type definitions for proj4leaflet 1.0
+// Project: https://github.com/kartena/Proj4Leaflet#readme
+// Definitions by: BendingBender <https://github.com/BendingBender>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="leaflet" />
+
+declare namespace L {
+  namespace Proj {
+    class CRS implements L.CRS {
+      projection: Projection;
+      transformation: Transformation;
+      code?: string;
+      wrapLng?: [number, number];
+      wrapLat?: [number, number];
+      infinite: boolean;
+
+      constructor(projection: InterfaceProjection, options?: ProjCRSOptions);
+      constructor(code: string, proj4def: string, options?: ProjCRSOptions);
+
+      latLngToPoint(latlng: LatLngExpression, zoom: number): Point;
+
+      pointToLatLng(point: PointExpression, zoom: number): LatLng;
+
+      project(latlng: LatLng | LatLngLiteral): Point;
+
+      unproject(point: PointExpression): LatLng;
+
+      scale(zoom: number): number;
+
+      zoom(scale: number): number;
+
+      getProjectedBounds(zoom: number): Bounds;
+
+      distance(latlng1: LatLngExpression, latlng2: LatLngExpression): number;
+
+      wrapLatLng(latlng: LatLng | LatLngLiteral): LatLng;
+    }
+
+    class GeoJSON extends L.GeoJSON {
+    }
+
+    const geoJson: (geojson?: GeoJSONGeoJsonObject, options?: GeoJSONOptions) => GeoJSON;
+
+    class ImageOverlay extends L.ImageOverlay {
+    }
+
+    const imageOverlay: (imageUrl: string, bounds: LatLngBoundsExpression, options?: ImageOverlayOptions) => ImageOverlay;
+
+    interface ProjCRSOptions {
+      bounds?: Bounds;
+      origin?: [number, number];
+      scales?: number[];
+      resolutions?: number[];
+      transformation?: Transformation;
+    }
+
+    interface InterfaceProjection {
+      datum: string;
+      b: number;
+      rf: number;
+      sphere: number;
+      es: number;
+      e: number;
+      ep2: number;
+      forward(coordinates: TemplateCoordinates): number[];
+      inverse(coordinates: TemplateCoordinates): number[];
+    }
+
+    type TemplateCoordinates = number[] | InterfaceCoordinates;
+
+    interface InterfaceCoordinates {
+      x: number;
+      y: number;
+      z?: number;
+      m?: number;
+    }
+  }
+}

--- a/types/proj4leaflet/package.json
+++ b/types/proj4leaflet/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@types/leaflet": "^1.0.65",
+    "@types/leaflet": "^1.0.65"
   }
 }

--- a/types/proj4leaflet/package.json
+++ b/types/proj4leaflet/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@types/leaflet": "^1.0.65",
+  }
+}

--- a/types/proj4leaflet/package.json
+++ b/types/proj4leaflet/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "@types/leaflet": "^1.0.65"
-  }
-}

--- a/types/proj4leaflet/proj4leaflet-tests.ts
+++ b/types/proj4leaflet/proj4leaflet-tests.ts
@@ -1,0 +1,73 @@
+import * as proj4 from "proj4";
+import LatLngBoundsExpression = L.LatLngBoundsExpression;
+
+const crs = new L.Proj.CRS('EPSG:2400',
+  '+lon_0=15.808277777799999 +lat_0=0.0 +k=1.0 +x_0=1500000.0 ' +
+  '+y_0=0.0 +proj=tmerc +ellps=bessel +units=m ' +
+  '+towgs84=414.1,41.3,603.1,-0.855,2.141,-7.023,0 +no_defs',
+  {
+    resolutions: [8192, 4096, 2048] // 3 example zoom level resolutions
+  }
+);
+
+const map = L.map('map', {
+  crs,
+  worldCopyJump: false
+});
+
+L.tileLayer('http://tile.example.com/example/{z}/{x}/{y}.png').addTo(map);
+
+const crs2 = new L.Proj.CRS('EPSG:3006',
+  '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  {
+    origin: [218128.7031, 6126002.9379],
+    resolutions: [8192, 4096, 2048] // 3 example zoom level resolutions
+  }
+);
+
+const crs3 = new L.Proj.CRS('EPSG:3006',
+  '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
+  {
+    origin: [218128.7031, 6126002.9379],
+    resolutions: [8192, 4096, 2048],
+    scales: [1, 2],
+    bounds: new L.Bounds([[1, 2], [3, 4]]),
+    transformation: new L.Transformation(1, 2, 3, 4),
+  }
+);
+
+// geoJson
+proj4.defs("urn:ogc:def:crs:EPSG::26915", "+proj=utm +zone=15 +ellps=GRS80 +datum=NAD83 +units=m +no_defs");
+
+const geojson = {
+  type: "Feature",
+  geometry: {
+    type: "Point",
+    coordinates: [481650, 4980105]
+  },
+  crs: {
+    type: "name",
+    properties: {
+      name: "urn:ogc:def:crs:EPSG::26915"
+    }
+  }
+};
+
+const map2 = L.map('map');
+
+L.Proj.geoJson(geojson).addTo(map);
+new L.Proj.GeoJSON(geojson).addTo(map);
+
+// imageOverlay
+const imageBounds: LatLngBoundsExpression =
+  [[145323.20011251318, 475418.56045463786], [175428.80013969325, 499072.9604685671]];
+
+L.Proj.imageOverlay('http://geo.flevoland.nl/arcgis/rest/services/Groen_Natuur/Agrarische_Natuur/MapServer/export?' +
+  'format=png24&transparent=true&f=image&bboxSR=28992&imageSR=28992&layers=show%3A0' +
+  '&bbox=145323.20011251318%2C475418.56045463786%2C175428.80013969325%2C499072.9604685671&size=560%2C440',
+  imageBounds);
+
+new L.Proj.ImageOverlay('http://geo.flevoland.nl/arcgis/rest/services/Groen_Natuur/Agrarische_Natuur/MapServer/export?' +
+  'format=png24&transparent=true&f=image&bboxSR=28992&imageSR=28992&layers=show%3A0' +
+  '&bbox=145323.20011251318%2C475418.56045463786%2C175428.80013969325%2C499072.9604685671&size=560%2C440',
+  imageBounds);

--- a/types/proj4leaflet/tsconfig.json
+++ b/types/proj4leaflet/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "proj4leaflet-tests.ts"
+    ]
+}

--- a/types/proj4leaflet/tslint.json
+++ b/types/proj4leaflet/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

As an aside, I couldn't find out how to import types from `proj4` definitions without losing the possibility to extend the global `L` namespace from leaflet. As soon as I start using the `import` syntax everything breaks apart. This is why I had to copy over several type definitions from `proj4`, namely: `InterfaceProjection`, `TemplateCoordinates` and `InterfaceCoordinates`.
