### PR TITLE
Add type definitions for semver-compare

### DIFF
--- a/types/semver-compare/index.d.ts
+++ b/types/semver-compare/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Kovács Vince <https://github.com/vincekovacs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "semver-compare" {
-    function compare<T>(a: T, b: T): number
+declare function semverCompare<T>(a: T, b: T): number;
 
-    export default compare
-}
+export = semverCompare;

--- a/types/semver-compare/index.d.ts
+++ b/types/semver-compare/index.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for semver-compare 1.0
+// Project: https://github.com/substack/semver-compare
+// Definitions by: Kovács Vince <https://github.com/vincekovacs>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "semver-compare" {
+    function compare<T>(a: T, b: T): number
+
+    export default compare
+}

--- a/types/semver-compare/semver-compare-tests.ts
+++ b/types/semver-compare/semver-compare-tests.ts
@@ -1,4 +1,4 @@
-import cmp = require("semver-compare")
+import SemverCompare = require("semver-compare")
 
 var versions = [
     "1.2.3",
@@ -11,4 +11,4 @@ var versions = [
     "10.5.5",
     "11.3.0",
 ]
-console.log(versions.sort(cmp).join("\n"))
+console.log(versions.sort(SemverCompare).join("\n"))

--- a/types/semver-compare/semver-compare-tests.ts
+++ b/types/semver-compare/semver-compare-tests.ts
@@ -1,6 +1,6 @@
-import SemverCompare = require("semver-compare")
+import SemverCompare = require("semver-compare");
 
-var versions = [
+const versions = [
     "1.2.3",
     "4.11.6",
     "4.2.0",
@@ -10,5 +10,5 @@ var versions = [
     "2.3.1",
     "10.5.5",
     "11.3.0",
-]
-console.log(versions.sort(SemverCompare).join("\n"))
+];
+versions.sort(SemverCompare).join("\n");

--- a/types/semver-compare/semver-compare-tests.ts
+++ b/types/semver-compare/semver-compare-tests.ts
@@ -1,0 +1,14 @@
+import cmp = require("semver-compare")
+
+var versions = [
+    "1.2.3",
+    "4.11.6",
+    "4.2.0",
+    "1.5.19",
+    "1.5.5",
+    "4.1.3",
+    "2.3.1",
+    "10.5.5",
+    "11.3.0",
+]
+console.log(versions.sort(cmp).join("\n"))

--- a/types/semver-compare/tsconfig.json
+++ b/types/semver-compare/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "semver-compare-tests.ts"
+    ]
+}

--- a/types/semver-compare/tslint.json
+++ b/types/semver-compare/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
