### PR TITLE
Update material-ui/index.d.ts to fix a typo in TextFieldProps

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1922,7 +1922,7 @@ declare namespace __MaterialUI {
         min?: number;
         max?: number;
         maxlength?: string;
-        minlegnth?: string;
+        minlength?: string;
         step?: number;
         autoComplete?: string;
     }


### PR DESCRIPTION
Fixed a typo in TextFieldProps.

I saw this in the type definition file and thought it looked weird. I have no other real reasons.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
I didn't have code that used this, and I couldn't find where this was used in https://github.com/callemall/material-ui
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~[ ] Provide a URL to documentation or source code which provides context for the suggested changes:~
- ~[ ] Increase the version number in the header if appropriate.~
- ~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~