### PR TITLE
Add 'undefined' to ua-parser-js return values

### DIFF
--- a/types/ua-parser-js/index.d.ts
+++ b/types/ua-parser-js/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for ua-parser-js v0.7.10
 // Project: https://github.com/faisalman/ua-parser-js
-// Definitions by: Viktor Miroshnikov <https://github.com/superduper>, Lucas Woo <https://github.com/legendecas>
+// Definitions by: Viktor Miroshnikov <https://github.com/superduper>, Lucas Woo <https://github.com/legendecas>, Pablo Rodríguez <https://github.com/MeLlamoPablo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace IUAParser {
@@ -18,31 +18,31 @@ declare namespace IUAParser {
          * Tizen, UCBrowser, Vivaldi, w3m, Yandex
          *
          */
-        name: string;
+        name: string | undefined;
 
         /**
          * Determined dynamically
          */
-        version: string;
+        version: string | undefined;
 
         /**
          * Determined dynamically
          * @deprecated
          */
-        major: string;
+        major: string | undefined;
     }
 
     export interface IDevice {
         /**
          * Determined dynamically
          */
-        model: string;
+        model: string | undefined;
 
         /**
          * Possible type:
          * console, mobile, tablet, smarttv, wearable, embedded
          */
-        type: string;
+        type: string | undefined;
 
         /**
          * Possible vendor:
@@ -51,7 +51,7 @@ declare namespace IUAParser {
          * Nintendo, Nokia, Nvidia, Ouya, Palm, Panasonic, Polytron, RIM, Samsung, Sharp,
          * Siemens, Sony-Ericsson, Sprint, Xbox, ZTE
          */
-        vendor: string;
+        vendor: string | undefined;
     }
 
     export interface IEngine {
@@ -60,11 +60,11 @@ declare namespace IUAParser {
          * Amaya, EdgeHTML, Gecko, iCab, KHTML, Links, Lynx, NetFront, NetSurf, Presto,
          * Tasman, Trident, w3m, WebKit
          */
-        name: string;
+        name: string | undefined;
         /**
          * Determined dynamically
          */
-        version: string;
+        version: string | undefined;
     }
 
     export interface IOS {
@@ -77,11 +77,11 @@ declare namespace IUAParser {
          * RIM Tablet OS, RISC OS, Sailfish, Series40, Slackware, Solaris, SUSE, Symbian, Tizen,
          * Ubuntu, UNIX, VectorLinux, WebOS, Windows [Phone/Mobile], Zenwalk
          */
-        name: string;
+        name: string | undefined;
         /**
          * Determined dynamically
          */
-        version: string;
+        version: string | undefined;
     }
 
     export interface ICPU {
@@ -90,7 +90,7 @@ declare namespace IUAParser {
          *  68k, amd64, arm, arm64, avr, ia32, ia64, irix, irix64, mips, mips64, pa-risc,
          *  ppc, sparc, sparc64
          */
-        architecture: string;
+        architecture: string | undefined;
     }
 
     export interface IResult {


### PR DESCRIPTION
The type definitions for ua-parser-js are missing undefined on its return values. UAParser will return undefined if given an invalid user agent string, and will also return undefined on values that can't be figured out based on a valid string.

For instance:

```js
const UAParser = require("ua-parser-js")
const ua = new UAParser("Fake ua")

console.log(ua.getBrowser().name) // undefined
```

Since the user agent string can be spoofed by the client, it is reasonable to add these undefined checks to prevent TypeErrors at runtime.

======================================================

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/ua-parser-js
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
