### PR TITLE
Update helmet types with support for expect-ct

### DIFF
--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for helmet
 // Project: https://github.com/helmetjs/helmet
-// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>, Evan Hahn <https://github.com/EvanHahn>
+// Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>, Evan Hahn <https://github.com/EvanHahn>, Elliot Blackburn <https://github.com/bluehatbrit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import express = require('express');
@@ -19,7 +19,8 @@ declare namespace helmet {
         ieNoOpen?: boolean,
         noCache?: boolean,
         noSniff?: boolean,
-        xssFilter?: boolean | IHelmetXssFilterConfiguration
+        xssFilter?: boolean | IHelmetXssFilterConfiguration,
+        expectCt?: boolean | IHelmetExpectCtConfiguration,
     }
 
     export interface IHelmetContentSecurityPolicyDirectiveFunction {
@@ -94,6 +95,12 @@ declare namespace helmet {
 
     export interface IHelmetXssFilterConfiguration {
         setOnOldIE?: boolean;
+    }
+
+    export interface IHelmetExpectCtConfiguration {
+        enforce?: boolean;
+        maxAge?: number;
+        reportUri?: string;
     }
 
     /**
@@ -179,5 +186,12 @@ declare namespace helmet {
          * @return {RequestHandler} The Request handler.
          */
         xssFilter(options?: IHelmetXssFilterConfiguration): express.RequestHandler;
+
+        /**
+         * @summary Adds the
+         * @param {helmet.IHelmetExpectCtConfiguration} options
+         * @returns {e.RequestHandler}
+         */
+        expectCt(options?: IHelmetExpectCtConfiguration): express.RequestHandler;
     }
 }

--- a/types/helmet/index.d.ts
+++ b/types/helmet/index.d.ts
@@ -188,7 +188,7 @@ declare namespace helmet {
         xssFilter(options?: IHelmetXssFilterConfiguration): express.RequestHandler;
 
         /**
-         * @summary Adds the
+         * @summary Adds the "Expect-CT" header.
          * @param {helmet.IHelmetExpectCtConfiguration} options
          * @returns {e.RequestHandler}
          */


### PR DESCRIPTION
I've added a new interface for helmet options which allows users to setup Expect-CT header options, this was released not too long ago but isn't in the current types. I considered updating the types for the new structure but I've not had time and the changes are very minor so I decided to just make the addition, I hope this is okay.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/helmetjs/helmet
- [x] Increase the version number in the header if appropriate.
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

