### PR TITLE
[hls.js] Change nextLevel to number type. 

### DIFF
--- a/types/hls.js/index.d.ts
+++ b/types/hls.js/index.d.ts
@@ -1659,7 +1659,7 @@ declare class Hls {
    *
    * set to -1 for automatic level selection
    */
-  nextLevel: Hls.Level;
+  nextLevel: number;
   /**
    * get: return last loaded fragment quality level
    * set: quality level for next loaded fragment


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Some notes:
hls.nextLevel should be in number type because it is used as an index for selection for next level in code. Similar logic might apply to other types like nextLoadLevel, etc. I only change this one because I only tested this one in my code.
