### PR TITLE
Angular: add comment about debugInfo on scope()

### DIFF
--- a/types/angular/jqlite.d.ts
+++ b/types/angular/jqlite.d.ts
@@ -661,8 +661,21 @@ interface JQuery {
 
     controller(name?: string): any;
     injector(): ng.auto.IInjectorService;
-    /** It's declared generic for custom scope interfaces */
+    /**
+     * Returns the `$scope` of the element.
+     *
+     * **IMPORTANT**: Requires `debugInfoEnabled` to be true.
+     *
+     * See https://docs.angularjs.org/guide/production#disabling-debug-data for more information.
+     */
     scope<T extends ng.IScope>(): T;
+    /**
+     * Returns the `$scope` of the element.
+     *
+     * **IMPORTANT**: Requires `debugInfoEnabled` to be true.
+     *
+     * See https://docs.angularjs.org/guide/production#disabling-debug-data for more information.
+     */
     isolateScope<T extends ng.IScope>(): T;
 
     inheritedData(key: string, value: any): this;


### PR DESCRIPTION
Add a comment explaining that the scope() and isolatedScope() methods requires debugInfoEnabled(true) to return the $scope.

This fixes #18743 