### PR TITLE
GoogleMaps: allowing ComponentRestrictions as string|string[]

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2518,7 +2518,7 @@ declare namespace google.maps {
         }
 
         export interface ComponentRestrictions {
-            country: string;
+            country: string|string[];
         }
 
         export interface PlaceAspectRating {


### PR DESCRIPTION
Google API allows the Autocomplete ComponentRestrictions to be either a single string (`{'country': 'us'}`) or a string array (`{'country': ['us','gb','fr']}`)

Reference: 
Single value: https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-hotelsearch
Multiple values: https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-multiple-countries
