### PR TITLE
[openlayers] fix declaration for forEachSegment

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -3970,7 +3970,7 @@ declare module ol {
              * @template T,S
              * @api
              */
-            forEachSegment<T, S>(callback: (() => T), opt_this?: S): (T | boolean);
+            forEachSegment<T, S>(callback: ((this: S, start: ol.Coordinate, end: ol.Coordinate) => T), opt_this?: S): (T | boolean);
 
             /**
              * Returns the coordinate at `m` using linear interpolation, or `null` if no


### PR DESCRIPTION
The declaration in `LineString.forEachSegment` for the callback method input args appears to be wrong (though I'm fairly new to TypeScript). For instance, the example at https://openlayers.org/en/latest/examples/line-arrows.html won't work like that. It should accept at least `start` and `end` coordinate arguments.

-----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://openlayers.org/en/latest/examples/line-arrows.html