### PR TITLE
[redlock] change Lock to class declaration, simplify LockError definition

### DIFF
--- a/types/redlock/index.d.ts
+++ b/types/redlock/index.d.ts
@@ -13,6 +13,12 @@ export = Redlock;
 declare namespace Redlock {
     type Callback<T> = (err: any, value?: T) => void;
 
+    interface LockConstructor {
+        new(redlock: Redlock, resource: string, value: string | null, expiration: number): Lock;
+        (redlock: Redlock, resource: string, value: string | null, expiration: number): Lock;
+        readonly prototype: Lock;
+    }
+
     interface Lock {
         redlock: Redlock;
         resource: string;
@@ -52,6 +58,7 @@ declare namespace Redlock {
 
 declare class Redlock extends EventEmitter {
     LockError: Redlock.LockErrorConstructor;
+    Lock: Redlock.LockConstructor;
     driftFactor: number;
     retryCount: number;
     retryDelay: number;

--- a/types/redlock/index.d.ts
+++ b/types/redlock/index.d.ts
@@ -13,20 +13,13 @@ export = Redlock;
 declare namespace Redlock {
     type Callback<T> = (err: any, value?: T) => void;
 
-    interface LockConstructor {
-        new(redlock: Redlock, resource: string, value: string | null, expiration: number): Lock;
-        (redlock: Redlock, resource: string, value: string | null, expiration: number): Lock;
-        readonly prototype: Lock;
-    }
-
-    interface Lock {
+    class Lock {
         redlock: Redlock;
         resource: string;
         value: string | null;
         expiration: number;
-
+        constructor(redlock: Redlock, resource: string, value: string | null, expiration: number);
         unlock(callback?: Callback<void>): Promise<void>;
-
         extend(ttl: number, callback?: Callback<Lock>): Promise<Lock>;
     }
 
@@ -40,14 +33,9 @@ declare namespace Redlock {
         extendScript?(origExtendScript: string): string;
     }
 
-    interface LockErrorConstructor {
-        new(message?: string): LockError;
-        (message?: string): LockError;
-        readonly prototype: LockError;
-    }
-
-    interface LockError extends Error {
+    class LockError extends Error {
         readonly name: 'LockError';
+        constructor(message?: string);
     }
 
     interface CompatibleRedisClient {
@@ -57,8 +45,8 @@ declare namespace Redlock {
 }
 
 declare class Redlock extends EventEmitter {
-    LockError: Redlock.LockErrorConstructor;
-    Lock: Redlock.LockConstructor;
+    LockError: typeof Redlock.LockError;
+    Lock: typeof Redlock.Lock;
     driftFactor: number;
     retryCount: number;
     retryDelay: number;

--- a/types/redlock/redlock-tests.ts
+++ b/types/redlock/redlock-tests.ts
@@ -91,6 +91,8 @@ redlock.lock('locks:account:322456', 1000, (err, lock) => {
     }
 });
 
+new Object() instanceof redlock.Lock;
+
 new Error() instanceof redlock.LockError;
 
 redlock.LockError.prototype;

--- a/types/redlock/v2/index.d.ts
+++ b/types/redlock/v2/index.d.ts
@@ -12,20 +12,13 @@ export = Redlock;
 declare namespace Redlock {
     type Callback<T> = (err: any, value?: T) => void;
 
-    interface LockConstructor {
-        new(redlock: Redlock, resource: string, value: any, expiration: number): Lock;
-        (redlock: Redlock, resource: string, value: any, expiration: number): Lock;
-        readonly prototype: Lock;
-    }
-
-    interface Lock {
+    class Lock {
         redlock: Redlock;
         resource: string;
         value: any;
         expiration: number;
-
+        constructor(redlock: Redlock, resource: string, value: any, expiration: number);
         unlock(callback?: Callback<void>): Promise<void>;
-
         extend(ttl: number, callback?: Callback<Lock>): Promise<Lock>;
     }
 
@@ -35,20 +28,15 @@ declare namespace Redlock {
         retryDelay?: number;
     }
 
-    interface LockErrorConstructor {
-        new(message?: string): LockError;
-        (message?: string): LockError;
-        readonly prototype: LockError;
-    }
-
-    interface LockError extends Error {
+    class LockError extends Error {
         readonly name: 'LockError';
+        constructor(message?: string);
     }
 }
 
 declare class Redlock {
-    LockError: Redlock.LockErrorConstructor;
-    Lock: Redlock.LockConstructor;
+    LockError: typeof Redlock.LockError;
+    Lock: typeof Redlock.Lock;
 
     driftFactor: number;
     retryCount: number;

--- a/types/redlock/v2/index.d.ts
+++ b/types/redlock/v2/index.d.ts
@@ -12,6 +12,12 @@ export = Redlock;
 declare namespace Redlock {
     type Callback<T> = (err: any, value?: T) => void;
 
+    interface LockConstructor {
+        new(redlock: Redlock, resource: string, value: any, expiration: number): Lock;
+        (redlock: Redlock, resource: string, value: any, expiration: number): Lock;
+        readonly prototype: Lock;
+    }
+
     interface Lock {
         redlock: Redlock;
         resource: string;
@@ -42,6 +48,7 @@ declare namespace Redlock {
 
 declare class Redlock {
     LockError: Redlock.LockErrorConstructor;
+    Lock: Redlock.LockConstructor;
 
     driftFactor: number;
     retryCount: number;
@@ -54,7 +61,7 @@ declare class Redlock {
     acquire(resource: string, ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
     lock(resource: string, ttl: number, callback?: Redlock.Callback<Redlock.Lock>): Promise<Redlock.Lock>;
 
-    disposer(resource: string, ttl: number, errorHandler?: Redlock.Callback<void>): any; // bluebird Disposer
+    disposer(resource: string, ttl: number, errorHandler?: Redlock.Callback<void>): Promise.Disposer<Redlock.Lock>; // bluebird Disposer
 
     release(lock: Redlock.Lock, callback?: Redlock.Callback<void>): Promise<void>;
     unlock(lock: Redlock.Lock, callback?: Redlock.Callback<void>): Promise<void>;

--- a/types/redlock/v2/redlock-tests.ts
+++ b/types/redlock/v2/redlock-tests.ts
@@ -1,6 +1,7 @@
 import * as Redlock from 'redlock';
 import { Lock } from 'redlock';
 import { RedisClient } from 'redis';
+import { using } from 'bluebird';
 
 let redlock: Redlock;
 let client: RedisClient = <RedisClient> {};
@@ -18,9 +19,7 @@ redlock.acquire('resource', 30, (err: any, lock: Lock) => {});
 redlock.lock('resource', 30).then((lock: Lock) => {});
 redlock.lock('resource', 30, (err: any, lock: Lock) => {});
 
-// There is currently no way to test the disposer as the bluebird typings does not
-// expose the .using method.
-// promise.using(redlock.disposer('resource', 30), (lock: Lock) => {});
+using(redlock.disposer('resource', 30), (lock: Lock) => Promise.resolve());
 
 redlock.release(lock);
 redlock.release(lock, (err: any) => {});
@@ -35,3 +34,10 @@ lock.unlock((err) => {});
 
 lock.extend(30).then((lock: Lock) => {});
 lock.extend(30, (err: any, lock: Lock) => {});
+
+new Object() instanceof redlock.Lock;
+
+new Error() instanceof redlock.LockError;
+
+redlock.LockError.prototype;
+const lockError: Redlock.LockError = new redlock.LockError();


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mike-marcacci/node-redlock/blob/master/redlock.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.