### PR TITLE
advise against `T | any` in Common Mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ For a good example package, see [base64-js](https://github.com/DefinitelyTyped/D
 * Using the types `Function` and `Object` is almost never a good idea. In 99% of cases it's possible to specify a more specific type. Examples are `(x: number) => number` for [functions](http://www.typescriptlang.org/docs/handbook/functions.html#function-types) and `{ x: number, y: number }` for objects. If there is no certainty at all about the type, [`any`](http://www.typescriptlang.org/docs/handbook/basic-types.html#any) is the right choice, not `Object`. If the only known fact about the type is that it's some object, use the type [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), not `Object` or `{ [key: string]: any }`.
 * `var foo: string | any`: 
     When `any` is used in a union type, the resulting type is still `any`. So while the `string` portion of this type annotation may _look_ useful, it in fact offers no additional typechecking over simply using `any`.
-    Depending on the intention, acceptable alternatives could be: `any`, `string`, or `string | object`.
+    Depending on the intention, acceptable alternatives could be `any`, `string`, or `string | object`.
 
 
 #### Removing a package

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ For a good example package, see [base64-js](https://github.com/DefinitelyTyped/D
     Example where it is not acceptable: `function parseJson<T>(json: string): T;`.
     Exception: `new Map<string, number>()` is OK.
 * Using the types `Function` and `Object` is almost never a good idea. In 99% of cases it's possible to specify a more specific type. Examples are `(x: number) => number` for [functions](http://www.typescriptlang.org/docs/handbook/functions.html#function-types) and `{ x: number, y: number }` for objects. If there is no certainty at all about the type, [`any`](http://www.typescriptlang.org/docs/handbook/basic-types.html#any) is the right choice, not `Object`. If the only known fact about the type is that it's some object, use the type [`object`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#object-type), not `Object` or `{ [key: string]: any }`.
+* `var foo: string | any`: 
+    When `any` is used in a union type, the resulting type is still `any`. So while the `string` portion of this type annotation may _look_ useful, it in fact offers no additional typechecking over simply using `any`.
+    Depending on the intention, acceptable alternatives could be: `any`, `string`, or `string | object`.
 
 
 #### Removing a package


### PR DESCRIPTION
Updating Readme/Common Mistakes. This is a common pattern I see, but would appreciate someone checking my advice for accuracy and simplicity @andy-ms @RyanCavanaugh 