### PR TITLE
Added declared namespace to strip-json-comments

### DIFF
--- a/types/strip-json-comments/index.d.ts
+++ b/types/strip-json-comments/index.d.ts
@@ -9,4 +9,5 @@ interface StripJsonOptions {
 }
 
 declare function stripJsonComments(input: string, opts?: StripJsonOptions): string;
+declare namespace stripJsonComments { }
 export = stripJsonComments;

--- a/types/strip-json-comments/strip-json-comments-tests.ts
+++ b/types/strip-json-comments/strip-json-comments-tests.ts
@@ -3,9 +3,14 @@
 // Definitions by: Dylan R. E. Moonfire <https://github.com/dmoonfire/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import stripJsonComments = require("strip-json-comments");
+import * as stripJsonComments from "strip-json-comments";
 
 const json = '{/*rainbows*/"unicorn":"cake"}';
 
 JSON.parse(stripJsonComments(json));
 //=> {unicorn: 'cake'}
+
+stripJsonComments(json, {});
+stripJsonComments(json, {
+    whitespace: true
+});


### PR DESCRIPTION
Allows it to be imported as an ES2015 module with `import * as` usage.

Fixes #15722.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/strip-json-comments (not explicit)
- [x] ~~Increase the version number in the header if appropriate.~~
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~