### PR TITLE
add possibility of null return value from RichUtils.handleKeyCommand

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -5,6 +5,7 @@
 //                 Yale Cason <https://github.com/ghotiphud>
 //                 Ryan Schwers <https://github.com/schwers>
 //                 Michael Wu <https://github.com/michael-yx-wu>
+//                 Willis Plummer <https://github.com/willisplummer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -888,7 +888,7 @@ declare namespace Draft {
                  */
                 static toggleInlineStyle(editorState: EditorState, inlineStyle: string): EditorState;
 
-                static toggleLink(editorState: EditorState, targetSelection: SelectionState, entityKey: string): EditorState;
+                static toggleLink(editorState: EditorState, targetSelection: SelectionState, entityKey: string | null): EditorState;
 
                 /**
                  * When a collapsed cursor is at the start of an empty styled block, allow

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -862,8 +862,8 @@ declare namespace Draft {
                 static getCurrentBlockType(editorState: EditorState): string;
                 static getDataObjectForLinkURL(uri: URI): Object;
 
-                static handleKeyCommand(editorState: EditorState, command: DraftEditorCommand): EditorState | null;
-                static handleKeyCommand(editorState: EditorState, command: string): EditorState | null;
+                static handleKeyCommand(editorState: EditorState, command: DraftEditorCommand): EditorState;
+                static handleKeyCommand(editorState: EditorState, command: string): null;
 
                 static insertSoftNewline(editorState: EditorState): EditorState;
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -862,8 +862,8 @@ declare namespace Draft {
                 static getCurrentBlockType(editorState: EditorState): string;
                 static getDataObjectForLinkURL(uri: URI): Object;
 
-                static handleKeyCommand(editorState: EditorState, command: DraftEditorCommand): EditorState;
-                static handleKeyCommand(editorState: EditorState, command: string): EditorState;
+                static handleKeyCommand(editorState: EditorState, command: DraftEditorCommand): EditorState | null;
+                static handleKeyCommand(editorState: EditorState, command: string): EditorState | null;
 
                 static insertSoftNewline(editorState: EditorState): EditorState;
 


### PR DESCRIPTION
I encountered some runtime errors because the typing of `RichUtils.handleKeyCommand` didn't reflect the possibility of a `null` return value. This fixes by specifying that in the case of the overload (an unknown command string), null is returned.

See the source code [here](https://github.com/facebook/draft-js/blob/master/src/model/modifier/RichTextEditorUtil.js#L78) and the documentation [here](https://github.com/facebook/draft-js/blob/master/docs/APIReference-RichUtils.md#handlekeycommand)