### PR TITLE
pg-connection-string fix

### DIFF
--- a/types/pg-connection-string/index.d.ts
+++ b/types/pg-connection-string/index.d.ts
@@ -6,8 +6,8 @@
 
 export function parse(connectionString: string): {
     host: string;
-    database: string;
-    port: string;
+    database: string | null;
+    port: string | null;
     application_name?: string;
     client_encoding?: string;
     fallback_application_name?: string;


### PR DESCRIPTION
`port` and `database` should be nullable:

```
> parse("postgres://");
{ port: null, host: '', database: null, user: '', password: '' }
```

```
> parse("postgres://foo");
{ port: null, host: 'foo', database: null, user: '', password: '' }
```

```
> parse("postgres://foo/foo");
{ port: null,
  host: 'foo',
  database: 'foo',
  user: '',
  password: '' }
```