### PR TITLE
q.reject parameter is optional

### DIFF
--- a/types/q/index.d.ts
+++ b/types/q/index.d.ts
@@ -30,7 +30,7 @@ declare namespace Q {
 
 		resolve(value?: IWhenable<T>): void;
 
-		reject(reason: any): void;
+		reject(reason?: any): void;
 
 		notify(value: any): void;
 
@@ -145,7 +145,7 @@ declare namespace Q {
 		/**
 		 * A sugar method, equivalent to promise.then(function () { throw reason; }).
 		 */
-		thenReject(reason: any): Promise<T>;
+		thenReject(reason?: any): Promise<T>;
 
 		/**
 		 * Attaches a handler that will observe the value of the promise when it becomes fulfilled, returning a promise for that same value, perhaps deferred but not replaced by the promise returned
@@ -324,7 +324,7 @@ declare namespace Q {
 	 */
 	export function reject<T>(reason?: any): Promise<T>;
 
-	export function Promise<T>(resolver: (resolve: (val?: IWhenable<T>) => void, reject: (reason: any) => void, notify: (progress: any) => void) => void): Promise<T>;
+	export function Promise<T>(resolver: (resolve: (val?: IWhenable<T>) => void, reject: (reason?: any) => void, notify: (progress: any) => void) => void): Promise<T>;
 
 	/**
 	 * Creates a new version of func that accepts any combination of promise and non-promise values, converting them to their fulfillment values before calling the original func. The returned version


### PR DESCRIPTION
Please fill in this template.

- [ ✔ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ✔ ] Test the change in your own code. (Compile and run.)
- [ ✔ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ✔ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ✔ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ✔ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kriskowal/q/blob/master/q.js#L1135
- [ ✔ ] Increase the version number in the header if appropriate.
- [ ✔ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


I've been using q.reject in my code for a while now without adding a parameter, which just turns up as "undefined" in the catch.  There is no need or check that will break something if the reason for the reject isn't given, hence I've made this parameter optional.