### PR TITLE
Update flux-standard-action

### DIFF
--- a/types/flux-standard-action/index.d.ts
+++ b/types/flux-standard-action/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for flux-standard-action 0.5.0
 // Project: https://github.com/acdlite/flux-standard-action
 // Definitions by: Qubo <https://github.com/tkqubo>
+//                 Simon Fridlund <https://github.com/zimme>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
@@ -16,12 +17,12 @@ export interface Action<T> {
 
 /** Usage: `var action: Action<string> & AnyMeta;` */
 export interface AnyMeta {
-    meta: any
+    meta?: any;
 }
 
 /** Usage: `var action: Action<string> & TypedMeta<string>;` */
 export interface TypedMeta<T> {
-    meta: T
+    meta?: T;
 }
 
 export declare function isFSA(action: any): action is Action<any>;


### PR DESCRIPTION
This update makes `meta` optional as per the specification.