### PR TITLE
Add maxLength type for material ui text field

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1846,6 +1846,7 @@ declare namespace __MaterialUI {
         autoFocus?: boolean;
         min?: number;
         max?: number;
+        maxLength?: string;
         step?: number;
         autoComplete?: string;
     }

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1846,7 +1846,8 @@ declare namespace __MaterialUI {
         autoFocus?: boolean;
         min?: number;
         max?: number;
-        maxLength?: string;
+        maxlength?: string;
+        minlegnth?: string;
         step?: number;
         autoComplete?: string;
     }


### PR DESCRIPTION
Added a one more prop type for material-ui TextField component, it appears it is not well documented, but I have tested it and it is working.

Link to original issue on github https://github.com/callemall/material-ui/issues/1578.
