### PR TITLE
[electron-packager] clarify the signatures for platform-specific options

### DIFF
--- a/types/electron-packager/index.d.ts
+++ b/types/electron-packager/index.d.ts
@@ -188,7 +188,7 @@ declare namespace electronPackager {
         /**
          * The URL protocol scheme(s) to associate the app with
          */
-        protocol?: string;
+        protocol?: string[];
         /**
          * The descriptive name(s) of the URL protocol scheme(s) specified via the protocol option.
          * Maps to the CFBundleURLName metadata property.

--- a/types/electron-packager/index.d.ts
+++ b/types/electron-packager/index.d.ts
@@ -63,8 +63,8 @@ declare namespace electronPackager {
         OriginalFilename?: string;
         ProductName?: string;
         InternalName?: string;
-        "requested-execution-level": any;
-        "application-manifest": any;
+        "requested-execution-level"?: "asInvoker" | "highestAvailable" | "requireAdministrator";
+        "application-manifest"?: string;
     }
 
     /** Electron-packager Options. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
   - First commit: `node-rcedit` doesn't require these two parameters, and [the docs](https://github.com/electron/node-rcedit#rceditexepath-options-callback) indicate they can be specified more explicitly than `any`.
   - Second commit: [`protocol`](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#protocol) and [`protocolName`](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#protocolname) are arrays that are [merged](https://github.com/electron-userland/electron-packager/blob/93160a02b0b190f490e19e4d7e862be5d8a1512a/common.js#L44-L51) into the resulting `protocols` value - I previously used this directly despite it being undocumented.
- ~~[ ] Increase the version number in the header if appropriate.~~
- ~~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

