### PR TITLE
Quill typings - remove duplicate interface, add static keyword to three methods

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -128,70 +128,6 @@ export interface EventEmitter {
     off(eventName: "editor-change", handler: EditorChangeHandler): EventEmitter;
 }
 
-export interface Quill extends EventEmitter {
-    /**
-     * @private Internal API
-     */
-    root: HTMLDivElement;
-    clipboard: ClipboardStatic;
-    deleteText(index: number, length: number, source?: Sources): DeltaStatic;
-    disable(): void;
-    enable(enabled?: boolean): void;
-    getContents(index?: number, length?: number): DeltaStatic;
-    getLength(): number;
-    getText(index?: number, length?: number): string;
-    insertEmbed(index: number, type: string, value: any, source?: Sources): DeltaStatic;
-    insertText(index: number, text: string, source?: Sources): DeltaStatic;
-    insertText(index: number, text: string, format: string, value: any, source?: Sources): DeltaStatic;
-    insertText(index: number, text: string, formats: StringMap, source?: Sources): DeltaStatic;
-    /**
-     * @deprecated Remove in 2.0. Use clipboard.dangerouslyPasteHTML(index: number, html: string, source: Sources)
-     */
-    pasteHTML(index: number, html: string, source?: Sources): string;
-    /**
-     * @deprecated Remove in 2.0. Use clipboard.dangerouslyPasteHTML(html: string, source: Sources): void;
-     */
-    pasteHTML(html: string, source?: Sources): string;
-    setContents(delta: DeltaStatic, source?: Sources): DeltaStatic;
-    setText(text: string, source?: Sources): DeltaStatic;
-    update(source?: Sources): void;
-    updateContents(delta: DeltaStatic, source?: Sources): DeltaStatic;
-
-    format(name: string, value: any, source?: Sources): DeltaStatic;
-    formatLine(index: number, length: number, source?: Sources): DeltaStatic;
-    formatLine(index: number, length: number, format: string, value: any, source?: Sources): DeltaStatic;
-    formatLine(index: number, length: number, formats: StringMap, source?: Sources): DeltaStatic;
-    formatText(index: number, length: number, source?: Sources): DeltaStatic;
-    formatText(index: number, length: number, format: string, value: any, source?: Sources): DeltaStatic;
-    formatText(index: number, length: number, formats: StringMap, source?: Sources): DeltaStatic;
-    getFormat(range?: RangeStatic): StringMap;
-    getFormat(index: number, length?: number): StringMap;
-    removeFormat(index: number, length: number, source?: Sources): DeltaStatic;
-
-    blur(): void;
-    focus(): void;
-    getBounds(index: number, length?: number): BoundsStatic;
-    getSelection(focus?: boolean): RangeStatic;
-    hasFocus(): boolean;
-    setSelection(index: number, length: number, source?: Sources): void;
-    setSelection(range: RangeStatic, source?: Sources): void;
-
-    debug(level: string|boolean): void;
-    import(path: string): any;
-    register(path: string, def: any, suppressWarning?: boolean): void;
-    register(defs: StringMap, suppressWarning?: boolean): void;
-    addContainer(classNameOrDomNode: string|Node, refNode?: Node): any;
-    getModule(name: string): any;
-
-    // Blot interface is not exported on Parchment
-    find(domNode: Node, bubble?: boolean): Quill | any;
-    getIndex(blot: any): number;
-    getLeaf(index: number): any;
-    getLine(index: number): [any, number];
-    getLines(index?: number, length?: number): any[];
-    getLines(range: RangeStatic): any[];
-}
-
 export class Quill implements Quill {
     /**
      * @private Internal API
@@ -241,15 +177,15 @@ export class Quill implements Quill {
     setSelection(index: number, length: number, source?: Sources): void;
     setSelection(range: RangeStatic, source?: Sources): void;
 
-    debug(level: string|boolean): void;
-    import(path: string): any;
-    register(path: string, def: any, suppressWarning?: boolean): void;
-    register(defs: StringMap, suppressWarning?: boolean): void;
+    static debug(level: string|boolean): void;
+    static import(path: string): any;
+    static register(path: string, def: any, suppressWarning?: boolean): void;
+    static register(defs: StringMap, suppressWarning?: boolean): void;
     addContainer(classNameOrDomNode: string|Node, refNode?: Node): any;
     getModule(name: string): any;
 
     // Blot interface is not exported on Parchment
-    find(domNode: Node, bubble?: boolean): Quill | any;
+    static find(domNode: Node, bubble?: boolean): Quill | any;
     getIndex(blot: any): number;
     getLeaf(index: number): any;
     getLine(index: number): [any, number];

--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -128,7 +128,7 @@ export interface EventEmitter {
     off(eventName: "editor-change", handler: EditorChangeHandler): EventEmitter;
 }
 
-export class Quill implements Quill, EventEmitter {
+export class Quill implements EventEmitter {
     /**
      * @private Internal API
      */

--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -128,7 +128,7 @@ export interface EventEmitter {
     off(eventName: "editor-change", handler: EditorChangeHandler): EventEmitter;
 }
 
-export class Quill implements Quill {
+export class Quill implements Quill, EventEmitter {
     /**
      * @private Internal API
      */
@@ -177,18 +177,31 @@ export class Quill implements Quill {
     setSelection(index: number, length: number, source?: Sources): void;
     setSelection(range: RangeStatic, source?: Sources): void;
 
+    // static methods: debug, import, register, find
     static debug(level: string|boolean): void;
     static import(path: string): any;
     static register(path: string, def: any, suppressWarning?: boolean): void;
     static register(defs: StringMap, suppressWarning?: boolean): void;
+    static find(domNode: Node, bubble?: boolean): Quill | any;
+
     addContainer(classNameOrDomNode: string|Node, refNode?: Node): any;
     getModule(name: string): any;
 
     // Blot interface is not exported on Parchment
-    static find(domNode: Node, bubble?: boolean): Quill | any;
     getIndex(blot: any): number;
     getLeaf(index: number): any;
     getLine(index: number): [any, number];
     getLines(index?: number, length?: number): any[];
     getLines(range: RangeStatic): any[];
+
+    // EventEmitter methods
+    on(eventName: "text-change", handler: TextChangeHandler): EventEmitter;
+    on(eventName: "selection-change", handler: SelectionChangeHandler): EventEmitter;
+    on(eventName: "editor-change", handler: EditorChangeHandler): EventEmitter;
+    once(eventName: "text-change", handler: TextChangeHandler): EventEmitter;
+    once(eventName: "selection-change", handler: SelectionChangeHandler): EventEmitter;
+    once(eventName: "editor-change", handler: EditorChangeHandler): EventEmitter;
+    off(eventName: "text-change", handler: TextChangeHandler): EventEmitter;
+    off(eventName: "selection-change", handler: SelectionChangeHandler): EventEmitter;
+    off(eventName: "editor-change", handler: EditorChangeHandler): EventEmitter;
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Context for update: https://quilljs.com/docs/api/#register 

There are two changes here, one of which may be unnecessary, I suppose. The important change I made was to flag `import`, `register`, `debug`, and `find` as static methods on the class. The second change I made was to eliminate the duplicative interface Quill - having a class for it should be sufficient (they were identical save for the EventEmitter extension).

@sumitkm @guillaume-ro-fr 
