### PR TITLE
Undeclared `DrawItems` and Unacceptable Value for `contentComponents` Attribute

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -7,6 +7,7 @@
 //                 petejkim <https://github.com/petejkim>
 //                 Kyle Roach <https://github.com/iRoachie>
 //                 phanalpha <https://github.com/phanalpha>
+//                 charlesfamu <https://github.com/charlesfamu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -523,13 +524,17 @@ export function StackNavigator<T>(
   stackConfig?: StackNavigatorConfig,
 ): NavigationContainer;
 
+// DrawerItems
+export const DrawerItems: React.ReactElement<any>;
+
+
 /**
  * Drawer Navigator
  */
 export interface DrawerViewConfig {
   drawerWidth: number,
   drawerPosition: 'left' | 'right',
-  contentComponent: React.ComponentClass<any>,
+  contentComponent: (props: any) => React.ReactElement<any> | React.ComponentClass<any>,
   contentOptions?: any,
   style?: ViewStyle,
 }

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -525,7 +525,7 @@ export function StackNavigator<T>(
 ): NavigationContainer;
 
 // DrawerItems
-export const DrawerItems: React.ReactElement<any>;
+export const DrawerItems: React.ComponentClass<any>;
 
 
 /**


### PR DESCRIPTION
The `DrawerItems` method isn't a declared type and the contentComponent attribute in `DrawerViewConfig` doesn't accept methods that return a react element.