### PR TITLE
added an optional (react) style property to the react-fontawesome definition file.

### DIFF
--- a/types/react-fontawesome/index.d.ts
+++ b/types/react-fontawesome/index.d.ts
@@ -16,10 +16,9 @@ declare namespace FontAwesome {
     type FontAwesomeStack = '1x' | '2x';
     type FontAwesomeFlip = 'horizontal' | 'vertical';
 
-    interface FontAwesomeProps {
+    type FontAwesomeProps = React.HTMLProps<FontAwesome> | {
         ariaLabel?: string;
         border?: boolean;
-        className?: string;
         cssModule?: any;
         fixedWidth?: boolean;
         flip?: FontAwesomeFlip;
@@ -31,8 +30,7 @@ declare namespace FontAwesome {
         spin?: boolean;
         stack?: FontAwesomeStack;
         tag?: string;
-        style?: React.CSSProperties;
-    }
+    };
 }
 
 declare class FontAwesome extends React.Component<FontAwesome.FontAwesomeProps> {}

--- a/types/react-fontawesome/index.d.ts
+++ b/types/react-fontawesome/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for react-fontawesome 1.6
 // Project: https://github.com/danawoodman/react-fontawesome
-// Definitions by: Timur Rustamov <https://github.com/timurrustamov>,
+// Definitions by: Timur Rustamov <https://github.com/timurrustamov>
 //                 Anton Kandybo <https://github.com/dublicator>
 //                 Vincas Stonys <https://github.com/vincaslt>
+//                 Gavin Gregory <https://github.com/gavingregory>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -12,8 +13,8 @@ export = FontAwesome;
 
 declare namespace FontAwesome {
     type FontAwesomeSize = 'lg' | '2x' | '3x' | '4x' | '5x';
-    type FontAwesomeStack = "1x" | "2x";
-    type FontAwesomeFlip = "horizontal" | "vertical";
+    type FontAwesomeStack = '1x' | '2x';
+    type FontAwesomeFlip = 'horizontal' | 'vertical';
 
     interface FontAwesomeProps {
         ariaLabel?: string;
@@ -30,6 +31,7 @@ declare namespace FontAwesome {
         spin?: boolean;
         stack?: FontAwesomeStack;
         tag?: string;
+        style?: React.CSSProperties;
     }
 }
 

--- a/types/react-fontawesome/react-fontawesome-tests.tsx
+++ b/types/react-fontawesome/react-fontawesome-tests.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import FontAwesome = require('react-fontawesome');
 
-class TestComponent extends React.Component {
+class BasicTestComponent extends React.Component {
   render() {
     return (
       <FontAwesome
@@ -10,6 +10,17 @@ class TestComponent extends React.Component {
         name="rocket"
         size="2x"
         spin
+      />
+    );
+  }
+}
+
+class CSSTestComponent extends React.Component {
+  render() {
+    return (
+      <FontAwesome
+        name="rocket"
+        style={{backgroundColor: 'red', color: 'blue'}}
       />
     );
   }


### PR DESCRIPTION
Hey there, react-fontawesome supports a `style` prop, however the typescript definition doesn't allow for it. I've made the relevant changes to fix it.

Note: it would have been nicer to have instead had `FontAwesomeProps extend React.HtmlProps<FontAwesome>` however there is a conflict with the `size` property that react-fontawesome has used, so this is not currently possible.

I have instead just added an optional `style` property.

Hope this is OK, let me know if there are any changes required!

Thanks, Gavin.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](https://github.com/danawoodman/react-fontawesome#examples)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

