### PR TITLE
Fix for issue #18946 in quill typings

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -205,3 +205,5 @@ export class Quill implements EventEmitter {
     off(eventName: "selection-change", handler: SelectionChangeHandler): EventEmitter;
     off(eventName: "editor-change", handler: EditorChangeHandler): EventEmitter;
 }
+
+export default Quill;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:  

This fixes #18946. You should be able to `import Quill from 'quill'` and treat Quill as a constructor (and access Quill statics). I think the change from `import * as Quill` was prior to my touching this code - in [this version](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2ea2588a3365a49c2829a200977d776a7df09d46/types/quill/index.d.ts) they took out the namespace-style declaration and replaced it with the modern export class / interface approach.

So this is probably still a breaking change, relative to the 0.X version of these typings, but it's an improvement. 

cc: @buu700 @guillaume-ro-fr 