### PR TITLE
providing type definitions for jquery-editable-select

### DIFF
--- a/types/jquery-editable-select/index.d.ts
+++ b/types/jquery-editable-select/index.d.ts
@@ -1,0 +1,71 @@
+// Type definitions for jquery-editable-select 2.2.5
+// Project: https://github.com/indrimuska/jquery-editable-select
+// Definitions by: Vincent Biret <https://github.com/baywet>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery"/>
+
+declare namespace JQueryEditableSelect {
+    interface EditableSelectOptions {
+        /**
+         * Filter (or not) items in list while typing.
+         */
+        filter?: boolean;
+        /**
+         * Easing used for showing and hiding the dropdown list.
+         */
+        effects?: 'default' | 'slide' | 'fade';
+        /**
+         * Duration of the easings (in milliseconds).
+         */
+        duration?: number | 'fast' | 'slow';
+        /**
+         * Where to append the dropdown list in the DOM.
+         */
+        appendTo?: string | JQuery;
+        /**
+         * How dropdown list is triggered.
+         */
+        trigger?: 'focus'| 'manual'
+    }
+}
+
+interface JQuery {
+    /**
+     * Transforms the <select> into a typeahead field. Accepts an optional options object.
+     *
+     * @param options Options setting the editable select behavior
+     */
+    editableSelect(options?: JQueryEditableSelect.EditableSelectOptions): JQuery;
+    /**
+     * Manually shows/hide/filters/clears/destorys the dropdown list.
+     *
+     * @param action Action to apply
+     */
+    editableSelect(action: 'show'| 'hide'| 'filter' | 'clear'| 'destroy'): void;
+    /**
+     * Manually sets the value of the text field to the value of the $element passed as parameter.
+     *
+     * @param action Action to apply, must be 'select'
+     * @param element element to select (it must be one of the elements in the dropdown list)
+     */
+    editableSelect(action: 'select', element: JQuery): void;
+    /**
+     * Adds a new option in the dropdown list
+     *
+     * @param action Action to apply, must be 'add'
+     * @param text Test to be displayed
+     * @param index position to insert the element at.
+     * @param attrs optional attributes to add to the element
+     * @param data optional data to add to the element
+     */
+    editableSelect(action: 'add', text: string , index?: number, attrs?: {name: string, value: string}[], data?: string): void;
+    /**
+     * Removes an option in the dropdown list at the given index.
+     *
+     * @param action Action to apply, must be 'remove'
+     * @param index position of the element to remove.
+     */
+    editableSelect(action: 'remove', index: number): void;
+}

--- a/types/jquery-editable-select/index.d.ts
+++ b/types/jquery-editable-select/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jquery-editable-select 2.2.5
+// Type definitions for jquery-editable-select 2.2
 // Project: https://github.com/indrimuska/jquery-editable-select
 // Definitions by: Vincent Biret <https://github.com/baywet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -27,7 +27,7 @@ declare namespace JQueryEditableSelect {
         /**
          * How dropdown list is triggered.
          */
-        trigger?: 'focus'| 'manual'
+        trigger?: 'focus'| 'manual';
     }
 }
 
@@ -60,7 +60,7 @@ interface JQuery {
      * @param attrs optional attributes to add to the element
      * @param data optional data to add to the element
      */
-    editableSelect(action: 'add', text: string , index?: number, attrs?: {name: string, value: string}[], data?: string): void;
+    editableSelect(action: 'add', text: string , index?: number, attrs?: Array<{name: string, value: string}>, data?: string): void;
     /**
      * Removes an option in the dropdown list at the given index.
      *

--- a/types/jquery-editable-select/jquery-editable-select-tests.ts
+++ b/types/jquery-editable-select/jquery-editable-select-tests.ts
@@ -1,0 +1,15 @@
+function test_editable_select() {
+    $("#select").editableSelect();
+    $("#select").editableSelect({ filter: true, duration: 'slow', effects: 'default', appendTo: '.someelementclass', trigger: 'focus'});
+    $("#select").editableSelect('remove', 0);
+    $("#select").editableSelect('destroy');
+    $("#select").editableSelect('hide');
+    $("#select").editableSelect('show');
+    $("#select").editableSelect('filter');
+    $("#select").editableSelect('clear');
+    $("#select").editableSelect('select', $('#option1'));
+    $("#select").editableSelect('add', 'some text');
+    $("#select").editableSelect('add', 'some text', 0);
+    $("#select").editableSelect('add', 'some text', 0, [{name: 'attribute1', value: 'attribute1value'}]);
+    $("#select").editableSelect('add', 'some text', 0, [{name: 'attribute1', value: 'attribute1value'}], 'some data');
+}

--- a/types/jquery-editable-select/tsconfig.json
+++ b/types/jquery-editable-select/tsconfig.json
@@ -5,9 +5,9 @@
             "es6",
             "dom"
         ],
-        "noImplicitAny": false,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/jquery-editable-select/tsconfig.json
+++ b/types/jquery-editable-select/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": false,
+        "noImplicitThis": false,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-editable-select-tests.ts"
+    ]
+}

--- a/types/jquery-editable-select/tslint.json
+++ b/types/jquery-editable-select/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "ban-types": false
+    }
+}

--- a/types/jquery-editable-select/tslint.json
+++ b/types/jquery-editable-select/tslint.json
@@ -1,6 +1,5 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "ban-types": false
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
