### PR TITLE
@types/angular-strap - Missing IModalOptions

### DIFF
--- a/types/angular-strap/index.d.ts
+++ b/types/angular-strap/index.d.ts
@@ -45,6 +45,7 @@ declare namespace mgcrea.ngStrap {
             template?: string;
             templateUrl?: string;
             contentTemplate?: string;
+            prefixClass?:  string;
             prefixEvent?: string;
             id?: string;
             scope?: ng.IScope;

--- a/types/angular-strap/index.d.ts
+++ b/types/angular-strap/index.d.ts
@@ -49,6 +49,10 @@ declare namespace mgcrea.ngStrap {
             prefixEvent?: string;
             id?: string;
             scope?: ng.IScope;
+            onBeforeHide?: (modal: IModal) => void;
+            onHide?: (modal: IModal) => void;
+            onBeforeShow?: (modal: IModal) => void;
+            onShow?: (modal: IModal) => void;
         }
 
         interface IModalScope extends ng.IScope {


### PR DESCRIPTION
The interface is missing `prefixClass` from `IModalOptions`, and optional callbacks.
https://github.com/mgcrea/angular-strap/blob/master/dist/modules/modal.js#L15
https://github.com/mgcrea/angular-strap/blob/master/dist/modules/modal.js#L308

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mgcrea/angular-strap/blob/master/dist/modules/modal.js#L15
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.