### PR TITLE
next.js type update issues

### DIFF
--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -43,11 +43,11 @@ declare module 'next' {
     start(): Promise<void>;
     run(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: UrlLike): Promise<void>;
 
-    render(req: http.IncomingMessage, res: http.ServerResponse, pathname: string, query: {[key: string]: any}, parsedUrl: UrlLike): Promise<void>;
-    renderError(err: any, req: http.IncomingMessage, res: http.ServerResponse, pathname: string, query: {[key: string]: any}): Promise<void>;
+    render(req: http.IncomingMessage, res: http.ServerResponse, pathname: string, query?: {[key: string]: any}, parsedUrl?: UrlLike): Promise<void>;
+    renderError(err: any, req: http.IncomingMessage, res: http.ServerResponse, pathname: string, query?: {[key: string]: any}): Promise<void>;
     render404(req: http.IncomingMessage, res: http.ServerResponse, parsedUrl: UrlLike): Promise<void>;
-    renderToHTML(req: http.IncomingMessage, res: http.ServerResponse, pathname: string, query: {[key: string]: any}): Promise<string>;
-    renderErrorToHTML(err: any, req: http.IncomingMessage, res: http.ServerResponse, pathname: string, query: {[key: string]: any}): Promise<string>;
+    renderToHTML(req: http.IncomingMessage, res: http.ServerResponse, pathname: string, query?: {[key: string]: any}): Promise<string>;
+    renderErrorToHTML(err: any, req: http.IncomingMessage, res: http.ServerResponse, pathname: string, query?: {[key: string]: any}): Promise<string>;
 
     serveStatic(req: http.IncomingMessage, res: http.ServerResponse, path: string): Promise<void>;
     isServeableUrl(path: string): boolean;
@@ -59,7 +59,8 @@ declare module 'next' {
     send404(res: http.ServerResponse): void;
   }
 
-  export default function(options?: ServerOptions): Server;
+  function next(options?: ServerOptions): Server;
+  export = next;
 }
 
 declare module 'next/error' {
@@ -71,7 +72,11 @@ declare module 'next/head' {
   import * as React from 'react';
 
   function defaultHead(): JSX.Element[];
-  export default class extends React.Component<{}, {}> {}
+  export default class extends React.Component<{}, {}> {
+    static canUseDOM: boolean;
+    static peek(): Array<React.ReactElement<any>>;
+    static rewind(): Array<React.ReactElement<any>>;
+  }
 }
 
 declare module 'next/document' {
@@ -147,8 +152,8 @@ declare module 'next/router' {
     readonly components: { [key: string]: { Component: React.ComponentType<any>, err: any } };
     readonly pathname: string;
     readonly route: string;
-    readonly asPath: string;
-    readonly query: { [key: string]: any };
+    readonly asPath?: string;
+    readonly query?: { [key: string]: any };
 
     // router methods
     reload(route: string): Promise<void>;

--- a/types/next/next-tests.ts
+++ b/types/next/next-tests.ts
@@ -1,4 +1,4 @@
-import createServer from 'next';
+import createServer = require('next');
 import * as http from 'http';
 import * as url from 'url';
 
@@ -12,7 +12,7 @@ const server = createServer({
     anotherProperty: {
       key: true
     }
-  }
+  },
 });
 
 const voidFunc = () => {};
@@ -31,8 +31,10 @@ function handle(req: http.IncomingMessage, res: http.ServerResponse) {
   handler(req, res, parsedUrl).then(voidFunc);
   server.run(req, res, parsedUrl).then(voidFunc);
 
+  server.render(req, res, '/path/to/resource').then(voidFunc);
   server.render(req, res, '/path/to/resource', {}, parsedUrl).then(voidFunc);
   server.render(req, res, '/path/to/resource', { key: 'value' }, parsedUrl).then(voidFunc);
+  server.renderError(new Error(), req, res, '/path/to/resource').then(voidFunc);
   server.renderError(new Error(), req, res, '/path/to/resource', { key: 'value' }).then(voidFunc);
   server.renderError('this can be an error, too!', req, res, '/path/to/resource', { key: 'value' }).then(voidFunc);
   server.render404(req, res, parsedUrl).then(voidFunc);

--- a/types/next/test/next-head-tests.tsx
+++ b/types/next/test/next-head-tests.tsx
@@ -7,3 +7,13 @@ const jsx = (
     {elements}
   </Head>
 );
+
+if (!Head.canUseDOM) {
+  Head.rewind().map(
+    x => [x.key, x.props, x.type]
+  );
+}
+
+Head.peek().map(
+  x => [x.key, x.props, x.type]
+);

--- a/types/next/test/next-router-tests.tsx
+++ b/types/next/test/next-router-tests.tsx
@@ -20,9 +20,12 @@ function split(routeLike: string) {
   });
 }
 
+if (Router.asPath) {
+  split(Router.asPath);
+  split(Router.asPath);
+}
+
 split(Router.pathname);
-split(Router.asPath);
-split(Router.asPath);
 
 const query = `?${qs.stringify(Router.query)}`;
 


### PR DESCRIPTION
This fixes some of the issues from #17781.
 
- Some of the `render` parameters should've been made optional.
- The export style of the `'next'` module wasn't correct.
- Added some missing static methods to `Head`
- Some readonly properties of `Router` can be `undefined`.

Note that this also means that `'next'` technically needs to be imported
like `import next = require('next');`

Sources:
- Comments from #17781 
- https://github.com/zeit/next.js/blob/89d4e0af4aff35c70db3d292d59bf05fd3ae3866/lib/head.js
- https://github.com/zeit/next.js/blob/89d4e0af4aff35c70db3d292d59bf05fd3ae3866/lib/side-effect.js#L39-L57
