### PR TITLE
Type definitions for Passport-GitHub (2)

### DIFF
--- a/types/passport-github2/index.d.ts
+++ b/types/passport-github2/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for passport-github 1.1
+// Project: https://github.com/jaredhanson/passport-github
+// Definitions by: Yasunori Ohoka <https://github.com/yasupeke>
+//                 Maarten Mulders <https://github.com/mthmulders/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import passport = require('passport');
+import express = require('express');
+
+export interface Profile extends passport.Profile {
+    profileUrl: string;
+}
+
+export interface StrategyOption {
+    clientID: string;
+    clientSecret: string;
+    callbackURL: string;
+
+    scope?: string[];
+    userAgent?: string;
+
+    authorizationURL?: string;
+    tokenURL?: string;
+    scopeSeparator?: string;
+    customHeaders?: string;
+    userProfileURL?: string;
+}
+
+export class Strategy implements passport.Strategy {
+    constructor(options: StrategyOption, verify: (accessToken: string, refreshToken: string, profile: Profile, done: (error: any, user?: any) => void) => void);
+    userProfile: (accessToken: string, done?: (error: any, profile: Profile) => void) => void;
+
+    name: string;
+    authenticate: (req: express.Request, options?: passport.AuthenticateOptions) => void;
+}

--- a/types/passport-github2/passport-github2-tests.ts
+++ b/types/passport-github2/passport-github2-tests.ts
@@ -1,0 +1,42 @@
+/**
+ * Created by jcabresos on 4/19/2014.
+ */
+import passport = require('passport');
+import github = require('passport-github2');
+
+// just some test model
+const User = {
+    findOrCreate(id: string, provider: string, callback: (err: any, user: any) => void): void {
+        callback(null, { username: 'james' });
+    }
+};
+
+const callbackURL = process.env.PASSPORT_GITHUB_CALLBACK_URL;
+const clientID = process.env.PASSPORT_GITHUB_CONSUMER_KEY;
+const clientSecret = process.env.PASSPORT_GITHUB_CONSUMER_SECRET;
+
+if (typeof callbackURL === "undefined") {
+  throw new Error("callbackURL is undefined");
+}
+
+if (typeof clientID === "undefined") {
+  throw new Error("clientID is undefined");
+}
+
+if (typeof clientSecret === "undefined") {
+  throw new Error("clientSecret is undefined");
+}
+
+passport.use(new github.Strategy(
+    {
+        callbackURL,
+        clientID,
+        clientSecret
+    },
+    (accessToken: string, refreshToken: string, profile: github.Profile, done: (error: any, user?: any) => void) => {
+        User.findOrCreate(profile.id, profile.provider, (err, user) => {
+            if (err) { return done(err); }
+            done(null, user);
+        });
+    })
+);

--- a/types/passport-github2/tsconfig.json
+++ b/types/passport-github2/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "passport-github2-tests.ts"
+    ]
+}

--- a/types/passport-github2/tslint.json
+++ b/types/passport-github2/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

I merely copied the existing type definitions for passport-github. The authors of passport-github2 state that the original passport-github is "not maintained [..] for a long time". If you would want to use passport-github2 right now, you cannot, since there is no type definition for it.