### PR TITLE
[bunyan] fix: streams can be named

### DIFF
--- a/types/bunyan/bunyan-tests.ts
+++ b/types/bunyan/bunyan-tests.ts
@@ -5,9 +5,6 @@ let ringBufferOptions: Logger.RingBufferOptions = {
 };
 let ringBuffer: Logger.RingBuffer = new Logger.RingBuffer(ringBufferOptions);
 ringBuffer.write("hello");
-ringBuffer.end();
-ringBuffer.destroy();
-ringBuffer.destroySoon();
 
 let level: number;
 level = Logger.resolveLevel("trace");
@@ -46,7 +43,7 @@ let options: Logger.LoggerOptions = {
     }, {
         type: 'raw',
         stream: process.stderr,
-        level: Logger.WARN
+        level: Logger.FATAL + 1, // disabled, as stderr explodes when given raw streams
     }, {
         type: 'raw',
         stream: ringBuffer,
@@ -77,16 +74,6 @@ log.levels('foo');
 log.levels(0, Logger.INFO);
 log.levels(0, 'info');
 log.levels('foo', Logger.WARN);
-
-let child = log.child({ name: 'child' });
-child.reopenFileStreams();
-log.addStream({ path: '/dev/null' });
-child.level(Logger.DEBUG);
-child.level('debug');
-child.levels(0, Logger.ERROR);
-child.levels(0, 'error');
-child.levels('stream1', Logger.FATAL);
-child.levels('stream1', 'fatal');
 
 let buffer = new Buffer(0);
 let error = new Error('');
@@ -138,3 +125,17 @@ class MyLogger extends Logger {
         super(options);
     }
 }
+
+let child = log.child({ widget_type: 'wuzzle' });
+child.reopenFileStreams();
+log.addStream({ path: '/dev/null' });
+child.level(Logger.DEBUG);
+child.level('debug');
+child.levels(0, Logger.ERROR);
+child.levels(0, 'error');
+child.levels('foo', Logger.FATAL);
+child.levels('foo', 'fatal');
+
+ringBuffer.end();
+ringBuffer.destroy();
+ringBuffer.destroySoon();

--- a/types/bunyan/bunyan-tests.ts
+++ b/types/bunyan/bunyan-tests.ts
@@ -29,7 +29,8 @@ let options: Logger.LoggerOptions = {
     streams: [{
         type: 'stream',
         stream: process.stdout,
-        level: Logger.TRACE
+        level: Logger.TRACE,
+        name: 'foo'
     }, {
         type: 'file',
         path: '/tmp/test.log',
@@ -68,6 +69,14 @@ log.addSerializers(
         res: Logger.stdSerializers.res
     }
 );
+
+let levels: number[] = log.levels();
+level = log.levels(0);
+log.levels('foo');
+
+log.levels(0, Logger.INFO);
+log.levels(0, 'info');
+log.levels('foo', Logger.WARN);
 
 let child = log.child({ name: 'child' });
 child.reopenFileStreams();

--- a/types/bunyan/bunyan-tests.ts
+++ b/types/bunyan/bunyan-tests.ts
@@ -121,7 +121,7 @@ recursive.whats['huh'] = recursive;
 JSON.stringify(recursive, Logger.safeCycles());
 
 class MyLogger extends Logger {
-    constructor() {sales@powertec.com.au
+    constructor() {
         super(options);
     }
 }

--- a/types/bunyan/index.d.ts
+++ b/types/bunyan/index.d.ts
@@ -228,6 +228,7 @@ declare namespace Logger {
         closeOnExit?: boolean;
         period?: string;
         count?: number;
+        name?: string;
     }
 
     interface LoggerOptions {


### PR DESCRIPTION
as documented in <https://github.com/trentm/node-bunyan#levels> _(last few lines of the examples, on & after `log.levels(foo)`)_

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/trentm/node-bunyan#levels>
- [ ] ~Increase the version number in the header if appropriate.~ n/a
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ n/a