### PR TITLE
[react-select] add onNewOptionClick prop to ReactCreatableSelectProps

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -7,6 +7,7 @@
 //                 Mark Vujevits <https://github.com/vujevits>
 //                 Mike Deverell <https://github.com/devrelm>
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
+//                 Onat Yigit Mercan <https://github.com/onatm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -49,6 +50,7 @@ declare namespace ReactSelectClass {
     type OnChangeSingleHandler<TValue = OptionValues> = OnChangeHandler<Option<TValue>>;
     type OnChangeMultipleHandler<TValue = OptionValues> = OnChangeHandler<Options<TValue>>;
     type OnChangeHandler<TOption = Option | Options> = (newValue: TOption | null) => void;
+    type OnNewOptionClickHandler = (option: Option) => void;
 
     type LoadOptionsHandler = LoadOptionsAsyncHandler | LoadOptionsLegacyHandler;
     type LoadOptionsAsyncHandler = (input: string) => Promise<AutocompleteResult>;
@@ -453,6 +455,11 @@ declare namespace ReactSelectClass {
          * Decides if a keyDown event (eg its 'keyCode') should result in the creation of a new option.
          */
         shouldKeyDownEventCreateNewOption?: ShouldKeyDownEventCreateNewOptionHandler;
+
+        /**
+         * new option click handler: function (option) {}
+         */
+        onNewOptionClick?: OnNewOptionClickHandler;
     }
 
     interface ReactAsyncSelectProps extends ReactSelectProps {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/JedWatson/react-select/blob/master/src/Creatable.js#L283>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR adds missing `onNewOptionClick` prop to `ReactCreatableSelectProps`.
