### PR TITLE
[amqplib] enable strictNullChecks

### DIFF
--- a/types/amqplib/amqplib-tests.ts
+++ b/types/amqplib/amqplib-tests.ts
@@ -16,13 +16,19 @@ amqp.connect('amqp://localhost')
     .then(connection => {
         return connection.createChannel()
             .tap(channel => channel.checkQueue('myQueue'))
-            .then(channel => channel.consume('myQueue', newMsg => console.log('New Message: ' + newMsg.content.toString())))
+            .then(channel => {
+                return channel.consume('myQueue', newMsg => {
+                    if (newMsg != null) {
+                        // test promise api properties
+                        if (newMsg.properties.contentType === 'application/json') {
+                            console.log('New Message: ' + newMsg.content.toString());
+                        }
+                    }
+                });
+            })
             .finally(() => connection.close());
     });
 
-// test promise api properties
-let amqpMessage: amqp.Message;
-amqpMessage.properties.contentType = 'application/json';
 let amqpAssertExchangeOptions: amqp.Options.AssertExchange;
 let anqpAssertExchangeReplies: amqp.Replies.AssertExchange;
 
@@ -49,7 +55,14 @@ amqpcb.connect('amqp://localhost', (err, connection) => {
           if (!err) {
               channel.assertQueue('myQueue', {}, (err, ok) => {
                   if (!err) {
-                      channel.consume('myQueue', newMsg => console.log('New Message: ' + newMsg.content.toString()));
+                      channel.consume('myQueue', newMsg => {
+                          if (newMsg != null) {
+                              // test callback api properties
+                              if (newMsg.properties.contentType === 'application/json') {
+                                  console.log('New Message: ' + newMsg.content.toString());
+                              }
+                          }
+                      });
                   }
               });
           }
@@ -57,8 +70,5 @@ amqpcb.connect('amqp://localhost', (err, connection) => {
     }
 });
 
-// test callback api properties
-let amqpcbMessage: amqpcb.Message;
-amqpcbMessage.properties.contentType = 'application/json';
 let amqpcbAssertExchangeOptions: amqpcb.Options.AssertExchange;
 let anqpcbAssertExchangeReplies: amqpcb.Replies.AssertExchange;

--- a/types/amqplib/callback_api.d.ts
+++ b/types/amqplib/callback_api.d.ts
@@ -31,7 +31,7 @@ export interface Channel extends events.EventEmitter {
     publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
     sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
 
-    consume(queue: string, onMessage: (msg: Message) => any, options?: Options.Consume, callback?: (err: any, ok: Replies.Consume) => void): void;
+    consume(queue: string, onMessage: (msg: Message | null) => any, options?: Options.Consume, callback?: (err: any, ok: Replies.Consume) => void): void;
 
     cancel(consumerTag: string, callback?: (err: any, ok: Replies.Empty) => void): void;
     get(queue: string, options?: Options.Get, callback?: (err: any, ok: Message | false) => void): void;

--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -40,7 +40,7 @@ export interface Channel extends events.EventEmitter {
     publish(exchange: string, routingKey: string, content: Buffer, options?: Options.Publish): boolean;
     sendToQueue(queue: string, content: Buffer, options?: Options.Publish): boolean;
 
-    consume(queue: string, onMessage: (msg: Message) => any, options?: Options.Consume): Promise<Replies.Consume>;
+    consume(queue: string, onMessage: (msg: Message | null) => any, options?: Options.Consume): Promise<Replies.Consume>;
 
     cancel(consumerTag: string): Promise<Replies.Empty>;
     get(queue: string, options?: Options.Get): Promise<Message | false>;

--- a/types/amqplib/tsconfig.json
+++ b/types/amqplib/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.squaremobius.net/amqp.node/channel_api.html#channel_consume
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

The motivation for this pull request is the following statement in the [documentation](http://www.squaremobius.net/amqp.node/channel_api.html#channel_consume):

> If the consumer is cancelled by RabbitMQ, the message callback will be invoked with null.