### PR TITLE
[react-native] Added missing type cases for ItemSeparatorComponent on FlatList

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3491,7 +3491,7 @@ export interface FlatListProperties<ItemT> extends VirtualizedListProperties<Ite
     /**
      * Rendered in between each item, but not at the top or bottom
      */
-    ItemSeparatorComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
+    ItemSeparatorComponent?: React.ComponentType<any> | null
 
     /**
      * Rendered when the list is empty.

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3491,7 +3491,7 @@ export interface FlatListProperties<ItemT> extends VirtualizedListProperties<Ite
     /**
      * Rendered in between each item, but not at the top or bottom
      */
-    ItemSeparatorComponent?: React.ComponentClass<any> | null
+    ItemSeparatorComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
 
     /**
      * Rendered when the list is empty.

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -208,11 +208,22 @@ InteractionManager.runAfterInteractions(() => {
 }).then(() => 'done')
 
 export class FlatListTest extends React.Component<FlatListProperties<number>, {}> {
+    _renderItem = (rowData: any) => {
+        return (
+            <View>
+                <Text> {rowData.item} </Text>
+            </View>
+        );
+      }
+
+    _renderSeparator= () => <View style={{height: 1, width: '100%', backgroundColor: 'gray'}} />
+
     render() {
         return (
             <FlatList
                 data={[1, 2, 3, 4, 5]}
-                renderItem={(info: { item: number }) => <View><Text>{info.item}</Text></View>}
+                renderItem={this._renderItem}
+                ItemSeparatorComponent={this._renderSeparator}
             />
         );
     }


### PR DESCRIPTION
Fixes #18823

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://facebook.github.io/react-native/docs/flatlist.html#itemseparatorcomponent>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fixes #18823 