### PR TITLE
multer: Fix a problem when implement the `_handleFile`

### DIFF
--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -6,6 +6,7 @@
 //                 Michael Ledin <https://github.com/mxl>
 //                 HyunSeob Lee <https://github.com/hyunseob>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 import * as express from 'express';
 
@@ -48,20 +49,8 @@ declare namespace multer {
     }
 
     interface StorageEngine {
-        _handleFile(req: express.Request, file: Express.Multer.File, callback: (error?: any, info?: FileInfo) => void): void;
+        _handleFile(req: express.Request, file: Express.Multer.File, callback: (error?: any, info?: Partial<Express.Multer.File>) => void): void;
         _removeFile(req: express.Request, file: Express.Multer.File, callback: (error: Error) => void): void;
-    }
-
-    interface FileInfo {
-        fieldname?: string;
-        originalname?: string;
-        encoding?: string;
-        mimetype?: string;
-        size?: number;
-        destination?: string;
-        filename?: string;
-        path?: string;
-        buffer?: Buffer;
     }
 
     interface DiskStorageOptions {

--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -4,6 +4,7 @@
 //                 vilicvane <https://vilic.github.io/>
 //                 David Broder-Rodgers <https://github.com/DavidBR-SW>
 //                 Michael Ledin <https://github.com/mxl>
+//                 HyunSeob Lee <https://github.com/hyunseob>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as express from 'express';
@@ -47,8 +48,20 @@ declare namespace multer {
     }
 
     interface StorageEngine {
-        _handleFile(req: express.Request, file: Express.Multer.File, callback: (error?: any, info?: Express.Multer.File) => void): void;
+        _handleFile(req: express.Request, file: Express.Multer.File, callback: (error?: any, info?: FileInfo) => void): void;
         _removeFile(req: express.Request, file: Express.Multer.File, callback: (error: Error) => void): void;
+    }
+
+    interface FileInfo {
+        fieldname?: string;
+        originalname?: string;
+        encoding?: string;
+        mimetype?: string;
+        size?: number;
+        destination?: string;
+        filename?: string;
+        path?: string;
+        buffer?: Buffer;
     }
 
     interface DiskStorageOptions {


### PR DESCRIPTION
When implementing the `StorageEngine`, I did have to implement `_handleFile` & `_removeFile`.
But it had a problem. When I call the `callback` function, I have to specify all fields of the `Express.Multer.File` interface. Actually, it's not required.

So, I add a new interface which named `FileInfo`. It's similar to `Express.Multer.File`, but all fields are optional.