### PR TITLE
[catbox] fix classes

### DIFF
--- a/types/catbox/catbox-tests.ts
+++ b/types/catbox/catbox-tests.ts
@@ -1,0 +1,8 @@
+import Catbox = require("catbox");
+import Memory = require("catbox-memory");
+
+const client = new Catbox.Client(Memory);
+
+const cache = new Catbox.Policy({
+    expiresIn: 5000,
+}, client, 'cache');

--- a/types/catbox/catbox-tests.ts
+++ b/types/catbox/catbox-tests.ts
@@ -1,8 +1,16 @@
 import Catbox = require("catbox");
 
-const Memory = (): void => {};
+const Memory: Catbox.EnginePrototypeOrObject = {
+    start(callback: Catbox.CallBackNoResult) {},
+    stop() {},
+    get() {},
+    set() {},
+    drop() {},
+    isReady(): boolean { return true; },
+    validateSegmentName(segment: string): null { return null; },
+};
 
-const client = new Catbox.Client(Memory as any, { partition: 'cache' });
+const client = new Catbox.Client(Memory, { partition: 'cache' });
 
 const cache = new Catbox.Policy({
     expiresIn: 5000,

--- a/types/catbox/catbox-tests.ts
+++ b/types/catbox/catbox-tests.ts
@@ -1,8 +1,19 @@
 import Catbox = require("catbox");
-import Memory = require("catbox-memory");
 
-const client = new Catbox.Client(Memory);
+const Memory = (): void => {};
+
+const client = new Catbox.Client(Memory as any, { partition: 'cache' });
 
 const cache = new Catbox.Policy({
     expiresIn: 5000,
 }, client, 'cache');
+
+cache.set('foo', 'bar', 5000, () => {});
+
+cache.get('foo', () => {});
+
+cache.drop('foo', () => {});
+
+cache.isReady();
+
+cache.stats();

--- a/types/catbox/index.d.ts
+++ b/types/catbox/index.d.ts
@@ -23,8 +23,8 @@ export interface CallBackWithResult<T> {
  *  * partition - the partition name used to isolate the cached results across multiple clients. The partition name is used as the MongoDB database name, the Riak bucket, or as a key prefix in Redis and Memcached. To share the cache across multiple clients, use the same partition name.
  * @see {@link https://github.com/hapijs/catbox#client}
  */
-export interface Client extends ClientApi {
-    new(engine: EnginePrototypeOrObject, options: ClientOptions): Client;
+export class Client extends ClientApi {
+    constructor(engine: EnginePrototypeOrObject, options: ClientOptions);
 }
 
 type EnginePrototypeOrObject = EnginePrototype | ClientApi;
@@ -41,7 +41,7 @@ export interface EnginePrototype {
  * The Client object provides the following methods:
  * @see {@link https://github.com/hapijs/catbox#api}
  */
-export interface ClientApi {
+export class ClientApi {
     /** start(callback) - creates a connection to the cache server. Must be called before any other method is available. The callback signature is function(err). */
     start(callback: CallBackNoResult): void;
     /** stop() - terminates the connection to the cache server. */
@@ -105,8 +105,8 @@ export interface ClientOptions {
  *  * segment - required when cache is provided. The segment name used to isolate cached items within the cache partition.
  * @see {@link https://github.com/hapijs/catbox#policy}
  */
-export interface Policy extends PolicyAPI {
-    new(options: PolicyOptions, cache: Client, segment: string): Policy;
+export class Policy extends PolicyAPI {
+    constructor(options: PolicyOptions, cache: Client, segment: string);
 }
 
 /**
@@ -114,7 +114,7 @@ export interface Policy extends PolicyAPI {
  * The Policy object provides the following methods:
  * @see {@link https://github.com/hapijs/catbox#api-1}
  */
-export interface PolicyAPI {
+export class PolicyAPI {
     /**
      * get(id, callback) - retrieve an item from the cache. If the item is not found and the generateFunc method was provided, a new value is generated, stored in the cache, and returned. Multiple concurrent requests are queued and processed once. The method arguments are:
      *  * id - the unique item identifier (within the policy segment). Can be a string or an object with the required 'id' key.
@@ -181,7 +181,7 @@ export interface PolicyOptions {
      * staleIn - number of milliseconds to mark an item stored in cache as stale and attempt to regenerate it when generateFunc is provided. Must be less than expiresIn. Alternatively function that returns staleIn value in milliseconds. The function signature is function(stored, ttl) where:
      *  * stored - the timestamp when the item was stored in the cache (in milliseconds).
      *  * ttl - the remaining time-to-live (not the original value used when storing the object).
-    */
+     */
     staleIn?: number | ((stored: number, ttl: number) => number);
     /** staleTimeout - number of milliseconds to wait before returning a stale value while generateFunc is generating a fresh value. */
     staleTimeout?: number;

--- a/types/catbox/index.d.ts
+++ b/types/catbox/index.d.ts
@@ -6,12 +6,8 @@
 
 import * as Boom from 'boom';
 
-export interface CallBackNoResult {
-    (err?: Boom.BoomError): void;
-}
-export interface CallBackWithResult<T> {
-    (err: Boom.BoomError | null | undefined, result: T): void;
-}
+export type CallBackNoResult = (err?: Boom.BoomError) => void;
+export type CallBackWithResult<T> = (err: Boom.BoomError | null | undefined, result: T) => void;
 
 /**
  * Client
@@ -20,7 +16,8 @@ export interface CallBackWithResult<T> {
  *  * function - a prototype function with the signature function(options). catbox will call new func(options).
  *  * object - a pre instantiated client implementation object. Does not support passing options.
  * options - the strategy configuration object. Each strategy defines its own configuration options with the following common options:
- *  * partition - the partition name used to isolate the cached results across multiple clients. The partition name is used as the MongoDB database name, the Riak bucket, or as a key prefix in Redis and Memcached. To share the cache across multiple clients, use the same partition name.
+ *  * partition - the partition name used to isolate the cached results across multiple clients. The partition name is used as the MongoDB database name,
+ *    the Riak bucket, or as a key prefix in Redis and Memcached. To share the cache across multiple clients, use the same partition name.
  * @see {@link https://github.com/hapijs/catbox#client}
  */
 export class Client implements ClientApi {
@@ -34,7 +31,7 @@ export class Client implements ClientApi {
      * get(key, callback) - retrieve an item from the cache engine if found where:
      *  * key - a cache key object (see [ICacheKey]).
      *  * callback - a function with the signature function(err, cached). If the item is not found, both err and cached are null. If found, the cached object is returned
-    */
+     */
     get(key: CacheKey, callback: CallBackWithResult<null | CachedObject>): CacheItem;
     /**
      * set(key, value, ttl, callback) - store an item in the cache for a specified length of time, where:
@@ -56,7 +53,7 @@ export class Client implements ClientApi {
     validateSegmentName(segment: string): null | Boom.BoomError;
 }
 
-type EnginePrototypeOrObject = EnginePrototype | ClientApi;
+export type EnginePrototypeOrObject = EnginePrototype | ClientApi;
 
 /**
  * A prototype CatBox engine function
@@ -79,7 +76,7 @@ export interface ClientApi {
      * get(key, callback) - retrieve an item from the cache engine if found where:
      *  * key - a cache key object (see [ICacheKey]).
      *  * callback - a function with the signature function(err, cached). If the item is not found, both err and cached are null. If found, the cached object is returned
-    */
+     */
     get(key: CacheKey, callback: CallBackWithResult<null | CachedObject>): CacheItem;
     /**
      * set(key, value, ttl, callback) - store an item in the cache for a specified length of time, where:
@@ -121,14 +118,15 @@ export interface CachedObject {
     ttl: number;
 }
 
-type CacheItem = any;
+export type CacheItem = any;
 
 export interface ClientOptions {
     partition: string;
 }
 
 /**
- * The Policy object provides a convenient cache interface by setting a global policy which is automatically applied to every storage action. The object is constructed using new Policy(options, [cache, segment]) where:
+ * The Policy object provides a convenient cache interface by setting a global policy which is automatically applied to every storage action.
+ * The object is constructed using new Policy(options, [cache, segment]) where:
  *  * options - an object with the IPolicyOptions structure
  *  * cache - a Client instance (which has already been started).
  *  * segment - required when cache is provided. The segment name used to isolate cached items within the cache partition.
@@ -137,7 +135,8 @@ export interface ClientOptions {
 export class Policy implements PolicyAPI {
     constructor(options: PolicyOptions, cache: Client, segment: string);
     /**
-     * get(id, callback) - retrieve an item from the cache. If the item is not found and the generateFunc method was provided, a new value is generated, stored in the cache, and returned. Multiple concurrent requests are queued and processed once. The method arguments are:
+     * get(id, callback) - retrieve an item from the cache. If the item is not found and the generateFunc method was provided,
+     * a new value is generated, stored in the cache, and returned. Multiple concurrent requests are queued and processed once. The method arguments are:
      *  * id - the unique item identifier (within the policy segment). Can be a string or an object with the required 'id' key.
      *  * callback - the return function.
      */
@@ -146,7 +145,8 @@ export class Policy implements PolicyAPI {
      * set(id, value, ttl, callback) - store an item in the cache where:
      *  * id - the unique item identifier (within the policy segment).
      *  * value - the string or object value to be stored.
-     *  * ttl - a time-to-live override value in milliseconds after which the item is automatically removed from the cache (or is marked invalid). This should be set to 0 in order to use the caching rules configured when creating the Policy object.
+     *  * ttl - a time-to-live override value in milliseconds after which the item is automatically removed from the cache (or is marked invalid).
+     *    This should be set to 0 in order to use the caching rules configured when creating the Policy object.
      *  * callback - a function with the signature function(err).
      */
     set(id: string | {id: string}, value: CacheItem, ttl: number | null, callback: CallBackNoResult): void;
@@ -173,7 +173,8 @@ export class Policy implements PolicyAPI {
  */
 export interface PolicyAPI {
     /**
-     * get(id, callback) - retrieve an item from the cache. If the item is not found and the generateFunc method was provided, a new value is generated, stored in the cache, and returned. Multiple concurrent requests are queued and processed once. The method arguments are:
+     * get(id, callback) - retrieve an item from the cache. If the item is not found and the generateFunc method was provided,
+     * a new value is generated, stored in the cache, and returned. Multiple concurrent requests are queued and processed once. The method arguments are:
      *  * id - the unique item identifier (within the policy segment). Can be a string or an object with the required 'id' key.
      *  * callback - the return function.
      */
@@ -182,7 +183,8 @@ export interface PolicyAPI {
      * set(id, value, ttl, callback) - store an item in the cache where:
      *  * id - the unique item identifier (within the policy segment).
      *  * value - the string or object value to be stored.
-     *  * ttl - a time-to-live override value in milliseconds after which the item is automatically removed from the cache (or is marked invalid). This should be set to 0 in order to use the caching rules configured when creating the Policy object.
+     *  * ttl - a time-to-live override value in milliseconds after which the item is automatically removed from the cache (or is marked invalid).
+     *    This should be set to 0 in order to use the caching rules configured when creating the Policy object.
      *  * callback - a function with the signature function(err).
      */
     set(id: string | {id: string}, value: CacheItem, ttl: number | null, callback: CallBackNoResult): void;
@@ -209,9 +211,7 @@ export interface PolicyAPI {
  * @param cached - null if a valid item was not found in the cache, or IPolicyGetCallbackCachedOptions
  * @param report - an object with logging information about the generation operation
  */
-export interface PolicyGetCallback{
-    (err: null | Boom.BoomError, value: CacheItem, cached: PolicyGetCallbackCachedOptions, report: PolicyGetCallbackReportLog): void;
-}
+export type PolicyGetCallback = (err: null | Boom.BoomError, value: CacheItem, cached: PolicyGetCallbackCachedOptions, report: PolicyGetCallbackReportLog) => void;
 
 export interface PolicyGetCallbackCachedOptions {
     /** item - the cached value. */
@@ -235,14 +235,19 @@ export interface PolicyOptions {
     /** generateFunc - a function used to generate a new cache item if one is not found in the cache when calling get(). The method's signature is function(id, next) where: */
     generateFunc?: GenerateFunc;
     /**
-     * staleIn - number of milliseconds to mark an item stored in cache as stale and attempt to regenerate it when generateFunc is provided. Must be less than expiresIn. Alternatively function that returns staleIn value in milliseconds. The function signature is function(stored, ttl) where:
+     * staleIn - number of milliseconds to mark an item stored in cache as stale and attempt to regenerate it when generateFunc is provided.
+     * Must be less than expiresIn. Alternatively function that returns staleIn value in milliseconds. The function signature is function(stored, ttl) where:
      *  * stored - the timestamp when the item was stored in the cache (in milliseconds).
      *  * ttl - the remaining time-to-live (not the original value used when storing the object).
      */
     staleIn?: number | ((stored: number, ttl: number) => number);
     /** staleTimeout - number of milliseconds to wait before returning a stale value while generateFunc is generating a fresh value. */
     staleTimeout?: number;
-    /** generateTimeout - number of milliseconds to wait before returning a timeout error when the generateFunc function takes too long to return a value. When the value is eventually returned, it is stored in the cache for future requests. Required if generateFunc is present. Set to false to disable timeouts which may cause all get() requests to get stuck forever. */
+    /**
+     * generateTimeout - number of milliseconds to wait before returning a timeout error when the generateFunc function takes too long to return a value.
+     * When the value is eventually returned, it is stored in the cache for future requests. Required if generateFunc is present.
+     * Set to false to disable timeouts which may cause all get() requests to get stuck forever.
+     */
     generateTimeout?: number | false;
     /** dropOnError - if true, an error or timeout in the generateFunc causes the stale value to be evicted from the cache. Defaults to true. */
     dropOnError?: boolean;
@@ -250,7 +255,10 @@ export interface PolicyOptions {
     generateOnReadError?: boolean;
     /** generateIgnoreWriteError - if false, an upstream cache write error will be passed back with the generated value when calling the get() method. Defaults to true. */
     generateIgnoreWriteError?: boolean;
-    /** pendingGenerateTimeout - number of milliseconds while generateFunc call is in progress for a given id, before a subsequent generateFunc call is allowed. Defaults to 0, no blocking of concurrent generateFunc calls beyond staleTimeout. */
+    /**
+     * pendingGenerateTimeout - number of milliseconds while generateFunc call is in progress for a given id, before a subsequent generateFunc call is allowed.
+     * Defaults to 0, no blocking of concurrent generateFunc calls beyond staleTimeout.
+     */
     pendingGenerateTimeout?: number;
 }
 
@@ -265,9 +273,7 @@ export interface PolicyOptions {
  *      * ttl - the cache ttl value in milliseconds. Set to 0 to skip storing in the cache. Defaults to the cache global policy.
  * @see {@link https://github.com/hapijs/catbox#policy}
  */
-export interface GenerateFunc {
-    (id: string, next: ((err: null | Boom.BoomError, value: CacheItem, ttl?: number) => void)): void;
-}
+export type GenerateFunc = (id: string, next: ((err: null | Boom.BoomError, value: CacheItem, ttl?: number) => void)) => void;
 
 /**
  * An object with logging information about the generation operation containing the following keys (as relevant):
@@ -299,6 +305,6 @@ export interface CacheStatisticsObject {
     stales: number;
     /** generates - number of calls to the generate function. */
     generates: number;
-    /** errors - cache operations errors.  TODO check this*/
+    /** errors - cache operations errors. TODO check this */
     errors: number;
 }

--- a/types/catbox/tsconfig.json
+++ b/types/catbox/tsconfig.json
@@ -16,6 +16,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "index.d.ts"
+        "index.d.ts",
+        "catbox-tests.ts"
     ]
 }

--- a/types/catbox/tslint.json
+++ b/types/catbox/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [hapi/catbox#client](https://github.com/hapijs/catbox#client) and [hapi/catbox#policy](https://github.com/hapijs/catbox#policy)

When I currently use catbox directly (without Hapi):

```ts
/*
 * npm dependencies
 */
import * as catbox from 'catbox';
import * as redis  from 'catbox-redis';

/*
 * internal dependencies
 */
import { config } from 'lib/config';

const client = new catbox.Client(redis, config.cache);

const cache = new catbox.Policy({
    dropOnError: false,
    expiresIn: 5000,
    generateTimeout: 60,
}, client, 'cache');
```

it fails with this error because the exported types are interfaces instead of classes:

```
14 const client = new catbox.Client(redis, config.cache);
                             ~~~~~~

src/lib/cache.ts(14,27): error TS2339: Property 'Client' does not exist on type 'typeof "/Users/lenovouser/Development/test-catbox/node_modules/@types/catbox/index"'.


16 const URLCache = new catbox.Policy({
                               ~~~~~~

src/lib/cache.ts(16,29): error TS2339: Property 'Policy' does not exist on type 'typeof "/Users/lenovouser/Development/test-catbox/node_modules/@types/catbox/index"'.
```

@jasonswearingen & @AJamesPhillips to me this seems to be the correct fix or am I missing something? The catbox documentation also states that both are classes.