### PR TITLE
zen-observable types now conform to the tc39 spec

### DIFF
--- a/types/zen-observable/index.d.ts
+++ b/types/zen-observable/index.d.ts
@@ -53,11 +53,12 @@ declare class Observable<T> {
     reduce(callback: (previousValue: T, currentValue: T) => T, initialValue?: T): Observable<T>;
     reduce<R>(callback: (previousValue: R, currentValue: T) => R, initialValue?: R): Observable<R>;
     flatMap<R>(callback: (value: T) => ZenObservable.ObservableLike<R>): Observable<R>;
+
+    static from<R>(observable: Observable<R> | ZenObservable.ObservableLike<R> | ArrayLike<R>): Observable<R>;
+    static of<R>(...items: R[]): Observable<R>;
 }
 
 declare namespace Observable {
-    function from<T>(observable: Observable<T> | ZenObservable.ObservableLike<T> | ArrayLike<T>): Observable<T>;
-    function of<T>(...items: T[]): Observable<T>;
 }
 
 export = Observable;


### PR DESCRIPTION
`of` and `from` are static methods on the Observable class.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint zen-observable`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zenparsing/zen-observable/issues/31
- [x] Increase the version number in the header if appropriate.
