### PR TITLE
[webpack-dev-server] Exported the configuration interface for the server

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -1,54 +1,54 @@
-// Type definitions for webpack-dev-server 2.4.5
+// Type definitions for webpack-dev-server 2.4
 // Project: https://github.com/webpack/webpack-dev-server
 // Definitions by: maestroh <https://github.com/maestroh>
+//                 Dave Parslow <https://github.com/daveparslow>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "webpack-dev-server" {
-    import * as webpack from 'webpack';
-    import * as core from 'express-serve-static-core';
-    import * as serveStatic from 'serve-static';
-    import * as http from 'http';
+import * as webpack from 'webpack';
+import * as core from 'express-serve-static-core';
+import * as serveStatic from 'serve-static';
+import * as http from 'http';
 
-    namespace WebpackDevServer {
-        export interface Configuration {
-            contentBase?: string;
-            hot?: boolean;
-            https?: boolean;
-            historyApiFallback?: boolean;
-            compress?: boolean;
-            proxy?: any;
-            staticOptions?: any;
-            quiet?: boolean;
-            noInfo?: boolean;
-            lazy?: boolean;
-            filename?: string| RegExp;
-            watchOptions?: webpack.WatchOptions;
-            publicPath: string;
-            headers?: any;
-            stats?: webpack.compiler.StatsOptions| webpack.compiler.StatsToStringOptions;
-            public?: string;
-            disableHostCheck?: boolean;
+declare namespace WebpackDevServer {
+    interface Configuration {
+        contentBase?: string;
+        hot?: boolean;
+        https?: boolean;
+        historyApiFallback?: boolean;
+        compress?: boolean;
+        proxy?: any;
+        staticOptions?: any;
+        quiet?: boolean;
+        noInfo?: boolean;
+        lazy?: boolean;
+        filename?: string| RegExp;
+        watchOptions?: webpack.WatchOptions;
+        publicPath: string;
+        headers?: any;
+        stats?: webpack.compiler.StatsOptions| webpack.compiler.StatsToStringOptions;
+        public?: string;
+        disableHostCheck?: boolean;
 
-            setup?(app: core.Express): void;
-        }
-
-        export interface WebpackDevServer {
-            new (
-                webpack: webpack.compiler.Compiler,
-                config: Configuration
-            ):WebpackDevServer;
-
-            listen(port: number,
-                hostname: string,
-                callback?: Function
-            ): http.Server;
-
-            listen(port: number,
-                callback?: Function
-            ): http.Server;
-        }
+        setup?(app: core.Express): void;
     }
-    var wds: WebpackDevServer.WebpackDevServer;
-
-    export = wds;
 }
+
+declare class WebpackDevServer {
+    constructor(
+        webpack: webpack.compiler.Compiler,
+        config: WebpackDevServer.Configuration
+    );
+
+    listen(
+        port: number,
+        hostname: string,
+        callback?: (...args: any[]) => any
+    ): http.Server;
+
+    listen(
+        port: number,
+        callback?: (...args: any[]) => any
+    ): http.Server;
+}
+
+export = WebpackDevServer;

--- a/types/webpack-dev-server/tslint.json
+++ b/types/webpack-dev-server/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -1,15 +1,16 @@
 import * as webpack from 'webpack';
 import * as WebpackDevServer from 'webpack-dev-server';
-var compiler = webpack({});
+import * as core from 'express-serve-static-core';
+let compiler = webpack({});
 
 // basic example
-var server = new WebpackDevServer(compiler, {
+let server = new WebpackDevServer(compiler, {
     publicPath: "/assets/"
 });
 server.listen(8080);
 
-// API example
-server = new WebpackDevServer(compiler, {
+// Configuration can be used as a type
+let config: WebpackDevServer.Configuration = {
     // webpack-dev-server options
     contentBase: "/path/to/directory",
     // or: contentBase: "http://localhost/",
@@ -41,12 +42,12 @@ server = new WebpackDevServer(compiler, {
         "**": "http://localhost:9090"
     },
 
-    setup: function (app) {
+    setup: (app: core.Express) => {
         // Here you can access the Express app object and add your own custom middleware to it.
         // For example, to define custom handlers for some paths:
-        // app.get('/some/path', function(req, res) {
-        //   res.json({ custom: 'response' });
-        // });
+        app.get('/some/path', (req, res) => {
+            res.json({ custom: 'response' });
+        });
     },
 
     // pass [static options](http://expressjs.com/en/4x/api.html#express.static) to inner express server
@@ -66,5 +67,8 @@ server = new WebpackDevServer(compiler, {
     publicPath: "/assets/",
     headers: { "X-Custom-Header": "yes" },
     stats: { colors: true }
-});
-server.listen(8080, "localhost", function () { });
+};
+
+// API example
+server = new WebpackDevServer(compiler, config);
+server.listen(8080, "localhost", () => {});


### PR DESCRIPTION
Exported the configuration interface for the server
Added class for the server instead of interface
Added TS lint file and fixed errors

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/dev-server/
- [x] Increase the version number in the header if appropriate.
No version change (removed the minor version due to TS lint error that appeared when TS lint was enabled
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
Added tslint file