### PR TITLE
[got] Fix return type of json request

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -19,6 +19,7 @@ got('todomvc.com')
 got('todomvc.com').cancel();
 
 got('todomvc.com', {json: true}).then(response => obj = response.body);
+got('todomvc.com', {json: true}).then(response => str = response.body);
 got('todomvc.com', {json: true, body: {}}).then(response => obj = response.body);
 got('todomvc.com', {json: true, body: [{}]}).then(response => obj = response.body);
 got('todomvc.com', {json: true, form: true}).then(response => obj = response.body);

--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -18,13 +18,29 @@ got('todomvc.com')
 
 got('todomvc.com').cancel();
 
-got('todomvc.com', {json: true}).then(response => obj = response.body);
-got('todomvc.com', {json: true}).then(response => str = response.body);
-got('todomvc.com', {json: true, body: {}}).then(response => obj = response.body);
-got('todomvc.com', {json: true, body: [{}]}).then(response => obj = response.body);
-got('todomvc.com', {json: true, form: true}).then(response => obj = response.body);
-got('todomvc.com', {json: true, form: true, encoding: null}).then(response => obj = response.body);
-got('todomvc.com', {json: true, form: true, encoding: null, hostname: 'todomvc'}).then(response => obj = response.body);
+got('todomvc.com', {json: true}).then((response) => {
+    response.body; // $ExpectType any
+});
+
+got('todomvc.com', {json: true, body: {}}).then((response) => {
+    response.body; // $ExpectType any
+});
+
+got('todomvc.com', {json: true, body: [{}]}).then((response) => {
+    response.body; // $ExpectType any
+});
+
+got('todomvc.com', {json: true, form: true}).then((response) => {
+    response.body; // $ExpectType any
+});
+
+got('todomvc.com', {json: true, form: true, encoding: null}).then((response) => {
+    response.body; // $ExpectType any
+});
+
+got('todomvc.com', {json: true, form: true, encoding: null, hostname: 'todomvc'}).then((response) => {
+    response.body; // $ExpectType any
+});
 
 got('todomvc.com', {form: true}).then(response => str = response.body);
 got('todomvc.com', {form: true, body: {}}).then(response => str = response.body);

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for got 7.1
 // Project: https://github.com/sindresorhus/got#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -21,7 +22,7 @@ declare namespace got {
     // tslint:disable unified-signatures
     interface GotFn {
         (url: GotUrl): GotPromise<string>;
-        (url: GotUrl, options: GotJSONOptions): GotPromise<object>;
+        (url: GotUrl, options: GotJSONOptions): GotPromise<any>;
         (url: GotUrl, options: GotFormOptions<string>): GotPromise<string>;
         (url: GotUrl, options: GotFormOptions<null>): GotPromise<Buffer>;
         (url: GotUrl, options: GotBodyOptions<string>): GotPromise<string>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/sindresorhus/got/blob/8b040afc0749523fcaaf6db81702c27e74f7a1d2/index.js#L312
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

-----

When requesting JSON from remote servers, anything that is considered valid JSON by `JSON.parse` is returned as the `body` property. That includes JSON scalars (which I think at first was not valid as the root, but the spec was later amended by a different RFC to allow it...).

Since the return value of `JSON.parse` is typed as `any`, I opted for using the same here.