### PR TITLE
	Update definitions to v4

### DIFF
--- a/types/webpack-chain/index.d.ts
+++ b/types/webpack-chain/index.d.ts
@@ -83,7 +83,7 @@ declare namespace Config {
 	class Module extends ChainedMap<Config> {
 		rules: TypedChainedMap<this, Rule>;
 		rule(name: string): Rule;
-		noParse: TypedChainedSet<this, RegExp>;
+		noParse(noParse: RegExp | RegExp[] | ((contentPath: string) => boolean )): this;
 	}
 
 	class Output extends ChainedMap<Config> {

--- a/types/webpack-chain/index.d.ts
+++ b/types/webpack-chain/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for webpack-chain 3.0
 // Project: https://github.com/mozilla-neutrino/webpack-chain
-// Definitions by: Eirikur Nilsson <https://github.com/eirikurn>
+// Definitions by: Eirikur Nilsson <https://github.com/eirikurn>, Paul Sachs <https://github.com/psachs21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as webpack from 'webpack';

--- a/types/webpack-chain/webpack-chain-tests.ts
+++ b/types/webpack-chain/webpack-chain-tests.ts
@@ -83,7 +83,7 @@ config
 		.end()
 
 	.module
-		.noParse.add(/.min.js$/).end()
+		.noParse(/.min.js$/)
 		.rule('compile')
 			.test(/.js$/)
 			.include


### PR DESCRIPTION
Definition now matches supported noParse of webpack@3 and webpack-chain@4