### PR TITLE
Added declarations for 'draft-convert'.

### DIFF
--- a/types/draft-convert/draft-convert-tests.ts
+++ b/types/draft-convert/draft-convert-tests.ts
@@ -1,0 +1,5 @@
+import { convertToHTML, convertFromHTML } from 'draft-convert';
+
+let html: string = "<p>Hello World</p>";
+let contentState: any = convertFromHTML(html);
+let reHtml: string = convertToHTML(contentState);

--- a/types/draft-convert/index.d.ts
+++ b/types/draft-convert/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for draft-convert v1.4.8
+// Project: https://github.com/hubspot/draft-convert
+// Definitions by: guicapanema <https://github.com/guicapanema/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+export function convertFromHTML(...args: any[]): any;
+
+export function convertToHTML(...args: any[]): any;
+
+export function parseHTML(html: any): any;
+
+export namespace convertFromHTML {
+    const prototype: {
+    };
+
+}
+
+export namespace convertToHTML {
+    const prototype: {
+    };
+
+}
+
+export namespace parseHTML {
+    const prototype: {
+    };
+
+}

--- a/types/draft-convert/index.d.ts
+++ b/types/draft-convert/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for draft-convert v1.4.8
+// Type definitions for draft-convert 1.4
 // Project: https://github.com/hubspot/draft-convert
 // Definitions by: guicapanema <https://github.com/guicapanema/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -13,17 +13,14 @@ export function parseHTML(html: any): any;
 export namespace convertFromHTML {
     const prototype: {
     };
-
 }
 
 export namespace convertToHTML {
     const prototype: {
     };
-
 }
 
 export namespace parseHTML {
     const prototype: {
     };
-
 }

--- a/types/draft-convert/tsconfig.json
+++ b/types/draft-convert/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"lib": [
+			"es6",
+			"dom"
+		],
+		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": false,
+		"baseUrl": "../",
+		"typeRoots": [
+			"../"
+		],
+		"types": [],
+		"noEmit": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.d.ts",
+		"draft-convert-tests.ts"
+	]
+}

--- a/types/draft-convert/tslint.json
+++ b/types/draft-convert/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is my first shot at doing both typings and GitHub pull requests, so I'm sorry in advance if there's any problems.

Added type declarations for the 'draft-convert' package which I needed to use in a project. All types are `any` for now, but if this works out I'll try and add specific types later on.