### PR TITLE
[esprima] Add jsx-flag to Options

### DIFF
--- a/types/esprima/index.d.ts
+++ b/types/esprima/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Esprima v2.1.0
 // Project: http://esprima.org
-// Definitions by: teppeis <https://github.com/teppeis>, RReverser <https://github.com/RReverser>
+// Definitions by: teppeis <https://github.com/teppeis>, RReverser <https://github.com/RReverser>, allesklarbeidir <https://github.com/allesklarbeidir>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="estree" />
@@ -31,6 +31,7 @@ declare namespace esprima {
         tolerant?: boolean;
         source?: boolean;
         sourceType?: 'script' | 'module';
+        jsx?: boolean;
     }
 
     const Syntax: {


### PR DESCRIPTION
JSX is supported by the esprima parser.
JSX-Support is enabled via a flag in the options parameter.
The JSX-Flag was missing in the typescript definitions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
> [https://github.com/jquery/esprima#features](url)
> Experimental support for JSX, a syntax extension for React