### PR TITLE
Add alter and dropTimestamps functions on TableBuilder to Knex.js typings

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -416,6 +416,7 @@ declare namespace Knex {
         dropUnique(columnNames: (string | Raw)[], indexName?: string): TableBuilder;
         dropPrimary(constraintName?: string): TableBuilder;
         dropIndex(columnNames: (string | Raw)[], indexName?: string): TableBuilder;
+        dropTimestamps(): ColumnBuilder;
     }
 
     interface CreateTableBuilder extends TableBuilder {
@@ -428,6 +429,7 @@ declare namespace Knex {
     }
 
     interface AlterTableBuilder extends TableBuilder {
+        alter(): ColumnBuilder;
     }
 
     interface MySqlAlterTableBuilder extends AlterTableBuilder {


### PR DESCRIPTION
Add `dropTimestamps` function on `TableBuilder`
Add `alter` on `AlterTableBuilder`

http://knexjs.org/#Schema-alter
http://knexjs.org/#Schema-dropTimestamps

