### PR TITLE
[meteor] Added missing parameters to Meteor's Accounts.config function

### DIFF
--- a/types/meteor/accounts.d.ts
+++ b/types/meteor/accounts.d.ts
@@ -31,6 +31,9 @@ declare module Accounts {
         restrictCreationByEmailDomain?: string | Function;
         loginExpirationInDays?: number;
         oauthSecretKey?: string;
+        passwordResetTokenExpirationInDays?: number;
+        passwordEnrollTokenExpirationInDays?: number;
+        ambiguousErrorMessages?: boolean;
     }): void;
 
     function onLogin(func: Function): {
@@ -73,6 +76,9 @@ declare module "meteor/accounts-base" {
             restrictCreationByEmailDomain?: string | Function;
             loginExpirationInDays?: number;
             oauthSecretKey?: string;
+            passwordResetTokenExpirationInDays?: number;
+            passwordEnrollTokenExpirationInDays?: number;
+            ambiguousErrorMessages?: boolean;
         }): void;
 
         function onLogin(func: Function): {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. No tests are effected.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

Added 3 missing parameters from Meteor's Accounts.config function. 
http://docs.meteor.com/api/accounts-multi.html#AccountsCommon-config
`passwordResetTokenExpirationInDays` has been there since 1.4.1
`passwordEnrollTokenExpirationInDays `since 1.4.2
`ambiguousErrorMessages` since 1.5

My first pull request so please bear with me if I am doing something wrong. 