### PR TITLE
[material-ui] Adds missing props to GridTile

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1051,7 +1051,6 @@ declare namespace __MaterialUI {
         interface GridTileProps {
             actionIcon?: React.ReactElement<any>;
             actionPosition?: "left" | "right";
-            children?: React.ReactNode;
             cols?: number;
             containerElement?: string | React.ReactElement<any> | React.ComponentClass<any>;
             rows?: number;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1051,11 +1051,13 @@ declare namespace __MaterialUI {
         interface GridTileProps {
             actionIcon?: React.ReactElement<any>;
             actionPosition?: "left" | "right";
+            children?: React.ReactNode;
             cols?: number;
             containerElement?: string | React.ReactElement<any> | React.ComponentClass<any>;
             rows?: number;
             style?: React.CSSProperties;
             subtitle?: React.ReactNode;
+            subtitleStyle?: React.CSSProperties;
             title?: React.ReactNode;
             titleBackground?: string;
             titlePosition?: "top" | "bottom";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

I created this pull request to add missing properties (children, subtitleStyle) from [Material UI docs](http://www.material-ui.com/#/components/grid-list) to GridTile. 
[First commit](https://github.com/nbgraham/DefinitelyTyped/commit/fa404b00ca801d352aefe11c8ec9c5a0b6ffa712) which does that.

When running `npm run lint material-ui`, I realized there was no tslint.json so I created the default one:
```
{ "extends": "dtslint/dt.json" }
```

Then there were a lot of lint errors.

I fixed them all in `material-ui-tests.tsx` and only a few of them in `index.d.ts`.
There were hundreds - if not thousands - of `'export' keyword is redundant here` errors, but I wasn't sure how to fix them without actually messing up exports.