### PR TITLE
[enzyme] fix broken usage of React.HTMLAttributes interface due to recent changes to [react]

### DIFF
--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -10,7 +10,7 @@
 // TypeScript Version: 2.3
 
 /// <reference types="cheerio" />
-import { ReactElement, Component, HTMLAttributes as ReactHTMLAttributes, SVGAttributes as ReactSVGAttributes } from "react";
+import { ReactElement, Component, AllHTMLAttributes as ReactHTMLAttributes, SVGAttributes as ReactSVGAttributes } from "react";
 
 export type HTMLAttributes = ReactHTMLAttributes<{}> & ReactSVGAttributes<{}>;
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L2330
  - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L2385
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The interface for `React.HTMLAttributes` has been broken apart into multiple interfaces (as of `@types/react-15.0.38`), each specific to a particular DOM element type (`SelectHTMLAttributes`, `TdHTMLAttributes`, etc), and the unified interface with all of the possible DOM element attributes is now `AllHTMLAttributes`.  When running `.find()` with a selector the returned object, which could be any element, has a type with the declared properties of `HTMLAttributes` which is now limited to only those props in common between all DOM elements.  By changing the interface imported from React as the "default" collection of attributes this PR preserves the generic return type of `.find()` and other functions.

This is my first PR to DefinitelyTyped.  I've tried to follow the template and README but if there's anything else I should do please let me know and I'll take care of it immediately.