### PR TITLE
Update react-maskedinput props to accept default HTML input attributes

### DIFF
--- a/types/react-maskedinput/index.d.ts
+++ b/types/react-maskedinput/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for react-maskedinput 4.0
 // Project: https://github.com/insin/react-maskedinput
-// Definitions by: Karol Janyst <https://github.com/LKay>,
-//     Adam Lavin <https://github.com/lavoaster>
+// Definitions by: Karol Janyst <https://github.com/LKay>
+//                 Adam Lavin <https://github.com/lavoaster>
+//                 Carlos Bonetti <https://github.com/CarlosBonetti>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -16,7 +17,7 @@ export interface CharsFormatters {
   [char: string]: FormatCharacter;
 }
 
-export interface MaskedInputProps extends React.HTMLAttributes<any> {
+export interface MaskedInputProps extends React.InputHTMLAttributes<any> {
   mask: string;
   formatCharacter?: CharsFormatters;
   placeholderChar?: string;

--- a/types/react-maskedinput/react-maskedinput-tests.tsx
+++ b/types/react-maskedinput/react-maskedinput-tests.tsx
@@ -13,7 +13,11 @@ class Test extends React.Component {
                                     transform: (char: string) => char
                                 }
                             }
-                         } />
+                         }
+                         name="react-maskedinput-test"
+                         placeholder="XXX"
+                         disabled={false}
+                />
         );
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/insin/react-maskedinput#other-props
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

***

According to react-maskedinput documentation (specifcally here: https://github.com/insin/react-maskedinput#other-props), all unhandled props will passed down to the underlying `input` component. In that case, all valid HTML input attributes should be accepted as `MaskedInput` props. The current definition version does not accept, for example ,`name` or `disabled` props, which are basic and widely used input attributes.

The proposition is to change the base interface of `MaskedInputProps` from `HTMLAttributes` to `InputHTMLAttributes`.