### PR TITLE
SystemJS: Remove typeCheck from typescriptOptions

### DIFF
--- a/types/systemjs/index.d.ts
+++ b/types/systemjs/index.d.ts
@@ -237,13 +237,7 @@ declare namespace SystemJSLoader {
              * Note: This setting is specific to plugin-typescript.
              */
             tsconfig?: boolean | string,
-            /**
-             * A flag which controls whether the files are type-checked or simply transpiled.
-             * Set this option to "strict" to have the builds fail when compiler errors are encountered.
-             * Note: The strict option only affects builds and bundles via the SystemJS or JSPM Builder.
-             * Note: This setting is specific to plugin-typescript.
-             */
-            typeCheck?: boolean | "strict",
+
             [key: string]: any
         };
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/frankwallis/plugin-typescript/commit/032500978ef08b6cd98e0d1ea3947b417be6160b
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

As discussed in frankwallis/plugin-typescript/issues/194, the `typeCheck` option is no longer supported as of plugin-typescript@7.0.0.

This is a non-breaking change as the `typescriptOptions` property still contains any arbitrary index signature. The intent here is simply to not suggest the option as it has been removed.