### PR TITLE
[TinyMCE] Fix content_css attribute type in Settings weak type

### DIFF
--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -133,7 +133,7 @@ export interface Settings {
 
   body_id?: string;
 
-  content_css?: string;
+  content_css?: string | string[];
 
   content_style?: string;
 


### PR DESCRIPTION
Docs: `Type: String, Array`
https://www.tinymce.com/docs/configure/content-appearance/#content_css