### PR TITLE
Remove duplicate time field in request package typings 

### DIFF
--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -154,7 +154,6 @@ declare namespace request {
         ca?: string | Buffer | string[] | Buffer[];
         har?: HttpArchiveRequest;
         useQuerystring?: boolean;
-        time?: boolean;
     }
 
     interface UriOptions {


### PR DESCRIPTION
For some reason the time field exists twice in CoreOptions in "request" typings.