### PR TITLE
[Draft.js]: Extended DraftEditorProps to improve mobile web behaviors

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -102,6 +102,11 @@ declare namespace Draft {
 
                 tabIndex?: number;
 
+                // exposed especially to help improve mobile web behaviors
+                autoCapitalize?: string;
+                autoComplete?: string;
+                autoCorrect?: string;
+
                 ariaActiveDescendantID?: string;
                 ariaAutoComplete?: string;
                 ariaDescribedBy?: string;


### PR DESCRIPTION
Fixing issue in mobile browsers described above:
https://stackoverflow.com/questions/41256672/draft-js-editor-lost-focus-on-android-browsers-after-first-word
The original ref on Facebook source code:
https://github.com/facebook/draft-js/blob/master/src/component/base/DraftEditorProps.js#L89