### PR TITLE
Added promiseTypeSuffixes to redux-promise-middleware config

### DIFF
--- a/types/redux-promise-middleware/index.d.ts
+++ b/types/redux-promise-middleware/index.d.ts
@@ -5,4 +5,4 @@
 
 import { Middleware } from 'redux';
 
-export default function promiseMiddleware(config?: { promiseTypeSuffixes: string[] }): Middleware;
+export default function promiseMiddleware(config?: { promiseTypeSuffixes?: string[], promiseTypeSeparator?: string }): Middleware;


### PR DESCRIPTION
Added `promiseTypeSeparator`, `promiseTypeSuffixes` made optional.

URLs to source code which provides context for the suggested changes:
- https://github.com/pburtchaell/redux-promise-middleware/issues/165
- https://github.com/pburtchaell/redux-promise-middleware/pull/166
