### PR TITLE
[browser-bunyan] Improve ConsoleFormattedStream, add ConsoleRawStream

### DIFF
--- a/types/browser-bunyan/browser-bunyan-tests.ts
+++ b/types/browser-bunyan/browser-bunyan-tests.ts
@@ -1,8 +1,25 @@
 import * as bunyan from "browser-bunyan";
 
 const log = bunyan.createLogger({
-        name: 'play',
-        serializers: bunyan.stdSerializers
+    name: 'myLogger',
+    streams: [
+        {
+            level: 'info',
+            stream: new bunyan.ConsoleFormattedStream()
+        }
+    ],
+    serializers: bunyan.stdSerializers,
+    src: true
 });
-log.debug({foo: 'bar'}, 'hi at debug');
-log.trace('hi at trace');
+
+log.info('hi on info');
+
+const log2 = bunyan.createLogger({
+    name: 'myLogger',
+    stream: new bunyan.ConsoleRawStream()
+});
+
+const myObject = { x: 1, y: 2 };
+log.info({ obj: myObject }, 'This is my object:');
+
+new bunyan.ConsoleFormattedStream({ logByLevel: true });

--- a/types/browser-bunyan/index.d.ts
+++ b/types/browser-bunyan/index.d.ts
@@ -1,12 +1,31 @@
 // Type definitions for browser-bunyan 0.4
 // Project: https://github.com/philmander/browser-bunyan
 // Definitions by: Paul Lockwood <https://github.com/PaulLockwood>
+//                 Michael Strobel <https://github.com/kryops>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import bunyan = require("bunyan");
+/// <reference types="node" />
 
-declare module "bunyan" {
-    function ConsoleFormattedStream(): void;
+import * as bunyan from 'bunyan';
+
+declare namespace BrowserBunyan {
+    interface ConsoleFormattedStreamOptions {
+        logByLevel?: boolean;
+    }
+
+    interface ConsoleFormattedStream {
+        new(options?: ConsoleFormattedStreamOptions): NodeJS.WritableStream;
+    }
+
+    interface ConsoleRawStream {
+        new(options?: ConsoleFormattedStreamOptions): NodeJS.WritableStream;
+    }
 }
 
-export = bunyan;
+type BrowserBunyan = typeof bunyan & {
+    ConsoleFormattedStream: BrowserBunyan.ConsoleFormattedStream
+    ConsoleRawStream: BrowserBunyan.ConsoleRawStream
+};
+
+declare const browserBunyan: BrowserBunyan;
+export = browserBunyan;


### PR DESCRIPTION
- extend bunyan in the export instead of augmenting it globally
- add tests from the project's README

I used `NodeJS.WritableStream` in an awkward way because this package simulates and extends the `bunyan` module in the browser, and that wants a `NodeJS.WritableStream` as `stream` property. Not sure if there is a better solution - I wanted to avoid using `any`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/browser-bunyan#built-in-log-streams
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
