### PR TITLE
Add type definitions of express-fileupload

### DIFF
--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -1,0 +1,14 @@
+import * as express from 'express';
+import { RequestHandler } from 'express-serve-static-core';
+import fileUpload = require('express-fileupload');
+
+const app = express();
+
+app.use(fileUpload());
+
+const uploadHandler: RequestHandler = (req, res, next) => {
+    console.log(req.files.field.name);
+    console.log(req.files.field2[0].name);
+};
+
+app.post('/upload', uploadHandler);

--- a/types/express-fileupload/express-fileupload-tests.ts
+++ b/types/express-fileupload/express-fileupload-tests.ts
@@ -1,14 +1,29 @@
 import * as express from 'express';
-import { RequestHandler } from 'express-serve-static-core';
-import fileUpload = require('express-fileupload');
+import { RequestHandler, Request, Response, NextFunction } from 'express-serve-static-core';
+import { fileUpload, UploadedFile } from 'express-fileupload';
 
-const app = express();
+const app: express.Express = express();
 
-app.use(fileUpload());
+app.use(fileUpload({debug: true}));
 
-const uploadHandler: RequestHandler = (req, res, next) => {
-    console.log(req.files.field.name);
-    console.log(req.files.field2[0].name);
+function isUploadedFile(file: UploadedFile | UploadedFile[]): file is UploadedFile {
+    return typeof file === 'object' && (<UploadedFile> file).name !== undefined;
+}
+
+const uploadHandler: RequestHandler = (req: Request, res: Response, next: NextFunction) => {
+    if (typeof req.files === 'object') {
+        const fileField = req.files.field;
+        if (isUploadedFile(fileField)) {
+            console.log(fileField.name);
+        }
+
+        const fileList = req.files.fileList;
+        if (Array.isArray(fileList)) {
+            for (const file of fileList) {
+                console.log(file.name);
+            }
+        }
+    }
 };
 
 app.post('/upload', uploadHandler);

--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -2,25 +2,35 @@
 // Project: https://github.com/richardgirges/express-fileupload#readme
 // Definitions by: Gintautas Miselis <https://github.com/Naktibalda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-/// <reference types="express" />
+import express = require('express');
 
-declare namespace Express {
-    interface Request {
-        files?: ExpressFileUpload.FileArray;
+declare global {
+    namespace Express {
+        interface Request {
+            files?: FileArray;
+        }
     }
 }
 
-declare namespace ExpressFileUpload {
-    class FileArray {
-        [index: string]: UploadedFile | UploadedFile[]
-    }
-
-    interface UploadedFile {
-        name: string;
-        encoding: string;
-        mimetype: string;
-        data: Buffer;
-        mv(targetLocation: string, callback: (err: any) => {}): void;
-    }
+export class FileArray {
+    [index: string]: UploadedFile | UploadedFile[]
 }
+
+export interface UploadedFile {
+    name: string;
+    encoding: string;
+    mimetype: string;
+    data: Buffer;
+    mv(path: string, callback: (err: any) => {}): void;
+}
+
+export interface Options {
+    debug?: boolean;
+    safeFileNames?: boolean;
+    preserveExtension?: boolean | string | number;
+    [property: string]: any;
+}
+
+export function fileUpload(options?: Options): express.RequestHandler;

--- a/types/express-fileupload/index.d.ts
+++ b/types/express-fileupload/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for express-fileupload 0.1
+// Project: https://github.com/richardgirges/express-fileupload#readme
+// Definitions by: Gintautas Miselis <https://github.com/Naktibalda>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="express" />
+
+declare namespace Express {
+    interface Request {
+        files?: ExpressFileUpload.FileArray;
+    }
+}
+
+declare namespace ExpressFileUpload {
+    class FileArray {
+        [index: string]: UploadedFile | UploadedFile[]
+    }
+
+    interface UploadedFile {
+        name: string;
+        encoding: string;
+        mimetype: string;
+        data: Buffer;
+        mv(targetLocation: string, callback: (err: any) => {}): void;
+    }
+}

--- a/types/express-fileupload/tsconfig.json
+++ b/types/express-fileupload/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-fileupload-tests.ts"
+    ]
+}

--- a/types/express-fileupload/tslint.json
+++ b/types/express-fileupload/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.