### PR TITLE
React: capitalize autoComplete property

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2392,7 +2392,7 @@ declare namespace React {
         allowTransparency?: boolean;
         alt?: string;
         async?: boolean;
-        autocomplete?: string;
+        autoComplete?: string;
         autoFocus?: boolean;
         autoPlay?: boolean;
         capture?: boolean;
@@ -2577,7 +2577,7 @@ declare namespace React {
     interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
         acceptCharset?: string;
         action?: string;
-        autocomplete?: string;
+        autoComplete?: string;
         encType?: string;
         method?: string;
         name?: string;
@@ -2623,7 +2623,7 @@ declare namespace React {
     interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
         accept?: string;
         alt?: string;
-        autocomplete?: string;
+        autoComplete?: string;
         autoFocus?: boolean;
         capture?: boolean; // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
         checked?: boolean;
@@ -2816,7 +2816,7 @@ declare namespace React {
     }
 
     interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
-        autocomplete?: string;
+        autoComplete?: string;
         autoFocus?: boolean;
         cols?: number;
         dirName?: string;


### PR DESCRIPTION
According to React documentation the correct property name is autoComplete
https://facebook.github.io/react/docs/dom-elements.html

