### PR TITLE
[jquery] Change isEmptyObject() to return boolean

### DIFF
--- a/types/angular-resource/index.d.ts
+++ b/types/angular-resource/index.d.ts
@@ -53,14 +53,14 @@ declare module 'angular' {
         interface IActionHash {
             [action: string]: IActionDescriptor;
         }
-        
+
         interface IResourceResponse {
             config: any;
             data: any;
             headers: any;
             resource: any;
             status: number;
-            statusText: string
+            statusText: string;
         }
 
         interface IResourceInterceptor {

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -587,7 +587,7 @@ interface JQueryStatic<TElement extends Node = HTMLElement> {
      * @see {@link https://api.jquery.com/jQuery.isEmptyObject/}
      * @since 1.4
      */
-    isEmptyObject(obj: any): obj is {};
+    isEmptyObject(obj: any): boolean;
     /**
      * Determine if the argument passed is a JavaScript function object.
      *

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -627,12 +627,8 @@ function JQueryStatic() {
     }
 
     function isEmptyObject() {
-        function type_guard(obj: object) {
-            if ($.isEmptyObject(obj)) {
-                // $ExpectType {}
-                obj;
-            }
-        }
+        // $ExpectType boolean
+        $.isEmptyObject({});
     }
 
     function isFunction() {

--- a/types/jquery/jquery-tests.ts
+++ b/types/jquery/jquery-tests.ts
@@ -622,6 +622,9 @@ function JQueryStatic() {
             if ($.isArray(obj)) {
                 // $ExpectType any[]
                 obj;
+            } else {
+                // $ExpectType object
+                obj;
             }
         }
     }
@@ -636,6 +639,9 @@ function JQueryStatic() {
             if ($.isFunction(obj)) {
                 // $ExpectType Function
                 obj;
+            } else {
+                // $ExpectType object
+                obj;
             }
         }
     }
@@ -644,6 +650,9 @@ function JQueryStatic() {
         function type_guard(obj: boolean) {
             if ($.isNumeric(obj)) {
                 // $ExpectType (true & number) | (false & number)
+                obj;
+            } else {
+                // $ExpectType boolean
                 obj;
             }
         }
@@ -662,6 +671,9 @@ function JQueryStatic() {
         function type_guard(obj: object) {
             if ($.isWindow(obj)) {
                 // $ExpectType Window
+                obj;
+            } else {
+                // $ExpectType object
                 obj;
             }
         }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

Fixes #18149 

`isEmptyObject()` does not work as intended as a type guard. When a value is not an empty object, its type is narrowed to `never`.