### PR TITLE
Fix linting errors for `babel-template`

### DIFF
--- a/types/babel-template/babel-template-tests.ts
+++ b/types/babel-template/babel-template-tests.ts
@@ -1,5 +1,3 @@
-/// <reference types="babel-generator" />
-
 // Example from https://github.com/babel/babel/tree/master/packages/babel-template
 import template = require('babel-template');
 import generate from 'babel-generator';

--- a/types/babel-template/index.d.ts
+++ b/types/babel-template/index.d.ts
@@ -1,13 +1,9 @@
-// Type definitions for babel-template v6.7
+// Type definitions for babel-template 6.25
 // Project: https://github.com/babel/babel/tree/master/packages/babel-template
 // Definitions by: Troy Gerwien <https://github.com/yortus>
 //                 Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
-
-/// <reference types="babylon" />
-/// <reference types="babel-types" />
-
 
 import { BabylonOptions } from 'babylon';
 import * as t from 'babel-types';
@@ -20,4 +16,3 @@ export = template;
 declare function template(code: string, opts?: BabylonOptions): UseTemplate;
 
 type UseTemplate = (nodes?: {[placeholder: string]: Node}) => Node;
-

--- a/types/babel-template/tslint.json
+++ b/types/babel-template/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR only fixes linting errors. No other changes a re included.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Only linting fixes, no api changes.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.