### PR TITLE
[node] Add http2 type definitions

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6008,7 +6008,7 @@ declare module "http2" {
         graceful?: boolean;
         errorCode?: number;
         lastStreamID?: number;
-        opaqueData?: Buffer | number[];
+        opaqueData?: Buffer | Uint8Array;
     }
 
     export interface SessionState {
@@ -6041,83 +6041,119 @@ declare module "http2" {
 
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: "close", listener: () => void): this;
-        addListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
         addListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         addListener(event: "localSettings", listener: (settings: Settings) => void): this;
         addListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        addListener(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         addListener(event: "socketError", listener: (err: Error) => void): this;
         addListener(event: "timeout", listener: () => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "close"): boolean;
-        emit(event: "connect", session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "frameError", frameType: number, errorCode: number, streamID: number): boolean;
         emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
         emit(event: "localSettings", settings: Settings): boolean;
         emit(event: "remoteSettings", settings: Settings): boolean;
-        emit(event: "stream", stream: Http2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "socketError", err: Error): boolean;
         emit(event: "timeout"): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
         on(event: "close", listener: () => void): this;
-        on(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
         on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         on(event: "localSettings", listener: (settings: Settings) => void): this;
         on(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        on(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         on(event: "socketError", listener: (err: Error) => void): this;
         on(event: "timeout", listener: () => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
         once(event: "close", listener: () => void): this;
-        once(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
         once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         once(event: "localSettings", listener: (settings: Settings) => void): this;
         once(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        once(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         once(event: "socketError", listener: (err: Error) => void): this;
         once(event: "timeout", listener: () => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
         prependListener(event: "close", listener: () => void): this;
-        prependListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
         prependListener(event: "error", listener: (err: Error) => void): this;
         prependListener(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
         prependListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        prependListener(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependListener(event: "socketError", listener: (err: Error) => void): this;
         prependListener(event: "timeout", listener: () => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         prependOnceListener(event: "close", listener: () => void): this;
-        prependOnceListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
         prependOnceListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependOnceListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        prependOnceListener(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependOnceListener(event: "socketError", listener: (err: Error) => void): this;
         prependOnceListener(event: "timeout", listener: () => void): this;
     }
 
     export interface ClientHttp2Session extends Http2Session {
-        request(headers: OutgoingHttpHeaders, options?: ClientSessionRequestOptions): ClientHttp2Stream;
+        request(headers?: OutgoingHttpHeaders, options?: ClientSessionRequestOptions): ClientHttp2Stream;
+
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        addListener(event: "stream", listener: (stream: ClientHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "connect", session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket): boolean;
+        emit(event: "stream", stream: ClientHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        on(event: "stream", listener: (stream: ClientHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        once(event: "stream", listener: (stream: ClientHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        prependListener(event: "stream", listener: (stream: ClientHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        prependOnceListener(event: "stream", listener: (stream: ClientHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
     }
 
     export interface ServerHttp2Session extends Http2Session {
         readonly server: Http2Server | Http2SecureServer;
+
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "connect", session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket): boolean;
+        emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        on(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        once(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "connect", listener: (session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
     }
 
     // Http2Server

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -13,6 +13,7 @@
 //                 wwwy3y3 <https://github.com/wwwy3y3>
 //                 Daniel Imms <https://github.com/Tyriar>
 //                 Deividas Bakanas <https://github.com/DeividasBakanas>
+//                 Kelvin Jin <https://github.com/kjin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -5840,8 +5841,12 @@ declare module "http2" {
     import * as tls from "tls";
     import * as url from "url";
 
-    export interface Headers {
+    export interface IncomingHttpHeaders {
         [headerField: string]: string | string[];
+    }
+
+    export interface OutgoingHttpHeaders {
+        [headerField: string]: number | string | string[] | undefined;
     }
 
     // Http2Stream
@@ -5864,7 +5869,7 @@ declare module "http2" {
 
     export interface ServerStreamResponseOptions {
         endStream?: boolean;
-        getTrailers?: (trailers: Headers) => void;
+        getTrailers?: (trailers: IncomingHttpHeaders) => void;
     }
 
     export interface StatOptions {
@@ -5873,8 +5878,8 @@ declare module "http2" {
     }
 
     export interface ServerStreamFileResponseOptions {
-        statCheck?: (stats: fs.Stats, headers: Headers, statOptions: StatOptions) => void;
-        getTrailers?: (trailers: Headers) => void;
+        statCheck?: (stats: fs.Stats, headers: IncomingHttpHeaders, statOptions: StatOptions) => void;
+        getTrailers?: (trailers: IncomingHttpHeaders) => void;
         offset?: number;
         length?: number;
     }
@@ -5899,85 +5904,85 @@ declare module "http2" {
         addListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
         addListener(event: "streamClosed", listener: (code: number) => void): this;
         addListener(event: "timeout", listener: () => void): this;
-        addListener(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+        addListener(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "aborted"): boolean;
         emit(event: "frameError", frameType: number, errorCode: number): boolean;
         emit(event: "streamClosed", code: number): boolean;
         emit(event: "timeout"): boolean;
-        emit(event: "trailers", trailers: Headers, flags: number): boolean;
+        emit(event: "trailers", trailers: IncomingHttpHeaders, flags: number): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
         on(event: "aborted", listener: () => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
         on(event: "streamClosed", listener: (code: number) => void): this;
         on(event: "timeout", listener: () => void): this;
-        on(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+        on(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
         once(event: "aborted", listener: () => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
         once(event: "streamClosed", listener: (code: number) => void): this;
         once(event: "timeout", listener: () => void): this;
-        once(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+        once(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
         prependListener(event: "aborted", listener: () => void): this;
         prependListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
         prependListener(event: "streamClosed", listener: (code: number) => void): this;
         prependListener(event: "timeout", listener: () => void): this;
-        prependListener(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+        prependListener(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         prependOnceListener(event: "aborted", listener: () => void): this;
         prependOnceListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
         prependOnceListener(event: "streamClosed", listener: (code: number) => void): this;
         prependOnceListener(event: "timeout", listener: () => void): this;
-        prependOnceListener(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
     }
 
     export interface ClientHttp2Stream extends Http2Stream {
         addListener(event: string, listener: (...args: any[]) => void): this;
-        addListener(event: "headers", listener: (headers: Headers, flags: number) => void): this;
-        addListener(event: "push", listener: (headers: Headers, flags: number) => void): this;
-        addListener(event: "response", listener: (headers: Headers, flags: number) => void): this;
+        addListener(event: "headers", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        addListener(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        addListener(event: "response", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
-        emit(event: "headers", headers: Headers, flags: number): boolean;
-        emit(event: "push", headers: Headers, flags: number): boolean;
-        emit(event: "response", headers: Headers, flags: number): boolean;
+        emit(event: "headers", headers: IncomingHttpHeaders, flags: number): boolean;
+        emit(event: "push", headers: IncomingHttpHeaders, flags: number): boolean;
+        emit(event: "response", headers: IncomingHttpHeaders, flags: number): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
-        on(event: "headers", listener: (headers: Headers, flags: number) => void): this;
-        on(event: "push", listener: (headers: Headers, flags: number) => void): this;
-        on(event: "response", listener: (headers: Headers, flags: number) => void): this;
+        on(event: "headers", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        on(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        on(event: "response", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
-        once(event: "headers", listener: (headers: Headers, flags: number) => void): this;
-        once(event: "push", listener: (headers: Headers, flags: number) => void): this;
-        once(event: "response", listener: (headers: Headers, flags: number) => void): this;
+        once(event: "headers", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        once(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        once(event: "response", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
-        prependListener(event: "headers", listener: (headers: Headers, flags: number) => void): this;
-        prependListener(event: "push", listener: (headers: Headers, flags: number) => void): this;
-        prependListener(event: "response", listener: (headers: Headers, flags: number) => void): this;
+        prependListener(event: "headers", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        prependListener(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        prependListener(event: "response", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
-        prependOnceListener(event: "headers", listener: (headers: Headers, flags: number) => void): this;
-        prependOnceListener(event: "push", listener: (headers: Headers, flags: number) => void): this;
-        prependOnceListener(event: "response", listener: (headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "headers", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        prependOnceListener(event: "push", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
+        prependOnceListener(event: "response", listener: (headers: IncomingHttpHeaders, flags: number) => void): this;
     }
 
     export interface ServerHttp2Stream extends Http2Stream {
-        additionalHeaders(headers: Headers): void;
+        additionalHeaders(headers: OutgoingHttpHeaders): void;
         readonly headersSent: boolean;
         readonly pushAllowed: boolean;
-        pushStream(headers: Headers, callback?: (pushStream: ServerHttp2Stream) => void): void;
-        pushStream(headers: Headers, options?: StreamPriorityOptions, callback?: (pushStream: ServerHttp2Stream) => void): void;
-        respond(headers?: Headers, options?: ServerStreamResponseOptions): void;
-        respondWithFD(fd: number, headers?: Headers, options?: ServerStreamResponseOptions): void;
-        respondWithFD(path: string, headers?: Headers, options?: ServerStreamResponseOptions): void;
+        pushStream(headers: OutgoingHttpHeaders, callback?: (pushStream: ServerHttp2Stream) => void): void;
+        pushStream(headers: OutgoingHttpHeaders, options?: StreamPriorityOptions, callback?: (pushStream: ServerHttp2Stream) => void): void;
+        respond(headers?: OutgoingHttpHeaders, options?: ServerStreamResponseOptions): void;
+        respondWithFD(fd: number, headers?: OutgoingHttpHeaders, options?: ServerStreamResponseOptions): void;
+        respondWithFD(path: string, headers?: OutgoingHttpHeaders, options?: ServerStreamResponseOptions): void;
     }
 
     // Http2Session
@@ -5996,7 +6001,7 @@ declare module "http2" {
         exclusive?: boolean;
         parent?: number;
         weight?: number;
-        getTrailers?: (trailers: Headers, flags: number) => void;
+        getTrailers?: (trailers: IncomingHttpHeaders, flags: number) => void;
     }
 
     export interface SessionShutdownOptions {
@@ -6042,7 +6047,7 @@ declare module "http2" {
         addListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         addListener(event: "localSettings", listener: (settings: Settings) => void): this;
         addListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        addListener(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        addListener(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         addListener(event: "socketError", listener: (err: Error) => void): this;
         addListener(event: "timeout", listener: () => void): this;
 
@@ -6054,7 +6059,7 @@ declare module "http2" {
         emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
         emit(event: "localSettings", settings: Settings): boolean;
         emit(event: "remoteSettings", settings: Settings): boolean;
-        emit(event: "stream", stream: Http2Stream, headers: Headers, flags: number): boolean;
+        emit(event: "stream", stream: Http2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "socketError", err: Error): boolean;
         emit(event: "timeout"): boolean;
 
@@ -6066,7 +6071,7 @@ declare module "http2" {
         on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         on(event: "localSettings", listener: (settings: Settings) => void): this;
         on(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        on(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        on(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         on(event: "socketError", listener: (err: Error) => void): this;
         on(event: "timeout", listener: () => void): this;
 
@@ -6078,7 +6083,7 @@ declare module "http2" {
         once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         once(event: "localSettings", listener: (settings: Settings) => void): this;
         once(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        once(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        once(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         once(event: "socketError", listener: (err: Error) => void): this;
         once(event: "timeout", listener: () => void): this;
 
@@ -6090,7 +6095,7 @@ declare module "http2" {
         prependListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        prependListener(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        prependListener(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependListener(event: "socketError", listener: (err: Error) => void): this;
         prependListener(event: "timeout", listener: () => void): this;
 
@@ -6102,13 +6107,13 @@ declare module "http2" {
         prependOnceListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
         prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
         prependOnceListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
-        prependOnceListener(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "stream", listener: (stream: Http2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependOnceListener(event: "socketError", listener: (err: Error) => void): this;
         prependOnceListener(event: "timeout", listener: () => void): this;
     }
 
     export interface ClientHttp2Session extends Http2Session {
-        request(headers: Headers, options?: ClientSessionRequestOptions): ClientHttp2Stream;
+        request(headers: OutgoingHttpHeaders, options?: ClientSessionRequestOptions): ClientHttp2Stream;
     }
 
     export interface ServerHttp2Session extends Http2Session {
@@ -6146,42 +6151,42 @@ declare module "http2" {
         addListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(event: "socketError", listener: (err: Error) => void): this;
-        addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         addListener(event: "timeout", listener: () => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "socketError", err: Error): boolean;
-        emit(event: "stream", stream: ServerHttp2Stream, headers: Headers, flags: number): boolean;
+        emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
         on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(event: "socketError", listener: (err: Error) => void): this;
-        on(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        on(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         on(event: "timeout", listener: () => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
         once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(event: "socketError", listener: (err: Error) => void): this;
-        once(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        once(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         once(event: "timeout", listener: () => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
         prependListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(event: "socketError", listener: (err: Error) => void): this;
-        prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependListener(event: "timeout", listener: () => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         prependOnceListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(event: "socketError", listener: (err: Error) => void): this;
-        prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependOnceListener(event: "timeout", listener: () => void): this;
     }
 
@@ -6190,7 +6195,7 @@ declare module "http2" {
         addListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         addListener(event: "sessionError", listener: (err: Error) => void): this;
         addListener(event: "socketError", listener: (err: Error) => void): this;
-        addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
 
@@ -6198,7 +6203,7 @@ declare module "http2" {
         emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
         emit(event: "sessionError", err: Error): boolean;
         emit(event: "socketError", err: Error): boolean;
-        emit(event: "stream", stream: ServerHttp2Stream, headers: Headers, flags: number): boolean;
+        emit(event: "stream", stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number): boolean;
         emit(event: "timeout"): boolean;
         emit(event: "unknownProtocol", socket: tls.TLSSocket): boolean;
 
@@ -6206,7 +6211,7 @@ declare module "http2" {
         on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         on(event: "sessionError", listener: (err: Error) => void): this;
         on(event: "socketError", listener: (err: Error) => void): this;
-        on(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        on(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         on(event: "timeout", listener: () => void): this;
         on(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
 
@@ -6214,7 +6219,7 @@ declare module "http2" {
         once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         once(event: "sessionError", listener: (err: Error) => void): this;
         once(event: "socketError", listener: (err: Error) => void): this;
-        once(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        once(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         once(event: "timeout", listener: () => void): this;
         once(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
 
@@ -6222,7 +6227,7 @@ declare module "http2" {
         prependListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         prependListener(event: "sessionError", listener: (err: Error) => void): this;
         prependListener(event: "socketError", listener: (err: Error) => void): this;
-        prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependListener(event: "timeout", listener: () => void): this;
         prependListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
 
@@ -6230,14 +6235,14 @@ declare module "http2" {
         prependOnceListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
         prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
         prependOnceListener(event: "socketError", listener: (err: Error) => void): this;
-        prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void): this;
         prependOnceListener(event: "timeout", listener: () => void): this;
         prependOnceListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
     }
 
     export interface Http2ServerRequest extends stream.Readable {
         destroy(err: Error): void;
-        headers: Headers;
+        headers: IncomingHttpHeaders;
         httpVersion: string;
         method: string;
         rawHeaders: string[];
@@ -6245,7 +6250,7 @@ declare module "http2" {
         setTimeout(msecs: number, callback?: () => void): void;
         socket: net.Socket | tls.TLSSocket;
         stream: ServerHttp2Stream;
-        trailers: Headers;
+        trailers: IncomingHttpHeaders;
         url: string;
 
         addListener(event: string, listener: (...args: any[]) => void): this;
@@ -6268,7 +6273,7 @@ declare module "http2" {
     }
 
     export interface Http2ServerResponse extends events.EventEmitter {
-        addTrailers(trailers: Headers): void;
+        addTrailers(trailers: OutgoingHttpHeaders): void;
         connection: net.Socket | tls.TLSSocket;
         end(callback?: () => void): void;
         end(data?: string | Buffer, callback?: () => void): void;
@@ -6276,12 +6281,12 @@ declare module "http2" {
         finished: boolean;
         getHeader(name: string): string;
         getHeaderNames(): string[];
-        getHeaders(): Headers;
+        getHeaders(): OutgoingHttpHeaders;
         hasHeader(name: string): boolean;
         readonly headersSent: boolean;
         removeHeader(name: string): void;
         sendDate: boolean;
-        setHeader(name: string, value: string | string[]): void;
+        setHeader(name: string, value: number | string | string[]): void;
         setTimeout(msecs: number, callback?: () => void): void;
         socket: net.Socket | tls.TLSSocket;
         statusCode: number;
@@ -6290,9 +6295,9 @@ declare module "http2" {
         write(chunk: string | Buffer, callback?: (err: Error) => void): boolean;
         write(chunk: string | Buffer, encoding?: string, callback?: (err: Error) => void): boolean;
         writeContinue(): void;
-        writeHead(statusCode: number, headers?: Headers): void;
-        writeHead(statusCode: number, statusMessage?: string, headers?: Headers): void;
-        createPushResponse(headers: Headers, callback?: (err: Error) => void): void;
+        writeHead(statusCode: number, headers?: OutgoingHttpHeaders): void;
+        writeHead(statusCode: number, statusMessage?: string, headers?: OutgoingHttpHeaders): void;
+        createPushResponse(headers: OutgoingHttpHeaders, callback?: (err: Error) => void): void;
 
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5840,7 +5840,9 @@ declare module "http2" {
     import * as tls from "tls";
     import * as url from "url";
 
-    type Headers = Object;
+    export interface Headers {
+        [headerField: string]: string | string[];
+    }
 
     // Http2Stream
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5831,3 +5831,733 @@ declare module "async_hooks" {
      */
     export function createHook(options: HookCallbacks): AsyncHook;
 }
+
+declare module "http2" {
+    import * as events from "events";
+    import * as fs from "fs";
+    import * as net from "net";
+    import * as stream from "stream";
+    import * as tls from "tls";
+    import * as url from "url";
+
+    type Headers = Object;
+
+    // Http2Stream
+
+    export interface StreamPriorityOptions {
+        exclusive?: boolean;
+        parent?: number;
+        weight?: number;
+        silent?: boolean;
+    }
+
+    export interface StreamState {
+        localWindowSize?: number;
+        state?: number;
+        streamLocalClose?: number;
+        streamRemoteClose?: number;
+        sumDependencyWeight?: number;
+        weight?: number;
+    }
+
+    export interface ServerStreamResponseOptions {
+        endStream?: boolean;
+        getTrailers?: (trailers: Headers) => void;
+    }
+
+    export interface StatOptions {
+        offset: number;
+        length: number;
+    }
+
+    export interface ServerStreamFileResponseOptions {
+        statCheck?: (stats: fs.Stats, headers: Headers, statOptions: StatOptions) => void;
+        getTrailers?: (trailers: Headers) => void;
+        offset?: number;
+        length?: number;
+    }
+
+    export interface Http2Stream extends stream.Duplex {
+        readonly aborted: boolean;
+        readonly destroyed: boolean;
+        priority(options: StreamPriorityOptions): void;
+        readonly rstCode: number;
+        rstStream(code: number): void;
+        rstWithNoError(): void;
+        rstWithProtocolError(): void;
+        rstWithCancel(): void;
+        rstWithRefuse(): void;
+        rstWithInternalError(): void;
+        readonly session: Http2Session;
+        setTimeout(msecs: number, callback?: () => void): void;
+        readonly state: StreamState;
+
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "aborted", listener: () => void): this;
+        addListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        addListener(event: "streamClosed", listener: (code: number) => void): this;
+        addListener(event: "timeout", listener: () => void): this;
+        addListener(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "aborted"): boolean;
+        emit(event: "frameError", frameType: number, errorCode: number): boolean;
+        emit(event: "streamClosed", code: number): boolean;
+        emit(event: "timeout"): boolean;
+        emit(event: "trailers", trailers: Headers, flags: number): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "aborted", listener: () => void): this;
+        on(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        on(event: "streamClosed", listener: (code: number) => void): this;
+        on(event: "timeout", listener: () => void): this;
+        on(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "aborted", listener: () => void): this;
+        once(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        once(event: "streamClosed", listener: (code: number) => void): this;
+        once(event: "timeout", listener: () => void): this;
+        once(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "aborted", listener: () => void): this;
+        prependListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        prependListener(event: "streamClosed", listener: (code: number) => void): this;
+        prependListener(event: "timeout", listener: () => void): this;
+        prependListener(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "aborted", listener: () => void): this;
+        prependOnceListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        prependOnceListener(event: "streamClosed", listener: (code: number) => void): this;
+        prependOnceListener(event: "timeout", listener: () => void): this;
+        prependOnceListener(event: "trailers", listener: (trailers: Headers, flags: number) => void): this;
+    }
+
+    export interface ClientHttp2Stream extends Http2Stream {
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "headers", listener: (headers: Headers, flags: number) => void): this;
+        addListener(event: "push", listener: (headers: Headers, flags: number) => void): this;
+        addListener(event: "response", listener: (headers: Headers, flags: number) => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "headers", headers: Headers, flags: number): boolean;
+        emit(event: "push", headers: Headers, flags: number): boolean;
+        emit(event: "response", headers: Headers, flags: number): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "headers", listener: (headers: Headers, flags: number) => void): this;
+        on(event: "push", listener: (headers: Headers, flags: number) => void): this;
+        on(event: "response", listener: (headers: Headers, flags: number) => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "headers", listener: (headers: Headers, flags: number) => void): this;
+        once(event: "push", listener: (headers: Headers, flags: number) => void): this;
+        once(event: "response", listener: (headers: Headers, flags: number) => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "headers", listener: (headers: Headers, flags: number) => void): this;
+        prependListener(event: "push", listener: (headers: Headers, flags: number) => void): this;
+        prependListener(event: "response", listener: (headers: Headers, flags: number) => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "headers", listener: (headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "push", listener: (headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "response", listener: (headers: Headers, flags: number) => void): this;
+    }
+
+    export interface ServerHttp2Stream extends Http2Stream {
+        additionalHeaders(headers: Headers): void;
+        readonly headersSent: boolean;
+        readonly pushAllowed: boolean;
+        pushStream(headers: Headers, callback?: (pushStream: ServerHttp2Stream) => void): void;
+        pushStream(headers: Headers, options?: StreamPriorityOptions, callback?: (pushStream: ServerHttp2Stream) => void): void;
+        respond(headers?: Headers, options?: ServerStreamResponseOptions): void;
+        respondWithFD(fd: number, headers?: Headers, options?: ServerStreamResponseOptions): void;
+        respondWithFD(path: string, headers?: Headers, options?: ServerStreamResponseOptions): void;
+    }
+
+    // Http2Session
+
+    export interface Settings {
+        headerTableSize?: number;
+        enablePush?: boolean;
+        initialWindowSize?: number;
+        maxFrameSize?: number;
+        maxConcurrentStreams?: number;
+        maxHeaderListSize?: number;
+    }
+
+    export interface ClientSessionRequestOptions {
+        endStream?: boolean;
+        exclusive?: boolean;
+        parent?: number;
+        weight?: number;
+        getTrailers?: (trailers: Headers, flags: number) => void;
+    }
+
+    export interface SessionShutdownOptions {
+        graceful?: boolean;
+        errorCode?: number;
+        lastStreamID?: number;
+        opaqueData?: Buffer | number[];
+    }
+
+    export interface SessionState {
+        effectiveLocalWindowSize?: number;
+        effectiveRecvDataLength?: number;
+        nextStreamID?: number;
+        localWindowSize?: number;
+        lastProcStreamID?: number;
+        remoteWindowSize?: number;
+        outboundQueueSize?: number;
+        deflateDynamicTableSize?: number;
+        inflateDynamicTableSize?: number;
+    }
+
+    export interface Http2Session extends events.EventEmitter {
+        destroy(): void;
+        readonly destroyed: boolean;
+        readonly localSettings: Settings;
+        readonly pendingSettingsAck: boolean;
+        readonly remoteSettings: Settings;
+        rstStream(stream: Http2Stream, code?: number): void;
+        setTimeout(msecs: number, callback?: () => void): void;
+        shutdown(callback?: () => void): void;
+        shutdown(options: SessionShutdownOptions, callback?: () => void): void;
+        readonly socket: net.Socket | tls.TLSSocket;
+        readonly state: SessionState;
+        priority(stream: Http2Stream, options: StreamPriorityOptions): void;
+        settings(settings: Settings): void;
+        readonly type: number;
+
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "close", listener: () => void): this;
+        addListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        addListener(event: "error", listener: (err: Error) => void): this;
+        addListener(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
+        addListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        addListener(event: "localSettings", listener: (settings: Settings) => void): this;
+        addListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
+        addListener(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        addListener(event: "socketError", listener: (err: Error) => void): this;
+        addListener(event: "timeout", listener: () => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "close"): boolean;
+        emit(event: "connect", session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket): boolean;
+        emit(event: "error", err: Error): boolean;
+        emit(event: "frameError", frameType: number, errorCode: number, streamID: number): boolean;
+        emit(event: "goaway", errorCode: number, lastStreamID: number, opaqueData: Buffer): boolean;
+        emit(event: "localSettings", settings: Settings): boolean;
+        emit(event: "remoteSettings", settings: Settings): boolean;
+        emit(event: "stream", stream: Http2Stream, headers: Headers, flags: number): boolean;
+        emit(event: "socketError", err: Error): boolean;
+        emit(event: "timeout"): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "close", listener: () => void): this;
+        on(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        on(event: "error", listener: (err: Error) => void): this;
+        on(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
+        on(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        on(event: "localSettings", listener: (settings: Settings) => void): this;
+        on(event: "remoteSettings", listener: (settings: Settings) => void): this;
+        on(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        on(event: "socketError", listener: (err: Error) => void): this;
+        on(event: "timeout", listener: () => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "close", listener: () => void): this;
+        once(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        once(event: "error", listener: (err: Error) => void): this;
+        once(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
+        once(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        once(event: "localSettings", listener: (settings: Settings) => void): this;
+        once(event: "remoteSettings", listener: (settings: Settings) => void): this;
+        once(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        once(event: "socketError", listener: (err: Error) => void): this;
+        once(event: "timeout", listener: () => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        prependListener(event: "error", listener: (err: Error) => void): this;
+        prependListener(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
+        prependListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        prependListener(event: "localSettings", listener: (settings: Settings) => void): this;
+        prependListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
+        prependListener(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        prependListener(event: "socketError", listener: (err: Error) => void): this;
+        prependListener(event: "timeout", listener: () => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "connect", listener: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): this;
+        prependOnceListener(event: "error", listener: (err: Error) => void): this;
+        prependOnceListener(event: "frameError", listener: (frameType: number, errorCode: number, streamID: number) => void): this;
+        prependOnceListener(event: "goaway", listener: (errorCode: number, lastStreamID: number, opaqueData: Buffer) => void): this;
+        prependOnceListener(event: "localSettings", listener: (settings: Settings) => void): this;
+        prependOnceListener(event: "remoteSettings", listener: (settings: Settings) => void): this;
+        prependOnceListener(event: "stream", listener: (stream: Http2Stream, headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "socketError", listener: (err: Error) => void): this;
+        prependOnceListener(event: "timeout", listener: () => void): this;
+    }
+
+    export interface ClientHttp2Session extends Http2Session {
+        request(headers: Headers, options?: ClientSessionRequestOptions): ClientHttp2Stream;
+    }
+
+    export interface ServerHttp2Session extends Http2Session {
+        readonly server: Http2Server | Http2SecureServer;
+    }
+
+    // Http2Server
+
+    export interface SessionOptions {
+        maxDeflateDynamicTableSize?: number;
+        maxReservedRemoteStreams?: number;
+        maxSendHeaderBlockLength?: number;
+        paddingStrategy?: number;
+        peerMaxConcurrentStreams?: number;
+        selectPadding?: (frameLen: number, maxFrameLen: number) => number;
+        settings?: Settings;
+    }
+
+    export type ClientSessionOptions = SessionOptions;
+    export type ServerSessionOptions = SessionOptions;
+
+    export type SecureClientSessionOptions = ClientSessionOptions & tls.ConnectionOptions;
+    export type SecureServerSessionOptions = ClientSessionOptions & tls.TlsOptions;
+
+    export interface ServerOptions extends ServerSessionOptions {
+        allowHTTP1?: boolean;
+    }
+
+    export interface SecureServerOptions extends ServerSessionOptions {
+        allowHTTP1?: boolean;
+    }
+
+    export interface Http2Server extends net.Server {
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        addListener(event: "sessionError", listener: (err: Error) => void): this;
+        addListener(event: "socketError", listener: (err: Error) => void): this;
+        addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        addListener(event: "timeout", listener: () => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
+        emit(event: "sessionError", err: Error): boolean;
+        emit(event: "socketError", err: Error): boolean;
+        emit(event: "stream", stream: ServerHttp2Stream, headers: Headers, flags: number): boolean;
+        emit(event: "timeout"): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        on(event: "sessionError", listener: (err: Error) => void): this;
+        on(event: "socketError", listener: (err: Error) => void): this;
+        on(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        on(event: "timeout", listener: () => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        once(event: "sessionError", listener: (err: Error) => void): this;
+        once(event: "socketError", listener: (err: Error) => void): this;
+        once(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        once(event: "timeout", listener: () => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        prependListener(event: "sessionError", listener: (err: Error) => void): this;
+        prependListener(event: "socketError", listener: (err: Error) => void): this;
+        prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        prependListener(event: "timeout", listener: () => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
+        prependOnceListener(event: "socketError", listener: (err: Error) => void): this;
+        prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "timeout", listener: () => void): this;
+    }
+
+    export interface Http2SecureServer extends tls.Server {
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        addListener(event: "sessionError", listener: (err: Error) => void): this;
+        addListener(event: "socketError", listener: (err: Error) => void): this;
+        addListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        addListener(event: "timeout", listener: () => void): this;
+        addListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "request", request: Http2ServerRequest, response: Http2ServerResponse): boolean;
+        emit(event: "sessionError", err: Error): boolean;
+        emit(event: "socketError", err: Error): boolean;
+        emit(event: "stream", stream: ServerHttp2Stream, headers: Headers, flags: number): boolean;
+        emit(event: "timeout"): boolean;
+        emit(event: "unknownProtocol", socket: tls.TLSSocket): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        on(event: "sessionError", listener: (err: Error) => void): this;
+        on(event: "socketError", listener: (err: Error) => void): this;
+        on(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        on(event: "timeout", listener: () => void): this;
+        on(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        once(event: "sessionError", listener: (err: Error) => void): this;
+        once(event: "socketError", listener: (err: Error) => void): this;
+        once(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        once(event: "timeout", listener: () => void): this;
+        once(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        prependListener(event: "sessionError", listener: (err: Error) => void): this;
+        prependListener(event: "socketError", listener: (err: Error) => void): this;
+        prependListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        prependListener(event: "timeout", listener: () => void): this;
+        prependListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "request", listener: (request: Http2ServerRequest, response: Http2ServerResponse) => void): this;
+        prependOnceListener(event: "sessionError", listener: (err: Error) => void): this;
+        prependOnceListener(event: "socketError", listener: (err: Error) => void): this;
+        prependOnceListener(event: "stream", listener: (stream: ServerHttp2Stream, headers: Headers, flags: number) => void): this;
+        prependOnceListener(event: "timeout", listener: () => void): this;
+        prependOnceListener(event: "unknownProtocol", listener: (socket: tls.TLSSocket) => void): this;
+    }
+
+    export interface Http2ServerRequest extends stream.Readable {
+        destroy(err: Error): void;
+        headers: Headers;
+        httpVersion: string;
+        method: string;
+        rawHeaders: string[];
+        rawTrailers: string[];
+        setTimeout(msecs: number, callback?: () => void): void;
+        socket: net.Socket | tls.TLSSocket;
+        stream: ServerHttp2Stream;
+        trailers: Headers;
+        url: string;
+
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "aborted", hadError: boolean, code: number): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+    }
+
+    export interface Http2ServerResponse extends events.EventEmitter {
+        addTrailers(trailers: Headers): void;
+        connection: net.Socket | tls.TLSSocket;
+        end(callback?: () => void): void;
+        end(data?: string | Buffer, callback?: () => void): void;
+        end(data?: string | Buffer, encoding?: string, callback?: () => void): void;
+        finished: boolean;
+        getHeader(name: string): string;
+        getHeaderNames(): string[];
+        getHeaders(): Headers;
+        hasHeader(name: string): boolean;
+        readonly headersSent: boolean;
+        removeHeader(name: string): void;
+        sendDate: boolean;
+        setHeader(name: string, value: string | string[]): void;
+        setTimeout(msecs: number, callback?: () => void): void;
+        socket: net.Socket | tls.TLSSocket;
+        statusCode: number;
+        statusMessage: '';
+        stream: ServerHttp2Stream;
+        write(chunk: string | Buffer, callback?: (err: Error) => void): boolean;
+        write(chunk: string | Buffer, encoding?: string, callback?: (err: Error) => void): boolean;
+        writeContinue(): void;
+        writeHead(statusCode: number, headers?: Headers): void;
+        writeHead(statusCode: number, statusMessage?: string, headers?: Headers): void;
+        createPushResponse(headers: Headers, callback?: (err: Error) => void): void;
+
+        addListener(event: string, listener: (...args: any[]) => void): this;
+        addListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+        addListener(event: "close", listener: () => void): this;
+        addListener(event: "drain", listener: () => void): this;
+        addListener(event: "error", listener: (error: Error) => void): this;
+        addListener(event: "finish", listener: () => void): this;
+
+        emit(event: string | symbol, ...args: any[]): boolean;
+        emit(event: "aborted", hadError: boolean, code: number): boolean;
+        emit(event: "close"): boolean;
+        emit(event: "drain"): boolean;
+        emit(event: "error", error: Error): boolean;
+        emit(event: "finish"): boolean;
+
+        on(event: string, listener: (...args: any[]) => void): this;
+        on(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+        on(event: "close", listener: () => void): this;
+        on(event: "drain", listener: () => void): this;
+        on(event: "error", listener: (error: Error) => void): this;
+        on(event: "finish", listener: () => void): this;
+
+        once(event: string, listener: (...args: any[]) => void): this;
+        once(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+        once(event: "close", listener: () => void): this;
+        once(event: "drain", listener: () => void): this;
+        once(event: "error", listener: (error: Error) => void): this;
+        once(event: "finish", listener: () => void): this;
+
+        prependListener(event: string, listener: (...args: any[]) => void): this;
+        prependListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+        prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "drain", listener: () => void): this;
+        prependListener(event: "error", listener: (error: Error) => void): this;
+        prependListener(event: "finish", listener: () => void): this;
+
+        prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+        prependOnceListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;
+        prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "drain", listener: () => void): this;
+        prependOnceListener(event: "error", listener: (error: Error) => void): this;
+        prependOnceListener(event: "finish", listener: () => void): this;
+    }
+
+    // Public API
+
+    export const constants: {
+        NGHTTP2_SESSION_SERVER: number;
+        NGHTTP2_SESSION_CLIENT: number;
+        NGHTTP2_STREAM_STATE_IDLE: number;
+        NGHTTP2_STREAM_STATE_OPEN: number;
+        NGHTTP2_STREAM_STATE_RESERVED_LOCAL: number;
+        NGHTTP2_STREAM_STATE_RESERVED_REMOTE: number;
+        NGHTTP2_STREAM_STATE_HALF_CLOSED_LOCAL: number;
+        NGHTTP2_STREAM_STATE_HALF_CLOSED_REMOTE: number;
+        NGHTTP2_STREAM_STATE_CLOSED: number;
+        NGHTTP2_NO_ERROR: number;
+        NGHTTP2_PROTOCOL_ERROR: number;
+        NGHTTP2_INTERNAL_ERROR: number;
+        NGHTTP2_FLOW_CONTROL_ERROR: number;
+        NGHTTP2_SETTINGS_TIMEOUT: number;
+        NGHTTP2_STREAM_CLOSED: number;
+        NGHTTP2_FRAME_SIZE_ERROR: number;
+        NGHTTP2_REFUSED_STREAM: number;
+        NGHTTP2_CANCEL: number;
+        NGHTTP2_COMPRESSION_ERROR: number;
+        NGHTTP2_CONNECT_ERROR: number;
+        NGHTTP2_ENHANCE_YOUR_CALM: number;
+        NGHTTP2_INADEQUATE_SECURITY: number;
+        NGHTTP2_HTTP_1_1_REQUIRED: number;
+        NGHTTP2_ERR_FRAME_SIZE_ERROR: number;
+        NGHTTP2_FLAG_NONE: number;
+        NGHTTP2_FLAG_END_STREAM: number;
+        NGHTTP2_FLAG_END_HEADERS: number;
+        NGHTTP2_FLAG_ACK: number;
+        NGHTTP2_FLAG_PADDED: number;
+        NGHTTP2_FLAG_PRIORITY: number;
+        DEFAULT_SETTINGS_HEADER_TABLE_SIZE: number;
+        DEFAULT_SETTINGS_ENABLE_PUSH: number;
+        DEFAULT_SETTINGS_INITIAL_WINDOW_SIZE: number;
+        DEFAULT_SETTINGS_MAX_FRAME_SIZE: number;
+        MAX_MAX_FRAME_SIZE: number;
+        MIN_MAX_FRAME_SIZE: number;
+        MAX_INITIAL_WINDOW_SIZE: number;
+        NGHTTP2_DEFAULT_WEIGHT: number;
+        NGHTTP2_SETTINGS_HEADER_TABLE_SIZE: number;
+        NGHTTP2_SETTINGS_ENABLE_PUSH: number;
+        NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS: number;
+        NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE: number;
+        NGHTTP2_SETTINGS_MAX_FRAME_SIZE: number;
+        NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE: number;
+        PADDING_STRATEGY_NONE: number;
+        PADDING_STRATEGY_MAX: number;
+        PADDING_STRATEGY_CALLBACK: number;
+        HTTP2_HEADER_STATUS: string;
+        HTTP2_HEADER_METHOD: string;
+        HTTP2_HEADER_AUTHORITY: string;
+        HTTP2_HEADER_SCHEME: string;
+        HTTP2_HEADER_PATH: string;
+        HTTP2_HEADER_ACCEPT_CHARSET: string;
+        HTTP2_HEADER_ACCEPT_ENCODING: string;
+        HTTP2_HEADER_ACCEPT_LANGUAGE: string;
+        HTTP2_HEADER_ACCEPT_RANGES: string;
+        HTTP2_HEADER_ACCEPT: string;
+        HTTP2_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN: string;
+        HTTP2_HEADER_AGE: string;
+        HTTP2_HEADER_ALLOW: string;
+        HTTP2_HEADER_AUTHORIZATION: string;
+        HTTP2_HEADER_CACHE_CONTROL: string;
+        HTTP2_HEADER_CONNECTION: string;
+        HTTP2_HEADER_CONTENT_DISPOSITION: string;
+        HTTP2_HEADER_CONTENT_ENCODING: string;
+        HTTP2_HEADER_CONTENT_LANGUAGE: string;
+        HTTP2_HEADER_CONTENT_LENGTH: string;
+        HTTP2_HEADER_CONTENT_LOCATION: string;
+        HTTP2_HEADER_CONTENT_MD5: string;
+        HTTP2_HEADER_CONTENT_RANGE: string;
+        HTTP2_HEADER_CONTENT_TYPE: string;
+        HTTP2_HEADER_COOKIE: string;
+        HTTP2_HEADER_DATE: string;
+        HTTP2_HEADER_ETAG: string;
+        HTTP2_HEADER_EXPECT: string;
+        HTTP2_HEADER_EXPIRES: string;
+        HTTP2_HEADER_FROM: string;
+        HTTP2_HEADER_HOST: string;
+        HTTP2_HEADER_IF_MATCH: string;
+        HTTP2_HEADER_IF_MODIFIED_SINCE: string;
+        HTTP2_HEADER_IF_NONE_MATCH: string;
+        HTTP2_HEADER_IF_RANGE: string;
+        HTTP2_HEADER_IF_UNMODIFIED_SINCE: string;
+        HTTP2_HEADER_LAST_MODIFIED: string;
+        HTTP2_HEADER_LINK: string;
+        HTTP2_HEADER_LOCATION: string;
+        HTTP2_HEADER_MAX_FORWARDS: string;
+        HTTP2_HEADER_PREFER: string;
+        HTTP2_HEADER_PROXY_AUTHENTICATE: string;
+        HTTP2_HEADER_PROXY_AUTHORIZATION: string;
+        HTTP2_HEADER_RANGE: string;
+        HTTP2_HEADER_REFERER: string;
+        HTTP2_HEADER_REFRESH: string;
+        HTTP2_HEADER_RETRY_AFTER: string;
+        HTTP2_HEADER_SERVER: string;
+        HTTP2_HEADER_SET_COOKIE: string;
+        HTTP2_HEADER_STRICT_TRANSPORT_SECURITY: string;
+        HTTP2_HEADER_TRANSFER_ENCODING: string;
+        HTTP2_HEADER_TE: string;
+        HTTP2_HEADER_UPGRADE: string;
+        HTTP2_HEADER_USER_AGENT: string;
+        HTTP2_HEADER_VARY: string;
+        HTTP2_HEADER_VIA: string;
+        HTTP2_HEADER_WWW_AUTHENTICATE: string;
+        HTTP2_HEADER_HTTP2_SETTINGS: string;
+        HTTP2_HEADER_KEEP_ALIVE: string;
+        HTTP2_HEADER_PROXY_CONNECTION: string;
+        HTTP2_METHOD_ACL: string;
+        HTTP2_METHOD_BASELINE_CONTROL: string;
+        HTTP2_METHOD_BIND: string;
+        HTTP2_METHOD_CHECKIN: string;
+        HTTP2_METHOD_CHECKOUT: string;
+        HTTP2_METHOD_CONNECT: string;
+        HTTP2_METHOD_COPY: string;
+        HTTP2_METHOD_DELETE: string;
+        HTTP2_METHOD_GET: string;
+        HTTP2_METHOD_HEAD: string;
+        HTTP2_METHOD_LABEL: string;
+        HTTP2_METHOD_LINK: string;
+        HTTP2_METHOD_LOCK: string;
+        HTTP2_METHOD_MERGE: string;
+        HTTP2_METHOD_MKACTIVITY: string;
+        HTTP2_METHOD_MKCALENDAR: string;
+        HTTP2_METHOD_MKCOL: string;
+        HTTP2_METHOD_MKREDIRECTREF: string;
+        HTTP2_METHOD_MKWORKSPACE: string;
+        HTTP2_METHOD_MOVE: string;
+        HTTP2_METHOD_OPTIONS: string;
+        HTTP2_METHOD_ORDERPATCH: string;
+        HTTP2_METHOD_PATCH: string;
+        HTTP2_METHOD_POST: string;
+        HTTP2_METHOD_PRI: string;
+        HTTP2_METHOD_PROPFIND: string;
+        HTTP2_METHOD_PROPPATCH: string;
+        HTTP2_METHOD_PUT: string;
+        HTTP2_METHOD_REBIND: string;
+        HTTP2_METHOD_REPORT: string;
+        HTTP2_METHOD_SEARCH: string;
+        HTTP2_METHOD_TRACE: string;
+        HTTP2_METHOD_UNBIND: string;
+        HTTP2_METHOD_UNCHECKOUT: string;
+        HTTP2_METHOD_UNLINK: string;
+        HTTP2_METHOD_UNLOCK: string;
+        HTTP2_METHOD_UPDATE: string;
+        HTTP2_METHOD_UPDATEREDIRECTREF: string;
+        HTTP2_METHOD_VERSION_CONTROL: string;
+        HTTP_STATUS_CONTINUE: number;
+        HTTP_STATUS_SWITCHING_PROTOCOLS: number;
+        HTTP_STATUS_PROCESSING: number;
+        HTTP_STATUS_OK: number;
+        HTTP_STATUS_CREATED: number;
+        HTTP_STATUS_ACCEPTED: number;
+        HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION: number;
+        HTTP_STATUS_NO_CONTENT: number;
+        HTTP_STATUS_RESET_CONTENT: number;
+        HTTP_STATUS_PARTIAL_CONTENT: number;
+        HTTP_STATUS_MULTI_STATUS: number;
+        HTTP_STATUS_ALREADY_REPORTED: number;
+        HTTP_STATUS_IM_USED: number;
+        HTTP_STATUS_MULTIPLE_CHOICES: number;
+        HTTP_STATUS_MOVED_PERMANENTLY: number;
+        HTTP_STATUS_FOUND: number;
+        HTTP_STATUS_SEE_OTHER: number;
+        HTTP_STATUS_NOT_MODIFIED: number;
+        HTTP_STATUS_USE_PROXY: number;
+        HTTP_STATUS_TEMPORARY_REDIRECT: number;
+        HTTP_STATUS_PERMANENT_REDIRECT: number;
+        HTTP_STATUS_BAD_REQUEST: number;
+        HTTP_STATUS_UNAUTHORIZED: number;
+        HTTP_STATUS_PAYMENT_REQUIRED: number;
+        HTTP_STATUS_FORBIDDEN: number;
+        HTTP_STATUS_NOT_FOUND: number;
+        HTTP_STATUS_METHOD_NOT_ALLOWED: number;
+        HTTP_STATUS_NOT_ACCEPTABLE: number;
+        HTTP_STATUS_PROXY_AUTHENTICATION_REQUIRED: number;
+        HTTP_STATUS_REQUEST_TIMEOUT: number;
+        HTTP_STATUS_CONFLICT: number;
+        HTTP_STATUS_GONE: number;
+        HTTP_STATUS_LENGTH_REQUIRED: number;
+        HTTP_STATUS_PRECONDITION_FAILED: number;
+        HTTP_STATUS_PAYLOAD_TOO_LARGE: number;
+        HTTP_STATUS_URI_TOO_LONG: number;
+        HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE: number;
+        HTTP_STATUS_RANGE_NOT_SATISFIABLE: number;
+        HTTP_STATUS_EXPECTATION_FAILED: number;
+        HTTP_STATUS_TEAPOT: number;
+        HTTP_STATUS_MISDIRECTED_REQUEST: number;
+        HTTP_STATUS_UNPROCESSABLE_ENTITY: number;
+        HTTP_STATUS_LOCKED: number;
+        HTTP_STATUS_FAILED_DEPENDENCY: number;
+        HTTP_STATUS_UNORDERED_COLLECTION: number;
+        HTTP_STATUS_UPGRADE_REQUIRED: number;
+        HTTP_STATUS_PRECONDITION_REQUIRED: number;
+        HTTP_STATUS_TOO_MANY_REQUESTS: number;
+        HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE: number;
+        HTTP_STATUS_UNAVAILABLE_FOR_LEGAL_REASONS: number;
+        HTTP_STATUS_INTERNAL_SERVER_ERROR: number;
+        HTTP_STATUS_NOT_IMPLEMENTED: number;
+        HTTP_STATUS_BAD_GATEWAY: number;
+        HTTP_STATUS_SERVICE_UNAVAILABLE: number;
+        HTTP_STATUS_GATEWAY_TIMEOUT: number;
+        HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED: number;
+        HTTP_STATUS_VARIANT_ALSO_NEGOTIATES: number;
+        HTTP_STATUS_INSUFFICIENT_STORAGE: number;
+        HTTP_STATUS_LOOP_DETECTED: number;
+        HTTP_STATUS_BANDWIDTH_LIMIT_EXCEEDED: number;
+        HTTP_STATUS_NOT_EXTENDED: number;
+        HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED: number;
+    };
+
+    export function getDefaultSettings(): Settings;
+    export function getPackedSettings(): Settings;
+    export function getUnpackedSettings(): Settings;
+
+    export function createServer(onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
+    export function createServer(options: ServerOptions, onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
+
+    export function createSecureServer(onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
+    export function createSecureServer(options: SecureServerOptions, onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
+
+    export function connect(authority: string | url.URL, listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;
+    export function connect(authority: string | url.URL, options?: ClientSessionOptions | SecureClientSessionOptions, listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;
+}

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5836,14 +5836,13 @@ declare module "async_hooks" {
 declare module "http2" {
     import * as events from "events";
     import * as fs from "fs";
-    import * as http from "http";
     import * as net from "net";
     import * as stream from "stream";
     import * as tls from "tls";
     import * as url from "url";
 
-    export interface IncomingHttpHeaders extends http.IncomingHttpHeaders {}
-    export interface OutgoingHttpHeaders extends http.OutgoingHttpHeaders {}
+    import { IncomingHttpHeaders, OutgoingHttpHeaders } from "http";
+    export { IncomingHttpHeaders, OutgoingHttpHeaders } from "http";
 
     // Http2Stream
 
@@ -6212,8 +6211,8 @@ declare module "http2" {
         settings?: Settings;
     }
 
-    export interface ClientSessionOptions extends SessionOptions {}
-    export interface ServerSessionOptions extends SessionOptions {}
+    export type ClientSessionOptions = SessionOptions;
+    export type ServerSessionOptions = SessionOptions;
 
     export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions {}
     export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions {}

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5836,18 +5836,14 @@ declare module "async_hooks" {
 declare module "http2" {
     import * as events from "events";
     import * as fs from "fs";
+    import * as http from "http";
     import * as net from "net";
     import * as stream from "stream";
     import * as tls from "tls";
     import * as url from "url";
 
-    export interface IncomingHttpHeaders {
-        [headerField: string]: string | string[];
-    }
-
-    export interface OutgoingHttpHeaders {
-        [headerField: string]: number | string | string[] | undefined;
-    }
+    export interface IncomingHttpHeaders extends http.IncomingHttpHeaders {}
+    export interface OutgoingHttpHeaders extends http.OutgoingHttpHeaders {}
 
     // Http2Stream
 
@@ -5901,42 +5897,90 @@ declare module "http2" {
 
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: "aborted", listener: () => void): this;
+        addListener(event: "close", listener: () => void): this;
+        addListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+        addListener(event: "drain", listener: () => void): this;
+        addListener(event: "end", listener: () => void): this;
+        addListener(event: "error", listener: (err: Error) => void): this;
+        addListener(event: "finish", listener: () => void): this;
         addListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        addListener(event: "pipe", listener: (src: stream.Readable) => void): this;
+        addListener(event: "unpipe", listener: (src: stream.Readable) => void): this;
         addListener(event: "streamClosed", listener: (code: number) => void): this;
         addListener(event: "timeout", listener: () => void): this;
         addListener(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
 
         emit(event: string | symbol, ...args: any[]): boolean;
         emit(event: "aborted"): boolean;
+        emit(event: "close"): boolean;
+        emit(event: "data", chunk: Buffer | string): boolean;
+        emit(event: "drain"): boolean;
+        emit(event: "end"): boolean;
+        emit(event: "error", err: Error): boolean;
+        emit(event: "finish"): boolean;
         emit(event: "frameError", frameType: number, errorCode: number): boolean;
+        emit(event: "pipe", src: stream.Readable): boolean;
+        emit(event: "unpipe", src: stream.Readable): boolean;
         emit(event: "streamClosed", code: number): boolean;
         emit(event: "timeout"): boolean;
         emit(event: "trailers", trailers: IncomingHttpHeaders, flags: number): boolean;
 
         on(event: string, listener: (...args: any[]) => void): this;
         on(event: "aborted", listener: () => void): this;
+        on(event: "close", listener: () => void): this;
+        on(event: "data", listener: (chunk: Buffer | string) => void): this;
+        on(event: "drain", listener: () => void): this;
+        on(event: "end", listener: () => void): this;
+        on(event: "error", listener: (err: Error) => void): this;
+        on(event: "finish", listener: () => void): this;
         on(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        on(event: "pipe", listener: (src: stream.Readable) => void): this;
+        on(event: "unpipe", listener: (src: stream.Readable) => void): this;
         on(event: "streamClosed", listener: (code: number) => void): this;
         on(event: "timeout", listener: () => void): this;
         on(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
 
         once(event: string, listener: (...args: any[]) => void): this;
         once(event: "aborted", listener: () => void): this;
+        once(event: "close", listener: () => void): this;
+        once(event: "data", listener: (chunk: Buffer | string) => void): this;
+        once(event: "drain", listener: () => void): this;
+        once(event: "end", listener: () => void): this;
+        once(event: "error", listener: (err: Error) => void): this;
+        once(event: "finish", listener: () => void): this;
         once(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        once(event: "pipe", listener: (src: stream.Readable) => void): this;
+        once(event: "unpipe", listener: (src: stream.Readable) => void): this;
         once(event: "streamClosed", listener: (code: number) => void): this;
         once(event: "timeout", listener: () => void): this;
         once(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
 
         prependListener(event: string, listener: (...args: any[]) => void): this;
         prependListener(event: "aborted", listener: () => void): this;
+        prependListener(event: "close", listener: () => void): this;
+        prependListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+        prependListener(event: "drain", listener: () => void): this;
+        prependListener(event: "end", listener: () => void): this;
+        prependListener(event: "error", listener: (err: Error) => void): this;
+        prependListener(event: "finish", listener: () => void): this;
         prependListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        prependListener(event: "pipe", listener: (src: stream.Readable) => void): this;
+        prependListener(event: "unpipe", listener: (src: stream.Readable) => void): this;
         prependListener(event: "streamClosed", listener: (code: number) => void): this;
         prependListener(event: "timeout", listener: () => void): this;
         prependListener(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
 
         prependOnceListener(event: string, listener: (...args: any[]) => void): this;
         prependOnceListener(event: "aborted", listener: () => void): this;
+        prependOnceListener(event: "close", listener: () => void): this;
+        prependOnceListener(event: "data", listener: (chunk: Buffer | string) => void): this;
+        prependOnceListener(event: "drain", listener: () => void): this;
+        prependOnceListener(event: "end", listener: () => void): this;
+        prependOnceListener(event: "error", listener: (err: Error) => void): this;
+        prependOnceListener(event: "finish", listener: () => void): this;
         prependOnceListener(event: "frameError", listener: (frameType: number, errorCode: number) => void): this;
+        prependOnceListener(event: "pipe", listener: (src: stream.Readable) => void): this;
+        prependOnceListener(event: "unpipe", listener: (src: stream.Readable) => void): this;
         prependOnceListener(event: "streamClosed", listener: (code: number) => void): this;
         prependOnceListener(event: "timeout", listener: () => void): this;
         prependOnceListener(event: "trailers", listener: (trailers: IncomingHttpHeaders, flags: number) => void): this;
@@ -5981,8 +6025,8 @@ declare module "http2" {
         pushStream(headers: OutgoingHttpHeaders, callback?: (pushStream: ServerHttp2Stream) => void): void;
         pushStream(headers: OutgoingHttpHeaders, options?: StreamPriorityOptions, callback?: (pushStream: ServerHttp2Stream) => void): void;
         respond(headers?: OutgoingHttpHeaders, options?: ServerStreamResponseOptions): void;
-        respondWithFD(fd: number, headers?: OutgoingHttpHeaders, options?: ServerStreamResponseOptions): void;
-        respondWithFD(path: string, headers?: OutgoingHttpHeaders, options?: ServerStreamResponseOptions): void;
+        respondWithFD(fd: number, headers?: OutgoingHttpHeaders, options?: ServerStreamFileResponseOptions): void;
+        respondWithFile(path: string, headers?: OutgoingHttpHeaders, options?: ServerStreamFileResponseOptions): void;
     }
 
     // Http2Session
@@ -6168,17 +6212,17 @@ declare module "http2" {
         settings?: Settings;
     }
 
-    export type ClientSessionOptions = SessionOptions;
-    export type ServerSessionOptions = SessionOptions;
+    export interface ClientSessionOptions extends SessionOptions {}
+    export interface ServerSessionOptions extends SessionOptions {}
 
-    export type SecureClientSessionOptions = ClientSessionOptions & tls.ConnectionOptions;
-    export type SecureServerSessionOptions = ClientSessionOptions & tls.TlsOptions;
+    export interface SecureClientSessionOptions extends ClientSessionOptions, tls.ConnectionOptions {}
+    export interface SecureServerSessionOptions extends ServerSessionOptions, tls.TlsOptions {}
 
     export interface ServerOptions extends ServerSessionOptions {
         allowHTTP1?: boolean;
     }
 
-    export interface SecureServerOptions extends ServerSessionOptions {
+    export interface SecureServerOptions extends SecureServerSessionOptions {
         allowHTTP1?: boolean;
     }
 
@@ -6277,7 +6321,6 @@ declare module "http2" {
     }
 
     export interface Http2ServerRequest extends stream.Readable {
-        destroy(err: Error): void;
         headers: IncomingHttpHeaders;
         httpVersion: string;
         method: string;
@@ -6314,7 +6357,7 @@ declare module "http2" {
         end(callback?: () => void): void;
         end(data?: string | Buffer, callback?: () => void): void;
         end(data?: string | Buffer, encoding?: string, callback?: () => void): void;
-        finished: boolean;
+        readonly finished: boolean;
         getHeader(name: string): string;
         getHeaderNames(): string[];
         getHeaders(): OutgoingHttpHeaders;
@@ -6592,14 +6635,14 @@ declare module "http2" {
     };
 
     export function getDefaultSettings(): Settings;
-    export function getPackedSettings(): Settings;
-    export function getUnpackedSettings(): Settings;
+    export function getPackedSettings(settings: Settings): Settings;
+    export function getUnpackedSettings(buf: Buffer | Uint8Array): Settings;
 
     export function createServer(onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
     export function createServer(options: ServerOptions, onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
 
-    export function createSecureServer(onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
-    export function createSecureServer(options: SecureServerOptions, onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2Server;
+    export function createSecureServer(onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2SecureServer;
+    export function createSecureServer(options: SecureServerOptions, onRequestHandler?: (request: Http2ServerRequest, response: Http2ServerResponse) => void): Http2SecureServer;
 
     export function connect(authority: string | url.URL, listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;
     export function connect(authority: string | url.URL, options?: ClientSessionOptions | SecureClientSessionOptions, listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -27,6 +27,7 @@ import * as repl from "repl";
 import * as v8 from "v8";
 import * as dns from "dns";
 import * as async_hooks from "async_hooks";
+import * as http2 from "http2";
 
 // Specifically test buffer module regression.
 import { Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer } from "buffer";
@@ -2834,5 +2835,548 @@ namespace zlib_tests {
     {
         const deflate = zlib.deflateSync('test');
         const inflate = zlib.inflateSync(deflate.toString());
+    }
+}
+
+///////////////////////////////////////////////////////////
+/// HTTP/2 Tests                                        ///
+///////////////////////////////////////////////////////////
+
+namespace http2_tests {
+    // Headers & Settings
+    {
+        let headers: http2.OutgoingHttpHeaders = {
+            ':status': 200,
+            'content-type': 'text-plain',
+            ABC: ['has', 'more', 'than', 'one', 'value'],
+            undef: undefined
+        };
+
+        let settings: http2.Settings = {
+            headerTableSize: 0,
+            enablePush: true,
+            initialWindowSize: 0,
+            maxFrameSize: 0,
+            maxConcurrentStreams: 0,
+            maxHeaderListSize: 0
+        };
+    }
+
+    // Http2Session
+    {
+        let http2Session: http2.Http2Session;
+        let ee: events.EventEmitter = http2Session;
+
+        http2Session.on('close', () => {});
+        http2Session.on('connect', (session: http2.Http2Session, socket: net.Socket) => {});
+        http2Session.on('error', (err: Error) => {});
+        http2Session.on('frameError', (frameType: number, errorCode: number, streamID: number) => {});
+        http2Session.on('goaway', (errorCode: number, lastStreamID: number, opaqueData: Buffer) => {});
+        http2Session.on('localSettings', (settings: http2.Settings) => {});
+        http2Session.on('remoteSettings', (settings: http2.Settings) => {});
+        http2Session.on('stream', (stream: http2.Http2Stream, headers: http2.IncomingHttpHeaders, flags: number) => {});
+        http2Session.on('socketError', (err: Error) => {});
+        http2Session.on('timeout', () => {});
+
+        http2Session.destroy();
+
+        let destroyed: boolean = http2Session.destroyed;
+        let pendingSettingsAck: boolean = http2Session.pendingSettingsAck;
+        let settings: http2.Settings = http2Session.localSettings;
+        settings = http2Session.remoteSettings;
+
+        let headers: http2.OutgoingHttpHeaders;
+        let options: http2.ClientSessionRequestOptions = {
+            endStream: true,
+            exclusive: true,
+            parent: 0,
+            weight: 0,
+            getTrailers: (trailers: http2.IncomingHttpHeaders) => {}
+        };
+        (http2Session as http2.ClientHttp2Session).request();
+        (http2Session as http2.ClientHttp2Session).request(headers);
+        (http2Session as http2.ClientHttp2Session).request(headers, options);
+
+        let stream: http2.Http2Stream;
+        http2Session.rstStream(stream);
+        http2Session.rstStream(stream, 0);
+
+        http2Session.setTimeout(100, () => {});
+
+        let shutdownOptions: http2.SessionShutdownOptions = {
+            graceful: true,
+            errorCode: 0,
+            lastStreamID: 0,
+            opaqueData: Buffer.from([])
+        };
+        shutdownOptions.opaqueData = Uint8Array.from([]);
+        http2Session.shutdown(shutdownOptions);
+        http2Session.shutdown(shutdownOptions, () => {});
+
+        let socket: net.Socket | tls.TLSSocket = http2Session.socket;
+        let state: http2.SessionState = http2Session.state;
+        state = {
+            effectiveLocalWindowSize: 0,
+            effectiveRecvDataLength: 0,
+            nextStreamID: 0,
+            localWindowSize: 0,
+            lastProcStreamID: 0,
+            remoteWindowSize: 0,
+            outboundQueueSize: 0,
+            deflateDynamicTableSize: 0,
+            inflateDynamicTableSize: 0
+        };
+
+        http2Session.priority(stream, {
+            exclusive: true,
+            parent: 0,
+            weight: 0,
+            silent: true
+        });
+
+        http2Session.settings(settings);
+    }
+
+    // Http2Stream
+    {
+        let http2Stream: http2.Http2Stream;
+        let duplex: stream.Duplex = http2Stream;
+
+        http2Stream.on('aborted', () => {});
+        http2Stream.on('error', (err: Error) => {});
+        http2Stream.on('frameError', (frameType: number, errorCode: number, streamID: number) => {});
+        http2Stream.on('streamClosed', (code: number) => {});
+        http2Stream.on('timeout', () => {});
+        http2Stream.on('trailers', (trailers: http2.IncomingHttpHeaders, flags: number) => {});
+
+        let aborted: boolean = http2Stream.aborted;
+        let destroyed: boolean = http2Stream.destroyed;
+
+        http2Stream.priority({
+            exclusive: true,
+            parent: 0,
+            weight: 0,
+            silent: true
+        });
+
+        let rstCode: number = http2Stream.rstCode;
+        http2Stream.rstStream(rstCode);
+        http2Stream.rstWithNoError();
+        http2Stream.rstWithProtocolError();
+        http2Stream.rstWithCancel();
+        http2Stream.rstWithRefuse();
+        http2Stream.rstWithInternalError();
+
+        let sesh: http2.Http2Session = http2Stream.session;
+
+        http2Stream.setTimeout(100, () => {});
+
+        let state: http2.StreamState = http2Stream.state;
+        state = {
+            localWindowSize: 0,
+            state: 0,
+            streamLocalClose: 0,
+            streamRemoteClose: 0,
+            sumDependencyWeight: 0,
+            weight: 0
+        };
+
+        // ClientHttp2Stream
+        let clientHttp2Stream: http2.ClientHttp2Stream;
+        clientHttp2Stream.on('headers', (headers: http2.IncomingHttpHeaders, flags: number) => {});
+        clientHttp2Stream.on('push', (headers: http2.IncomingHttpHeaders, flags: number) => {});
+        clientHttp2Stream.on('response', (headers: http2.IncomingHttpHeaders, flags: number) => {});
+
+        // ServerHttp2Stream
+        let serverHttp2Stream: http2.ServerHttp2Stream;
+        let headers: http2.OutgoingHttpHeaders;
+
+        serverHttp2Stream.additionalHeaders(headers);
+        let headerSent: boolean = serverHttp2Stream.headersSent;
+        let pushAllowed: boolean = serverHttp2Stream.pushAllowed;
+        serverHttp2Stream.pushStream(headers, (pushStream: http2.ServerHttp2Stream) => {});
+
+        let options: http2.ServerStreamResponseOptions = {
+            endStream: true,
+            getTrailers: (trailers: http2.IncomingHttpHeaders) => {}
+        };
+        serverHttp2Stream.respond();
+        serverHttp2Stream.respond(headers);
+        serverHttp2Stream.respond(headers, options);
+
+        let options2: http2.ServerStreamFileResponseOptions = {
+            statCheck: (stats: fs.Stats, headers: http2.IncomingHttpHeaders, statOptions: http2.StatOptions) => {},
+            getTrailers: (trailers: http2.IncomingHttpHeaders) => {},
+            offset: 0,
+            length: 0
+        };
+        serverHttp2Stream.respondWithFD(0);
+        serverHttp2Stream.respondWithFD(0, headers);
+        serverHttp2Stream.respondWithFD(0, headers, options2);
+        serverHttp2Stream.respondWithFile('');
+        serverHttp2Stream.respondWithFile('', headers);
+        serverHttp2Stream.respondWithFile('', headers, options2);
+    }
+
+    // Http2Server / Http2SecureServer
+    {
+        let http2Server: http2.Http2Server;
+        let http2SecureServer: http2.Http2SecureServer;
+        let s1: net.Server = http2Server;
+        let s2: tls.Server = http2SecureServer;
+        [http2Server, http2SecureServer].forEach((server) => {
+            server.on('sessionError', (err: Error) => {});
+            server.on('socketError', (err: Error) => {});
+            server.on('stream', (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders, flags: number) => {});
+            server.on('request', (request: http2.Http2ServerRequest, response: http2.Http2ServerResponse) => {});
+            server.on('timeout', () => {});
+        });
+
+        http2SecureServer.on('unknownProtocol', (socket: tls.TLSSocket) => {});
+    }
+
+    // Public API (except constants)
+    {
+        let settings: http2.Settings;
+        let serverOptions: http2.ServerOptions = {
+            maxDeflateDynamicTableSize: 0,
+            maxReservedRemoteStreams: 0,
+            maxSendHeaderBlockLength: 0,
+            paddingStrategy: 0,
+            peerMaxConcurrentStreams: 0,
+            selectPadding: (frameLen: number, maxFrameLen: number) => 0,
+            settings,
+            allowHTTP1: true
+        };
+        let secureServerOptions: http2.SecureServerOptions = Object.assign(serverOptions);
+        secureServerOptions.ca = '';
+        let onRequestHandler = (request: http2.Http2ServerRequest, response: http2.Http2ServerResponse) => {
+            // Http2ServerRequest
+
+            let readable: stream.Readable = request;
+            let incomingHeaders: http2.IncomingHttpHeaders = request.headers;
+            incomingHeaders = request.trailers;
+            let httpVersion: string = request.httpVersion;
+            let method: string = request.method;
+            let rawHeaders: string[] = request.rawHeaders;
+            rawHeaders = request.rawTrailers;
+            let socket: net.Socket | tls.TLSSocket = request.socket;
+            let stream: http2.ServerHttp2Stream = request.stream;
+            let url: string = request.url;
+
+            request.setTimeout(0, () => {});
+            request.on('aborted', (hadError: boolean, code: number) => {});
+
+            // Http2ServerResponse
+
+            let outgoingHeaders: http2.OutgoingHttpHeaders;
+            response.addTrailers(outgoingHeaders);
+            socket = response.connection;
+            let finished: boolean = response.finished;
+            response.sendDate = true;
+            response.statusCode = 200;
+            response.statusMessage = '';
+            socket = response.socket;
+            stream = response.stream;
+
+            method = response.getHeader(':method');
+            let headers: string[] = response.getHeaderNames();
+            outgoingHeaders = response.getHeaders();
+            let hasMethod = response.hasHeader(':method');
+            response.removeHeader(':method');
+            response.setHeader(':method', 'GET');
+            response.setHeader(':status', 200);
+            response.setHeader('some-list', ['', '']);
+            let headersSent: boolean = response.headersSent;
+
+            response.setTimeout(0, () => {});
+            response.createPushResponse(outgoingHeaders);
+            response.createPushResponse(outgoingHeaders, (err: Error) => {});
+
+            response.writeContinue();
+            response.writeHead(200);
+            response.writeHead(200, outgoingHeaders);
+            response.writeHead(200, 'OK', outgoingHeaders);
+            response.writeHead(200, 'OK');
+            response.write('');
+            response.write('', (err: Error) => {});
+            response.write('', 'utf8');
+            response.write('', 'utf8', (err: Error) => {});
+            response.write(Buffer.from([]));
+            response.write(Buffer.from([]), (err: Error) => {});
+            response.write(Buffer.from([]), 'utf8');
+            response.write(Buffer.from([]), 'utf8', (err: Error) => {});
+            response.end();
+            response.end(() => {});
+            response.end('');
+            response.end('', () => {});
+            response.end('', 'utf8');
+            response.end('', 'utf8', () => {});
+            response.end(Buffer.from([]));
+            response.end(Buffer.from([]), () => {});
+            response.end(Buffer.from([]), 'utf8');
+            response.end(Buffer.from([]), 'utf8', () => {});
+
+            request.on('aborted', (hadError: boolean, code: number) => {});
+            request.on('close', () => {});
+            request.on('drain', () => {});
+            request.on('error', (error: Error) => {});
+            request.on('finish', () => {});
+        };
+
+        let http2Server: http2.Http2Server;
+        let http2SecureServer: http2.Http2SecureServer;
+
+        http2Server = http2.createServer();
+        http2Server = http2.createServer(serverOptions);
+        http2Server = http2.createServer(onRequestHandler);
+        http2Server = http2.createServer(serverOptions, onRequestHandler);
+
+        http2SecureServer = http2.createSecureServer();
+        http2SecureServer = http2.createSecureServer(secureServerOptions);
+        http2SecureServer = http2.createSecureServer(onRequestHandler);
+        http2SecureServer = http2.createSecureServer(secureServerOptions, onRequestHandler);
+
+        let clientSessionOptions: http2.ClientSessionOptions = {
+            maxDeflateDynamicTableSize: 0,
+            maxReservedRemoteStreams: 0,
+            maxSendHeaderBlockLength: 0,
+            paddingStrategy: 0,
+            peerMaxConcurrentStreams: 0,
+            selectPadding: (frameLen: number, maxFrameLen: number) => 0,
+            settings
+        };
+        let secureClientSessionOptions: http2.SecureClientSessionOptions = Object.assign(clientSessionOptions);
+        secureClientSessionOptions.ca = '';
+        let onConnectHandler = (session: http2.Http2Session, socket: net.Socket) => {};
+
+        let clientHttp2Session: http2.ClientHttp2Session;
+
+        clientHttp2Session = http2.connect('');
+        clientHttp2Session = http2.connect('', onConnectHandler);
+        clientHttp2Session = http2.connect('', clientSessionOptions);
+        clientHttp2Session = http2.connect('', clientSessionOptions, onConnectHandler);
+        clientHttp2Session = http2.connect('', secureClientSessionOptions);
+        clientHttp2Session = http2.connect('', secureClientSessionOptions, onConnectHandler);
+
+        settings = http2.getDefaultSettings();
+        settings = http2.getPackedSettings(settings);
+        settings = http2.getUnpackedSettings(Buffer.from([]));
+        settings = http2.getUnpackedSettings(Uint8Array.from([]));
+    }
+
+    // constants
+    {
+        const constants = http2.constants;
+        let num: number;
+        let str: string;
+        num = constants.NGHTTP2_SESSION_SERVER;
+        num = constants.NGHTTP2_SESSION_CLIENT;
+        num = constants.NGHTTP2_STREAM_STATE_IDLE;
+        num = constants.NGHTTP2_STREAM_STATE_OPEN;
+        num = constants.NGHTTP2_STREAM_STATE_RESERVED_LOCAL;
+        num = constants.NGHTTP2_STREAM_STATE_RESERVED_REMOTE;
+        num = constants.NGHTTP2_STREAM_STATE_HALF_CLOSED_LOCAL;
+        num = constants.NGHTTP2_STREAM_STATE_HALF_CLOSED_REMOTE;
+        num = constants.NGHTTP2_STREAM_STATE_CLOSED;
+        num = constants.NGHTTP2_NO_ERROR;
+        num = constants.NGHTTP2_PROTOCOL_ERROR;
+        num = constants.NGHTTP2_INTERNAL_ERROR;
+        num = constants.NGHTTP2_FLOW_CONTROL_ERROR;
+        num = constants.NGHTTP2_SETTINGS_TIMEOUT;
+        num = constants.NGHTTP2_STREAM_CLOSED;
+        num = constants.NGHTTP2_FRAME_SIZE_ERROR;
+        num = constants.NGHTTP2_REFUSED_STREAM;
+        num = constants.NGHTTP2_CANCEL;
+        num = constants.NGHTTP2_COMPRESSION_ERROR;
+        num = constants.NGHTTP2_CONNECT_ERROR;
+        num = constants.NGHTTP2_ENHANCE_YOUR_CALM;
+        num = constants.NGHTTP2_INADEQUATE_SECURITY;
+        num = constants.NGHTTP2_HTTP_1_1_REQUIRED;
+        num = constants.NGHTTP2_ERR_FRAME_SIZE_ERROR;
+        num = constants.NGHTTP2_FLAG_NONE;
+        num = constants.NGHTTP2_FLAG_END_STREAM;
+        num = constants.NGHTTP2_FLAG_END_HEADERS;
+        num = constants.NGHTTP2_FLAG_ACK;
+        num = constants.NGHTTP2_FLAG_PADDED;
+        num = constants.NGHTTP2_FLAG_PRIORITY;
+        num = constants.DEFAULT_SETTINGS_HEADER_TABLE_SIZE;
+        num = constants.DEFAULT_SETTINGS_ENABLE_PUSH;
+        num = constants.DEFAULT_SETTINGS_INITIAL_WINDOW_SIZE;
+        num = constants.DEFAULT_SETTINGS_MAX_FRAME_SIZE;
+        num = constants.MAX_MAX_FRAME_SIZE;
+        num = constants.MIN_MAX_FRAME_SIZE;
+        num = constants.MAX_INITIAL_WINDOW_SIZE;
+        num = constants.NGHTTP2_DEFAULT_WEIGHT;
+        num = constants.NGHTTP2_SETTINGS_HEADER_TABLE_SIZE;
+        num = constants.NGHTTP2_SETTINGS_ENABLE_PUSH;
+        num = constants.NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS;
+        num = constants.NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
+        num = constants.NGHTTP2_SETTINGS_MAX_FRAME_SIZE;
+        num = constants.NGHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE;
+        num = constants.PADDING_STRATEGY_NONE;
+        num = constants.PADDING_STRATEGY_MAX;
+        num = constants.PADDING_STRATEGY_CALLBACK;
+        num = constants.HTTP_STATUS_CONTINUE;
+        num = constants.HTTP_STATUS_SWITCHING_PROTOCOLS;
+        num = constants.HTTP_STATUS_PROCESSING;
+        num = constants.HTTP_STATUS_OK;
+        num = constants.HTTP_STATUS_CREATED;
+        num = constants.HTTP_STATUS_ACCEPTED;
+        num = constants.HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION;
+        num = constants.HTTP_STATUS_NO_CONTENT;
+        num = constants.HTTP_STATUS_RESET_CONTENT;
+        num = constants.HTTP_STATUS_PARTIAL_CONTENT;
+        num = constants.HTTP_STATUS_MULTI_STATUS;
+        num = constants.HTTP_STATUS_ALREADY_REPORTED;
+        num = constants.HTTP_STATUS_IM_USED;
+        num = constants.HTTP_STATUS_MULTIPLE_CHOICES;
+        num = constants.HTTP_STATUS_MOVED_PERMANENTLY;
+        num = constants.HTTP_STATUS_FOUND;
+        num = constants.HTTP_STATUS_SEE_OTHER;
+        num = constants.HTTP_STATUS_NOT_MODIFIED;
+        num = constants.HTTP_STATUS_USE_PROXY;
+        num = constants.HTTP_STATUS_TEMPORARY_REDIRECT;
+        num = constants.HTTP_STATUS_PERMANENT_REDIRECT;
+        num = constants.HTTP_STATUS_BAD_REQUEST;
+        num = constants.HTTP_STATUS_UNAUTHORIZED;
+        num = constants.HTTP_STATUS_PAYMENT_REQUIRED;
+        num = constants.HTTP_STATUS_FORBIDDEN;
+        num = constants.HTTP_STATUS_NOT_FOUND;
+        num = constants.HTTP_STATUS_METHOD_NOT_ALLOWED;
+        num = constants.HTTP_STATUS_NOT_ACCEPTABLE;
+        num = constants.HTTP_STATUS_PROXY_AUTHENTICATION_REQUIRED;
+        num = constants.HTTP_STATUS_REQUEST_TIMEOUT;
+        num = constants.HTTP_STATUS_CONFLICT;
+        num = constants.HTTP_STATUS_GONE;
+        num = constants.HTTP_STATUS_LENGTH_REQUIRED;
+        num = constants.HTTP_STATUS_PRECONDITION_FAILED;
+        num = constants.HTTP_STATUS_PAYLOAD_TOO_LARGE;
+        num = constants.HTTP_STATUS_URI_TOO_LONG;
+        num = constants.HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE;
+        num = constants.HTTP_STATUS_RANGE_NOT_SATISFIABLE;
+        num = constants.HTTP_STATUS_EXPECTATION_FAILED;
+        num = constants.HTTP_STATUS_TEAPOT;
+        num = constants.HTTP_STATUS_MISDIRECTED_REQUEST;
+        num = constants.HTTP_STATUS_UNPROCESSABLE_ENTITY;
+        num = constants.HTTP_STATUS_LOCKED;
+        num = constants.HTTP_STATUS_FAILED_DEPENDENCY;
+        num = constants.HTTP_STATUS_UNORDERED_COLLECTION;
+        num = constants.HTTP_STATUS_UPGRADE_REQUIRED;
+        num = constants.HTTP_STATUS_PRECONDITION_REQUIRED;
+        num = constants.HTTP_STATUS_TOO_MANY_REQUESTS;
+        num = constants.HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE;
+        num = constants.HTTP_STATUS_UNAVAILABLE_FOR_LEGAL_REASONS;
+        num = constants.HTTP_STATUS_INTERNAL_SERVER_ERROR;
+        num = constants.HTTP_STATUS_NOT_IMPLEMENTED;
+        num = constants.HTTP_STATUS_BAD_GATEWAY;
+        num = constants.HTTP_STATUS_SERVICE_UNAVAILABLE;
+        num = constants.HTTP_STATUS_GATEWAY_TIMEOUT;
+        num = constants.HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED;
+        num = constants.HTTP_STATUS_VARIANT_ALSO_NEGOTIATES;
+        num = constants.HTTP_STATUS_INSUFFICIENT_STORAGE;
+        num = constants.HTTP_STATUS_LOOP_DETECTED;
+        num = constants.HTTP_STATUS_BANDWIDTH_LIMIT_EXCEEDED;
+        num = constants.HTTP_STATUS_NOT_EXTENDED;
+        num = constants.HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED;
+        str = constants.HTTP2_HEADER_STATUS;
+        str = constants.HTTP2_HEADER_METHOD;
+        str = constants.HTTP2_HEADER_AUTHORITY;
+        str = constants.HTTP2_HEADER_SCHEME;
+        str = constants.HTTP2_HEADER_PATH;
+        str = constants.HTTP2_HEADER_ACCEPT_CHARSET;
+        str = constants.HTTP2_HEADER_ACCEPT_ENCODING;
+        str = constants.HTTP2_HEADER_ACCEPT_LANGUAGE;
+        str = constants.HTTP2_HEADER_ACCEPT_RANGES;
+        str = constants.HTTP2_HEADER_ACCEPT;
+        str = constants.HTTP2_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN;
+        str = constants.HTTP2_HEADER_AGE;
+        str = constants.HTTP2_HEADER_ALLOW;
+        str = constants.HTTP2_HEADER_AUTHORIZATION;
+        str = constants.HTTP2_HEADER_CACHE_CONTROL;
+        str = constants.HTTP2_HEADER_CONNECTION;
+        str = constants.HTTP2_HEADER_CONTENT_DISPOSITION;
+        str = constants.HTTP2_HEADER_CONTENT_ENCODING;
+        str = constants.HTTP2_HEADER_CONTENT_LANGUAGE;
+        str = constants.HTTP2_HEADER_CONTENT_LENGTH;
+        str = constants.HTTP2_HEADER_CONTENT_LOCATION;
+        str = constants.HTTP2_HEADER_CONTENT_MD5;
+        str = constants.HTTP2_HEADER_CONTENT_RANGE;
+        str = constants.HTTP2_HEADER_CONTENT_TYPE;
+        str = constants.HTTP2_HEADER_COOKIE;
+        str = constants.HTTP2_HEADER_DATE;
+        str = constants.HTTP2_HEADER_ETAG;
+        str = constants.HTTP2_HEADER_EXPECT;
+        str = constants.HTTP2_HEADER_EXPIRES;
+        str = constants.HTTP2_HEADER_FROM;
+        str = constants.HTTP2_HEADER_HOST;
+        str = constants.HTTP2_HEADER_IF_MATCH;
+        str = constants.HTTP2_HEADER_IF_MODIFIED_SINCE;
+        str = constants.HTTP2_HEADER_IF_NONE_MATCH;
+        str = constants.HTTP2_HEADER_IF_RANGE;
+        str = constants.HTTP2_HEADER_IF_UNMODIFIED_SINCE;
+        str = constants.HTTP2_HEADER_LAST_MODIFIED;
+        str = constants.HTTP2_HEADER_LINK;
+        str = constants.HTTP2_HEADER_LOCATION;
+        str = constants.HTTP2_HEADER_MAX_FORWARDS;
+        str = constants.HTTP2_HEADER_PREFER;
+        str = constants.HTTP2_HEADER_PROXY_AUTHENTICATE;
+        str = constants.HTTP2_HEADER_PROXY_AUTHORIZATION;
+        str = constants.HTTP2_HEADER_RANGE;
+        str = constants.HTTP2_HEADER_REFERER;
+        str = constants.HTTP2_HEADER_REFRESH;
+        str = constants.HTTP2_HEADER_RETRY_AFTER;
+        str = constants.HTTP2_HEADER_SERVER;
+        str = constants.HTTP2_HEADER_SET_COOKIE;
+        str = constants.HTTP2_HEADER_STRICT_TRANSPORT_SECURITY;
+        str = constants.HTTP2_HEADER_TRANSFER_ENCODING;
+        str = constants.HTTP2_HEADER_TE;
+        str = constants.HTTP2_HEADER_UPGRADE;
+        str = constants.HTTP2_HEADER_USER_AGENT;
+        str = constants.HTTP2_HEADER_VARY;
+        str = constants.HTTP2_HEADER_VIA;
+        str = constants.HTTP2_HEADER_WWW_AUTHENTICATE;
+        str = constants.HTTP2_HEADER_HTTP2_SETTINGS;
+        str = constants.HTTP2_HEADER_KEEP_ALIVE;
+        str = constants.HTTP2_HEADER_PROXY_CONNECTION;
+        str = constants.HTTP2_METHOD_ACL;
+        str = constants.HTTP2_METHOD_BASELINE_CONTROL;
+        str = constants.HTTP2_METHOD_BIND;
+        str = constants.HTTP2_METHOD_CHECKIN;
+        str = constants.HTTP2_METHOD_CHECKOUT;
+        str = constants.HTTP2_METHOD_CONNECT;
+        str = constants.HTTP2_METHOD_COPY;
+        str = constants.HTTP2_METHOD_DELETE;
+        str = constants.HTTP2_METHOD_GET;
+        str = constants.HTTP2_METHOD_HEAD;
+        str = constants.HTTP2_METHOD_LABEL;
+        str = constants.HTTP2_METHOD_LINK;
+        str = constants.HTTP2_METHOD_LOCK;
+        str = constants.HTTP2_METHOD_MERGE;
+        str = constants.HTTP2_METHOD_MKACTIVITY;
+        str = constants.HTTP2_METHOD_MKCALENDAR;
+        str = constants.HTTP2_METHOD_MKCOL;
+        str = constants.HTTP2_METHOD_MKREDIRECTREF;
+        str = constants.HTTP2_METHOD_MKWORKSPACE;
+        str = constants.HTTP2_METHOD_MOVE;
+        str = constants.HTTP2_METHOD_OPTIONS;
+        str = constants.HTTP2_METHOD_ORDERPATCH;
+        str = constants.HTTP2_METHOD_PATCH;
+        str = constants.HTTP2_METHOD_POST;
+        str = constants.HTTP2_METHOD_PRI;
+        str = constants.HTTP2_METHOD_PROPFIND;
+        str = constants.HTTP2_METHOD_PROPPATCH;
+        str = constants.HTTP2_METHOD_PUT;
+        str = constants.HTTP2_METHOD_REBIND;
+        str = constants.HTTP2_METHOD_REPORT;
+        str = constants.HTTP2_METHOD_SEARCH;
+        str = constants.HTTP2_METHOD_TRACE;
+        str = constants.HTTP2_METHOD_UNBIND;
+        str = constants.HTTP2_METHOD_UNCHECKOUT;
+        str = constants.HTTP2_METHOD_UNLINK;
+        str = constants.HTTP2_METHOD_UNLOCK;
+        str = constants.HTTP2_METHOD_UPDATE;
+        str = constants.HTTP2_METHOD_UPDATEREDIRECTREF;
+        str = constants.HTTP2_METHOD_VERSION_CONTROL;
     }
 }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3048,7 +3048,7 @@ namespace http2_tests {
             settings,
             allowHTTP1: true
         };
-        let secureServerOptions: http2.SecureServerOptions = Object.assign(serverOptions);
+        let secureServerOptions: http2.SecureServerOptions = { ...serverOptions };
         secureServerOptions.ca = '';
         let onRequestHandler = (request: http2.Http2ServerRequest, response: http2.Http2ServerResponse) => {
             // Http2ServerRequest
@@ -3146,7 +3146,7 @@ namespace http2_tests {
             selectPadding: (frameLen: number, maxFrameLen: number) => 0,
             settings
         };
-        let secureClientSessionOptions: http2.SecureClientSessionOptions = Object.assign(clientSessionOptions);
+        let secureClientSessionOptions: http2.SecureClientSessionOptions = { ...clientSessionOptions };
         secureClientSessionOptions.ca = '';
         let onConnectHandler = (session: http2.Http2Session, socket: net.Socket) => {};
 


### PR DESCRIPTION
Node 8.4+ ships `http2` behind a command-line flag: https://github.com/nodejs/node/pull/14811

This change introduces types for `http2`, as incorporated from the http2 docs and implementation. I am currently working on adding tests as well, and will add those as soon as possible.

This is my first time contributing to DefinitelyTyped, so please provide feedback on any anti-patterns I may be stumbling upon. In particular, I am not sure which objects should be labeled interface and which classes (they are currently all interfaces), and whether it's necessary to include all the events that are currently listed.

There are a few things to note which might be good to know in reviewing:
- There is a name conflict with an npm module that currently does not have types. This issue has been resolved; however, it might cause issues for people using TypeScript and the npm `http2` module.
- For now, `http2` won't be available if the `--expose-http2` flag isn't present.
- Some of this code is auto-generated. The pre-generated version of the code is in this repo: https://github.com/kjin/node-h2-types

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/http2.html
- [ ] Increase the version number in the header if appropriate.
