### PR TITLE
Fix small bug in chai-as-promised types

### DIFF
--- a/types/chai-as-promised/chai-as-promised-tests.ts
+++ b/types/chai-as-promised/chai-as-promised-tests.ts
@@ -37,6 +37,7 @@ thenableNum = thenableNum.should.be.rejectedWith(TestClass);
 thenableNum = thenableNum.should.be.rejectedWith(TestClass, /message/);
 thenableNum = thenableNum.should.be.rejectedWith(TestClass, 'message');
 thenableNum = thenableNum.should.eventually.equal(3).notify(() => console.log('done'));
+thenableNum = thenableNum.should.eventually.become(3);
 thenableNum = thenableNum.should.be.fulfilled.and.notify(() => console.log('done'));
 
 // Complex examples on https://github.com/domenic/chai-as-promised#working-with-non-promisefriendly-test-runners

--- a/types/chai-as-promised/index.d.ts
+++ b/types/chai-as-promised/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for chai-as-promised
 // Project: https://github.com/domenic/chai-as-promised/
-// Definitions by: jt000 <https://github.com/jt000>, Yuki Kokubun <https://github.com/Kuniwak>, Leonard Thieu <https://github.com/leonard-thieu>
+// Definitions by: jt000 <https://github.com/jt000>, Yuki Kokubun <https://github.com/Kuniwak>, Leonard Thieu <https://github.com/leonard-thieu>, Mike Lazer-Walker <https://github.com/lazerwalker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="chai" />
@@ -32,7 +32,7 @@ declare namespace Chai {
     // Eventually does not have .then(), but PromisedAssertion have.
     interface Eventually extends PromisedLanguageChains, PromisedNumericComparison, PromisedTypeComparison {
         // From chai-as-promised
-        become(expected: PromiseLike<any>): PromisedAssertion;
+        become(expected: any): PromisedAssertion;
         fulfilled: PromisedAssertion;
         rejected: PromisedAssertion;
         rejectedWith(expected: any, message?: string | RegExp): PromisedAssertion;


### PR DESCRIPTION
The `eventually.become` interface didn't match the other `become` definitions. Includes test that fails without the fix.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: There's no easily one-line doc or source to show this is what it should be, but you can see it matches the equivalent `Assertion` API a few lines up (https://github.com/lazerwalker/DefinitelyTyped/blob/bfa639858a16e1a71fbfd1b871d328df558bb250/types/chai-as-promised/index.d.ts#L25) as well as other `expected` method params in the same API (https://github.com/lazerwalker/DefinitelyTyped/blob/bfa639858a16e1a71fbfd1b871d328df558bb250/types/chai-as-promised/index.d.ts#L28). The included test should be recognizable as expected behavior, but it fails without this change.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
