### PR TITLE
ReactSelect - noResultsText property can be a React Component

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -284,7 +284,7 @@ declare namespace ReactSelectClass {
          * placeholder displayed when there are no matching search results or a falsy value to hide it
          * @default "No results found"
          */
-        noResultsText?: string;
+        noResultsText?: string | JSX.Element;
         /**
          * onBlur handler: function (event) {}
          */
@@ -494,7 +494,7 @@ declare namespace ReactSelectClass {
         /**
          *  placeholder displayed when there are no matching search results (shared with Select)
          */
-        noResultsText?: string;
+        noResultsText?: string | JSX.Element;
         /**
          *  field placeholder; displayed when there's no value (shared with Select)
          */

--- a/types/react-select/react-select-tests.tsx
+++ b/types/react-select/react-select-tests.tsx
@@ -171,4 +171,12 @@ describe("Examples", () => {
             valueRenderer={props => null}
         />;
     });
+
+    it("No Results renderer with string", () => {
+        <ReactSelect noResultsText="no results" />;
+    });
+
+    it("No Results renderer with element", () => {
+        <ReactSelect noResultsText={<i>no results</i>} />;
+    });
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/JedWatson/react-select#further-options>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

According to the [react-select documentation](https://github.com/JedWatson/react-select#further-options), the noResultsText property can be a React Component. This pull request adds the JSX.Element union type to the noResultsText property of the ReactSelect and AsyncReactSelect intefaces.