### PR TITLE
UglifyJS IE8 flag

### DIFF
--- a/types/uglify-js/index.d.ts
+++ b/types/uglify-js/index.d.ts
@@ -92,6 +92,7 @@ declare namespace UglifyJS {
         mangle?: Object;
         output?: MinifyOutput,
         compress?: Object;
+        ie8?: boolean;
     }
 
     interface MinifyOutput {


### PR DESCRIPTION
Added the IE8 flag as documented in https://github.com/mishoo/UglifyJS2#minify-options.

This type definition might need some review; the mangling/compression objects don't have strict interfaces defined, and by mistyping a property I was able to get an output other than MinifyOutput from the minify function.

Otherwise very good though, thanks!