### PR TITLE
`react-select`: make event handlers accept HTMLInputElement as type parameter

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -82,6 +82,11 @@ declare namespace ReactSelectClass {
          * @default false
          */
         disabled?: boolean;
+        /**
+         * In the event that a custom menuRenderer is provided, Option should be able
+         * to accept arbitrary key-value pairs. See react-virtualized-select.
+         */
+        [property: string]: any;
     }
 
     type OptionValues = string | number | boolean;

--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -32,11 +32,11 @@ declare namespace ReactSelectClass {
     type MenuRendererHandler = (props: MenuRendererProps) => HandlerRendererResult;
     type OnCloseHandler = () => void;
     type OnInputChangeHandler = (inputValue: string) => void;
-    type OnInputKeyDownHandler = React.KeyboardEventHandler<HTMLDivElement>;
+    type OnInputKeyDownHandler = React.KeyboardEventHandler<HTMLDivElement | HTMLInputElement>;
     type OnMenuScrollToBottomHandler = () => void;
     type OnOpenHandler = () => void;
-    type OnFocusHandler = React.FocusEventHandler<HTMLDivElement>;
-    type OnBlurHandler = React.FocusEventHandler<HTMLDivElement>;
+    type OnFocusHandler = React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
+    type OnBlurHandler = React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
     type OptionRendererHandler = (option: Option) => HandlerRendererResult;
     type ValueRendererHandler = (option: Option) => HandlerRendererResult;
     type OnValueClickHandler = (value: string, event: React.MouseEvent<HTMLAnchorElement>) => void;

--- a/types/react-select/react-select-tests.tsx
+++ b/types/react-select/react-select-tests.tsx
@@ -77,15 +77,44 @@ describe("react-select", () => {
     });
 
     it("Overriding default key-down behavior with onInputKeyDown", () => {
-        const keyDownHandler: ReactSelect.OnInputKeyDownHandler = event => {
-            const e: React.KeyboardEvent<HTMLDivElement> = event;
-        };
+        const keyDownHandler: ReactSelect.OnInputKeyDownHandler = (event => {
+            const divEvent = event as React.KeyboardEvent<HTMLDivElement>;
+            const inputEvent = event as React.KeyboardEvent<HTMLInputElement>;
+        });
     });
 
     it("Updating input values with onInputChange", () => {
         const cleanInput: ReactSelect.OnInputChangeHandler = inputValue => {
             return inputValue.replace(/[^0-9]/g, "");
         };
+    });
+});
+
+describe("Focus events", () => {
+    it("Passing custom onFocus", () => {
+        class Component extends React.PureComponent {
+            render() {
+                return (
+                    <ReactSelect onFocus={(e) => {
+                        const inputEvent = e as React.FocusEvent<HTMLInputElement>;
+                        const divEvent = e as React.FocusEvent<HTMLDivElement>;
+                    }} />
+                );
+            }
+        }
+    });
+
+    it("Passing custom onBlur", () => {
+        class Component extends React.PureComponent {
+            render() {
+                return (
+                    <ReactSelect onBlur={(e) => {
+                        const inputEvent = e as React.FocusEvent<HTMLInputElement>;
+                        const divEvent = e as React.FocusEvent<HTMLDivElement>;
+                    }} />
+                );
+            }
+        }
     });
 });
 


### PR DESCRIPTION
This PR changes the type parameter of `OnInputKeyDownHandler`, `OnFocusHandler`, and `OnBlurHandler` from `HTMLDivElement` to `HTMLInputElement | HTMLDivElement`. This is because the `Select` base component can set these handlers on _either_ a `div` or `input` (see link for context below).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/blob/master/src/Select.js#L805
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
