### PR TITLE
express and express-serve-static - Add RenderCallback defintion

### DIFF
--- a/express-serve-static-core/index.d.ts
+++ b/express-serve-static-core/index.d.ts
@@ -34,6 +34,8 @@ type PathParams = string | RegExp | (string | RegExp)[];
 
 type RequestHandlerParams = RequestHandler | ErrorRequestHandler | (RequestHandler | ErrorRequestHandler)[];
 
+type RenderCallback = (err: Error, html: string) => void;
+
 interface IRouterMatcher<T> {
     (path: PathParams, ...handlers: RequestHandler[]): T;
     (path: PathParams, ...handlers: RequestHandlerParams[]): T;
@@ -833,8 +835,8 @@ interface Response extends http.ServerResponse, Express.Response {
         *  - `cache`     boolean hinting to the engine it should cache
         *  - `filename`  filename of the view being rendered
         */
-    render(view: string, options?: Object, callback?: (err: Error, html: string) => void): void;
-    render(view: string, callback?: (err: Error, html: string) => void): void;
+    render(view: string, options?: Object, callback?: RenderCallback): void;
+    render(view: string, callback?: RenderCallback): void;
 
     locals: any;
 
@@ -1049,8 +1051,8 @@ interface Application extends IRouter, Express.Application {
         * @param options or fn
         * @param fn
         */
-    render(name: string, options?: Object, callback?: (err: Error, html: string) => void): void;
-    render(name: string, callback: (err: Error, html: string) => void): void;
+    render(name: string, options?: Object, callback?: RenderCallback): void;
+    render(name: string, callback: RenderCallback): void;
 
 
     /**

--- a/express/index.d.ts
+++ b/express/index.d.ts
@@ -59,10 +59,11 @@ declare namespace e {
     interface Handler extends core.Handler { }
     interface IRoute extends core.IRoute { }
     interface IRouter<T> extends core.IRouter { }
-    interface IRouterHandler<T> extends core.IRouterHandler<T> { }    
+    interface IRouterHandler<T> extends core.IRouterHandler<T> { }
     interface IRouterMatcher<T> extends core.IRouterMatcher<T> { }
     interface MediaType extends core.MediaType { }
     interface NextFunction extends core.NextFunction { }
+    type RenderCallback = core.RenderCallback
     interface Request extends core.Request { }
     interface RequestHandler extends core.RequestHandler { }
     interface RequestParamHandler extends core.RequestParamHandler { }


### PR DESCRIPTION
Description:

The Render methods accepts a callback of type ```(err: Error, html: string) => void```. But this is not defined as a type. In order to allow this callback to be pass in functions, like when we implement Angular Universal, I created a type for it (```RenderCallback```) and externalised it through @types/express.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/felipegoncalvesmarques/DefinitelyTyped/blob/master/express-serve-static-core/index.d.ts