### PR TITLE
[got] Add extra attributes to redirect options

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -63,6 +63,7 @@ let req: http.ClientRequest;
 let res: http.IncomingMessage | undefined;
 let opts: got.GotOptions<string | null>;
 let err: got.GotError;
+let href: string | undefined;
 
 const stream = got.stream('todomvc.com');
 stream.addListener('request', (r) => req = r);
@@ -70,6 +71,7 @@ stream.addListener('response', (r) => res = r);
 stream.addListener('redirect', (r, o) => {
     res = r;
     opts = o;
+    href = o.href;
 });
 stream.addListener('error', (e, b, r) => {
     err = e;
@@ -81,6 +83,7 @@ stream.on('response', (r) => res = r);
 stream.on('redirect', (r, o) => {
     res = r;
     opts = o;
+    href = o.href;
 });
 stream.on('error', (e, b, r) => {
     err = e;
@@ -92,6 +95,7 @@ stream.once('response', (r) => res = r);
 stream.once('redirect', (r, o) => {
     res = r;
     opts = o;
+    href = o.href;
 });
 stream.once('error', (e, b, r) => {
     err = e;
@@ -103,6 +107,7 @@ stream.prependListener('response', (r) => res = r);
 stream.prependListener('redirect', (r, o) => {
     res = r;
     opts = o;
+    href = o.href;
 });
 stream.prependListener('error', (e, b, r) => {
     err = e;
@@ -114,6 +119,7 @@ stream.prependOnceListener('response', (r) => res = r);
 stream.prependOnceListener('redirect', (r, o) => {
     res = r;
     opts = o;
+    href = o.href;
 });
 stream.prependOnceListener('error', (e, b, r) => {
     err = e;
@@ -125,6 +131,7 @@ stream.removeListener('response', (r) => res = r);
 stream.removeListener('redirect', (r, o) => {
     res = r;
     opts = o;
+    href = o.href;
 });
 stream.removeListener('error', (e, b, r) => {
     err = e;

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -1,11 +1,13 @@
 // Type definitions for got 7.1
 // Project: https://github.com/sindresorhus/got#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 /// <reference types="node"/>
 
+import { Url } from 'url';
 import * as http from 'http';
 import * as nodeStream from 'stream';
 
@@ -79,32 +81,32 @@ declare namespace got {
     interface GotEmitter {
         addListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         addListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        addListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null>) => void): this;
+        addListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         addListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
 
         on(event: 'request', listener: (req: http.ClientRequest) => void): this;
         on(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        on(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null>) => void): this;
+        on(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         on(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
 
         once(event: 'request', listener: (req: http.ClientRequest) => void): this;
         once(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        once(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null>) => void): this;
+        once(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         once(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
 
         prependListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         prependListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null>) => void): this;
+        prependListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         prependListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
 
         prependOnceListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         prependOnceListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        prependOnceListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null>) => void): this;
+        prependOnceListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         prependOnceListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
 
         removeListener(event: 'request', listener: (req: http.ClientRequest) => void): this;
         removeListener(event: 'response', listener: (res: http.IncomingMessage) => void): this;
-        removeListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null>) => void): this;
+        removeListener(event: 'redirect', listener: (res: http.IncomingMessage, nextOptions: GotOptions<string | null> & Url) => void): this;
         removeListener(event: 'error', listener: (error: GotError, body?: any, res?: http.IncomingMessage) => void): this;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/sindresorhus/got/blob/8b040afc0749523fcaaf6db81702c27e74f7a1d2/index.js#L128
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

------

I was getting a `Property 'href' does not exist on type 'GotOptions<string | null>'.` error when trying to read out the the target of the redirection. This correctly returns a union (which is what `Object.assign` returns) per the source code of got.