### PR TITLE
[react-native-vector-icons] Make loadFont file parameter optional

### DIFF
--- a/types/react-native-vector-icons/Icon.d.ts
+++ b/types/react-native-vector-icons/Icon.d.ts
@@ -191,7 +191,7 @@ export class Icon extends React.Component<IconProps, any> {
     size?: number
   ): Promise<ImageSource>;
   static loadFont(
-    file: string
+    file?: string
   ): Promise<void>;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/oblador/react-native-vector-icons/blob/master/lib/create-icon-set.js#L149-L160>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
---

This is a fix for #18862 .
The `file` in `Icon.loadFont()` is optional.