### PR TITLE
[Enzyme] make ReactWrapper and ShallowWrapper classes

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -4,7 +4,7 @@ import { Component, ReactElement, HTMLAttributes, ComponentClass, StatelessCompo
 
 // Help classes/interfaces
 interface MyComponentProps {
-    stringProp: string;
+    stringProp?: string;
     numberProp?: number;
 }
 
@@ -351,6 +351,17 @@ function ShallowWrapperTest() {
     function test_svg() {
         numOrStringVal = shallowWrapper.find('svg').props().strokeWidth;
     }
+
+    function test_constructor() {
+        let anyWrapper: ShallowWrapper;
+        anyWrapper = new ShallowWrapper(<MyComponent />);
+        anyWrapper = new ShallowWrapper<MyComponentProps>(<MyComponent />);
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent />);
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>([<MyComponent />, <MyComponent />]);
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent />, shallowWrapper);
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent />, null, { lifecycleExperimental: true });
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent />, shallowWrapper, { lifecycleExperimental: true });
+    }
 }
 
 // ReactWrapper
@@ -671,8 +682,20 @@ function ReactWrapperTest() {
     function test_everyWhere() {
         boolVal = reactWrapper.everyWhere((aReactWrapper: ReactWrapper<MyComponentProps, MyComponentState>) => true);
     }
+
     function test_isEmptyRender() {
         boolVal = reactWrapper.isEmptyRender();
+    }
+
+    function test_constructor() {
+        let anyWrapper: ReactWrapper;
+        anyWrapper = new ReactWrapper(<MyComponent />);
+        anyWrapper = new ReactWrapper<MyComponentProps>(<MyComponent />);
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent />);
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>([<MyComponent />, <MyComponent />]);
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent />, reactWrapper);
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent />, null, { attachTo: document.createElement('div') });
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent />, reactWrapper, { attachTo: document.createElement('div') });
     }
 }
 

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -45,7 +45,7 @@ export type EnzymeSelector = string | StatelessComponent<any> | ComponentClass<a
 
 export type Intercepter<T> = (intercepter: T) => void;
 
-export interface CommonWrapper<P, S> {
+export interface CommonWrapper<P = {}, S = {}> {
     /**
      * Returns a new wrapper with only the nodes of the current wrapper that, when passed into the provided predicate function, return true.
      * @param predicate
@@ -368,9 +368,13 @@ export interface CommonWrapper<P, S> {
     length: number;
 }
 
-export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
+export class ShallowWrapper {
+    constructor(nodes: JSX.Element[] | JSX.Element, root?: ShallowWrapper, options?: ShallowRendererProps);
+}
+
+export interface ShallowWrapper<P = {}, S = {}> extends CommonWrapper<P, S> {
     shallow(options?: ShallowRendererProps): ShallowWrapper<P, S>;
-    unmount(): ShallowWrapper<any, any>;
+    unmount(): this;
 
     /**
      * Find every node in the render tree that matches the provided selector.
@@ -386,8 +390,7 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
      * @param selector The selector to match.
      */
     filter<P2>(component: ComponentClass<P2> | StatelessComponent<P2>): this;
-    filter(props: Partial<P>): this;
-    filter(selector: string): this;
+    filter(selector: Partial<P> | string): this;
 
     /**
      * Finds every node in the render tree that returns true for the provided predicate function.
@@ -449,9 +452,13 @@ export interface ShallowWrapper<P, S> extends CommonWrapper<P, S> {
     parent(): ShallowWrapper<any, any>;
 }
 
-export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
-    unmount(): ReactWrapper<any, any>;
-    mount(): ReactWrapper<any, any>;
+export class ReactWrapper {
+    constructor(nodes: JSX.Element | JSX.Element[], root?: ReactWrapper, options?: MountRendererProps);
+}
+
+export interface ReactWrapper<P = {}, S = {}> extends CommonWrapper<P, S> {
+    unmount(): this;
+    mount(): this;
 
     /**
      * Returns a wrapper of the node that matches the provided reference name.
@@ -493,8 +500,7 @@ export interface ReactWrapper<P, S> extends CommonWrapper<P, S> {
      * @param selector The selector to match.
      */
     filter<P2>(component: ComponentClass<P2> | StatelessComponent<P2>): this;
-    filter(props: Partial<P>): this;
-    filter(selector: string): this;
+    filter(props: Partial<P> | string): this;
 
     /**
      * Returns a new wrapper with all of the children of the node(s) in the current wrapper. Optionally, a selector


### PR DESCRIPTION
Fixes #18534

Also makes type parameters optional for the wrappers since required TS version is already 2.3 for enzyme

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/enzyme/blob/master/src/ShallowWrapper.js#L117-L154, https://github.com/airbnb/enzyme/blob/master/src/ReactWrapper.jsx#L69-L109 
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.