### PR TITLE
update react-redux connect options

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -164,7 +164,7 @@ interface MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> {
     (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TMergedProps;
 }
 
-interface Options<TStateProps = any, TOwnProps = any, TMergedProps = any> extends ConnectOptions {
+interface Options<TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends ConnectOptions {
     /**
      * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
      * preventing unnecessary updates, assuming that the component is a “pure” component

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -164,7 +164,7 @@ interface MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> {
     (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TMergedProps;
 }
 
-interface Options<TStateProps, TOwnProps, TMergedProps = any> extends ConnectOptions {
+interface Options<TStateProps = any, TOwnProps = any, TMergedProps = any> extends ConnectOptions {
     /**
      * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
      * preventing unnecessary updates, assuming that the component is a “pure” component
@@ -181,7 +181,7 @@ interface Options<TStateProps, TOwnProps, TMergedProps = any> extends ConnectOpt
     areStatesEqual?: (nextState: any, prevState: any) => boolean;
     
     /**
-     * When pure, compares incoming store state to its previous value.
+     * When pure, compares incoming props to its previous value.
      * @default shallowEqual
      */
     areOwnPropsEqual?: (nextOwnProps: TOwnProps, prevOwnProps: TOwnProps) => boolean;

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -109,28 +109,28 @@ export declare function connect<TStateProps, no_dispatch, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: null | undefined,
     mergeProps: null | undefined,
-    options: Options
+    options: Options<TStateProps, TOwnProps>
 ): InferableComponentEnhancerWithProps<DispatchProp<any> & TStateProps, TOwnProps>;
 
 export declare function connect<no_state, TDispatchProps, TOwnProps>(
     mapStateToProps: null | undefined,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
-    options: Options
+    options: Options<no_state, TOwnProps>
 ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: null | undefined,
-    options: Options
+    options: Options<TStateProps, TOwnProps>
 ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
 export declare function connect<TStateProps, TDispatchProps, TOwnProps, TMergedProps>(
     mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps>,
     mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
     mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
-    options: Options
+    options: Options<TStateProps, TOwnProps, TMergedProps>
 ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 
 interface MapStateToProps<TStateProps, TOwnProps> {
@@ -164,7 +164,7 @@ interface MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps> {
     (stateProps: TStateProps, dispatchProps: TDispatchProps, ownProps: TOwnProps): TMergedProps;
 }
 
-interface Options extends ConnectOptions {
+interface Options<TStateProps, TOwnProps, TMergedProps = any> extends ConnectOptions {
     /**
      * If true, implements shouldComponentUpdate and shallowly compares the result of mergeProps,
      * preventing unnecessary updates, assuming that the component is a “pure” component
@@ -173,11 +173,30 @@ interface Options extends ConnectOptions {
      * @default true
      */
     pure?: boolean;
+
     /**
-     * If true, stores a ref to the wrapped component instance and makes it available via
-     * getWrappedInstance() method. Defaults to false.
+     * When pure, compares incoming store state to its previous value.
+     * @default strictEqual
      */
-    withRef?: boolean;
+    areStatesEqual?: (nextState: any, prevState: any) => boolean;
+    
+    /**
+     * When pure, compares incoming store state to its previous value.
+     * @default shallowEqual
+     */
+    areOwnPropsEqual?: (nextOwnProps: TOwnProps, prevOwnProps: TOwnProps) => boolean;
+    
+    /**
+     * When pure, compares the result of mapStateToProps to its previous value.
+     * @default shallowEqual
+     */
+    areStatePropsEqual?: (nextStateProps: TStateProps, prevStateProps: TStateProps) => boolean;
+
+    /**
+     * When pure, compares the result of mergeProps to its previous value.
+     * @default shallowEqual
+     */
+    areMergedPropsEqual?: (nextMergedProps: TMergedProps, prevMergedProps: TMergedProps) => boolean;    
 }
 
 /**

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -196,7 +196,7 @@ interface Options<TStateProps, TOwnProps, TMergedProps = any> extends ConnectOpt
      * When pure, compares the result of mergeProps to its previous value.
      * @default shallowEqual
      */
-    areMergedPropsEqual?: (nextMergedProps: TMergedProps, prevMergedProps: TMergedProps) => boolean;    
+    areMergedPropsEqual?: (nextMergedProps: TMergedProps, prevMergedProps: TMergedProps) => boolean;
 }
 
 /**


### PR DESCRIPTION
The existing Options had a redundant "withRef" parameter (it was already inheriting from ConnectOptions), and were missing some helper functions for diffing state and props:

https://github.com/reactjs/react-redux/blob/master/docs/api.md#arguments

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-redux/blob/master/docs/api.md#arguments
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
