### PR TITLE
[recompose] Add generic onlyUpdateForKeys

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -197,6 +197,10 @@ declare module 'recompose' {
     export function onlyUpdateForKeys(
         propKeys: Array<string>
     ) : InferableComponentEnhancer<{}>;
+    export function onlyUpdateForKeys<T>(
+        propKeys: Array<keyof T>
+    ) : InferableComponentEnhancer<{}>;
+
 
     // onlyUpdateForPropTypes: https://github.com/acdlite/recompose/blob/master/docs/API.md#onlyUpdateForPropTypes
     export const onlyUpdateForPropTypes: InferableComponentEnhancer<{}>;

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -273,3 +273,14 @@ function testWithObservableConfig() {
   let mapPropsStreamMost = mapPropsStreamWithConfig(mostConfig)
   mapPropsStreamMost = mapPropsStream
 }
+
+function testOnlyUpdateForKeys() {
+    interface Props {
+        foo: number;
+        bar: string;
+    }
+    const component: React.StatelessComponent<Props> = (props) => <div>{props.foo} {props.bar}</div>
+    onlyUpdateForKeys<Props>(['foo'])(component)
+    // This should be a compile error
+    // onlyUpdateForKeys<Props>(['fo'])(component)
+}


### PR DESCRIPTION
Adds an overload for `onlyUpdateForKeys` that allows a generic parameter for the component props type. This allows us to use `keyof` to provide type checking on the property names.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
