### PR TITLE
(requestretry): Fix namespace, add promiseFactory

### DIFF
--- a/types/requestretry/index.d.ts
+++ b/types/requestretry/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for requestretry 1.12
 // Project: https://github.com/FGRibreau/node-request-retry
 // Definitions by: Eric Byers <https://github.com/EricByers>
+// 				   Andrew Throener <https://github.com/trainerbill>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -8,10 +9,9 @@
 import request = require('request');
 import http = require('http');
 
-type RetryStrategy = (err: Error, response: http.IncomingMessage, body: any) => boolean;
-
-declare namespace requestRetry {
-	interface RequestAPI extends request.RequestAPI<request.Request, RequestRetryOptions, request.RequiredUriUrl> {
+declare namespace requestretry {
+	type RetryStrategy = (err: Error, response: http.IncomingMessage, body: any) => boolean;
+	interface RetryRequestAPI extends request.RequestAPI<request.Request, RequestRetryOptions, request.RequiredUriUrl> {
 		RetryStrategies: {
 			'HttpError': RetryStrategy;
 			'HTTPOrNetworkError': RetryStrategy;
@@ -21,10 +21,11 @@ declare namespace requestRetry {
 
 	interface RequestRetryOptions extends request.CoreOptions {
 		maxAttempts?: number;
+		promiseFactory?(resolver: any): any;
 		retryDelay?: number;
 		retryStrategy?: RetryStrategy;
 	}
 }
 
-declare let requestretry: requestRetry.RequestAPI;
+declare let requestretry: requestretry.RetryRequestAPI;
 export = requestretry;

--- a/types/requestretry/requestretry-tests.ts
+++ b/types/requestretry/requestretry-tests.ts
@@ -73,3 +73,15 @@ request({
 }, (err, response, body) => {
 	// Body.
 });
+
+// Define options
+const options: request.RequestRetryOptions = {
+	maxAttempts: 2,
+	promiseFactory: (resolver: any) => {
+		return new Promise(resolver);
+	},
+	retryDelay: 4,
+	retryStrategy: (err: Error, response: http.IncomingMessage, body: any) => {
+		return true;
+	},
+};


### PR DESCRIPTION
- Fixed the namespace so that namespace is exported.  Needed access to RequestRetryOptions.
- Added promiseFactory to RequestRetryOptions.
- Added test for RequestRetryOptions export.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/FGRibreau/node-request-retry
- [x ] Increase the version number in the header if appropriate.
- [ x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.