### PR TITLE
Add types for react-geosuggest

### DIFF
--- a/types/react-geosuggest/index.d.ts
+++ b/types/react-geosuggest/index.d.ts
@@ -1,0 +1,79 @@
+// Type definitions for react-geosuggest 2.3
+// Project: https://github.com/ubilabs/react-geosuggest
+// Definitions by: Brad Menchl <https://github.com/brmenchl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="googlemaps" />
+
+import { Component, InputHTMLAttributes } from "react";
+
+export default class Geosuggest extends Component<GeosuggestProps> {
+    focus(): void;
+    blur(): void;
+    update(value: string): void;
+    clear(): void;
+}
+
+export interface GeosuggestProps extends InputHTMLAttributes<HTMLInputElement> {
+    placeholder?: string;
+    initialValue?: string;
+    className?: string;
+    style?: Styles;
+    inputClassName?: string;
+    disabled?: boolean;
+    location?: google.maps.LatLng;
+    radius?: number;
+    bounds?: google.maps.LatLngBounds;
+    country?: string | string[];
+    types?: QueryType[];
+    fixtures?: Fixture[];
+    maxFixtures?: number;
+    googleMaps?: typeof google.maps;
+    ignoreTab?: boolean;
+    queryDelay?: number;
+    highlightMatch?: boolean;
+    onFocus?(): void;
+    onBlur?(value: any): void;
+    onChange?(value: any): void;
+    onKeyDown?(event: any): void;
+    onKeyPress?(event: any): void;
+    onSuggestSelect?(suggest: Suggest): void;
+    onActivateSuggest?(suggest: Suggest): void;
+    onSuggestNoResults?(userInput: string): void;
+    getSuggestLabel?(googleSuggest: google.maps.places.AutocompletePrediction): string;
+    renderSuggestItem?(googleSuggest: google.maps.places.AutocompletePrediction): any;
+    skipSuggest?(googleSuggest: google.maps.places.AutocompletePrediction): boolean;
+    autoActivateFirstSuggest?: boolean;
+    label?: string;
+    suggestsClassName?: string;
+    suggestsHiddenClassName?: string;
+    suggestsItemClassName?: string;
+    suggestsItemActiveClassName?: string;
+    autoComplete?: string;
+}
+
+export interface Styles {
+    input?: Record<string, any>;
+    suggestItem?: Record<string, any>;
+    suggests?: Record<string, any>;
+}
+
+export type QueryType
+    = 'establishment'
+    | 'geocode'
+    | '(cities)'
+    | '(regions)';
+
+export interface Fixture {
+    className?: string;
+    label: string;
+    location?: google.maps.LatLng;
+}
+
+export interface Suggest {
+    gmaps?: google.maps.GeocoderResult;
+    label: string;
+    location: {lat: string, lng: string};
+    placeId: string;
+}

--- a/types/react-geosuggest/react-geosuggest-tests.tsx
+++ b/types/react-geosuggest/react-geosuggest-tests.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import Geosuggest, { Suggest, Styles } from "react-geosuggest";
+
+const fixtures = [
+    {label: "New York", location: new google.maps.LatLng(40.7033127, -73.979681)},
+    {label: "Rio", location: new google.maps.LatLng(-22.066452, -42.9232368)},
+    {label: "Tokyo", location: new google.maps.LatLng(35.673343, 139.710388)},
+];
+
+const styles: Styles = {
+    input: {color: "blue"},
+    suggests: {width: 4},
+    suggestItem: {display: "flex"},
+};
+
+function onFocus() {}
+function onActivateSuggest(suggest: Suggest) {}
+function getSuggestLabel(suggest: google.maps.places.AutocompletePrediction) { return 'label'; }
+function renderSuggestItem(suggest: google.maps.places.AutocompletePrediction) { return <div>HELLO WORLD</div>; }
+function skipSuggest(suggest: google.maps.places.AutocompletePrediction) { return false; }
+function onBlur(value: string) {}
+function onKeyDown(event: any) {}
+function onKeyPress(event: any) {}
+function onChange(value: string) {}
+function onSuggestSelect(suggest: Suggest) {}
+function onSuggestNoResults(userInput: string) {}
+
+class ReactGeosuggest extends React.Component {
+    private geosuggest: any;
+
+    render() {
+        return (
+            <div>
+                <Geosuggest
+                    autoActivateFirstSuggest={true}
+                    autoComplete="off"
+                    bounds={new google.maps.LatLngBounds()}
+                    className="className"
+                    country={["US"]}
+                    disabled={false}
+                    fixtures={fixtures}
+                    getSuggestLabel={getSuggestLabel}
+                    highlightMatch={true}
+                    ignoreTab={true}
+                    initialValue="Hamburg"
+                    inputClassName="inputClassName"
+                    label="label"
+                    location={new google.maps.LatLng(53.558572, 9.9278215)}
+                    maxFixtures={10}
+                    onActivateSuggest={onActivateSuggest}
+                    onBlur={onBlur}
+                    onChange={onChange}
+                    onFocus={onFocus}
+                    onKeyDown={onKeyDown}
+                    onKeyPress={onKeyPress}
+                    onSuggestNoResults={onSuggestNoResults}
+                    onSuggestSelect={onSuggestSelect}
+                    placeholder="Start typing!"
+                    queryDelay={250}
+                    radius={20}
+                    ref={el => this.geosuggest = el}
+                    renderSuggestItem={renderSuggestItem}
+                    skipSuggest={skipSuggest}
+                    style={styles}
+                    suggestsClassName="suggestsClassName"
+                    suggestsHiddenClassName="suggestsHiddenClassName"
+                    suggestsItemActiveClassName="suggestsItemActiveClassName"
+                    suggestsItemClassName="suggestsItemClassName"
+                    types={["geocode", "(regions)"]}
+                />
+
+                <button onClick={this.geosuggest.focus}>Focus</button>
+                <button onClick={this.geosuggest.update("New Zealand")}>Update</button>
+                <button onClick={this.geosuggest.clear}>Clear</button>
+            </div>
+        );
+    }
+}

--- a/types/react-geosuggest/tsconfig.json
+++ b/types/react-geosuggest/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6", "dom"
+        ],
+        "jsx": "react",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-geosuggest-tests.tsx"
+    ]
+}

--- a/types/react-geosuggest/tslint.json
+++ b/types/react-geosuggest/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
https://github.com/ubilabs/react-geosuggest

- The package does not include types and the maintainers have been a bit unresponsive, so I'd rather get into DT.

