### PR TITLE
Add support for use_index in pouchdb-find 6.3.4

### DIFF
--- a/types/pouchdb-find/index.d.ts
+++ b/types/pouchdb-find/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pouchdb-find 0.10
+// Type definitions for pouchdb-find 6.3
 // Project: https://pouchdb.com/
 // Definitions by: Jakub Navratil <https://github.com/trubit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -96,6 +96,9 @@ declare namespace PouchDB {
 
             /** Number of docs to skip before returning. */
             skip?: number;
+
+            /** Set which index to use for the query. It can be “design-doc-name” or “[‘design-doc-name’, ‘name’]”. */
+            use_index?: string | [string, string];
         }
 
         interface FindResponse<Content extends {}> {

--- a/types/pouchdb-find/pouchdb-find-tests.ts
+++ b/types/pouchdb-find/pouchdb-find-tests.ts
@@ -6,7 +6,13 @@ function testFind() {
         fields: ['fieldName'],
         sort: ['fieldName'],
         limit: 1,
-        skip: 1
+        skip: 1,
+        use_index: 'ddocName'
+    });
+
+    db.find({
+        selector: {},
+        use_index: ['ddocName', 'name']
     });
 
     db.find({


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://pouchdb.com/api.html#query_index

https://github.com/pouchdb/pouchdb/commit/0faacb921d1efe3392c90af6fa124045023e1809

@WorldMaker