### PR TITLE
Update Restify server interface

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -305,6 +305,12 @@ export interface Server extends http.Server {
 
     /** Once listen() is called, this will be filled in with where the server is running. */
     url: string;
+
+    /** Node server instance */
+    server: http.Server;
+
+    /** Router instance */
+    router: Router;
 }
 
 export interface RouterOptions {

--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -1,6 +1,7 @@
 import * as restify from "restify";
 import * as url from "url";
 import * as Logger from "bunyan";
+import * as http from "http";
 
 let server = new restify.Server();
 
@@ -115,6 +116,8 @@ server.name = "";
 server.versions = [""];
 server.acceptable = ["test"];
 server.url = "";
+server.server = new http.Server();
+server.router = new restify.Router({});
 
 server.address().port;
 server.address().family;


### PR DESCRIPTION
Definitions updated to add `server` and `router` properties to the *Restify* `Server` interface as documented in the [Getting Started Guide](http://restify.com/docs/home/).