### PR TITLE
angular: Better types for HTTP interceptors & response objects

### DIFF
--- a/types/angular-animate/index.d.ts
+++ b/types/angular-animate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://angularjs.org
 // Definitions by: Michel Salib <https://github.com/michelsalib>, Adi Dahiya <https://github.com/adidahiya>, Raphael Schweizer <https://github.com/rasch>, Cody Schaaf <https://github.com/codyschaaf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 declare var _: string;
 export = _;

--- a/types/angular-animate/index.d.ts
+++ b/types/angular-animate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://angularjs.org
 // Definitions by: Michel Salib <https://github.com/michelsalib>, Adi Dahiya <https://github.com/adidahiya>, Raphael Schweizer <https://github.com/rasch>, Cody Schaaf <https://github.com/codyschaaf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.1
 
 declare var _: string;
 export = _;

--- a/types/angular-feature-flags/angular-feature-flags-tests.ts
+++ b/types/angular-feature-flags/angular-feature-flags-tests.ts
@@ -1,8 +1,8 @@
-import * as angular from "angular";
+import * as ng from 'angular';
 
-let myApp = angular.module('myApp', ['feature-flags']);
+const myApp = ng.module('myApp', ['feature-flags']);
 
-const flagsData: Array<angular.featureflags.FlagData> = [
+const flagsData: Array<ng.featureflags.FlagData> = [
     {
         key: '1',
         active: true,
@@ -17,15 +17,16 @@ const flagsData: Array<angular.featureflags.FlagData> = [
     }
 ];
 
-myApp.config(function (featureFlagsProvider: angular.featureflags.FeatureFlagsProvider) {
+myApp.config(function(featureFlagsProvider: ng.featureflags.FeatureFlagsProvider) {
     featureFlagsProvider.setInitialFlags(flagsData);
 });
 
-myApp.run(function ($q: angular.IQService, $http: angular.IHttpService, featureFlags: angular.featureflags.FeatureFlagsService) {
-    let deferred = $q.defer();
-    deferred.resolve(flagsData);
-
-    featureFlags.set(deferred.promise);
-
+myApp.run(function(
+    $q: ng.IQService,
+    $http: ng.IHttpService,
+    featureFlags: ng.featureflags.FeatureFlagsService
+) {
+    featureFlags.set($q.resolve(flagsData));
     featureFlags.set($http.get('/data/flags.json'));
+    featureFlags.set($http.get<Array<ng.featureflags.FlagData>>('/data/flags.json'));
 });

--- a/types/angular-feature-flags/index.d.ts
+++ b/types/angular-feature-flags/index.d.ts
@@ -6,9 +6,9 @@
 
 /// <reference types="angular" />
 
-import * as angular from "angular";
+import * as ng from 'angular';
 
-declare module "angular" {
+declare module 'angular' {
     namespace featureflags {
         export interface FlagData {
             /**
@@ -27,17 +27,22 @@ declare module "angular" {
             name: string;
 
             /**
-             * A long description of the flag to further explain the feature being toggled (only visible in the list of flags)
+             * A long description of the flag to further explain the feature being toggled
+             * (only visible in the list of flags)
              */
             description: string;
         }
 
         export interface FeatureFlagsProvider {
-            setInitialFlags(flags: Array<FlagData>): void;
+            setInitialFlags(flags: ReadonlyArray<FlagData>): void;
         }
 
         export interface FeatureFlagsService {
-            set(flagsPromise: angular.IPromise<FlagData> | angular.IHttpPromise<FlagData>): void;
+            set(
+                flagsPromise:
+                    | ng.IPromise<ReadonlyArray<FlagData>>
+                    | ng.IHttpPromise<ReadonlyArray<FlagData>>
+            ): void;
         }
     }
 }

--- a/types/angular-resource/angular-resource-tests.ts
+++ b/types/angular-resource/angular-resource-tests.ts
@@ -59,10 +59,9 @@ function MainController($resource: ng.resource.IResourceService): void {
     });
 }
 
-import IHttpPromiseCallbackArg = angular.IHttpPromiseCallbackArg;
+import IHttpResponse = angular.IHttpResponse;
 
 interface IMyData {}
-interface IMyHttpPromiseCallbackArg extends IHttpPromiseCallbackArg<IMyData> {}
 interface IMyResource extends angular.resource.IResource<IMyResource> {}
 interface IMyResourceClass extends angular.resource.IResourceClass<IMyResource> {}
 
@@ -87,7 +86,7 @@ angular.injector(['ng']).invoke(function ($cacheFactory: angular.ICacheFactorySe
     actionDescriptor.withCredentials = true;
     actionDescriptor.responseType = 'response type';
     actionDescriptor.interceptor = {
-        response() { return {} as IMyHttpPromiseCallbackArg; },
+        response() { return {} as IHttpResponse<IMyData>; },
         responseError() {}
     };
     actionDescriptor.cancellable = true;

--- a/types/angular-ui-router/angular-ui-router-tests.ts
+++ b/types/angular-ui-router/angular-ui-router-tests.ts
@@ -157,7 +157,7 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
 
             // Note that we do not concern ourselves with what to do if this request fails,
             // because if it fails, the web page will be redirected away to the login screen.
-            this.$http({ url: "/api/me", method: "GET" }).then((response: ng.IHttpPromiseCallbackArg<any>) => {
+            this.$http({ url: "/api/me", method: "GET" }).then((response: ng.IHttpResponse) => {
                 this.currentUser = response.data;
 
                 // sync the ui-state with the location in the browser, which effectively

--- a/types/angular-ui-router/angular-ui-router-tests.ts
+++ b/types/angular-ui-router/angular-ui-router-tests.ts
@@ -157,7 +157,7 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
 
             // Note that we do not concern ourselves with what to do if this request fails,
             // because if it fails, the web page will be redirected away to the login screen.
-            this.$http({ url: "/api/me", method: "GET" }).then((response: ng.IHttpResponse) => {
+            this.$http({ url: "/api/me", method: "GET" }).then((response: ng.IHttpResponse<any>) => {
                 this.currentUser = response.data;
 
                 // sync the ui-state with the location in the browser, which effectively

--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -433,7 +433,7 @@ httpFoo.then((x) => {
     x.toFixed();
 });
 
-httpFoo.then((response: ng.IHttpResponse<any>) => {
+httpFoo.then((response: ng.IHttpResponse) => {
     const h = response.headers('test');
     h.charAt(0);
     const hs = response.headers();

--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -61,31 +61,38 @@ angular.module('http-auth-interceptor', [])
  * $http interceptor.
  * On 401 response - it stores the request and broadcasts 'event:angular-auth-loginRequired'.
  */
-    .config(['$httpProvider', 'authServiceProvider', ($httpProvider: ng.IHttpProvider, authServiceProvider: any) => {
-        $httpProvider.defaults.headers.common = {Authorization: 'Bearer token'};
-        $httpProvider.defaults.headers.get['Authorization'] = 'Bearer token';
-        $httpProvider.defaults.headers.post['Authorization'] = (config: ng.IRequestConfig) => 'Bearer token';
+    .config([
+        '$httpProvider',
+        ($httpProvider: ng.IHttpProvider) => {
+            $httpProvider.defaults.headers.common = { Authorization: 'Bearer token' };
+            $httpProvider.defaults.headers.get.Authorization = 'Bearer token';
+            $httpProvider.defaults.headers.post['Authorization'] = (config: ng.IRequestConfig) =>
+                'Bearer token';
 
-        const interceptor = ['$rootScope', '$q', ($rootScope: ng.IScope, $q: ng.IQService) => {
-            function success(response: ng.IHttpPromiseCallbackArg<any>) {
-                return response;
-            }
-
-            function error(response: ng.IHttpPromiseCallbackArg<any>) {
-                if (response.status === 401) {
-                    const deferred = $q.defer<void>();
-                    authServiceProvider.pushToBuffer(response.config, deferred);
-                    $rootScope.$broadcast('event:auth-loginRequired');
-                    return deferred.promise;
+            const interceptor = [
+                '$rootScope', '$q', 'authService',
+                ($rootScope: ng.IScope, $q: ng.IQService, authService: any) => {
+                    return {
+                        request(config: ng.IRequestConfig) {
+                            if (!config.params) config.params = {};
+                            config.params.rnd = Math.random();
+                            return config;
+                        },
+                        responseError(rejection: any) {
+                            if (rejection.status === 401) {
+                                const deferred = $q.defer<ng.IHttpResponse>();
+                                authService.pushToBuffer(rejection.config, deferred);
+                                $rootScope.$broadcast('event:auth-loginRequired');
+                                return deferred.promise;
+                            }
+                            return $q.reject(rejection);
+                        }
+                    };
                 }
-                // otherwise
-                return $q.reject(response);
-            }
-
-            return (promise: ng.IHttpPromise<any>) => promise.then(success, error);
-        }];
-        $httpProvider.interceptors.push(interceptor);
-    }]);
+            ];
+            $httpProvider.interceptors.push(interceptor);
+        }
+    ]);
 
 namespace HttpAndRegularPromiseTests {
     interface Person {
@@ -105,7 +112,7 @@ namespace HttpAndRegularPromiseTests {
 
     function someController($scope: SomeControllerScope, $http: ng.IHttpService, $q: ng.IQService) {
         $http.get<ExpectedResponse>('http://somewhere/some/resource')
-            .then((response: ng.IHttpPromiseCallbackArg<ExpectedResponse>) => {
+            .then((response: ng.IHttpResponse<ExpectedResponse>) => {
                 // typing lost, so something like
                 // const i: number = response.data
                 // would type check
@@ -113,7 +120,7 @@ namespace HttpAndRegularPromiseTests {
             });
 
         $http.get<ExpectedResponse>('http://somewhere/some/resource')
-            .then((response: ng.IHttpPromiseCallbackArg<ExpectedResponse>) => {
+            .then((response: ng.IHttpResponse<ExpectedResponse>) => {
                 // typing lost, so something like
                 // const i: number = response.data
                 // would NOT type check
@@ -426,7 +433,7 @@ httpFoo.then((x) => {
     x.toFixed();
 });
 
-httpFoo.then((response: ng.IHttpPromiseCallbackArg<any>) => {
+httpFoo.then((response: ng.IHttpResponse<any>) => {
     const h = response.headers('test');
     h.charAt(0);
     const hs = response.headers();
@@ -565,7 +572,7 @@ namespace TestPromise {
         (reason) => anyOf3(reject, tresult, tresultPromise)
     ));
 
-    assertPromiseType<ng.IHttpPromiseCallbackArg<TResult>>(promise.then((result) => tresultHttpPromise));
+    assertPromiseType<ng.IHttpResponse<TResult>>(promise.then((result) => tresultHttpPromise));
 
     assertPromiseType<TResult | TOther>(promise.then((result) => result, (any) => tother));
     assertPromiseType<TResult | angular.IPromise<TResult> | angular.IPromise<never> | TOther | angular.IPromise<TOther>>(promise.then(
@@ -580,8 +587,8 @@ namespace TestPromise {
     assertPromiseType<TResult | TOther>(promise.then((result) => result, (any) => tother, (any) => any));
     assertPromiseType<TResult | TOther>(promise.then((result) => tresultPromise, (any) => totherPromise));
     assertPromiseType<TResult | TOther>(promise.then((result) => tresultPromise, (any) => totherPromise, (any) => any));
-    assertPromiseType<ng.IHttpPromiseCallbackArg<TResult | TOther>>(promise.then((result) => tresultHttpPromise, (any) => totherHttpPromise));
-    assertPromiseType<ng.IHttpPromiseCallbackArg<TResult | TOther>>(promise.then((result) => tresultHttpPromise, (any) => totherHttpPromise, (any) => any));
+    assertPromiseType<ng.IHttpResponse<TResult | TOther>>(promise.then((result) => tresultHttpPromise, (any) => totherHttpPromise));
+    assertPromiseType<ng.IHttpResponse<TResult | TOther>>(promise.then((result) => tresultHttpPromise, (any) => totherHttpPromise, (any) => any));
 
     assertPromiseType<TOther>(promise.then((result) => tother));
     assertPromiseType<TOther>(promise.then((result) => tother, (any) => any));
@@ -589,9 +596,9 @@ namespace TestPromise {
     assertPromiseType<TOther>(promise.then((result) => totherPromise));
     assertPromiseType<TOther>(promise.then((result) => totherPromise, (any) => any));
     assertPromiseType<TOther>(promise.then((result) => totherPromise, (any) => any, (any) => any));
-    assertPromiseType<ng.IHttpPromiseCallbackArg<TOther>>(promise.then((result) => totherHttpPromise));
-    assertPromiseType<ng.IHttpPromiseCallbackArg<TOther>>(promise.then((result) => totherHttpPromise, (any) => any));
-    assertPromiseType<ng.IHttpPromiseCallbackArg<TOther>>(promise.then((result) => totherHttpPromise, (any) => any, (any) => any));
+    assertPromiseType<ng.IHttpResponse<TOther>>(promise.then((result) => totherHttpPromise));
+    assertPromiseType<ng.IHttpResponse<TOther>>(promise.then((result) => totherHttpPromise, (any) => any));
+    assertPromiseType<ng.IHttpResponse<TOther>>(promise.then((result) => totherHttpPromise, (any) => any, (any) => any));
 
     assertPromiseType<boolean>(promise.then((result) => tresult, (any) => tother).then(ambiguous => isTResult(ambiguous) ? ambiguous.c : ambiguous.f));
 
@@ -602,10 +609,10 @@ namespace TestPromise {
     assertPromiseType<TResult | angular.IPromise<never>>(promise.catch((err) => anyOf2(tresult, reject)));
     assertPromiseType<TResult>(promise.catch((err) => anyOf3(tresult, tresultPromise, reject)));
     assertPromiseType<TResult>(promise.catch((err) => tresultPromise));
-    assertPromiseType<TResult | ng.IHttpPromiseCallbackArg<TResult>>(promise.catch((err) => tresultHttpPromise));
+    assertPromiseType<TResult | ng.IHttpResponse<TResult>>(promise.catch((err) => tresultHttpPromise));
     assertPromiseType<TResult | TOther>(promise.catch((err) => tother));
     assertPromiseType<TResult | TOther>(promise.catch((err) => totherPromise));
-    assertPromiseType<TResult | ng.IHttpPromiseCallbackArg<TOther>>(promise.catch((err) => totherHttpPromise));
+    assertPromiseType<TResult | ng.IHttpResponse<TOther>>(promise.catch((err) => totherHttpPromise));
 
     assertPromiseType<boolean>(promise.catch((err) => tother).then(ambiguous => isTResult(ambiguous) ? ambiguous.c : ambiguous.f));
 

--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -62,16 +62,16 @@ angular.module('http-auth-interceptor', [])
  * On 401 response - it stores the request and broadcasts 'event:angular-auth-loginRequired'.
  */
     .config([
-        '$httpProvider',
-        ($httpProvider: ng.IHttpProvider) => {
+        '$httpProvider', 'authServiceProvider',
+        ($httpProvider: ng.IHttpProvider, authServiceProvider: AuthService) => {
             $httpProvider.defaults.headers.common = { Authorization: 'Bearer token' };
             $httpProvider.defaults.headers.get.Authorization = 'Bearer token';
             $httpProvider.defaults.headers.post['Authorization'] = (config: ng.IRequestConfig) =>
                 'Bearer token';
 
             const interceptor = [
-                '$rootScope', '$q', 'authService',
-                ($rootScope: ng.IScope, $q: ng.IQService, authService: any) => {
+                '$rootScope', '$q',
+                ($rootScope: ng.IScope, $q: ng.IQService) => {
                     return {
                         request(config: ng.IRequestConfig) {
                             if (!config.params) config.params = {};
@@ -80,8 +80,8 @@ angular.module('http-auth-interceptor', [])
                         },
                         responseError(rejection: any) {
                             if (rejection.status === 401) {
-                                const deferred = $q.defer<ng.IHttpResponse>();
-                                authService.pushToBuffer(rejection.config, deferred);
+                                const deferred = $q.defer<ng.IHttpResponse<any>>();
+                                authServiceProvider.pushToBuffer(rejection.config, deferred);
                                 $rootScope.$broadcast('event:auth-loginRequired');
                                 return deferred.promise;
                             }
@@ -433,7 +433,7 @@ httpFoo.then((x) => {
     x.toFixed();
 });
 
-httpFoo.then((response: ng.IHttpResponse) => {
+httpFoo.then((response: ng.IHttpResponse<any>) => {
     const h = response.headers('test');
     h.charAt(0);
     const hs = response.headers();

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -9,6 +9,9 @@
 
 /// <reference path="jqlite.d.ts" />
 
+// NOTE: @types/angular technically doesn't require TypeScript 2.3, only TypeScript 2.1.
+// It has a TypeScript 2.3 header so that merging tests with @types/jquery v3 will work.
+
 declare var angular: angular.IAngularStatic;
 
 // Support for painless dependency injection
@@ -1520,7 +1523,7 @@ declare namespace angular {
         (data: T, status: number, headers: IHttpHeadersGetter, config: IRequestConfig): void;
     }
 
-    interface IHttpResponse<T = any> {
+    interface IHttpResponse<T> {
         data: T;
         status: number;
         headers: IHttpHeadersGetter;

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1520,23 +1520,27 @@ declare namespace angular {
         (data: T, status: number, headers: IHttpHeadersGetter, config: IRequestConfig): void;
     }
 
-    interface IHttpPromiseCallbackArg<T> {
-        data?: T;
-        status?: number;
-        headers?: IHttpHeadersGetter;
-        config?: IRequestConfig;
-        statusText?: string;
+    interface IHttpResponse<T = any> {
+        data: T;
+        status: number;
+        headers: IHttpHeadersGetter;
+        config: IRequestConfig;
+        statusText: string;
+        /** Added in AngularJS 1.6.6 */
+        xhrStatus: 'complete' | 'error' | 'timeout' | 'abort';
     }
 
-    interface IHttpPromise<T> extends IPromise<IHttpPromiseCallbackArg<T>> {
-    }
+    /** @deprecated The old name of IHttpResponse. Kept for compatibility. */
+    type IHttpPromiseCallbackArg<T> = IHttpResponse<T>;
+
+    type IHttpPromise<T> = IPromise<IHttpResponse<T>>;
 
     // See the jsdoc for transformData() at https://github.com/angular/angular.js/blob/master/src/ng/http.js#L228
     interface IHttpRequestTransformer {
         (data: any, headersGetter: IHttpHeadersGetter): any;
     }
 
-    // The definition of fields are the same as IHttpPromiseCallbackArg
+    // The definition of fields are the same as IHttpResponse
     interface IHttpResponseTransformer {
         (data: any, headersGetter: IHttpHeadersGetter, status: number): any;
     }
@@ -1609,10 +1613,10 @@ declare namespace angular {
     }
 
     interface IHttpInterceptor {
-        request?(config: IRequestConfig): IRequestConfig|IPromise<IRequestConfig>;
-        requestError?(rejection: any): any;
-        response?<T>(response: IHttpPromiseCallbackArg<T>): IPromise<IHttpPromiseCallbackArg<T>>|IHttpPromiseCallbackArg<T>;
-        responseError?(rejection: any): any;
+        request?(config: IRequestConfig): IRequestConfig | IPromise<IRequestConfig>;
+        requestError?(rejection: any): IRequestConfig | IPromise<IRequestConfig>;
+        response?<T>(response: IHttpResponse<T>): IPromise<IHttpResponse<T>> | IHttpResponse<T>;
+        responseError?<T>(rejection: any): IPromise<IHttpResponse<T>> | IHttpResponse<T>;
     }
 
     interface IHttpInterceptorFactory {

--- a/types/ng-file-upload/ng-file-upload-tests.ts
+++ b/types/ng-file-upload/ng-file-upload-tests.ts
@@ -44,9 +44,9 @@ class UploadController {
 			}).progress((evt: angular.angularFileUpload.IFileProgressEvent) => {
 				let percent = parseInt((100.0 * evt.loaded / evt.total).toString(), 10);
 				console.log("upload progress: " + percent + "% for " + evt.config.data.media[0]);
-			}).catch((response: ng.IHttpPromiseCallbackArg<any>) => {
+			}).catch((response: ng.IHttpResponse) => {
 				console.error(response.data, response.status, response.statusText, response.headers);
-			}).then((response: ng.IHttpPromiseCallbackArg<any>) => {
+			}).then((response: ng.IHttpResponse) => {
 				// file is uploaded successfully
 				console.log("Success!", response.data, response.status, response.headers, response.config);
 			});

--- a/types/ng-file-upload/ng-file-upload-tests.ts
+++ b/types/ng-file-upload/ng-file-upload-tests.ts
@@ -44,9 +44,9 @@ class UploadController {
 			}).progress((evt: angular.angularFileUpload.IFileProgressEvent) => {
 				let percent = parseInt((100.0 * evt.loaded / evt.total).toString(), 10);
 				console.log("upload progress: " + percent + "% for " + evt.config.data.media[0]);
-			}).catch((response: ng.IHttpResponse) => {
+			}).catch((response: ng.IHttpResponse<any>) => {
 				console.error(response.data, response.status, response.statusText, response.headers);
-			}).then((response: ng.IHttpResponse) => {
+			}).then((response: ng.IHttpResponse<any>) => {
 				// file is uploaded successfully
 				console.log("Success!", response.data, response.status, response.headers, response.config);
 			});


### PR DESCRIPTION
1) Renamed `IHttpPromiseCallbackArg` with a better name: `IHttpResponse`. Its fields were erroneously marked as optional, fixed this.

2) Improved typing and tests for interceptors. Fixed #19185.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/ng/service/$http
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.