### PR TITLE
Revert "react-transition-group Added {} state to remedy Component Requires 2 type arguments"

### DIFF
--- a/types/react-transition-group/CSSTransition.d.ts
+++ b/types/react-transition-group/CSSTransition.d.ts
@@ -33,6 +33,6 @@ export interface CSSTransitionProps extends TransitionProps {
     classNames: string | CSSTransitionClassNames;
 }
 
-declare class CSSTransition extends Component<CSSTransitionProps, any> {}
+declare class CSSTransition extends Component<CSSTransitionProps> {}
 
 export default CSSTransition;

--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -66,6 +66,6 @@ export interface TransitionProps extends TransitionActions {
  * ```
  *
  */
-declare class Transition extends Component<TransitionProps, any> {}
+declare class Transition extends Component<TransitionProps> {}
 
 export default Transition;

--- a/types/react-transition-group/TransitionGroup.d.ts
+++ b/types/react-transition-group/TransitionGroup.d.ts
@@ -1,4 +1,4 @@
-import { Component, HTMLProps, ReactElement, ReactType } from "react";
+import { Component, ReactType, HTMLProps, ReactElement } from "react";
 import { TransitionActions, TransitionProps } from "react-transition-group/Transition";
 
 export interface IntrinsicTransitionGroupProps<T extends keyof JSX.IntrinsicElements = "div"> extends TransitionActions {
@@ -71,6 +71,6 @@ export type TransitionGroupProps<T extends keyof JSX.IntrinsicElements = "div", 
  * components. This means you can mix and match animations across different
  * list items.
  */
-declare class TransitionGroup extends Component<TransitionGroupProps, any> {}
+declare class TransitionGroup extends Component<TransitionGroupProps> {}
 
 export default TransitionGroup;


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#18086

This was a workaround for an outdated react version. The correct fix is the ensure your type dependencies are all up to date.