### PR TITLE
[react-notification-system-redux] Update use of Component to be backwards compatible

### DIFF
--- a/types/react-notification-system-redux/index.d.ts
+++ b/types/react-notification-system-redux/index.d.ts
@@ -12,7 +12,7 @@ export as namespace Notifications;
 
 export = Notifications;
 
-declare class Notifications extends Component<Notifications.NotificationsProps> {}
+declare class Notifications extends Component<Notifications.NotificationsProps, {}> {}
 
 declare namespace Notifications {
     type NotificationsState = Notification[];


### PR DESCRIPTION
Prior to [@types/react 15.0.31](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17288), `Component` had no default `state`, so it had to be invoked with `Component<IProps, {}>` rather than `Component<IProps>`.  This PR converts the *react-notification-system-redux* typings to use the former invocation so that it's backwards compatible, for those of us who cannot upgrade `@types/react` without breaking a whole load of other things in our code-base.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

