### PR TITLE
Datatables.net-buttons - Add support for more button column types and support the filename option

### DIFF
--- a/types/datatables.net-buttons/datatables.net-buttons-tests.ts
+++ b/types/datatables.net-buttons/datatables.net-buttons-tests.ts
@@ -8,8 +8,18 @@ $(document).ready(function () {
                     extend: 'excel',
                     text: 'Excel',
                     className: 'class',
+                    filename: "exported_file.csv",
                     exportOptions: {
                         columns: ':visible'
+                    }
+                },
+                {
+                    extend: 'excel',
+                    text: 'Excel',
+                    className: 'class',
+                    filename: "exported_file.csv",
+                    exportOptions: {
+                        columns: [1, 6, 2, 3, 4]
                     }
                 },
                 {

--- a/types/datatables.net-buttons/index.d.ts
+++ b/types/datatables.net-buttons/index.d.ts
@@ -86,6 +86,11 @@ declare namespace DataTables {
          */
         title?: string;
 
+        /**
+         * Define what the exported filename should be
+         */
+        filename?: string;
+
         exportOptions?: ButtonExportOptions;
         autoPrint?: boolean;
         customize?: FunctionButtonCustomize;
@@ -95,7 +100,7 @@ declare namespace DataTables {
         (dt: DataTables.Api, config: any): boolean
     }
     export interface ButtonExportOptions {
-        columns?: string;
+        columns?: string | number | string[] | number[];
     }
 
     export interface ButtonKey {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://datatables.net/reference/type/column-selector
https://datatables.net/reference/button/csvHtml5
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
