### PR TITLE
history: Correct typing for history.push prompt.

### DIFF
--- a/types/history/history-tests.ts
+++ b/types/history/history-tests.ts
@@ -61,7 +61,7 @@ let input = { value: "" };
         history.goBack();
     }
 
-    let unblock = history.block(true);
+    let unblock = history.block("Test Prompt");
     unblock();
 
     history.entries.forEach(function (location) {

--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -1,6 +1,9 @@
-// Type definitions for history 4.6.2
+// Type definitions for history 4.6.3
 // Project: https://github.com/mjackson/history
-// Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>, Nathan Brown <https://github.com/ngbrown>, Young Rok Kim <https://github.com/rokoroku>
+// Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>, 
+//                 Nathan Brown <https://github.com/ngbrown>, 
+//                 Young Rok Kim <https://github.com/rokoroku>,
+//                 Alexander Lyon <https://github.com/arlyon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 export as namespace History;
 
@@ -18,7 +21,7 @@ export interface History {
     go(n: number): void;
     goBack(): void;
     goForward(): void;
-    block(prompt?: boolean): UnregisterCallback;
+    block(prompt?: string): UnregisterCallback;
     listen(listener: LocationListener): UnregisterCallback;
     createHref(location: LocationDescriptorObject): Href;
 }


### PR DESCRIPTION
The documentation (and code) states that history.block takes an optional string to set the prompt when trying to block a user from leaving the page. This means that the boolean is incorrect, and it should be a string. For reference, here is the relevant documentation:

https://github.com/ReactTraining/history#blocking-transitions

Additionally, the code in one of the create(.*)History files:

https://github.com/ReactTraining/history/blob/8d98aec1366b86e3832dbfd7dcc480d1f9a5275c/modules/createBrowserHistory.js#L267-L283

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/history#blocking-transitions
- [x] Increase the version number in the header if appropriate.