### PR TITLE
[swaggerize-express] Add RouteSegment i/f and extended Options.handlers to accept

### DIFF
--- a/types/swaggerize-express/index.d.ts
+++ b/types/swaggerize-express/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for swaggerize-express 4.x
 // Project: https://github.com/krakenjs/swaggerize-express
 // Definitions by: TANAKA Koichi <https://github.com/mugeso/>
+//                 Nick Morton <https://github.com/nickmorton>    
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /* =================== USAGE ===================
@@ -222,10 +223,14 @@ declare namespace swaggerize {
         }
     }
 
+    export interface RouteSegment {
+        [urlSegment: string]: RouteSegment | express.RequestHandler;
+    }
+
     export interface Options {
         api: Swagger.ApiDefinition
         docspath: String
-        handlers: String
+        handlers: String | RouteSegment
     }
 
     export interface IConfig {

--- a/types/swaggerize-express/swaggerize-express-tests.ts
+++ b/types/swaggerize-express/swaggerize-express-tests.ts
@@ -19,6 +19,30 @@ app.use(swaggerize(<swaggerize.Options>{
     handlers: './handlers'
 }));
 
+app.use(swaggerize(<swaggerize.Options>{
+    api: {
+        swagger: "2.0",
+        host: "localhost:8080",
+        info: {
+            title: "swaggerize-express.d.ts test",
+            version: "1"
+        },
+        paths: {
+
+        }
+    },
+    docspath: '/api-docs',
+    handlers: {
+        'api': {
+            'v1': {
+                'version': {
+                    '$get': (req: express.Request, res: express.Response) => res.send('v1')
+                }
+            }
+        }
+    }
+}));
+
 var server = app.listen(18888, 'localhost', function () {
     (<swaggerize.SwaggerizedExpress>app).swagger.api.host = server.address().address + ':' + server.address().port;
 });


### PR DESCRIPTION
Extended the Options.handlers property to accept either a string or a hierarchical object containing route segments with handler methods on the verb leaf-nodes. This is in-line with the swaggerize-express package. See the documention link below.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/krakenjs/swaggerize-express#handlers-object>>
- [n/a] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
