### PR TITLE
[node@4] accept string in zlib input

### DIFF
--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -802,20 +802,20 @@ declare module "zlib" {
     export function createInflateRaw(options?: ZlibOptions): InflateRaw;
     export function createUnzip(options?: ZlibOptions): Unzip;
 
-    export function deflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateSync(buf: Buffer, options?: ZlibOptions): any;
-    export function deflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function deflateRawSync(buf: Buffer, options?: ZlibOptions): any;
-    export function gzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gzipSync(buf: Buffer, options?: ZlibOptions): any;
-    export function gunzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function gunzipSync(buf: Buffer, options?: ZlibOptions): any;
-    export function inflate(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateSync(buf: Buffer, options?: ZlibOptions): any;
-    export function inflateRaw(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function inflateRawSync(buf: Buffer, options?: ZlibOptions): any;
-    export function unzip(buf: Buffer, callback: (error: Error, result: any) =>void ): void;
-    export function unzipSync(buf: Buffer, options?: ZlibOptions): any;
+    export function deflate(buf: Buffer | string, callback: (error: Error, result: any) =>void ): void;
+    export function deflateSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function deflateRaw(buf: Buffer | string, callback: (error: Error, result: any) =>void ): void;
+    export function deflateRawSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function gzip(buf: Buffer | string, callback: (error: Error, result: any) =>void ): void;
+    export function gzipSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function gunzip(buf: Buffer | string, callback: (error: Error, result: any) =>void ): void;
+    export function gunzipSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function inflate(buf: Buffer | string, callback: (error: Error, result: any) =>void ): void;
+    export function inflateSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function inflateRaw(buf: Buffer | string, callback: (error: Error, result: any) =>void ): void;
+    export function inflateRawSync(buf: Buffer | string, options?: ZlibOptions): any;
+    export function unzip(buf: Buffer | string, callback: (error: Error, result: any) =>void ): void;
+    export function unzipSync(buf: Buffer | string, options?: ZlibOptions): any;
 
     // Constants
     export var Z_NO_FLUSH: number;

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -363,6 +363,23 @@ function stream_readable_pipe_test() {
     r.close();
 }
 
+
+////////////////////////////////////////////////////
+/// zlib tests : http://nodejs.org/api/zlib.html ///
+////////////////////////////////////////////////////
+
+namespace zlib_tests {
+    {
+        const gzipped = zlib.gzipSync('test');
+        const unzipped = zlib.gunzipSync(gzipped.toString());
+    }
+
+    {
+        const deflate = zlib.deflateSync('test');
+        const inflate = zlib.inflateSync(deflate.toString());
+    }
+}
+
 ////////////////////////////////////////////////////////
 /// Crypto tests : http://nodejs.org/api/crypto.html ///
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
Essentially allows strings to be used as input in place of buffers for zlib convenience methods.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/latest-v4.x/api/zlib.html#zlib_convenience_methods
- [x] Increase the version number in the header if appropriate. - not needed
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. - not needed
