### PR TITLE
Updated webappsec-credential-management specs to the latest Working Draft version of 08/04/2017.

### DIFF
--- a/types/webappsec-credential-management/index.d.ts
+++ b/types/webappsec-credential-management/index.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for W3C (WebAppSec) Credential Management API Level 1, 0.2
+// Type definitions for W3C (WebAppSec) Credential Management API Level 1, 0.3
 // Project: https://github.com/w3c/webappsec-credential-management
 // Definitions by: Iain McGinniss <https://github.com/iainmcgin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-// Spec: http://www.w3.org/TR/2016/WD-credential-management-1-20160425/
+// Spec: https://www.w3.org/TR/2017/WD-credential-management-1-20170804
 
 /* ************************* FETCH MODIFICATIONS *******************************
  * The credential management spec modifies fetch(), by adding a new
@@ -81,13 +81,34 @@ interface CredentialsContainer {
     store(credential: Credential): Promise<Credential>;
 
     /**
+     * Create a {@link Credential} asynchronously.
+     *
+     * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#dom-credentialscontainer-create}
+     */
+    create(options: CredentialCreationOptions): Promise<Credential|null>;
+
+    /**
      * Ask the credential manager to require user mediation before returning
      * credentials for the origin in which the method is called. This might be
      * called after a user signs out of a website, for instance, in order to
      * ensure that they are not automatically signed back in next time they
      * visits.
+     *
+     * @deprecated Use {@link preventSilentAccess} instead.
+     * @see {@link https://www.w3.org/TR/2016/WD-credential-management-1-20160425/#dom-credentialscontainer-requireusermediation}
      */
     requireUserMediation(): Promise<void>;
+
+    /**
+     * Ask the credential manager to require user mediation before returning
+     * credentials for the origin in which the method is called. This might be
+     * called after a user signs out of a website, for instance, in order to
+     * ensure that they are not automatically signed back in next time they
+     * visits.
+     *
+     * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#dom-credentialscontainer-preventsilentaccess}
+     */
+    preventSilentAccess(): Promise<void>;
 }
 
 /**
@@ -247,6 +268,11 @@ declare class FederatedCredential extends SiteBoundCredential {
 }
 
 /**
+ * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#enumdef-credentialmediationrequirement}
+ */
+type CredentialMediationRequirement = 'silent'|'optional'|'required';
+
+/**
  * @see {@link https://www.w3.org/TR/credential-management-1/#dictdef-credentialrequestoptions}
  */
 interface CredentialRequestOptions {
@@ -265,8 +291,40 @@ interface CredentialRequestOptions {
     /**
      * If {@code true}, the user agent will only attempt to provide a Credential
      * without user interaction. Defaults to {@code false}.
+     *
+     * @deprecated Use {@link mediation} instead.
      */
     unmediated?: boolean;
+
+    /**
+     * This property specifies the mediation requirements for a given credential
+     * request.
+     */
+    mediation?: CredentialMediationRequirement;
+}
+
+/**
+ * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#typedefdef-passwordcredentialinit}
+ */
+type PasswordCredentialInit = PasswordCredentialData|HTMLFormElement;
+
+/**
+ * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#dictdef-federatedcredentialinit}
+ */
+type FederatedCredentialInit = FederatedCredentialData;
+
+/**
+ * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#dictdef-credentialcreationoptions}
+ */
+interface CredentialCreationOptions {
+    /**
+     * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#dictdef-federatedcredentialinit}
+     */
+    password?: PasswordCredentialInit;
+    /**
+     * @see {@link https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#dom-credentialcreationoptions-federated}
+     */
+    federated?: FederatedCredentialInit;
 }
 
 /**

--- a/types/webappsec-credential-management/webappsec-credential-management-tests.ts
+++ b/types/webappsec-credential-management/webappsec-credential-management-tests.ts
@@ -21,6 +21,51 @@ function passwordBasedSignIn() {
     });
 }
 
+// https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#mediation-examples
+function signInMediationSilent() {
+    window.addEventListener('load', _ => {
+        if (!navigator.credentials) {
+            return;
+        }
+        navigator.credentials.get({
+            password: true,
+            mediation: 'silent'
+        }).then((credential) => {
+            // Hooray! Let’s sign the user in using these credentials!
+        });
+    });
+}
+
+// https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#mediation-examples
+function signInMediationRequired() {
+    window.addEventListener('load', _ => {
+        if (!navigator.credentials) {
+            return;
+        }
+        navigator.credentials.get({
+            password: true,
+            mediation: 'required'
+        }).then((credential) => {
+            // Hooray! Let’s sign the user in using these credentials!
+        });
+    });
+}
+
+// https://www.w3.org/TR/2017/WD-credential-management-1-20170804/#mediation-examples
+function signInMediationOptional() {
+    window.addEventListener('load', _ => {
+        if (!navigator.credentials) {
+            return;
+        }
+        navigator.credentials.get({
+            password: true,
+            mediation: 'optional'
+        }).then((credential) => {
+            // Hooray! Let’s sign the user in using these credentials!
+        });
+    });
+}
+
 // federated sign-in example from Section 1.2.2:
 // https://www.w3.org/TR/credential-management-1/#examples-federated-signin
 function federatedSignIn() {
@@ -121,12 +166,66 @@ function formEncodedPost(credential: PasswordCredential, token: string) {
 
 // requireUserMediation example: not included in the spec, but included here
 // to ensure it typechecks correctly.
-function signOut() {
+function signOutDeprecated() {
     if (!navigator.credentials) {
         return;
     }
 
     navigator.credentials.requireUserMediation().then(() => {
         document.location.assign('/');
+    });
+}
+
+function signOut() {
+    if (!navigator.credentials) {
+        return;
+    }
+
+    navigator.credentials.preventSilentAccess().then(() => {
+        document.location.assign('/');
+    });
+}
+
+// Example not included in spec but added to ensure it typechecks
+// correctly.
+function createPasswordCredential() {
+    if (!navigator.credentials) {
+        return;
+    }
+
+    navigator.credentials.create({
+        password: {id: 'username', password: 'password'}
+    }).then((credential) => {
+        // Credential created!
+    });
+}
+
+// Example not included in spec but added to ensure it typechecks
+// correctly.
+function createPasswordCredentialWithForm() {
+    if (!navigator.credentials) {
+        return;
+    }
+
+    const formElt = document.querySelector('#form') as HTMLFormElement;
+
+    navigator.credentials.create({
+        password: formElt
+    }).then((credential) => {
+        // Credential created!
+    });
+}
+
+// Example not included in spec but added to ensure it typechecks
+// correctly.
+function createFederatedCredential() {
+    if (!navigator.credentials) {
+        return;
+    }
+
+    navigator.credentials.create({
+        federated: {id: 'username', provider: 'provider'}
+    }).then((credential) => {
+        // Credential created!
     });
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.w3.org/TR/2017/WD-credential-management-1-20170804
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
