### PR TITLE
adding type definition for datatables.net rowreorder extension

### DIFF
--- a/types/datatables.net-rowreorder/datatables.net-rowreorder-tests.ts
+++ b/types/datatables.net-rowreorder/datatables.net-rowreorder-tests.ts
@@ -1,0 +1,14 @@
+$(document).ready(() => {
+    const config: DataTables.Settings = {
+            // reorder extension options
+            rowReorder: {
+                dataSrc: "somesrc",
+                editor: {},
+                enable: true,
+                formOptions: {},
+                selector: "someselector",
+                snapX: true,
+                update: true,
+            },
+        };
+});

--- a/types/datatables.net-rowreorder/index.d.ts
+++ b/types/datatables.net-rowreorder/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for JQuery DataTables RowReorder extension 1.1
+// Project: http://datatables.net/extensions/rowreorder/
+// Definitions by: Vincent Biret <https://github.com/baywet>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+/// <reference types="datatables.net"/>
+
+declare namespace DataTables {
+    interface Settings {
+        /**
+         * Enable and configure the RowReorder extension for DataTables
+         */
+        rowReorder?: RowReorderSettings;
+    }
+
+    interface RowReorderSettings {
+        /**
+         * Configure the data point that will be used for the reordering data
+         */
+        dataSrc?: string;
+        /**
+         * Attach an Editor instance for database updating
+         */
+        editor?: any;
+        /**
+         * Enable / disable RowReorder's user interaction
+         */
+        enable?: boolean;
+        /**
+         * Set the options for the Editor form when submitting data
+         */
+        formOptions?: any;
+        /**
+         * Define the selector used to pick the elements that will start a drag
+         */
+        selector?: string;
+        /**
+         * Horizontal position control of the row being dragged
+         */
+        snapX?: number | boolean;
+        /**
+         * Control automatic of data when a row is dropped
+         */
+        update?: boolean;
+    }
+}

--- a/types/datatables.net-rowreorder/tsconfig.json
+++ b/types/datatables.net-rowreorder/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "datatables.net-rowreorder-tests.ts"
+    ]
+}

--- a/types/datatables.net-rowreorder/tslint.json
+++ b/types/datatables.net-rowreorder/tslint.json
@@ -1,0 +1,5 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

[extension documentation](https://datatables.net/extensions/rowreorder/)
