### PR TITLE
Use Node.js like export syntax for interoping

### DIFF
--- a/types/css-modules/index.d.ts
+++ b/types/css-modules/index.d.ts
@@ -19,20 +19,20 @@ interface SelectorNode {
 
 declare module '*.css' {
     const styles: SelectorNode & Stringifyable;
-    export default styles;
+    export = styles;
 }
 
 declare module '*.scss' {
     const styles: SelectorNode & Stringifyable;
-    export default styles;
+    export = styles;
 }
 
 declare module '*.sass' {
     const styles: SelectorNode & Stringifyable;
-    export default styles;
+    export = styles;
 }
 
 declare module '*.less' {
     const styles: SelectorNode & Stringifyable;
-    export default styles;
+    export = styles;
 }


### PR DESCRIPTION
Some module bundlers (Rollup being exception) don't inject interopabilty code that looks at `default` prop of exports object and then if not found, uses `exports` object itself as fallback.
