### PR TITLE
Fix electron-packager's protocol options

### DIFF
--- a/types/electron-packager/index.d.ts
+++ b/types/electron-packager/index.d.ts
@@ -185,15 +185,12 @@ declare namespace electronPackager {
          * If present, signs OS X target apps when the host platform is OS X and XCode is installed.
          */
         osxSign?: boolean | ElectronOsXSignOptions;
-        /**
-         * The URL protocol scheme(s) to associate the app with
-         */
-        protocol?: string[];
-        /**
-         * The descriptive name(s) of the URL protocol scheme(s) specified via the protocol option.
-         * Maps to the CFBundleURLName metadata property.
-         */
-        protocolName?: string[];
+
+        /** The URL protocol schemes the app supports. */
+        protocols: Array<{
+            name: string
+            schemes: string[]
+        }>;
 
         /**
          * Windows targets only

--- a/types/electron-packager/index.d.ts
+++ b/types/electron-packager/index.d.ts
@@ -187,7 +187,7 @@ declare namespace electronPackager {
         osxSign?: boolean | ElectronOsXSignOptions;
 
         /** The URL protocol schemes the app supports. */
-        protocols: Array<{
+        protocols?: Array<{
             name: string
             schemes: string[]
         }>;


### PR DESCRIPTION
Replace `protocol` and `protocolName` with `protocols`.

The CLI accepts the former, while the programatic interface accepts the latter.

https://github.com/electron-userland/electron-packager/blob/93523ba8dbe8626906a6ef51db3ee02d54e19ad0/common.js#L44-L51

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/electron-userland/electron-packager/blob/93523ba8dbe8626906a6ef51db3ee02d54e19ad0/common.js#L44-L51>
- ~~[ ] Increase the version number in the header if appropriate.~~
- ~~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~