### PR TITLE
google-apps-script: `getProperty(key)` may return null

### DIFF
--- a/types/google-apps-script/google-apps-script.properties.d.ts
+++ b/types/google-apps-script/google-apps-script.properties.d.ts
@@ -22,7 +22,7 @@ declare namespace GoogleAppsScript {
       deleteProperty(key: string): Properties;
       getKeys(): String[];
       getProperties(): Object;
-      getProperty(key: string): string;
+      getProperty(key: string): string | null;
       setProperties(properties: Object): Properties;
       setProperties(properties: Object, deleteAllOthers: boolean): Properties;
       setProperty(key: string, value: string): Properties;
@@ -60,7 +60,7 @@ declare namespace GoogleAppsScript {
       deleteProperty(key: string): ScriptProperties;
       getKeys(): String[];
       getProperties(): Object;
-      getProperty(key: string): string;
+      getProperty(key: string): string | null;
       setProperties(properties: Object): ScriptProperties;
       setProperties(properties: Object, deleteAllOthers: boolean): ScriptProperties;
       setProperty(key: string, value: string): ScriptProperties;
@@ -77,7 +77,7 @@ declare namespace GoogleAppsScript {
       deleteProperty(key: string): UserProperties;
       getKeys(): String[];
       getProperties(): Object;
-      getProperty(key: string): string;
+      getProperty(key: string): string | null;
       setProperties(properties: Object): UserProperties;
       setProperties(properties: Object, deleteAllOthers: boolean): UserProperties;
       setProperty(key: string, value: string): UserProperties;


### PR DESCRIPTION
`getProperty(key)` returns null if no such key exists, according to [the reference](https://developers.google.com/apps-script/reference/properties/properties#getProperty(String)).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/apps-script/reference/properties/properties#getProperty(String)>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
