### PR TITLE
updates umzug types to support reverting all migrations

### DIFF
--- a/types/umzug/index.d.ts
+++ b/types/umzug/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Umzug v1.8.0
+// Type definitions for Umzug v2.0.1
 // Project: https://github.com/sequelize/umzug
 // Definitions by: Ivan Drinchev <https://github.com/drinchev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -122,7 +122,7 @@ declare namespace umzug {
 
     }
 
-    interface UpDownToOptions {
+    interface UpToOptions {
 
         /**
          * It is also possible to pass the name of a migration in order to
@@ -130,6 +130,17 @@ declare namespace umzug {
          * migration name.
          */
         to: string;
+
+    }
+
+    interface DownToOptions {
+
+        /**
+         * It is also possible to pass the name of a migration in order to
+         * just run the migrations from the current state to the passed
+         * migration name. down allows to pass 0 to revert everything.
+         */
+        to: string | 0;
 
     }
 
@@ -170,19 +181,19 @@ declare namespace umzug {
          */
         up(migration?: string): Promise<Migration[]>;
         up(migrations?: string[]): Promise<Migration[]>;
-        up(options?: UpDownToOptions | UpDownMigrationsOptions): Promise<Migration[]>;
+        up(options?: UpToOptions | UpDownMigrationsOptions): Promise<Migration[]>;
 
         /**
          * The down method can be used to revert the last executed migration.
          */
         down(migration?: string): Promise<Migration[]>;
         down(migrations?: string[]): Promise<Migration[]>;
-        down(options?: UpDownToOptions | UpDownMigrationsOptions): Promise<Migration[]>;
+        down(options?: DownToOptions | UpDownMigrationsOptions): Promise<Migration[]>;
 
     }
 
     interface UmzugStatic {
-        new (options?: UmzugOptions): Umzug;
+        new(options?: UmzugOptions): Umzug;
     }
 }
 

--- a/types/umzug/umzug-tests.ts
+++ b/types/umzug/umzug-tests.ts
@@ -50,6 +50,8 @@ umzug.down({ migrations: ['20141101203500-task', '20141101203501-task-2'] });
 umzug.down('20141101203500-task'); // Runs just the passed migration
 umzug.down(['20141101203500-task', '20141101203501-task-2']);
 
+umzug.down({to: 0}); // Reverts every migration. 
+
 var AnotherUmzug = new Umzug({
   // The storage.
   // Possible values: 'json', 'sequelize', an object


### PR DESCRIPTION
Umzug allows to pass {to: 0} to the down method to revert all performed migrations.
This PR allows to pass either a string or 0 to down while keeping up options untouched.
It also adds a test for the added option.