### PR TITLE
Added `Partial<State>` to use in `React.Component.setState()` in `react`

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -279,8 +279,6 @@ declare namespace React {
         // tslint:disable:unified-signatures
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
         setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
-        setState(f: (prevState: S, props: P) => Partial<S>, callback?: () => any): void;
-        setState(state: Partial<S>, callback?: () => any): void;
         // tslint:enable:unified-signatures
 
         forceUpdate(callBack?: () => any): void;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -279,6 +279,8 @@ declare namespace React {
         // tslint:disable:unified-signatures
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
         setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
+        setState(f: (prevState: S, props: P) => Partial<S>, callback?: () => any): void;
+        setState(state: Partial<S>, callback?: () => any): void;
         // tslint:enable:unified-signatures
 
         forceUpdate(callBack?: () => any): void;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -731,3 +731,21 @@ declare var x: React.DOMElement<{
         transition: string;
     };
 }, Element>;
+
+// Test the use of `Partial<T>` in `setState()`
+// --------------------------------------------------------------------------
+{
+    interface ComponentState {
+        state1: string;
+        state2: string;
+    }
+
+    class Component extends React.Component<{}, ComponentState> {
+        some() {
+            const newState: Partial<ComponentState> = {};
+            newState.state1 = 'a';
+            if (true) newState.state2 = 'b';
+            this.setState(newState);
+        }
+    }
+}

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -280,6 +280,8 @@ declare namespace React {
         // tslint:disable:unified-signatures
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
         setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
+        setState(f: (prevState: S, props: P) => Partial<S>, callback?: () => any): void;
+        setState(state: Partial<S>, callback?: () => any): void;
         // tslint:enable:unified-signatures
 
         forceUpdate(callBack?: () => any): void;

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -280,8 +280,6 @@ declare namespace React {
         // tslint:disable:unified-signatures
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
         setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
-        setState(f: (prevState: S, props: P) => Partial<S>, callback?: () => any): void;
-        setState(state: Partial<S>, callback?: () => any): void;
         // tslint:enable:unified-signatures
 
         forceUpdate(callBack?: () => any): void;

--- a/types/react/v15/test/index.ts
+++ b/types/react/v15/test/index.ts
@@ -731,3 +731,21 @@ declare var x: React.DOMElement<{
         transition: string;
     };
 }, Element>;
+
+// Test the use of `Partial<T>` in `setState()`
+// --------------------------------------------------------------------------
+{
+    interface ComponentState {
+        state1: string;
+        state2: string;
+    }
+
+    class Component extends React.Component<{}, ComponentState> {
+        some() {
+            const newState: Partial<ComponentState> = {};
+            newState.state1 = 'a';
+            if (true) newState.state2 = 'b';
+            this.setState(newState);
+        }
+    }
+}


### PR DESCRIPTION
Add `setState ()` declaration to use `Partial <State>` in `React.Component.setState ()`.

```
interface State {
  a: number;
  b: string;
}
```

```
class extends React.Component<{}, State> {
  some() {
    const newState: Partial<State> = {};
    newState.a = 123;
    if (this.props.x === 1) newState.b = '123';
    this.setState(newState);
  }
}
```
This change enables code using `Patial<T>` in `setState()` as above.


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.