### PR TITLE
corrected: in async.queue.push(task,callback) callback is not called with the task interface.

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -28,7 +28,7 @@ interface AsyncQueue<T> {
     idle(): boolean;
     concurrency: number;
     push<E>(task: T, callback?: ErrorCallback<E>): void;
-    push<R,E>(task: T, callback?: AsyncResultCallback<T, R>): void;
+    push<R,E>(task: T, callback?: AsyncResultCallback<R, E>): void;
     push<E>(task: T[], callback?: ErrorCallback<E>): void;
     unshift<E>(task: T, callback?: ErrorCallback<E>): void;
     unshift<E>(task: T[], callback?: ErrorCallback<E>): void;

--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -28,7 +28,7 @@ interface AsyncQueue<T> {
     idle(): boolean;
     concurrency: number;
     push<E>(task: T, callback?: ErrorCallback<E>): void;
-    push<E>(task: T, callback?: AsyncResultCallback<T, E>): void;
+    push<R,E>(task: T, callback?: AsyncResultCallback<T, R>): void;
     push<E>(task: T[], callback?: ErrorCallback<E>): void;
     unshift<E>(task: T, callback?: ErrorCallback<E>): void;
     unshift<E>(task: T[], callback?: ErrorCallback<E>): void;
@@ -53,8 +53,8 @@ interface AsyncPriorityQueue<T> {
     concurrency: number;
     started: boolean;
     paused: boolean;
-    push<E>(task: T, priority: number, callback?: AsyncResultArrayCallback<T, E>): void;
-    push<E>(task: T[], priority: number, callback?: AsyncResultArrayCallback<T, E>): void;
+    push<R,E>(task: T, priority: number, callback?: AsyncResultArrayCallback<R, E>): void;
+    push<R,E>(task: T[], priority: number, callback?: AsyncResultArrayCallback<R, E>): void;
     saturated: () => any;
     empty: () => any;
     drain: () => any;

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -271,9 +271,9 @@ async.waterfall([
 ], function (err, result) { });
 
 
-var q = async.queue<any,Error>(function (task: any, callback: () => void) {
+var q = async.queue<any,Error>(function (task: any, callback: (err?:Error,msg?:string) => void) {
     console.log('hello ' + task.name);
-    callback();
+    callback(undefined,'a message.');
 }, 2);
 
 
@@ -289,6 +289,10 @@ q.push({ name: 'bar' }, function (err) {
 
 q.push([{ name: 'baz' }, { name: 'bay' }, { name: 'bax' }], function (err) {
     console.log('finished processing bar');
+});
+
+q.push<string,Error>({name: 'foo'}, function (err,msg) {
+  console.log('foo finished with a message "'+ msg! + '"');
 });
 
 q.unshift({ name: 'foo' });


### PR DESCRIPTION
`async.queue.push` `callback` function is not called with the `task` object. So, I changed the `queue.push` generic signature to accommodate this.
Actually it is an ugly hack, and I don't like it. The actual signature for this `callback` is dependent on the `queue.Worker`, but I could not found a better way.
I changed the test accordingly, but as I said an ugly hack.
Any further collaborations is appreciated.