### PR TITLE
Extract ClientConfig type from init params.

### DIFF
--- a/types/gapi.auth2/index.d.ts
+++ b/types/gapi.auth2/index.d.ts
@@ -107,6 +107,58 @@ declare namespace gapi.auth2 {
     scope?: string;
   }
 
+  /**
+   * Interface that represents the different configuration parameters for the gapi.auth2.init method.
+   * Reference: https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2clientconfig
+   */
+  interface ClientConfig {
+    /**
+     * The app's client ID, found and created in the Google Developers Console.
+     */
+    client_id?: string;
+
+    /**
+     * The domains for which to create sign-in cookies. Either a URI, single_host_origin, or none.
+     * Defaults to single_host_origin if unspecified.
+     */
+    cookie_policy?: string;
+
+    /**
+     * The scopes to request, as a space-delimited string. Optional if fetch_basic_profile is not set to false.
+     */
+    scope?: string;
+
+    /**
+     * Fetch users' basic profile information when they sign in. Adds 'profile' and 'email' to the requested scopes. True if unspecified.
+     */
+    fetch_basic_profile?: boolean;
+
+    /**
+     * The Google Apps domain to which users must belong to sign in. This is susceptible to modification by clients,
+     * so be sure to verify the hosted domain property of the returned user. Use GoogleUser.getHostedDomain() on the client,
+     * and the hd claim in the ID Token on the server to verify the domain is what you expected.
+     */
+    hosted_domain?: string;
+
+    /**
+     * Used only for OpenID 2.0 client migration. Set to the value of the realm that you are currently using for OpenID 2.0,
+     * as described in <a href="https://developers.google.com/accounts/docs/OpenID#openid-connect">OpenID 2.0 (Migration)</a>.
+     */
+    openid_realm?: string;
+
+    /**
+     * The UX mode to use for the sign-in flow.
+     * By default, it will open the consent flow in a popup.
+     */
+    ux_mode?: "popup" | "redirect";
+
+    /**
+     * If using ux_mode='redirect', this parameter allows you to override the default redirect_uri that will be used at the end of the consent flow.
+     * The default redirect_uri is the current URL stripped of query parameters and hash fragment.
+     */
+    redirect_uri?: string;
+  }
+
   class SigninOptionsBuilder {
     setAppPackageName(name: string): any;
     setFetchBasicProfile(fetch: boolean): any;
@@ -237,53 +289,11 @@ declare namespace gapi.auth2 {
     disconnect(): void;
   }
 
-  function init(params: {
-    /**
-     * The app's client ID, found and created in the Google Developers Console.
-     */
-    client_id?: string;
-
-    /**
-     * The domains for which to create sign-in cookies. Either a URI, single_host_origin, or none.
-     * Defaults to single_host_origin if unspecified.
-     */
-    cookie_policy?: string;
-
-    /**
-     * The scopes to request, as a space-delimited string. Optional if fetch_basic_profile is not set to false.
-     */
-    scope?: string;
-
-    /**
-     * Fetch users' basic profile information when they sign in. Adds 'profile' and 'email' to the requested scopes. True if unspecified.
-     */
-    fetch_basic_profile?: boolean;
-
-    /**
-     * The Google Apps domain to which users must belong to sign in. This is susceptible to modification by clients,
-     * so be sure to verify the hosted domain property of the returned user. Use GoogleUser.getHostedDomain() on the client,
-     * and the hd claim in the ID Token on the server to verify the domain is what you expected.
-     */
-    hosted_domain?: string;
-
-    /**
-     * Used only for OpenID 2.0 client migration. Set to the value of the realm that you are currently using for OpenID 2.0,
-     * as described in <a href="https://developers.google.com/accounts/docs/OpenID#openid-connect">OpenID 2.0 (Migration)</a>.
-     */
-    openid_realm?: string;
-
-    /**
-     * The UX mode to use for the sign-in flow.
-     * By default, it will open the consent flow in a popup.
-     */
-    ux_mode?: "popup" | "redirect";
-
-    /**
-     * If using ux_mode='redirect', this parameter allows you to override the default redirect_uri that will be used at the end of the consent flow.
-     * The default redirect_uri is the current URL stripped of query parameters and hash fragment.
-     */
-    redirect_uri?: string;
-  }): GoogleAuth;
+  /**
+   * Initializes the GoogleAuth object.
+   * Reference: https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2initparams
+   */
+  function init(params: ClientConfig): GoogleAuth;
 
   /**
    * Returns the GoogleAuth object. You must initialize the GoogleAuth object with gapi.auth2.init() before calling this method.


### PR DESCRIPTION
This allows API consumers to cleanly construct init params outside of the init call.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2clientconfig
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
