### PR TITLE
react-redux: Make dispatch property optional in DispatchProp<S>

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -24,7 +24,7 @@ type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: n
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
 export interface DispatchProp<S> {
-  dispatch: Dispatch<S>;
+  dispatch?: Dispatch<S>;
 }
 
 interface AdvancedComponentDecorator<TProps, TOwnProps> {

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -514,3 +514,38 @@ namespace RemoveInjectedAndPassOnRest {
 
     <Spinner foo='bar' />
 }
+
+namespace TestControlledComponentWithoutDispatchProp {
+
+    interface MyState {
+        count: number;
+    }
+
+    interface MyProps {
+        label: string;
+        // `dispatch` is optional, but setting it to anything
+        // other than Dispatch<T> will cause an error
+        //
+        // dispatch: Dispatch<any>; // OK
+        // dispatch: number; // ERROR
+    }
+
+    function mapStateToProps(state: MyState) {
+        return {
+            label: `The count is ${state.count}`,
+        }
+    }
+
+    class MyComponent extends React.Component<MyProps> {
+        render() {
+            return <span>{this.props.label}</span>;
+        }
+    }
+
+    const MyFuncComponent = (props: MyProps) => (
+        <span>{props.label}</span>
+    );
+
+    const MyControlledComponent = connect(mapStateToProps)(MyComponent);
+    const MyControlledFuncComponent = connect(mapStateToProps)(MyFuncComponent);
+}


### PR DESCRIPTION
A lot of times when you don't specify `mapDispatchToProps`, you don't actually need to dispatch anything. (i.e. you're writing a "read-only"/display component) In that scenario, however, ReactRedux will inject `dispatch` to your props, so it makes sense to include `DispatchProp<S>`, so that you don't accidentally declare `dispatch` as being of a different type. However, making the field mandatory is not ideal, since you end up having to add it to every component controlled by react-redux. (And you might not want/need that)

This PR makes `dispatch` optional, so that the function returned by `connect()` can also take React components that don't have a `dispatch` prop declared (But we get to keep the type checking for the classes that do)