### PR TITLE
[redux-optimistic-ui] Use string literals for action types instead of type string 

### DIFF
--- a/types/redux-optimistic-ui/index.d.ts
+++ b/types/redux-optimistic-ui/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/mattkrick/redux-optimistic-ui
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /// <reference types="redux" />
 
@@ -66,13 +67,13 @@ declare module "redux-optimistic-ui" {
     /**
      * Start optimistic action
      */
-    export const BEGIN: string;
+    export const BEGIN = '@@optimist/BEGIN';
     /**
      * Finish optimistic action and commit results
      */
-    export const COMMIT: string;
+    export const COMMIT = '@@optimist/COMMIT';
     /**
      * Revert optimistic action
      */
-    export const REVERT: string;
+    export const REVERT = '@@optimist/REVERT';
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/mattkrick/redux-optimistic-ui#write-some-middleware](https://github.com/mattkrick/redux-optimistic-ui#write-some-middleware)

`BEGIN`, `COMMIT` and `REVERT` are all string constants provided by the library. By assigning them in the definition file as well, we can take advantage of union types when referencing them.