### PR TITLE
[lodash] improved iteratee parameters, simplified forEach and flatMap overloads

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -6363,37 +6363,7 @@ declare namespace _ {
 
     //_.each
     interface LoDashStatic {
-        /**
-         * @see _.forEach
-         */
-        each<TString extends string | null | undefined>(
-            collection: TString,
-            iteratee?: StringIterator<any>
-        ): TString;
-
-        /**
-         * @see _.forEach
-         */
-        each<T, TList extends List<T> | null | undefined>(
-            collection: TList,
-            iteratee?: ListIterator<T, any>
-        ): TList;
-
-        /**
-         * @see _.forEach
-         */
-        each<T, TDictionary extends Dictionary<T> | null | undefined>(
-            collection: TDictionary,
-            iteratee?: DictionaryIterator<T, any>
-        ): TDictionary;
-
-        /**
-         * @see _.forEach
-         */
-        each<T extends {} | null | undefined>(
-            collection: T,
-            iteratee?: ObjectIterator<any, any>
-        ): T;
+        each: typeof _.forEach;
     }
 
     interface LoDashImplicitWrapper<T> {
@@ -6452,37 +6422,7 @@ declare namespace _ {
 
     //_.eachRight
     interface LoDashStatic {
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<TString extends string | null | undefined>(
-            collection: TString,
-            iteratee?: StringIterator<any>
-        ): TString;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T, TList extends List<T> | null | undefined>(
-            collection: TList,
-            iteratee?: ListIterator<T, any>
-        ): TList;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T, TDictionary extends Dictionary<T> | null | undefined>(
-            collection: TDictionary,
-            iteratee?: DictionaryIterator<T, any>
-        ): TDictionary;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T extends {} | null | undefined>(
-            collection: T,
-            iteratee?: ObjectIterator<any, any>
-        ): T;
+        eachRight: typeof _.forEachRight;
     }
 
     interface LoDashImplicitWrapper<T> {
@@ -7218,7 +7158,7 @@ declare namespace _ {
          * @see _.forEach
          */
         forEach<T, TList extends List<T> | null | undefined>(
-            collection: TList,
+            collection: TList & (List<T> | null | undefined),
             iteratee?: ListIterator<T, any>
         ): TList;
 
@@ -7226,7 +7166,7 @@ declare namespace _ {
          * @see _.forEach
          */
         forEach<T, TDictionary extends Dictionary<T> | null | undefined>(
-            collection: TDictionary,
+            collection: TDictionary & (Dictionary<T> | null | undefined),
             iteratee?: DictionaryIterator<T, any>
         ): TDictionary;
 
@@ -7313,7 +7253,7 @@ declare namespace _ {
          * @see _.forEachRight
          */
         forEachRight<T, TList extends List<T> | null | undefined>(
-            collection: TList,
+            collection: TList & (List<T> | null | undefined),
             iteratee?: ListIterator<T, any>
         ): TList;
 
@@ -7321,7 +7261,7 @@ declare namespace _ {
          * @see _.forEachRight
          */
         forEachRight<T, TDictionary extends Dictionary<T> | null | undefined>(
-            collection: TDictionary,
+            collection: TDictionary & (Dictionary<T> | null | undefined),
             iteratee?: DictionaryIterator<T, any>
         ): TDictionary;
 

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -7023,21 +7023,7 @@ declare namespace _ {
          * @return Returns the new flattened array.
          */
         flatMap<T>(
-            collection: List<Many<T>> | null | undefined
-        ): T[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<T>(
-            collection: Dictionary<Many<T>> | null | undefined
-        ): T[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<T>(
-            collection: NumericDictionary<Many<T>> | null | undefined
+            collection: List<Many<T>> | Dictionary<Many<T>> | NumericDictionary<Many<T>> | null | undefined
         ): T[];
 
         /**
@@ -7071,30 +7057,6 @@ declare namespace _ {
             collection: object | null | undefined,
             iteratee?: ObjectIterator<any, Many<TResult>> | string
         ): TResult[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap(
-            collection: List<any> | null | undefined,
-            iteratee: object
-        ): boolean[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap(
-            collection: Dictionary<any> | null | undefined,
-            iteratee: object
-        ): boolean[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap(
-            collection: NumericDictionary<any> | null | undefined,
-            iteratee: object
-        ): boolean[];
 
         /**
          * @see _.flatMap

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -6366,98 +6366,34 @@ declare namespace _ {
         /**
          * @see _.forEach
          */
-        each<T>(
-            collection: T[],
-            iteratee?: ListIterator<T, any>
-        ): T[];
-
-        /**
-         * @see _.forEach
-         */
-        each(
-            collection: string,
+        each<TString extends string | null | undefined>(
+            collection: TString,
             iteratee?: ListIterator<string, any>
-        ): string;
+        ): TString;
 
         /**
          * @see _.forEach
          */
-        each<T>(
-            collection: List<T>,
+        each<T, TList extends List<T> | null | undefined>(
+            collection: TList,
             iteratee?: ListIterator<T, any>
-        ): List<T>;
+        ): TList;
 
         /**
          * @see _.forEach
          */
-        each<T>(
-            collection: Dictionary<T>,
+        each<T, TDictionary extends Dictionary<T> | null | undefined>(
+            collection: TDictionary,
             iteratee?: DictionaryIterator<T, any>
-        ): Dictionary<T>;
+        ): TDictionary;
 
         /**
          * @see _.forEach
          */
-        each<T extends {}>(
+        each<T extends {} | null | undefined>(
             collection: T,
             iteratee?: ObjectIterator<any, any>
         ): T;
-
-        /**
-         * @see _.forEach
-         */
-        each<T extends {}, TValue>(
-            collection: T,
-            iteratee?: ObjectIterator<TValue, any>
-        ): T;
-
-        /**
-         * @see _.forEach
-         */
-        each<T>(
-            collection: T[] | null | undefined,
-            iteratee?: ListIterator<T, any>
-        ): T[] | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        each(
-            collection: string | null | undefined,
-            iteratee?: ListIterator<string, any>
-        ): string | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        each<T>(
-            collection: List<T> | null | undefined,
-            iteratee?: ListIterator<T, any>
-        ): List<T> | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        each<T>(
-            collection: Dictionary<T> | null | undefined,
-            iteratee?: DictionaryIterator<T, any>
-        ): Dictionary<T> | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        each<T extends {}>(
-            collection: T | null | undefined,
-            iteratee?: ObjectIterator<any, any>
-        ): T | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        each<T extends {}, TValue>(
-            collection: T | null | undefined,
-            iteratee?: ObjectIterator<TValue, any>
-        ): T | null | undefined;
     }
 
     interface LoDashImplicitWrapper<T> {
@@ -6519,98 +6455,34 @@ declare namespace _ {
         /**
          * @see _.forEachRight
          */
-        eachRight(
-            collection: string,
+        eachRight<TString extends string | null | undefined>(
+            collection: TString,
             iteratee?: ListIterator<string, any>
-        ): string;
+        ): TString;
 
         /**
          * @see _.forEachRight
          */
-        eachRight<T>(
-            collection: T[],
+        eachRight<T, TList extends List<T> | null | undefined>(
+            collection: TList,
             iteratee?: ListIterator<T, any>
-        ): T[];
+        ): TList;
 
         /**
          * @see _.forEachRight
          */
-        eachRight<T>(
-            collection: List<T>,
-            iteratee?: ListIterator<T, any>
-        ): List<T>;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T>(
-            collection: Dictionary<T>,
+        eachRight<T, TDictionary extends Dictionary<T> | null | undefined>(
+            collection: TDictionary,
             iteratee?: DictionaryIterator<T, any>
-        ): Dictionary<T>;
+        ): TDictionary;
 
         /**
          * @see _.forEachRight
          */
-        eachRight<T extends {}>(
+        eachRight<T extends {} | null | undefined>(
             collection: T,
             iteratee?: ObjectIterator<any, any>
         ): T;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T extends {}, TValue>(
-            collection: T,
-            iteratee?: ObjectIterator<TValue, any>
-        ): T;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight(
-            collection: string | null | undefined,
-            iteratee?: ListIterator<string, any>
-        ): string | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T>(
-            collection: T[] | null | undefined,
-            iteratee?: ListIterator<T, any>
-        ): T[] | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T>(
-            collection: List<T> | null | undefined,
-            iteratee?: ListIterator<T, any>
-        ): List<T> | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T>(
-            collection: Dictionary<T> | null | undefined,
-            iteratee?: DictionaryIterator<T, any>
-        ): Dictionary<T> | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T extends {}>(
-            collection: T | null | undefined,
-            iteratee?: ObjectIterator<any, any>
-        ): T | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        eachRight<T extends {}, TValue>(
-            collection: T | null | undefined,
-            iteratee?: ObjectIterator<TValue, any>
-        ): T | null | undefined;
     }
 
     interface LoDashImplicitWrapper<T> {
@@ -6703,15 +6575,7 @@ declare namespace _ {
          */
         every<T>(
             collection: List<T>|Dictionary<T>|NumericDictionary<T> | null | undefined,
-            predicate?: string|any[]
-        ): boolean;
-
-        /**
-         * @see _.every
-         */
-        every<T>(
-            collection: List<T>|Dictionary<T>|NumericDictionary<T> | null | undefined,
-            predicate?: PartialObject<T>
+            predicate?: string|any[]|PartialObject<T>
         ): boolean;
     }
 
@@ -6827,10 +6691,26 @@ declare namespace _ {
          * @param thisArg The this binding of predicate.
          * @return Returns the new filtered array.
          */
+        filter<T, S extends T>(
+            collection: List<T> | null | undefined,
+            predicate: ListIteratorTypeGuard<T, S>
+        ): S[];
+
+        /**
+         * @see _.filter
+         */
         filter<T>(
             collection: List<T> | null | undefined,
             predicate?: ListIterator<T, boolean>
         ): T[];
+
+        /**
+         * @see _.filter
+         */
+        filter<T, S extends T>(
+            collection: Dictionary<T> | null | undefined,
+            predicate: DictionaryIteratorTypeGuard<T, S>
+        ): S[];
 
         /**
          * @see _.filter
@@ -6853,15 +6733,7 @@ declare namespace _ {
          */
         filter<T>(
             collection: List<T>|Dictionary<T> | null | undefined,
-            predicate: string|RegExp
-        ): T[];
-
-        /**
-         * @see _.filter
-         */
-        filter<T>(
-            collection: List<T>|Dictionary<T> | null | undefined,
-            predicate: PartialObject<T>
+            predicate: string | [string, any] | RegExp | PartialObject<T>
         ): T[];
     }
 
@@ -6878,42 +6750,32 @@ declare namespace _ {
         /**
          * @see _.filter
          */
-        filter(
-            predicate: ListIterator<T, boolean>
-        ): LoDashImplicitArrayWrapper<T>;
+        filter<S extends T>(
+            predicate: ListIteratorTypeGuard<T, S>
+        ): LoDashImplicitArrayWrapper<S>;
 
         /**
          * @see _.filter
          */
         filter(
-            predicate: string|RegExp
+            predicate: ListIterator<T, boolean> | string | [string, any] | RegExp | PartialObject<T>
         ): LoDashImplicitArrayWrapper<T>;
-
-        /**
-         * @see _.filter
-         */
-        filter(predicate: PartialObject<T>): LoDashImplicitArrayWrapper<T>;
     }
 
     interface LoDashImplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.filter
          */
-        filter<T>(
-            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>
-        ): LoDashImplicitArrayWrapper<T>;
+        filter<T, S extends T>(
+            predicate: ListIteratorTypeGuard<T, S>
+        ): LoDashImplicitArrayWrapper<S>;
 
         /**
          * @see _.filter
          */
         filter<T>(
-            predicate: string|RegExp
+            predicate: ListIterator<T, boolean> | DictionaryIterator<T, boolean> | string | [string, any] | RegExp | PartialObject<T>
         ): LoDashImplicitArrayWrapper<T>;
-
-        /**
-         * @see _.filter
-         */
-        filter<T>(predicate: PartialObject<T>): LoDashImplicitArrayWrapper<T>;
     }
 
     interface LoDashExplicitWrapper<T> {
@@ -6929,42 +6791,32 @@ declare namespace _ {
         /**
          * @see _.filter
          */
-        filter(
-            predicate: ListIterator<T, boolean>
-        ): LoDashExplicitArrayWrapper<T>;
+        filter<S extends T>(
+            predicate: ListIteratorTypeGuard<T, S>
+        ): LoDashExplicitArrayWrapper<S>;
 
         /**
          * @see _.filter
          */
         filter(
-            predicate: string|RegExp
+            predicate: ListIterator<T, boolean> | string | [string, any] | RegExp | PartialObject<T>
         ): LoDashExplicitArrayWrapper<T>;
-
-        /**
-         * @see _.filter
-         */
-        filter(predicate: PartialObject<T>): LoDashExplicitArrayWrapper<T>;
     }
 
     interface LoDashExplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
         /**
          * @see _.filter
          */
-        filter<T>(
-            predicate: ListIterator<T, boolean>|DictionaryIterator<T, boolean>
-        ): LoDashExplicitArrayWrapper<T>;
+        filter<T, S extends T>(
+            predicate: ListIteratorTypeGuard<T, S>
+        ): LoDashExplicitArrayWrapper<S>;
 
         /**
          * @see _.filter
          */
         filter<T>(
-            predicate: string|RegExp
+            predicate: ListIterator<T, boolean> | DictionaryIterator<T, boolean> | string | [string, any] | RegExp | PartialObject<T>
         ): LoDashExplicitArrayWrapper<T>;
-
-        /**
-         * @see _.filter
-         */
-        filter<T>(predicate: PartialObject<T>): LoDashExplicitArrayWrapper<T>;
     }
 
     //_.find
@@ -6987,11 +6839,29 @@ declare namespace _ {
          * @param fromIndex The index to search from.
          * @return Returns the matched element, else undefined.
          */
+        find<T, S extends T>(
+            collection: List<T> | null | undefined,
+            predicate: ListIteratorTypeGuard<T, S>,
+            fromIndex?: number
+        ): S|undefined;
+        
+        /**
+         * @see _.find
+         */
         find<T>(
             collection: List<T> | null | undefined,
             predicate?: ListIterator<T, boolean>,
             fromIndex?: number
         ): T|undefined;
+
+        /**
+         * @see _.find
+         */
+        find<T, S extends T>(
+            collection: Dictionary<T> | null | undefined,
+            predicate: DictionaryIteratorTypeGuard<T, S>,
+            fromIndex?: number
+        ): S|undefined;
 
         /**
          * @see _.find
@@ -7007,16 +6877,7 @@ declare namespace _ {
          */
         find<T>(
             collection: List<T>|Dictionary<T> | null | undefined,
-            predicate?: string,
-            fromIndex?: number
-        ): T|undefined;
-
-        /**
-         * @see _.find
-         */
-        find<T>(
-            collection: List<T>|Dictionary<T> | null | undefined,
-            predicate?: PartialObject<T>,
+            predicate?: string | PartialObject<T> | [string, any],
             fromIndex?: number
         ): T|undefined;
     }
@@ -7025,24 +6886,16 @@ declare namespace _ {
         /**
          * @see _.find
          */
-        find(
-            predicate?: ListIterator<T, boolean>,
+        find<S extends T>(
+            predicate: ListIteratorTypeGuard<T, S>,
             fromIndex?: number
-        ): T|undefined;
+        ): S|undefined;
 
         /**
          * @see _.find
          */
         find(
-            predicate?: string,
-            fromIndex?: number
-        ): T|undefined;
-
-        /**
-         * @see _.find
-         */
-        find(
-            predicate?: PartialObject<T>,
+            predicate?: ListIterator<T, boolean> | string | PartialObject<T> | [string, any],
             fromIndex?: number
         ): T|undefined;
     }
@@ -7052,23 +6905,7 @@ declare namespace _ {
          * @see _.find
          */
         find<TResult>(
-            predicate?: ListIterator<TResult, boolean>|DictionaryIterator<TResult, boolean>,
-            fromIndex?: number
-        ): TResult|undefined;
-
-        /**
-         * @see _.find
-         */
-        find<TResult>(
-            predicate?: string,
-            fromIndex?: number
-        ): TResult|undefined;
-
-        /**
-         * @see _.find
-         */
-        find<TResult>(
-            predicate?: PartialObject<TResult>,
+            predicate?: ListIterator<TResult, boolean> | DictionaryIterator<TResult, boolean> | string | PartialObject<TResult> | [string, any],
             fromIndex?: number
         ): TResult|undefined;
     }
@@ -7078,23 +6915,7 @@ declare namespace _ {
          * @see _.find
          */
         find(
-            predicate?: ListIterator<T, boolean>,
-            fromIndex?: number
-        ): any;
-
-        /**
-         * @see _.find
-         */
-        find(
-            predicate?: string,
-            fromIndex?: number
-        ): any;
-
-        /**
-         * @see _.find
-         */
-        find(
-            predicate?: PartialObject<T>,
+            predicate?: ListIterator<T, boolean> | string | PartialObject<T> | [string, any],
             fromIndex?: number
         ): any;
     }
@@ -7105,120 +6926,79 @@ declare namespace _ {
         * This method is like _.find except that it iterates over elements of a collection from
         * right to left.
         * @param collection Searches for a value in this list.
-        * @param callback The function called per iteration.
+        * @param predicate The function called per iteration.
         * @param fromIndex The index to search from.
         * @return The found element, else undefined.
         **/
-        findLast<T>(
-            collection: T[] | null | undefined,
-            callback: ListIterator<T, boolean>,
+        findLast<T, S extends T>(
+            collection: List<T> | null | undefined,
+            predicate: ListIteratorTypeGuard<T, S>,
             fromIndex?: number
-        ): T|undefined;
-
+        ): S|undefined;
+        
         /**
-        * @see _.find
-        **/
+         * @see _.findLast
+         */
         findLast<T>(
             collection: List<T> | null | undefined,
-            callback: ListIterator<T, boolean>,
+            predicate?: ListIterator<T, boolean>,
             fromIndex?: number
         ): T|undefined;
 
         /**
-        * @see _.find
-        **/
+         * @see _.findLast
+         */
+        findLast<T, S extends T>(
+            collection: Dictionary<T> | null | undefined,
+            predicate: DictionaryIteratorTypeGuard<T, S>,
+            fromIndex?: number
+        ): S|undefined;
+
+        /**
+         * @see _.findLast
+         */
         findLast<T>(
             collection: Dictionary<T> | null | undefined,
-            callback: DictionaryIterator<T, boolean>,
+            predicate?: DictionaryIterator<T, boolean>,
             fromIndex?: number
         ): T|undefined;
 
         /**
-        * @see _.find
-        * @param _.pluck style callback
-        **/
-        findLast<W, T>(
-            collection: T[] | null | undefined,
-            whereValue: W,
-            fromIndex?: number
-        ): T|undefined;
-
-        /**
-        * @see _.find
-        * @param _.pluck style callback
-        **/
-        findLast<W, T>(
-            collection: List<T> | null | undefined,
-            whereValue: W,
-            fromIndex?: number
-        ): T|undefined;
-
-        /**
-        * @see _.find
-        * @param _.pluck style callback
-        **/
-        findLast<W, T>(
-            collection: Dictionary<T> | null | undefined,
-            whereValue: W,
-            fromIndex?: number
-        ): T|undefined;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
+         * @see _.findLast
+         */
         findLast<T>(
-            collection: T[] | null | undefined,
-            pluckValue: string,
-            fromIndex?: number
-        ): T|undefined;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
-        findLast<T>(
-            collection: List<T> | null | undefined,
-            pluckValue: string,
-            fromIndex?: number
-        ): T|undefined;
-
-        /**
-        * @see _.find
-        * @param _.where style callback
-        **/
-        findLast<T>(
-            collection: Dictionary<T> | null | undefined,
-            pluckValue: string,
+            collection: List<T>|Dictionary<T> | null | undefined,
+            predicate?: string | PartialObject<T> | [string, any],
             fromIndex?: number
         ): T|undefined;
     }
 
     interface LoDashImplicitArrayWrapperBase<T, TArray extends T[] | null | undefined, TWrapper> {
         /**
-        * @see _.findLast
-        */
-        findLast(
-            callback: ListIterator<T, boolean>,
+         * @see _.findLast
+         */
+        findLast<S extends T>(
+            predicate: ListIteratorTypeGuard<T, S>,
             fromIndex?: number
-        ): T|undefined;
-        /**
-        * @see _.findLast
-        * @param _.where style callback
-        */
-        findLast<W>(
-            whereValue: W,
-            fromIndex?: number
-        ): T|undefined;
+        ): S|undefined;
 
         /**
-        * @see _.findLast
-        * @param _.where style callback
-        */
+         * @see _.findLast
+         */
         findLast(
-            pluckValue: string,
+            predicate?: ListIterator<T, boolean> | string | PartialObject<T> | [string, any],
             fromIndex?: number
         ): T|undefined;
+    }
+
+    interface LoDashImplicitObjectWrapperBase<T, TObject extends T | null | undefined, TWrapper> {
+        /**
+         * @see _.findLast
+         */
+        findLast<TResult>(
+            predicate?: ListIterator<TResult, boolean> | DictionaryIterator<TResult, boolean> | string | PartialObject<TResult> | [string, any],
+            fromIndex?: number
+        ): TResult|undefined;
     }
 
     interface LoDashExplicitWrapperBase<T, TWrapper> {
@@ -7226,23 +7006,7 @@ declare namespace _ {
          * @see _.findLast
          */
         findLast(
-            predicate?: ListIterator<T, boolean>,
-            fromIndex?: number
-        ): any;
-
-        /**
-         * @see _.findLast
-         */
-        findLast(
-            predicate?: string,
-            fromIndex?: number
-        ): any;
-
-        /**
-         * @see _.findLast
-         */
-        findLast(
-            predicate?: PartialObject<T>,
+            predicate?: ListIterator<T, boolean> | string | PartialObject<T> | [string, any],
             fromIndex?: number
         ): any;
     }
@@ -7258,9 +7022,16 @@ declare namespace _ {
          * @param iteratee The function invoked per iteration.
          * @return Returns the new flattened array.
          */
+        flatMap<T>(
+            collection: List<Many<T>> | null | undefined
+        ): T[];
+
+        /**
+         * @see _.flatMap
+         */
         flatMap<T, TResult>(
             collection: List<T> | null | undefined,
-            iteratee?: ListIterator<T, Many<TResult>>
+            iteratee: ListIterator<T, Many<TResult>>
         ): TResult[];
 
         /**
@@ -7268,15 +7039,22 @@ declare namespace _ {
          */
         flatMap<TResult>(
             collection: List<any> | null | undefined,
-            iteratee?: ListIterator<any, Many<TResult>>
+            iteratee: ListIterator<any, Many<TResult>>
         ): TResult[];
+
+        /**
+         * @see _.flatMap
+         */
+        flatMap<T>(
+            collection: Dictionary<Many<T>> | null | undefined
+        ): T[];
 
         /**
          * @see _.flatMap
          */
         flatMap<T, TResult>(
             collection: Dictionary<T> | null | undefined,
-            iteratee?: DictionaryIterator<T, Many<TResult>>
+            iteratee: DictionaryIterator<T, Many<TResult>>
         ): TResult[];
 
         /**
@@ -7284,15 +7062,22 @@ declare namespace _ {
          */
         flatMap<TResult>(
             collection: Dictionary<any> | null | undefined,
-            iteratee?: DictionaryIterator<any, Many<TResult>>
+            iteratee: DictionaryIterator<any, Many<TResult>>
         ): TResult[];
+
+        /**
+         * @see _.flatMap
+         */
+        flatMap<T>(
+            collection: NumericDictionary<Many<T>> | null | undefined
+        ): T[];
 
         /**
          * @see _.flatMap
          */
         flatMap<T, TResult>(
             collection: NumericDictionary<T> | null | undefined,
-            iteratee?: NumericDictionaryIterator<T, Many<TResult>>
+            iteratee: NumericDictionaryIterator<T, Many<TResult>>
         ): TResult[];
 
         /**
@@ -7300,7 +7085,7 @@ declare namespace _ {
          */
         flatMap<TResult>(
             collection: NumericDictionary<any> | null | undefined,
-            iteratee?: NumericDictionaryIterator<any, Many<TResult>>
+            iteratee: NumericDictionaryIterator<any, Many<TResult>>
         ): TResult[];
 
         /**
@@ -7529,98 +7314,34 @@ declare namespace _ {
          * @param iteratee The function invoked per iteration.
          * @param thisArg The this binding of iteratee.
          */
-        forEach<T>(
-            collection: T[],
-            iteratee?: ListIterator<T, any>
-        ): T[];
-
-        /**
-         * @see _.forEach
-         */
-        forEach(
-            collection: string,
+        eachRight<TString extends string | null | undefined>(
+            collection: TString,
             iteratee?: ListIterator<string, any>
-        ): string;
+        ): TString;
 
         /**
          * @see _.forEach
          */
-        forEach<T>(
-            collection: List<T>,
+        forEach<T, TList extends List<T> | null | undefined>(
+            collection: TList,
             iteratee?: ListIterator<T, any>
-        ): List<T>;
+        ): TList;
 
         /**
          * @see _.forEach
          */
-        forEach<T>(
-            collection: Dictionary<T>,
+        forEach<T, TDictionary extends Dictionary<T> | null | undefined>(
+            collection: TDictionary,
             iteratee?: DictionaryIterator<T, any>
-        ): Dictionary<T>;
+        ): TDictionary;
 
         /**
          * @see _.forEach
          */
-        forEach<T extends {}>(
+        forEach<T extends {} | null | undefined>(
             collection: T,
             iteratee?: ObjectIterator<any, any>
         ): T;
-
-        /**
-         * @see _.forEach
-         */
-        forEach<T extends {}, TValue>(
-            collection: T,
-            iteratee?: ObjectIterator<TValue, any>
-        ): T;
-
-        /**
-         * @see _.forEach
-         */
-        forEach<T>(
-            collection: T[] | null | undefined,
-            iteratee?: ListIterator<T, any>
-        ): T[] | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        forEach(
-            collection: string | null | undefined,
-            iteratee?: ListIterator<string, any>
-        ): string | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        forEach<T>(
-            collection: List<T> | null | undefined,
-            iteratee?: ListIterator<T, any>
-        ): List<T> | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        forEach<T>(
-            collection: Dictionary<T> | null | undefined,
-            iteratee?: DictionaryIterator<T, any>
-        ): Dictionary<T> | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        forEach<T extends {}>(
-            collection: T | null | undefined,
-            iteratee?: ObjectIterator<any, any>
-        ): T | null | undefined;
-
-        /**
-         * @see _.forEach
-         */
-        forEach<T extends {}, TValue>(
-            collection: T | null | undefined,
-            iteratee?: ObjectIterator<TValue, any>
-        ): T | null | undefined;
     }
 
     interface LoDashImplicitWrapper<T> {
@@ -7688,98 +7409,34 @@ declare namespace _ {
          * @param iteratee The function called per iteration.
          * @param thisArg The this binding of callback.
          */
-        forEachRight<T>(
-            collection: T[],
-            iteratee?: ListIterator<T, any>
-        ): T[];
-
-        /**
-         * @see _.forEachRight
-         */
-        forEachRight(
-            collection: string,
+        forEachRight<TString extends string | null | undefined>(
+            collection: TString,
             iteratee?: ListIterator<string, any>
-        ): string;
+        ): TString;
 
         /**
          * @see _.forEachRight
          */
-        forEachRight<T>(
-            collection: List<T>,
+        forEachRight<T, TList extends List<T> | null | undefined>(
+            collection: TList,
             iteratee?: ListIterator<T, any>
-        ): List<T>;
+        ): TList;
 
         /**
          * @see _.forEachRight
          */
-        forEachRight<T>(
-            collection: Dictionary<T>,
+        forEachRight<T, TDictionary extends Dictionary<T> | null | undefined>(
+            collection: TDictionary,
             iteratee?: DictionaryIterator<T, any>
-        ): Dictionary<T>;
+        ): TDictionary;
 
         /**
          * @see _.forEachRight
          */
-        forEachRight<T extends {}>(
+        forEachRight<T extends {} | null | undefined>(
             collection: T,
             iteratee?: ObjectIterator<any, any>
         ): T;
-
-        /**
-         * @see _.forEachRight
-         */
-        forEachRight<T extends {}, TValue>(
-            collection: T,
-            iteratee?: ObjectIterator<TValue, any>
-        ): T;
-
-        /**
-         * @see _.forEachRight
-         */
-        forEachRight<T>(
-            collection: T[] | null | undefined,
-            iteratee?: ListIterator<T, any>
-        ): T[] | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        forEachRight(
-            collection: string | null | undefined,
-            iteratee?: ListIterator<string, any>
-        ): string | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        forEachRight<T>(
-            collection: List<T> | null | undefined,
-            iteratee?: ListIterator<T, any>
-        ): List<T> | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        forEachRight<T>(
-            collection: Dictionary<T> | null | undefined,
-            iteratee?: DictionaryIterator<T, any>
-        ): Dictionary<T> | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        forEachRight<T extends {}>(
-            collection: T | null | undefined,
-            iteratee?: ObjectIterator<any, any>
-        ): T | null | undefined;
-
-        /**
-         * @see _.forEachRight
-         */
-        forEachRight<T extends {}, TValue>(
-            collection: T | null | undefined,
-            iteratee?: ObjectIterator<TValue, any>
-        ): T | null | undefined;
     }
 
     interface LoDashImplicitWrapper<T> {
@@ -13834,7 +13491,12 @@ declare namespace _ {
        */
       meanBy<T>(
         collection: List<T> | null | undefined,
-        iteratee?: DictionaryIterator<T, any>
+        iteratee?: ListIterator<T, any> | string
+      ): number;
+
+      meanBy<T>(
+        collection: Dictionary<T> | null | undefined,
+        iteratee?: DictionaryIterator<T, any> | string
       ): number;
     }
 
@@ -18990,9 +18652,9 @@ declare namespace _ {
          * _.filter(users, 'age > 36');
          * // => [{ 'user': 'fred', 'age': 40 }]
          */
-        iteratee<TResult>(
-            func: Function
-        ): (...args: any[]) => TResult;
+        iteratee<TFunction extends Function>(
+            func: TFunction
+        ): TFunction;
 
         /**
          * @see _.iteratee
@@ -19958,7 +19620,11 @@ declare namespace _ {
 
     type ListIterator<T, TResult> = (value: T, index: number, collection: List<T>) => TResult;
 
+    type ListIteratorTypeGuard<T, S extends T> = (value: T, index: number, collection: List<T>) => value is S;
+
     type DictionaryIterator<T, TResult> = (value: T, key: string, collection: Dictionary<T>) => TResult;
+
+    type DictionaryIteratorTypeGuard<T, S extends T> = (value: T, key: string, collection: Dictionary<T>) => value is S;
 
     type NumericDictionaryIterator<T, TResult> = (value: T, key: number, collection: Dictionary<T>) => TResult;
 

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -6368,7 +6368,7 @@ declare namespace _ {
          */
         each<TString extends string | null | undefined>(
             collection: TString,
-            iteratee?: ListIterator<string, any>
+            iteratee?: StringIterator<any>
         ): TString;
 
         /**
@@ -6401,7 +6401,7 @@ declare namespace _ {
          * @see _.forEach
          */
         each(
-            iteratee: ListIterator<string, any>
+            iteratee: StringIterator<any>
         ): LoDashImplicitWrapper<string>;
     }
 
@@ -6428,7 +6428,7 @@ declare namespace _ {
          * @see _.forEach
          */
         each(
-            iteratee: ListIterator<string, any>
+            iteratee: StringIterator<any>
         ): LoDashExplicitWrapper<string>;
     }
 
@@ -6457,7 +6457,7 @@ declare namespace _ {
          */
         eachRight<TString extends string | null | undefined>(
             collection: TString,
-            iteratee?: ListIterator<string, any>
+            iteratee?: StringIterator<any>
         ): TString;
 
         /**
@@ -6490,7 +6490,7 @@ declare namespace _ {
          * @see _.forEachRight
          */
         eachRight(
-            iteratee: ListIterator<string, any>
+            iteratee: StringIterator<any>
         ): LoDashImplicitWrapper<string>;
     }
 
@@ -6517,7 +6517,7 @@ declare namespace _ {
          * @see _.forEachRight
          */
         eachRight(
-            iteratee: ListIterator<string, any>
+            iteratee: StringIterator<any>
         ): LoDashExplicitWrapper<string>;
     }
 
@@ -7029,41 +7029,9 @@ declare namespace _ {
         /**
          * @see _.flatMap
          */
-        flatMap<T, TResult>(
-            collection: List<T> | null | undefined,
-            iteratee: ListIterator<T, Many<TResult>>
-        ): TResult[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<TResult>(
-            collection: List<any> | null | undefined,
-            iteratee: ListIterator<any, Many<TResult>>
-        ): TResult[];
-
-        /**
-         * @see _.flatMap
-         */
         flatMap<T>(
             collection: Dictionary<Many<T>> | null | undefined
         ): T[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<T, TResult>(
-            collection: Dictionary<T> | null | undefined,
-            iteratee: DictionaryIterator<T, Many<TResult>>
-        ): TResult[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<TResult>(
-            collection: Dictionary<any> | null | undefined,
-            iteratee: DictionaryIterator<any, Many<TResult>>
-        ): TResult[];
 
         /**
          * @see _.flatMap
@@ -7076,72 +7044,65 @@ declare namespace _ {
          * @see _.flatMap
          */
         flatMap<T, TResult>(
+            collection: List<T> | null | undefined,
+            iteratee: ListIterator<T, Many<TResult>> | string
+        ): TResult[];
+
+        /**
+         * @see _.flatMap
+         */
+        flatMap<T, TResult>(
+            collection: Dictionary<T> | null | undefined,
+            iteratee: DictionaryIterator<T, Many<TResult>> | string
+        ): TResult[];
+
+        /**
+         * @see _.flatMap
+         */
+        flatMap<T, TResult>(
             collection: NumericDictionary<T> | null | undefined,
-            iteratee: NumericDictionaryIterator<T, Many<TResult>>
+            iteratee: NumericDictionaryIterator<T, Many<TResult>> | string
         ): TResult[];
 
         /**
          * @see _.flatMap
          */
         flatMap<TResult>(
+            collection: object | null | undefined,
+            iteratee?: ObjectIterator<any, Many<TResult>> | string
+        ): TResult[];
+
+        /**
+         * @see _.flatMap
+         */
+        flatMap(
+            collection: List<any> | null | undefined,
+            iteratee: object
+        ): boolean[];
+
+        /**
+         * @see _.flatMap
+         */
+        flatMap(
+            collection: Dictionary<any> | null | undefined,
+            iteratee: object
+        ): boolean[];
+
+        /**
+         * @see _.flatMap
+         */
+        flatMap(
             collection: NumericDictionary<any> | null | undefined,
-            iteratee: NumericDictionaryIterator<any, Many<TResult>>
-        ): TResult[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<TObject extends Object, TResult>(
-            collection: TObject | null | undefined,
-            iteratee?: ObjectIterator<any, Many<TResult>>
-        ): TResult[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<TResult>(
-            collection: Object | null | undefined,
-            iteratee?: ObjectIterator<any, Many<TResult>>
-        ): TResult[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<TWhere extends Object, TObject extends Object>(
-            collection: TObject | null | undefined,
-            iteratee: TWhere
+            iteratee: object
         ): boolean[];
 
         /**
          * @see _.flatMap
          */
-        flatMap<TObject extends Object, TResult>(
-            collection: TObject | null | undefined,
-            iteratee: Object|string
-        ): TResult[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<TObject extends Object>(
-            collection: TObject | null | undefined,
-            iteratee: [string, any]
+        flatMap(
+            collection: object | null | undefined,
+            iteratee: object
         ): boolean[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<TResult>(
-            collection: string | null | undefined
-        ): string[];
-
-        /**
-         * @see _.flatMap
-         */
-        flatMap<TResult>(
-            collection: Object | null | undefined,
-            iteratee?: Object|string
-        ): TResult[];
     }
 
     interface LoDashImplicitWrapper<T> {
@@ -7149,7 +7110,7 @@ declare namespace _ {
          * @see _.flatMap
          */
         flatMap<TResult>(
-            iteratee: ListIterator<string, Many<TResult>>
+            iteratee: StringIterator<Many<TResult>>
         ): LoDashImplicitArrayWrapper<TResult>;
 
         /**
@@ -7169,15 +7130,8 @@ declare namespace _ {
         /**
          * @see _.flatMap
          */
-        flatMap<TWhere extends Object>(
-            iteratee: TWhere
-        ): LoDashImplicitArrayWrapper<boolean>;
-
-        /**
-         * @see _.flatMap
-         */
         flatMap(
-            iteratee: [string, any]
+            iteratee: object
         ): LoDashImplicitArrayWrapper<boolean>;
 
         /**
@@ -7204,15 +7158,8 @@ declare namespace _ {
         /**
          * @see _.flatMap
          */
-        flatMap<TWhere extends Object>(
-            iteratee: TWhere
-        ): LoDashImplicitArrayWrapper<boolean>;
-
-        /**
-         * @see _.flatMap
-         */
         flatMap(
-            iteratee: [string, any]
+            iteratee: object
         ): LoDashImplicitArrayWrapper<boolean>;
 
         /**
@@ -7226,7 +7173,7 @@ declare namespace _ {
          * @see _.flatMap
          */
         flatMap<TResult>(
-            iteratee: ListIterator<string, Many<TResult>>
+            iteratee: StringIterator<Many<TResult>>
         ): LoDashExplicitArrayWrapper<TResult>;
 
         /**
@@ -7246,15 +7193,8 @@ declare namespace _ {
         /**
          * @see _.flatMap
          */
-        flatMap<TWhere extends Object>(
-            iteratee: TWhere
-        ): LoDashExplicitArrayWrapper<boolean>;
-
-        /**
-         * @see _.flatMap
-         */
         flatMap(
-            iteratee: [string, any]
+            iteratee: object
         ): LoDashExplicitArrayWrapper<boolean>;
 
         /**
@@ -7281,15 +7221,8 @@ declare namespace _ {
         /**
          * @see _.flatMap
          */
-        flatMap<TWhere extends Object>(
-            iteratee: TWhere
-        ): LoDashExplicitArrayWrapper<boolean>;
-
-        /**
-         * @see _.flatMap
-         */
         flatMap(
-            iteratee: [string, any]
+            iteratee: object
         ): LoDashExplicitArrayWrapper<boolean>;
 
         /**
@@ -7314,9 +7247,9 @@ declare namespace _ {
          * @param iteratee The function invoked per iteration.
          * @param thisArg The this binding of iteratee.
          */
-        eachRight<TString extends string | null | undefined>(
+        forEach<TString extends string | null | undefined>(
             collection: TString,
-            iteratee?: ListIterator<string, any>
+            iteratee?: StringIterator<any>
         ): TString;
 
         /**
@@ -7349,7 +7282,7 @@ declare namespace _ {
          * @see _.forEach
          */
         forEach(
-            iteratee: ListIterator<string, any>
+            iteratee: StringIterator<any>
         ): LoDashImplicitWrapper<string>;
     }
 
@@ -7376,7 +7309,7 @@ declare namespace _ {
          * @see _.forEach
          */
         forEach(
-            iteratee: ListIterator<string, any>
+            iteratee: StringIterator<any>
         ): LoDashExplicitWrapper<string>;
     }
 
@@ -7411,7 +7344,7 @@ declare namespace _ {
          */
         forEachRight<TString extends string | null | undefined>(
             collection: TString,
-            iteratee?: ListIterator<string, any>
+            iteratee?: StringIterator<any>
         ): TString;
 
         /**
@@ -7444,7 +7377,7 @@ declare namespace _ {
          * @see _.forEachRight
          */
         forEachRight(
-            iteratee: ListIterator<string, any>
+            iteratee: StringIterator<any>
         ): LoDashImplicitWrapper<string>;
     }
 
@@ -7471,7 +7404,7 @@ declare namespace _ {
          * @see _.forEachRight
          */
         forEachRight(
-            iteratee: ListIterator<string, any>
+            iteratee: StringIterator<any>
         ): LoDashExplicitWrapper<string>;
     }
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -718,6 +718,7 @@ namespace TestFindIndex {
         result = _.findIndex<TResult>(list, '');
         result = _.findIndex<{a: number}, TResult>(list, {a: 42});
         result = _.findIndex<TResult>(list, predicateFn, fromIndex);
+        result = _.findIndex([{ b: 5 }], ['b', 5]);
 
         result = _<TResult>(array).findIndex();
         result = _<TResult>(array).findIndex(predicateFn);
@@ -771,6 +772,7 @@ namespace TestFindLastIndex {
         result = _.findLastIndex<TResult>(list, '');
         result = _.findLastIndex<{a: number}, TResult>(list, {a: 42});
         result = _.findLastIndex<TResult>(list, predicateFn, fromIndex);
+        result = _.findLastIndex([{ b: 5 }], ['b', 5]);
 
         result = _<TResult>(array).findLastIndex();
         result = _<TResult>(array).findLastIndex(predicateFn);
@@ -3445,8 +3447,9 @@ namespace TestEach {
     let dictionary: _.Dictionary<TResult> = {};
     let nilArray: TResult[] | null | undefined = [] as any;
     let nilList: _.List<TResult> | null | undefined = [] as any;
-    let obj: any = {};
-    let nilDictionary: _.Dictionary<TResult> | null | undefined = obj;
+    let nilDictionary: _.Dictionary<TResult> | null | undefined = any;
+    let undefinedList: _.List<TResult> | undefined = [] as any;
+    let undefinedDictionary: _.Dictionary<TResult> | undefined = any;
 
     let stringIterator: (char: string, index: number, string: string) => any = (char: string, index: number, string: string) => 1;
     let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value: TResult, index: number, collection: _.List<TResult>) => 1;
@@ -3467,37 +3470,49 @@ namespace TestEach {
     {
         let result: TResult[];
 
-        result = _.each<TResult>(array, listIterator);
+        result = _.each(array, listIterator);
     }
 
     {
         let result: TResult[] | null | undefined;
 
-        result = _.each<TResult>(nilArray, listIterator);
+        result = _.each(nilArray, listIterator);
     }
 
     {
         let result: _.List<TResult>;
 
-        result = _.each<TResult>(list, listIterator);
+        result = _.each(list, listIterator);
     }
 
     {
         let result: _.List<TResult> | null | undefined;
 
-        result = _.each<TResult>(nilList, listIterator);
+        result = _.each(nilList, listIterator);
     }
 
     {
         let result: _.Dictionary<TResult | null | undefined>;
 
-        result = _.each<TResult>(dictionary, dictionaryIterator);
+        result = _.each(dictionary, dictionaryIterator);
     }
 
     {
         let result: _.Dictionary<TResult> | null | undefined;
 
-        result = _.each<TResult>(nilDictionary, dictionaryIterator);
+        result = _.each(nilDictionary, dictionaryIterator);
+    }
+
+    {
+        let result: _.List<TResult> | undefined;
+
+        result = _.each(undefinedList, listIterator);
+    }
+
+    {
+        let result: _.Dictionary<TResult> | undefined;
+
+        result = _.each(undefinedDictionary, dictionaryIterator);
     }
 
     {
@@ -3556,8 +3571,9 @@ namespace TestEachRight {
     let dictionary: _.Dictionary<TResult> = {};
     let nilArray: TResult[] | null | undefined = [] as any;
     let nilList: _.List<TResult> | null | undefined = [] as any;
-    let obj: any = {};
-    let nilDictionary: _.Dictionary<TResult> | null | undefined = obj;
+    let nilDictionary: _.Dictionary<TResult> | null | undefined = any;
+    let undefinedList: _.List<TResult> | undefined = [] as any;
+    let undefinedDictionary: _.Dictionary<TResult> | undefined = any;
 
     let stringIterator: (char: string, index: number, string: string) => any = (char: string, index: number, string: string) => 1;
     let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value: TResult, index: number, collection: _.List<TResult>) => 1;
@@ -3578,37 +3594,49 @@ namespace TestEachRight {
     {
         let result: TResult[];
 
-        result = _.eachRight<TResult>(array, listIterator);
+        result = _.eachRight(array, listIterator);
     }
 
     {
         let result: TResult[] | null | undefined;
 
-        result = _.eachRight<TResult>(nilArray, listIterator);
+        result = _.eachRight(nilArray, listIterator);
     }
 
     {
         let result: _.List<TResult>;
 
-        result = _.eachRight<TResult>(list, listIterator);
+        result = _.eachRight(list, listIterator);
     }
 
     {
         let result: _.List<TResult> | null | undefined;
 
-        result = _.eachRight<TResult>(nilList, listIterator);
+        result = _.eachRight(nilList, listIterator);
     }
 
     {
         let result: _.Dictionary<TResult | null | undefined>;
 
-        result = _.eachRight<TResult>(dictionary, dictionaryIterator);
+        result = _.eachRight(dictionary, dictionaryIterator);
     }
 
     {
         let result: _.Dictionary<TResult> | null | undefined;
 
-        result = _.eachRight<TResult>(nilDictionary, dictionaryIterator);
+        result = _.eachRight(nilDictionary, dictionaryIterator);
+    }
+
+    {
+        let result: _.List<TResult> | undefined;
+
+        result = _.eachRight(undefinedList, listIterator);
+    }
+
+    {
+        let result: _.Dictionary<TResult> | undefined;
+
+        result = _.eachRight(undefinedDictionary, dictionaryIterator);
     }
 
     {
@@ -3779,16 +3807,19 @@ namespace TestFilter {
         result = _.filter<TResult>(array, '');
         result = _.filter<TResult>(array, /./);
         result = _.filter<TResult>(array, {a: 42});
+        result = _.filter<TResult>(array, ["a", 42]);
 
         result = _.filter<TResult>(list, listIterator);
         result = _.filter<TResult>(list, '');
         result = _.filter<TResult>(list, /./);
         result = _.filter<TResult>(list, {a: 42});
+        result = _.filter<TResult>(list, ["a", 42]);
 
         result = _.filter<TResult>(dictionary, dictionaryIterator);
         result = _.filter<TResult>(dictionary, '');
         result = _.filter<TResult>(dictionary, /./);
         result = _.filter<TResult>(dictionary, {a: 42});
+        result = _.filter<TResult>(dictionary, ["a", 42]);
     }
 
     {
@@ -3804,16 +3835,19 @@ namespace TestFilter {
         result = _(array).filter('');
         result = _(array).filter(/./);
         result = _(array).filter({a: 42});
+        result = _(array).filter(["a", 42]);
 
         result = _(list).filter<TResult>(listIterator);
         result = _(list).filter<TResult>('');
         result = _(list).filter<TResult>(/./);
         result = _(list).filter<TResult>({a: 42});
+        result = _(list).filter<TResult>(["a", 42]);
 
         result = _(dictionary).filter<TResult>(dictionaryIterator);
         result = _(dictionary).filter<TResult>('');
         result = _(dictionary).filter<TResult>(/./);
         result = _(dictionary).filter<TResult>({a: 42});
+        result = _(dictionary).filter<TResult>(["a", 42]);
     }
 
     {
@@ -3829,16 +3863,32 @@ namespace TestFilter {
         result = _(array).chain().filter('');
         result = _(array).chain().filter(/./);
         result = _(array).chain().filter({a: 42});
+        result = _(array).chain().filter(["a", 42]);
 
         result = _(list).chain().filter<TResult>(listIterator);
         result = _(list).chain().filter<TResult>('');
         result = _(list).chain().filter<TResult>(/./);
         result = _(list).chain().filter<TResult>({a: 42});
+        result = _(list).chain().filter<TResult>(["a", 42]);
 
         result = _(dictionary).chain().filter<TResult>(dictionaryIterator);
         result = _(dictionary).chain().filter<TResult>('');
         result = _(dictionary).chain().filter<TResult>(/./);
         result = _(dictionary).chain().filter<TResult>({a: 42});
+        result = _(dictionary).chain().filter<TResult>(["a", 42]);
+    }
+
+    {
+        // Test filtering with type guard
+        let a2: Array<string | number> | null | undefined = any;
+        let d2: _.Dictionary<string | number> | null | undefined = any;
+
+        _.filter(a2, (item: string | number): item is number => typeof item === "number"); // $ExpectType number[]
+        _.filter(d2, (item: string | number): item is number => typeof item === "number"); // $ExpectType number[]
+        _(a2).filter((item: string | number): item is number => typeof item === "number"); // $ExpectType LoDashImplicitArrayWrapper<number>
+        _(d2).filter((item: string | number): item is number => typeof item === "number"); // $ExpectType LoDashImplicitArrayWrapper<number>
+        _(a2).chain().filter((item: string | number): item is number => typeof item === "number"); // $ExpectType LoDashExplicitArrayWrapper<number>
+        _(d2).chain().filter((item: string | number): item is number => typeof item === "number"); // $ExpectType LoDashExplicitArrayWrapper<number>
     }
 }
 
@@ -3854,6 +3904,7 @@ namespace TestFind {
 
     let result: TResult | undefined;
 
+    result = _.find(array);
     result = _.find<TResult>(array);
     result = _.find<TResult>(array, listIterator);
     result = _.find<TResult>(array, listIterator, 1);
@@ -3861,7 +3912,10 @@ namespace TestFind {
     result = _.find<TResult>(array, '', 1);
     result = _.find<TResult>(array, {a: 42});
     result = _.find<TResult>(array, {a: 42}, 1);
+    result = _.find(array, ['a', 5]);
+    result = _.find(array, ['a', 5], 1);
 
+    result = _.find(list);
     result = _.find<TResult>(list);
     result = _.find<TResult>(list, listIterator);
     result = _.find<TResult>(list, listIterator, 1);
@@ -3869,7 +3923,10 @@ namespace TestFind {
     result = _.find<TResult>(list, '', 1);
     result = _.find<TResult>(list, {a: 42});
     result = _.find<TResult>(list, {a: 42}, 1);
+    result = _.find(list, ['a', 5]);
+    result = _.find(list, ['a', 5], 1);
 
+    result = _.find(dictionary);
     result = _.find<TResult>(dictionary);
     result = _.find<TResult>(dictionary, dictionaryIterator);
     result = _.find<TResult>(dictionary, dictionaryIterator, 1);
@@ -3877,6 +3934,8 @@ namespace TestFind {
     result = _.find<TResult>(dictionary, '', 1);
     result = _.find<TResult>(dictionary, {a: 42});
     result = _.find<TResult>(dictionary, {a: 42}, 1);
+    result = _.find(dictionary, ['a', 5]);
+    result = _.find(dictionary, ['a', 5], 1);
 
     result = _(array).find();
     result = _(array).find(listIterator);
@@ -3885,6 +3944,8 @@ namespace TestFind {
     result = _(array).find('', 1);
     result = _(array).find({a: 42});
     result = _(array).find({a: 42}, 1);
+    result = _(array).find(['a', 5]);
+    result = _(array).find(['a', 5], 1);
 
     result = _(list).find<TResult>();
     result = _(list).find<TResult>(listIterator);
@@ -3893,6 +3954,8 @@ namespace TestFind {
     result = _(list).find<TResult>('', 1);
     result = _(list).find<TResult>({a: 42});
     result = _(list).find<TResult>({a: 42}, 1);
+    result = _(list).find<TResult>(['a', 5]);
+    result = _(list).find<TResult>(['a', 5], 1);
 
     result = _(dictionary).find<TResult>();
     result = _(dictionary).find<TResult>(dictionaryIterator);
@@ -3901,19 +3964,91 @@ namespace TestFind {
     result = _(dictionary).find<TResult>('', 1);
     result = _(dictionary).find<TResult>({a: 42});
     result = _(dictionary).find<TResult>({a: 42}, 1);
+    result = _(dictionary).find<TResult>(['a', 5]);
+    result = _(dictionary).find<TResult>(['a', 5], 1);
+
+    result = _.find([any as TResult, null, undefined], (value: TResult | null | undefined): value is TResult | undefined => value !== null);
+    result = _([any as TResult, null, undefined]).find((value: TResult | null | undefined): value is TResult | undefined => value !== null);
 }
 
-result = <number>_.findLast([1, 2, 3, 4], num => num % 2 == 0);
-result = <IFoodCombined>_.findLast(foodsCombined, { 'type': 'vegetable' });
-result = <IFoodCombined>_.findLast(foodsCombined, 'organic');
+// _.findLast
+namespace TestFindLast {
+    let array: TResult[] | null | undefined = [] as any;
+    let list: _.List<TResult> | null | undefined = [] as any;
+    let obj: any = {};
+    let dictionary: _.Dictionary<TResult> | null | undefined = obj;
 
-result = <IFoodCombined>_.findLast(foodsCombined, 'organic', 1);
+    let listIterator = (value: TResult, index: number, collection: _.List<TResult>) => true;
+    let dictionaryIterator = (value: TResult, key: string, collection: _.Dictionary<TResult>) => true;
 
-result = <number>_([1, 2, 3, 4]).findLast(num => num % 2 == 0);
-result = <IFoodCombined>_(foodsCombined).findLast({ 'type': 'vegetable' });
-result = <IFoodCombined>_(foodsCombined).findLast('organic');
+    let result: TResult | undefined;
 
-result = <IFoodCombined>_(foodsCombined).findLast('organic', 1);
+    result = _.findLast(array);
+    result = _.findLast<TResult>(array);
+    result = _.findLast<TResult>(array, listIterator);
+    result = _.findLast<TResult>(array, listIterator, 1);
+    result = _.findLast<TResult>(array, '');
+    result = _.findLast<TResult>(array, '', 1);
+    result = _.findLast<TResult>(array, {a: 42});
+    result = _.findLast<TResult>(array, {a: 42}, 1);
+    result = _.findLast(array, ['a', 5]);
+    result = _.findLast(array, ['a', 5], 1);
+
+    result = _.findLast(list);
+    result = _.findLast<TResult>(list);
+    result = _.findLast<TResult>(list, listIterator);
+    result = _.findLast<TResult>(list, listIterator, 1);
+    result = _.findLast<TResult>(list, '');
+    result = _.findLast<TResult>(list, '', 1);
+    result = _.findLast<TResult>(list, {a: 42});
+    result = _.findLast<TResult>(list, {a: 42}, 1);
+    result = _.findLast(list, ['a', 5]);
+    result = _.findLast(list, ['a', 5], 1);
+
+    result = _.findLast(dictionary);
+    result = _.findLast<TResult>(dictionary);
+    result = _.findLast<TResult>(dictionary, dictionaryIterator);
+    result = _.findLast<TResult>(dictionary, dictionaryIterator, 1);
+    result = _.findLast<TResult>(dictionary, '');
+    result = _.findLast<TResult>(dictionary, '', 1);
+    result = _.findLast<TResult>(dictionary, {a: 42});
+    result = _.findLast<TResult>(dictionary, {a: 42}, 1);
+    result = _.findLast(dictionary, ['a', 5]);
+    result = _.findLast(dictionary, ['a', 5], 1);
+
+    result = _(array).findLast();
+    result = _(array).findLast(listIterator);
+    result = _(array).findLast(listIterator, 1);
+    result = _(array).findLast('');
+    result = _(array).findLast('', 1);
+    result = _(array).findLast({a: 42});
+    result = _(array).findLast({a: 42}, 1);
+    result = _(array).findLast(['a', 5]);
+    result = _(array).findLast(['a', 5], 1);
+
+    result = _(list).findLast<TResult>();
+    result = _(list).findLast<TResult>(listIterator);
+    result = _(list).findLast<TResult>(listIterator, 1);
+    result = _(list).findLast<TResult>('');
+    result = _(list).findLast<TResult>('', 1);
+    result = _(list).findLast<TResult>({a: 42});
+    result = _(list).findLast<TResult>({a: 42}, 1);
+    result = _(list).findLast<TResult>(['a', 5]);
+    result = _(list).findLast<TResult>(['a', 5], 1);
+
+    result = _(dictionary).findLast<TResult>();
+    result = _(dictionary).findLast<TResult>(dictionaryIterator);
+    result = _(dictionary).findLast<TResult>(dictionaryIterator, 1);
+    result = _(dictionary).findLast<TResult>('');
+    result = _(dictionary).findLast<TResult>('', 1);
+    result = _(dictionary).findLast<TResult>({a: 42});
+    result = _(dictionary).findLast<TResult>({a: 42}, 1);
+    result = _(dictionary).findLast<TResult>(['a', 5]);
+    result = _(dictionary).findLast<TResult>(['a', 5], 1);
+
+    result = _.findLast([any as TResult, null, undefined], (value: TResult | null | undefined): value is TResult | undefined => value !== null);
+    result = _([any as TResult, null, undefined]).findLast((value: TResult | null | undefined): value is TResult | undefined => value !== null);
+}
 
 // _.flatMap
 namespace TestFlatMap {
@@ -3942,7 +4077,7 @@ namespace TestFlatMap {
         let result: string[];
 
         result = _.flatMap<string>('abc');
-        result = _.flatMap<string>('abc');
+        result = _.flatMap('abc');
 
         result = _.flatMap<string, string>('abc', stringIterator);
         result = _.flatMap<string>('abc', stringIterator);
@@ -3951,7 +4086,7 @@ namespace TestFlatMap {
     {
         let result: number[];
 
-        result = _.flatMap<number|number[], number>(numArray);
+        result = _.flatMap(numArray);
         result = _.flatMap<number>(numArray);
 
         result = _.flatMap<number|number[], number>(numArray, listIterator);
@@ -3960,7 +4095,7 @@ namespace TestFlatMap {
         result = _.flatMap<({a: number}|{a: number}[])[], number>(objArray, 'a');
         result = _.flatMap<number>(objArray, 'a');
 
-        result = _.flatMap<number|number[], number>(numList);
+        result = _.flatMap(numList);
         result = _.flatMap<number>(numList);
 
         result = _.flatMap<number|number[], number>(numList, listIterator);
@@ -3969,7 +4104,7 @@ namespace TestFlatMap {
         result = _.flatMap<_.List<{a: number}|{a: number}[]>, number>(objList, 'a');
         result = _.flatMap<number>(objList, 'a');
 
-        result = _.flatMap<number|number[], number>(numDictionary);
+        result = _.flatMap(numDictionary);
         result = _.flatMap<number>(numDictionary);
 
         result = _.flatMap<number|number[], number>(numDictionary, dictionaryIterator);
@@ -3978,7 +4113,7 @@ namespace TestFlatMap {
         result = _.flatMap<_.Dictionary<{a: number}|{a: number}[]>, number>(objDictionary, 'a');
         result = _.flatMap<number>(objDictionary, 'a');
 
-        result = _.flatMap<number|number[], number>(numNumericDictionary);
+        result = _.flatMap(numNumericDictionary);
         result = _.flatMap<number>(numNumericDictionary);
 
         result = _.flatMap<number|number[], number>(numNumericDictionary, numericDictionaryIterator);
@@ -4114,8 +4249,9 @@ namespace TestForEach {
     let dictionary: _.Dictionary<TResult> = {};
     let nilArray: TResult[] | null | undefined = [] as any;
     let nilList: _.List<TResult> | null | undefined = [] as any;
-    let obj: any = {};
-    let nilDictionary: _.Dictionary<TResult> | null | undefined = obj;
+    let nilDictionary: _.Dictionary<TResult> | null | undefined = any;
+    let undefinedList: _.List<TResult> | undefined = [] as any;
+    let undefinedDictionary: _.Dictionary<TResult> | undefined = any;
 
     let stringIterator: (char: string, index: number, string: string) => any = (char: string, index: number, string: string) => 1;
     let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value: TResult, index: number, collection: _.List<TResult>) => 1;
@@ -4136,37 +4272,49 @@ namespace TestForEach {
     {
         let result: TResult[];
 
-        result = _.forEach<TResult>(array, listIterator);
+        result = _.forEach(array, listIterator);
     }
 
     {
         let result: TResult[] | null | undefined;
 
-        result = _.forEach<TResult>(nilArray, listIterator);
+        result = _.forEach(nilArray, listIterator);
     }
 
     {
         let result: _.List<TResult>;
 
-        result = _.forEach<TResult>(list, listIterator);
+        result = _.forEach(list, listIterator);
     }
 
     {
         let result: _.List<TResult> | null | undefined;
 
-        result = _.forEach<TResult>(nilList, listIterator);
+        result = _.forEach(nilList, listIterator);
     }
 
     {
         let result: _.Dictionary<TResult | null | undefined>;
 
-        result = _.forEach<TResult>(dictionary, dictionaryIterator);
+        result = _.forEach(dictionary, dictionaryIterator);
     }
 
     {
         let result: _.Dictionary<TResult> | null | undefined;
 
-        result = _.forEach<TResult>(nilDictionary, dictionaryIterator);
+        result = _.forEach(nilDictionary, dictionaryIterator);
+    }
+
+    {
+        let result: _.List<TResult> | undefined;
+
+        result = _.forEach(undefinedList, listIterator);
+    }
+
+    {
+        let result: _.Dictionary<TResult> | undefined;
+
+        result = _.forEach(undefinedDictionary, dictionaryIterator);
     }
 
     {
@@ -4261,8 +4409,9 @@ namespace TestForEachRight {
     let dictionary: _.Dictionary<TResult> = {};
     let nilArray: TResult[] | null | undefined = [] as any;
     let nilList: _.List<TResult> | null | undefined = [] as any;
-    let obj: any = {};
-    let nilDictionary: _.Dictionary<TResult> | null | undefined = obj;
+    let nilDictionary: _.Dictionary<TResult> | null | undefined = any;
+    let undefinedList: _.List<TResult> | undefined = [] as any;
+    let undefinedDictionary: _.Dictionary<TResult> | undefined = any;
 
     let stringIterator: (char: string, index: number, string: string) => any = (char: string, index: number, string: string) => 1;
     let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value: TResult, index: number, collection: _.List<TResult>) => 1;
@@ -4283,37 +4432,49 @@ namespace TestForEachRight {
     {
         let result: TResult[];
 
-        result = _.forEachRight<TResult>(array, listIterator);
+        result = _.forEachRight(array, listIterator);
     }
 
     {
         let result: TResult[] | null | undefined;
 
-        result = _.forEachRight<TResult>(nilArray, listIterator);
+        result = _.forEachRight(nilArray, listIterator);
     }
 
     {
         let result: _.List<TResult>;
 
-        result = _.forEachRight<TResult>(list, listIterator);
+        result = _.forEachRight(list, listIterator);
     }
 
     {
         let result: _.List<TResult> | null | undefined;
 
-        result = _.forEachRight<TResult>(nilList, listIterator);
+        result = _.forEachRight(nilList, listIterator);
     }
 
     {
         let result: _.Dictionary<TResult | null | undefined>;
 
-        result = _.forEachRight<TResult>(dictionary, dictionaryIterator);
+        result = _.forEachRight(dictionary, dictionaryIterator);
     }
 
     {
         let result: _.Dictionary<TResult> | null | undefined;
 
-        result = _.forEachRight<TResult>(nilDictionary, dictionaryIterator);
+        result = _.forEachRight(nilDictionary, dictionaryIterator);
+    }
+
+    {
+        let result: _.List<TResult> | undefined;
+
+        result = _.forEachRight(undefinedList, listIterator);
+    }
+
+    {
+        let result: _.Dictionary<TResult> | undefined;
+
+        result = _.forEachRight(undefinedDictionary, dictionaryIterator);
     }
 
     {
@@ -6906,7 +7067,7 @@ namespace TestIsArray {
         let value: number|string[]|boolean[] = any;
 
         if (_.isArray(value)) {
-            value; // $ExpectType boolean[] | string[]
+            value; // $ExpectType string[] | boolean[]
         }
         else {
             value; // $ExpectType number
@@ -8271,7 +8432,20 @@ namespace TestMean {
 
     let result: number;
 
+    result = _.mean(array);
     result = _.mean<number>(array);
+
+    result = _(array).mean();
+}
+
+// _.meanBy
+namespace TestMean {
+    let array: TResult[] = [];
+
+    let result: number;
+
+    result = _.meanBy(array, (x) => x.a);
+    result = _.meanBy(array, 'a');
 
     result = _(array).mean();
 }
@@ -9451,6 +9625,8 @@ namespace TestFindKey {
 
         result = _.findKey<{a: number;}, {a: string;}>({a: ''}, {a: 42});
 
+        result = _.findKey({a: { b: 5 }}, ['b', 5]);
+
         result = _<{a: string;}>({a: ''}).findKey();
 
         result = _<{a: string;}>({a: ''}).findKey(predicateFn);
@@ -9503,6 +9679,8 @@ namespace TestFindLastKey {
         result = _.findLastKey<{a: string;}>({a: ''}, '');
 
         result = _.findLastKey<{a: number;}, {a: string;}>({a: ''}, {a: 42});
+
+        result = _.findLastKey({a: { b: 5 }}, ['b', 5]);
 
         result = _<{a: string;}>({a: ''}).findLastKey();
 
@@ -11964,9 +12142,9 @@ namespace TestIdentity {
 // _.iteratee
 namespace TestIteratee {
     {
-        let result: (...args: any[]) => TResult;
-
-        result = _.iteratee<TResult>(Function);
+        _.iteratee((...args: any[]): TResult => any); // $ExpectType (...args: any[]) => TResult
+        _.iteratee((a: TResult): boolean => any); // $ExpectType (a: TResult) => boolean
+        _.iteratee((a: TResult | undefined): a is undefined => any); // $ExpectType (a: TResult | undefined) => a is undefined
     }
 
     {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3448,8 +3448,6 @@ namespace TestEach {
     let nilArray: TResult[] | null | undefined = [] as any;
     let nilList: _.List<TResult> | null | undefined = [] as any;
     let nilDictionary: _.Dictionary<TResult> | null | undefined = any;
-    let undefinedList: _.List<TResult> | undefined = [] as any;
-    let undefinedDictionary: _.Dictionary<TResult> | undefined = any;
 
     let stringIterator: (char: string, index: number, string: string) => any = (char: string, index: number, string: string) => 1;
     let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value: TResult, index: number, collection: _.List<TResult>) => 1;
@@ -3501,18 +3499,6 @@ namespace TestEach {
         let result: _.Dictionary<TResult> | null | undefined;
 
         result = _.each(nilDictionary, dictionaryIterator);
-    }
-
-    {
-        let result: _.List<TResult> | undefined;
-
-        result = _.each(undefinedList, listIterator);
-    }
-
-    {
-        let result: _.Dictionary<TResult> | undefined;
-
-        result = _.each(undefinedDictionary, dictionaryIterator);
     }
 
     {
@@ -3572,8 +3558,6 @@ namespace TestEachRight {
     let nilArray: TResult[] | null | undefined = [] as any;
     let nilList: _.List<TResult> | null | undefined = [] as any;
     let nilDictionary: _.Dictionary<TResult> | null | undefined = any;
-    let undefinedList: _.List<TResult> | undefined = [] as any;
-    let undefinedDictionary: _.Dictionary<TResult> | undefined = any;
 
     let stringIterator: (char: string, index: number, string: string) => any = (char: string, index: number, string: string) => 1;
     let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value: TResult, index: number, collection: _.List<TResult>) => 1;
@@ -3625,18 +3609,6 @@ namespace TestEachRight {
         let result: _.Dictionary<TResult> | null | undefined;
 
         result = _.eachRight(nilDictionary, dictionaryIterator);
-    }
-
-    {
-        let result: _.List<TResult> | undefined;
-
-        result = _.eachRight(undefinedList, listIterator);
-    }
-
-    {
-        let result: _.Dictionary<TResult> | undefined;
-
-        result = _.eachRight(undefinedDictionary, dictionaryIterator);
     }
 
     {
@@ -4230,89 +4202,136 @@ namespace TestForEach {
     let nilArray: TResult[] | null | undefined = [] as any;
     let nilList: _.List<TResult> | null | undefined = [] as any;
     let nilDictionary: _.Dictionary<TResult> | null | undefined = any;
-    let undefinedList: _.List<TResult> | undefined = [] as any;
-    let undefinedDictionary: _.Dictionary<TResult> | undefined = any;
 
-    let stringIterator: (char: string, index: number, string: string) => any = (char: string, index: number, string: string) => 1;
-    let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value: TResult, index: number, collection: _.List<TResult>) => 1;
-    let dictionaryIterator: (value: TResult, key: string, collection: _.Dictionary<TResult>) => any = (value: TResult, key: string, collection: _.Dictionary<TResult>) => 1;
+    let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value, index, collection) => 1;
+    let dictionaryIterator: (value: TResult, key: string, collection: _.Dictionary<TResult>) => any = (value, key, collection) => 1;
+    let objectIterator: (value: number | string | boolean, key: string, collection: TResult) => any = (value, key, collection) => 1;
 
     {
         let result: string;
 
-        result = _.forEach('', stringIterator);
+        result = _.forEach('', (value, index, collection) => {
+            value; // $ExpectType string
+            index; // $ExpectType number
+            collection; // $ExpectType string
+        });
     }
 
     {
         let result: string | null | undefined;
 
-        result = _.forEach('' as (string | null | undefined), stringIterator);
+        result = _.forEach('' as (string | null | undefined), (value, index, collection) => {
+            value; // $ExpectType string
+            index; // $ExpectType number
+            collection; // $ExpectType string
+        });
     }
 
     {
         let result: TResult[];
-
-        result = _.forEach(array, listIterator);
+        result = _.forEach(array, (value, index, collection: TResult[]) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+        });
+        result = _.forEach(array, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            // Note: ideally we'd like collection TResult[], but it seems the best we can get is List<TResult>.
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: TResult[] | null | undefined;
 
-        result = _.forEach(nilArray, listIterator);
+        result = _.forEach(array, (value, index, collection: TResult[]) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+        });
+        result = _.forEach(nilArray, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            // Note: ideally we'd like collection TResult[], but it seems the best we can get is List<TResult>.
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: _.List<TResult>;
 
-        result = _.forEach(list, listIterator);
+        result = _.forEach(list, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: _.List<TResult> | null | undefined;
 
-        result = _.forEach(nilList, listIterator);
+        result = _.forEach(nilList, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
-        let result: _.Dictionary<TResult | null | undefined>;
+        let result: _.Dictionary<TResult>;
 
-        result = _.forEach(dictionary, dictionaryIterator);
+        result = _.forEach(dictionary, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType string
+            collection; // $ExpectType Dictionary<TResult>
+        });
     }
 
     {
         let result: _.Dictionary<TResult> | null | undefined;
 
-        result = _.forEach(nilDictionary, dictionaryIterator);
+        result = _.forEach(nilDictionary, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType string
+            collection; // $ExpectType Dictionary<TResult>
+        });
     }
 
     {
-        let result: _.List<TResult> | undefined;
+        let sample1: TResult = any;
+        sample1 = _.forEach(sample1, objectIterator);
 
-        result = _.forEach(undefinedList, listIterator);
-    }
-
-    {
-        let result: _.Dictionary<TResult> | undefined;
-
-        result = _.forEach(undefinedDictionary, dictionaryIterator);
+        let sample2: TResult | null | undefined = any;
+        sample2 = _.forEach(sample2, objectIterator);
     }
 
     {
         let result: _.LoDashImplicitWrapper<string>;
 
-        result = _('').forEach(stringIterator);
+        result = _('').forEach((value, index, collection) => {
+            value; // $ExpectType string
+            index; // $ExpectType number
+            collection; // $ExpectType string
+        });
     }
 
     {
         let result: _.LoDashImplicitArrayWrapper<TResult>;
 
-        result = _(array).forEach(listIterator);
+        result = _(array).forEach((value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: _.LoDashImplicitNillableArrayWrapper<TResult>;
 
-        result = _(nilArray).forEach(listIterator);
+        result = _(nilArray).forEach((value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
@@ -4342,19 +4361,31 @@ namespace TestForEach {
     {
         let result: _.LoDashExplicitWrapper<string>;
 
-        result = _('').chain().forEach(stringIterator);
+        result = _('').chain().forEach((value, index, collection) => {
+            value; // $ExpectType string
+            index; // $ExpectType number
+            collection; // $ExpectType string
+        });
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<TResult>;
 
-        result = _(array).chain().forEach(listIterator);
+        result = _(array).chain().forEach((value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: _.LoDashExplicitNillableArrayWrapper<TResult>;
 
-        result = _(nilArray).chain().forEach(listIterator);
+        result = _(nilArray).chain().forEach((value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
@@ -4390,77 +4421,98 @@ namespace TestForEachRight {
     let nilArray: TResult[] | null | undefined = [] as any;
     let nilList: _.List<TResult> | null | undefined = [] as any;
     let nilDictionary: _.Dictionary<TResult> | null | undefined = any;
-    let undefinedList: _.List<TResult> | undefined = [] as any;
-    let undefinedDictionary: _.Dictionary<TResult> | undefined = any;
 
-    let stringIterator: (char: string, index: number, string: string) => any = (char: string, index: number, string: string) => 1;
     let listIterator: (value: TResult, index: number, collection: _.List<TResult>) => any = (value: TResult, index: number, collection: _.List<TResult>) => 1;
     let dictionaryIterator: (value: TResult, key: string, collection: _.Dictionary<TResult>) => any = (value: TResult, key: string, collection: _.Dictionary<TResult>) => 1;
 
     {
         let result: string;
 
-        result = _.forEachRight('', stringIterator);
+        result = _.forEachRight('', (value, index, collection) => {
+            value; // $ExpectType string
+            index; // $ExpectType number
+            collection; // $ExpectType string
+        });
     }
 
     {
         let result: string | null | undefined;
 
-        result = _.forEachRight('' as (string | null | undefined), stringIterator);
+        result = _.forEachRight('' as (string | null | undefined), (value, index, collection) => {
+            value; // $ExpectType string
+            index; // $ExpectType number
+            collection; // $ExpectType string
+        });
     }
 
     {
         let result: TResult[];
 
-        result = _.forEachRight(array, listIterator);
+        result = _.forEachRight(array, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: TResult[] | null | undefined;
 
-        result = _.forEachRight(nilArray, listIterator);
+        result = _.forEachRight(nilArray, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: _.List<TResult>;
 
-        result = _.forEachRight(list, listIterator);
+        result = _.forEachRight(list, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: _.List<TResult> | null | undefined;
 
-        result = _.forEachRight(nilList, listIterator);
+        result = _.forEachRight(nilList, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
-        let result: _.Dictionary<TResult | null | undefined>;
+        let result: _.Dictionary<TResult>;
 
-        result = _.forEachRight(dictionary, dictionaryIterator);
+        result = _.forEachRight(dictionary, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType string
+            collection; // $ExpectType Dictionary<TResult>
+        });
     }
 
     {
         let result: _.Dictionary<TResult> | null | undefined;
 
-        result = _.forEachRight(nilDictionary, dictionaryIterator);
-    }
-
-    {
-        let result: _.List<TResult> | undefined;
-
-        result = _.forEachRight(undefinedList, listIterator);
-    }
-
-    {
-        let result: _.Dictionary<TResult> | undefined;
-
-        result = _.forEachRight(undefinedDictionary, dictionaryIterator);
+        result = _.forEachRight(nilDictionary, (value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType string
+            collection; // $ExpectType Dictionary<TResult>
+        });
     }
 
     {
         let result: _.LoDashImplicitWrapper<string>;
 
-        result = _('').forEachRight(stringIterator);
+        result = _('').forEachRight((value, index, collection) => {
+            value; // $ExpectType string
+            index; // $ExpectType number
+            collection; // $ExpectType string
+        });
     }
 
     {
@@ -4502,25 +4554,37 @@ namespace TestForEachRight {
     {
         let result: _.LoDashExplicitWrapper<string>;
 
-        result = _('').chain().forEachRight(stringIterator);
+        result = _('').chain().forEachRight((value, index, collection) => {
+            value; // $ExpectType string
+            index; // $ExpectType number
+            collection; // $ExpectType string
+        });
     }
 
     {
         let result: _.LoDashExplicitArrayWrapper<TResult>;
 
-        result = _(array).chain().forEachRight(listIterator);
+        result = _(array).chain().forEachRight((value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: _.LoDashExplicitNillableArrayWrapper<TResult>;
 
-        result = _(nilArray).chain().forEachRight(listIterator);
+        result = _(nilArray).chain().forEachRight((value, index, collection) => {
+            value; // $ExpectType TResult
+            index; // $ExpectType number
+            collection; // $ExpectType ArrayLike<TResult>
+        });
     }
 
     {
         let result: _.LoDashExplicitObjectWrapper<_.List<TResult>>;
 
-        result = _(list).chain().forEachRight<TResult>(listIterator);
+        result = _(list).chain().forEachRight(listIterator);
     }
 
     {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4067,11 +4067,11 @@ namespace TestFlatMap {
 
     let stringIterator: (value: string, index: number, collection: _.List<string>) => string|string[] = (a, b, c) => "";
 
-    let listIterator: (value: number, index: number, collection: _.List<number|number[]>) => number|number[] = (a, b, c) => 1;
+    let listIterator: (value: number|number[], index: number, collection: _.List<number|number[]>) => number|number[] = (a, b, c) => 1;
 
-    let dictionaryIterator: (value: number, key: number, collection: _.Dictionary<number|number[]>) => number|number[] = (a, b, c) => 1;
+    let dictionaryIterator: (value: number|number[], key: string, collection: _.Dictionary<number|number[]>) => number|number[] = (a, b, c) => 1;
 
-    let numericDictionaryIterator: (value: number, key: number, collection: _.NumericDictionary<number|number[]>) => number|number[] = (a, b, c) => 1;
+    let numericDictionaryIterator: (value: number|number[], key: number, collection: _.NumericDictionary<number|number[]>) => number|number[] = (a, b, c) => 1;
 
     {
         let result: string[];
@@ -4080,7 +4080,7 @@ namespace TestFlatMap {
         result = _.flatMap('abc');
 
         result = _.flatMap<string, string>('abc', stringIterator);
-        result = _.flatMap<string>('abc', stringIterator);
+        result = _.flatMap('abc', stringIterator);
     }
 
     {
@@ -4089,70 +4089,50 @@ namespace TestFlatMap {
         result = _.flatMap(numArray);
         result = _.flatMap<number>(numArray);
 
+        result = _.flatMap(numArray, listIterator);
         result = _.flatMap<number|number[], number>(numArray, listIterator);
-        result = _.flatMap<number>(numArray, listIterator);
 
-        result = _.flatMap<({a: number}|{a: number}[])[], number>(objArray, 'a');
         result = _.flatMap<number>(objArray, 'a');
 
         result = _.flatMap(numList);
         result = _.flatMap<number>(numList);
 
+        result = _.flatMap(numList, listIterator);
         result = _.flatMap<number|number[], number>(numList, listIterator);
-        result = _.flatMap<number>(numList, listIterator);
 
-        result = _.flatMap<_.List<{a: number}|{a: number}[]>, number>(objList, 'a');
         result = _.flatMap<number>(objList, 'a');
 
         result = _.flatMap(numDictionary);
         result = _.flatMap<number>(numDictionary);
 
+        result = _.flatMap(numDictionary, dictionaryIterator);
         result = _.flatMap<number|number[], number>(numDictionary, dictionaryIterator);
-        result = _.flatMap<number>(numDictionary, dictionaryIterator);
 
-        result = _.flatMap<_.Dictionary<{a: number}|{a: number}[]>, number>(objDictionary, 'a');
         result = _.flatMap<number>(objDictionary, 'a');
 
         result = _.flatMap(numNumericDictionary);
         result = _.flatMap<number>(numNumericDictionary);
 
+        result = _.flatMap(numNumericDictionary, numericDictionaryIterator);
         result = _.flatMap<number|number[], number>(numNumericDictionary, numericDictionaryIterator);
-        result = _.flatMap<number>(numNumericDictionary, numericDictionaryIterator);
 
         result = _.flatMap<_.NumericDictionary<{a: number}|{a: number}[]>, number>(objNumericDictionary, 'a');
-        result = _.flatMap<number>(objNumericDictionary, 'a');
     }
 
     {
         let result: boolean[];
 
-        result = _.flatMap<({a: number}|{a: number}[])[], boolean>(objArray, ['a', 42]);
-        result = _.flatMap<boolean>(objArray, ['a', 42]);
+        result = _.flatMap(objArray, ['a', 42]);
+        result = _.flatMap(objArray, {'a': 42});
 
-        result = _.flatMap<{a: number}, ({a: number}|{a: number}[])[]>(objArray, {'a': 42});
-        result = _.flatMap<({a: number}|{a: number}[])[], boolean>(objArray, {'a': 42});
-        result = _.flatMap<boolean>(objArray, {'a': 42});
+        result = _.flatMap(objList, ['a', 42]);
+        result = _.flatMap(objList, {'a': 42});
 
-        result = _.flatMap<_.List<{a: number}|{a: number}[]>, boolean>(objList, ['a', 42]);
-        result = _.flatMap<boolean>(objList, ['a', 42]);
+        result = _.flatMap(objDictionary, ['a', 42]);
+        result = _.flatMap(objDictionary, {'a': 42});
 
-        result = _.flatMap<{a: number}, _.List<{a: number}|{a: number}[]>>(objList, {'a': 42});
-        result = _.flatMap<_.List<{a: number}|{a: number}[]>, boolean>(objList, {'a': 42});
-        result = _.flatMap<boolean>(objList, {'a': 42});
-
-        result = _.flatMap<_.Dictionary<{a: number}|{a: number}[]>, boolean>(objDictionary, ['a', 42]);
-        result = _.flatMap<boolean>(objDictionary, ['a', 42]);
-
-        result = _.flatMap<{a: number}, _.Dictionary<{a: number}|{a: number}[]>>(objDictionary, {'a': 42});
-        result = _.flatMap<_.Dictionary<{a: number}|{a: number}[]>, boolean>(objDictionary, {'a': 42});
-        result = _.flatMap<boolean>(objDictionary, {'a': 42});
-
-        result = _.flatMap<_.NumericDictionary<{a: number}|{a: number}[]>, boolean>(objNumericDictionary, ['a', 42]);
-        result = _.flatMap<boolean>(objNumericDictionary, ['a', 42]);
-
-        result = _.flatMap<{a: number}, _.NumericDictionary<{a: number}|{a: number}[]>>(objNumericDictionary, {'a': 42});
-        result = _.flatMap<_.NumericDictionary<{a: number}|{a: number}[]>, boolean>(objNumericDictionary, {'a': 42});
-        result = _.flatMap<boolean>(objNumericDictionary, {'a': 42});
+        result = _.flatMap(objNumericDictionary, ['a', 42]);
+        result = _.flatMap(objNumericDictionary, {'a': 42});
     }
 
     {
@@ -4186,16 +4166,16 @@ namespace TestFlatMap {
         let result: _.LoDashImplicitArrayWrapper<boolean>;
 
         result = _(objArray).flatMap(['a', 42]);
-        result = _(objArray).flatMap<{a: number}>({a: 42});
+        result = _(objArray).flatMap({a: 42});
 
         result = _(objList).flatMap(['a', 42]);
-        result = _(objList).flatMap<{a: number}>({a: 42});
+        result = _(objList).flatMap({a: 42});
 
         result = _(objDictionary).flatMap(['a', 42]);
-        result = _(objDictionary).flatMap<{a: number}>({a: 42});
+        result = _(objDictionary).flatMap({a: 42});
 
         result = _(objNumericDictionary).flatMap(['a', 42]);
-        result = _(objNumericDictionary).flatMap<{a: number}>({a: 42});
+        result = _(objNumericDictionary).flatMap({a: 42});
     }
 
     {
@@ -4229,16 +4209,16 @@ namespace TestFlatMap {
         let result: _.LoDashExplicitArrayWrapper<boolean>;
 
         result = _(objArray).chain().flatMap(['a', 42]);
-        result = _(objArray).chain().flatMap<{a: number}>({a: 42});
+        result = _(objArray).chain().flatMap({a: 42});
 
         result = _(objList).chain().flatMap(['a', 42]);
-        result = _(objList).chain().flatMap<{a: number}>({a: 42});
+        result = _(objList).chain().flatMap({a: 42});
 
         result = _(objDictionary).chain().flatMap(['a', 42]);
-        result = _(objDictionary).chain().flatMap<{a: number}>({a: 42});
+        result = _(objDictionary).chain().flatMap({a: 42});
 
         result = _(objNumericDictionary).chain().flatMap(['a', 42]);
-        result = _(objNumericDictionary).chain().flatMap<{a: number}>({a: 42});
+        result = _(objNumericDictionary).chain().flatMap({a: 42});
     }
 }
 


### PR DESCRIPTION
Changes:

- simplified `forEach` overloads
- iteratee functions accept tuple (i.e. `[string, any]`) when necessary
- `filter`, `find`, and `findLast` now work with type guard predicates
- `flatMap` returns the correct type when no iteratee is specified

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.4#iteratee
- [ ] Increase the version number in the header if appropriate. (not appropriate)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.