### PR TITLE
[react] Add missing autoComplete and dirName attributes on textarea

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2815,8 +2815,10 @@ declare namespace React {
     }
 
     interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
+        autoComplete?: string;
         autoFocus?: boolean;
         cols?: number;
+        dirName?: string;
         disabled?: boolean;
         form?: string;
         maxLength?: number;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -12,6 +12,7 @@
 //                 Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 //                 Stéphane Goetz <https://github.com/onigoetz>
+//                 Mike Deverell <https://github.com/devrelm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2392,7 +2392,7 @@ declare namespace React {
         allowTransparency?: boolean;
         alt?: string;
         async?: boolean;
-        autoComplete?: string;
+        autocomplete?: string;
         autoFocus?: boolean;
         autoPlay?: boolean;
         capture?: boolean;
@@ -2577,7 +2577,7 @@ declare namespace React {
     interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
         acceptCharset?: string;
         action?: string;
-        autoComplete?: string;
+        autocomplete?: string;
         encType?: string;
         method?: string;
         name?: string;
@@ -2623,7 +2623,7 @@ declare namespace React {
     interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
         accept?: string;
         alt?: string;
-        autoComplete?: string;
+        autocomplete?: string;
         autoFocus?: boolean;
         capture?: boolean; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean;
@@ -2816,7 +2816,7 @@ declare namespace React {
     }
 
     interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
-        autoComplete?: string;
+        autocomplete?: string;
         autoFocus?: boolean;
         cols?: number;
         dirName?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  https://www.w3.org/TR/html5/forms.html#the-textarea-element
  https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element
