### PR TITLE
[TinyMCE] Add the ability to pass strings to width, height, min_heigh…

### DIFF
--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -87,7 +87,7 @@ export interface Settings {
 
   fixed_toolbar_container?: string;
 
-  height?: number;
+  height?: number | string;
 
   inline?: boolean;
 
@@ -103,9 +103,9 @@ export interface Settings {
 
   menubar?: string | boolean;
 
-  min_height?: number;
+  min_height?: number | string;
 
-  min_width?: number;
+  min_width?: number | string;
 
   preview_styles?: boolean | string;
 
@@ -127,7 +127,7 @@ export interface Settings {
 
   toolbar?: boolean | string | string[];
 
-  width?: number;
+  width?: number | string;
 
   body_class?: string;
 


### PR DESCRIPTION
…t and min_width Settings attributes

So we can use percentages when specifying those properties as well

Signed-off-by: Thiago Lacerda <thiagotbl@gmail.com>

Please fill in this template.