### PR TITLE
[react-motion] Adds any as state interface to avoid TS compiler error

### DIFF
--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -123,7 +123,7 @@ interface TransitionProps {
      */
     willLeave?: (styleThatLeft: TransitionStyle) => Style | void;
 }
-export class TransitionMotion extends Component<TransitionProps> { }
+export class TransitionMotion extends Component<TransitionProps, any> { }
 
 
 interface StaggeredMotionProps {
@@ -137,7 +137,7 @@ interface StaggeredMotionProps {
      */
     styles: (previousInterpolatedStyles?: Array<PlainStyle>) => Array<Style>;
 }
-export declare class StaggeredMotion extends Component<StaggeredMotionProps> { }
+export declare class StaggeredMotion extends Component<StaggeredMotionProps, any> { }
 
 
 /**


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

I am getting this error in my project.
```
ERROR in [at-loader] ./node_modules/@types/react-motion/index.d.ts:126:39 
    TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).

ERROR in [at-loader] ./node_modules/@types/react-motion/index.d.ts:140:46 
    TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).
```

For TransitionMotion and StaggeredMotion Component
Typescript expected two arguments for ReactComponents, so I added any for the state.