### PR TITLE
jsonwebtoken.sign function type definition fixed. fixes #18469

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -83,6 +83,8 @@ export interface SignCallback {
     (err: Error, encoded: string): void;
 }
 
+export type Secret = string | Buffer | {key: string, passphrase: string}
+
 /**
  * Synchronously sign the given payload into a JSON Web Token string
  * @param {String|Object|Buffer} payload - Payload to sign, could be an literal, buffer or string
@@ -90,7 +92,7 @@ export interface SignCallback {
  * @param {SignOptions} [options] - Options for the signature
  * @returns {String} The JSON Web Token string
  */
-export declare function sign(payload: string | Buffer | object, secretOrPrivateKey: string | Buffer, options?: SignOptions): string;
+export declare function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, options?: SignOptions): string;
 
 /**
  * Sign the given payload into a JSON Web Token string
@@ -99,8 +101,8 @@ export declare function sign(payload: string | Buffer | object, secretOrPrivateK
  * @param {SignOptions} [options] - Options for the signature
  * @param {Function} callback - Callback to get the encoded token on
  */
-export declare function sign(payload: string | Buffer | object, secretOrPrivateKey: string | Buffer, callback: SignCallback): void;
-export declare function sign(payload: string | Buffer | object, secretOrPrivateKey: string | Buffer, options: SignOptions, callback: SignCallback): void;
+export declare function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, callback: SignCallback): void;
+export declare function sign(payload: string | Buffer | object, secretOrPrivateKey: Secret, options: SignOptions, callback: SignCallback): void;
 
 /**
  * Synchronously verify given token using a secret or a public key to get a decoded token

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -36,6 +36,10 @@ token = jwt.sign(testObject, 'shhhhh', { keyid: "theKeyId"});
 cert = fs.readFileSync('private.key');  // get private key
 token = jwt.sign(testObject, cert, { algorithm: 'RS256'});
 
+// sign with encrypted RSA SHA256 private key (only PEM encoding is supported)
+const privKey: Buffer = fs.readFileSync('encrypted_private.key');  // get private key
+const secret = {key: privKey.toString(), passphrase: 'keypwd'}
+token = jwt.sign(testObject, secret, { algorithm: 'RS256' }); // the algorithm option is mandatory in this case
 
 // sign asynchronously
 jwt.sign(testObject, cert, { algorithm: 'RS256' }, function(err: Error, token: string) {


### PR DESCRIPTION
The type definition for the sign function was incorrect, because it only defined the secret (second)
parameter as `string | Buffer` however it can also be an object of `{key: string, passphrase: string}`
if used with an encrypted RSA private key. 

URL to the documentation: https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback
