### PR TITLE
WatchIgnorePlugin constructor should allow array of string paths

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -919,7 +919,7 @@ declare namespace webpack {
     }
 
     class WatchIgnorePlugin extends Plugin {
-        constructor(paths: string[] | RegExp[]);
+        constructor(paths: (string | RegExp)[]);
     }
 
     namespace optimize {

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -919,7 +919,7 @@ declare namespace webpack {
     }
 
     class WatchIgnorePlugin extends Plugin {
-        constructor(paths: RegExp[]);
+        constructor(paths: string[] | RegExp[]);
     }
 
     namespace optimize {

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -919,7 +919,7 @@ declare namespace webpack {
     }
 
     class WatchIgnorePlugin extends Plugin {
-        constructor(paths: (string | RegExp)[]);
+        constructor(paths: Array<string | RegExp>);
     }
 
     namespace optimize {


### PR DESCRIPTION
Fix webpack `WatchIgnorePlugin` constructor arguments to allow providing an array of absolute path strings.  This is specified in the webpack documentation for the `WatchIgnorePlugin`  plugin (see link below).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/plugins/watch-ignore-plugin/

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
