### PR TITLE
[aws-lambda] S3CreateEvent.Records should be Array<S3Record> instead of Tuple

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -22,43 +22,44 @@ var snsEvtRec: AWSLambda.SNSEventRecord;
 var snsMsg: AWSLambda.SNSMessage;
 var snsMsgAttr: AWSLambda.SNSMessageAttribute;
 var snsMsgAttrs: AWSLambda.SNSMessageAttributes;
-var S3CreateEvent: AWSLambda.S3CreateEvent = {
-    Records: [{
-        eventVersion: 'string',
-        eventSource: 'string',
-        awsRegion: 'string',
-        eventTime: 'string',
-        eventName: 'string',
-        userIdentity: {
-            principalId: 'string'
-        },
-        requestParameters: {
-            sourceIPAddress: 'string'
-        },
-        responseElements: {
-            'x-amz-request-id': 'string',
-            'x-amz-id-2': 'string'
-        },
-        s3: {
-            s3SchemaVersion: 'string',
-            configurationId: 'string',
-            bucket: {
-                name: 'string',
-                ownerIdentity: {
-                    principalId: 'string'
-                },
-                arn: 'string'
+var S3EvtRec: AWSLambda.S3EventRecord = {  
+    eventVersion: '2.0',
+    eventSource: 'aws:s3',
+    awsRegion: 'us-east-1',
+    eventTime: '1970-01-01T00:00:00.000Z',
+    eventName: 'ObjectCreated:Put',
+    userIdentity: {  
+        principalId: 'AIDAJDPLRKLG7UEXAMPLE'
+    },
+    requestParameters:{  
+        sourceIPAddress: '127.0.0.1'
+    },
+    responseElements: {  
+        'x-amz-request-id': 'C3D13FE58DE4C810',
+        'x-amz-id-2': 'FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD'
+    },
+    s3: {  
+        s3SchemaVersion: '1.0',
+        configurationId: 'testConfigRule',
+        bucket: {  
+            name: 'mybucket',
+            ownerIdentity: {  
+                principalId: 'A3NL1KOZZKExample'
             },
-            object: {
-                key: 'string',
-                size: 1,
-                eTag: 'string',
-                versionId: 'string',
-                sequencer: 'string'
-            }
+            arn: 'arn:aws:s3:::mybucket'
+        },
+        object: {  
+            key: 'HappyFace.jpg',
+            size: 1024,
+            eTag: 'd41d8cd98f00b204e9800998ecf8427e',
+            versionId: '096fKKXTRTtl3on89fVO.nfljtsv6qko',
+            sequencer: '0055AED6DCD90281E5'
         }
     }
-    ]
+};
+
+var S3CreateEvent: AWSLambda.S3CreateEvent = {
+    Records: [S3EvtRec]
 };
 var cognitoUserPoolEvent: AWSLambda.CognitoUserPoolEvent;
 var cloudformationCustomResourceEvent: AWSLambda.CloudFormationCustomResourceEvent;

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for AWS Lambda
 // Project: http://docs.aws.amazon.com/lambda
-// Definitions by: James Darbyshire <https://github.com/darbio/aws-lambda-typescript>, Michael Skarum <https://github.com/skarum>, Stef Heyenrath <https://github.com/StefH/DefinitelyTyped>, Toby Hede <https://github.com/tobyhede>, Rich Buggy <https://github.com/buggy>, Yoriki Yamaguchi <https://github.com/y13i>
+// Definitions by: James Darbyshire <https://github.com/darbio/aws-lambda-typescript>, Michael Skarum <https://github.com/skarum>, Stef Heyenrath <https://github.com/StefH/DefinitelyTyped>, Toby Hede <https://github.com/tobyhede>, Rich Buggy <https://github.com/buggy>, Yoriki Yamaguchi <https://github.com/y13i>, wwwy3y3 <https://github.com/wwwy3y3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // API Gateway "event"
@@ -85,43 +85,44 @@ interface SNSEvent {
  * S3Create event
  * https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
  */
-interface S3CreateEvent {
-    Records: [{
-        eventVersion: string;
-        eventSource: string;
-        awsRegion: string
-        eventTime: string;
-        eventName: string;
-        userIdentity: {
-            principalId: string;
-        },
-        requestParameters: {
-            sourceIPAddress: string;
-        },
-        responseElements: {
-            'x-amz-request-id': string;
-            'x-amz-id-2': string;
-        },
-        s3: {
-            s3SchemaVersion: string;
-            configurationId: string;
-            bucket: {
-                name: string;
-                ownerIdentity: {
-                    principalId: string;
-                },
-                arn: string;
+interface S3EventRecord {
+    eventVersion: string;
+    eventSource: string;
+    awsRegion: string
+    eventTime: string;
+    eventName: string;
+    userIdentity: {
+        principalId: string;
+    },
+    requestParameters: {
+        sourceIPAddress: string;
+    },
+    responseElements: {
+        'x-amz-request-id': string;
+        'x-amz-id-2': string;
+    },
+    s3: {
+        s3SchemaVersion: string;
+        configurationId: string;
+        bucket: {
+            name: string;
+            ownerIdentity: {
+                principalId: string;
             },
-            object: {
-                key: string;
-                size: number;
-                eTag: string;
-                versionId: string;
-                sequencer: string;
-            }
+            arn: string;
+        },
+        object: {
+            key: string;
+            size: number;
+            eTag: string;
+            versionId: string;
+            sequencer: string;
         }
     }
-    ];
+}
+
+interface S3CreateEvent {
+    Records: Array<S3EventRecord>;
 }
 
 /**


### PR DESCRIPTION
## fix
* S3CreateEvent.Records fix from Tuple to Array<S3Record>
* use real data for S3CreateEvent test

## Template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.