### PR TITLE
[sequelize]  Deferrable option mistakenly refers to the interface and not it's con…

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -4433,7 +4433,7 @@ declare namespace sequelize {
          *
          * PostgreSQL only
          */
-        deferrable?: Deferrable;
+        deferrable?: DeferrableInitiallyDeferred | DeferrableInitiallyImmediate | DeferrableNot | DeferrableSetDeferred | DeferrableSetImmediate;
 
     }
 


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://docs.sequelizejs.com/manual/tutorial/models-definition.html>>

When defining a model, the type misdefinition doesn't allow you to use the Sequelize builtins for Deferrable FK references.

