### PR TITLE
Fix callbacks in react-portal and react-sidebar

### DIFF
--- a/types/react-portal/index.d.ts
+++ b/types/react-portal/index.d.ts
@@ -7,7 +7,7 @@
 import * as React from "react";
 
 interface CallBackProps extends React.Props<any> {
-    closePortal(): {};
+    closePortal(): void;
 }
 
 interface ReactPortalProps {
@@ -15,10 +15,10 @@ interface ReactPortalProps {
     openByClickOn?: React.ReactElement<CallBackProps>;
     closeOnEsc?: boolean;
     closeOnOutsideClick?: boolean;
-    onOpen?(node: HTMLDivElement): {};
-    beforeClose?(node: HTMLDivElement, resetPortalState: () => void): {};
-    onClose?(): {};
-    onUpdate?(): {};
+    onOpen?(node: HTMLDivElement): void;
+    beforeClose?(node: HTMLDivElement, resetPortalState: () => void): void;
+    onClose?(): void;
+    onUpdate?(): void;
 }
 
 declare const ReactPortal: React.ComponentClass<ReactPortalProps>;

--- a/types/react-portal/react-portal-tests.tsx
+++ b/types/react-portal/react-portal-tests.tsx
@@ -8,17 +8,29 @@ export default class App extends React.Component {
     const button1 = <button>Open portal with pseudo modal</button>;
 
     return (
-      <Portal closeOnEsc closeOnOutsideClick openByClickOn={button1}>
-        <PseudoModal>
-          <h2>Pseudo Modal</h2>
-          <p>This react component is appended to the document body.</p>
-        </PseudoModal>
-      </Portal>
+      <div>
+        <Portal
+          isOpened={false}
+          openByClickOn={button1}
+          closeOnEsc
+          closeOnOutsideClick
+          onOpen={(node: HTMLDivElement) => {}}
+          beforeClose={(node: HTMLDivElement, resetPortalState) => resetPortalState()}
+          onClose={() => {}}
+          onUpdate={() => {}}
+        >
+          <PseudoModal>
+            <h2>Pseudo Modal</h2>
+            <p>This react component is appended to the document body.</p>
+          </PseudoModal>
+        </Portal>
+        <Portal />
+      </div>
     );
   }
 }
 
-export class PseudoModal extends React.Component<{ closePortal?(): {} }> {
+export class PseudoModal extends React.Component<{ closePortal?(): void }> {
   render() {
     return (
       <div>

--- a/types/react-sidebar/index.d.ts
+++ b/types/react-sidebar/index.d.ts
@@ -10,7 +10,7 @@ export interface SidebarProps {
     contentClassName?: string;
     docked?: boolean;
     dragToggleDistance?: number;
-    onSetOpen?(): {};
+    onSetOpen?(): void;
     open?: boolean;
     overlayClassName?: string;
     pullRight?: boolean;

--- a/types/react-sidebar/react-sidebar-tests.tsx
+++ b/types/react-sidebar/react-sidebar-tests.tsx
@@ -7,6 +7,14 @@ const sidebarStyle: SidebarStyles = {
     content: { width: "300px" }
 };
 
-const sidebar1 = <Sidebar docked={true} open={true} sidebar={sidebar} styles={sidebarStyle}>
-                    <h1>Content</h1>
-                </Sidebar>;
+const sidebar1 = (
+    <Sidebar
+        docked={true}
+        open={true}
+        sidebar={sidebar}
+        styles={sidebarStyle}
+        onSetOpen={() => {}}
+    >
+        <h1>Content</h1>
+    </Sidebar>
+);


### PR DESCRIPTION
This might be a common pitfall when writing definitions. See discussion here:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/15526#issuecomment-322781094

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [react-portal](https://github.com/tajo/react-portal#onopen-funcdomnode) and [react-sidebar](https://github.com/balloob/react-sidebar#supported-props)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.