### PR TITLE
flatpicker plugins type support

### DIFF
--- a/types/flatpickr/index.d.ts
+++ b/types/flatpickr/index.d.ts
@@ -70,7 +70,7 @@ declare namespace Flatpickr {
         weekNumbers?: boolean;
         wrap?: boolean;
         locale?: string | Locale;
-        plugins?: any;
+        plugins?: any[];
     }
 
     interface Locale {

--- a/types/flatpickr/index.d.ts
+++ b/types/flatpickr/index.d.ts
@@ -70,6 +70,7 @@ declare namespace Flatpickr {
         weekNumbers?: boolean;
         wrap?: boolean;
         locale?: string | Locale;
+        plugins?: any;
     }
 
     interface Locale {


### PR DESCRIPTION
flatpicker needs to support plugins.
it is optional parmas type 'any'.

https://chmln.github.io/flatpickr/plugins/

