### PR TITLE
@types/webdriverio $$ returns an Array of Clients

### DIFF
--- a/types/webdriverio/index.d.ts
+++ b/types/webdriverio/index.d.ts
@@ -1561,7 +1561,7 @@ declare namespace WebdriverIO {
         $(selector: string): Client<RawResult<Element>> & RawResult<Element>;
         $<P>(selector: string): Client<P>;
 
-        $$(selector: string): Client<Array<RawResult<Element>>> & Array<RawResult<Element>>;
+        $$(selector: string): Array<Client<RawResult<Element>>> & Array<RawResult<Element>>;
         $$<P>(selector: string): Client<P>;
 
         addCommand(


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation for the base JS class](https://github.com/webdriverio/webdriverio/blob/master/lib/commands/$$.js)
[Homepage code example also shows usage of $$](http://webdriver.io/)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

From the docs on the homepage (and in our migration effort from es2015 -> typescript) the following code should work:
```
var results = browser.$$('.commands.property a').filter(function (link) {
    return link.isVisible();
]});

results[1].click();
```

Currently it returns: `Property ‘click’ does not exist on type ‘RawResult<Element>‘`
