### PR TITLE
[paper] Correct return type for `Rectangle.scale` and `Rectangle.expand`

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -793,27 +793,27 @@ declare module 'paper' {
          * Expands the rectangle by the specified amount in horizontal and vertical directions.
          * @param amount - the amount to expand the rectangle in both directions
          */
-        expand(amount: number | Size | Point): void;
+        expand(amount: number | Size | Point): Rectangle;
 
         /**
          * Expands the rectangle by the specified amounts in horizontal and vertical directions.
          * @param hor - the amount to expand the rectangle in horizontal direction
          * @param ver - the amount to expand the rectangle in vertical direction
          */
-        expand(hor: number, ver: number): void;
+        expand(hor: number, ver: number): Rectangle;
 
         /**
          * Scales the rectangle by the specified amount from its center.
          * @param amount - the amount to scale by
          */
-        scale(amount: number): void;
+        scale(amount: number): Rectangle;
 
         /**
          * Scales the rectangle in horizontal direction by the specified hor amount and in vertical direction by the specified ver amount from its center.
          * @param hor - the amount to scale the rectangle in horizontal direction
          * @param ver - the amount to scale the rectangle in vertical direction
          */
-        scale(hor: number, ver: number): void;
+        scale(hor: number, ver: number): Rectangle;
 
     }
     /**


### PR DESCRIPTION
The definition for both methods returned void although they return a new Rectangle instance.
See https://github.com/paperjs/paper.js/blob/c403c86a23f54f07bb7e9448c7f05df5cebb464c/src/basic/Rectangle.js#L805-L833

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
