### PR TITLE
[pouchdb-core] PouchDB.Core.GetMeta should always contain _rev

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -165,7 +165,7 @@ declare namespace PouchDB {
              * Only present if `GetOptions.conflicts` is `true`
              */
             _conflicts?: RevisionId[];
-            _rev?: RevisionId;
+            _rev: RevisionId;
             /** Only present if `GetOptions.revs` is `true` */
             _revs_info?: RevisionInfo[];
             /** Only present if `GetOptions.revs_info` is `true` */

--- a/types/pouchdb-core/pouchdb-core-tests.ts
+++ b/types/pouchdb-core/pouchdb-core-tests.ts
@@ -104,7 +104,11 @@ function testBasics() {
     db.post(model, null, (error, response) => {
     });
 
-    db.get(id).then((result) => model = result);
+    db.get(id).then((result) => {
+        model = result;
+        isString(result._id);
+        isString(result._rev);
+    });
     db.get(id, null, (error, result) => {
     });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://pouchdb.com/api.html#fetch_document
https://pouchdb.com/api.html#bulk_get

----

Both `.get` and `.bulkGet` that relies on `GetMeta` always have `_rev` in their successful response. Without rectifying this, the responses from this have type conflict with `ExistingDocument` regarding optionality of `_rev` which shouldn't be the case.