### PR TITLE
[redux-auth-wrapper] Export locationHelperBuilder from history4/locationWrapper inst

### DIFF
--- a/types/redux-auth-wrapper/history4/locationHelper.d.ts
+++ b/types/redux-auth-wrapper/history4/locationHelper.d.ts
@@ -1,0 +1,7 @@
+export {
+    LocationHelper,
+    LocationHelperConfig
+} from "redux-auth-wrapper/history3/redirect";
+
+import { locationHelperBuilder } from "redux-auth-wrapper/history3/redirect";
+export default locationHelperBuilder;

--- a/types/redux-auth-wrapper/redux-auth-wrapper-tests.tsx
+++ b/types/redux-auth-wrapper/redux-auth-wrapper-tests.tsx
@@ -13,9 +13,9 @@ import {
 
 import {
     connectedRouterRedirect,
-    connectedReduxRedirect,
-    locationHelperBuilder
+    connectedReduxRedirect
 } from "redux-auth-wrapper/history4/redirect";
+import locationHelperBuilder from "redux-auth-wrapper/history4/locationHelper";
 
 import { authWrapper } from "redux-auth-wrapper/authWrapper";
 import { connectedAuthWrapper } from "redux-auth-wrapper/connectedAuthWrapper";

--- a/types/redux-auth-wrapper/tsconfig.json
+++ b/types/redux-auth-wrapper/tsconfig.json
@@ -18,6 +18,7 @@
     "files": [
         "history3/redirect.d.ts",
         "history4/redirect.d.ts",
+        "history4/locationHelper.d.ts",
         "authWrapper.d.ts",
         "connectedAuthWrapper.d.ts",
         "index.d.ts",


### PR DESCRIPTION
`locationHelperBuilder` should be exported from `redux-auth-wrapper/history4/locationHelper`, not `redux-auth-wrapper/history4/redirect` ([docs](https://mjrussell.github.io/redux-auth-wrapper/docs/API.html#locationhelperbuilder)). I suspect this issue exists with the `locationHelperBuilder` export of `history3` as well, but haven't been able to test it.

cc @LKay 