### PR TITLE
[redux-form] added additional tests to test and demonstrate type infe…

### DIFF
--- a/types/redux-form/lib/reduxForm.d.ts
+++ b/types/redux-form/lib/reduxForm.d.ts
@@ -55,6 +55,12 @@ export interface InjectedArrayProps {
     unshift(field: string, value: any): void;
 }
 
+export interface RegisteredField {
+    count: number;
+    name: string;
+    type: "Field" | "FieldArray";
+}
+
 export interface InjectedFormProps<FormData = {}, P = {}> {
     anyTouched: boolean;
     array: InjectedArrayProps;
@@ -82,6 +88,7 @@ export interface InjectedFormProps<FormData = {}, P = {}> {
     untouch(...field: string[]): void;
     valid: boolean;
     warning: any;
+    registeredFields: { [name: string]: RegisteredField }
 }
 
 export interface ConfigProps<FormData = {}, P = {}> {
@@ -123,7 +130,7 @@ export interface FormInstance<FormData, P> extends Component<P> {
 }
 
 export interface DecoratedComponentClass<FormData, P> {
-    new (props?: P, context?: any): FormInstance<FormData, P>;
+    new(props?: P, context?: any): FormInstance<FormData, P>;
 }
 
 export type FormDecorator<FormData, P, Config> =

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -31,6 +31,13 @@ interface TestFormData {
     foo: string;
 }
 
+/* Some tests only make sense with multiple values */
+interface MultivalueFormData {
+    foo: string
+    bar?: string
+    fizz: string
+}
+
 interface TestFormComponentProps {
     foo: string;
 }
@@ -144,6 +151,38 @@ const TestForms: StatelessComponent = () => {
         </div>
     )
 }
+
+// Specifying form data type is not required here, but is recommended to avoid confusion
+const testFormWithValidationDecorator = reduxForm<MultivalueFormData>({
+    form: "testWithValidation",
+    validate: (values, props) => {
+        return {
+            foo: "Bad foo"
+        }
+    }
+})
+
+// Specifying form data type is not required here, but is recommended to avoid confusion
+const testFormWithInitialValuesDecorator = reduxForm<MultivalueFormData>({
+    form: "testWithValidation",
+    initialValues: {
+        foo: "A Foo is here"
+    }
+})
+
+// Specifying form data type *is* required here, because type inference will guess the type of 
+// the form data type parameter to be {foo: string}. The result of validate does not contain "foo"
+const testFormWithInitialValuesAndValidationDecorator = reduxForm<MultivalueFormData>({
+    form: "testWithValidation",
+    initialValues: {
+        foo: "A Foo is here"
+    },
+    validate: (values, props) => {
+        return {
+            bar: "Bad foo"
+        }
+    }
+})
 
 type TestProps = {} & InjectedFormProps<TestFormData>;
 const Test = reduxForm({


### PR DESCRIPTION
…rence when both initialValues and validate are present and added registeredFields property to InjectedFormProps

Tests are mainly to document how to specify the type, for anyone else who is confused by this. It also adds some test coverage to this particular case.

registeredFields is a missing filed which is injected into decorated forms.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18434
- [] Increase the version number in the header if appropriate.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

@LKay 

