### PR TITLE
fix #18615: ReactDOM: remove node from dependencies

### DIFF
--- a/types/react-dom/node-stream/index.d.ts
+++ b/types/react-dom/node-stream/index.d.ts
@@ -1,20 +1,18 @@
-/// <reference types="node" />
 import { ReactElement } from 'react';
-import * as stream from 'stream';
 
 /**
  * Render a ReactElement to its initial HTML. This should only be used on the
  * server.
  * See https://facebook.github.io/react/docs/react-dom-stream.html#rendertostream
  */
-export function renderToStream(element: ReactElement<any>): stream.Readable;
+export function renderToStream(element: ReactElement<any>): any;
 
 /**
  * Similar to renderToStream, except this doesn't create extra DOM attributes
  * such as data-react-id that React uses internally.
  * See https://facebook.github.io/react/docs/react-dom-stream.html#rendertostaticstream
  */
-export function renderToStaticStream(element: ReactElement<any>): stream.Readable;
+export function renderToStaticStream(element: ReactElement<any>): any;
 export const version: string;
 
 export as namespace ReactDOMNodeStream;

--- a/types/react-dom/react-dom-tests.ts
+++ b/types/react-dom/react-dom-tests.ts
@@ -3,7 +3,6 @@ import * as ReactDOM from 'react-dom';
 import * as ReactDOMServer from 'react-dom/server';
 import * as ReactDOMNodeStream from 'react-dom/node-stream';
 import * as ReactTestUtils from 'react-dom/test-utils';
-import * as stream from 'stream';
 
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
@@ -41,11 +40,11 @@ describe('ReactDOMServer', () => {
 
 describe('ReactDOMNodeStream', () => {
     it('renderToStream', () => {
-        const content: stream.Readable = ReactDOMNodeStream.renderToStream(React.createElement('div'));
+        const content: any = ReactDOMNodeStream.renderToStream(React.createElement('div'));
     });
 
     it('renderToStaticStream', () => {
-        const content: stream.Readable = ReactDOMNodeStream.renderToStaticStream(React.createElement('div'));
+        const content: any = ReactDOMNodeStream.renderToStaticStream(React.createElement('div'));
     });
 });
 


### PR DESCRIPTION
PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18493/files add types/node to tsconfig, which breaks some function in non-node environment. This PR remove node dependency by make `renderToStream` returns any.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
