### PR TITLE
[deepmerge] Allow partial types in deepmerge

### DIFF
--- a/types/deepmerge/deepmerge-tests.ts
+++ b/types/deepmerge/deepmerge-tests.ts
@@ -1,19 +1,29 @@
 import * as deepmerge from "deepmerge";
 
 const x = {
-  foo: { bar: 3 },
-  array: [{ does: 'work', too: [1, 2, 3] }]
+    foo: { bar: 3 },
+    array: [{ does: 'work', too: [1, 2, 3] }]
 };
 const y = {
-  foo: { baz: 4 },
-  quux: 5,
-  array: [{ does: 'work', too: [4, 5, 6] }, { really: 'yes' }]
+    foo: { baz: 4 },
+    quux: 5,
+    array: [{ does: 'work', too: [4, 5, 6] }, { really: 'yes' }]
 };
 
 const expected = {
-  foo: { bar: 3, baz: 4 },
-  array: [{ does: 'work', too: [1, 2, 3, 4, 5, 6] }, { really: 'yes' }],
-  quux: 5
+    foo: { bar: 3, baz: 4 },
+    array: [{ does: 'work', too: [1, 2, 3, 4, 5, 6] }, { really: 'yes' }],
+    quux: 5
 };
 
-const result = deepmerge<any>(x, y);
+const result = deepmerge(x, y);
+const anyResult = deepmerge<any>(x, y);
+
+function reverseConcat(dest: number[], src: number[]) {
+    return src.concat(dest);
+}
+
+const withOptions = deepmerge(x, y, {
+    clone: false,
+    arrayMerge: reverseConcat
+});

--- a/types/deepmerge/deepmerge-tests.ts
+++ b/types/deepmerge/deepmerge-tests.ts
@@ -16,4 +16,14 @@ const expected = {
   quux: 5
 };
 
-const result = deepmerge<any>(x, y);
+const result = deepmerge(x, y);
+const anyResult = deepmerge<any>(x, y);
+
+function reverseConcat(dest: number[], src: number[]) {
+    return src.concat(dest);
+}
+
+const withOptions = deepmerge(x, y, {
+  clone: false,
+  arrayMerge: reverseConcat
+});

--- a/types/deepmerge/index.d.ts
+++ b/types/deepmerge/index.d.ts
@@ -1,17 +1,19 @@
 // Type definitions for deepmerge 1.3
 // Project: https://github.com/KyleAMathews/deepmerge
 // Definitions by: marvinscharle <https://github.com/marvinscharle>
+//                 syy1125 <https://github.com/syy1125>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = deepmerge;
 
-declare function deepmerge<T>(x: T, y: T, options?: deepmerge.Options<T>): T;
+declare function deepmerge<T>(x: Partial<T>, y: Partial<T>, options?: deepmerge.Options): T;
+declare function deepmerge<T1, T2>(x: T1, y: T2, options?: deepmerge.Options): T1 & T2;
 
 declare namespace deepmerge {
-    interface Options<T> {
+    interface Options {
         clone?: boolean;
-        arrayMerge?(destination: T, source: T, options?: Options<T>): T;
+        arrayMerge?(destination: any[], source: any[], options?: Options): any[];
     }
 
-    function all<T>(objects: T[], options?: Options<T>): T;
+    function all<T>(objects: Array<Partial<T>>, options?: Options): T;
 }

--- a/types/deepmerge/index.d.ts
+++ b/types/deepmerge/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: marvinscharle <https://github.com/marvinscharle>
 //                 syy1125 <https://github.com/syy1125>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 export = deepmerge;
 


### PR DESCRIPTION
Sometimes `deepmerge` is used for overwriting only a few properties in a larger object. Allowing partial types lets users deepmerge without having to typecast in those cases.
In addition, I also adjusted typings for arrayMerge to indicate that it will be operating on two arrays.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/deepmerge]
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.