### PR TITLE
react-redux: fix dispatchToProps being passed as object

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -148,12 +148,8 @@ interface MapDispatchToPropsFunction<TDispatchProps, TOwnProps> {
     (dispatch: Dispatch<any>, ownProps: TOwnProps): TDispatchProps;
 }
 
-interface MapDispatchToPropsObject {
-    [name: string]: ActionCreator<any>;
-}
-
 type MapDispatchToProps<TDispatchProps, TOwnProps> =
-    MapDispatchToPropsFunction<TDispatchProps, TOwnProps> | MapDispatchToPropsObject;
+    MapDispatchToPropsFunction<TDispatchProps, TOwnProps> | TDispatchProps;
 
 interface MapDispatchToPropsFactory<TDispatchProps, TOwnProps> {
     (dispatch: Dispatch<any>, ownProps: TOwnProps): MapDispatchToProps<TDispatchProps, TOwnProps>;
@@ -180,13 +176,13 @@ interface Options<TStateProps = {}, TOwnProps = {}, TMergedProps = {}> extends C
      * @default strictEqual
      */
     areStatesEqual?: (nextState: any, prevState: any) => boolean;
-    
+
     /**
      * When pure, compares incoming props to its previous value.
      * @default shallowEqual
      */
     areOwnPropsEqual?: (nextOwnProps: TOwnProps, prevOwnProps: TOwnProps) => boolean;
-    
+
     /**
      * When pure, compares the result of mapStateToProps to its previous value.
      * @default shallowEqual

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1,7 +1,7 @@
 import { Component, ReactElement } from 'react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Store, Dispatch, bindActionCreators } from 'redux';
+import { Store, Dispatch, ActionCreator, bindActionCreators } from 'redux';
 import { connect, Provider, DispatchProp, MapStateToProps } from 'react-redux';
 import objectAssign = require('object-assign');
 
@@ -548,4 +548,24 @@ namespace TestControlledComponentWithoutDispatchProp {
 
     const MyControlledComponent = connect(mapStateToProps)(MyComponent);
     const MyControlledFuncComponent = connect(mapStateToProps)(MyFuncComponent);
+}
+
+namespace TestDispatchToPropsAsObject {
+    const onClick: ActionCreator<{}> = null;
+    const mapStateToProps = (state: any) => {
+        return {
+            title: state.app.title as string,
+        };
+    };
+    const dispatchToProps = {
+        onClick,
+    };
+
+    type Props = { title: string; } & typeof dispatchToProps;
+    const HeaderComponent: React.StatelessComponent<Props> = (props) => {
+        return <h1>{props.title}</h1>;
+    }
+
+    const Header = connect(mapStateToProps, dispatchToProps)(HeaderComponent);
+    <Header />
 }


### PR DESCRIPTION
This PR fixes the resulting wrapped component type returned by the `connect()` HOC when the given `dispatchToProps` argument is an object. (Fixes issue #18955)

Previously we were using `MapDispatchToPropsObject` but that doesn't work with `Omit<T, K>`, so dispatch props were being preserved on the resulting object. I've replaced that with `TDispatchProps` instead.

I've added test code by @horiuchi, adapted from:
https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18955

Everything _seems_ to be working fine after this change, but I'm unsure if there might be any unintended consequences of this change.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18955
- [x] Increase the version number in the header if appropriate. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **N/A**

**Edit:** Looks like my editor also automatically removed extraneous whitespace... I can omit that change from the PR if you'd like... Otherwise you may consider it as a bonus fix 😜 
