### PR TITLE
[soap] Update SOAP definitions

### DIFF
--- a/types/soap/index.d.ts
+++ b/types/soap/index.d.ts
@@ -108,7 +108,7 @@ export class Client extends EventEmitter {
     setEndpoint(endpoint: string): void;
     setSOAPAction(action: string): void;
     setSecurity(security: ISecurity): void;
-    [key: string]: any; // [method: string]: ISOAPMethod | Function;
+    [method: string]: ISOAPMethod | Function;
 }
 
 declare function createClient(wsdlPath: string, options: IOptions, fn: (err: any, client: Client) => void): void;
@@ -125,7 +125,6 @@ export class Server extends EventEmitter {
     log(type: string, data: any): any;
     authorizeConnection(req: any): boolean;
     authenticate(security: ISecurity): boolean;
-    [key: string]: any;
 }
 
 export function listen(server: any, path: string, service: any, wsdl: string): Server;

--- a/types/soap/index.d.ts
+++ b/types/soap/index.d.ts
@@ -9,7 +9,7 @@
 
 import { EventEmitter } from 'events';
 
-export interface ISOAPMethod {
+export interface ISoapMethod {
     (args: any, callback: (err: any, result: any, raw: any, soapHeader: any) => void, options?: any, extraHeaders?: any): void;
 }
 
@@ -30,16 +30,16 @@ export interface IServices {
     [serviceName: string]: IService;
 }
 
-export interface IXMLAttribute {
+export interface IXmlAttribute {
     name: string;
     value: string;
 }
 
-export interface IWSDLBaseOptions {
+export interface IWsdlBaseOptions {
     attributesKey?: string;
     valueKey?: string;
     xmlKey?: string;
-    overrideRootElement?: { namespace: string; xmlnsAttributes?: IXMLAttribute[]; };
+    overrideRootElement?: { namespace: string; xmlnsAttributes?: IXmlAttribute[]; };
     ignoredNamespaces?: boolean | string[] | { namespaces?: string[]; override?: boolean; };
     ignoreBaseNameSpaces?: boolean;
     escapeXML?: boolean;
@@ -47,7 +47,7 @@ export interface IWSDLBaseOptions {
     wsdl_options?: { [key: string]: any };
 }
 
-export interface IOptions extends IWSDLBaseOptions {
+export interface IOptions extends IWsdlBaseOptions {
     disableCache?: boolean;
     endpoint?: string;
     envelopeKey?: string;
@@ -60,7 +60,7 @@ export interface IOptions extends IWSDLBaseOptions {
     [key: string]: any;
 }
 
-export interface IServerOptions extends IWSDLBaseOptions {
+export interface IServerOptions extends IWsdlBaseOptions {
     path: string;
     services: IServices;
     xml?: string;
@@ -108,7 +108,7 @@ export class Client extends EventEmitter {
     setEndpoint(endpoint: string): void;
     setSOAPAction(action: string): void;
     setSecurity(security: ISecurity): void;
-    [method: string]: ISOAPMethod | Function;
+    [method: string]: ISoapMethod | Function;
 }
 
 declare function createClient(wsdlPath: string, options: IOptions, fn: (err: any, client: Client) => void): void;
@@ -183,5 +183,5 @@ export function passwordDigest(nonce: string, created: string, password: string)
 // @onury - Some interfaces are renamed for semantics. We add these for
 // backwards compatibility.
 export interface Security extends ISecurity {}
-export interface SoapMethod extends ISOAPMethod {}
+export interface SoapMethod extends ISoapMethod {}
 export interface Option extends IOptions {}

--- a/types/soap/index.d.ts
+++ b/types/soap/index.d.ts
@@ -13,6 +13,32 @@ export interface ISoapMethod {
     (args: any, callback: (err: any, result: any, raw: any, soapHeader: any) => void, options?: any, extraHeaders?: any): void;
 }
 
+// SOAP Fault 1.1 & 1.2
+// https://github.com/vpulim/node-soap#soap-fault
+export type ISoapFault = ISoapFault12 | ISoapFault11;
+
+// SOAP Fault 1.1
+export interface ISoapFault11 {
+    Fault: {
+        faultcode: number | string;
+        faultstring: string;
+        detail?: string;
+        statusCode?: number;
+    };
+}
+
+// SOAP Fault 1.2
+// 1.2 also supports additional, optional elements:
+// Role, Node, Detail but soap module does not seem to implement them
+// https://www.w3.org/TR/soap12/#soapfault
+export interface ISoapFault12 {
+    Fault: {
+        Code: { Value: string; Subcode?: { Value: string; }; };
+        Reason: { Text: string; }
+        statusCode?: number;
+    };
+}
+
 export interface ISecurity {
     addOptions(options: any): void;
     toXML(): string;

--- a/types/soap/index.d.ts
+++ b/types/soap/index.d.ts
@@ -140,14 +140,14 @@ export class HttpClient {
 }
 
 export class BasicAuthSecurity implements ISecurity {
-    constructor(username: string, password: string, defaults: any);
+    constructor(username: string, password: string, defaults?: any);
     addHeaders(headers: any): void;
     addOptions(options: any): void;
     toXML(): string;
 }
 
 export class BearerSecurity implements ISecurity {
-    constructor(token: string, defaults: any);
+    constructor(token: string, defaults?: any);
     addHeaders(headers: any): void;
     addOptions(options: any): void;
     toXML(): string;
@@ -173,8 +173,8 @@ export class ClientSSLSecurity implements ISecurity {
 }
 
 export class ClientSSLSecurityPFX implements ISecurity {
-    constructor(pfx: string | Buffer, passphrase: string, defaults: any);
-    constructor(pfx: string | Buffer, defaults: any);
+    constructor(pfx: string | Buffer, passphrase: string, defaults?: any);
+    constructor(pfx: string | Buffer, defaults?: any);
     addOptions(options: any): void;
     toXML(): string;
 }

--- a/types/soap/index.d.ts
+++ b/types/soap/index.d.ts
@@ -1,87 +1,188 @@
-// Type definitions for soap 0.18
+// Type definitions for soap 0.19
 // Project: https://www.npmjs.com/package/soap
-// Definitions by: Leo Liang <https://github.com/aleung>, Cage Fox <https://github.com/cagefox>
+// Definitions by:  Leo Liang <https://github.com/aleung>
+//                  Cage Fox <https://github.com/cagefox>
+//                  Onur Yildirim <https://github.com/onury>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-import * as events from 'events';
+import { EventEmitter } from 'events';
 
-interface Security {
+export interface ISOAPMethod {
+    (args: any, callback: (err: any, result: any, raw: any, soapHeader: any) => void, options?: any, extraHeaders?: any): void;
 }
 
-export interface SoapMethod {
-    (args: any, callback: (err: any, result: any) => void, options?: any, extraHeaders?: any): void;
+export interface ISecurity {
+    addOptions(options: any): void;
+    toXML(): string;
 }
 
-export class BasicAuthSecurity implements Security {
-    constructor(username: string, password: string);
+export interface IServicePort {
+    [methodName: string]: (args:any, callback?: (data: any) => void, headers?: any, req?: any) => any;
 }
 
-export class BearerSecurity implements Security {
-    constructor(token: string);
+export interface IService {
+    [portName: string]: IServicePort;
 }
 
-export class WSSecurity implements Security {
-    constructor(username: string, password: string, options?: any);
+export interface IServices {
+    [serviceName: string]: IService;
 }
 
-export class ClientSSLSecurity implements Security {
-    constructor(key: Buffer | string, cert: Buffer | string, ca: Buffer | string, defaults?: any);
-    constructor(key: Buffer | string, cert: Buffer | string, defaults?: any);
+export interface IXMLAttribute {
+    name: string;
+    value: string;
 }
 
-export interface Client extends events.EventEmitter {
+export interface IWSDLBaseOptions {
+    attributesKey?: string;
+    valueKey?: string;
+    xmlKey?: string;
+    overrideRootElement?: { namespace: string; xmlnsAttributes?: IXMLAttribute[]; };
+    ignoredNamespaces?: boolean | string[] | { namespaces?: string[]; override?: boolean; };
+    ignoreBaseNameSpaces?: boolean;
+    escapeXML?: boolean;
+    wsdl_headers?: { [key: string]: any };
+    wsdl_options?: { [key: string]: any };
+}
+
+export interface IOptions extends IWSDLBaseOptions {
+    disableCache?: boolean;
+    endpoint?: string;
+    envelopeKey?: string;
+    httpClient?: HttpClient;
+    request?: (options: any, callback?: (error: any, res: any, body: any) => void) => void;
+    stream?: boolean;
+    // wsdl options that only work for client
+    forceSoap12Headers?: boolean;
+    customDeserializer?: any;
+    [key: string]: any;
+}
+
+export interface IServerOptions extends IWSDLBaseOptions {
+    path: string;
+    services: IServices;
+    xml?: string;
+    uri?: string;
+    suppressStack?: boolean;
+    [key: string]: any;
+}
+
+export class WSDL {
+    constructor(definition: any, uri: string, options?: IOptions);
+    ignoredNamespaces: string[];
+    ignoreBaseNameSpaces: boolean;
+    valueKey: string;
+    xmlKey: string;
+    xmlnsInEnvelope: string;
+    onReady(callback: (err:Error) => void): void;
+    processIncludes(callback: (err:Error) => void): void;
+    describeServices(): { [k: string]: any };
+    toXML(): string;
+    xmlToObject(xml: any, callback?: (err:Error, result:any) => void): any;
+    findSchemaObject(nsURI: string, qname: string): any;
+    objectToDocumentXML(name: string, params: any, nsPrefix?: string, nsURI?: string, type?: string): any;
+    objectToRpcXML(name: string, params: any, nsPrefix?: string, nsURI?: string, isParts?: any): string;
+    isIgnoredNameSpace(ns: string): boolean;
+    filterOutIgnoredNameSpace(ns: string): string;
+    objectToXML(obj: any, name: string, nsPrefix?: any, nsURI?: string, isFirst?: boolean, xmlnsAttr?: any, schemaObject?: any, nsContext?: any): string;
+    processAttributes(child: any, nsContext: any): string;
+    findSchemaType(name: any, nsURI: any): any;
+    findChildSchemaObject(parameterTypeObj: any, childName: any, backtrace?: any): any;
+}
+
+export class Client extends EventEmitter {
+    constructor(wsdl: WSDL, endpoint?: string, options?: IOptions);
     addBodyAttribute(bodyAttribute: any, name?: string, namespace?: string, xmlns?: string): void;
     addHttpHeader(name: string, value: any): void;
-    addSoapHeader(soapHeader: any, name?: string, namespace?: string, xmlns?: string): number;
+    addSoapHeader(soapHeader: any, name?: string, namespace?: any, xmlns?: string): number;
     changeSoapHeader(index: number, soapHeader: any, name?: string, namespace?: string, xmlns?: string): void;
     clearBodyAttributes(): void;
     clearHttpHeaders(): void;
     clearSoapHeaders(): void;
     describe(): any;
     getBodyAttributes(): any[];
-    getHttpHeaders(): any[];
-    getSoapHeaders(): any[];
+    getHttpHeaders(): { [k:string]: string };
+    getSoapHeaders(): string[];
     setEndpoint(endpoint: string): void;
     setSOAPAction(action: string): void;
-    setSecurity(s: Security): void;
-    [method: string]: SoapMethod | Function;
+    setSecurity(security: ISecurity): void;
+    [key: string]: any; // [method: string]: ISOAPMethod | Function;
 }
 
-export interface Server extends events.EventEmitter {
-    addSoapHeader(soapHeader: any, name: any, namespace: any, xmlns: any): any;
-    changeSoapHeader(index: any, soapHeader: any, name: any, namespace: any, xmlns: any): any;
-    getSoapHeaders(): any;
-    clearSoapHeaders(): any;
-    log(type: any, data: any): any;
+declare function createClient(wsdlPath: string, options: IOptions, fn: (err: any, client: Client) => void): void;
+
+export class Server extends EventEmitter {
+    constructor(server: any, path: string, services: IServices, wsdl: WSDL, options: IServerOptions);
+    path: string;
+    services: IServices;
+    wsdl: WSDL;
+    addSoapHeader(soapHeader: any, name?: string, namespace?: any, xmlns?: string): number;
+    changeSoapHeader(index: any, soapHeader: any, name?: any, namespace?: any, xmlns?: any): void;
+    getSoapHeaders(): string[];
+    clearSoapHeaders(): void;
+    log(type: string, data: any): any;
+    authorizeConnection(req: any): boolean;
+    authenticate(security: ISecurity): boolean;
+    [key: string]: any;
 }
+
 export function listen(server: any, path: string, service: any, wsdl: string): Server;
-declare function createClient(wsdlPath: string, options: Option, fn: (err: any, client: Client) => void): void;
-
-export interface Option {
-    attributesKey?: string;
-    disableCache?: boolean;
-    endpoint?: string;
-    envelopeKey?: string;
-    escapeXML?: boolean;
-    forceSoap12Headers?: boolean;
-    httpClient?: HttpClient;
-    ignoreBaseNameSpaces?: boolean,
-    ignoredNamespaces?: string[] | { namespaces: string[], override: boolean };
-    overrideRootElement?: { namespace: string, xmlnsAttributes?: string[] };
-    request?: (options: any, callback?: (error: any, res: any, body: any) => void) => void;
-    stream?: boolean;
-    valueKey?: string;
-    wsdl_headers?: { [key: string]: any };
-    wsdl_options?: { [key: string]: any };
-    xmlKey?: string;
-}
+export function listen(server: any, options: IServerOptions): Server;
 
 export class HttpClient {
-    constructor(options?: Option);
+    constructor(options?: IOptions);
     buildRequest(rurl: string, data: any | string, exheaders?: { [key: string]: any }, exoptions?: { [key: string]: any }): any;
     handleResponse(req: any, res: any, body: any | string): any | string;
     request(rurl: string, data: any | string, callback: (err: any, res: any, body: any | string) => void, exheaders?: { [key: string]: any }, exoptions?: { [key: string]: any }): any;
     requestStream(rurl: string, data: any | string, exheaders?: { [key: string]: any }, exoptions?: { [key: string]: any }): any;
 }
+
+export class BasicAuthSecurity implements ISecurity {
+    constructor(username: string, password: string, defaults: any);
+    addHeaders(headers: any): void;
+    addOptions(options: any): void;
+    toXML(): string;
+}
+
+export class BearerSecurity implements ISecurity {
+    constructor(token: string, defaults: any);
+    addHeaders(headers: any): void;
+    addOptions(options: any): void;
+    toXML(): string;
+}
+
+export class WSSecurity implements ISecurity {
+    constructor(username: string, password: string, options?: any);
+    addOptions(options: any): void;
+    toXML(): string;
+}
+
+export class WSSecurityCert implements ISecurity {
+    constructor(privatePEM: any, publicP12PEM: any, password: any);
+    addOptions(options: any): void;
+    toXML(): string;
+}
+
+export class ClientSSLSecurity implements ISecurity {
+    constructor(key: string | Buffer, cert: string | Buffer, ca?: string | any[] | Buffer, defaults?: any);
+    constructor(key: string | Buffer, cert: string | Buffer, defaults?: any);
+    addOptions(options: any): void;
+    toXML(): string;
+}
+
+export class ClientSSLSecurityPFX implements ISecurity {
+    constructor(pfx: string | Buffer, passphrase: string, defaults: any);
+    constructor(pfx: string | Buffer, defaults: any);
+    addOptions(options: any): void;
+    toXML(): string;
+}
+
+export function passwordDigest(nonce: string, created: string, password: string): string;
+
+// @onury - Some interfaces are renamed for semantics. We add these for
+// backwards compatibility.
+export interface Security extends ISecurity {}
+export interface SoapMethod extends ISOAPMethod {}
+export interface Option extends IOptions {}

--- a/types/soap/soap-tests.ts
+++ b/types/soap/soap-tests.ts
@@ -89,6 +89,19 @@ let myService = {
                 return {
                     name: headers.Token
                 };
+            },
+
+            FaultFunction: (args: any) => {
+                let fault:soap.ISoapFault = {
+                    Fault: {
+                        Code: {
+                            Value: 'soap:Sender',
+                            Subcode: { Value: 'rpc:BadArguments' }
+                        },
+                        Reason: { Text: 'Processing Error' }
+                    }
+                };
+                throw fault;
             }
         }
     }

--- a/types/soap/soap-tests.ts
+++ b/types/soap/soap-tests.ts
@@ -48,10 +48,10 @@ soap.createClient(url, wsdlOptions, (err: any, client: soap.Client) => {
     client.getHttpHeaders();
     client.getSoapHeaders();
     client.setSOAPAction('action');
-    (client['create'] as soap.ISOAPMethod)({ name: 'value' }, (err: any, result: any) => {
+    (client['create'] as soap.ISoapMethod)({ name: 'value' }, (err: any, result: any) => {
         // result is an object
     });
-    (client['create'] as soap.ISOAPMethod)({ name: 'value' }, (err: any, result: any) => {
+    (client['create'] as soap.ISoapMethod)({ name: 'value' }, (err: any, result: any) => {
         // result is an object
     }, {});
     client.on('request', (obj: any) => {

--- a/types/soap/soap-tests.ts
+++ b/types/soap/soap-tests.ts
@@ -1,18 +1,18 @@
-import * as SOAP from 'soap';
+import * as soap from 'soap';
 import * as events from 'events';
 import * as fs from 'fs';
 import * as http from 'http';
 
 const url = 'http://example.com/wsdl?wsdl';
 // wsdlOptions set only default values
-const wsdlOptions = <SOAP.IOptions>{
+const wsdlOptions = <soap.IOptions>{
     attributesKey: 'attributes',
     disableCache: false,
     endpoint: url,
     envelopeKey: 'soap',
     escapeXML: true,
     forceSoap12Headers: false,
-    httpClient: new SOAP.HttpClient(),
+    httpClient: new soap.HttpClient(),
     ignoreBaseNameSpaces: false,
     ignoredNamespaces: ['tns', 'targetNamespace', 'typedNamespace'],
     request: require('request'),
@@ -23,18 +23,18 @@ const wsdlOptions = <SOAP.IOptions>{
     xmlKey: '$xml'
 };
 
-SOAP.createClient(url, wsdlOptions, (err: any, client: SOAP.Client) => {
+soap.createClient(url, wsdlOptions, (err: any, client: soap.Client) => {
     let securityOptions = { hasTimeStamp: false };
-    client.setSecurity(new SOAP.WSSecurity('user', 'password', securityOptions));
-    client.setSecurity(new SOAP.BasicAuthSecurity('user', 'password'));
-    client.setSecurity(new SOAP.BearerSecurity('token'));
-    client.setSecurity(new SOAP.WSSecurity('user', 'password', securityOptions));
-    client.setSecurity(new SOAP.WSSecurityCert('*****', 'cert', ''));
+    client.setSecurity(new soap.WSSecurity('user', 'password', securityOptions));
+    client.setSecurity(new soap.BasicAuthSecurity('user', 'password'));
+    client.setSecurity(new soap.BearerSecurity('token'));
+    client.setSecurity(new soap.WSSecurity('user', 'password', securityOptions));
+    client.setSecurity(new soap.WSSecurityCert('*****', 'cert', ''));
     let defaults = { rejectUnauthorized: false };
-    client.setSecurity(new SOAP.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca', defaults));
-    client.setSecurity(new SOAP.ClientSSLSecurity('/path/to/key', '/path/to/cert', defaults));
-    client.setSecurity(new SOAP.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca'));
-    client.setSecurity(new SOAP.ClientSSLSecurityPFX('pfx', 'password', defaults));
+    client.setSecurity(new soap.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca', defaults));
+    client.setSecurity(new soap.ClientSSLSecurity('/path/to/key', '/path/to/cert', defaults));
+    client.setSecurity(new soap.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca'));
+    client.setSecurity(new soap.ClientSSLSecurityPFX('pfx', 'password', defaults));
     client.setEndpoint('http://localhost');
     client.describe();
     client.addBodyAttribute({});
@@ -48,10 +48,10 @@ SOAP.createClient(url, wsdlOptions, (err: any, client: SOAP.Client) => {
     client.getHttpHeaders();
     client.getSoapHeaders();
     client.setSOAPAction('action');
-    (client['create'] as SOAP.ISOAPMethod)({ name: 'value' }, (err: any, result: any) => {
+    (client['create'] as soap.ISOAPMethod)({ name: 'value' }, (err: any, result: any) => {
         // result is an object
     });
-    (client['create'] as SOAP.ISOAPMethod)({ name: 'value' }, (err: any, result: any) => {
+    (client['create'] as soap.ISOAPMethod)({ name: 'value' }, (err: any, result: any) => {
         // result is an object
     }, {});
     client.on('request', (obj: any) => {
@@ -100,4 +100,4 @@ let xml = fs.readFileSync('myservice.wsdl', 'utf8'),
     });
 
 server.listen(8000);
-SOAP.listen(server, '/wsdl', myService, xml);
+soap.listen(server, '/wsdl', myService, xml);

--- a/types/soap/soap-tests.ts
+++ b/types/soap/soap-tests.ts
@@ -1,18 +1,18 @@
-import * as soap from 'soap';
+import * as SOAP from 'soap';
 import * as events from 'events';
 import * as fs from 'fs';
 import * as http from 'http';
 
 const url = 'http://example.com/wsdl?wsdl';
 // wsdlOptions set only default values
-const wsdlOptions = <soap.Option>{
+const wsdlOptions = <SOAP.IOptions>{
     attributesKey: 'attributes',
     disableCache: false,
     endpoint: url,
     envelopeKey: 'soap',
     escapeXML: true,
     forceSoap12Headers: false,
-    httpClient: new soap.HttpClient(),
+    httpClient: new SOAP.HttpClient(),
     ignoreBaseNameSpaces: false,
     ignoredNamespaces: ['tns', 'targetNamespace', 'typedNamespace'],
     request: require('request'),
@@ -23,16 +23,18 @@ const wsdlOptions = <soap.Option>{
     xmlKey: '$xml'
 };
 
-soap.createClient(url, wsdlOptions, (err: any, client: soap.Client) => {
+SOAP.createClient(url, wsdlOptions, (err: any, client: SOAP.Client) => {
     let securityOptions = { hasTimeStamp: false };
-    client.setSecurity(new soap.WSSecurity('user', 'password', securityOptions));
-    client.setSecurity(new soap.BasicAuthSecurity('user', 'password'));
-    client.setSecurity(new soap.BearerSecurity('token'));
-    client.setSecurity(new soap.WSSecurity('user', 'password', securityOptions));
+    client.setSecurity(new SOAP.WSSecurity('user', 'password', securityOptions));
+    client.setSecurity(new SOAP.BasicAuthSecurity('user', 'password'));
+    client.setSecurity(new SOAP.BearerSecurity('token'));
+    client.setSecurity(new SOAP.WSSecurity('user', 'password', securityOptions));
+    client.setSecurity(new SOAP.WSSecurityCert('*****', 'cert', ''));
     let defaults = { rejectUnauthorized: false };
-    client.setSecurity(new soap.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca', defaults));
-    client.setSecurity(new soap.ClientSSLSecurity('/path/to/key', '/path/to/cert', defaults));
-    client.setSecurity(new soap.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca'));
+    client.setSecurity(new SOAP.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca', defaults));
+    client.setSecurity(new SOAP.ClientSSLSecurity('/path/to/key', '/path/to/cert', defaults));
+    client.setSecurity(new SOAP.ClientSSLSecurity('/path/to/key', '/path/to/cert', '/path/to/ca'));
+    client.setSecurity(new SOAP.ClientSSLSecurityPFX('pfx', 'password', defaults));
     client.setEndpoint('http://localhost');
     client.describe();
     client.addBodyAttribute({});
@@ -46,18 +48,18 @@ soap.createClient(url, wsdlOptions, (err: any, client: soap.Client) => {
     client.getHttpHeaders();
     client.getSoapHeaders();
     client.setSOAPAction('action');
-    (client['create'] as soap.SoapMethod)({ name: 'value' }, (err: any, result: any) => {
+    (client['create'] as SOAP.ISOAPMethod)({ name: 'value' }, (err: any, result: any) => {
         // result is an object
     });
-    (client['create'] as soap.SoapMethod)({ name: 'value' }, (err: any, result: any) => {
+    (client['create'] as SOAP.ISOAPMethod)({ name: 'value' }, (err: any, result: any) => {
         // result is an object
     }, {});
     client.on('request', (obj: any) => {
-        //obj is an object
+        // obj is an object
     });
 });
 
-var myService = {
+let myService = {
     MyService: {
         MyPort: {
             MyFunction: (args: any) => {
@@ -92,10 +94,10 @@ var myService = {
     }
 };
 
-var xml = fs.readFileSync('myservice.wsdl', 'utf8'),
+let xml = fs.readFileSync('myservice.wsdl', 'utf8'),
     server = http.createServer((request, response) => {
         response.end('404: Not Found: ' + request.url);
     });
 
 server.listen(8000);
-soap.listen(server, '/wsdl', myService, xml);
+SOAP.listen(server, '/wsdl', myService, xml);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/vpulim/node-soap>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Changes

- `Server` and `Client` are now exported as classes instead of interfaces. This allows proper inheritance. 
- Added missing soap module exports: `WSDL`, `WSSecurityCert`, `ClientSSLSecurityPFX`, `passwordDigest` 
- Updated existing signatures for missing arguments or members. 
- Added interfaces: `IWSDLBaseOptions`, `IServerOptions`, `IXMLAttribute`, `IServicePort`, `IService`, `IServices`. 
- Semantics:
    - Refactored `Security` to `ISecurity` (`Security` is still declared for compatibility reasons)   - Refactored `Option` to `IOptions` (`Option` is still declared for compatibility reasons)
   - Refactored `SoapMethod` to `ISOAPMethod` (`SoapMethod` is still declared for compatibility reasons)
- Updated tests.
- Fixes #18497

