### PR TITLE
Add babel-plugin-syntax-jsx package

### DIFF
--- a/types/babel-plugin-syntax-jsx/babel-plugin-syntax-jsx-tests.ts
+++ b/types/babel-plugin-syntax-jsx/babel-plugin-syntax-jsx-tests.ts
@@ -1,0 +1,10 @@
+import jsx from "babel-plugin-syntax-jsx";
+
+// Example taken from the babel plugin handbook:
+// https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#-enabling-syntax-in-plugins
+export default function myBabelPlugin() {
+    return {
+        visitor: {},
+        inherits: jsx,
+    };
+}

--- a/types/babel-plugin-syntax-jsx/index.d.ts
+++ b/types/babel-plugin-syntax-jsx/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for babel-plugin-syntax-jsx 6.18
+// Project: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx
+// Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// NB: This export doesn't match the handbook example, where `jsx` is the default export.
+// But it does match the runtime behaviour (at least at the time of this writing). For some reason,
+// babel-plugin-syntax-jsx/lib/index.js has this line at the bottom: module.exports = exports["default"];
+declare function jsx(): {
+    manipulateOptions(opts: any, parserOpts: { plugins: string[] }): void;
+};
+
+export default jsx;

--- a/types/babel-plugin-syntax-jsx/tsconfig.json
+++ b/types/babel-plugin-syntax-jsx/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "babel-plugin-syntax-jsx-tests.ts"
+    ]
+}

--- a/types/babel-plugin-syntax-jsx/tslint.json
+++ b/types/babel-plugin-syntax-jsx/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.