### PR TITLE
[nearley] adapt typings to v2.11

### DIFF
--- a/types/nearley/index.d.ts
+++ b/types/nearley/index.d.ts
@@ -25,7 +25,6 @@ export class Parser {
      */
     results: any[];
 
-    constructor(rules: CompiledRules, start: string, options?: ParserOptions);
     constructor(grammar: Grammar, options?: ParserOptions);
 
     /**
@@ -54,35 +53,37 @@ export class Rule {
     id: number;
     name: string;
     symbols: any[];
-    postprocess?(data: any[], reference: number, wantedBy: any): void;
+    postprocess?: Postprocessor;
 
-    constructor(name: string, symbols: any[], postprocess?: (data: any[], reference: number, wantedBy: any) => void);
+    constructor(name: string, symbols: any[], postprocess?: Postprocessor);
 
     toString(withCursorAt?: number): string;
 }
 
 export class Grammar {
-    static fromCompiled(rules: CompiledRules, start?: string): Grammar;
+    static fromCompiled(rules: CompiledRules): Grammar;
 
     rules: Rule[];
     start: string;
     byName: {[ruleName: string]: Rule[]};
     lexer?: Lexer;
 
-    constructor(rules: Rule[], start?: string);
+    constructor(rules: Rule[]);
 }
 
 export interface CompiledRules {
     Lexer?: Lexer;
-    ParserStart: number;
+    ParserStart: string;
     ParserRules: ParserRule[];
 }
 
 export interface ParserRule {
     name: string;
     symbols: any[];
-    postprocess?(data: any[], reference: number, wantedBy: any): void;
+    postprocess?: Postprocessor;
 }
+
+export type Postprocessor = (data: any[], reference: number, wantedBy: {}) => void;
 
 export interface Lexer {
     /**

--- a/types/nearley/index.d.ts
+++ b/types/nearley/index.d.ts
@@ -1,26 +1,16 @@
-// Type definitions for nearley 2.9
+// Type definitions for nearley 2.11
 // Project: https://github.com/Hardmath123/nearley#readme
 // Definitions by: Nikita Litvin <https://github.com/deltaidea>
+//                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace nearley;
 
 export class Parser {
-    constructor(rules: Rule[], start: string, options?: ParserOptions);
-    constructor(grammar: Grammar, options?: ParserOptions);
     /**
-     * The Parser object can be fed data in parts with .feed(data).
-     * You can then find an array of parsings with the .results property.
-     * If results is empty, then there are no parsings.
-     * If results contains multiple values, then that combination is ambiguous.
-     *
-     * @throws If there are no possible parsings, nearley will throw an error
-     * whose offset property is the index of the offending token.
+     * Reserved token for indicating a parse fail.
      */
-    feed(chunk: string): void;
-    finish(): any[];
-    restore(column: {[x: string]: any, lexerState: LexerState}): void;
-    save(): LexerState;
+    static fail: {};
 
     grammar: Grammar;
     options: ParserOptions;
@@ -35,10 +25,22 @@ export class Parser {
      */
     results: any[];
 
+    constructor(rules: CompiledRules, start: string, options?: ParserOptions);
+    constructor(grammar: Grammar, options?: ParserOptions);
+
     /**
-     * Reserved token for indicating a parse fail.
+     * The Parser object can be fed data in parts with .feed(data).
+     * You can then find an array of parsings with the .results property.
+     * If results is empty, then there are no parsings.
+     * If results contains multiple values, then that combination is ambiguous.
+     *
+     * @throws If there are no possible parsings, nearley will throw an error
+     * whose offset property is the index of the offending token.
      */
-    static fail: {};
+    feed(chunk: string): this;
+    finish(): any[];
+    restore(column: {[key: string]: any, lexerState: LexerState}): void;
+    save(): {[key: string]: any, lexerState: LexerState};
 }
 
 export interface ParserOptions {
@@ -47,26 +49,46 @@ export interface ParserOptions {
 }
 
 export class Rule {
-    constructor(name: any, symbols: any, postprocess: any);
-    toString(withCursorAt: any): any;
     static highestId: number;
+
+    id: number;
+    name: string;
+    symbols: any[];
+    postprocess?(data: any[], reference: number, wantedBy: any): void;
+
+    constructor(name: string, symbols: any[], postprocess?: (data: any[], reference: number, wantedBy: any) => void);
+
+    toString(withCursorAt?: number): string;
 }
 
 export class Grammar {
-    constructor(rules: Rule[], start: string);
+    static fromCompiled(rules: CompiledRules, start?: string): Grammar;
+
     rules: Rule[];
-    byName: {[x: string]: Rule};
+    start: string;
+    byName: {[ruleName: string]: Rule[]};
+    lexer?: Lexer;
+
+    constructor(rules: Rule[], start?: string);
 }
 
-export namespace Grammar {
-    function fromCompiled(rules: Rule[], start: string): Grammar;
+export interface CompiledRules {
+    Lexer?: Lexer;
+    ParserStart: number;
+    ParserRules: ParserRule[];
+}
+
+export interface ParserRule {
+    name: string;
+    symbols: any[];
+    postprocess?(data: any[], reference: number, wantedBy: any): void;
 }
 
 export interface Lexer {
     /**
-     * Sets the internal buffer to chunk, and restore line/col/state info taken from save().
+     * Sets the internal buffer to data, and restores line/col/state info taken from save().
      */
-    reset(chunk: string, state?: LexerState): void;
+    reset(data: string, state?: LexerState): void;
     /**
      * Returns e.g. {type, value, line, col, …}. Only the value attribute is required.
      */
@@ -81,18 +103,10 @@ export interface Lexer {
      * Returns a string with an error message describing the line/col of the offending token.
      * You might like to include a preview of the line in question.
      */
-    formatError(token: Token): string;
-    /**
-     * Returns true if the lexer can emit tokens with that name.
-     * Used to resolve %-specifiers in compiled nearley grammars.
-     */
-    has(tokenType: string): boolean;
+    formatError(token: Token, message: string): string;
 }
 
-export interface Token {
-    [x: string]: any;
-    value: string;
-}
+export type Token = string | { value: string; };
 
 export interface LexerState {
     [x: string]: any;

--- a/types/nearley/nearley-tests.ts
+++ b/types/nearley/nearley-tests.ts
@@ -1,15 +1,14 @@
 import { Parser, Rule, Grammar, CompiledRules, Lexer } from 'nearley';
 
 declare const compiledRules: CompiledRules;
-declare const parserStart: string;
 declare const lexer: Lexer;
 
 compiledRules.Lexer; // $ExpectType Lexer | undefined
-compiledRules.ParserStart; // $ExpectType number
+compiledRules.ParserStart; // $ExpectType string
 compiledRules.ParserRules; // $ExpectType ParserRule[]
 compiledRules.ParserRules[0].name; // $ExpectType string
 compiledRules.ParserRules[0].symbols; // $ExpectType any[]
-compiledRules.ParserRules[0].postprocess; // $ExpectType ((data: any[], reference: number, wantedBy: any) => void) | undefined
+compiledRules.ParserRules[0].postprocess; // $ExpectType Postprocessor | undefined
 
 lexer.reset('');
 lexer.reset('', {});
@@ -23,15 +22,13 @@ const rule = new Rule(compiledRules.ParserRules[0].name, compiledRules.ParserRul
 rule.id; // $ExpectType number
 rule.name; // $ExpectType string
 rule.symbols; // $ExpectType any[]
-rule.postprocess; // $ExpectType ((data: any[], reference: number, wantedBy: any) => void) | undefined
+rule.postprocess; // $ExpectType Postprocessor | undefined
 
 rule.toString(); // $ExpectType string
 rule.toString(1);
 
 Grammar.fromCompiled(compiledRules); // $ExpectType Grammar
-Grammar.fromCompiled(compiledRules, ''); // $ExpectType Grammar
 const grammar = new Grammar([rule]);
-new Grammar([rule], '');
 
 grammar.rules; // $ExpectType Rule[]
 grammar.start; // $ExpectType string
@@ -40,10 +37,7 @@ grammar.lexer; // $ExpectType Lexer | undefined
 
 Parser.fail; // $ExpectType {}
 
-const parser = new Parser(compiledRules, parserStart);
-new Parser(compiledRules, parserStart, {lexer});
-new Parser(compiledRules, parserStart, {keepHistory: false});
-new Parser(grammar);
+const parser = new Parser(grammar);
 new Parser(grammar, {lexer});
 new Parser(grammar, {keepHistory: false});
 

--- a/types/nearley/nearley-tests.ts
+++ b/types/nearley/nearley-tests.ts
@@ -1,12 +1,64 @@
-import { Parser, Grammar, Rule, Lexer } from 'nearley';
+import { Parser, Rule, Grammar, CompiledRules, Lexer } from 'nearley';
 
-declare const parserRules: Rule[];
+declare const compiledRules: CompiledRules;
 declare const parserStart: string;
 declare const lexer: Lexer;
-declare const grammar: Grammar;
 
-let parser = new Parser(parserRules, parserStart, { lexer, keepHistory: false });
-parser = new Parser(grammar);
+compiledRules.Lexer; // $ExpectType Lexer | undefined
+compiledRules.ParserStart; // $ExpectType number
+compiledRules.ParserRules; // $ExpectType ParserRule[]
+compiledRules.ParserRules[0].name; // $ExpectType string
+compiledRules.ParserRules[0].symbols; // $ExpectType any[]
+compiledRules.ParserRules[0].postprocess; // $ExpectType ((data: any[], reference: number, wantedBy: any) => void) | undefined
+
+lexer.reset('');
+lexer.reset('', {});
+lexer.next(); // $ExpectType string | { value: string; } | undefined
+lexer.save(); // $ExpectType LexerState
+lexer.formatError('', ''); // $ExpectType string
+lexer.formatError({value: ''}, '');
+
+const rule = new Rule(compiledRules.ParserRules[0].name, compiledRules.ParserRules[0].symbols, compiledRules.ParserRules[0].postprocess);
+
+rule.id; // $ExpectType number
+rule.name; // $ExpectType string
+rule.symbols; // $ExpectType any[]
+rule.postprocess; // $ExpectType ((data: any[], reference: number, wantedBy: any) => void) | undefined
+
+rule.toString(); // $ExpectType string
+rule.toString(1);
+
+Grammar.fromCompiled(compiledRules); // $ExpectType Grammar
+Grammar.fromCompiled(compiledRules, ''); // $ExpectType Grammar
+const grammar = new Grammar([rule]);
+new Grammar([rule], '');
+
+grammar.rules; // $ExpectType Rule[]
+grammar.start; // $ExpectType string
+grammar.byName; // $ExpectType { [ruleName: string]: Rule[]; }
+grammar.lexer; // $ExpectType Lexer | undefined
+
+Parser.fail; // $ExpectType {}
+
+const parser = new Parser(compiledRules, parserStart);
+new Parser(compiledRules, parserStart, {lexer});
+new Parser(compiledRules, parserStart, {keepHistory: false});
+new Parser(grammar);
+new Parser(grammar, {lexer});
+new Parser(grammar, {keepHistory: false});
+
+parser.grammar; // $ExpectType Grammar
+parser.options; // $ExpectType ParserOptions
+parser.lexer; // $ExpectType Lexer
+parser.lexerState; // $ExpectType LexerState | undefined
+parser.current; // $ExpectType number
+parser.results; // $ExpectType any[]
+
+parser.feed(''); // $ExpectType Parser
+parser.finish(); // $ExpectType any[]
+const state = parser.save();
+state; // $ExpectType { [key: string]: any; lexerState: LexerState; }
+parser.restore(state);
 
 try {
     parser.feed("<123>");


### PR DESCRIPTION
Fixes #19255.

@Hardmath123, @notsonotso, @deltaidea: Does this look like it fixes your errors?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nearley.js.org
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.