### PR TITLE
[sinon] Add "keyof" type checking to sinon.spy and sinon.stub

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -96,8 +96,8 @@ declare namespace Sinon {
 
     interface SinonSpyStatic {
         (): SinonSpy;
-        (func: any): SinonSpy;
-        (obj: any, method: string): SinonSpy;
+        (func: Function): SinonSpy;
+        <T>(obj: T, method: keyof T): SinonSpy;
     }
 
     interface SinonStatic {
@@ -153,8 +153,8 @@ declare namespace Sinon {
     interface SinonStubStatic {
         (): SinonStub;
         (obj: any): SinonStub;
-        (obj: any, method: string): SinonStub;
-        (obj: any, method: string, func: any): SinonStub;
+        <T>(obj: T, method: keyof T): SinonStub;
+        <T>(obj: T, method: keyof T, func: Function): SinonStub;
     }
 
     interface SinonStatic {

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -30,7 +30,7 @@ function testTwo() {
 
 function testThree() {
     let obj = { thisObj: true };
-    let callback = sinon.spy({}, "method");
+    let callback = sinon.spy<any>({}, "method");
     let proxy = once(callback);
     proxy.call(obj, callback, 1, 2, 3);
     if (callback.calledOn(obj)) { console.log("test3 calledOn success"); } else { console.log("test3 calledOn failure"); }
@@ -168,7 +168,7 @@ function testSetMatcher() {
 }
 
 function testGetterStub() {
-    const myObj: any = {
+    const myObj = {
         prop: 'foo'
     };
 
@@ -177,7 +177,7 @@ function testGetterStub() {
 }
 
 function testSetterStub() {
-    const myObj: any = {
+    const myObj = {
         prop: 'foo',
         prop2: 'bar'
     };
@@ -187,7 +187,7 @@ function testSetterStub() {
 }
 
 function testValueStub() {
-    const myObj: any = {
+    const myObj = {
         prop: 'foo'
     };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://sinonjs.org/releases/v2.3.8/spies/
http://sinonjs.org/releases/v2.3.8/stubs/

As noted in the documentation `sinon.stub` and `sinon.spy` replace a method on the given object with a stubbed/intercepted version based on the string name of the method. These changes use `keyof` to assert that a property with that name is known to exist on the first argument.

Additionally, this PR adds a `Function` typing for the "func" overloads of `stub` and `spy`.

Limitations:
- Stubbing a method that does not exist now requires an extra type parameter. E.g. 
   * Invalid: `sinon.stub({ }, 'method');`
   * Valid: `sinon.stub<any>({ }, 'method');`
   * Valid: `sinon.stub({ method: () => null }, 'method');`
- Some expressions typecheck but will fail at runtime because the stubbed property is not a function:
   * Type checks but invalid: `sinon.spy({ prop: true }, 'prop');`
   * Type checks but invalid: `class Bar { prop = false; }; sinon.spy(new Bar(), 'prop');`
   * Type checks and valid: `class Foo { func () { }; }; sinon.spy(new Foo(), 'func');`