### PR TITLE
Flux: added StoresList type

### DIFF
--- a/types/flux/lib/FluxContainer.d.ts
+++ b/types/flux/lib/FluxContainer.d.ts
@@ -37,8 +37,10 @@ export interface RealOptions {
 
 export type ComponentConstructor<TProps> = React.ComponentClass<TProps> | React.StatelessComponent<TProps>;
 
+export type StoresList = Array<FluxStore<any>>;
+
 export interface ComponentStatic<TProps, TState, TContext> {
-    getStores(maybeProps?: TProps, maybeContext?: TContext): Array<FluxStore<any>>;
+    getStores(maybeProps?: TProps, maybeContext?: TContext): StoresList;
     calculateState(prevState: TState, maybeProps?: TProps, maybeContext?: TContext): TState;
 }
 

--- a/types/flux/test/FluxUtils.tsx
+++ b/types/flux/test/FluxUtils.tsx
@@ -38,7 +38,7 @@ interface State {
 }
 
 class CounterContainer extends React.Component<Props, State> {
-    static getStores() {
+    static getStores(): Container.StoresList {
         return [Store];
     }
 


### PR DESCRIPTION
Added TypeScript type `StoresList`. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


When using tslint rule [typedef](https://palantir.github.io/tslint/rules/typedef/), you must always add a return type.
So, to avoid using this:
```ts
class Container {
     static getStores(): Array<FluxStore<any>> {
// ...
```

Now you should use this:
```ts
class Container {
     static getStores(): Container.StoresList {
// ...
```