### PR TITLE
koa-session: flesh out types for `beforeSave` and `valid` hooks

### DIFF
--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -64,7 +64,7 @@ declare namespace session {
         /**
          * Hook: before save session
          */
-        beforeSave(...rest: any[]): void;
+        beforeSave?(...rest: any[]): void;
     }
     interface sessionProps {
         /**

--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -59,7 +59,7 @@ declare namespace session {
         /**
          * Hook: valid session value before use it
          */
-        valid?(...rest: any[]): void;
+        valid?(ctx: Koa.Context, session: sessionProps): void;
 
         /**
          * Hook: before save session

--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -64,7 +64,7 @@ declare namespace session {
         /**
          * Hook: before save session
          */
-        beforeSave?(...rest: any[]): void;
+        beforeSave?(ctx: Koa.Context, session: sessionProps): void;
     }
     interface sessionProps {
         /**


### PR DESCRIPTION
`koa-session` does not actually require this  `beforeSave` or `valid` and will prescribe built in behavior for it.

This PR removes `any[]` as arguments for the hooks and puts the actual types that are required for these hooks.

Sources:

`beforeSave`: https://github.com/koajs/session/blob/ec88cfb095ddbfa9a0db465e3f9e459fb6f92bec/lib/context.js#L215-L218

`valid`: https://github.com/koajs/session/blob/cb6d2c8448f21f6cf42efdb031798c9608f05602/lib/context.js#L161