### PR TITLE
Add "type" parameter to Select2AjaxOptions

### DIFF
--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -24,6 +24,7 @@ interface Select2AjaxOptions {
     * Url to make request to, Can be string or a function returning a string.
     */
     url?: any;
+	type?: string;
     dataType?: string;
     delay?: number;
     headers?: any;


### PR DESCRIPTION
In order to support POST ajax requests when using a remote data source with Select2, the type option is needed. Select2 supports this, though it is not specifically documented in Select2's reference materials.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - Select2 by default uses jQuery.ajax: https://select2.github.io/options.html#can-an-ajax-plugin-other-than-jqueryajax-be-used
  - "type" (string) is a supported parameter of jQuery.ajax: http://api.jquery.com/jquery.ajax/
- [x] Increase the version number in the header if appropriate. **n/a**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **n/a**
