### PR TITLE
[react-router-dom] Adding className to NavLinkProps

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -48,6 +48,7 @@ declare module 'react-router-dom' {
   interface NavLinkProps extends LinkProps {
     activeClassName?: string;
     activeStyle?: React.CSSProperties;
+    className?: string;
     exact?: boolean;
     strict?: boolean;
     isActive?<P>(match: match<P>, location: H.Location): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

<hr/>

The `react-router-dom`'s NavLink has a [`className` prop](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/modules/NavLink.js#L49) and it isn't included on types/react-router-dom.

Edit: just realised it is inherited. 