### PR TITLE
[auth0-js] Added support for optional user_metadata in signup

### DIFF
--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -130,7 +130,10 @@ webAuth.signupAndAuthorize({
     connection: 'the_connection',
     email: 'me@example.com',
     password: '123456',
-    scope: 'openid'
+    scope: 'openid',
+    user_metadata: {
+        foo: 'bar'
+    }
 }, function (err, data) {
 
 });

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Auth0.js 8.6
 // Project: https://github.com/auth0/auth0.js
 // Definitions by: Adrian Chia <https://github.com/adrianchia>
+//                 Matt Durrant <https://github.com/mdurrant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace auth0;
@@ -624,6 +625,7 @@ interface DbSignUpOptions {
     password: string;
     connection: string;
     scope?: string;
+    user_metadata?: any;
 }
 
 interface ParseHashOptions {


### PR DESCRIPTION
This change supports the user_metadata object to pass custom fields to the auth0 api using the signup and signupAndAuthorize methods

[x] Use a meaningful title for the pull request. Include the name of the package modified.

[x] Test the change in your own code. (Compile and run.)

[x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).

[x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

[x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

[x] Provide a URL to documentation or source code which provides context for the suggested changes: [click](https://auth0.com/docs/libraries/custom-signup#using-the-api)

[ ] Increase the version number in the header if appropriate.

[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
