### PR TITLE
add types for 'parse-link-header' module

### DIFF
--- a/types/parse-link-header/index.d.ts
+++ b/types/parse-link-header/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for parse-link-header 1.0
+// Project: https://github.com/thlorenz/parse-link-header
+// Definitions by: Nick Zelei <https://github.com/zelein>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace parseLinkHeader {
+    interface Link {
+        url: string;
+        rel: string;
+        [queryParam: string]: string;
+    }
+
+    interface Links {
+        [rel: string]: Link;
+    }
+}
+
+declare function parseLinkHeader(linkHeader: string): parseLinkHeader.Links;
+export = parseLinkHeader;

--- a/types/parse-link-header/index.d.ts
+++ b/types/parse-link-header/index.d.ts
@@ -15,5 +15,5 @@ declare namespace parseLinkHeader {
     }
 }
 
-declare function parseLinkHeader(linkHeader: string): parseLinkHeader.Links;
+declare function parseLinkHeader(linkHeader: string): parseLinkHeader.Links | null;
 export = parseLinkHeader;

--- a/types/parse-link-header/parse-link-header-tests.ts
+++ b/types/parse-link-header/parse-link-header-tests.ts
@@ -1,0 +1,8 @@
+import * as parse from "parse-link-header";
+
+const linkHeader =
+    '<https://api.github.com/user/9287/repos?page=3&per_page=100>; rel="next", ' +
+    '<https://api.github.com/user/9287/repos?page=1&per_page=100>; rel="prev"; pet="cat", ' +
+    '<https://api.github.com/user/9287/repos?page=5&per_page=100>; rel="last"';
+
+const links: parse.Links = parse(linkHeader);

--- a/types/parse-link-header/parse-link-header-tests.ts
+++ b/types/parse-link-header/parse-link-header-tests.ts
@@ -5,4 +5,4 @@ const linkHeader =
     '<https://api.github.com/user/9287/repos?page=1&per_page=100>; rel="prev"; pet="cat", ' +
     '<https://api.github.com/user/9287/repos?page=5&per_page=100>; rel="last"';
 
-const links: parse.Links = parse(linkHeader);
+const links: parse.Links | null = parse(linkHeader);

--- a/types/parse-link-header/tsconfig.json
+++ b/types/parse-link-header/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parse-link-header-tests.ts"
+    ]
+}

--- a/types/parse-link-header/tslint.json
+++ b/types/parse-link-header/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
