### PR TITLE
Update klaw-sync type definition

### DIFF
--- a/types/klaw-sync/index.d.ts
+++ b/types/klaw-sync/index.d.ts
@@ -5,32 +5,36 @@
 
 /// <reference types="node" />
 
-import * as fs from "fs"
+import * as fs from 'fs'
 
-export interface Item {
-  path: string
-  stats: fs.Stats
+declare namespace klawSync {
+  interface Item {
+    path: string
+    stats: fs.Stats
+  }
+
+  interface Options {
+    /**
+     *  any paths or `micromatch` patterns to ignore.
+     *
+     * For more information on micromatch patterns: https://github.com/jonschlinkert/micromatch#features
+     */
+    ignore?: string | string[]
+    /**
+     * True to only return files (ignore directories).
+     *
+     * Defaults to false if not specified.
+     */
+    nodir?: boolean
+    /**
+     * True to only return directories (ignore files).
+     *
+     * Defaults to false if not specified.
+     */
+    nofile?: boolean
+  }
 }
 
-export interface Options {
-  /**
-   *  any paths or `micromatch` patterns to ignore.
-   *
-   * For more information on micromatch patterns: https://github.com/jonschlinkert/micromatch#features
-   */
-  ignore?: string | string[]
-  /**
-   * True to only return files (ignore directories).
-   *
-   * Defaults to false if not specified.
-   */
-  nodir?: boolean
-  /**
-   * True to only return directories (ignore files).
-   *
-   * Defaults to false if not specified.
-   */
-  nofile?: boolean
-}
+declare function klawSync(root: string, options?: klawSync.Options): ReadonlyArray<klawSync.Item>
 
-export function klawSync(root: string, options?: Options): ReadonlyArray<Item>
+export = klawSync

--- a/types/klaw-sync/klaw-sync-tests.ts
+++ b/types/klaw-sync/klaw-sync-tests.ts
@@ -1,20 +1,20 @@
-import { klawSync, Item } from "klaw-sync"
-import * as path from "path"
+import * as path from 'path'
+import klawSync = require('klaw-sync')
 
-const outputMessage = (result: Item) => {
+const outputMessage = (result: klawSync.Item) => {
   console.log(`file: ${result.path} has size '${result.stats.size}'`)
 }
 
 klawSync('/some/dir').forEach(outputMessage)
 
-const defaultOptions = { }
+const defaultOptions = {}
 
 klawSync('/some/dir', defaultOptions).forEach(outputMessage)
 
 const options = {
-  ignore: [ '.exe' ],
+  ignore: ['.exe'],
   nodir: true,
-  nofile: false
+  nofile: false,
 }
 
 klawSync('/some/dir', options).forEach(outputMessage)


### PR DESCRIPTION
The type definition is incorrect. klawSync only exports via `module.exports =` and therefore `exports =` must be used.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
