### PR TITLE
[reactstrap] Adding getRef to focus-able components for (old) release 3.8.1

### DIFF
--- a/types/reactstrap/lib/Button.d.ts
+++ b/types/reactstrap/lib/Button.d.ts
@@ -7,6 +7,7 @@ interface Props extends React.HTMLProps<HTMLButtonElement> {
   color?: string;
   disabled?: boolean;
   tag?: React.ReactType;
+  getRef?: string | ((instance: HTMLButtonElement) => any);
 
   onClick?: React.MouseEventHandler<any>;
   size?: any;

--- a/types/reactstrap/lib/CardLink.d.ts
+++ b/types/reactstrap/lib/CardLink.d.ts
@@ -2,6 +2,7 @@ import { CSSModule } from '../index';
 
 interface Props {
   tag?: React.ReactType;
+  getRef?: string | ((instance: HTMLButtonElement) => any);
   className?: string;
   cssModule?: CSSModule;
   href?: string;

--- a/types/reactstrap/lib/Form.d.ts
+++ b/types/reactstrap/lib/Form.d.ts
@@ -3,6 +3,7 @@ import { CSSModule } from '../index';
 interface Props extends React.HTMLProps<HTMLFormElement> {
   inline?: boolean;
   tag?: React.ReactType;
+  getRef?: string | ((instance: HTMLButtonElement) => any);
   className?: string;
   cssModule?: CSSModule;
 }

--- a/types/reactstrap/lib/Input.d.ts
+++ b/types/reactstrap/lib/Input.d.ts
@@ -38,6 +38,7 @@ interface InputProps extends Intermediate {
   size?: string;
   state?: string;
   tag?: React.ReactType;
+  getRef?: string | ((instance: HTMLButtonElement) => any);
   addon?: boolean;
   className?: string;
   cssModule?: CSSModule;

--- a/types/reactstrap/lib/NavLink.d.ts
+++ b/types/reactstrap/lib/NavLink.d.ts
@@ -2,6 +2,7 @@ import { CSSModule } from '../index';
 
 interface Props extends React.HTMLProps<HTMLAnchorElement> {
   tag?: React.ReactType;
+  getRef?: string | ((instance: HTMLButtonElement) => any);
   disabled?: boolean;
   active?: boolean;
   className?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactstrap/reactstrap/blob/d153a7801bb88f117a5e6c92b4bf838c9af3feb5/CHANGELOG.md#381-2016-11-01
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.