### PR TITLE
Add CodeMirror DOM events

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -102,6 +102,8 @@ declare namespace CodeMirror {
     To fire your own events, use CodeMirror.signal(target, name, args...), where target is a non-DOM-node object. */
     function signal(target: any, name: string, ...args: any[]): void;
 
+    type DOMEvent = 'mousedown' | 'dblclick' | 'touchstart' | 'contextmenu' | 'keydown' | 'keypress' | 'keyup' | 'cut' | 'copy' | 'paste' | 'dragstart' | 'dragenter' | 'dragover' | 'dragleave' | 'drop';
+
     interface Editor {
 
         /** Tells you whether the editor currently has focus. */
@@ -405,9 +407,9 @@ declare namespace CodeMirror {
         on(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void ): void;
         off(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void ): void;
 
-        /** Fires when the editor's contents are copied. */
-        on(eventName: 'copy', handler: (instance: CodeMirror.Editor, event: Event) => void ): void;
-        off(eventName: 'copy', handler: (instance: CodeMirror.Editor, event: Event) => void ): void;
+        /** Fires when one of the DOM events fires. */
+        on(eventName: DOMEvent, handler: (instance: CodeMirror.Editor, event: Event) => void ): void;
+        off(eventName: DOMEvent, handler: (instance: CodeMirror.Editor, event: Event) => void ): void;
     
         /** Expose the state object, so that the Editor.state.completionActive property is reachable*/
         state: any;

--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -405,6 +405,10 @@ declare namespace CodeMirror {
         on(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void ): void;
         off(eventName: 'renderLine', handler: (instance: CodeMirror.Editor, line: CodeMirror.LineHandle, element: HTMLElement) => void ): void;
 
+        /** Fires when the editor's contents are copied. */
+        on(eventName: 'copy', handler: (instance: CodeMirror.Editor, event: Event) => void ): void;
+        off(eventName: 'copy', handler: (instance: CodeMirror.Editor, event: Event) => void ): void;
+    
         /** Expose the state object, so that the Editor.state.completionActive property is reachable*/
         state: any;
     }


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://codemirror.net/doc/manual.html#events>
- ~~[ ] Increase the version number in the header if appropriate.~~
- ~~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~