### PR TITLE
fix(stripe-checkout): fix removed stripe package in favor of stripe-v2

### DIFF
--- a/types/stripe-checkout/index.d.ts
+++ b/types/stripe-checkout/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for Stripe Checkout
+// Type definitions for Stripe Checkout 1.0
 // Project: https://stripe.com/checkout
 // Definitions by: Chris Wrench <https://github.com/cgwrench>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="stripe/v2"/>
+/// <reference types="stripe-v2"/>
 
 interface StripeCheckoutStatic {
     configure(options: StripeCheckoutOptions): StripeCheckoutHandler;
@@ -16,7 +16,7 @@ interface StripeCheckoutHandler {
 
 interface StripeCheckoutOptions {
     key?: string;
-    token?: (token: StripeTokenResponse) => void;
+    token?(token: stripe.StripeTokenResponse): void;
     image?: string;
     name?: string;
     description?: string;
@@ -33,8 +33,8 @@ interface StripeCheckoutOptions {
     bitcoin?: boolean;
     alipay?: boolean | 'auto';
     alipayReusable?: boolean;
-    opened?: () => void;
-    closed?: () => void;
+    opened?(): void;
+    closed?(): void;
 }
 
 declare var StripeCheckout: StripeCheckoutStatic;

--- a/types/stripe-checkout/stripe-checkout-tests.ts
+++ b/types/stripe-checkout/stripe-checkout-tests.ts
@@ -1,7 +1,7 @@
 // Test the minimum amount of configuration required.
-var handler = StripeCheckout.configure({
+let handler = StripeCheckout.configure({
 	key: "my-secret-key",
-	token: function(token: StripeTokenResponse) {
+	token: (token: stripe.StripeTokenResponse) => {
 		console.log(token.id);
 	}
 });
@@ -11,9 +11,9 @@ handler.open();
 handler.close();
 
 // Test all configuration options.
-var options: StripeCheckoutOptions = {
+const options: StripeCheckoutOptions = {
 	key: "my-secret-key",
-	token: function(token: StripeTokenResponse) {
+	token: (token: stripe.StripeTokenResponse) => {
 		console.log(token.id);
 	},
     image: "http://placehold.it/128x128",
@@ -31,9 +31,9 @@ var options: StripeCheckoutOptions = {
     alipay: "auto",
     alipayReusable: false,
     shippingAddress: false,
-    opened: function() {},
-    closed: function() {}
-}
+    opened: () => {},
+    closed: () => {}
+};
 
 handler = StripeCheckout.configure(options);
 

--- a/types/stripe-checkout/tslint.json
+++ b/types/stripe-checkout/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Fixing issue reported in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/15303

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/checkout
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.