### PR TITLE
[highcharts] Add visible property to IndividualSeriesOptions

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -4,6 +4,7 @@
 //                 Dan Lewi Harkestad <http://github.com/baltie>
 //                 Albert Ozimek <https://github.com/AlbertOzimek>
 //                 Juliën Hanssens <https://github.com/hanssens>
+//                 Jeremy Attali <https://github.com/jtheoof>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -5369,6 +5370,11 @@ declare namespace Highcharts {
          * @since 2.1
          */
         stack?: any;
+        /**
+         * Set the initial visibility of the series.
+         * @default true
+         */
+        visible?: boolean;
         /**
          * When using dual or multiple x axes, this number defines which xAxis the particular series is connected to. It
          * refers to either the axis id or the index of the axis in the xAxis array, with 0 being the first.


### PR DESCRIPTION
`visible` property is present in all interfaces extending `IndividualSeriesOptions` as per
[api](http://api.highcharts.com/highcharts/series).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://api.highcharts.com/highcharts/series%3Carea%3E.visible
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.