### PR TITLE
[OpenLayers] Add definition for new method map.getFeaturesAtPixel()

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -6772,6 +6772,18 @@ declare module ol {
         ): (T);
 
         /**
+         * Get all features that intersect a pixel on the viewport.
+         * @param {ol.Pixel} pixel Pixel.
+         * @param {olx.AtPixelOptions=} opt_options Optional options.
+         * @return {?Array.<(ol.Feature|ol.render.Feature)>} The detected features or null if none were found.
+         * @api stable
+         */
+        getFeaturesAtPixel(
+            pixel: ol.Pixel,
+            opt_options?: olx.AtPixelOptions
+        ): (Array<ol.Feature|ol.render.Feature>|null);
+
+        /**
          * Detect layers that have a color value at a pixel on the viewport, and
          * execute a callback with each matching layer. Layers included in the
          * detection can be configured through `opt_layerFilter`.

--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for OpenLayers v4.1.0
+// Type definitions for OpenLayers v4.3.0
 // Project: http://openlayers.org/
 // Definitions by: Olivier Sechet <https://github.com/osechet>, Guilhem Brouat <https://github.com/ganlhi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
Add TypeScript definition for method `map.getFeaturesAtPixel()` introduced in [OpenLayers v4.3.0](https://github.com/openlayers/openlayers/releases/tag/v4.3.0).

Reference: https://openlayers.org/en/latest/apidoc/ol.Map.html#getFeaturesAtPixel