### PR TITLE
Add missing definitions for source-map

### DIFF
--- a/types/source-map/index.d.ts
+++ b/types/source-map/index.d.ts
@@ -1,136 +1,332 @@
-// Type definitions for source-map v0.5.6
+// Type definitions for source-map 0.5
 // Project: https://github.com/mozilla/source-map
-// Definitions by: Morten Houston Ludvigsen <https://github.com/MortenHoustonLudvigsen>
+// Definitions by: Morten Houston Ludvigsen <https://github.com/MortenHoustonLudvigsen>,
+//                 Ron Buckton <https://github.com/rbuckton>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = SourceMap;
 export as namespace sourceMap;
 
-declare namespace SourceMap {
-    interface StartOfSourceMap {
-        file?: string;
-        sourceRoot?: string;
-        skipValidation?: boolean;
-    }
+export interface StartOfSourceMap {
+    file?: string;
+    sourceRoot?: string;
+    skipValidation?: boolean;
+}
 
-    interface RawSourceMap {
-        version: number;
-        sources: string[];
-        names: string[];
-        sourceRoot?: string;
-        sourcesContent?: string[];
-        mappings: string;
-        file: string;
-    }
+export interface RawSourceMap {
+    version: number;
+    sources: string[];
+    names: string[];
+    sourceRoot?: string;
+    sourcesContent?: string[];
+    mappings: string;
+    file: string;
+}
 
-    interface Position {
-        line: number;
-        column: number;
-    }
+export interface RawIndexMap extends StartOfSourceMap {
+    version: number;
+    sections: RawSection[];
+}
 
-    interface MappedPosition extends Position {
-        source: string;
-        name?: string;
-    }
+export interface RawSection {
+    offset: Position;
+    map: RawSourceMap;
+}
 
-    interface MappingItem {
-        source: string;
-        generatedLine: number;
-        generatedColumn: number;
-        originalLine: number;
-        originalColumn: number;
-        name: string;
-    }
+export interface Position {
+    line: number;
+    column: number;
+}
 
-    interface Mapping {
-        generated: Position;
-        original: Position;
-        source: string;
-        name?: string;
-    }
+export interface NullablePosition {
+    line: number | null;
+    column: number | null;
+    lastColumn: number | null;
+}
 
-    interface CodeWithSourceMap {
-        code: string;
-        map: SourceMapGenerator;
-    }
+export interface MappedPosition {
+    source: string;
+    line: number;
+    column: number;
+    name?: string;
+}
 
-    class SourceMapConsumer {
-        public static GENERATED_ORDER: number;
-        public static ORIGINAL_ORDER: number;
+export interface NullableMappedPosition {
+    source: string | null;
+    line: number | null;
+    column: number | null;
+    name: string | null;
+}
 
-        constructor(rawSourceMap: RawSourceMap | string);
+export interface MappingItem {
+    source: string;
+    generatedLine: number;
+    generatedColumn: number;
+    originalLine: number;
+    originalColumn: number;
+    name: string;
+}
 
-        public computeColumnSpans(): void;
+export interface Mapping {
+    generated: Position;
+    original: Position;
+    source: string;
+    name?: string;
+}
 
-        public originalPositionFor(generatedPosition: Position): MappedPosition;
+export interface CodeWithSourceMap {
+    code: string;
+    map: SourceMapGenerator;
+}
 
-        public generatedPositionFor(originalPosition: MappedPosition): Position;
+export interface SourceMapConsumer {
+    /**
+     * Compute the last column for each generated mapping. The last column is
+     * inclusive.
+     */
+    computeColumnSpans(): void;
 
-        public allGeneratedPositionsFor(originalPosition: MappedPosition): Position[];
+    /**
+     * Returns the original source, line, and column information for the generated
+     * source's line and column positions provided. The only argument is an object
+     * with the following properties:
+     *
+     *   - line: The line number in the generated source.
+     *   - column: The column number in the generated source.
+     *   - bias: Either 'SourceMapConsumer.GREATEST_LOWER_BOUND' or
+     *     'SourceMapConsumer.LEAST_UPPER_BOUND'. Specifies whether to return the
+     *     closest element that is smaller than or greater than the one we are
+     *     searching for, respectively, if the exact element cannot be found.
+     *     Defaults to 'SourceMapConsumer.GREATEST_LOWER_BOUND'.
+     *
+     * and an object is returned with the following properties:
+     *
+     *   - source: The original source file, or null.
+     *   - line: The line number in the original source, or null.
+     *   - column: The column number in the original source, or null.
+     *   - name: The original identifier, or null.
+     */
+    originalPositionFor(generatedPosition: Position & { bias?: number }): NullableMappedPosition;
 
-        public hasContentsOfAllSources(): boolean;
+    /**
+     * Returns the generated line and column information for the original source,
+     * line, and column positions provided. The only argument is an object with
+     * the following properties:
+     *
+     *   - source: The filename of the original source.
+     *   - line: The line number in the original source.
+     *   - column: The column number in the original source.
+     *   - bias: Either 'SourceMapConsumer.GREATEST_LOWER_BOUND' or
+     *     'SourceMapConsumer.LEAST_UPPER_BOUND'. Specifies whether to return the
+     *     closest element that is smaller than or greater than the one we are
+     *     searching for, respectively, if the exact element cannot be found.
+     *     Defaults to 'SourceMapConsumer.GREATEST_LOWER_BOUND'.
+     *
+     * and an object is returned with the following properties:
+     *
+     *   - line: The line number in the generated source, or null.
+     *   - column: The column number in the generated source, or null.
+     */
+    generatedPositionFor(originalPosition: MappedPosition & { bias?: number }): NullablePosition;
 
-        public sourceContentFor(source: string, returnNullOnMissing?: boolean): string;
+    /**
+     * Returns all generated line and column information for the original source,
+     * line, and column provided. If no column is provided, returns all mappings
+     * corresponding to a either the line we are searching for or the next
+     * closest line that has any mappings. Otherwise, returns all mappings
+     * corresponding to the given line and either the column we are searching for
+     * or the next closest column that has any offsets.
+     *
+     * The only argument is an object with the following properties:
+     *
+     *   - source: The filename of the original source.
+     *   - line: The line number in the original source.
+     *   - column: Optional. the column number in the original source.
+     *
+     * and an array of objects is returned, each with the following properties:
+     *
+     *   - line: The line number in the generated source, or null.
+     *   - column: The column number in the generated source, or null.
+     */
+    allGeneratedPositionsFor(originalPosition: MappedPosition): NullablePosition[];
 
-        public eachMapping(callback: (mapping: MappingItem) => void, context?: any, order?: number): void;
-    }
+    /**
+     * Return true if we have the source content for every source in the source
+     * map, false otherwise.
+     */
+    hasContentsOfAllSources(): boolean;
 
-    class SourceMapGenerator {
-        constructor(startOfSourceMap?: StartOfSourceMap);
+    /**
+     * Returns the original source content. The only argument is the url of the
+     * original source file. Returns null if no original source content is
+     * available.
+     */
+    sourceContentFor(source: string, returnNullOnMissing?: boolean): string | null;
 
-        public static fromSourceMap(sourceMapConsumer: SourceMapConsumer): SourceMapGenerator;
+    /**
+     * Iterate over each mapping between an original source/line/column and a
+     * generated line/column in this source map.
+     *
+     * @param callback
+     *        The function that is called with each mapping.
+     * @param context
+     *        Optional. If specified, this object will be the value of `this` every
+     *        time that `aCallback` is called.
+     * @param order
+     *        Either `SourceMapConsumer.GENERATED_ORDER` or
+     *        `SourceMapConsumer.ORIGINAL_ORDER`. Specifies whether you want to
+     *        iterate over the mappings sorted by the generated file's line/column
+     *        order or the original's source/line/column order, respectively. Defaults to
+     *        `SourceMapConsumer.GENERATED_ORDER`.
+     */
+    eachMapping(callback: (mapping: MappingItem) => void, context?: any, order?: number): void;
+}
 
-        public addMapping(mapping: Mapping): void;
+export interface SourceMapConsumerConstructor {
+    prototype: SourceMapConsumer;
 
-        public setSourceContent(sourceFile: string, sourceContent: string): void;
+    GENERATED_ORDER: number;
+    ORIGINAL_ORDER: number;
+    GREATEST_LOWER_BOUND: number;
+    LEAST_UPPER_BOUND: number;
 
-        public applySourceMap(sourceMapConsumer: SourceMapConsumer, sourceFile?: string, sourceMapPath?: string): void;
+    new (rawSourceMap: RawSourceMap): BasicSourceMapConsumer;
+    new (rawSourceMap: RawIndexMap): IndexedSourceMapConsumer;
+    new (rawSourceMap: RawSourceMap | RawIndexMap | string): BasicSourceMapConsumer | IndexedSourceMapConsumer;
 
-        public toString(): string;
+    /**
+     * Create a BasicSourceMapConsumer from a SourceMapGenerator.
+     *
+     * @param sourceMap
+     *        The source map that will be consumed.
+     */
+    fromSourceMap(sourceMap: SourceMapGenerator): BasicSourceMapConsumer;
+}
 
-        public toJSON(): RawSourceMap;
-    }
+export const SourceMapConsumer: SourceMapConsumerConstructor;
 
-    class SourceNode {
-        children: SourceNode [];
-        sourceContents: any;
-        line: number;
-        column: number;
-        source: string;
-        name: string;
+export interface BasicSourceMapConsumer extends SourceMapConsumer {
+    file: string;
+    sourceRoot: string;
+    sources: string[];
+    sourcesContent: string[];
+}
 
-        constructor();
-        constructor(line: number, column: number, source: string);
-        constructor(
-            line: number,
-            column: number,
-            source: string,
-            chunks?: (string | SourceNode)[] | SourceNode | string,
-            name?: string
-        );
+export interface BasicSourceMapConsumerConstructor {
+    prototype: BasicSourceMapConsumer;
 
-        public static fromStringWithSourceMap(
-            code: string,
-            sourceMapConsumer: SourceMapConsumer,
-            relativePath?: string
-        ): SourceNode;
+    new (rawSourceMap: RawSourceMap | string): BasicSourceMapConsumer;
 
-        public add(chunk: (string | SourceNode)[] | SourceNode | string): SourceNode;
+    /**
+     * Create a BasicSourceMapConsumer from a SourceMapGenerator.
+     *
+     * @param sourceMap
+     *        The source map that will be consumed.
+     */
+    fromSourceMap(sourceMap: SourceMapGenerator): BasicSourceMapConsumer;
+}
 
-        public prepend(chunk: (string | SourceNode)[] | SourceNode | string): SourceNode;
+export const BasicSourceMapConsumer: BasicSourceMapConsumerConstructor;
 
-        public setSourceContent(sourceFile: string, sourceContent: string): void;
+export interface IndexedSourceMapConsumer extends SourceMapConsumer {
+    sources: string[];
+}
 
-        public walk(fn: (chunk: string, mapping: MappedPosition) => void): void;
+export interface IndexedSourceMapConsumerConstructor {
+    prototype: IndexedSourceMapConsumer;
 
-        public walkSourceContents(fn: (file: string, content: string) => void): void;
+    new (rawSourceMap: RawIndexMap | string): IndexedSourceMapConsumer;
+}
 
-        public join(sep: string): SourceNode;
+export const IndexedSourceMapConsumer: IndexedSourceMapConsumerConstructor;
 
-        public replaceRight(pattern: string, replacement: string): SourceNode;
+export class SourceMapGenerator {
+    constructor(startOfSourceMap?: StartOfSourceMap);
 
-        public toString(): string;
+    /**
+     * Creates a new SourceMapGenerator based on a SourceMapConsumer
+     *
+     * @param sourceMapConsumer The SourceMap.
+     */
+    static fromSourceMap(sourceMapConsumer: SourceMapConsumer): SourceMapGenerator;
 
-        public toStringWithSourceMap(startOfSourceMap?: StartOfSourceMap): CodeWithSourceMap;
-    }
+    /**
+     * Add a single mapping from original source line and column to the generated
+     * source's line and column for this source map being created. The mapping
+     * object should have the following properties:
+     *
+     *   - generated: An object with the generated line and column positions.
+     *   - original: An object with the original line and column positions.
+     *   - source: The original source file (relative to the sourceRoot).
+     *   - name: An optional original token name for this mapping.
+     */
+    addMapping(mapping: Mapping): void;
+
+    /**
+     * Set the source content for a source file.
+     */
+    setSourceContent(sourceFile: string, sourceContent: string): void;
+
+    /**
+     * Applies the mappings of a sub-source-map for a specific source file to the
+     * source map being generated. Each mapping to the supplied source file is
+     * rewritten using the supplied source map. Note: The resolution for the
+     * resulting mappings is the minimium of this map and the supplied map.
+     *
+     * @param sourceMapConsumer The source map to be applied.
+     * @param sourceFile Optional. The filename of the source file.
+     *        If omitted, SourceMapConsumer's file property will be used.
+     * @param sourceMapPath Optional. The dirname of the path to the source map
+     *        to be applied. If relative, it is relative to the SourceMapConsumer.
+     *        This parameter is needed when the two source maps aren't in the same
+     *        directory, and the source map to be applied contains relative source
+     *        paths. If so, those relative source paths need to be rewritten
+     *        relative to the SourceMapGenerator.
+     */
+    applySourceMap(sourceMapConsumer: SourceMapConsumer, sourceFile?: string, sourceMapPath?: string): void;
+
+    toString(): string;
+
+    toJSON(): RawSourceMap;
+}
+
+export class SourceNode {
+    children: SourceNode[];
+    sourceContents: any;
+    line: number;
+    column: number;
+    source: string;
+    name: string;
+
+    constructor();
+    constructor(
+        line: number,
+        column: number,
+        source: string,
+        chunks?: Array<(string | SourceNode)> | SourceNode | string,
+        name?: string
+    );
+
+    static fromStringWithSourceMap(
+        code: string,
+        sourceMapConsumer: SourceMapConsumer,
+        relativePath?: string
+    ): SourceNode;
+
+    add(chunk: Array<(string | SourceNode)> | SourceNode | string): SourceNode;
+
+    prepend(chunk: Array<(string | SourceNode)> | SourceNode | string): SourceNode;
+
+    setSourceContent(sourceFile: string, sourceContent: string): void;
+
+    walk(fn: (chunk: string, mapping: MappedPosition) => void): void;
+
+    walkSourceContents(fn: (file: string, content: string) => void): void;
+
+    join(sep: string): SourceNode;
+
+    replaceRight(pattern: string, replacement: string): SourceNode;
+
+    toString(): string;
+
+    toStringWithSourceMap(startOfSourceMap?: StartOfSourceMap): CodeWithSourceMap;
 }

--- a/types/source-map/source-map-tests.ts
+++ b/types/source-map/source-map-tests.ts
@@ -2,7 +2,7 @@ import SourceMap = require('source-map');
 
 function testSourceMapConsumer() {
     function testConstructor() {
-        var scm: SourceMap.SourceMapConsumer;
+        let scm: SourceMap.SourceMapConsumer;
 
         // create with full RawSourceMap
         scm = new SourceMap.SourceMapConsumer({
@@ -31,33 +31,52 @@ function testSourceMapConsumer() {
             mappings: 'foo',
             file: 'sdf'
         });
+
+        // create from index map
+        let iscm: SourceMap.IndexedSourceMapConsumer = new SourceMap.SourceMapConsumer({
+            version: 3,
+            sections: [
+                { offset: { line: 0, column: 0 }, map: {
+                    version: 3,
+                    sources: ['foo', 'bar'],
+                    names: ['foo', 'bar'],
+                    mappings: 'foo',
+                    file: 'foo'
+                } }
+            ]
+        });
+
+        let scg: SourceMap.SourceMapGenerator;
+        let bscm: SourceMap.BasicSourceMapConsumer = SourceMap.SourceMapConsumer.fromSourceMap(scg);
     }
 
     function testOriginalPositionFor(scm: SourceMap.SourceMapConsumer) {
-        var origPos: SourceMap.MappedPosition;
+        let origPos: SourceMap.MappedPosition;
         origPos = scm.originalPositionFor({ line: 42, column: 42 });
+        origPos = scm.originalPositionFor({ line: 42, column: 42, bias: SourceMap.SourceMapConsumer.LEAST_UPPER_BOUND });
     }
 
     function testAllGeneratedPositionsFor(scm: SourceMap.SourceMapConsumer) {
-        var origPos: SourceMap.MappedPosition;
-        var origPoses: SourceMap.Position[];
+        let origPos: SourceMap.MappedPosition;
+        let origPoses: SourceMap.Position[];
         origPoses = scm.allGeneratedPositionsFor(origPos);
     }
 
     function testGeneratedPositionFor(scm: SourceMap.SourceMapConsumer) {
-        var genPos: SourceMap.Position;
+        let genPos: SourceMap.Position;
         genPos = scm.generatedPositionFor({ line: 42, column: 42, source: 'foo' });
         genPos = scm.generatedPositionFor({ line: 42, column: 42, source: 'foo', name: 'bar' });
+        genPos = scm.generatedPositionFor({ line: 42, column: 42, source: 'foo', name: 'bar', bias: SourceMap.SourceMapConsumer.LEAST_UPPER_BOUND });
     }
 
     function testSourceContentFor(scm: SourceMap.SourceMapConsumer) {
-        var content: string;
+        let content: string;
         content = scm.sourceContentFor('foo');
     }
 
     function testEachMapping(scm: SourceMap.SourceMapConsumer) {
-        var x: SourceMap.MappingItem;
-        var context: {};
+        let x: SourceMap.MappingItem;
+        let context: {};
 
         scm.eachMapping(mapping => { x = mapping; });
         scm.eachMapping(mapping => { x = mapping; }, context);
@@ -68,7 +87,7 @@ function testSourceMapConsumer() {
 
 function testSourceMapGenerator() {
     function testConstructor() {
-        var generator: SourceMap.SourceMapGenerator;
+        let generator: SourceMap.SourceMapGenerator;
 
         generator = new SourceMap.SourceMapGenerator();
         generator = new SourceMap.SourceMapGenerator({
@@ -113,14 +132,14 @@ function testSourceMapGenerator() {
     }
 
     function testToString(generator: SourceMap.SourceMapGenerator) {
-        var str: string;
+        let str: string;
         str = generator.toString();
     }
 }
 
 function testSourceNode() {
     function testConstructor() {
-        var node: SourceMap.SourceNode;
+        let node: SourceMap.SourceNode;
 
         node = new SourceMap.SourceNode();
         node = new SourceMap.SourceNode(42, 42, 'foo');
@@ -130,7 +149,7 @@ function testSourceNode() {
     }
 
     function testFromStringWithSourceMap(scm: SourceMap.SourceMapConsumer) {
-        var node: SourceMap.SourceNode;
+        let node: SourceMap.SourceNode;
 
         node = SourceMap.SourceNode.fromStringWithSourceMap('foo', scm);
         node = SourceMap.SourceNode.fromStringWithSourceMap('foo', scm, 'bar');
@@ -153,15 +172,15 @@ function testSourceNode() {
     }
 
     function testWalk(node: SourceMap.SourceNode) {
-        var chunk: string;
-        var mapping: SourceMap.MappedPosition;
+        let chunk: string;
+        let mapping: SourceMap.MappedPosition;
 
         node.walk((c, m) => { chunk = c; mapping = m; });
     }
 
     function testWalkSourceContents(node: SourceMap.SourceNode) {
-        var file: string;
-        var content: string;
+        let file: string;
+        let content: string;
 
         node.walkSourceContents((f, c) => { file = f; content = c; });
     }
@@ -175,12 +194,12 @@ function testSourceNode() {
     }
 
     function testToString(node: SourceMap.SourceNode) {
-        var str: string;
+        let str: string;
         str = node.toString();
     }
 
     function testToStringWithSourceMap(node: SourceMap.SourceNode, sos: SourceMap.StartOfSourceMap) {
-        var result: SourceMap.CodeWithSourceMap;
+        let result: SourceMap.CodeWithSourceMap;
         result = node.toStringWithSourceMap();
         result = node.toStringWithSourceMap(sos);
     }

--- a/types/source-map/tslint.json
+++ b/types/source-map/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds some missing members and the correct return types to support `--strictNullChecks`. This also adds the `BasicSourceMapConsumer` and `IndexSourceMapConsumer` exports. While they both have prototypes that extend from `SourceMapConsumer` they do not have constructors that extend from `SourceMapConsumer`. As a result, I refactored `SourceMapConsumer` into a class-like variable declaration to illustrate the actual underlying semantics of the types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/source-map
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.