### PR TITLE
[TinyMCE] Fix windowManager attribute name in Editor type

### DIFF
--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -358,7 +358,7 @@ export class Editor extends util.Observable {
 
   undoManager: UndoManager;
 
-  WindowManager: WindowManager;
+  windowManager: WindowManager;
 
   addButton(name: string, settings: {}): void;
 


### PR DESCRIPTION
Since it is a property of the Editor, it should follow the standard
followed by other properties: first letter should be lowercase

Signed-off-by: Thiago Lacerda <thiagotbl@gmail.com>