### PR TITLE
[react-redux] Add connectAdvanced from v5

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for react-redux 4.4.47
-// Project: https://github.com/rackt/react-redux
-// Definitions by: Qubo <https://github.com/tkqubo>, Sean Kelley <https://github.com/seansfkelley>, Thomas Hasner <https://github.com/thasner>
+// Type definitions for react-redux 5.0.5
+// Project: https://github.com/reactjs/react-redux
+// Definitions by: Qubo <https://github.com/tkqubo>, Sean Kelley <https://github.com/seansfkelley>, Thomas Hasner <https://github.com/thasner>, Kenzie Togami <https://github.com/kenzierocks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -17,6 +17,10 @@ type ActionCreator<A> = Redux.ActionCreator<A>;
 
 export interface DispatchProp<S> {
   dispatch: Dispatch<S>;
+}
+
+interface AdvancedComponentDecorator<TProps, TOwnProps> {
+    (component: Component<TProps>): ComponentClass<TOwnProps>;
 }
 
 interface ComponentDecorator<TMergedProps, TOwnProps> {
@@ -149,7 +153,7 @@ interface MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> {
     (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TMergedProps;
 }
 
-interface Options {
+interface Options extends ConnectOptions {
     /**
      * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
      * preventing unnecessary updates, assuming that the component is a “pure” component
@@ -163,6 +167,82 @@ interface Options {
      * getWrappedInstance() method. Defaults to false.
      */
     withRef?: boolean;
+}
+
+/**
+ * Connects a React component to a Redux store. It is the base for {@link connect} but is less opinionated about
+ * how to combine <code>state</code>, <code>props</code>, and <code>dispatch</code> into your final props. It makes no
+ * assumptions about defaults or memoization of results, leaving those responsibilities to the caller.It does not
+ * modify the component class passed to it; instead, it returns a new, connected component class for you to use.
+ *
+ * @param selectorFactory The selector factory. See {@type SelectorFactory} for details.
+ * @param connectOptions If specified, further customizes the behavior of the connector. Additionally, any extra
+ *     options will be passed through to your <code>selectorFactory</code> in the <code>factoryOptions</code> argument.
+ */
+export declare function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = {}>(
+    selectorFactory: SelectorFactory<S, TProps, TOwnProps, TFactoryOptions>,
+    connectOptions?: ConnectOptions & TFactoryOptions
+): AdvancedComponentDecorator<TProps, TOwnProps>;
+
+/**
+ * Initializes a selector function (during each instance's constructor). That selector function is called any time the
+ * connector component needs to compute new props, as a result of a store state change or receiving new props. The
+ * result of <code>selector</code> is expected to be a plain object, which is passed as the props to the wrapped
+ * component. If a consecutive call to <code>selector</code> returns the same object (<code>===</code>) as its previous
+ * call, the component will not be re-rendered. It's the responsibility of <code>selector</code> to return that
+ * previous object when appropriate.
+ */
+export interface SelectorFactory<S, TProps, TOwnProps, TFactoryOptions> {
+    (dispatch: Dispatch<S>, factoryOptions: TFactoryOptions): Selector<S, TProps, TOwnProps>
+}
+
+export interface Selector<S, TProps, TOwnProps> {
+    (state: S, ownProps: TOwnProps): TProps
+}
+
+export interface ConnectOptions {
+    /**
+     * Computes the connector component's displayName property relative to that of the wrapped component. Usually
+     * overridden by wrapper functions.
+     *
+     * @default name => 'ConnectAdvanced('+name+')'
+     * @param componentName
+     */
+    getDisplayName?: (componentName: string) => string
+    /**
+     * Shown in error messages. Usually overridden by wrapper functions.
+     *
+     * @default 'connectAdvanced'
+     */
+    methodName?: string
+    /**
+     * If defined, a property named this value will be added to the props passed to the wrapped component. Its value
+     * will be the number of times the component has been rendered, which can be useful for tracking down unnecessary
+     * re-renders.
+     *
+     * @default undefined
+     */
+    renderCountProp?: string
+    /**
+     * Controls whether the connector component subscribes to redux store state changes. If set to false, it will only
+     * re-render on <code>componentWillReceiveProps</code>.
+     *
+     * @default true
+     */
+    shouldHandleStateChanges?: boolean
+    /**
+     * The key of props/context to get the store. You probably only need this if you are in the inadvisable position of
+     * having multiple stores.
+     *
+     * @default 'store'
+     */
+    storeKey?: string
+    /**
+     * If true, stores a ref to the wrapped component instance and makes it available via getWrappedInstance() method.
+     *
+     * @default false
+     */
+    withRef?: boolean
 }
 
 export interface ProviderProps {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-redux/blob/master/docs/api.md#user-content-connectAdvanced
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR adds the `connectAdvanced` function from `react-redux` v5. I didn't add any other functions, but I can if completeness is desired. I did add a `tslint.json`, but I got the following error running the linter:

```
[REDACTED]/DefinitelyTyped/node_modules/dtslint/bin/rules/definitelytyped-header-parser.js:83
        const [, version, a, b, c, v, nameReverse] = match;
              ^

SyntaxError: Unexpected token [
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> ([REDACTED]/DefinitelyTyped/node_modules/dtslint/bin/index.js:15:41)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
```
