### PR TITLE
Use last version of i18next package for i18next-express-middleware

### DIFF
--- a/types/i18next-express-middleware/index.d.ts
+++ b/types/i18next-express-middleware/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://i18next.com/
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 declare namespace I18next {
     interface I18nextOptions extends i18nextExpressMiddleware.I18nextOptions { }
@@ -94,8 +95,8 @@ declare module "i18next-express-middleware" {
         init(services: any, options?: Object, allOptions?: Object): void;
     }
 
-    export function getResourcesHandler(i18next: i18next.I18n, options: Object): express.Handler;
-    export function handle(i18next: i18next.I18n, options?: Object): express.Handler;
+    export function getResourcesHandler(i18next: i18next.i18n, options: Object): express.Handler;
+    export function handle(i18next: i18next.i18n, options?: Object): express.Handler;
 
     /**
      * @summary Gets handler for missing key.
@@ -103,5 +104,5 @@ declare module "i18next-express-middleware" {
      * @param {Object}          options The options.
      * @return {express.Handler} The express handler.
      */
-    export function missingKeyHandler(i18next: i18next.I18n, options: Object): express.Handler;
+    export function missingKeyHandler(i18next: i18next.i18n, options: Object): express.Handler;
 }

--- a/types/i18next-express-middleware/tsconfig.json
+++ b/types/i18next-express-middleware/tsconfig.json
@@ -11,11 +11,6 @@
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "i18next": [
-                "i18next/v2"
-            ]
-        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This commit allow to use the last type definition file for version 8.4 of the i18next package inside the package i18next-express-middleware. Previously, the used the type definition for i18next 2.3