### PR TITLE
Add title types to some react-bootstrap elements to allow JSX

### DIFF
--- a/types/react-bootstrap/lib/Dropdown.d.ts
+++ b/types/react-bootstrap/lib/Dropdown.d.ts
@@ -24,5 +24,6 @@ declare namespace Dropdown {
     open?: boolean;
     pullRight?: boolean;
     role?: string;
+    title?: any; // TODO: Add more specific type; Mark as non-optional
   }
 }

--- a/types/react-bootstrap/lib/Popover.d.ts
+++ b/types/react-bootstrap/lib/Popover.d.ts
@@ -14,4 +14,5 @@ interface PopoverProps extends React.HTMLProps<Popover> {
   placement?: string;
   positionLeft?: number | string; // String support added since v0.30.0
   positionTop?: number | string; // String support added since v0.30.0
+  title?: any; // TODO: Add more specific type
 }

--- a/types/react-bootstrap/lib/SplitButton.d.ts
+++ b/types/react-bootstrap/lib/SplitButton.d.ts
@@ -5,10 +5,12 @@ declare class SplitButton extends React.Component<SplitButtonProps> { }
 declare namespace SplitButton { }
 export = SplitButton
 
-interface SplitButtonProps extends React.HTMLProps<SplitButton> {
+interface SplitButtonBaseProps {
   bsStyle?: string;
   bsSize?: Sizes;
   dropdownTitle?: any; // TODO: Add more specific type
   dropup?: boolean;
   pullRight?: boolean;
+  title: any; // TODO: Add more specific type
 }
+type SplitButtonProps = SplitButtonBaseProps & React.HTMLProps<SplitButton>;

--- a/types/react-bootstrap/lib/Tab.d.ts
+++ b/types/react-bootstrap/lib/Tab.d.ts
@@ -12,11 +12,13 @@ declare class Tab extends React.Component<TabProps> {
 declare namespace Tab { }
 export = Tab
 
-interface TabProps extends TransitionCallbacks, React.HTMLProps<Tab> {
+interface TabBaseProps extends TransitionCallbacks {
   animation?: boolean;
   'aria-labelledby'?: string;
   bsClass?: string;
   eventKey?: any; // TODO: Add more specific type
   unmountOnExit?: boolean;
   tabClassName?: string;
+  title?: any; // TODO: Add more specific type; Mark as non-optional
 }
+type TabProps = TabBaseProps & React.HTMLProps<Tab>;

--- a/types/react-bootstrap/test/react-bootstrap-individual-components-tests.tsx
+++ b/types/react-bootstrap/test/react-bootstrap-individual-components-tests.tsx
@@ -176,7 +176,7 @@ export class ReactBootstrapIndividualComponentsTest extends React.Component {
         <ResponsiveEmbed />
         <Row />
         <SafeAnchor />
-        <SplitButton />
+        <SplitButton title="foo" />
         <SplitToggle />
         <Tab />
         <TabContainer />

--- a/types/react-bootstrap/test/react-bootstrap-tests.tsx
+++ b/types/react-bootstrap/test/react-bootstrap-tests.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { Component, CSSProperties } from 'react';
 import {
     Button, ButtonToolbar, Modal, Well, ButtonGroup,
-    DropdownButton, MenuItem, Panel, ListGroup,
-    ListGroupItem, Accordion, Tooltip,
+    DropdownButton, SplitButton, MenuItem, Panel,
+    ListGroup, ListGroupItem, Accordion, Tooltip,
     OverlayTrigger, Popover, ProgressBar,
     Nav, NavItem, Navbar, NavDropdown,
     Tabs, Tab, Pager, PageItem,
@@ -416,6 +416,14 @@ export class ReactBootstrapTest extends Component {
                 </div>
 
                 <div style={style}>
+                  <div style={{ height: 120, position: 'relative' }}>
+                    <Popover placement='right' positionLeft={200} positionTop={50} title={<h2>JSX title</h2>}>
+                      And here's some <strong>amazing</strong> content. It's very engaging. right?
+                    </Popover>
+                  </div>
+                </div>
+
+                <div style={style}>
                   <ButtonToolbar>
                     <OverlayTrigger trigger='click' placement='left' overlay={<Popover title='Popover left'><strong>Holy guacamole!</strong> Check this info.</Popover>}>
                       <Button bsStyle='default'>Holy guacamole!</Button>
@@ -541,6 +549,9 @@ export class ReactBootstrapTest extends Component {
                           <MenuItem divider />
                           <MenuItem eventKey='4'>Separated link</MenuItem>
                         </NavDropdown>
+                        <NavDropdown eventKey={4} title={<strong>JSX title</strong>} id='jsx-title-nav-dropdown'>
+                          <MenuItem eventKey='1'>Do a thing</MenuItem>
+                        </NavDropdown>
                       </Nav>
                       <Navbar.Text>
                           Signed in as: <Navbar.Link href="#">Mark Otto</Navbar.Link>
@@ -593,7 +604,7 @@ export class ReactBootstrapTest extends Component {
                 <div style={style}>
                   <Tabs defaultActiveKey={1} animation={false}>
                     <Tab eventKey={1} title='Tab 1'>Tab 1 content</Tab>
-                    <Tab eventKey={2} title='Tab 2'>Tab 2 content</Tab>
+                    <Tab eventKey={2} title={<div>Tab<hr/>2</div>}>Tab 2 content</Tab>
                     <Tab eventKey={3} title='Tab 3' disabled>Tab 3 content</Tab>
                   </Tabs>
                 </div>
@@ -1073,6 +1084,31 @@ export class ReactBootstrapTest extends Component {
                                 >
                                     <MenuItem key="1">Item</MenuItem>
                                 </DropdownButton>
+                            </InputGroup>
+                        </FormGroup>
+
+                        <FormGroup>
+                            <InputGroup>
+                                <FormControl type="text" />
+                                <DropdownButton
+                                  componentClass={InputGroup.Button}
+                                  id="input-dropdown-addon"
+                                  title={<h2>JSX title</h2>}
+                                >
+                                    <MenuItem key="1">Item</MenuItem>
+                                </DropdownButton>
+                            </InputGroup>
+                        </FormGroup>
+
+                        <FormGroup>
+                            <InputGroup>
+                                <FormControl type="text" />
+                                <SplitButton
+                                  id="input-splitbutton-addon"
+                                  title={<h2>JSX title</h2>}
+                                >
+                                    <MenuItem key="1">Item</MenuItem>
+                                </SplitButton>
                             </InputGroup>
                         </FormGroup>
 


### PR DESCRIPTION
Some elements are listed in the documentation of react-bootstrap as accepting a node, but their types definitions don't mention it and in fact extend `React.HTMLProps` which has a conflicting title type (`string | undefined`). 

This isn't an ideal solution but it does prevent the errors from cropping up when trying to pass a node as a title. This sort of solution was suggested [here](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14934#issuecomment-284471494).



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present __<-- ran tsc__).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/12085>>, <<https://github.com/DefinitelyTyped/DefinitelyTyped/issues/12086>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
