### PR TITLE
Binding functions may return undefined for babel-traverse

### DIFF
--- a/types/babel-traverse/index.d.ts
+++ b/types/babel-traverse/index.d.ts
@@ -98,9 +98,9 @@ export class Scope {
 
     bindingIdentifierEquals(name: string, node: Node): boolean;
 
-    getBinding(name: string): Binding;
+    getBinding(name: string): Binding | undefined;
 
-    getOwnBinding(name: string): Binding;
+    getOwnBinding(name: string): Binding | undefined;
 
     getBindingIdentifier(name: string): t.Identifier;
 


### PR DESCRIPTION
This PR fixes an incorrect typing for `scope.getBindings()` and `scope.getOwnBindings()` which both return `undefined` when no binding is found.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
```js
const { transform } = require("babel-core");

function plugin() {
  return {
    visitor: {
      FunctionDeclaration(path) {
        console.log(
          path.scope.getBinding("baz"),
          path.scope.getOwnBinding("baz"),
        );
      },
    },
  };
}

transform(`function foo() {}`, { plugins: [plugin] });
// Logs: undefined, undefined
```
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.