### PR TITLE
[better-sqlite3] Fix types for ran query results and custom operators

### DIFF
--- a/types/better-sqlite3/index.d.ts
+++ b/types/better-sqlite3/index.d.ts
@@ -9,7 +9,7 @@ import * as Integer from 'integer';
 
 interface RunResult {
 	changes: number;
-	lastInsertRowID: number;
+	lastInsertROWID: Integer.IntLike;
 }
 
 declare class Statement {
@@ -48,6 +48,7 @@ interface RegistrationOptions {
 	name?: string;
 	varargs?: boolean;
 	deterministic?: boolean;
+	safeIntegers?: boolean;
 }
 
 interface Database {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/JoshuaWise/better-sqlite3/blob/master/src/objects/statement.lzz#L126>>, <<https://github.com/JoshuaWise/better-sqlite3/blob/master/lib/register.js#L26>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
