### PR TITLE
[angular-material] Adds missing methods `openFrom`, `closeTo`, and `multiple` to the IPresetDialog interface

### DIFF
--- a/types/angular-material/index.d.ts
+++ b/types/angular-material/index.d.ts
@@ -61,9 +61,9 @@ declare module 'angular' {
             controllerAs(controllerAs?: string): T;
             parent(parent?: string | Element | JQuery): T; // default: root node
             ariaLabel(ariaLabel: string): T;
-			openFrom(from: string | Element | Event | { top: number, left: number }): T;
-    		closeTo(to: string | Element | { top: number, left: number }): T;
-    		multiple(multiple: boolean): T;
+            openFrom(from: string | Element | Event | { top: number, left: number }): T;
+            closeTo(to: string | Element | { top: number, left: number }): T;
+            multiple(multiple: boolean): T;
         }
 
         // tslint:disable-next-line no-empty-interface

--- a/types/angular-material/index.d.ts
+++ b/types/angular-material/index.d.ts
@@ -61,6 +61,9 @@ declare module 'angular' {
             controllerAs(controllerAs?: string): T;
             parent(parent?: string | Element | JQuery): T; // default: root node
             ariaLabel(ariaLabel: string): T;
+			openFrom(from: string | Element | Event | { top: number, left: number }): T;
+    		closeTo(to: string | Element | { top: number, left: number }): T;
+    		multiple(multiple: boolean): T;
         }
 
         // tslint:disable-next-line no-empty-interface


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/angular/material/blob/master/src/components/dialog/dialog.js#L586](https://github.com/angular/material/blob/master/src/components/dialog/dialog.js#L586)
and
[https://material.angularjs.org/latest/api/service/$mdDialog](https://material.angularjs.org/latest/api/service/$mdDialog)
