### PR TITLE
[Joi] Add missing Joi.string().uuid()

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -519,6 +519,11 @@ export interface StringSchema extends AnySchema<StringSchema> {
      * Requires the string value to be a valid GUID.
      */
     guid(options?: GuidOptions): StringSchema;
+    
+    /**
+     * Alias for `guid` -- Requires the string value to be a valid GUID
+     */
+    uuid(options?: GuidOptions): StringSchema;
 
     /**
      * Requires the string value to be a valid hexadecimal string.


### PR DESCRIPTION
As per the [Joi API docs](https://github.com/hapijs/joi/blob/v10.5.0/API.md#stringguid---aliases-uuid) `uuid()` is an alias for `guid()`, so this is essentially a one-liner.