### PR TITLE
nodegit Repository.init method has a mandatory isBare parameter of type number.

### DIFF
--- a/types/nodegit/nodegit-tests.ts
+++ b/types/nodegit/nodegit-tests.ts
@@ -4,7 +4,7 @@ Git.Repository.discover("startPath", 1, "ceilingDirs").then((string) => {
     // Use string
 });
 
-Git.Repository.init("path", true).then((repository) => {
+Git.Repository.init("path", 0).then((repository) => {
     // Use repository
 });
 

--- a/types/nodegit/repository.d.ts
+++ b/types/nodegit/repository.d.ts
@@ -48,12 +48,12 @@ export class Repository {
      *
      * @static
      * @param {string} path
-     * @param {boolean} [isBare]
+     * @param {number} isBare
      * @returns {Promise<Repository>}
      *
      * @memberof Repository
      */
-    static init(path: string, isBare?: boolean): Promise<Repository>;
+    static init(path: string, isBare: number): Promise<Repository>;
     /**
      *
      *


### PR DESCRIPTION
As defined in the documentation, isBare should be of type number and is mandatory: http://www.nodegit.org/api/repository/#init

After testing the old code, it ran into a promise rejected because of the lack of this parameter.