### PR TITLE
elasticsearch: Change SearchResponse _version parameter to optional

### DIFF
--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -626,7 +626,7 @@ declare module Elasticsearch {
                 _id: string;
                 _score: number;
                 _source: T;
-                _version: number;
+                _version?: number;
                 _explanation?: Explanation;
                 fields?: any;
                 highlight?: any;


### PR DESCRIPTION
The _version parameter of an SearchResponse is optional. If you don't provide
it while indexing it is not in the SearchResponse.

See [Elasticsearch Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-versioning)