### PR TITLE
[node] rename `defaultEncoding` option property to `encoding`.

### DIFF
--- a/types/fs-extra-promise/fs-extra-promise-tests.ts
+++ b/types/fs-extra-promise/fs-extra-promise-tests.ts
@@ -202,7 +202,7 @@ readStream = fs.createReadStream(path, {
 writeStream = fs.createWriteStream(path);
 writeStream = fs.createWriteStream(path, {
 	flags: str,
-	defaultEncoding: str
+	encoding: str
 });
 
 function isDirectoryCallback(err: Error, isDirectory: boolean) {}

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -4227,7 +4227,7 @@ declare module "fs" {
      */
     export function createWriteStream(path: PathLike, options?: string | {
         flags?: string;
-        defaultEncoding?: string;
+        encoding?: string;
         fd?: number;
         mode?: number;
         autoClose?: boolean;


### PR DESCRIPTION
Based on the Node documentation fix that just landed: https://github.com/nodejs/node/issues/14611

The issue was also mentioned in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14981

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/issues/14611
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.