### PR TITLE
storybook__react: Remove dependency on @types/node

### DIFF
--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -4,11 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-/// <reference types="node" />
-
 import * as React from 'react';
 
-export type Renderable = React.StatelessComponent<any> | React.ComponentClass<any> | JSX.Element;
+export type Renderable = React.ComponentType<any> | JSX.Element;
 export type RenderFunction = () => Renderable;
 
 export type StoryDecorator = (story: RenderFunction, context: { kind: string, story: string }) => Renderable | null;
@@ -22,8 +20,8 @@ export interface Story {
 export function addDecorator(decorator: StoryDecorator): void;
 export function configure(fn: () => void, module: any): void;
 export function setAddon(addon: object): void;
-export function storiesOf(name: string, module: NodeModule): Story;
-export function storiesOf<T>(name: string, module: NodeModule): Story & T;
+export function storiesOf(name: string, module: any): Story;
+export function storiesOf<T>(name: string, module: any): Story & T;
 
 export interface StoryObject {
     name: string;

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 
-export type Renderable = React.StatelessComponent<any> | React.ComponentClass<any> | JSX.Element;
+export type Renderable = React.ComponentType<any> | JSX.Element;
 export type RenderFunction = () => Renderable;
 
 export type StoryDecorator = (story: RenderFunction, context: { kind: string, story: string }) => Renderable | null;

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 
-export type Renderable = React.ComponentType<any> | JSX.Element;
+export type Renderable = React.ComponentType | JSX.Element;
 export type RenderFunction = () => Renderable;
 
 export type StoryDecorator = (story: RenderFunction, context: { kind: string, story: string }) => Renderable | null;

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -4,9 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+/// <reference types="webpack-env" />
+
 import * as React from 'react';
 
-export type Renderable = React.ComponentType<any> | JSX.Element;
+export type Renderable = React.StatelessComponent<any> | React.ComponentClass<any> | JSX.Element;
 export type RenderFunction = () => Renderable;
 
 export type StoryDecorator = (story: RenderFunction, context: { kind: string, story: string }) => Renderable | null;
@@ -20,8 +22,8 @@ export interface Story {
 export function addDecorator(decorator: StoryDecorator): void;
 export function configure(fn: () => void, module: any): void;
 export function setAddon(addon: object): void;
-export function storiesOf(name: string, module: any): Story;
-export function storiesOf<T>(name: string, module: any): Story & T;
+export function storiesOf(name: string, module: NodeModule): Story;
+export function storiesOf<T>(name: string, module: NodeModule): Story & T;
 
 export interface StoryObject {
     name: string;

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -20,7 +20,7 @@ export interface Story {
 }
 
 export function addDecorator(decorator: StoryDecorator): void;
-export function configure(fn: () => void, module: any): void;
+export function configure(fn: () => void, module: NodeModule): void;
 export function setAddon(addon: object): void;
 export function storiesOf(name: string, module: NodeModule): Story;
 export function storiesOf<T>(name: string, module: NodeModule): Story & T;


### PR DESCRIPTION
Including `@types/node` is problematic because the storybook react api runs in a browser context. `@types/node` defines several globals that are incompatible with common browser contexts (such as `require` and `global`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- !Increase the version number in the header if appropriate.~
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
