### PR TITLE
Fixes estree type support of Esprima comments

### DIFF
--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -58,6 +58,7 @@ export interface Program extends BaseNode {
   type: "Program";
   sourceType: "script" | "module";
   body: Array<Statement | ModuleDeclaration>;
+  comments?: Array<Comment>;
 }
 
 interface BaseFunction extends BaseNode {
@@ -89,6 +90,7 @@ export interface EmptyStatement extends BaseStatement {
 export interface BlockStatement extends BaseStatement {
   type: "BlockStatement";
   body: Array<Statement>;
+  innerComments?: Array<Comment>;
 }
 
 export interface ExpressionStatement extends BaseStatement {


### PR DESCRIPTION
# Template

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Comment Support in Esprima](http://esprima.readthedocs.io/en/4.0/syntactic-analysis.html?highlight=comment#comment-collection)

# Notes

This makes two changes - both add additional support for Esprima's specific implementation of extending ASTs with comment information from the source code:

- Adds an optional `comments` field to the `Program`, which will be present if the AST is created with Esprima using the `{ comments: true }` option. This is [documented in Esprima](http://esprima.readthedocs.io/en/4.0/syntactic-analysis.html?highlight=comment#comment-collection)

- Adds an optional `innerComments` field to `BlockStatement` which will be present if the AST is created with Esprima using the `{ attachComments: true }` option, given the following code:

```.js
function foo(n) {
    // comments in an empty block are `innerComments`
}
```

**Note** `attachComments` is an undocumented feature of Esprima, but one which is already partially supported by this set of definitions, with the `trailingComments` and `leadingComments` fields.

Additionally, none of this is specified in the [ESTree specification](https://github.com/estree/estree) but it does not specify any comment support and  as previously stated, support for Esprima's specific comment extensions were already partially implemented here.

The following test code compiled and runs correctly (requires `esprima`):

```.ts
import { parse } from 'esprima';
import * as ESTree from 'estree';

let ast = parse(`
    function foo(){
        //= foo
    }
`, {
    attachComment: true
});

function logBlock(body: ESTree.BlockStatement) {
    console.log(body.innerComments);
}
logBlock((<ESTree.FunctionDeclaration>ast.body[0]).body);


ast = parse(`
    function foo(){
        //= foo
    }
`, {
    comment: true
});

function logProg(prog: ESTree.Program) {
    console.log(prog.comments);
}
logProg(ast);
```