### PR TITLE
Use ES2015 module style for react-transition-group

### DIFF
--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -8,7 +8,7 @@ import CSSTransition from "react-transition-group/CSSTransition";
 import Transition from "react-transition-group/Transition";
 import TransitionGroup from "react-transition-group/TransitionGroup";
 
-export = {
+export {
     CSSTransition,
     Transition,
     TransitionGroup


### PR DESCRIPTION
This merge request makes a minor modification to `react-transition-group/index.d.ts`. It switches the export style to the ES2015 module export (the *imports* in the file already use the ES2015 style, but the exports use the TypeScript style.) [This appears to cause an type-checking error when using ES2015 imports](https://github.com/reactjs/react-transition-group/issues/109#issuecomment-315721806). Here is the error:

```
error TS2497: Module '".../node_modules/@types/react-transition-group/index"' resolves to a non-module entity and cannot be imported using this construct.
```

Paging @LKay since he wrote the original definitions.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/reactjs/react-transition-group/blob/master/src/index.js
  - https://github.com/reactjs/react-transition-group/issues/109#issuecomment-315721806
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. ***Not making substantial changes.***

