### PR TITLE
[redux-actions] fix incorrect return type for combineActions()

### DIFF
--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -119,6 +119,4 @@ export function handleActions<State, Payload>(
     initialState: State
 ): Reducer<State, Payload>;
 
-export function combineActions(
-    ...actionTypes: Array<ActionFunctions<any> | string>
-): Array<ActionFunctions<any>>;
+export function combineActions(...actionTypes: Array<ActionFunctions<any> | string>): string;

--- a/types/redux-actions/redux-actions-tests.ts
+++ b/types/redux-actions/redux-actions-tests.ts
@@ -137,7 +137,7 @@ ReduxActions.handleAction(act3, (state, action) => {
 ReduxActions.handleAction(ReduxActions.combineActions(act1, act3, act2), (state, action) => {}, 0);
 
 ReduxActions.handleActions({
-  [<string> ReduxActions.combineActions(act1, act3, act2)](state, action) {}
+    [<string> ReduxActions.combineActions(act1, act3, act2)](state, action) {}
 }, 0);
 
 /* can't do this until it lands in 2.2, HKTs

--- a/types/redux-actions/redux-actions-tests.ts
+++ b/types/redux-actions/redux-actions-tests.ts
@@ -137,7 +137,7 @@ ReduxActions.handleAction(act3, (state, action) => {
 ReduxActions.handleAction(ReduxActions.combineActions(act1, act3, act2), (state, action) => {}, 0);
 
 ReduxActions.handleActions({
-    [<string> ReduxActions.combineActions(act1, act3, act2)](state, action) {}
+    [ReduxActions.combineActions(act1, act3, act2)](state, action) {}
 }, 0);
 
 /* can't do this until it lands in 2.2, HKTs

--- a/types/redux-actions/redux-actions-tests.ts
+++ b/types/redux-actions/redux-actions-tests.ts
@@ -136,6 +136,10 @@ ReduxActions.handleAction(act3, (state, action) => {
 
 ReduxActions.handleAction(ReduxActions.combineActions(act1, act3, act2), (state, action) => {}, 0);
 
+ReduxActions.handleActions({
+  [<string> ReduxActions.combineActions(act1, act3, act2)](state, action) {}
+}, 0);
+
 /* can't do this until it lands in 2.2, HKTs
 ReduxActions.handleAction(act, (state, action) => {
     action.payload === 'hello'


### PR DESCRIPTION
Fixes #18148.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://redux-actions.js.org/docs/api/combineActions.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.