### PR TITLE
Ramda: unfold: Enable the use of different types for the seed and result value.

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1768,8 +1768,8 @@ declare namespace R {
          * to stop iteration or an array of length 2 containing the value to add to the resulting
          * list and the seed to be used in the next call to the iterator function.
          */
-        unfold<T, TResult>(fn: (seed: T) => TResult[] | boolean, seed: T): TResult[];
-        unfold<T, TResult>(fn: (seed: T) => TResult[] | boolean): (seed: T) => TResult[];
+        unfold<T, TResult>(fn: (seed: T) => [TResult, T] | false, seed: T): TResult[];
+        unfold<T, TResult>(fn: (seed: T) => [TResult, T] | false): (seed: T) => TResult[];
 
         /**
          * Combines two lists into a set (i.e. no duplicates) composed of the

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -391,7 +391,7 @@ R.times(i, 5);
     R.take(2, [1, 2, 3, 4]); // => [1, 2]
 });
 (() => {
-    function f(n: number) {
+    function f(n: number): false | [number, number] {
         return n > 50 ? false : [-n, n + 10];
     }
 


### PR DESCRIPTION
Enables the use of different types for the seed and result value.
The [documentation](http://ramdajs.com/docs/#unfold) only has an example where the seed and result are the same type, but they can be the different.

As an example, a version of the documentation example code where the result is an array of strings:
```js
var f = n => n > 50 ? false : [`${-n}`, n + 10];
R.unfold(f, 10); //=> ['-10', '-20', '-30', '-40', '-50']
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://ramdajs.com/docs/#unfold
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.