### PR TITLE
Ramda: Values<T> should not resolve as {}[], instead it should resolve to T[]

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1916,7 +1916,7 @@ declare namespace R {
          * Note that the order of the output array is not guaranteed across
          * different JS platforms.
          */
-        values<T>(obj: { [index: string]: T } | any): T[];
+        values<T extends object, K extends keyof T>(obj: T): Array<T[K]>;
 
         /**
          * Returns a list of all the properties, including prototype properties, of the supplied

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1567,7 +1567,19 @@ class Rectangle {
 };
 
 () => {
-    const a = R.values({a: 1, b: 2, c: 3}); // => [1, 2, 3]
+    interface A {
+        a: string;
+        b: string;
+    }
+    const a1: A = { a: 'something', b: 'else' };
+    const v1 = R.values(a1);
+
+    const a = R.values({a: 1, b: 2, c: 3}); // => [1, 2, 3] (number[])
+    const addition = a[0] + a[1];
+
+    const b = R.values({a: 1, b: 'something'}); // b = (string|number)[]
+    const c = R.values({1: 3});
+    // const d = R.values('something');
 };
 
 () => {


### PR DESCRIPTION
This issue occurred due to some linting. It was assumed that

```ts
values<T>(obj: {[index: string]: T}): T[];
values<T>(obj: any): T[];
```
equals:

```ts
values<T>(obj: {[index: string]: T} | any): T[];
```

This doesn't seem to be the case. The argument will be resolved as any and values will return an {}[] instead.

So we have two options. We can either leave the additional definition in (breaking linting rules) or leave out the `any` entirely. This works for objects with string|numbers as keys, which should be %99.99 of the cases... unless I'm missing something.

This PR removes the any for the sake of simplicity. And adds some tests for the heck of it.
