### PR TITLE
[node] improve util.deprecate() typings, fix tests in v4 & v6 for TS >=2.3

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5190,7 +5190,7 @@ declare module "util" {
     export function isString(object: any): object is string;
     export function isSymbol(object: any): object is symbol;
     export function isUndefined(object: any): object is undefined;
-    export function deprecate(fn: Function, message: string): Function;
+    export function deprecate<T extends Function>(fn: T, message: string): T;
 
     export interface CustomPromisify<TCustom extends Function> extends Function {
         __promisify__: TCustom;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -643,6 +643,12 @@ namespace util_tests {
         var readPromised = util.promisify(fs.readFile);
         var sampleRead: Promise<any> = readPromised(__filename).then((data: Buffer): void => { }).catch((error: Error): void => { });
         assert(typeof util.promisify.custom === 'symbol');
+        // util.deprecate
+        const foo = () => {};
+        // $ExpectType () => void
+        util.deprecate(foo, 'foo() is deprecated, use bar() instead');
+        // $ExpectType <T extends Function>(fn: T, message: string) => T
+        util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
     }
 }
 

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -2272,6 +2272,7 @@ declare module "util" {
     export function isError(object: any): boolean;
     export function inherits(constructor: any, superConstructor: any): void;
     export function debuglog(key:string): (msg:string,...param: any[])=>void;
+    export function deprecate<T extends Function>(fn: T, message: string): T;
 }
 
 declare module "assert" {

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -347,6 +347,12 @@ namespace util_tests {
         util.inspect(["This is nice"], false, null);
         util.inspect(["This is nice"], { colors: true, depth: 5, customInspect: false });
         util.inspect(["This is nice"], { colors: true, depth: null, customInspect: false });
+        // util.deprecate
+        const foo = () => {};
+        // $ExpectType () => void
+        util.deprecate(foo, 'foo() is deprecated, use bar() instead');
+        // $ExpectType <T extends Function>(fn: T, message: string) => T
+        util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
     }
 }
 
@@ -467,7 +473,7 @@ namespace http_tests {
     }
 
     {
-        var request = http.request('http://0.0.0.0');
+        var request = http.request({ path: 'http://0.0.0.0' });
         request.once('error', function() { });
         request.setNoDelay(true);
         request.abort();

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -3681,7 +3681,7 @@ declare module "util" {
     export function isString(object: any): boolean;
     export function isSymbol(object: any): boolean;
     export function isUndefined(object: any): boolean;
-    export function deprecate(fn: Function, message: string): Function;
+    export function deprecate<T extends Function>(fn: T, message: string): T;
 }
 
 declare module "assert" {

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -480,7 +480,13 @@ namespace util_tests {
           showProxy: true,
           maxArrayLength: null,
           breakLength: Infinity
-        })
+        });
+        // util.deprecate
+        const foo = () => {};
+        // $ExpectType () => void
+        util.deprecate(foo, 'foo() is deprecated, use bar() instead');
+        // $ExpectType <T extends Function>(fn: T, message: string) => T
+        util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
     }
 }
 
@@ -918,7 +924,7 @@ namespace http_tests {
     }
 
     {
-        var request = http.request('http://0.0.0.0');
+        var request = http.request({ path: 'http://0.0.0.0' });
         request.once('error', function() { });
         request.setNoDelay(true);
         request.abort();

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -3834,7 +3834,7 @@ declare module "util" {
     export function isString(object: any): object is string;
     export function isSymbol(object: any): object is symbol;
     export function isUndefined(object: any): object is undefined;
-    export function deprecate(fn: Function, message: string): Function;
+    export function deprecate<T extends Function>(fn: T, message: string): T;
 }
 
 declare module "assert" {

--- a/types/node/v7/node-tests.ts
+++ b/types/node/v7/node-tests.ts
@@ -577,7 +577,13 @@ namespace util_tests {
           showProxy: true,
           maxArrayLength: null,
           breakLength: Infinity
-        })
+        });
+        // util.deprecate
+        const foo = () => {};
+        // $ExpectType () => void
+        util.deprecate(foo, 'foo() is deprecated, use bar() instead');
+        // $ExpectType <T extends Function>(fn: T, message: string) => T
+        util.deprecate(util.deprecate, 'deprecate() is deprecated, use bar() instead');
     }
 }
 
@@ -1015,7 +1021,7 @@ namespace http_tests {
     }
 
     {
-        var request = http.request('http://0.0.0.0');
+        var request = http.request({ path: 'http://0.0.0.0' });
         request.once('error', function() { });
         request.setNoDelay(true);
         request.abort();

--- a/types/react-measure/react-measure-tests.tsx
+++ b/types/react-measure/react-measure-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Measure, {ContentRect, withContentRect} from "react-measure";
+import Measure, { ContentRect, withContentRect } from "react-measure";
 
 class Test extends React.Component {
     render() {

--- a/types/react-svg-pan-zoom/index.d.ts
+++ b/types/react-svg-pan-zoom/index.d.ts
@@ -149,7 +149,7 @@ export interface Point {
 	y: number;
 }
 
-export interface ViewerMouseEvent<T>{
+export interface ViewerMouseEvent<T> {
 	originalEvent: React.MouseEvent<T>;
 	SVGViewer: SVGSVGElement;
 	point: Point;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_deprecate_function_string, https://nodejs.org/dist/latest-v6.x/docs/api/util.html#util_util_deprecate_function_string, https://nodejs.org/dist/latest-v4.x/docs/api/util.html#util_util_deprecate_function_string
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.