### PR TITLE
Improve react-transition-group import

### DIFF
--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -8,7 +8,7 @@ import CSSTransition from "react-transition-group/CSSTransition";
 import Transition from "react-transition-group/Transition";
 import TransitionGroup from "react-transition-group/TransitionGroup";
 
-export = {
+export {
     CSSTransition,
     Transition,
     TransitionGroup

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -3,6 +3,11 @@ import CSSTransition from "react-transition-group/CSSTransition";
 import Transition from "react-transition-group/Transition";
 import TransitionGroup from "react-transition-group/TransitionGroup";
 import Components = require("react-transition-group");
+import {
+    CSSTransition as CSSTransition2,
+    Transition as Transition2,
+    TransitionGroup as TransitionGroup2
+} from "react-transition-group";
 
 const Test: React.StatelessComponent = () => {
     function handleEnter(node: HTMLElement, isAppearing: boolean) {}


### PR DESCRIPTION
Allow to write:
```TypeScript
import { CSSTransition, Transition, TransitionGroup } from "react-transition-group";
```
instead of:
```TypeScript
import CSSTransition from "react-transition-group/CSSTransition";
import Transition from "react-transition-group/Transition";
import TransitionGroup from "react-transition-group/TransitionGroup";
```
(which is still possible)