### PR TITLE
Add Rangy Class Applier module to Rangy

### DIFF
--- a/types/rangy/rangy-classapplier.d.ts
+++ b/types/rangy/rangy-classapplier.d.ts
@@ -6,31 +6,31 @@
 ///<reference path="index.d.ts"/>
 
 interface RangyStatic {
-    createClassApplier(theClass: string, options?: RangyClassApplierOptions, tagNames?: Array<string> | string): RangyClassApplier;
+    createClassApplier(theClass: string, options?: RangyClassApplierOptions, tagNames?: string|string[]): RangyClassApplier;
 }
 
 interface RangyClassApplierOptions {
     elementTagName?: string;
-    elementProperties?: {[property: string]: any};
-    elementAttributes?: {[attribute: string]: any};
+    elementProperties?: {[property: string]: string};
+    elementAttributes?: {[attribute: string]: string};
     ignoreWhiteSpace?: boolean;
     applyToEditableOnly?: boolean;
-    tagNames?: Array<string> | string;
+    tagNames?: string|string[];
     normalize?: boolean;
     onElementCreate?: (element: Element, classApplier: RangyClassApplier) => void;
     useExistingElements?: boolean;
 }
 
 interface RangyClassApplier extends RangyClassApplierOptions {
-    applyToSelection(win?: Window): any;
-    undoToSelection(win?: Window): any;
+    applyToSelection(win?: Window): void;
+    undoToSelection(win?: Window): void;
     isAppliedToSelection(win?: Window): boolean;
-    toggleSelection(win?: Window): any
-    applyToRange(range: RangyRange): any;
-    undoToRange(range: RangyRange): any;
+    toggleSelection(win?: Window): void;
+    applyToRange(range: RangyRange): void;
+    undoToRange(range: RangyRange): void;
     isAppliedToRange(range: RangyRange): boolean;
-    toggleRange(range: RangyRange): any;
-    detach(doc?: Document|Window|HTMLIFrameElement): any;
+    toggleRange(range: RangyRange): void;
+    detach(doc?: Document|Window|HTMLIFrameElement): void;
     className: string;
     cssClass: string;
 }

--- a/types/rangy/rangy-classapplier.d.ts
+++ b/types/rangy/rangy-classapplier.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for Rangy Class Applier module
+// Project: https://github.com/timdown/rangy
+// Definitions by: Maxime Kjaer <https://github.com/MaximeKjaer>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+///<reference path="index.d.ts"/>
+
+interface RangyStatic {
+    createClassApplier(theClass: string, options?: RangyClassApplierOptions, tagNames?: Array<string>): RangyClassApplier;
+}
+
+interface RangyClassApplier {
+    applyToSelection(win?: Window): any;
+    undoToSelection(win?: Window): any;
+    isAppliedToSelection(win?: Window): boolean;
+    toggleSelection(win?: Window): any
+    applyToRange(range: RangyRange): any;
+    undoToRange(range: RangyRange): any;
+    isAppliedToRange(range: RangyRange): boolean;
+    toggleRange(range: RangyRange): any;
+    detach(doc?: Document|Window|HTMLIFrameElement): any;
+    className: string;
+    cssClass: string;
+}
+
+interface RangyClassApplierOptions {
+    elementTagName?: string;
+    elementProperties?: {[property: string]: any};
+    elementAttributes?: {[attribute: string]: any};
+    ignoreWhiteSpace?: boolean;
+    applyToEditableOnly?: boolean;
+    tagNames?: Array<string> | string;
+    normalize?: boolean;
+    onElementCreate?: (element: Element, classApplier: RangyClassApplier) => void;
+    useExistingElements?: boolean;
+}

--- a/types/rangy/rangy-classapplier.d.ts
+++ b/types/rangy/rangy-classapplier.d.ts
@@ -6,21 +6,7 @@
 ///<reference path="index.d.ts"/>
 
 interface RangyStatic {
-    createClassApplier(theClass: string, options?: RangyClassApplierOptions, tagNames?: Array<string>): RangyClassApplier;
-}
-
-interface RangyClassApplier {
-    applyToSelection(win?: Window): any;
-    undoToSelection(win?: Window): any;
-    isAppliedToSelection(win?: Window): boolean;
-    toggleSelection(win?: Window): any
-    applyToRange(range: RangyRange): any;
-    undoToRange(range: RangyRange): any;
-    isAppliedToRange(range: RangyRange): boolean;
-    toggleRange(range: RangyRange): any;
-    detach(doc?: Document|Window|HTMLIFrameElement): any;
-    className: string;
-    cssClass: string;
+    createClassApplier(theClass: string, options?: RangyClassApplierOptions, tagNames?: Array<string> | string): RangyClassApplier;
 }
 
 interface RangyClassApplierOptions {
@@ -33,4 +19,18 @@ interface RangyClassApplierOptions {
     normalize?: boolean;
     onElementCreate?: (element: Element, classApplier: RangyClassApplier) => void;
     useExistingElements?: boolean;
+}
+
+interface RangyClassApplier extends RangyClassApplierOptions {
+    applyToSelection(win?: Window): any;
+    undoToSelection(win?: Window): any;
+    isAppliedToSelection(win?: Window): boolean;
+    toggleSelection(win?: Window): any
+    applyToRange(range: RangyRange): any;
+    undoToRange(range: RangyRange): any;
+    isAppliedToRange(range: RangyRange): boolean;
+    toggleRange(range: RangyRange): any;
+    detach(doc?: Document|Window|HTMLIFrameElement): any;
+    className: string;
+    cssClass: string;
 }

--- a/types/rangy/rangy-tests.ts
+++ b/types/rangy/rangy-tests.ts
@@ -134,22 +134,22 @@ function testRangyClassApplier() {
 
     let rangyRange: RangyRange = rangy.createRange();
 
-    assertAny(classApplier.applyToSelection());
-    assertAny(classApplier.applyToSelection(window));
-    assertAny(classApplier.undoToSelection());
-    assertAny(classApplier.undoToSelection(window));
+    classApplier.applyToSelection();
+    classApplier.applyToSelection(window);
+    classApplier.undoToSelection();
+    classApplier.undoToSelection(window);
     assertBoolean(classApplier.isAppliedToSelection());
     assertBoolean(classApplier.isAppliedToSelection(window));
-    assertAny(classApplier.toggleSelection());
-    assertAny(classApplier.toggleSelection(window));
-    assertAny(classApplier.applyToRange(rangyRange));
-    assertAny(classApplier.undoToRange(rangyRange));
+    classApplier.toggleSelection();
+    classApplier.toggleSelection(window);
+    classApplier.applyToRange(rangyRange);
+    classApplier.undoToRange(rangyRange);
     assertBoolean(classApplier.isAppliedToRange(rangyRange));
-    assertAny(classApplier.toggleRange(rangyRange));
-    assertRangyRange(classApplier.detach(document));
-    assertRangyRange(classApplier.detach(window));
-    assertRangyRange(classApplier.detach(new HTMLIFrameElement));
-    assertRangyRange(classApplier.detach());
+    classApplier.toggleRange(rangyRange);
+    classApplier.detach(document);
+    classApplier.detach(window);
+    classApplier.detach(new HTMLIFrameElement);
+    classApplier.detach();
 
     let className: string = classApplier.className;
     className = classApplier.cssClass;

--- a/types/rangy/rangy-tests.ts
+++ b/types/rangy/rangy-tests.ts
@@ -1,5 +1,3 @@
-///<reference path="rangy-classapplier.d.ts"/>
-
 declare function assertAny(a:any):any;
 declare function assertBoolean(b:boolean):any;
 declare function assertString(s:string):any;

--- a/types/rangy/rangy-tests.ts
+++ b/types/rangy/rangy-tests.ts
@@ -133,6 +133,7 @@ function testRangyClassApplier() {
 
     let classApplier: RangyClassApplier;
     classApplier = rangy.createClassApplier('test', options, ['test1', 'test2']);
+    classApplier = rangy.createClassApplier('test', options, 'test1, test2');
 
     let rangyRange: RangyRange = rangy.createRange();
 

--- a/types/rangy/rangy-tests.ts
+++ b/types/rangy/rangy-tests.ts
@@ -1,4 +1,4 @@
-
+///<reference path="rangy-classapplier.d.ts"/>
 
 declare function assertAny(a:any):any;
 declare function assertBoolean(b:boolean):any;
@@ -100,4 +100,60 @@ function testSelection() {
     object = selection.saveCharacterRanges(node);
     selection.restoreCharacterRanges(node, object);
     assertString(selection.toHtml());
+}
+
+
+function testRangyClassApplier() {
+    function elementCreateFunction(element: Element, classApplier: RangyClassApplier): number {
+        return 1;
+    }
+
+    rangy.init();
+    let options: RangyClassApplierOptions = {
+        elementTagName: 'span',
+        elementProperties: {
+            name: 'test-name',
+            disabled: 'true'
+        },
+        elementAttributes: {
+            id: 'test-id',
+            type: 'test-type'
+        },
+        ignoreWhiteSpace: false,
+        applyToEditableOnly: true,
+        tagNames: ["span", "b", "strong", "a"],
+        normalize: false,
+        onElementCreate: elementCreateFunction,
+        useExistingElements: false
+    };
+
+    let options2: RangyClassApplierOptions = {
+        tagNames: 'span, b, strong, a'
+    };
+
+    let classApplier: RangyClassApplier;
+    classApplier = rangy.createClassApplier('test', options, ['test1', 'test2']);
+
+    let rangyRange: RangyRange = rangy.createRange();
+
+    assertAny(classApplier.applyToSelection());
+    assertAny(classApplier.applyToSelection(window));
+    assertAny(classApplier.undoToSelection());
+    assertAny(classApplier.undoToSelection(window));
+    assertBoolean(classApplier.isAppliedToSelection());
+    assertBoolean(classApplier.isAppliedToSelection(window));
+    assertAny(classApplier.toggleSelection());
+    assertAny(classApplier.toggleSelection(window));
+    assertAny(classApplier.applyToRange(rangyRange));
+    assertAny(classApplier.undoToRange(rangyRange));
+    assertBoolean(classApplier.isAppliedToRange(rangyRange));
+    assertAny(classApplier.toggleRange(rangyRange));
+    assertRangyRange(classApplier.detach(document));
+    assertRangyRange(classApplier.detach(window));
+    assertRangyRange(classApplier.detach(new HTMLIFrameElement));
+    assertRangyRange(classApplier.detach());
+
+    let className: string = classApplier.className;
+    className = classApplier.cssClass;
+
 }

--- a/types/rangy/rangy-tests.ts
+++ b/types/rangy/rangy-tests.ts
@@ -106,7 +106,6 @@ function testRangyClassApplier() {
         return 1;
     }
 
-    rangy.init();
     let options: RangyClassApplierOptions = {
         elementTagName: 'span',
         elementProperties: {

--- a/types/rangy/tsconfig.json
+++ b/types/rangy/tsconfig.json
@@ -18,6 +18,7 @@
     },
     "files": [
         "index.d.ts",
+        "rangy-classapplier.d.ts",
         "rangy-tests.ts"
     ]
 }


### PR DESCRIPTION
This PR introduces type definitions for the [Rangy Class Applier module](https://github.com/timdown/rangy/wiki/Class-Applier-Module) which is a part of [Rangy](https://github.com/timdown/rangy).

This module is a global plugin, since it adds a method to the global `RangyStatic` object `rangy`, and adds its own `ClassApplier` type to the global scope. As such I've tried to follow the [global plugin template](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-plugin-d-ts.html) and to add annotations for the dependence on the [global `rangy-core` library](https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html#dependencies-on-global-libraries). But this is my first contribution to DefinitelyTyped, so please tell me if that isn't the way to go.

***

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/timdown/rangy/wiki/Class-Applier-Module
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
