### PR TITLE
lodash: fixed issues with null/undefined parameters

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -17078,12 +17078,12 @@ declare namespace _ {
          */
 
         omit<TResult extends {}, T extends {}>(
-            object: T,
+            object: T | null | undefined,
             ...predicate: Array<Many<StringRepresentable>>
         ): TResult;
     }
 
-    interface LoDashImplicitObjectWrapper<T> {
+    interface LoDashImplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.omit
          */
@@ -17092,7 +17092,7 @@ declare namespace _ {
         ): LoDashImplicitObjectWrapper<TResult>;
     }
 
-    interface LoDashExplicitObjectWrapper<T> {
+    interface LoDashExplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.omit
          */
@@ -17122,12 +17122,12 @@ declare namespace _ {
          * // => { 'b': '2' }
          */
         omitBy<TResult extends {}, T extends {}>(
-            object: T,
+            object: T | null | undefined,
             predicate: ObjectIterator<any, boolean>
         ): TResult;
     }
 
-    interface LoDashImplicitObjectWrapper<T> {
+    interface LoDashImplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.omitBy
          */
@@ -17136,7 +17136,7 @@ declare namespace _ {
         ): LoDashImplicitObjectWrapper<TResult>;
     }
 
-    interface LoDashExplicitObjectWrapper<T> {
+    interface LoDashExplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.omitBy
          */
@@ -17165,12 +17165,12 @@ declare namespace _ {
          * // => { 'a': 1, 'c': 3 }
          */
         pick<TResult extends {}, T extends {}>(
-            object: T,
+            object: T | null | undefined,
             ...predicate: Array<Many<StringRepresentable>>
         ): TResult;
     }
 
-    interface LoDashImplicitObjectWrapper<T> {
+    interface LoDashImplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.pick
          */
@@ -17179,7 +17179,7 @@ declare namespace _ {
         ): LoDashImplicitObjectWrapper<TResult>;
     }
 
-    interface LoDashExplicitObjectWrapper<T> {
+    interface LoDashExplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.pick
          */
@@ -17208,12 +17208,12 @@ declare namespace _ {
          * // => { 'a': 1, 'c': 3 }
          */
         pickBy<TResult extends {}, T extends {}>(
-            object: T,
+            object: T | null | undefined,
             predicate?: ObjectIterator<any, boolean>
         ): TResult;
     }
 
-    interface LoDashImplicitObjectWrapper<T> {
+    interface LoDashImplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.pickBy
          */
@@ -17222,7 +17222,7 @@ declare namespace _ {
         ): LoDashImplicitObjectWrapper<TResult>;
     }
 
-    interface LoDashExplicitObjectWrapper<T> {
+    interface LoDashExplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.pickBy
          */
@@ -18904,7 +18904,12 @@ declare namespace _ {
          * @param value Any value.
          * @return Returns value.
          */
-        identity<T>(value?: T): T;
+        identity<T>(value: T): T;
+
+        /**
+         * @see _.identity
+         */
+        identity(): undefined;
     }
 
     interface LoDashImplicitWrapper<T> {
@@ -19964,7 +19969,7 @@ declare namespace _ {
     type MemoVoidDictionaryIterator<T, TResult> = (acc: TResult, curr: T, key: string, dict: Dictionary<T>) => void;
 
     /** Common interface between Arrays and jQuery objects */
-    type List<T> = ArrayLike<T>
+    type List<T> = ArrayLike<T>;
 
     interface Dictionary<T> {
         [index: string]: T;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -10375,109 +10375,114 @@ namespace TestMergeWith {
 
 // _.omit
 namespace TestOmit {
+    let obj: {} | null | undefined = any;
     let predicate: (element: any, key: string, collection: any) => boolean;
 
     {
         let result: TResult;
 
-        result = _.omit<TResult, Object>({}, 'a');
-        result = _.omit<TResult, Object>({}, 0, 'a');
-        result = _.omit<TResult, Object>({}, true, 0, 'a');
-        result = _.omit<TResult, Object>({}, ['b', 1, false], true, 0, 'a');
+        result = _.omit<TResult, Object>(obj, 'a');
+        result = _.omit<TResult, Object>(obj, 0, 'a');
+        result = _.omit<TResult, Object>(obj, true, 0, 'a');
+        result = _.omit<TResult, Object>(obj, ['b', 1, false], true, 0, 'a');
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<TResult>;
 
-        result = _({}).omit<TResult>('a');
-        result = _({}).omit<TResult>(0, 'a');
-        result = _({}).omit<TResult>(true, 0, 'a');
-        result = _({}).omit<TResult>(['b', 1, false], true, 0, 'a');
+        result = _(obj).omit<TResult>('a');
+        result = _(obj).omit<TResult>(0, 'a');
+        result = _(obj).omit<TResult>(true, 0, 'a');
+        result = _(obj).omit<TResult>(['b', 1, false], true, 0, 'a');
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<TResult>;
 
-        result = _({}).chain().omit<TResult>('a');
-        result = _({}).chain().omit<TResult>(0, 'a');
-        result = _({}).chain().omit<TResult>(true, 0, 'a');
-        result = _({}).chain().omit<TResult>(['b', 1, false], true, 0, 'a');
+        result = _(obj).chain().omit<TResult>('a');
+        result = _(obj).chain().omit<TResult>(0, 'a');
+        result = _(obj).chain().omit<TResult>(true, 0, 'a');
+        result = _(obj).chain().omit<TResult>(['b', 1, false], true, 0, 'a');
     }
 }
 
 // _.omitBy
 namespace TestOmitBy {
+    let obj: {} | null | undefined = any;
     let predicate = (element: any, key: string, collection: any) => true;
 
     {
         let result: TResult;
 
-        result = _.omitBy<TResult, Object>({}, predicate);
+        result = _.omitBy<TResult, Object>(obj, predicate);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<TResult>;
 
-        result = _({}).omitBy<TResult>(predicate);
+        result = _(obj).omitBy<TResult>(predicate);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<TResult>;
 
-        result = _({}).chain().omitBy<TResult>(predicate);
+        result = _(obj).chain().omitBy<TResult>(predicate);
     }
 }
 
 // _.pick
 namespace TestPick {
+    let obj: {} | null | undefined = any;
+
     {
         let result: TResult;
 
-        result = _.pick<TResult, Object>({}, 'a');
-        result = _.pick<TResult, Object>({}, 0, 'a');
-        result = _.pick<TResult, Object>({}, true, 0, 'a');
-        result = _.pick<TResult, Object>({}, ['b', 1, false], true, 0, 'a');
+        result = _.pick<TResult, Object>(obj, 'a');
+        result = _.pick<TResult, Object>(obj, 0, 'a');
+        result = _.pick<TResult, Object>(obj, true, 0, 'a');
+        result = _.pick<TResult, Object>(obj, ['b', 1, false], true, 0, 'a');
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<TResult>;
 
-        result = _({}).pick<TResult>('a');
-        result = _({}).pick<TResult>(0, 'a');
-        result = _({}).pick<TResult>(true, 0, 'a');
-        result = _({}).pick<TResult>(['b', 1, false], true, 0, 'a');
+        result = _(obj).pick<TResult>('a');
+        result = _(obj).pick<TResult>(0, 'a');
+        result = _(obj).pick<TResult>(true, 0, 'a');
+        result = _(obj).pick<TResult>(['b', 1, false], true, 0, 'a');
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<TResult>;
 
-        result = _({}).chain().pick<TResult>('a');
-        result = _({}).chain().pick<TResult>(0, 'a');
-        result = _({}).chain().pick<TResult>(true, 0, 'a');
-        result = _({}).chain().pick<TResult>(['b', 1, false], true, 0, 'a');
+        result = _(obj).chain().pick<TResult>('a');
+        result = _(obj).chain().pick<TResult>(0, 'a');
+        result = _(obj).chain().pick<TResult>(true, 0, 'a');
+        result = _(obj).chain().pick<TResult>(['b', 1, false], true, 0, 'a');
     }
 }
 
 // _.pickBy
 namespace TestPickBy {
+    let obj: {} | null | undefined = any;
     let predicate = (element: any, key: string, collection: any) => true;
 
     {
         let result: TResult;
 
-        result = _.pickBy<TResult, Object>({}, predicate);
+        result = _.pickBy<TResult, Object>(obj, predicate);
     }
 
     {
         let result: _.LoDashImplicitObjectWrapper<TResult>;
 
-        result = _({}).pickBy<TResult>(predicate);
+        result = _(obj).pickBy<TResult>(predicate);
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<TResult>;
 
-        result = _({}).chain().pickBy<TResult>(predicate);
+        result = _(obj).chain().pickBy<TResult>(predicate);
     }
 }
 
@@ -11947,6 +11952,12 @@ namespace TestIdentity {
         let result: _.LoDashExplicitObjectWrapper<{a: number}>;
 
         result = _({a: 42}).chain().identity();
+    }
+
+    {
+        let input: {} | null | undefined = any;
+        _.identity(input); // $ExpectType {} | null | undefined
+        _.identity(); // $ExpectType undefined
     }
 }
 


### PR DESCRIPTION
There was an issue with `_.identity` where if you pass in a possibly undefined input value, then `undefined` would be removed from the possible types of the output value. This is wrong because the output type should be exactly the same as the input type.

There were also a few functions that should accept null/undefined inputs, but didn't. Those are fixed with this PR.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [ ] Increase the version number in the header if appropriate. N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.