### PR TITLE
package: nightmare: Added "show?: boolean" to IConstructorOptions

### DIFF
--- a/types/nightmare/index.d.ts
+++ b/types/nightmare/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Nightmare 1.6.5
 // Project: https://github.com/segmentio/nightmare
 // Definitions by: horiuchi <https://github.com/horiuchi/>
+//                 Sam Yang <https://github.com/samyang-au>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -78,6 +79,7 @@ declare namespace Nightmare {
         proxyAuth?: string;
         cookiesFile?: string;
         phantomPath?: string;
+        show?: boolean;
     }
 
     export interface IRequest {

--- a/types/nightmare/nightmare-tests.ts
+++ b/types/nightmare/nightmare-tests.ts
@@ -318,3 +318,4 @@ new Nightmare()
   .use(testTitle('test term'))
   .run(done);
 
+new Nightmare({show: true});


### PR DESCRIPTION
Please fill in this template.

- [✓ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓ ] Test the change in your own code. (Compile and run.)
- [ ✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ✓] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ✓] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
ran tsc since no tslint.json is present

Select one of these and delete the others:

If changing an existing definition:
- [✓ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/segmentio/nightmare

In the **Examples** section it shows `var nightmare = Nightmare({ show: true });`.  Tested it and the option is available and shows the browser.

- [? ] Increase the version number in the header if appropriate.

Sorry, still quite new to this and not sure what this refers to.

- [✓ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

It's a really simple change so didn't add a tslint.json
