### PR TITLE
[recompose] Fixes many serious issues with recompose types

### DIFF
--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {
-    Component,
     // Higher-order components
     mapProps, withProps, withPropsOnChange, withHandlers,
     defaultProps, renameProp, renameProps, flattenProp,
@@ -27,67 +26,107 @@ import baconConfig from "recompose/baconObservableConfig";
 import kefirConfig from "recompose/kefirObservableConfig";
 
 function testMapProps() {
-    interface InnerProps { inn: number }
+    interface InnerProps {
+        inn: number
+        other: string
+     }
     interface OutterProps { out: string }
-    const innerComponent = ({inn}: InnerProps) => <div>{inn}</div>;
+    const InnerComponent = ({inn}: InnerProps) => <div>{inn}</div>;
 
-    const enhancer = mapProps((props: OutterProps) => ({ inn: 123 } as InnerProps));
-    const enhanced: React.ComponentClass<OutterProps> = enhancer(innerComponent);
+    const enhancer = mapProps((props: OutterProps) => ({ inn: 123 }));
+    const Enhanced = enhancer(InnerComponent);
+    const rendered = (
+        <Enhanced
+            other='foo'
+            out='bar'
+        />
+    )
 }
 
 function testWithProps() {
     interface InnerProps { inn: number }
-    interface OutterProps { out: string }
-    const innerComponent = ({inn}: InnerProps) => <div>{inn}</div>;
+    interface OutterProps { out: number }
+    const InnerComponent = ({inn}: InnerProps) => <div>{inn}</div>;
 
-    const enhancer = withProps((props: OutterProps) => ({ inn: 123 } as InnerProps));
-    const enhanced: React.ComponentClass<OutterProps> = enhancer(innerComponent);
+    const enhancer = withProps((props: OutterProps) => ({ inn: props.out }));
+    const Enhanced = enhancer(InnerComponent);
+    const rendered = (
+        <Enhanced out={123}/>
+    )
 
-    const enhancer2 = withProps<InnerProps, OutterProps>({ inn: 123 } as InnerProps);
-    const enhanced2: React.ComponentClass<OutterProps> = enhancer2(innerComponent);
+    const enhancer2 = withProps({ inn: 123 });
+    const Enhanced2 = enhancer2(InnerComponent);
+    const Rendered2 = (
+        <Enhanced2/>
+    )
 }
 
 function testWithPropsOnChange() {
     interface InnerProps { inn: number }
-    interface OutterProps { out: string }
-    const innerComponent = ({inn}: InnerProps) => <div>{inn}</div>;
+    interface OutterProps { out: number }
+    const InnerComponent = ({inn}: InnerProps) => <div>{inn}</div>;
 
-    const enhancer = withPropsOnChange(
-      (props: OutterProps, nextProps: OutterProps) => true,
-      (props: OutterProps) => ({ inn: 123 } as InnerProps));
-    const enhanced: React.ComponentClass<OutterProps> = enhancer(innerComponent);
+    const enhancer = withProps((props: OutterProps) => ({ inn: props.out }));
+    const Enhanced = enhancer(InnerComponent);
+    const rendered = (
+        <Enhanced out={123}/>
+    )
 
-    const enhancer2 = withPropsOnChange(
-      [ "out" ],
-      (props: OutterProps) => ({ inn: 123 } as InnerProps));
-    const enhanced2: React.ComponentClass<OutterProps> = enhancer2(innerComponent);
+    const enhancer2 = withProps({ inn: 123 });
+    const Enhanced2 = enhancer2(InnerComponent);
+    const Rendered2 = (
+        <Enhanced2/>
+    )
 }
 
 function testWithHandlers() {
-    interface InnerProps { onSubmit: React.MouseEventHandler<HTMLDivElement>; onChange: Function; }
-    interface OutterProps { out: string }
-    const innerComponent = ({onChange, onSubmit}: InnerProps) =>
+    interface InnerProps {
+        onSubmit: React.MouseEventHandler<HTMLDivElement>;
+        onChange: Function;
+        foo: string;
+    }
+    interface HandlerProps {
+        onSubmit: React.MouseEventHandler<HTMLDivElement>;
+        onChange: Function;
+    }
+    interface OutterProps { out: number; }
+    const InnerComponent: React.StatelessComponent<InnerProps> = ({onChange, onSubmit}) =>
       <div onClick={onSubmit}></div>;
 
-    const enhancer = withHandlers<InnerProps, OutterProps>({
-      onChange: (props: OutterProps) => (e: any) => {},
-      onSubmit: (props: OutterProps) => (e: any) => {},
+    const enhancer = withHandlers<OutterProps, HandlerProps>({
+      onChange: (props) => (e: any) => {},
+      onSubmit: (props) => (e: React.MouseEvent<any>) => {},
     });
-    const enhanced: React.ComponentClass<OutterProps> = enhancer(innerComponent);
+    const Enhanced = enhancer(InnerComponent);
+    const rendered = (
+        <Enhanced
+            foo="bar"
+            out={42}
+        />
+    )
 
-    const enhancer2 = withHandlers<InnerProps, OutterProps>((props: OutterProps) => ({
-      onChange: (props: OutterProps) => (e: any) => {},
-      onSubmit: (props: OutterProps) => (e: any) => {},
+    const enhancer2 = withHandlers<OutterProps, HandlerProps>((props) => ({
+      onChange: (props) => (e: any) => {},
+      onSubmit: (props) => (e: React.MouseEvent<any>) => {},
     }));
-    const enhanced2: React.ComponentClass<OutterProps> = enhancer2(innerComponent);
+    const Enhanced2 = enhancer2(InnerComponent);
+    const rendered2 = (
+        <Enhanced2
+            foo="bar"
+            out={42}
+        />
+    )
 }
 
 function testDefaultProps() {
-    interface Props { a?: string; b?: number; }
+    interface Props { a: string; b: number; c: number; }
     const innerComponent = ({a, b}: Props) => <div>{a}, {b}</div>;
 
     const enhancer = defaultProps({ a: "answer", b: 42 });
-    const enhanced: React.StatelessComponent<Props> = enhancer<Props, ({a, b}: Props) => JSX.Element>(innerComponent);
+    const Enhanced = enhancer(innerComponent);
+    const rendered = (
+        <Enhanced c={42} />
+    )
 }
 
 function testRenameProp() {
@@ -118,35 +157,59 @@ function testFlattenProp() {
 }
 
 function testWithState() {
-    interface InnerProps { count: number; setCount: (count: number) => void }
+    interface InnerProps { count: number; setCount: (count: number) => number }
     interface OutterProps { title: string }
-    const innerComponent: React.StatelessComponent<OutterProps & InnerProps> = (props) =>
+    const InnerComponent: React.StatelessComponent<InnerProps> = (props) =>
       <div onClick={() => props.setCount(0)}></div>;
 
-    const enhancer = withState<OutterProps>("count", "setCount", 0);
-    const enhanced: React.ComponentClass<OutterProps> = enhancer(innerComponent);
+    // We can't infer types for TOutter with this form because
+    // Typescript only allows all or nothing
+    // when defining generics. You can't infer some and define other.
+    // For TOutter to be defined as not "{}" we would have to define
+    // all the generics.
+    const enhancer = withState("count", "setCount", 0);
+    const Enhanced = enhancer(InnerComponent);
+    const rendered = (
+        <Enhanced />
+    );
 
-    const enhancer2 = withState<OutterProps>("count", "setCount",
+    // Here we're able to infer TOutter since it's defined in the initial state
+    // function and Typescript is able to infer it from there.
+    const enhancer2 = withState("count", "setCount",
       (p: OutterProps) => p.title.length);
-    const enhanced2: React.ComponentClass<OutterProps> = enhancer2(innerComponent);
+    const Enhanced2 = enhancer2(InnerComponent);
+    const rendered2 = (
+        <Enhanced2 title="foo" />
+    );
 }
 
 function testWithReducer() {
     interface State { count: number }
     interface Action { type: string }
     interface InnerProps { title: string; count: number; dispatch: (a: Action) => void; }
-    interface OutterProps { title: string; }
-    const innerComponent: React.StatelessComponent<InnerProps> = (props: InnerProps) =>
+    interface OutterProps { title: string; bar: number; }
+    const InnerComponent: React.StatelessComponent<InnerProps> = (props) =>
       <div onClick={() => props.dispatch({type: "INCREMENT"})}></div>;
 
+    // Same issue here inferring TOutter as with the "withState" form.
     const enhancer = withReducer("count", "dispatch",
       (s: number, a: Action) => s + 1, 0);
-    const enhanced: React.ComponentClass<OutterProps> = enhancer(innerComponent);
+    const Enhanced = enhancer(InnerComponent);
+    const rendered = (
+        <Enhanced title="foo"/>
+    );
 
+    // Here we successfully infer TOutter from the initial state function
     const enhancer2 = withReducer("count", "dispatch",
       (s: number, a: Action) => s + 1,
       (props: OutterProps) => props.title.length);
-    const enhanced2: React.ComponentClass<OutterProps> = enhancer2(innerComponent);
+    const Enhanced2 = enhancer2(InnerComponent);
+    const rendered2 = (
+        <Enhanced2
+            title="foo"
+            bar={42}
+        />
+    );
 }
 
 function testBranch() {


### PR DESCRIPTION
The current iteration of recompose types have two issues:

1) Only a handful of HOCs infer required props from their children.
2) Even when an HOC does infer props from its children, it does not remove
requirements for props it injects.

This leads to the parent component rendering a wrapped commponent to not
realize that props an HOC is injecting have already been handled and
leads to a lot of typing issues.

This PR updates a lot of the types to infer injected types and remove /
partial them from the required props list that are passed to their
parent.

Due to a couple of typing issues in the TS language itself there are
some missing pieces, namely `compose` cannot currently be typed. This PR,
however, makes huge strides in correcting and inferring types in recompose.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.