### PR TITLE
[@types/jest] Fix tsc rejects constructor arguments for Mock<T>, as it works like intended

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -475,7 +475,7 @@ declare namespace jest {
     }
 
     interface Mock<T> extends Function, MockInstance<T> {
-        new(...args: any[]): T;
+        new (...args: any[]): T;
         (...args: any[]): any;
     }
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -475,7 +475,7 @@ declare namespace jest {
     }
 
     interface Mock<T> extends Function, MockInstance<T> {
-        new (): T;
+        new(...args: any[]): T;
         (...args: any[]): any;
     }
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -539,6 +539,36 @@ describe('Mocks', () => {
         const anotherIns: jest.Mocked<TestApi> = new anotherMock() as any;
         anotherIns.testMethod.mockImplementation(() => 1);
     });
+
+    it('jest.fn() accepts constructor arguments', () => {
+        interface TestLog {
+            log(...msg: any[]): void;
+        }
+
+        class LogMock extends jest.fn<TestLog>((verbose?: boolean) => {
+            const mockLog = () => {
+                if (verbose) {
+                    return jest.fn((...args) => {
+                        const subj = args.shift() || "";
+                        console.log(subj, ...args);
+                    });
+                }
+                return jest.fn();
+            };
+
+            return {
+                log: mockLog()
+            };
+        }) {
+        }
+
+        const nonVerboseLog = new LogMock();
+        nonVerboseLog.log("this is completely catched by jest");
+        expect(nonVerboseLog.log).toBeCalledWith("this is completely catched by jest");
+        const verboseLog = new LogMock(true);
+        verboseLog.log("this should also be printed to the console");
+        expect(verboseLog.log).toBeCalledWith("this should also be printed to the console");
+    });
 });
 
 // https://facebook.github.io/jest/docs/en/expect.html#resolves


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...sGy1980de:master#diff-830a7c9e24903b49e811209b6cd30c58](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...sGy1980de:master#diff-830a7c9e24903b49e811209b6cd30c58)