### PR TITLE
vis: Add types for Options.locales

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -1703,6 +1703,33 @@ export interface Edge {
   id?: IdType;
 }
 
+export interface Locales {
+    [language: string]: LocaleMessages | undefined;
+    en?: LocaleMessages;
+    de?: LocaleMessages;
+    es?: LocaleMessages;
+    it?: LocaleMessages;
+    nl?: LocaleMessages;
+    'pt-br'?: LocaleMessages;
+    ru?: LocaleMessages;
+}
+
+export interface LocaleMessages {
+    edit?: string;
+    del?: string;
+    back?: string;
+    addNode?: string;
+    addEdge?: string;
+    editNode?: string;
+    editEdge?: string;
+    addDescription?: string;
+    edgeDescription?: string;
+    editEdgeDescription?: string;
+    createEdgeError?: string;
+    deleteClusterError?: string;
+    editClusterError?: string;
+}
+
 export interface Options {
   autoResize?: boolean;
 
@@ -1712,7 +1739,7 @@ export interface Options {
 
   locale?: string;
 
-  locales?: string[];
+  locales?: Locales;
 
   clickToUse?: boolean;
 

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -1715,19 +1715,19 @@ export interface Locales {
 }
 
 export interface LocaleMessages {
-    edit?: string;
-    del?: string;
-    back?: string;
-    addNode?: string;
-    addEdge?: string;
-    editNode?: string;
-    editEdge?: string;
-    addDescription?: string;
-    edgeDescription?: string;
-    editEdgeDescription?: string;
-    createEdgeError?: string;
-    deleteClusterError?: string;
-    editClusterError?: string;
+    edit: string;
+    del: string;
+    back: string;
+    addNode: string;
+    addEdge: string;
+    editNode: string;
+    editEdge: string;
+    addDescription: string;
+    edgeDescription: string;
+    editEdgeDescription: string;
+    createEdgeError: string;
+    deleteClusterError: string;
+    editClusterError: string;
 }
 
 export interface Options {

--- a/types/vis/vis-tests.ts
+++ b/types/vis/vis-tests.ts
@@ -194,7 +194,7 @@ network.setOptions(options2);
 //
 // Test code sample from http://visjs.org/docs/network/#locales
 //
-var locales = {
+const locales = {
   en: {
     edit: 'Edit',
     del: 'Delete selected',
@@ -210,10 +210,10 @@ var locales = {
     deleteClusterError: 'Clusters cannot be deleted.',
     editClusterError: 'Clusters cannot be edited.'
   }
-}
+};
 options = {
   locale: 'en',
-  locales: locales,
-}
+  locales,
+};
 
 network.setOptions(options);

--- a/types/vis/vis-tests.ts
+++ b/types/vis/vis-tests.ts
@@ -190,3 +190,30 @@ const options2 = {
 };
 
 network.setOptions(options2);
+
+//
+// Test code sample from http://visjs.org/docs/network/#locales
+//
+var locales = {
+  en: {
+    edit: 'Edit',
+    del: 'Delete selected',
+    back: 'Back',
+    addNode: 'Add Node',
+    addEdge: 'Add Edge',
+    editNode: 'Edit Node',
+    editEdge: 'Edit Edge',
+    addDescription: 'Click in an empty space to place a new node.',
+    edgeDescription: 'Click on a node and drag the edge to another node to connect them.',
+    editEdgeDescription: 'Click on the control points and drag them to a node to connect to it.',
+    createEdgeError: 'Cannot link edges to a cluster.',
+    deleteClusterError: 'Clusters cannot be deleted.',
+    editClusterError: 'Clusters cannot be edited.'
+  }
+}
+options = {
+  locale: 'en',
+  locales: locales,
+}
+
+network.setOptions(options);


### PR DESCRIPTION
Fixes #18687 
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://visjs.org/docs/network/#locales
