### PR TITLE
isUUID in Sequelize and Validator 

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -4765,7 +4765,7 @@ declare namespace sequelize {
         /**
          * only allow uuids
          */
-        isUUID?: number | { msg: string, args: number };
+        isUUID?: 3|4|5|"3"|"4"|"5"|"all" | { msg: string, args: number };
 
         /**
          * only allow date strings

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -4661,7 +4661,7 @@ declare namespace sequelize {
         /**
          * only allow uuids
          */
-        isUUID?: number | { msg: string, args: number };
+        isUUID?: 3|4|5|"3"|"4"|"5"|"all" | { msg: string, args: number };
 
         /**
          * only allow date strings

--- a/types/validator/index.d.ts
+++ b/types/validator/index.d.ts
@@ -156,7 +156,7 @@ declare namespace ValidatorJS {
     isURL(str: string, options?: IsURLOptions): boolean;
 
     // check if the string is a UUID. Must be one of ['3', '4', '5', 'all'], default is all.
-    isUUID(str: string, version?: string | number): boolean;
+    isUUID(str: string, version?: 3|4|5|"3"|"4"|"5"|"all"): boolean;
 
     // check if the string is uppercase.
     isUppercase(str: string): boolean;


### PR DESCRIPTION
Sequelize is using Validator to validates UUID strings. 
Validator supports 4 versions of UUID - 3,4,5 and all:
https://github.com/chriso/validator.js/blob/b59133b1727b6af355b403a9a97a19226cceb34b/lib/isUUID.js#L14-L19

This change is updating Sequelize's typescript to include `all` and change `number` type to a more specific type (3|4|5).
Update Validator's typescript to be more specific. instead of `string | number` set to (3|4|5|all)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
Validator:
https://github.com/chriso/validator.js/blob/b59133b1727b6af355b403a9a97a19226cceb34b/lib/isUUID.js#L14-L19
Sequelize readme:
`The validations are implemented by validator.js.` 
https://github.com/sequelize/sequelize/blob/33a07c6e900c4fff4cb0d2c318fa94de50268e16/docs/models-definition.md#validations

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.