### PR TITLE
[flake-idgen] Fix error TS2497

### DIFF
--- a/types/flake-idgen/index.d.ts
+++ b/types/flake-idgen/index.d.ts
@@ -14,6 +14,8 @@ interface ConstructorOptions {
     seqMask?: number;
 }
 
+declare namespace FlakeId {}
+
 declare class FlakeId {
     constructor(options?: ConstructorOptions);
     next(callback?: (err: Error, id: Buffer) => void): Buffer;


### PR DESCRIPTION
Fix error `TS2497: Module '".../node_modules/@types/flake-idgen/index"' resolves to a non-module entity and cannot be imported using this construct.`
on `import * as FlakeId from 'flake-idgen';`