### PR TITLE
node: Add scopeid for IPv6 interfaces

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1379,13 +1379,24 @@ declare module "os" {
         };
     }
 
-    export interface NetworkInterfaceInfo {
+    export interface NetworkInterfaceInfoIPv4 {
         address: string;
         netmask: string;
-        family: string;
+        family: "IPv4";
         mac: string;
         internal: boolean;
     }
+
+    export interface NetworkInterfaceInfoIPv6 {
+        address: string;
+        netmask: string;
+        family: "IPv6";
+        mac: string;
+        internal: boolean;
+        scopeid: number;
+    }
+
+    export type NetworkInterfaceInfo = NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6;
 
     export function hostname(): string;
     export function loadavg(): number[];

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1379,20 +1379,19 @@ declare module "os" {
         };
     }
 
-    export interface NetworkInterfaceInfoIPv4 {
+    export interface NetworkInterfaceBase {
         address: string;
         netmask: string;
-        family: "IPv4";
         mac: string;
         internal: boolean;
     }
 
-    export interface NetworkInterfaceInfoIPv6 {
-        address: string;
-        netmask: string;
+    export interface NetworkInterfaceInfoIPv4 extends NetworkInterfaceBase {
+        family: "IPv4";
+    }
+
+    export interface NetworkInterfaceInfoIPv6 extends NetworkInterfaceBase {
         family: "IPv6";
-        mac: string;
-        internal: boolean;
         scopeid: number;
     }
 


### PR DESCRIPTION
The scopeid field only exists if the interface is of family IPv6

https://nodejs.org/dist/latest-v6.x/docs/api/os.html#os_os_networkinterfaces

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v6.x/docs/api/os.html#os_os_networkinterfaces
- [ ] Increase the version number in the header if appropriate.
