### PR TITLE
Fixes #18734 for react-native NativeModule type.

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -9126,9 +9126,12 @@ export var NativeEventEmitter: NativeEventEmitter
 export var NativeAppEventEmitter: RCTNativeAppEventEmitter
 
 /**
- * Empty interface which can be augmented by other type definitions for the NativeModules var below.
+ * Interface for NativeModules which allows to augment NativeModules with type informations.
+ * See react-native-sensor-manager for example.
  */
-interface NativeModulesStatic {}
+interface NativeModulesStatic {
+    [name: string]: any;
+}
 
 /**
  * Native Modules written in ObjectiveC/Swift/Java exposed via the RCTBridge

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -39,7 +39,23 @@ import {
     ScrollViewProps,
     RefreshControl,
     TabBarIOS,
+    NativeModules
 } from 'react-native';
+
+declare module 'react-native' {
+    interface NativeTypedModule {
+        someFunction(): void;
+        someProperty: string;
+    }
+    interface NativeModulesStatic {
+        NativeTypedModule: NativeTypedModule
+    }
+}
+
+NativeModules.NativeUntypedModule;
+
+NativeModules.NativeTypedModule.someFunction();
+NativeModules.NativeTypedModule.someProperty = "";
 
 function testDimensions() {
   const {


### PR DESCRIPTION
 * Altered typing of NativeModulesStatic to enable NativeModule modules of type any and typed native modules at the same time.
 * Added test case for typed and untyped native modules.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
