### PR TITLE
[Hapi] Updated timeout property of RoutePayloadConfigurationObject

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -1025,7 +1025,7 @@ export interface RoutePayloadConfigurationObject {
     /** limits the size of incoming payloads to the specified byte count. Allowing very large payloads may cause the server to run out of memory. Defaults to 1048576 (1MB). */
     maxBytes?: number;
     /** payload reception timeout in milliseconds. Sets the maximum time allowed for the client to transmit the request payload (body) before giving up and responding with a Request Timeout (408) error response. Set to false to disable. Defaults to 10000 (10 seconds). */
-    timeout?: number;
+    timeout?: number | false;
     /** the directory used for writing file uploads. Defaults to os.tmpdir(). */
     uploads?: string;
     /**

--- a/types/hapi/test/route/additional-options.ts
+++ b/types/hapi/test/route/additional-options.ts
@@ -70,4 +70,12 @@ var payloadOptions: Hapi.RoutePayloadConfigurationObject = {
     allow: 'multipart/form-data',
     maxBytes: 123,
     output: 'file',
+    timeout: 1000
+};
+
+var payloadOptions: Hapi.RoutePayloadConfigurationObject = {
+    allow: 'multipart/form-data',
+    maxBytes: 123,
+    output: 'file',
+    timeout: false
 };


### PR DESCRIPTION
RoutePayloadConfigurationObject is an optional property which accepts a `number` or `false`.

As stated in the [docs](https://hapijs.com/api#route-options)

> timeout - payload reception timeout in milliseconds. Sets the maximum time allowed for the client to transmit the request payload (body) before giving up and responding with a Request Timeout (408) error response. Set to false to disable. Defaults to 10000 (10 seconds).