### PR TITLE
Type and export props from react-router's `withRouter`

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -13,6 +13,7 @@
 //                 Huy Nguyen <https://github.com/huy-nguyen>
 //                 Jérémy Fauvel <https://github.com/grmiade>
 //                 Daniel Roth <https://github.com/DaIgeb>
+//                 Ross Allen <https://github.com/ssorallen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -13,7 +13,6 @@
 //                 Huy Nguyen <https://github.com/huy-nguyen>
 //                 Jérémy Fauvel <https://github.com/grmiade>
 //                 Daniel Roth <https://github.com/DaIgeb>
-//                 Ross Allen <https://github.com/ssorallen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/react-router/v3/index.d.ts
+++ b/types/react-router/v3/index.d.ts
@@ -9,6 +9,7 @@
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 Karol Janyst <https://github.com/LKay>
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
+//                 Ross Allen <https://github.com/ssorallen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/react-router/v3/index.d.ts
+++ b/types/react-router/v3/index.d.ts
@@ -34,6 +34,7 @@ export { RouteProps, PlainRoute } from "react-router/lib/Route";
 export { IndexRouteProps } from "react-router/lib/IndexRoute";
 export { RedirectProps } from "react-router/lib/Redirect";
 export { IndexRedirectProps } from "react-router/lib/IndexRedirect";
+export { WithRouterProps } from "react-router/lib/withRouter";
 
 /* components */
 export { default as Router } from "react-router/lib/Router";

--- a/types/react-router/v3/lib/withRouter.d.ts
+++ b/types/react-router/v3/lib/withRouter.d.ts
@@ -1,12 +1,22 @@
 import { ComponentClass, StatelessComponent } from "react";
+import { InjectedRouter, Params } from "./Router";
+import { Location } from "history";
+import { PlainRoute } from "./Route";
 
 interface Options {
     withRef?: boolean;
 }
 
+export interface WithRouterProps {
+    location: Location;
+    params: Params;
+    router: InjectedRouter;
+    routes: PlainRoute[];
+}
+
 type ComponentConstructor<P> = ComponentClass<P> | StatelessComponent<P>;
 
-declare function withRouter<P, S>(component: ComponentConstructor<P> & S, options?: Options): ComponentClass<P> & S;
-declare function withRouter<P>(component: ComponentConstructor<P>, options?: Options): ComponentClass<P>;
+declare function withRouter<P, S>(component: ComponentConstructor<P & WithRouterProps> & S, options?: Options): ComponentClass<P> & S;
+declare function withRouter<P>(component: ComponentConstructor<P & WithRouterProps>, options?: Options): ComponentClass<P>;
 
 export default withRouter;

--- a/types/react-router/v3/react-router-tests.tsx
+++ b/types/react-router/v3/react-router-tests.tsx
@@ -104,6 +104,23 @@ class NotFound extends React.Component {
 	}
 }
 
+interface UserListProps {
+	users: string;
+}
+
+class UserList extends React.Component<UserListProps & WithRouterProps> {
+	render() {
+		const { location, params, router, routes } = this.props;
+		return <div>
+			<ul>
+				<li>{this.props.users}</li>
+			</ul>
+		</div>;
+	}
+}
+
+const UserListWithRouter = withRouter(UserList);
+
 type UsersProps = RouteComponentProps<{}, {}>;
 
 class Users extends React.Component<UsersProps> {
@@ -111,6 +128,7 @@ class Users extends React.Component<UsersProps> {
 		const { location, params, route, routes, router, routeParams } = this.props;
 		return <div>
 			This is a user list
+			<UserListWithRouter users="Suzanne, Fred" />
 		</div>;
 	}
 }

--- a/types/react-router/v3/react-router-tests.tsx
+++ b/types/react-router/v3/react-router-tests.tsx
@@ -20,7 +20,8 @@ import {
 	RouterContext,
 	LinkProps,
 	RedirectFunction,
-	RouteComponentProps
+	RouteComponentProps,
+	WithRouterProps
 } from "react-router";
 import { createHistory, History } from "history";
 
@@ -71,11 +72,7 @@ class Master extends Component {
 	}
 }
 
-interface DashboardProps {
-	router: InjectedRouter;
-}
-
-class Dashboard extends React.Component<DashboardProps> {
+class Dashboard extends React.Component<WithRouterProps> {
 	static staticMethodToBeHoisted(): void { }
 
 	navigate() {


### PR DESCRIPTION
In react-router v3.0.5, [`withRouter`][0] passes 4 props to the wrapped
component: `location`, `params`, `router`, and `routes`. These props are
different than those passed to `Route` components; these all come
directly from the Router either via `this.props` or `this.context`.

The component passed to `withRouter` are passed these props, but the
component returned from `withRouter` require only the component's own
props.

This implementation is similar to the one for react-router v4 in the root of types/react-router, but that one incorrectly creates a union with `RouteComponentProps<any>`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c9bd9cf538154169c9e61e179e0fd8d4d1ba2c26/types/react-router/index.d.ts#L102

[0]: https://github.com/ReactTraining/react-router/blob/v3.0.5/modules/withRouter.js#L40

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/v3.0.5/modules/withRouter.js#L40
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.