### PR TITLE
bootstrap.timepicker: add Date as defaultTime option

### DIFF
--- a/types/bootstrap.timepicker/index.d.ts
+++ b/types/bootstrap.timepicker/index.d.ts
@@ -1,13 +1,13 @@
 // Type definitions for bootstrap.timepicker
 // Project: https://github.com/jdewit/bootstrap-timepicker
-// Definitions by: derikwhittaker <https://github.com/derikwhittaker>
+// Definitions by: derikwhittaker <https://github.com/derikwhittaker>, Heather Booker <https://github.com/heatherbooker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 /// <reference types="jquery"/>
 
 interface TimepickerOptions {
-    defaultTime?: string|boolean;
+    defaultTime?: string|boolean|Date;
     disableFocus?: boolean;
     disableMousewheel?: boolean;
     explicitMode?: boolean;


### PR DESCRIPTION
`Date` is an accepted type for the `defaultTime` option, and this PR amends the definition to reflect that.

----------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (__or `tsc` if no `tslint.json` is present__).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/jdewit/bootstrap-timepicker/blob/gh-pages/js/bootstrap-timepicker.js#L793>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
