### PR TITLE
Fix/vast-client support for VastAd.creatives

### DIFF
--- a/types/vast-client/index.d.ts
+++ b/types/vast-client/index.d.ts
@@ -232,13 +232,36 @@ export interface VastError {
 }
 
 export interface VastCreative {
-    0: VastCreativeLinear;
-    1: VastCreativeCompanion;
+    id: string;
+    adId: string;
+    trackingEvents: VastTrackingEvents;
+    apiFramework: any;
+    sequence: any;
+    type: string;
+}
+
+export interface VastCreativeLinear extends VastCreative {
+    adParameters: any;
+    duration: number;
+    icons: string[];
+    mediaFiles: VastMediaFile[];
+    skipDelay: boolean;
+    videoClickThroughURLTemplate: string;
+    videoClickTrackingURLTemplates: string[];
+    videoCustomClickURLTempaltes: string[];
+}
+
+export interface VastCreativeNonLinear extends VastCreative {
+    variations: VastNonLinearAd[];
+}
+
+export interface VastCreativeCompanion extends VastCreative {
+    variations: VastCompanionAd[];
 }
 
 export interface VastAd {
     advertiser: any;
-    creatives: VastCreative;
+    creatives: VastCreative[];
     description: string;
     errorURLTemplates: string[];
     extensions: VastAdExtension[];
@@ -271,22 +294,22 @@ export interface VastAdChildAttributes {
     name: string;
 }
 
-export interface VastCreativeLinear {
-    adParameters: any;
-    duration: number;
-    icons: string[];
-    mediaFiles: VastMediaFile[];
-    skipDelay: boolean;
-    trackingEvents: VastTrackingEvents;
+export interface VastNonLinearAd {
+    nonLinearClickTrackingURLTemplates: string[];
+    nonLinearClickThroughURLTemplate: string;
+    adParameters: string;
     type: string;
-    videoClickThroughURLTemplate: string;
-    videoClickTrackingURLTemplates: string[];
-    videoCustomClickURLTempaltes: string[];
-}
-
-export interface VastCreativeCompanion {
-    type: string;
-    variations: VastCompanionAd[];
+    iframeResource: string;
+    htmlResource: string;
+    id: string;
+    width: string;
+    height: string;
+    expandedWidth: string;
+    expandedHeight: string;
+    scalablle: boolean;
+    maintainAspectRatio: boolean;
+    minSuggestedDuration: number;
+    apiFramework: any;
 }
 
 export interface VastCompanionAd {

--- a/types/vast-client/index.d.ts
+++ b/types/vast-client/index.d.ts
@@ -238,7 +238,7 @@ export interface VastCreative {
 
 export interface VastAd {
     advertiser: any;
-    creatives: VastCreative[];
+    creatives: VastCreative;
     description: string;
     errorURLTemplates: string[];
     extensions: VastAdExtension[];

--- a/types/vast-client/index.d.ts
+++ b/types/vast-client/index.d.ts
@@ -232,8 +232,8 @@ export interface VastError {
 }
 
 export interface VastCreative {
-    0: VastCreativeLinear,
-    1: VastCreativeCompanion
+    0: VastCreativeLinear;
+    1: VastCreativeCompanion;
 }
 
 export interface VastAd {

--- a/types/vast-client/index.d.ts
+++ b/types/vast-client/index.d.ts
@@ -231,9 +231,14 @@ export interface VastError {
     ERRORCODE: string;
 }
 
+export interface VastCreative {
+    0: VastCreativeLinear,
+    1: VastCreativeCompanion
+}
+
 export interface VastAd {
     advertiser: any;
-    creatives: VastCreativeLinear | VastCreativeCompanion[];
+    creatives: VastCreative[];
     description: string;
     errorURLTemplates: string[];
     extensions: VastAdExtension[];

--- a/types/vast-client/vast-client-tests.ts
+++ b/types/vast-client/vast-client-tests.ts
@@ -5,6 +5,13 @@ function cb(response: DMVAST.VastResponse, error: Error): void {
     if (error) return;
     // process the VAST response
     const ads: DMVAST.VastAd[] = response.ads;
+    const linearCreative = response.ads[0].creatives.filter(creative => {
+        return creative.type === 'linear';
+    });
+    if (linearCreative && linearCreative.length > 0) {
+        const creative = linearCreative[0] as DMVAST.VastCreativeLinear;
+        const mediaFiles = creative.mediaFiles;
+    }
 }
 
 // CLIENT


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dailymotion/vast-client-js/blob/master/src/ad.coffee
- [x] Increase the version number in the header if appropriate.
- [ x If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

VastAd.creatives always returns an array with creatives[0] = VastCreativeLinear and creatives[1] = VastCreativeCompanion.

Im not sure if TypeScript supports index signatures for arrays, so I hacked it a little bit so VastAd.creatives uses an object with index signatures.

This will throw errors if trying to iterate through creatives property so Im not sure if this is ideal.

An alternative will be VastAd.creatives: (VastCreativeLinear | VastCreativeCompanion)[] and then can be used like

const linear = vastAd.creatives[0] as VastCreativeLinear.