### PR TITLE
d3-sankey: Doc Update

### DIFF
--- a/types/d3-sankey/index.d.ts
+++ b/types/d3-sankey/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Last module patch version validated against: 0.7
+// Last module patch version validated against: 0.7.1
 
 import { Link } from 'd3-shape';
 
@@ -266,7 +266,7 @@ export interface SankeyLayout<Data, N extends SankeyExtraProperties, L extends S
     nodeId(nodeId: (node: SankeyNode<N, L>) => string | number): this;
 
     /**
-     * Return the current node alignment method, which defaults to d3.sankeyLeft.
+     * Return the current node alignment method, which defaults to d3.sankeyJustify.
      */
     nodeAlign(): (node: SankeyNode<N, L>, n: number) => number;
     /**


### PR DESCRIPTION
* [DOC] Fix default `nodeAlign` setting in JSDoc comment. See change in PR: d3/d3-sankey#38.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/d3/d3-sankey/pull/38>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.