### PR TITLE
koa-session: make `sessionConfig.valid` optional

### DIFF
--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -59,7 +59,7 @@ declare namespace session {
         /**
          * Hook: valid session value before use it
          */
-        valid(...rest: any[]): void;
+        valid?(...rest: any[]): void;
 
         /**
          * Hook: before save session

--- a/types/koa-session/koa-session-tests.ts
+++ b/types/koa-session/koa-session-tests.ts
@@ -1,5 +1,5 @@
 import * as Koa from 'koa';
-import session = require('koa-session');
+import * as session from 'koa-session';
 
 const app = new Koa();
 


### PR DESCRIPTION
`koa-session` does not actually require this validator and will provide a default behavior if its not supplied. 

Note: just a copy of #18728 . Screwed up the git history and my PR got closed.

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/koajs/session/blob/cb6d2c8448f21f6cf42efdb031798c9608f05602/lib/context.js#L152-L167
- [x] Increase the version number in the header if appropriate (N/A)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (N/A)