### PR TITLE
Fix Error TS2306 ("flowjs/index.d.ts not a module")

### DIFF
--- a/types/flowjs/index.d.ts
+++ b/types/flowjs/index.d.ts
@@ -83,3 +83,6 @@ declare namespace flowjs {
         getType(): string;
     }
 }
+
+export = flowjs;
+export as namespace flowjs;


### PR DESCRIPTION
I was trying to import the flowjs types, but I'm unable to do so because they are not exported. So this is just a small fix to export the types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/40379116/using-flow-js-in-angular-2-typescript