### PR TITLE
Add echart method and `graphic` declaration.

### DIFF
--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -9,6 +9,8 @@ declare namespace ECharts {
         renderer?: string
     }):ECharts;
 
+    const graphic: any;
+    
     function connect(group:string|Array<string>):void;
 
     function disConnect(group:string):void;
@@ -88,6 +90,24 @@ declare namespace ECharts {
             gridId?: string
             gridName?: string
         } | string, value: string|Array<any>): string|Array<any>
+            
+        convertFromPixel(finder: {
+            seriesIndex?: number,
+            seriesId?: string,
+            seriesName?: string,
+            geoIndex?: number,
+            geoId?: string,
+            geoName?: string,
+            xAxisIndex?: number,
+            xAxisId?: string,
+            xAxisName?: string,
+            yAxisIndex?: number,
+            yAxisId?: string,
+            yAxisName?: string,
+            gridIndex?: number,
+            gridId?: string
+            gridName?: string
+        } | string, value: Array<any>|string): Array<any>|string
     }
 
     interface EChartOption {

--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -9,7 +9,10 @@ declare namespace ECharts {
         renderer?: string
     }):ECharts;
 
-    const graphic: any;
+    const graphic: {
+        clipPointsByRect(points: number[][], rect: ERectangle): number[][];
+        clipRectByRect(targetRect: ERectangle, rect: ERectangle): ERectangle;
+    }
     
     function connect(group:string|Array<string>):void;
 
@@ -108,6 +111,13 @@ declare namespace ECharts {
             gridId?: string
             gridName?: string
         } | string, value: Array<any>|string): Array<any>|string
+    }
+
+    interface ERectangle {
+        x: number,
+        y: number,
+        width: number,
+        height: number
     }
 
     interface EChartOption {


### PR DESCRIPTION
0. Add declaration of graphic.
1. Add method ```convertFromPixel```

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://ecomfe.github.io/echarts-doc/public/en/api.html#echartsInstance.convertFromPixel
    - https://ecomfe.github.io/echarts-doc/public/en/api.html#echarts.graphic

Tested and used in my production code.