### PR TITLE
Add types for istanbuljs libraries

### DIFF
--- a/types/istanbul-lib-coverage/index.d.ts
+++ b/types/istanbul-lib-coverage/index.d.ts
@@ -1,0 +1,104 @@
+// Type definitions for istanbul-lib-coverage 1.1
+// Project: https://github.com/istanbuljs/istanbuljs
+// Definitions by: Jason Cheatham <https://github.com/jason0x43>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+export interface CoverageSummary {
+	lines: Totals;
+	statements: Totals;
+	branches: Totals;
+	functions: Totals;
+}
+
+export interface CoverageMapData {
+	[key: string]: FileCoverage;
+}
+
+export class CoverageMap {
+	constructor(data: CoverageMapData);
+	addFileCoverage(pathOrObject: string | FileCoverageData): void;
+	files(): string[];
+	fileCoverageFor(filename: string): FileCoverage;
+	filter(callback: (key: string) => boolean): void;
+	merge(data: CoverageMapData | CoverageMap): void;
+	toJSON(): object;
+	data: CoverageMapData;
+}
+
+export interface Location {
+	line: number;
+	column: number;
+}
+
+export interface Range {
+	start: Location;
+	end: Location;
+}
+
+export interface BranchMapping {
+	loc: Range;
+	type: string;
+	locations: Range[];
+	line: number;
+}
+
+export interface FunctionMapping {
+	name: string;
+	decl: Range;
+	loc: Range;
+	line: number;
+}
+
+export interface FileCoverageData {
+	path: string;
+	statementMap: { [key: string]: Range };
+	fnMap: { [key: string]: FunctionMapping };
+	branchMap: { [key: string]: BranchMapping };
+	s: { [key: string]: number };
+	f: { [key: string]: number };
+	b: { [key: string]: number[] };
+}
+
+export interface Totals {
+	total: number;
+	covered: number;
+	skipped: number;
+	pct: number;
+}
+
+export interface Coverage {
+	covered: number;
+	total: number;
+	coverage: number;
+}
+
+export class FileCoverage implements FileCoverageData {
+	constructor(data: string | FileCoverageData);
+	merge(other: FileCoverageData): void;
+	getBranchCoverageByLine(): { [line: number]: Coverage };
+	getLineCoverage(): { [line: number]: number };
+	getUncoveredLines(): number[];
+	resetHits(): void;
+	computeBranchTotals(): Totals;
+	computeSimpleTotals(): Totals;
+	toSummary(): CoverageSummary;
+	toJSON(): object;
+
+	data: FileCoverageData;
+	path: string;
+	statementMap: { [key: string]: Range };
+	fnMap: { [key: string]: FunctionMapping };
+	branchMap: { [key: string]: BranchMapping };
+	s: { [key: string]: number };
+	f: { [key: string]: number };
+	b: { [key: string]: number[] };
+}
+
+export const classes: {
+	FileCoverage: FileCoverage;
+};
+
+export function createCoverageMap(data?: CoverageMap | CoverageMapData): CoverageMap;
+export function createCoverageSummary(obj?: CoverageSummary): CoverageSummary;
+export function createFileCoverage(pathOrObject: string | FileCoverageData): FileCoverage;

--- a/types/istanbul-lib-coverage/istanbul-lib-coverage-tests.ts
+++ b/types/istanbul-lib-coverage/istanbul-lib-coverage-tests.ts
@@ -1,0 +1,65 @@
+import {
+	CoverageMapData,
+	CoverageSummary,
+	FileCoverageData,
+	createCoverageSummary,
+	createCoverageMap,
+	createFileCoverage
+} from 'istanbul-lib-coverage';
+
+const summaryData: CoverageSummary = {
+	lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
+	statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
+	functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
+	branches: { total: 0, covered: 0, skipped: 0, pct: 0 }
+};
+
+const coverageMapData: CoverageMapData = {};
+
+const fileCoverageData: FileCoverageData = {
+	path: 'foo',
+	statementMap: {},
+	fnMap: {},
+	branchMap: {},
+	s: {},
+	f: {},
+	b: {}
+};
+
+const summary = createCoverageSummary(summaryData);
+summary.branches;
+summary.lines;
+summary.functions;
+summary.statements;
+
+const map1 = createCoverageMap(coverageMapData);
+map1.data;
+const map2 = createCoverageMap(map1);
+map2.data;
+
+const fileCoverage1 = createFileCoverage('path/to/foo');
+fileCoverage1.data;
+const fileCoverage2 = createFileCoverage(fileCoverage1.data);
+fileCoverage2.data;
+const fileCoverage3 = createFileCoverage(fileCoverageData);
+fileCoverage3.data;
+
+// CoverageMap methods and properties
+map1.addFileCoverage('foo.js');
+map1.addFileCoverage(fileCoverageData);
+map1.files()[0];
+map1.fileCoverageFor('foo').path;
+map1.filter(name => false);
+map1.merge(map2);
+map1.merge(coverageMapData);
+
+// FileCoverage methods and properties
+fileCoverage1.merge(fileCoverageData);
+fileCoverage1.merge(fileCoverage2.data);
+fileCoverage1.getBranchCoverageByLine()[5].covered;
+isNaN(fileCoverage1.getLineCoverage()[5]);
+isNaN(fileCoverage1.getUncoveredLines()[5]);
+fileCoverage1.resetHits();
+fileCoverage1.computeBranchTotals().skipped;
+fileCoverage1.computeSimpleTotals().skipped;
+isNaN(fileCoverage1.toSummary().branches.total);

--- a/types/istanbul-lib-coverage/tsconfig.json
+++ b/types/istanbul-lib-coverage/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "files": [
+        "index.d.ts",
+        "istanbul-lib-coverage-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/istanbul-lib-coverage/tsconfig.json
+++ b/types/istanbul-lib-coverage/tsconfig.json
@@ -10,7 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/istanbul-lib-coverage/tslint.json
+++ b/types/istanbul-lib-coverage/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/istanbul-lib-hook/index.d.ts
+++ b/types/istanbul-lib-hook/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for istanbul-lib-hook 1.0
+// Project: https://github.com/istanbuljs/istanbuljs
+// Definitions by: Jason Cheatham <https://github.com/jason0x43>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+export interface Options {
+	verbose: boolean;
+}
+
+export interface HookRequireOptions extends Options {
+	extensions: string[];
+	postLoadHook(filename: string): void;
+}
+
+export function hookRequire(
+	matcher: Matcher,
+	transformer: Transformer,
+	options?: Partial<HookRequireOptions>
+): () => void;
+
+export function hookCreateScript(
+	matcher: Matcher,
+	transformer: Transformer,
+	options?: Partial<Options>
+): void;
+
+export function unhookCreateScript(): void;
+
+export function hookRunInThisContext(
+	matcher: Matcher,
+	transformer: Transformer,
+	options?: Partial<Options>
+): void;
+
+export function unhookRunInThisContext(): void;
+
+export function unloadRequireCache(matcher: Matcher): void;
+
+export type Matcher = (filename: string) => boolean;
+export type Transformer = (code: string, filepath: string) => string;

--- a/types/istanbul-lib-hook/istanbul-lib-hook-tests.ts
+++ b/types/istanbul-lib-hook/istanbul-lib-hook-tests.ts
@@ -1,0 +1,33 @@
+import {
+	hookRequire,
+	hookCreateScript,
+	unhookCreateScript,
+	hookRunInThisContext,
+	unhookRunInThisContext,
+	unloadRequireCache
+} from 'istanbul-lib-hook';
+
+const matcher = (filename: string) => true;
+const transformer = (code: string, filepath: string) => 'foo';
+
+hookRequire(matcher, transformer);
+hookRequire(matcher, transformer, {});
+hookRequire(matcher, transformer, { verbose: true });
+
+const retVal = hookRequire(matcher, transformer, {
+	extensions: ['.js'],
+	postLoadHook: (filename: string) => {}
+});
+retVal();
+
+hookCreateScript(matcher, transformer, {});
+hookCreateScript(matcher, transformer, { verbose: true });
+
+unhookCreateScript();
+
+hookRunInThisContext(matcher, transformer, {});
+hookRunInThisContext(matcher, transformer, { verbose: true });
+
+unhookRunInThisContext();
+
+unloadRequireCache(matcher);

--- a/types/istanbul-lib-hook/tsconfig.json
+++ b/types/istanbul-lib-hook/tsconfig.json
@@ -10,7 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/istanbul-lib-hook/tsconfig.json
+++ b/types/istanbul-lib-hook/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "files": [
+        "index.d.ts",
+        "istanbul-lib-hook-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/istanbul-lib-hook/tslint.json
+++ b/types/istanbul-lib-hook/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/istanbul-lib-instrument/index.d.ts
+++ b/types/istanbul-lib-instrument/index.d.ts
@@ -1,0 +1,77 @@
+// Type definitions for istanbul-lib-instrument 1.7
+// Project: https://github.com/istanbuljs/istanbuljs
+// Definitions by: Jason Cheatham <https://github.com/jason0x43>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import { FileCoverage, FileCoverageData, Range } from 'istanbul-lib-coverage';
+import { RawSourceMap } from 'source-map';
+import * as babelTypes from 'babel-types';
+
+export interface InstrumenterOptions {
+	coverageVariable: string;
+	preserveComments: boolean;
+	compact: boolean;
+	esModules: boolean;
+	autoWrap: boolean;
+	produceSourceMap: boolean;
+	sourceMapUrlCallback(filename: string, url: string): void;
+	debug: boolean;
+}
+
+export type InstrumenterCallback = (error: Error | null, code: string) => void;
+
+export class Instrumenter {
+	fileCoverage: FileCoverage;
+	sourceMap: RawSourceMap | null;
+	opts: InstrumenterOptions;
+
+	constructor(options?: Partial<InstrumenterOptions>);
+
+	normalizeOpts(options?: Partial<InstrumenterOptions>): InstrumenterOptions;
+
+	instrumentSync(
+		code: string,
+		filename: string,
+		inputSourceMap?: RawSourceMap
+	): string;
+
+	instrument(
+		code: string,
+		filenameOrCallback: string | InstrumenterCallback,
+		callback?: InstrumenterCallback,
+		inputSourceMap?: RawSourceMap
+	): void;
+
+	lastFileCoverage(): FileCoverageData;
+	lastSourceMap(): RawSourceMap;
+}
+
+export function createInstrumenter(
+	options?: Partial<InstrumenterOptions>
+): Instrumenter;
+
+export interface InitialCoverage {
+	path: string;
+	hash: string;
+	gcv: any;
+	coverageData: any;
+}
+
+export function readInitialCoverage(code: string): InitialCoverage;
+
+export interface Visitor {
+	enter(path: string): void;
+	exit(path: string): { fileCoverage: FileCoverage; sourceMappingURL: string };
+}
+
+export interface VisitorOptions {
+	coverageVariable: string;
+	inputSourceMap: RawSourceMap;
+}
+
+export function programVisitor(
+	types: typeof babelTypes,
+	sourceFilePath?: string,
+	opts?: Partial<VisitorOptions>
+): Visitor;

--- a/types/istanbul-lib-instrument/istanbul-lib-instrument-tests.ts
+++ b/types/istanbul-lib-instrument/istanbul-lib-instrument-tests.ts
@@ -24,8 +24,15 @@ const instrumenter = createInstrumenter({
 	debug: false
 });
 
+const sourceMap = {
+	version: 1,
+	sources: ['foo', 'bar'],
+	names: ['foo', 'bar'],
+	mappings: 'foo',
+	file: 'foo'
+};
 instrumenter.instrumentSync(code, filename);
-const newCode = instrumenter.instrumentSync(code, filename, {});
+const newCode = instrumenter.instrumentSync(code, filename, sourceMap);
 code.trim();
 
 // instrument with all args
@@ -35,7 +42,7 @@ instrumenter.instrument(code, filename, (error, code) => {
 	} else {
 		code.trim();
 	}
-}, {});
+}, sourceMap);
 
 // instrument without a filename
 instrumenter.instrument(code, (error, code) => {
@@ -58,7 +65,7 @@ initialCov.gcv;
 programVisitor(babelTypes);
 programVisitor(babelTypes, filename);
 programVisitor(babelTypes, filename, { coverageVariable: 'coverage' });
-const visitor = programVisitor(babelTypes, filename, { inputSourceMap: {} });
+const visitor = programVisitor(babelTypes, filename, { inputSourceMap: sourceMap });
 
 visitor.enter(filename);
 const data = visitor.exit(filename);

--- a/types/istanbul-lib-instrument/istanbul-lib-instrument-tests.ts
+++ b/types/istanbul-lib-instrument/istanbul-lib-instrument-tests.ts
@@ -1,0 +1,65 @@
+import {
+	createInstrumenter,
+	readInitialCoverage,
+	programVisitor
+} from 'istanbul-lib-instrument';
+
+import * as babelTypes from 'babel-types';
+
+const code = 'foo';
+const filename = 'bar.txt';
+
+createInstrumenter();
+createInstrumenter({});
+createInstrumenter({
+	coverageVariable: 'coverage'
+});
+const instrumenter = createInstrumenter({
+	preserveComments: true,
+	compact: false,
+	esModules: true,
+	autoWrap: false,
+	produceSourceMap: true,
+	sourceMapUrlCallback: (filename: string, url: string) => {},
+	debug: false
+});
+
+instrumenter.instrumentSync(code, filename);
+const newCode = instrumenter.instrumentSync(code, filename, {});
+code.trim();
+
+// instrument with all args
+instrumenter.instrument(code, filename, (error, code) => {
+	if (error) {
+		error.stack;
+	} else {
+		code.trim();
+	}
+}, {});
+
+// instrument without a filename
+instrumenter.instrument(code, (error, code) => {
+	if (error) {
+		error.stack;
+	} else {
+		code.trim();
+	}
+});
+
+const cov = instrumenter.lastFileCoverage();
+Object.create(cov);
+
+const map = instrumenter.lastSourceMap();
+Object.create(map);
+
+const initialCov = readInitialCoverage(code);
+initialCov.gcv;
+
+programVisitor(babelTypes);
+programVisitor(babelTypes, filename);
+programVisitor(babelTypes, filename, { coverageVariable: 'coverage' });
+const visitor = programVisitor(babelTypes, filename, { inputSourceMap: {} });
+
+visitor.enter(filename);
+const data = visitor.exit(filename);
+Object.create(data.fileCoverage);

--- a/types/istanbul-lib-instrument/tsconfig.json
+++ b/types/istanbul-lib-instrument/tsconfig.json
@@ -10,7 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/istanbul-lib-instrument/tsconfig.json
+++ b/types/istanbul-lib-instrument/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "files": [
+        "index.d.ts",
+        "istanbul-lib-instrument-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/istanbul-lib-instrument/tslint.json
+++ b/types/istanbul-lib-instrument/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/istanbul-lib-report/index.d.ts
+++ b/types/istanbul-lib-report/index.d.ts
@@ -1,0 +1,82 @@
+// Type definitions for istanbul-lib-report 1.1
+// Project: https://github.com/istanbuljs/istanbuljs
+// Definitions by: Jason Cheatham <https://github.com/jason0x43>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import { CoverageMap, FileCoverage, CoverageSummary } from 'istanbul-lib-coverage';
+
+export function createContext(options?: Partial<ContextOptions>): Context;
+export function getDefaultWatermarks(): Watermarks;
+
+export const summarizers: {
+	flat(coverageMap: CoverageMap): Tree;
+	nested(coverageMap: CoverageMap): Tree;
+	pkg(coverageMap: CoverageMap): Tree;
+};
+
+export interface ContextOptions {
+	dir: string;
+	watermarks: Watermarks;
+	sourceFinder(filepath: string): string;
+}
+
+export interface Context extends ContextOptions {
+	data: any;
+	writer: FileWriter;
+}
+
+export interface ContentWriter {
+	write(str: string): void;
+	colorize(str: string, cls?: string): string;
+	println(str: string): void;
+	close(): void;
+}
+
+export interface FileWriter {
+	writeForDir(subdir: string): FileWriter;
+	copyFile(source: string, dest: string): void;
+	writeFile(file: string | null): ContentWriter;
+}
+
+export interface Watermarks {
+	statements: number[];
+	functions: number[];
+	branches: number[];
+	lines: number[];
+}
+
+export interface Node {
+	getQualifiedName(): string;
+	getRelativeName(): string;
+	isRoot(): boolean;
+	getParent(): Node;
+	getChildren(): Node[];
+	isSummary(): boolean;
+	getCoverageSummary(filesOnly: boolean): CoverageSummary;
+	getFileCoverage(): FileCoverage;
+	visit(visitor: Visitor, state: any): void;
+}
+
+export interface ReportNode extends Node {
+	path: string;
+	parent: ReportNode | null;
+	fileCoverage: FileCoverage;
+	children: ReportNode[];
+	addChild(child: ReportNode): void;
+	asRelative(p: string): string;
+	visit(visitor: Visitor<ReportNode>, state: any): void;
+}
+
+export interface Visitor<N extends Node = Node> {
+	onStart(root: N, state: any): void;
+	onSummary(root: N, state: any): void;
+	onDetail(root: N, state: any): void;
+	onSummaryEnd(root: N, state: any): void;
+	onEnd(root: N, state: any): void;
+}
+
+export interface Tree<N extends Node = Node> {
+	getRoot(): N;
+	visit(visitor: Partial<Visitor<N>>, state: any): void;
+}

--- a/types/istanbul-lib-report/istanbul-lib-report-tests.ts
+++ b/types/istanbul-lib-report/istanbul-lib-report-tests.ts
@@ -1,0 +1,33 @@
+import {
+	createContext,
+	getDefaultWatermarks,
+	summarizers,
+	Watermarks
+} from 'istanbul-lib-report';
+
+import { CoverageMap } from 'istanbul-lib-coverage';
+
+const watermarks: Watermarks = {
+	statements: [],
+	branches: [],
+	functions: [],
+	lines: []
+};
+
+createContext();
+createContext({});
+const context = createContext({
+	dir: 'foo',
+	watermarks,
+	sourceFinder: (filepath: string) => ''
+});
+
+context.watermarks;
+context.sourceFinder('foo').trim();
+
+const defaultMarks: Watermarks = getDefaultWatermarks();
+
+const map = new CoverageMap({});
+summarizers.flat(map).getRoot();
+summarizers.nested(map).getRoot();
+summarizers.pkg(map).getRoot();

--- a/types/istanbul-lib-report/tsconfig.json
+++ b/types/istanbul-lib-report/tsconfig.json
@@ -10,7 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/istanbul-lib-report/tsconfig.json
+++ b/types/istanbul-lib-report/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "files": [
+        "index.d.ts",
+        "istanbul-lib-report-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/istanbul-lib-report/tslint.json
+++ b/types/istanbul-lib-report/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/istanbul-lib-source-maps/index.d.ts
+++ b/types/istanbul-lib-source-maps/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for istanbul-lib-source-maps 1.2
+// Project: https://github.com/istanbuljs/istanbuljs
+// Definitions by: Jason Cheatham <https://github.com/jason0x43>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import { CoverageMap } from 'istanbul-lib-coverage';
+import { RawSourceMap } from 'source-map';
+
+export function createSourceMapStore(
+	options?: Partial<MapStoreOptions>
+): MapStore;
+
+export interface MapStoreOptions {
+	verbose: boolean;
+	baseDir: string;
+	sourceStore: 'memory' | 'file';
+	tmpdir: string;
+}
+
+export interface MapStore {
+	baseDir: string | null;
+	verbose: boolean;
+	sourceStore: SourceStore;
+	data: {
+		[filepath: string]: {
+			type: string;
+			data: any;
+		};
+	};
+
+	registerURL(transformedFilePath: string, sourceMapUrl: string): void;
+	registerMap(filename: string, sourceMap: RawSourceMap): void;
+	transformCoverage(
+		coverageMap: CoverageMap
+	): { map: CoverageMap; sourceFinder(path: string): string };
+	dispose(): void;
+}
+
+export class SourceStore {
+	getSource(filepath: string): string | null;
+	registerSource(filepath: string, sourceText: string): void;
+}

--- a/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
+++ b/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
@@ -1,0 +1,34 @@
+import { createSourceMapStore } from 'istanbul-lib-source-maps';
+import { CoverageMap } from 'istanbul-lib-coverage';
+
+createSourceMapStore();
+createSourceMapStore({});
+const store = createSourceMapStore({
+	verbose: false,
+	baseDir: 'foo',
+	sourceStore: 'memory',
+	tmpdir: 'foo'
+});
+
+store.data['foo'].type.trim();
+
+const sourceMap = {
+	version: 1,
+	sources: ['foo', 'bar'],
+	names: ['foo', 'bar'],
+	mappings: 'foo',
+	file: 'foo'
+};
+store.registerMap('foo', sourceMap);
+
+store.registerURL('foo', 'foo');
+
+const map = new CoverageMap({});
+const transformed = store.transformCoverage(map);
+transformed.map.data;
+transformed.sourceFinder('foo').trim();
+
+store.dispose();
+
+store.sourceStore.registerSource('foo', 'bar');
+store.sourceStore.getSource('foo').trim();

--- a/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
+++ b/types/istanbul-lib-source-maps/istanbul-lib-source-maps-tests.ts
@@ -31,4 +31,7 @@ transformed.sourceFinder('foo').trim();
 store.dispose();
 
 store.sourceStore.registerSource('foo', 'bar');
-store.sourceStore.getSource('foo').trim();
+const source = store.sourceStore.getSource('foo');
+if (source != null) {
+	source.trim();
+}

--- a/types/istanbul-lib-source-maps/tsconfig.json
+++ b/types/istanbul-lib-source-maps/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "files": [
+        "index.d.ts",
+        "istanbul-lib-source-maps-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/istanbul-lib-source-maps/tsconfig.json
+++ b/types/istanbul-lib-source-maps/tsconfig.json
@@ -10,7 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/istanbul-lib-source-maps/tslint.json
+++ b/types/istanbul-lib-source-maps/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/istanbul-reports/index.d.ts
+++ b/types/istanbul-reports/index.d.ts
@@ -1,0 +1,50 @@
+// Type definitions for istanbul-reports 1.1
+// Project: https://github.com/istanbuljs/istanbuljs
+// Definitions by: Jason Cheatham <https://github.com/jason0x43>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import { Context, Node, FileWriter, Visitor } from 'istanbul-lib-report';
+import { CoverageSummary } from 'istanbul-lib-coverage';
+
+export function create<T extends keyof ReportOptions>(
+	name: T,
+	options?: Partial<ReportOptions[T]>
+): Visitor;
+
+export interface ReportOptions {
+	clover: RootedOptions;
+	cobertura: RootedOptions;
+	html: HtmlOptions;
+	json: Options;
+	'json-summary': Options;
+	lcov: never;
+	lcovonly: Options;
+	none: RootedOptions;
+	teamcity: Options & { blockName: string };
+	text: Options & { maxCols: number };
+	'text-lcov': Options;
+	'text-summary': Options;
+}
+
+export type ReportType = keyof ReportOptions;
+
+export interface Options {
+	file: string;
+}
+
+export interface RootedOptions extends Options {
+	projectRoot: string;
+}
+
+export interface HtmlOptions {
+	verbose: boolean;
+	linkMapper: LinkMapper;
+	subdir: string;
+}
+
+export interface LinkMapper {
+	getPath(node: string | Node): string;
+	relativePath(source: string | Node, target: string | Node): string;
+	assetPath(node: Node, name: string): string;
+}

--- a/types/istanbul-reports/istanbul-reports-tests.ts
+++ b/types/istanbul-reports/istanbul-reports-tests.ts
@@ -1,0 +1,44 @@
+import { create } from 'istanbul-reports';
+
+create('clover');
+create('clover', { file: 'foo', projectRoot: 'bar' });
+
+create('cobertura');
+create('cobertura', { file: 'foo', projectRoot: 'bar' });
+
+create('html');
+create('html', { verbose: false, subdir: 'foo' });
+create('html', {
+	linkMapper: {
+		getPath: () => 'foo',
+		relativePath: () => 'foo',
+		assetPath: () => 'foo'
+	}
+});
+
+create('json');
+create('json', { file: 'foo' });
+
+create('json-summary');
+create('json-summary', { file: 'foo' });
+
+create('lcov');
+
+create('lcovonly');
+create('lcovonly', { file: 'foo' });
+
+create('none');
+
+create('teamcity');
+create('teamcity', { file: 'foo' });
+create('teamcity', { file: 'foo', blockName: 'bar' });
+
+create('text');
+create('text', { file: 'foo' });
+create('text', { file: 'foo', maxCols: 3 });
+
+create('text-lcov');
+create('text-lcov', { file: 'foo' });
+
+create('text-summary');
+create('text-summary', { file: 'foo' });

--- a/types/istanbul-reports/tsconfig.json
+++ b/types/istanbul-reports/tsconfig.json
@@ -10,7 +10,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/istanbul-reports/tsconfig.json
+++ b/types/istanbul-reports/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "files": [
+        "index.d.ts",
+        "istanbul-reports-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/istanbul-reports/tslint.json
+++ b/types/istanbul-reports/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This PR includes typings for the libraries in the [istanbuljs monorepo](https://github.com/istanbuljs/istanbuljs/tree/master/packages):

* istanbul-lib-coverage
* istanbul-lib-hook
* istanbul-lib-instrument
* istanbul-lib-report
* istanbul-lib-source-maps
* istanbul-reports

This PR includes typings for all the libraries mentioned above because their inter-dependence was going to make individual PRs a pain.

This is related to https://github.com/theintern/intern/issues/765

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.