### PR TITLE
[node] Update async_hooks according to renaming done in 8.2.0

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5748,11 +5748,15 @@ declare module "async_hooks" {
     /**
      * Returns the asyncId of the current execution context.
      */
+    export function executionAsyncId(): number;
+    /// @deprecated - replaced by executionAsyncId()
     export function currentId(): number;
 
     /**
      * Returns the ID of the resource responsible for calling the callback that is currently being executed.
      */
+    export function triggerAsyncId(): number;
+    /// @deprecated - replaced by triggerAsyncId()
     export function triggerId(): number;
 
     export interface HookCallbacks {
@@ -5760,10 +5764,10 @@ declare module "async_hooks" {
          * Called when a class is constructed that has the possibility to emit an asynchronous event.
          * @param asyncId a unique ID for the async resource
          * @param type the type of the async resource
-         * @param triggerId the unique ID of the async resource in whose execution context this async resource was created
+         * @param triggerAsyncId the unique ID of the async resource in whose execution context this async resource was created
          * @param resource reference to the resource representing the async operation, needs to be released during destroy
          */
-        init?(asyncId: number, type: string, triggerId: number, resource: Object): void;
+        init?(asyncId: number, type: string, triggerAsyncId: number, resource: Object): void;
 
         /**
          * When an asynchronous operation is initiated or completes a callback is called to notify the user.

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2801,7 +2801,7 @@ client.listbreakpoints((err, body, packet) => { });
 ////////////////////////////////////////////////////
 namespace async_hooks_tests {
     const hooks: async_hooks.HookCallbacks = {
-        init: (asyncId: number, type: string, triggerId: number, resource: object) => void {},
+        init: (asyncId: number, type: string, triggerAsyncId: number, resource: object) => void {},
         before: (asyncId: number) => void {},
         after: (asyncId: number) => void {},
         destroy: (asyncId: number) => void {}
@@ -2810,4 +2810,7 @@ namespace async_hooks_tests {
     const asyncHook = async_hooks.createHook(hooks);
 
     asyncHook.enable().disable().enable();
+
+    const tId: number = async_hooks.triggerAsyncId();
+    const eId: number = async_hooks.executionAsyncId();
 }


### PR DESCRIPTION
Added `async_hooks.executionAsyncId()` and `triggerAsyncId()`. Deprecated `currentId()` and `triggerId()`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://nodejs.org/dist/latest-v8.x/docs/api/async_hooks.html#async_hooks_async_hooks_executionasyncid
https://nodejs.org/dist/latest-v8.x/docs/api/async_hooks.html#async_hooks_async_hooks_triggerasyncid
https://github.com/nodejs/node/pull/13490
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
