### PR TITLE
ssh2-sftp-client - change function name from remove to rename

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -35,7 +35,7 @@ declare module "ssh2-sftp-client" {
       put(stream:NodeJS.ReadableStream, remoteFilePath:string, useCompression?:boolean):Promise<void>;
       mkdir(remoteFilePath:string, recursive?:boolean):Promise<void>;
       delete(remoteFilePath:string):Promise<void>;
-      remove(remoteSourcePath:string, remoteDestPath:string):Promise<void>;
+      rename(remoteSourcePath:string, remoteDestPath:string):Promise<void>;
       end():Promise<void>;
     }
   }

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -20,6 +20,6 @@ client.mkdir('/remote/path/dir', true).then(() => null);
 
 client.delete('remote/path').then(() => null);
 
-client.remove('/remote/from', '/remote/to').then(() => null);
+client.rename('/remote/from', '/remote/to').then(() => null);
 
 client.end().then(() => null);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] npm run lint package-name (or tsc if no tslint.json is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jyu213/ssh2-sftp-client/blob/master/src/index.js
- [x] Increase the version number in the header if appropriate.
 If you are making substantial changes, consider adding a tslint.json containing { "extends": "dtslint/dt.json" }.


In the ssh2-sftp-client library, there is no remove function, only rename (the README of this package is misleading as it shows an example usage of a remove function which does not exist), as per [source code](https://github.com/jyu213/ssh2-sftp-client/blob/master/src/index.js)

Currently calling either remove or rename errors because there is a rename function which doesn't match the remove function type declaration.

NB a pull request has been made to ssh2-sftp-client library to clarify the README.



