### PR TITLE
Fix react-grid-layout Type Definition

### DIFF
--- a/types/react-grid-layout/index.d.ts
+++ b/types/react-grid-layout/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for react-grid-layout 0.14
 // Project: https://github.com/STRML/react-grid-layout
-// Definitions by: Andrew Birkholz <https://github.com/abirkholz>, Ali Taheri <https://github.com/alitaheri>
+// Definitions by: Andrew Birkholz <https://github.com/abirkholz>,
+//                 Ali Taheri <https://github.com/alitaheri>,
+//                 Zheyang Song <https://github.com/ZheyangSong>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -78,7 +80,7 @@ declare namespace ReactGridLayout {
     }
 
     type Layouts = {
-        [P in Breakpoints]: Layout;
+        [P in Breakpoints]?: Layout[];
     };
 
     type ItemCallback = (
@@ -250,7 +252,7 @@ declare namespace ReactGridLayout {
         /**
          * layouts is an object mapping breakpoints to layouts.
          *
-         * e.g. `{lg: Layout, md: Layout, ...}`
+         * e.g. `{lg: Layout[], md: Layout[], ...}`
          */
         layouts?: Layouts;
 

--- a/types/react-grid-layout/react-grid-layout-tests.tsx
+++ b/types/react-grid-layout/react-grid-layout-tests.tsx
@@ -31,8 +31,17 @@ class DefaultGridTest extends React.Component {
 
 class ResponsiveGridTest extends React.Component {
   render() {
+    const layouts = {
+      lg: [
+        { i: '1', x: 0, y: 0, w: 1, h: 2, static: true },
+        { i: '2', x: 1, y: 0, w: 3, h: 2, minW: 2, maxW: 4 },
+        { i: '3', x: 4, y: 0, w: 1, h: 2 }
+      ]
+    };
+
     return (
       <Responsive
+        layouts={layouts}
         width={800}
         breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
         cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}


### PR DESCRIPTION
+ each property of `Layouts` should be in shape of `Layout[]`
+ Refs:
    + https://github.com/STRML/react-grid-layout/blob/master/test/examples/0-showcase.jsx#L55
    + https://github.com/STRML/react-grid-layout/blob/master/test/examples/0-showcase.jsx#L84
    + https://github.com/STRML/react-grid-layout/blob/master/lib/responsiveUtils.js#L71
    + https://github.com/STRML/react-grid-layout/blob/master/lib/utils.js#L39

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
