### PR TITLE
fix(jest): add missing arguments for jest.doMock()

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -78,7 +78,7 @@ declare namespace jest {
     /**
      * Mocks a module with an auto-mocked version when it is being required.
      */
-    function doMock(moduleName: string): typeof jest;
+    function doMock(moduleName: string, factory?: any, options?: MockOptions): typeof jest;
     /**
      * Indicates that the module system should never return a mocked version
      * of the specified module from require() (e.g. that it should always return the real module).

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -598,3 +598,19 @@ declare const testResult: jest.TestResult;
 const myTestRunner: jest.TestFramework = () => Promise.resolve(testResult);
 
 const testResultsProcessor: jest.TestResultsProcessor = result => ({...result, numFailedTests: 1});
+
+// https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18826
+test('moduleName 1', () => {
+    jest.doMock('../moduleName', () => {
+        return jest.fn(() => 1);
+    });
+    const moduleName = require('../moduleName');
+    expect(moduleName()).toEqual(1);
+});
+test('moduleName 2', () => {
+    jest.doMock('../moduleName', () => {
+        return jest.fn(() => 2);
+    });
+    const moduleName = require('../moduleName');
+    expect(moduleName()).toEqual(2);
+});


### PR DESCRIPTION
Fixes #18826

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://facebook.github.io/jest/docs/en/jest-object.html#jestdomockmodulename-factory-options>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
