### PR TITLE
Add htmlbars-inline-precompile definition.

### DIFF
--- a/types/htmlbars-inline-precompile/htmlbars-inline-precompile-tests.ts
+++ b/types/htmlbars-inline-precompile/htmlbars-inline-precompile-tests.ts
@@ -1,0 +1,3 @@
+import hbs from 'htmlbars-inline-precompile';
+
+hbs`this is allowed`;

--- a/types/htmlbars-inline-precompile/htmlbars-inline-precompile-tests.ts
+++ b/types/htmlbars-inline-precompile/htmlbars-inline-precompile-tests.ts
@@ -1,3 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
 
-hbs`this is allowed`;
+const likeThisDotRender = (s: string | Array<string>) => {};
+
+likeThisDotRender(hbs`this is allowed`);

--- a/types/htmlbars-inline-precompile/htmlbars-inline-precompile-tests.ts
+++ b/types/htmlbars-inline-precompile/htmlbars-inline-precompile-tests.ts
@@ -1,5 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
 
-const likeThisDotRender = (s: string | Array<string>) => {};
+const likeThisDotRender = (s: string | string[]) => {};
 
 likeThisDotRender(hbs`this is allowed`);

--- a/types/htmlbars-inline-precompile/index.d.ts
+++ b/types/htmlbars-inline-precompile/index.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for htmlbars-inline-precompile 1.0
+// Project: ember-cli-htmlbars-inline-precompile
+// Definitions by: Chris Krycho <https://github.com/chriskrycho>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// This is a bit of a funky one: it's from a [Babel plugin], but is exported for
+// Ember applications as the module `"htmlbars-incline-precompile"`. It acts
+// like a tagged string from the perspective of consumers, but is actually an
+// AST transformation which generates a function as its output.
+//
+// [Babel plugin]: https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile#babel-plugin-htmlbars-inline-precompile-
+
+export default function hbs(tagged: TemplateStringsArray): () => {};

--- a/types/htmlbars-inline-precompile/index.d.ts
+++ b/types/htmlbars-inline-precompile/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for htmlbars-inline-precompile 1.0
-// Project: ember-cli-htmlbars-inline-precompile
+// Project: https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile
 // Definitions by: Chris Krycho <https://github.com/chriskrycho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 

--- a/types/htmlbars-inline-precompile/index.d.ts
+++ b/types/htmlbars-inline-precompile/index.d.ts
@@ -13,4 +13,4 @@
 // [Babel plugin]: https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile#babel-plugin-htmlbars-inline-precompile-
 // [output]: https://github.com/emberjs/ember-test-helpers/blob/77f9a53da9d8c19a85b3122788caadbcc59274c2/lib/ember-test-helpers/-legacy-overrides.js#L17-L42
 
-export default function hbs(tagged: TemplateStringsArray): string | Array<string>;
+export default function hbs(tagged: TemplateStringsArray): string | string[];

--- a/types/htmlbars-inline-precompile/index.d.ts
+++ b/types/htmlbars-inline-precompile/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // This is a bit of a funky one: it's from a [Babel plugin], but is exported for
-// Ember applications as the module `"htmlbars-incline-precompile"`. It acts
+// Ember applications as the module `"htmlbars-inline-precompile"`. It acts
 // like a tagged string from the perspective of consumers, but is actually an
 // AST transformation which generates a function as its output.
 //

--- a/types/htmlbars-inline-precompile/index.d.ts
+++ b/types/htmlbars-inline-precompile/index.d.ts
@@ -6,8 +6,11 @@
 // This is a bit of a funky one: it's from a [Babel plugin], but is exported for
 // Ember applications as the module `"htmlbars-inline-precompile"`. It acts
 // like a tagged string from the perspective of consumers, but is actually an
-// AST transformation which generates a function as its output.
+// AST transformation which generates a function as its output. That function in
+// turn [generates a string or array of strings][output] to use with the Ember
+// testing helper `this.render()`.
 //
 // [Babel plugin]: https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile#babel-plugin-htmlbars-inline-precompile-
+// [output]: https://github.com/emberjs/ember-test-helpers/blob/77f9a53da9d8c19a85b3122788caadbcc59274c2/lib/ember-test-helpers/-legacy-overrides.js#L17-L42
 
-export default function hbs(tagged: TemplateStringsArray): () => {};
+export default function hbs(tagged: TemplateStringsArray): string | Array<string>;

--- a/types/htmlbars-inline-precompile/tsconfig.json
+++ b/types/htmlbars-inline-precompile/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "htmlbars-inline-precompile-tests.ts"
+    ]
+}

--- a/types/htmlbars-inline-precompile/tslint.json
+++ b/types/htmlbars-inline-precompile/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Behavior is documented at [babel-plugin-htmlbars-inline-precompile](https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile#babel-plugin-htmlbars-inline-precompile-) and [ember-cli-htmlbars-inline-precompile](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile).

This isn't strictly accurate as typings go—it doesn't actually return *anything*!—but this is a common import for Ember tests (and some regular Ember app and addon code) and this accurately represents it for those imports.

Note that because this is really just sugar for a transform, there is no actual corresponding module. (This is strange, to be sure.)