### PR TITLE
[react-measure] Adds any as state interface for Measure to avoid TypeScript compiler errors

### DIFF
--- a/types/react-measure/index.d.ts
+++ b/types/react-measure/index.d.ts
@@ -7,7 +7,7 @@
 declare module "react-measure" {
     import * as React from "react";
 
-    class Measure extends React.Component<Measure.MeasureProps> { }
+    class Measure extends React.Component<Measure.MeasureProps, any> { }
     namespace Measure {
         type MeasurementType = "width" | "height" | "top" | "right" | "bottom" | "left";
         interface Dimensions {

--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -123,7 +123,7 @@ interface TransitionProps {
      */
     willLeave?: (styleThatLeft: TransitionStyle) => Style | void;
 }
-export class TransitionMotion extends Component<TransitionProps> { }
+export class TransitionMotion extends Component<TransitionProps, any> { }
 
 
 interface StaggeredMotionProps {
@@ -137,7 +137,7 @@ interface StaggeredMotionProps {
      */
     styles: (previousInterpolatedStyles?: Array<PlainStyle>) => Array<Style>;
 }
-export declare class StaggeredMotion extends Component<StaggeredMotionProps> { }
+export declare class StaggeredMotion extends Component<StaggeredMotionProps, any> { }
 
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


I am getting this error in my project.
```
[at-loader] ./node_modules/@types/react-measure/index.d.ts:10:27 
    TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).
```

Typescript expected two arguments for ReactComponents, so I added any for the state.