### PR TITLE
xmldoc: the constructor of XmlElement takes an XmlTag, not an XmlElement

### DIFF
--- a/types/xmldoc/index.d.ts
+++ b/types/xmldoc/index.d.ts
@@ -10,7 +10,7 @@ export class XmlDocument extends XmlElement {
 }
 
 export class XmlElement {
-    constructor(tag: XmlElement);
+    constructor(tag: XmlTag);
 
     name: string;
     attr: XmlAttributes;

--- a/types/xmldoc/index.d.ts
+++ b/types/xmldoc/index.d.ts
@@ -9,15 +9,20 @@ export class XmlDocument extends XmlElement {
     doctype: string;
 }
 
-export class XmlElement {
+export interface XmlNode {
+    toString(opts?: XmlOptions): string;
+    toStringWithIndent(indent: string, opts?: XmlOptions): string;
+}
+
+export class XmlElement implements XmlNode {
     constructor(tag: XmlTag);
 
     name: string;
     attr: XmlAttributes;
     val: string;
-    children: XmlElement[];
-    firstChild: XmlElement;
-    lastChild: XmlElement;
+    children: XmlNode[];
+    firstChild: XmlNode;
+    lastChild: XmlNode;
 
     eachChild(func: (child: XmlElement, index?: number, array?: XmlElement[]) => void): void;
     childNamed(name: string): XmlElement;
@@ -29,21 +34,21 @@ export class XmlElement {
     toStringWithIndent(indent: string, opts?: XmlOptions): string;
 }
 
-export class XmlTextNode {
+export class XmlTextNode implements XmlNode {
     constructor(text: string);
 
     toString(opts?: XmlOptions): string;
     toStringWithIndent(indent: string, opts?: XmlOptions): string;
 }
 
-export class XmlCDataNode {
+export class XmlCDataNode implements XmlNode {
     constructor(cdata: string);
 
     toString(opts?: XmlOptions): string;
     toStringWithIndent(indent: string, opts?: XmlOptions): string;
 }
 
-export class XmlCommentNode {
+export class XmlCommentNode implements XmlNode {
     constructor(comment: string);
 
     toString(opts?: XmlOptions): string;

--- a/types/xmldoc/tsconfig.json
+++ b/types/xmldoc/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
+        "strict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/xmldoc/tsconfig.json
+++ b/types/xmldoc/tsconfig.json
@@ -7,6 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "strictNullChecks": true,
         "strict": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/xmldoc/xmldoc-tests.ts
+++ b/types/xmldoc/xmldoc-tests.ts
@@ -1,4 +1,5 @@
 import * as xmldoc from "xmldoc";
+import { XmlElement } from "xmldoc";
 
 //
 // https://github.com/nfarina/xmldoc#usage
@@ -24,6 +25,12 @@ const nameNode = bookNode.descendantWithPath("author.name"); // return <name> no
 //
 const authorName = bookNode.valueWithPath("author.name");               // return "George R. R. Martin"
 const authorIsProper = bookNode.valueWithPath("author.name@isProper");  // return "true"
+
+//
+// XmlElement constructor takes an XmlTag
+// https://github.com/nfarina/xmldoc/blob/master/lib/xmldoc.js#L22
+//
+new XmlElement({ name: "foo", attributes: { bar: "baz" } });
 
 //
 // https://github.com/nfarina/xmldoc#tostringoptions

--- a/types/xmldoc/xmldoc-tests.ts
+++ b/types/xmldoc/xmldoc-tests.ts
@@ -1,5 +1,5 @@
 import * as xmldoc from "xmldoc";
-import { XmlElement } from "xmldoc";
+import { XmlElement, XmlTextNode, XmlCDataNode, XmlCommentNode } from "xmldoc";
 
 //
 // https://github.com/nfarina/xmldoc#usage
@@ -31,6 +31,14 @@ const authorIsProper = bookNode.valueWithPath("author.name@isProper");  // retur
 // https://github.com/nfarina/xmldoc/blob/master/lib/xmldoc.js#L22
 //
 new XmlElement({ name: "foo", attributes: { bar: "baz" } });
+
+//
+// Adding various types of children
+//
+const element = new XmlElement({ name: "foo", attributes: { bar: "baz" } });
+element.children.push(new XmlTextNode("some text"));
+element.children.push(new XmlCDataNode("some cdata"));
+element.children.push(new XmlCommentNode("some comment"));
 
 //
 // https://github.com/nfarina/xmldoc#tostringoptions


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nfarina/xmldoc/blob/master/lib/xmldoc.js#L22
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.