### PR TITLE
Add typings for read-chunk library

### DIFF
--- a/types/read-chunk/index.d.ts
+++ b/types/read-chunk/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for read-chunk v2.1.0
+// Project: https://github.com/sindresorhus/read-chunk
+// Definitions by: crispybee <https://github.com/crispybee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = ReadChunk;
+
+    /**
+     * Asynchronous: Reads a chunk from a file. Returns a Promise<Buffer>.
+     * @param {string} filePath The path to the file.
+     * @param {number} startingPosition Position to start reading.
+     * @param {number} length Number of bytes to read.
+     * @return {Promise<Buffer>} Returns a Promise<Buffer>.
+     */
+declare function ReadChunk(filePath: string, startingPosition: number, length: number): Promise<Buffer>;
+
+declare namespace ReadChunk {
+    /**
+     * Synchronous: Reads a chunk from a file. Returns a Buffer.
+     * @param {string} filePath The path to the file.
+     * @param {number} startingPosition Position to start reading.
+     * @param {number} length Number of bytes to read.
+     * @return {Buffer} Returns a Buffer.
+     */
+    function sync(filePath: string, startingPosition: number, length: number): Buffer;
+}
+

--- a/types/read-chunk/read-chunk-tests.ts
+++ b/types/read-chunk/read-chunk-tests.ts
@@ -1,0 +1,9 @@
+import readChunk = require('read-chunk');
+
+let chunk: Buffer = readChunk.sync('foo.txt', 1, 3);
+
+readChunk('foo.txt', 1, 3).then(value => {
+    console.log(value);
+}).catch(error => {
+    console.log(error);
+});

--- a/types/read-chunk/tsconfig.json
+++ b/types/read-chunk/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "read-chunk-tests.ts"
+    ]
+}

--- a/types/read-chunk/tslint.json
+++ b/types/read-chunk/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.