### PR TITLE
Adding missing race method to angular.IQService

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1040,7 +1040,7 @@ declare namespace angular {
          *
          * @param promises A list or hash of promises.
          */
-        race<T>(promises: IPromise<T>[] | {[key: string]: IPromise<T>}): IPromise<T>;
+        race<T>(promises: Array<IPromise<T>> | {[key: string]: IPromise<T>}): IPromise<T>;
         /**
          * Creates a promise that is resolved as rejected with the specified reason. This api should be used to forward rejection in a chain of promises. If you are dealing with the last promise in a promise chain, you don't need to worry about it.
          *

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1036,6 +1036,12 @@ declare namespace angular {
          */
         defer<T>(): IDeferred<T>;
         /**
+         * Returns a promise that resolves or rejects as soon as one of those promises resolves or rejects, with the value or reason from that promise.
+         *
+         * @param promises A list or hash of promises.
+         */
+        race(promises: IPromise<T>[] | {[key: string]: IPromise<T>}): IPromise<T>;
+        /**
          * Creates a promise that is resolved as rejected with the specified reason. This api should be used to forward rejection in a chain of promises. If you are dealing with the last promise in a promise chain, you don't need to worry about it.
          *
          * When comparing deferreds/promises to the familiar behavior of try/catch/throw, think of reject as the throw keyword in JavaScript. This also means that if you "catch" an error via a promise error callback and you want to forward the error to the promise derived from the current promise, you have to "rethrow" the error by returning a rejection constructed via reject.

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1040,7 +1040,7 @@ declare namespace angular {
          *
          * @param promises A list or hash of promises.
          */
-        race(promises: IPromise<T>[] | {[key: string]: IPromise<T>}): IPromise<T>;
+        race<T>(promises: IPromise<T>[] | {[key: string]: IPromise<T>}): IPromise<T>;
         /**
          * Creates a promise that is resolved as rejected with the specified reason. This api should be used to forward rejection in a chain of promises. If you are dealing with the last promise in a promise chain, you don't need to worry about it.
          *


### PR DESCRIPTION
https://docs.angularjs.org/api/ng/service/$q lists race(promises); as a valid method in AngularJS $q. Adding this type so it can be used accordingly.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/ng/service/$q
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

