### PR TITLE
[dockerode] Add missing parameter type to buildImage

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -74,6 +74,10 @@ docker.buildImage('archive.tar', { t: 'imageName' }, (err, response) => {
   // NOOP
 });
 
+docker.buildImage({context: '.', src: ['Dockerfile', 'test.sh']}, { t: 'imageName' }, (err, response) => {
+	// NOOP
+});
+
 docker.createContainer({ Tty: true }, (err, container) => {
   container.start((err, data) => {
     // NOOP

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for dockerode 2.4
 // Project: https://github.com/apocas/dockerode
-// Definitions by: Carl Winkler <https://github.com/seikho>, Nicolas Laplante <https://github.com/nlaplante>
+// Definitions by: Carl Winkler <https://github.com/seikho>
+//                 Nicolas Laplante <https://github.com/nlaplante>
+//                 ByeongHun Yoo <https://github.com/isac322>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -804,6 +806,11 @@ declare namespace Dockerode {
     tail?: number;
     timestamps?: boolean;
   }
+
+  interface ImageBuildContext {
+  	context: string;
+  	src: string[];
+  }
 }
 
 type Callback<T> = (error?: any, result?: T) => void;
@@ -830,9 +837,9 @@ declare class Dockerode {
   checkAuth(options: any, callback: Callback<any>): void;
   checkAuth(options: any): Promise<any>;
 
-  buildImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<any>): void;
-  buildImage(file: string | NodeJS.ReadableStream, callback: Callback<any>): void;
-  buildImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<any>;
+  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, options: {}, callback: Callback<any>): void;
+  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, callback: Callback<any>): void;
+  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, options?: {}): Promise<any>;
 
   getContainer(id: string): Dockerode.Container;
 


### PR DESCRIPTION
Usage of needed parameter:
https://github.com/apocas/dockerode#building-an-image3

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
