### PR TITLE
sharp: fix incorrect versions type

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -51,7 +51,32 @@ declare namespace sharp {
     /** An EventEmitter that emits a change event when a task is either queued, waiting for libuv to provide a worker thread, complete */
     const queue: NodeJS.EventEmitter;
     /** An Object containing the version numbers of libvips and its dependencies. */
-    const versions: string[];
+    const versions: {
+        vips: string;
+        cairo?: string;
+        croco?: string;
+        exif?: string;
+        expat?: string;
+        ffi?: string;
+        fontconfig?: string;
+        freetype?: string;
+        gdkpixbuf?: string;
+        gif?: string;
+        glib?: string;
+        gsf?: string;
+        harfbuzz?: string;
+        jpeg?: string;
+        lcms?: string;
+        orc?: string;
+        pango?: string;
+        pixman?: string;
+        png?: string;
+        svg?: string;
+        tiff?: string;
+        webp?: string;
+        xml?: string;
+        zlib?: string;
+    };
     const bool: BoolEnum;
 
     interface SharpInstance extends Duplex {

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -200,3 +200,9 @@ let simd: boolean = sharp.simd();
 
 simd = sharp.simd(true);
 // attempts to enable the use of SIMD, returning true if available
+
+const vipsVersion: string = sharp.versions.vips;
+
+if (sharp.versions.cairo) {
+    const cairoVersion: string = sharp.versions.cairo;
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

  - test that [sharp.versions is an object and sharp.versions.vips is a string](https://github.com/lovell/sharp/blob/99118634414fded871f679ee9923208579d19b93/test/unit/util.js#L126)
  - [versions defined as object](https://github.com/lovell/sharp/blob/d8765f955de2f037881da7487773ad02cea539cc/lib/constructor.js#L12)
  - [generated JSON file of dependency versions](https://github.com/lovell/sharp/blob/0a6d8b37adce2d034dd591224514b845b3c9d763/packaging/build/lin.sh#L227-L252)

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I'm unsure if the test of optional versions members is enough or we should check them all. If so what's the best way to do that?