### PR TITLE
Add declaration for Plotly.Plots

### DIFF
--- a/types/plotly.js/index.d.ts
+++ b/types/plotly.js/index.d.ts
@@ -14,6 +14,8 @@ export interface StaticPlots {
 	resize(root: Root): void;
 }
 
+export const Plots: StaticPlots;
+
 export interface Point {
 	x: number;
 	y: number;


### PR DESCRIPTION
Usage:

```js
Plotly.newPlot(node, data, layout)
  .then(() => Plotly.Plots.resize(node))
```