### PR TITLE
[material-ui] Added missing prop definitions for <DropDownMenu />

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1229,6 +1229,7 @@ declare namespace __MaterialUI {
 
         interface DropDownMenuProps {
             // <div/> is the element that gets the 'other' properties
+            anchorOrigin?: propTypes.origin;
             animated?: boolean;
             animation?: React.ComponentClass<Popover.PopoverAnimationProps>;
             autoWidth?: boolean;
@@ -1239,13 +1240,16 @@ declare namespace __MaterialUI {
             labelStyle?: React.CSSProperties;
             listStyle?: React.CSSProperties;
             maxHeight?: number;
+            menuItemStyle?: React.CSSProperties;
             menuStyle?: React.CSSProperties;
+            multiple?: boolean;
             onChange?(e: TouchTapEvent, index: number, menuItemValue: any): void;
             onClose?(e: TouchTapEvent): void;
             openImmediately?: boolean;
             selectedMenuItemStyle?: React.CSSProperties;
             selectionRenderer?(value: any, menuItem: any): void;
             style?: React.CSSProperties;
+            targetOrigin?: propTypes.origin;
             underlineStyle?: React.CSSProperties;
             value?: any;
         }

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -2764,6 +2764,17 @@ class DropDownMenuOpenImmediateExample extends React.Component<{}, {value?: numb
   }
 }
 
+const DropDownMenuAnchorExample: React.SFC<{}> = () => (
+  <DropDownMenu
+    value={1}
+    targetOrigin={{ horizontal: 'middle', vertical: 'top' }}
+    anchorOrigin={{ horizontal: 'middle', vertical: 'top' }}
+  >
+    <MenuItem value={1} primaryText="First" />
+    <MenuItem value={2} primaryText="Second" />
+  </DropDownMenu>
+);
+
 const items: Array<React.ReactElement<__MaterialUI.Menus.MenuItemProps>> = [];
 for (let i = 0; i < 100; i++) {
     items.push(<MenuItem value={i} key={i} primaryText={`Item ${i}`}/>);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.material-ui.com/v0.17.2/#/components/dropdown-menu
- [x] Increase the version number in the header if appropriate: **Not necessary, the version in the header supports the features I've added**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

