### PR TITLE
[redux-form] Improved typings for 'getFormMeta' selector

### DIFF
--- a/types/redux-form/v6/index.d.ts
+++ b/types/redux-form/v6/index.d.ts
@@ -12,6 +12,12 @@ import {
 
 export type FieldValue = any;
 
+export type FieldState = {
+    active?: boolean;
+    touched?: boolean;
+    visited?: boolean;
+}
+
 export type FieldType = "Field" | "FieldArray";
 
 export interface DataShape {
@@ -25,6 +31,10 @@ export type FormErrors<FormData extends DataShape> = {
 export type FormWarnings<FormData extends DataShape> = {
     [P in keyof FormData]?: ReactElement<any> | string | { _warning?: string };
 };
+
+export type FormMeta<FormData extends DataShape> = {
+    [P in keyof FormData]?: FieldState;
+}
 
 /**
  * A component class or stateless function component.

--- a/types/redux-form/v6/lib/reducer.d.ts
+++ b/types/redux-form/v6/lib/reducer.d.ts
@@ -1,5 +1,5 @@
 import { Action, Reducer } from "redux";
-import { FieldType } from "../index";
+import { FieldType, FieldState } from "../index";
 
 export interface FormReducer extends Reducer<FormStateMap> {
     /**
@@ -40,10 +40,4 @@ export interface FormState {
 export interface RegisteredFieldState {
     name: string;
     type: FieldType;
-}
-
-export interface FieldState {
-    active?: boolean;
-    touched?: boolean;
-    visited?: boolean;
 }

--- a/types/redux-form/v6/lib/selectors.d.ts
+++ b/types/redux-form/v6/lib/selectors.d.ts
@@ -1,4 +1,4 @@
-import { DataShape, FormErrors } from "../index";
+import { DataShape, FormErrors, FormMeta } from "../index";
 
 /**
  * A "selector" API to make it easier to connect() to form values. Creates a selector
@@ -27,6 +27,14 @@ export interface ErrorSelector {
 }
 
 /**
+ * Get form field meta
+ */
+export interface MetaSelector {
+    <FormData extends DataShape, State>(formName: string): (state: State) => FormMeta<FormData>;
+    <FormData extends DataShape>(formName: string): (state: any) => FormMeta<FormData>;
+}
+
+/**
  * Gets boolean info from form.
  */
 export interface BooleanSelector {
@@ -42,7 +50,7 @@ export const getFormValues: DataSelector;
 /**
  * Returns the form's fields meta data, namely touched and visited.
  */
-export const getFormMeta: DataSelector;
+export const getFormMeta: MetaSelector;
 
 /**
  * Gets the form's initial values.


### PR DESCRIPTION
Added more specific 'MetaSelector' and 'FormMeta' types to more strongly type the object returned from the 'getFormMeta' selector.

Looking at the code from the 'getFormMeta' selector (see https://github.com/erikras/redux-form/blob/master/src/selectors/getFormMeta.js) the meta information comes from the form 'fields' redux store value. In the current definition for the reducer that updates this value it uses the 'FieldState' interface (see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/redux-form/v6/lib/reducer.d.ts). The current definition for 'getFormMeta' doesn't map the structure to this interface so I have moved it up to the top level index definition file so that it can be used with both the reducer and a `FormMeta` type to correctly map a forms keys across to the FieldState interface.