### PR TITLE
(hapi): Add RouteConfiguration Partial

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -50,6 +50,10 @@ export interface Dictionary<T> {
     [key: string]: T;
 }
 
+type Partial<T> = {
+    [P in keyof T]?: T[P];
+};
+
 /**
  * Server
  * The Server object is the main application container. The server manages all incoming connections along with all the facilities provided by the framework. A server can contain more than one connection (e.g. listen to port 80 and 8080).
@@ -1103,6 +1107,9 @@ export interface RouteConfiguration {
     /** additional route options. The config value can be an object or a function that returns an object using the signature function(server) where server is the server the route is being added to and this is bound to the current realm's bind option. */
     config?: RouteAdditionalConfigurationOptions | ((server: Server) => RouteAdditionalConfigurationOptions);
 }
+
+export type RouteConfigurationPartial = Partial<RouteConfiguration>;
+
 
 /**
  * Route options

--- a/types/hapi/test/route/config.ts
+++ b/types/hapi/test/route/config.ts
@@ -17,6 +17,15 @@ var routeConfig: Hapi.RouteConfiguration = {
   method: ['OPTIONS', '*']
 };
 
+// partial
+var routeConfigPartial: Hapi.RouteConfigurationPartial = {
+  path: '/signin'
+};
+
+var routeConfigPartial: Hapi.RouteConfigurationPartial = {
+  method: 'POST'
+};
+
 // different handlers
 var routeConfig: Hapi.RouteConfiguration = {
   path: '/signin',


### PR DESCRIPTION
My plugin defines some routes but I want the path and method to have a default in the plugin.  Need a partial to allow passing the route as:
```
{
  config: { id: "someid" },
  handler: (request, reply) => {}
}
``

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://hapijs.com/api/16.1.1#route-configuration>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
