### PR TITLE
add missing setStartDate and setEndDate methods

### DIFF
--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -24,6 +24,9 @@ declare namespace daterangepicker {
 
         startDate: moment.Moment;
         endDate: moment.Moment;
+        
+        setStartDate(date: Date | moment.Moment | string): void;
+        setEndDate(date: Date | moment.Moment | string): void;
     }
 
     interface DatepickerEventObject extends JQueryEventObject {

--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Date Range Picker v2.1.19
+// Type definitions for Date Range Picker v2.1.25
 // Project: http://www.daterangepicker.com/
 // Definitions by: SirMartin <https://github.com/SirMartin/>
 //                 Steven Masala <https://github.com/smasala/>

--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Date Range Picker v2.1.19
 // Project: http://www.daterangepicker.com/
 // Definitions by: SirMartin <https://github.com/SirMartin/>
+//                 Steven Masala <https://github.com/smasala/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Add missing methods to *daterangepicker*:
- setStartDate
- setEndDate
http://www.daterangepicker.com/#methods

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.daterangepicker.com/#methods
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
