### PR TITLE
[Office-js] Add item.dateTimeCreated and ui.closeContainer

### DIFF
--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -160,6 +160,15 @@ declare namespace Office {
          * @param messageObject Accepts a message from the dialog to deliver to the add-in.
          */
         messageParent(messageObject: any): void;
+        /**
+         * Closes the UI container where the JavaScript is executing. 
+         * The behavior of this method is specified by the following table.
+         * When called from	            Behavior
+         * A UI-less command button	    No effect. Any dialogs opened by displayDialogAsync will remain open.
+         * A taskpane	                The taskpane will close. Any dialogs opened by displayDialogAsync will also close. If the taskpane supports pinning and was pinned by the user, it will be un-pinned.
+         * A module extension	        No effect. 
+         */
+        closeContainer(): void;
     }
     export interface DialogOptions {
         /**
@@ -1769,6 +1778,7 @@ declare namespace Office {
         body: Body;
         itemType: Office.MailboxEnums.ItemType;
         notificationMessages: NotificationMessages;
+        dateTimeCreated: Date;
         /**
          * Asynchronously loads custom properties that are specific to the item and a app for Office
          * @param callback The optional callback method


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run npm run lint package-name (or tsc if no tslint.json is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/OfficeDev/office-js-docs/blob/master/reference/shared/officeui.closecontainer.md](https://github.com/OfficeDev/office-js-docs/blob/master/reference/shared/officeui.closecontainer.md)
[https://github.com/OfficeDev/office-js-docs/blob/master/reference/outlook/1.5/Office.context.mailbox.item.md#datetimecreated-date](https://github.com/OfficeDev/office-js-docs/blob/master/reference/outlook/1.5/Office.context.mailbox.item.md#datetimecreated-date)