### PR TITLE
Add typings for npm-package-arg.

### DIFF
--- a/types/npm-package-arg/index.d.ts
+++ b/types/npm-package-arg/index.d.ts
@@ -1,0 +1,84 @@
+// Type definitions for npm-package-arg 5.1
+// Project: https://github.com/npm/npm-package-arg
+// Definitions by: Melvin Groenhoff <https://github.com/mgroenhoff>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Throws if the package name is invalid, a dist-tag is invalid or a URL's protocol is not supported.
+ * @param arg a string that you might pass to npm install, like:
+ * foo@1.2, @bar/foo@1.2, foo@user/foo, http://x.com/foo.tgz, git+https://github.com/user/foo, bitbucket:user/foo, foo.tar.gz, ../foo/bar/ or bar.
+ * If the arg you provide doesn't have a specifier part, eg foo then the specifier will default to latest.
+ * @param where Optionally the path to resolve file paths relative to. Defaults to process.cwd()
+ */
+declare function npa(arg: string, where?: string): npa.Result;
+
+declare namespace npa {
+    /**
+     * Throws if the package name is invalid, a dist-tag is invalid or a URL's protocol is not supported.
+     * @param name The name of the module you want to install. For example: foo or @bar/foo.
+     * @param spec The specifier indicating where and how you can get this module.
+     * Something like: 1.2, ^1.7.17, http://x.com/foo.tgz, git+https://github.com/user/foo, bitbucket:user/foo, file:foo.tar.gz or file:../foo/bar/. If not included then the default is latest.
+     * @param where Optionally the path to resolve file paths relative to. Defaults to process.cwd()
+     */
+    function resolve(name: string, spec: string, where?: string): Result;
+
+    class Result {
+        /**
+         * One of the following strings:
+         * * git - A git repo
+         * * tag - A tagged version, like "foo@latest"
+         * * version - A specific version number, like "foo@1.2.3"
+         * * range - A version range, like "foo@2.x"
+         * * file - A local .tar.gz, .tar or .tgz file.
+         * * directory - A local directory.
+         * * remote - An http url (presumably to a tgz)
+         */
+        type: "git" | "tag" | "version" | "range" | "file" | "directory" | "remote";
+        /**
+         * If true this specifier refers to a resource hosted on a registry. This is true for tag, version and range types.
+         */
+        registry: boolean;
+        /**
+         * If known, the name field expected in the resulting pkg.
+         */
+        name: string | null;
+        /**
+         * If a name is something like @org/module then the scope field will be set to @org. If it doesn't have a scoped name, then scope is null.
+         */
+        scope: string | null;
+        /**
+         * A version of name escaped to match the npm scoped packages specification. Mostly used when making requests against a registry. When name is null, escapedName will also be null.
+         */
+        escapedName: string | null;
+        /**
+         * The specifier part that was parsed out in calls to npa(arg), or the value of spec in calls to `npa.resolve(name, spec).
+         */
+        rawSpec: string;
+        /**
+         * The normalized specifier, for saving to package.json files. null for registry dependencies.
+         */
+        saveSpec: string | null;
+        /**
+         * The version of the specifier to be used to fetch this resource. null for shortcuts to hosted git dependencies as there isn't just one URL to try with them.
+         */
+        fetchSpec: string | null;
+        /**
+         * If set, this is a semver specifier to match against git tags with
+         */
+        gitRange?: string;
+        /**
+         * If set, this is the specific committish to use with a git dependency.
+         */
+        gitCommittish?: string;
+        /**
+         * If from === 'hosted' then this will be a hosted-git-info object. This property is not included when serializing the object as JSON.
+         */
+        hosted?: any;
+        /**
+         * The original un-modified string that was provided. If called as npa.resolve(name, spec) then this will be name + '@' + spec.
+         */
+        raw: string;
+    }
+}
+
+export = npa;

--- a/types/npm-package-arg/npm-package-arg-tests.ts
+++ b/types/npm-package-arg/npm-package-arg-tests.ts
@@ -1,0 +1,6 @@
+import * as npa from "npm-package-arg";
+
+const result1 = npa("npm-package-arg@5.1");
+const result2 = npa("npm-package-arg@5.1", "..");
+const result3 = npa.resolve("npm-package-arg", "^5.1.0");
+const result4 = npa.resolve("npm-package-arg", "^5.1.0", "..");

--- a/types/npm-package-arg/tsconfig.json
+++ b/types/npm-package-arg/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "npm-package-arg-tests.ts"
+    ]
+}

--- a/types/npm-package-arg/tslint.json
+++ b/types/npm-package-arg/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.