### PR TITLE
Allow DomainPropType to have only one defined axis, also allow Date domains

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -358,10 +358,7 @@ declare module "victory" {
     /**
      * Data domain type
      */
-    type DomainPropType = [number, number] | {
-        x: [number, number];
-        y: [number, number];
-    };
+    type DomainPropType = [number, number] | { x?: [number, number]; y: [number, number]; } | { x: [number, number]; y?: [number, number]; };
     /**
      * Domain padding
      */

--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -358,7 +358,8 @@ declare module "victory" {
     /**
      * Data domain type
      */
-    type DomainPropType = [number, number] | { x?: [number, number]; y: [number, number]; } | { x: [number, number]; y?: [number, number]; };
+    type DomainTuple = [number, number] | [Date, Date];
+    type DomainPropType = DomainTuple | { x?: DomainTuple; y: DomainTuple; } | { x: DomainTuple; y?: DomainTuple; };
     /**
      * Domain padding
      */

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -187,7 +187,7 @@ test = (
         dependentAxis
         padding={{left: 50, top: 20, bottom: 20}}
         scale="log"
-        domain={[1, 5]}
+        domain={{ x: [1, 5]}}
     />
 );
 

--- a/types/victory/victory-tests.tsx
+++ b/types/victory/victory-tests.tsx
@@ -187,7 +187,7 @@ test = (
         dependentAxis
         padding={{left: 50, top: 20, bottom: 20}}
         scale="log"
-        domain={{ x: [1, 5]}}
+        domain={{ x: [new Date(Date.UTC(2016, 0, 1)), new Date()], y: [1,5] }}
     />
 );
 


### PR DESCRIPTION
Victory allows to explicitly defined domain for only one axis like this `domain={{ y: [1, 2] }}`, in this case the other axis will be computed from props.
Domain props also accept Dates, couldn't find any mention in docs, but here is some code that deals with Dates https://github.com/FormidableLabs/victory-core/blob/c810b23589892e8650f40bdb801b2b671a92e800/src/victory-util/domain.js#L333. Also I use Date domains in my project which I'm now converting to TS.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/FormidableLabs/victory-core/blob/8637e418ae667ded38447fdd5363f2519a420eb4/test/client/spec/victory-util/domain.spec.js#L72
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
