### PR TITLE
[memory-fs] support ES6 import syntax

### DIFF
--- a/types/memory-fs/index.d.ts
+++ b/types/memory-fs/index.d.ts
@@ -80,4 +80,6 @@ declare class MemoryFileSystem {
     readFile(path: string, optArg: {}, callback: (err?: Error, result?: any) => any): void;
 }
 
+declare namespace MemoryFileSystem {}
+
 export = MemoryFileSystem;

--- a/types/memory-fs/test/index.ts
+++ b/types/memory-fs/test/index.ts
@@ -1,4 +1,4 @@
-import MemoryFileSystem = require('memory-fs');
+import * as MemoryFileSystem from 'memory-fs';
 
 const fs = new MemoryFileSystem({});
 


### PR DESCRIPTION
Support ES6 import syntax in `memory-fs`.
