### PR TITLE
Fix some Ember definitions.

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -2373,11 +2373,16 @@ declare namespace Ember {
         defaultTo(defaultPath: string): ComputedProperty;
         empty(dependentKey: string): ComputedProperty;
         equal(dependentKey: string, value: any): ComputedProperty;
+        filter(
+            dependentKey: string,
+            callback: (item: any, index?: number, array?: any[] ) => boolean
+        ): ComputedProperty;
+        filterBy(dependentKey: string, propertyKey: string, value: any): ComputedProperty;
         gt(dependentKey: string, value: number): ComputedProperty;
         gte(dependentKey: string, value: number): ComputedProperty;
         lt(dependentKey: string, value: number): ComputedProperty;
         lte(dependentKey: string, value: number): ComputedProperty;
-        map(...args: string[]): ComputedProperty;
+        map(dependentKey: string, callback: <T>(item: any, index: number) => T): ComputedProperty;
         match(dependentKey: string, regexp: RegExp): ComputedProperty;
         none(dependentKey: string): ComputedProperty;
         not(dependentKey: string): ComputedProperty;
@@ -2409,6 +2414,8 @@ declare namespace Ember {
     function generateController(container: Container, controllerName: string, context: any): Controller;
     function generateGuid(obj: any, prefix?: string): string;
     function get(obj: any, keyName: string): any;
+    function getProperties(obj: any, ...args: string[]): object;
+    function getProperties(obj: any, keys: string[]): object;
     /**
     getPath is deprecated since get now supports paths.
     **/
@@ -2464,9 +2471,11 @@ declare namespace Ember {
     function removeObserver(obj: any, path: string, target: any, method: Function): any;
     function required(): Descriptor;
     function rewatch(obj: any): void;
+
+    type RunMethod<T> = (...args: any[]) => T;
     const run: {
-        (method: Function): void;
-        (target: any, method: Function): void;
+        <T>(method: RunMethod<T> | string): T;
+        <T>(target: any, method: RunMethod<T> | string): T;
         begin(): void;
         cancel(timer: any): void;
         debounce(target: any, method: Function | string, ...args: any[]): void;


### PR DESCRIPTION
- Add definitions for [`computed.filter`](https://emberjs.com/api/ember/2.14.1/namespaces/Ember.computed/methods/filter?anchor=filter&show=inherited,protected,private,deprecated) and [`computed.filterBy`](https://emberjs.com/api/ember/2.14.1/namespaces/Ember.computed/methods/filterBy?anchor=filterBy&show=inherited,protected,private,deprecated).
- Add definitions for [`getProperties`](https://emberjs.com/api/ember/2.14/namespaces/Ember/methods/getProperties?anchor=getProperties) on Ember base object.
- Fix the [`computed.map`](https://emberjs.com/api/ember/2.14.1/namespaces/Ember.computed/methods/map?anchor=map&show=inherited,protected,private,deprecated) definition to actually include the callback
- Fix the [`run`](https://emberjs.com/api/ember/2.14/namespaces/Ember.run) method’s callback type.