### PR TITLE
@google-cloud/storage - createResumableUpload and custom file metadata

### DIFF
--- a/types/google-cloud__storage/google-cloud__storage-tests.ts
+++ b/types/google-cloud__storage/google-cloud__storage-tests.ts
@@ -19,6 +19,7 @@ import {
     FileMetadata,
     FilePrivateOptions,
     ReadStreamOptions,
+    ResumableUploadOptions,
     SignedPolicy,
     SignedPolicyOptions,
     SignedUrlConfig,
@@ -245,6 +246,16 @@ export class TestFile {
 
     copy(destination: string | Bucket | File): Promise<[File, ApiResponse]> {
         return this.file.copy(destination);
+    }
+
+    /**
+     * Create a unique resumable upload session URI. This is the first step when performing a resumable upload.
+     * @method createResumableUpload
+     * @param {ResumableUploadOptions} options
+     * @return {Promise<[string]}
+     */
+    createResumableUpload(options?: ResumableUploadOptions): Promise<[string]> {
+        return this.file.createResumableUpload(options);
     }
 
     /**

--- a/types/google-cloud__storage/index.d.ts
+++ b/types/google-cloud__storage/index.d.ts
@@ -19,7 +19,6 @@ declare namespace Storage {
         acl: Storage.Acl;
         combine(sources: string[] | File[], destination: string[] | File[]): Promise<[File, Storage.ApiResponse]>;
         create(config?: BucketConfig): Promise<[Bucket, Storage.ApiResponse]>;
-        createResumableUpload(options?: ResumableUploadOptions): Promise<[string]>;
         createChannel(id: string, config: ChannelConfig): Promise<[Channel, Storage.ApiResponse]>;
         delete(): Promise<[Storage.ApiResponse]>;
         deleteFiles(query?: BucketQuery): Promise<void>;
@@ -122,6 +121,7 @@ declare namespace Storage {
         acl: Acl;
         copy(destination: string | Bucket | File): Promise<[File, ApiResponse]>;
         createReadStream(options?: ReadStreamOptions): ReadStream;
+        createResumableUpload(options?: ResumableUploadOptions): Promise<[string]>;
         createWriteStream(options?: WriteStreamOptions): WriteStream;
         delete(): Promise<[ApiResponse]>;
         download(options?: DownloadOptions): Promise<[Buffer]>;

--- a/types/google-cloud__storage/index.d.ts
+++ b/types/google-cloud__storage/index.d.ts
@@ -19,6 +19,7 @@ declare namespace Storage {
         acl: Storage.Acl;
         combine(sources: string[] | File[], destination: string[] | File[]): Promise<[File, Storage.ApiResponse]>;
         create(config?: BucketConfig): Promise<[Bucket, Storage.ApiResponse]>;
+        createResumableUpload(options?: ResumableUploadOptions): Promise<[string]>;
         createChannel(id: string, config: ChannelConfig): Promise<[Channel, Storage.ApiResponse]>;
         delete(): Promise<[Storage.ApiResponse]>;
         deleteFiles(query?: BucketQuery): Promise<void>;
@@ -140,10 +141,18 @@ declare namespace Storage {
     }
 
     /**
+     * User-defined metadata.
+     */
+    interface CustomFileMetadata {
+        [key: string]: boolean | number | string | null;
+    }
+
+    /**
      * File metadata.
      */
     interface FileMetadata {
         contentType?: string;
+        metadata?: CustomFileMetadata;
     }
 
     /**
@@ -190,6 +199,17 @@ declare namespace Storage {
         promptSaveAs?: string;
         responseDisposition?: string;
         responseType?: string;
+    }
+
+    /**
+     * Options when obtaining a resumable upload URI.
+     */
+    interface ResumableUploadOptions {
+        metadata?: FileMetadata;
+        origin?: string;
+        predefinedAcl?: string;
+        private?: boolean;
+        public?: boolean;
     }
 
     /**


### PR DESCRIPTION
Add typings for File.createResumableUpload and the ability to define custom metadata on files.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
<https://googlecloudplatform.github.io/google-cloud-node/#/docs/storage/1.2.0/storage/file?method=createResumableUpload>
<https://googlecloudplatform.github.io/google-cloud-node/#/docs/storage/1.2.0/storage/file?method=setMetadata>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.