### PR TITLE
Add addOneTimeListener to events in google.visualization typings

### DIFF
--- a/types/google.visualization/google.visualization-tests.ts
+++ b/types/google.visualization/google.visualization-tests.ts
@@ -622,3 +622,22 @@ function test_OrgChart() {
     var collapsed = chart.getCollapsedNodes();
 
 }
+
+function test_addListeners() {
+    var data = new google.visualization.DataTable();
+        data.addColumn('string', 'Fruit');
+        data.addColumn('number', 'Calories');
+        data.addRows([
+            ['Apple', 95],
+            ['Banana', 105],
+            ['Kiwi', 42]
+        ]);
+    var chart = new google.visualization.LineChart(document.getElementById('chart_div'));
+    google.visualization.events.addOneTimeListener(chart, 'ready', () => {
+        console.log('Fruit chart ready');
+    });
+    google.visualization.events.addListener(chart, 'error', (err: any) => {
+        console.log('Fruit chart ' + err.id + ' error: ' + err.message);
+    });
+    chart.draw(data, {});
+}

--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -1178,6 +1178,8 @@ declare namespace google {
         namespace events {
             function addListener(visualization: any, eventName: string, callback: Function): any;
             function addListener(visualization: any, eventName: string, callback: (...args: any[]) => void): any;
+            function addOneTimeListener(visualization: any, eventName: string, callback: Function): any;
+            function addOneTimeListener(visualization: any, eventName: string, callback: (...args: any[]) => void): any;
             function removeListener(listener: any): void;
             function removeAllListeners(visualization: any): void;
             function trigger(visualization: any, eventName: string, args?: any): void;


### PR DESCRIPTION
Added definitions for events.addOneTimeListener() as described in the documentation at https://developers.google.com/chart/interactive/docs/reference#addonetimelistener