### PR TITLE
Include subQuery for sequelize version 3 as well

### DIFF
--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -3221,6 +3221,11 @@ declare namespace sequelize {
          * Apply DISTINCT(col) for FindAndCount(all)
          */
         distinct?: boolean;
+
+        /**
+         * Prevents a subquery on the main table when using include
+         */
+        subQuery?: boolean;
     }
 
     /**

--- a/types/sequelize/v3/sequelize-tests.ts
+++ b/types/sequelize/v3/sequelize-tests.ts
@@ -896,6 +896,7 @@ User.findAll( { attributes: [[s.fn('count', Sequelize.col('*')), 'count']] });
 User.findAll( { attributes: [[s.fn('count', Sequelize.col('*')), 'count']], group: ['sex'] });
 User.findAll( { attributes: [s.cast(s.fn('count', Sequelize.col('*')), 'INTEGER')] });
 User.findAll( { attributes: [[s.cast(s.fn('count', Sequelize.col('*')), 'INTEGER'), 'count']] });
+User.findAll( { subQuery: false, include : [User], order : [['id', 'ASC NULLS LAST']] } );
 
 User.findById( 'a string' );
 


### PR DESCRIPTION

As it was done on #16657. This refers to sequelize/sequelize#1756. The change was done but only for sequelize lastest version. Version 4. This subquery is available since version 2.0. Currently I was forced to pass `any` as a temporal solution on a project using version 3 of sequelize

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: sequelize/sequelize#1756
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
