### PR TITLE
[react-router-redux] Adds 'any' as state interface

### DIFF
--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -23,7 +23,7 @@ export interface ConnectedRouterProps<State> {
     store?: Store<State>;
     history?: History;
 }
-export class ConnectedRouter<State> extends React.Component<ConnectedRouterProps<State>> {}
+export class ConnectedRouter<State> extends React.Component<ConnectedRouterProps<State>, any> {}
 
 export const LOCATION_CHANGE: string;
 

--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -56,7 +56,7 @@ export interface LocationActionPayload {
 
 export interface RouterAction extends Action {
     type: typeof CALL_HISTORY_METHOD;
-    payload: LocationActionPayload;
+    payload?: LocationActionPayload;
 }
 
 export interface LocationChangeAction extends Action {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

I am getting these errors in my project.
```
ERROR in [at-loader] ./node_modules/@types/react-router-redux/index.d.ts:26:45 
    TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).
```

Typescript expected two arguments for ReactComponents, so I added any for the state.