### PR TITLE
[fetch-mock] Added missing flush() method to FetchMockStatic

### DIFF
--- a/types/fetch-mock/fetch-mock-tests.ts
+++ b/types/fetch-mock/fetch-mock-tests.ts
@@ -1,4 +1,5 @@
 import * as fetchMock from "fetch-mock";
+import { MockResponse } from "fetch-mock";
 
 fetchMock.mock("http://test.com", 200);
 fetchMock.mock(/test\.com/, 200);
@@ -65,3 +66,6 @@ const myMatcher: fetchMock.MockMatcherFunction = (
   url: string,
   opts: fetchMock.MockRequest
 ) => true;
+
+fetchMock.flush().then(resolved => resolved.forEach(console.log));
+fetchMock.flush().catch(r => r);

--- a/types/fetch-mock/index.d.ts
+++ b/types/fetch-mock/index.d.ts
@@ -1,6 +1,9 @@
-// Type definitions for fetch-mock 5.8
+// Type definitions for fetch-mock 5.12
 // Project: https://github.com/wheresrhys/fetch-mock
-// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Tamir Duberstein <https://github.com/tamird>, Risto Keravuori <https://github.com/merrywhether>
+// Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
+//                 Tamir Duberstein <https://github.com/tamird>
+//                 Risto Keravuori <https://github.com/merrywhether>
+//                 Chris Sinclair <https://github.com/chrissinclair>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -332,6 +335,12 @@ declare namespace fetchMock {
          * Chainable method that clears all data recorded for fetch()'s calls
          */
         reset(): this;
+
+        /**
+         * Returns a promise that resolves once all fetches handled by fetch-mock
+         * have resolved.
+         */
+        flush(): Promise<MockResponse[]>;
 
         /**
          * Returns all calls to fetch, grouped by whether fetch-mock matched


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wheresrhys/fetch-mock/pull/187
https://github.com/wheresrhys/fetch-mock/issues/97
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (already available)
