### PR TITLE
[material-ui] Adds missing subtitleStyleProps to GridTile

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1051,7 +1051,6 @@ declare namespace __MaterialUI {
         interface GridTileProps {
             actionIcon?: React.ReactElement<any>;
             actionPosition?: "left" | "right";
-            children?: React.ReactNode;
             cols?: number;
             containerElement?: string | React.ReactElement<any> | React.ComponentClass<any>;
             rows?: number;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1051,11 +1051,13 @@ declare namespace __MaterialUI {
         interface GridTileProps {
             actionIcon?: React.ReactElement<any>;
             actionPosition?: "left" | "right";
+            children?: React.ReactNode;
             cols?: number;
             containerElement?: string | React.ReactElement<any> | React.ComponentClass<any>;
             rows?: number;
             style?: React.CSSProperties;
             subtitle?: React.ReactNode;
+            subtitleStyle?: React.CSSProperties;
             title?: React.ReactNode;
             titleBackground?: string;
             titlePosition?: "top" | "bottom";


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

The subtitleStyle prop is missing. It's in the [Material UI docs](http://www.material-ui.com/#/components/grid-list) and the property works, but I'm getting a TS compiler error because its not in this typings file.
