### PR TITLE
classnames: Fix type error for falsy values with bind

### DIFF
--- a/types/classnames/bind.d.ts
+++ b/types/classnames/bind.d.ts
@@ -1,5 +1,3 @@
-export type ClassNamesFn = (
-    ...args: Array<string | string[] | Record<string, boolean | undefined | null>>
-) => string;
+import * as cn from "./index";
 
-export function bind(styles: Record<string, string>): ClassNamesFn;
+export function bind(styles: Record<string, string>): typeof cn;

--- a/types/classnames/classnames-tests.ts
+++ b/types/classnames/classnames-tests.ts
@@ -35,3 +35,6 @@ const styles = {
 
 const cx = cn.bind(styles);
 const className = cx('foo', ['bar'], { baz: true }); // => "abc def xyz"
+
+// falsey values are just ignored
+cx(null, 'bar', undefined, 0, 1, { baz: null }, ''); // => 'bar 1'


### PR DESCRIPTION
- Fix typing errors when using `classnames/bind` with falsy types.
- Don't duplicate types

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/classnames#usage
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.