### PR TITLE
[react-native] Adding useNativeDriver to EventConfig

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8057,7 +8057,8 @@ export namespace Animated {
 
     type Mapping = { [key: string]: Mapping } | AnimatedValue;
     interface EventConfig {
-        listener?: ValueListenerCallback
+        listener?: ValueListenerCallback;
+        useNativeDriver?: boolean;
     }
 
     /**


### PR DESCRIPTION
The AnimatedEvent class's constructor takes in a config parameter of type EventConfig.  This config object is passed to shouldUseNativeDriver, which only returns something other than false if useNativeDriver is ever set.

A case when useNativeDriver is set to true is when Animated.Event is used for an Animated.ScrollView's onScroll prop.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html
https://raw.githubusercontent.com/facebook/react-native/master/Libraries/Animated/src/AnimatedImplementation.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.