### PR TITLE
[react-router-redux] - switching action type from `string` to a specific string

### DIFF
--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -25,7 +25,7 @@ export interface ConnectedRouterProps<State> {
 }
 export class ConnectedRouter<State> extends React.Component<ConnectedRouterProps<State>> {}
 
-export const LOCATION_CHANGE: '@@router/LOCATION_CHANGE';
+export const LOCATION_CHANGE = '@@router/LOCATION_CHANGE';
 
 export interface RouterState {
     location: Location | null;
@@ -33,7 +33,7 @@ export interface RouterState {
 
 export const routerReducer: Reducer<RouterState>;
 
-export const CALL_HISTORY_METHOD: '@@router/CALL_HISTORY_METHOD';
+export const CALL_HISTORY_METHOD = '@@router/CALL_HISTORY_METHOD';
 
 export function push(location: LocationDescriptor, state?: LocationState): RouterAction;
 export function replace(location: LocationDescriptor, state?: LocationState): RouterAction;

--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -25,7 +25,7 @@ export interface ConnectedRouterProps<State> {
 }
 export class ConnectedRouter<State> extends React.Component<ConnectedRouterProps<State>> {}
 
-export const LOCATION_CHANGE: string;
+export const LOCATION_CHANGE: '@@router/LOCATION_CHANGE';
 
 export interface RouterState {
     location: Location | null;
@@ -33,7 +33,7 @@ export interface RouterState {
 
 export const routerReducer: Reducer<RouterState>;
 
-export const CALL_HISTORY_METHOD: string;
+export const CALL_HISTORY_METHOD: '@@router/CALL_HISTORY_METHOD';
 
 export function push(location: LocationDescriptor, state?: LocationState): RouterAction;
 export function replace(location: LocationDescriptor, state?: LocationState): RouterAction;


### PR DESCRIPTION
With action typed as `string`, reducers can't work correctly

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [1](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/modules/actions.js), [2](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-redux/modules/reducer.js)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
