### PR TITLE
[react-native-vector-icons] Add loadFont() method to Icons

### DIFF
--- a/types/react-native-vector-icons/Icon.d.ts
+++ b/types/react-native-vector-icons/Icon.d.ts
@@ -190,6 +190,9 @@ export class Icon extends React.Component<IconProps, any> {
     color: string,
     size?: number
   ): Promise<ImageSource>;
+  static loadFont(
+    file: string
+  ): Promise<void>
 }
 
 export namespace Icon {

--- a/types/react-native-vector-icons/Icon.d.ts
+++ b/types/react-native-vector-icons/Icon.d.ts
@@ -192,7 +192,7 @@ export class Icon extends React.Component<IconProps, any> {
   ): Promise<ImageSource>;
   static loadFont(
     file: string
-  ): Promise<void>
+  ): Promise<void>;
 }
 
 export namespace Icon {

--- a/types/react-native-vector-icons/index.d.ts
+++ b/types/react-native-vector-icons/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-native-vector-icons 4.2
+// Type definitions for react-native-vector-icons 4.3
 // Project: https://github.com/oblador/react-native-vector-icons
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
+//                 Tim Wang <https://github.com/timwangdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/oblador/react-native-vector-icons/blob/master/lib/create-icon-set.js#L149-L160>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
