### PR TITLE
Use correct type for rc-tooltip's overlay

### DIFF
--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for rc-tooltip v3.4.2
 // Project: https://github.com/react-component/tooltip
 // Definitions by: rhysd <https://rhysd.github.io>
+//                 ahstro <http://ahst.ro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -26,7 +27,7 @@ declare namespace Tooltip {
 		placement?: Placement | Object;
 		align?: Object;
 		onPopupAlign?: (popupDomNode: Element, align: Object) => void;
-		overlay: React.ReactElement<any> | (() => React.ReactElement<any>);
+		overlay: React.ReactNode;
 		arrowContent?: React.ReactNode;
 		getTooltipContainer?: () => Element;
 		destroyTooltipOnHide?: boolean;

--- a/types/rc-tooltip/rc-tooltip-tests.tsx
+++ b/types/rc-tooltip/rc-tooltip-tests.tsx
@@ -10,6 +10,13 @@ ReactDOM.render(
 );
 
 ReactDOM.render(
+    <Tooltip overlay="tooltip">
+        <a href='#'>hover</a>
+    </Tooltip>,
+    document.querySelector('.app')
+);
+
+ReactDOM.render(
     <Tooltip
         placement="bottomRight"
         trigger={['click', 'focus']}


### PR DESCRIPTION
The previous type signature doesn't allow e.g. strings to be passed in,
even though they're completely valid.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-component/tooltip/blob/80d17220b19017839d42d581089077c2ee9b2de8/src/Tooltip.jsx#L50
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
