### PR TITLE
Fix redux-batched-subscribe test

### DIFF
--- a/types/redux-batched-subscribe/redux-batched-subscribe-tests.ts
+++ b/types/redux-batched-subscribe/redux-batched-subscribe-tests.ts
@@ -25,6 +25,5 @@ const asyncNotify: BatchFunction = (() => {
 
 const store: Store<State> = createStore(
     rootReducer,
-    undefined,
     batchedSubscribe(asyncNotify)
 );


### PR DESCRIPTION
Following up on #19215.

The test for redux-batched-subscribe is failing since the call to redux's `createStore` has the wrong type for the second argument (`initialState` can not be undefined). Fix by removing `initialState` argument completely.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #19215
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
