### PR TITLE
@types/gm Add GetterOptions for working with streams and identify operations 

### DIFF
--- a/types/gm/gm-tests.ts
+++ b/types/gm/gm-tests.ts
@@ -1,70 +1,68 @@
 import gm = require('gm');
 import stream = require('stream');
 
-var src: string;
-var matrix: string;
-var enable: boolean;
-var ltr: boolean;
-var password: string;
-var bits: number;
-var intensity: number;
-var r: number;
-var g: number;
-var b: number;
-var opacity: number;
-var x: number;
-var y: number;
-var radius: number;
-var sigma: number;
-var width: number;
-var height: number;
-var color: string;
-var channel: string;
-var type: string;
-var factor: number;
-var numColors: number;
-var operator: string;
-var multiplier: number;
-var kernel: string;
-var usePercent: boolean;
-var time: number;
-var server: string;
-var method: string;
-var percent: number;
-var encoding: string;
-var options: string;
-var file: string;
-var distance: number;
-var geometry: string;
-var direction: string;
-var name: string;
-var offset: number;
-var blackPoint: number;
-var gamma: number;
-var whitePoint: number;
-var limit: string;
-var format: string;
-var iterations: number;
-var count: number;
-var b: number;
-var s: number;
-var h: number;
-var dest: string;
-var images: string[];
-var angle: number;
-var NxN: string;
-var size: number;
-var command: string;
-var index: number;
-var threshold: number;
-var attribute: string;
-var attrValue: string;
-var format: string;
-var font: string;
-var quality: number;
-var align: string;
-var depth: number;
-var readStream: stream.PassThrough;
+let src: string;
+let matrix: string;
+let enable: boolean;
+let ltr: boolean;
+let password: string;
+let bits: number;
+let intensity: number;
+let r: number;
+let g: number;
+let b: number;
+let opacity: number;
+let x: number;
+let y: number;
+let radius: number;
+let sigma: number;
+let width: number;
+let height: number;
+let color: string;
+let channel: string;
+let type: string;
+let factor: number;
+let numColors: number;
+let operator: string;
+let multiplier: number;
+let kernel: string;
+let usePercent: boolean;
+let time: number;
+let server: string;
+let method: string;
+let percent: number;
+let encoding: string;
+let options: string;
+let file: string;
+let distance: number;
+let geometry: string;
+let direction: string;
+let name: string;
+let offset: number;
+let blackPoint: number;
+let gamma: number;
+let whitePoint: number;
+let limit: string;
+let format: string;
+let iterations: number;
+let count: number;
+let s: number;
+let h: number;
+let dest: string;
+let images: string[];
+let angle: number;
+let NxN: string;
+let size: number;
+let command: string;
+let index: number;
+let threshold: number;
+let attribute: string;
+let attrValue: string;
+let font: string;
+let quality: number;
+let align: string;
+let depth: number;
+let readStream: stream.PassThrough;
 
 gm(src)
 	.adjoin()
@@ -358,17 +356,16 @@ gm(src).toBuffer((err, buffer) => {
 gm(src).toBuffer(format, (err, buffer) => {
 });
 
-var imageMagick = gm.subClass({ imageMagick: true });
-var readStream = imageMagick(src)
+let imageMagick = gm.subClass({ imageMagick: true });
+readStream = imageMagick(src)
 	.adjoin()
 	.stream();
 
-var passStream = imageMagick(readStream).stream();
+let passStream = imageMagick(readStream).stream();
 
-var buffers: Buffer[] = [];
-var buffer: Buffer;
+let buffers: Buffer[] = [];
+let buffer: Buffer;
 passStream.on('data', (chunk) => buffers.push(chunk as Buffer)).on('close', () => {
 	buffer = Buffer.concat(buffers);
-	var readstream = imageMagick(buffer).stream();
+	let readstream = imageMagick(buffer).stream();
 })
-

--- a/types/gm/gm-tests.ts
+++ b/types/gm/gm-tests.ts
@@ -19,7 +19,7 @@ let sigma: number;
 let width: number;
 let height: number;
 let color: string;
-let channel: string;
+let channel: gm.ChannelType;
 let type: string;
 let factor: number;
 let numColors: number;
@@ -32,7 +32,7 @@ let server: string;
 let method: string;
 let percent: number;
 let encoding: string;
-let options: string;
+let options: gm.ResizeOption;
 let file: string;
 let distance: number;
 let geometry: string;
@@ -368,4 +368,4 @@ let buffer: Buffer;
 passStream.on('data', (chunk) => buffers.push(chunk as Buffer)).on('close', () => {
 	buffer = Buffer.concat(buffers);
 	let readstream = imageMagick(buffer).stream();
-})
+});

--- a/types/gm/gm-tests.ts
+++ b/types/gm/gm-tests.ts
@@ -288,19 +288,35 @@ gm(src)
 	.windowGroup()
 	.color((err, color) => {
 	})
+	.color({ bufferStream: true }, (err, color) => {
+	})
 	.depth((err, bitdepth) => {
+	})
+	.depth({ bufferStream: true }, (err, bitdepth) => {
 	})
 	.filesize((err, size) => {
 	})
+	.filesize({ bufferStream: true }, (err, size) => {
+	})
 	.format((err, format) => {
+	})
+	.format({ bufferStream: true }, (err, format) => {
 	})
 	.identify((err, info) => {
 	})
+	.identify({ bufferStream: true }, (err, info) => {
+	})
 	.res((err, resolution) => {
+	})
+	.res({ bufferStream: true }, (err, resolution) => {
 	})
 	.size((err, size) => {
 	})
+	.size({ bufferStream: true }, (err, size) => {
+	})
 	.orientation((err, orient) => {
+	})
+	.orientation({ bufferStream: true }, (err, orient) => {
 	})
 	.draw(options)
 	.drawArc(x, y, x, y, radius, radius)

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for gm 1.17.0
+// Type definitions for gm 1.17
 // Project: https://github.com/aheckmann/gm
 // Definitions by: Joel Spadin <https://github.com/ChaosinaCan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -16,22 +16,6 @@ declare namespace m {
     interface ClassOptions {
         imageMagick?: boolean;
         nativeAutoOrient?: boolean;
-    }
-
-    interface CompareCallback {
-        (err: Error, isEqual: boolean, equality: number, raw: number): any;
-    }
-
-    interface GetterCallback<T> {
-        (err: Error, value: T): any;
-    }
-
-    interface GetterOptions {
-       bufferStream?: boolean;
-    }
-
-    interface WriteCallback {
-        (err: Error, stdout: string, stderr: string, cmd: string): any;
     }
 
     interface ChannelInfo<T> {
@@ -57,6 +41,10 @@ declare namespace m {
     interface Dimensions {
         width: number;
         height: number;
+    }
+
+    interface GetterOptions {
+       bufferStream?: boolean;
     }
 
     interface ImageInfo {
@@ -258,18 +246,7 @@ declare namespace m {
         fuzz(distance: number, percent?: boolean): State;
         gamma(r: number, g: number, b: number): State;
         gaussian(radius: number, sigma?: number): State;
-        /** Width and height are specified in percents */
-        geometry(width: number, height: number, option: '%'): State;
-        /** Specify maximum area in pixels */
-        geometry(width: number, height: number, option: '@'): State;
-        /** Ignore aspect ratio */
-        geometry(width: number, height: number, option: '!'): State;
-        /** Width and height are minimum values */
-        geometry(width: number, height: number, option: '^'): State;
-        /** Change dimensions only if image is smaller than width or height */
-        geometry(width: number, height: number, option: '<'): State;
-        /** Change dimensions only if image is larger than width or height */
-        geometry(width: number, height: number, option: '>'): State;
+
         geometry(width: number, height?: number, option?: string): State;
         geometry(geometry: string): State;
         greenPrimary(x: number, y: number): State;
@@ -440,17 +417,7 @@ declare namespace m {
         process(command: string): State;
         profile(filename: string): State;
         progress(): State;
-        randomThreshold(channelType: 'All', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Intensity', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Red', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Green', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Blue', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Cyan', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Magenta', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Yellow', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Black', LOWxHIGH: string): State;
-        randomThreshold(channelType: 'Opacity', LOWxHIGH: string): State;
-        randomThreshold(channelType: string, LOWxHIGH: string): State;
+        randomThreshold(channelType: ChannelType, LOWxHIGH: string): State;
         quality(level: number): State;
         raise(width: number, height: number): State;
         recolor(matrix: string): State;
@@ -465,19 +432,8 @@ declare namespace m {
         samplingFactor(horizontalFactor: number, verticalFactor: number): State;
         rawSize(width: number, height: number, offset?: number): State;
         resample(horizontal: number, vertical: number): State;
-        /** Width and height are specified in percents */
-        resize(width: number, height: number, option: '%'): State;
-        /** Specify maximum area in pixels */
-        resize(width: number, height: number, option: '@'): State;
-        /** Ignore aspect ratio */
-        resize(width: number, height: number, option: '!'): State;
-        /** Width and height are minimum values */
-        resize(width: number, height: number, option: '^'): State;
-        /** Change dimensions only if image is smaller than width or height */
-        resize(width: number, height: number, option: '<'): State;
-        /** Change dimensions only if image is larger than width or height */
-        resize(width: number, height: number, option: '>'): State;
-        resize(width: number, height?: number, option?: string): State;
+        resize(width: number, height: number, option: ResizeOption): State;
+        resize(width: number, height?: number, option?: ResizeOption): State;
         roll(horizontal: number, vertical: number): State;
         rotate(backgroundColor: string, degrees: number): State;
         scene(index: number): State;
@@ -636,6 +592,30 @@ declare namespace m {
     function compare(filename1: string, filename2: string, options: CompareOptions, callback: CompareCallback): void;
 
     function subClass(options: ClassOptions): SubClass;
+
+    type ChannelType = 'All'
+        | 'Intensity'
+        | 'Red'
+        | 'Green'
+        | 'Blue'
+        | 'Cyan'
+        | 'Magenta'
+        | 'Yellow'
+        | 'Black'
+        | 'Opacity';
+
+    type CompareCallback = (err: Error, isEqual: boolean, equality: number, raw: number) => any;
+
+    type GetterCallback<T> = (err: Error, value: T) => any;
+
+    type ResizeOption = '%' /** Width and height are specified in percents */
+        | '@' /** Specify maximum area in pixels */
+        | '!' /** Ignore aspect ratio */
+        | '^' /** Width and height are minimum values */
+        | '<' /** Change dimensions only if image is smaller than width or height */
+        | '>'; /** Change dimensions only if image is larger than width or height */
+
+    type WriteCallback = (err: Error, stdout: string, stderr: string, cmd: string) => any;
 }
 
 export = m;

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -27,6 +27,10 @@ declare namespace m {
         (err: Error, value: T): any;
     }
 
+    export interface GetterOptions {
+       bufferStream?: boolean;
+    }
+
     export interface WriteCallback {
         (err: Error, stdout: string, stderr: string, cmd: string): any;
     }
@@ -553,13 +557,21 @@ declare namespace m {
 
         // Getters
         color(callback: GetterCallback<number>): State;
+        color(opts: GetterOptions, callback: GetterCallback<number>): State;
         depth(callback: GetterCallback<number>): State;
+        depth(opts: GetterOptions, callback: GetterCallback<number>): State;
         filesize(callback: GetterCallback<string>): State;
+        filesize(opts: GetterOptions, callback: GetterCallback<string>): State;
         format(callback: GetterCallback<string>): State;
+        format(opts: GetterOptions, callback: GetterCallback<string>): State;
         identify(callback: GetterCallback<ImageInfo>): State;
+        identify(opts: GetterOptions, callback: GetterCallback<ImageInfo>): State;
         res(callback: GetterCallback<string>): State;
+        res(opts: GetterOptions, callback: GetterCallback<string>): State;
         size(callback: GetterCallback<Dimensions>): State;
+        size(opts: GetterOptions, callback: GetterCallback<Dimensions>): State;
         orientation(callback: GetterCallback<string>): State;
+        orientation(opts: GetterOptions, callback: GetterCallback<string>): State;
 
         // Drawing Operations
         draw(args: string): State;

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -246,8 +246,7 @@ declare namespace m {
         fuzz(distance: number, percent?: boolean): State;
         gamma(r: number, g: number, b: number): State;
         gaussian(radius: number, sigma?: number): State;
-
-        geometry(width: number, height?: number, option?: string): State;
+        geometry(width: number, height?: number, option?: ResizeOption): State;
         geometry(geometry: string): State;
         greenPrimary(x: number, y: number): State;
         gravity(direction: 'NorthWest'): State;

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -5,7 +5,6 @@
 
 /// <reference types="node"/>
 
-
 import stream = require('stream');
 
 declare function m(image: string): m.State;
@@ -14,53 +13,53 @@ declare function m(buffer: Buffer, image?: string): m.State;
 declare function m(width: number, height: number, color?: string): m.State;
 
 declare namespace m {
-    export interface ClassOptions {
+    interface ClassOptions {
         imageMagick?: boolean;
         nativeAutoOrient?: boolean;
     }
 
-    export interface CompareCallback {
+    interface CompareCallback {
         (err: Error, isEqual: boolean, equality: number, raw: number): any;
     }
 
-    export interface GetterCallback<T> {
+    interface GetterCallback<T> {
         (err: Error, value: T): any;
     }
 
-    export interface GetterOptions {
+    interface GetterOptions {
        bufferStream?: boolean;
     }
 
-    export interface WriteCallback {
+    interface WriteCallback {
         (err: Error, stdout: string, stderr: string, cmd: string): any;
     }
 
-    export interface ChannelInfo<T> {
+    interface ChannelInfo<T> {
         Red: T;
         Green: T;
         Blue: T;
     }
 
-    export interface CompareOptions {
+    interface CompareOptions {
         file?: string;
         highlightColor?: string;
         highlightStyle?: string;
         tolerance?: number;
     }
 
-    export interface ColorStatistics {
+    interface ColorStatistics {
         Minimum: string;
         Maximum: string;
         Mean: string;
         'Standard Deviation': string;
     }
 
-    export interface Dimensions {
+    interface Dimensions {
         width: number;
         height: number;
     }
 
-    export interface ImageInfo {
+    interface ImageInfo {
         'Background Color': string;
         'Border Color': string;
         'Channel Depths': ChannelInfo<string>;
@@ -103,7 +102,7 @@ declare namespace m {
         Type: string;
     }
 
-    export interface State {
+    interface State {
         // Image Operations
         adjoin(): State;
         affine(matrix: string): State;
@@ -625,18 +624,18 @@ declare namespace m {
         write(filename: string, callback: WriteCallback): void;
     }
 
-    export interface SubClass {
+    interface SubClass {
         (image: string): State;
         (stream: NodeJS.ReadableStream, image?: string): State;
         (buffer: Buffer, image?: string): State;
         (width: number, height: number, color?: string): State;
     }
 
-    export function compare(filename1: string, filename2: string, callback: CompareCallback): void;
-    export function compare(filename1: string, filename2: string, tolerance: number, callback: CompareCallback): void;
-    export function compare(filename1: string, filename2: string, options: CompareOptions, callback: CompareCallback): void;
+    function compare(filename1: string, filename2: string, callback: CompareCallback): void;
+    function compare(filename1: string, filename2: string, tolerance: number, callback: CompareCallback): void;
+    function compare(filename1: string, filename2: string, options: CompareOptions, callback: CompareCallback): void;
 
-    export function subClass(options: ClassOptions): SubClass;
+    function subClass(options: ClassOptions): SubClass;
 }
 
 export = m;

--- a/types/gm/tslint.json
+++ b/types/gm/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/gm/tslint.json
+++ b/types/gm/tslint.json
@@ -1,3 +1,7 @@
 {
-    "extends": "dtslint/dt.json"
+    "extends": "dtslint/dt.json",
+    "rules": {
+        // This package unifiable overloaded functions, lot of effort to fix
+        "unified-signatures": false
+    }
 }


### PR DESCRIPTION
First commit on DefinitelyTyped so I hope I've done things correctly.

Added GetterOptions interface because identify operations need to buffer readStream in memory if you need to write()/stream() afterwards and the current definitions did not cover that.
See: https://github.com/aheckmann/gm/blob/c6a6c5a/README.md#streams


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
  - I see some linting errors, fixed a couple but still some remain.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Documentation: https://github.com/aheckmann/gm/blob/c6a6c5a/README.md#streams
  - Source: https://github.com/aheckmann/gm/blob/c6a6c5a/lib/getters.js#L39
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.