### PR TITLE
Sequelize - added associate method to Model class

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3611,6 +3611,18 @@ declare namespace sequelize {
         Instance(): TInstance;
 
         /**
+         * Set up associations 
+         * eg .
+         * Submission.associate = function(models) {
+         *  Submission.hasMany(models.Transaction, {
+         *      foreignKey: 'submissionId',
+         *      as: 'transactions'
+         *     })
+         *  }
+         */
+        associate(models: any): void;
+
+        /**
          * Remove attribute from model definition
          *
          * @param attribute

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3612,6 +3612,7 @@ declare namespace sequelize {
 
         /**
          * Set up associations 
+         * 
          * eg .
          * Submission.associate = function(models) {
          *  Submission.hasMany(models.Transaction, {


### PR DESCRIPTION
Since version 4 the pattern for defining associations has changed as can be seen at 
http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html

This was giving me problems when testing as because this method was missing from the types library tsc was giving me a compile error.

Seems to be okay now I've added this. 
