### PR TITLE
Revert "express-session: req.session is not optional"

### DIFF
--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -12,7 +12,7 @@ import node = require('events');
 declare global {
   namespace Express {
     interface Request {
-      session: Session;
+      session?: Session;
       sessionID?: string;
     }
 


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#18039

`req.session` will be `undefined` when a connection to Redis cannot be made: https://github.com/tj/connect-redis#how-do-i-handle-lost-connections-to-redis

/cc @jacobbogers