### PR TITLE
@types/graphql-express: Asynchronous resolution of 'OptionsObj' in graphqlHTTP

### DIFF
--- a/types/express-graphql/express-graphql-tests.ts
+++ b/types/express-graphql/express-graphql-tests.ts
@@ -1,6 +1,6 @@
-import * as express from "express";
+import * as express from 'express';
 import 'express-session';
-import * as graphqlHTTP from "express-graphql";
+import * as graphqlHTTP from 'express-graphql';
 
 const app = express();
 const schema = {};
@@ -8,19 +8,29 @@ const schema = {};
 const graphqlOption: graphqlHTTP.OptionsObj = {
     graphiql: true,
     schema: schema,
-    formatError: (error:Error) => ({
-        message: error.message,
+    formatError: (error: Error) => ({
+        message: error.message
     })
 };
 
 const graphqlOptionRequest = (request: express.Request): graphqlHTTP.OptionsObj => ({
     graphiql: true,
     schema: schema,
-    context: request.session,
+    context: request.session
 });
 
-app.use("/graphql1", graphqlHTTP(graphqlOption));
+const graphqlOptionRequestAsync = async (request: express.Request): Promise<graphqlHTTP.OptionsObj> => {
+    return {
+        graphiql: true,
+        schema: await Promise.resolve(schema),
+        context: request.session
+    };
+};
 
-app.use("/graphql2", graphqlHTTP(graphqlOptionRequest));
+app.use('/graphql1', graphqlHTTP(graphqlOption));
 
-app.listen(8080);
+app.use('/graphql2', graphqlHTTP(graphqlOptionRequest));
+
+app.use('/graphqlasync', graphqlHTTP(graphqlOptionRequestAsync));
+
+app.listen(8080, () => console.log('GraphQL Server running on localhost:8080'));

--- a/types/express-graphql/index.d.ts
+++ b/types/express-graphql/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for express-graphql
 // Project: https://www.npmjs.org/package/express-graphql
-// Definitions by: Isman Usoh <https://github.com/isman-usoh>, Nitin Tutlani <https://github.com/nitintutlani>
+// Definitions by: Isman Usoh <https://github.com/isman-usoh>
+//                 Nitin Tutlani <https://github.com/nitintutlani>
+//                 Daniel Fader <https://github.com/hubel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Request, Response } from "express";
@@ -12,7 +14,7 @@ declare namespace graphqlHTTP {
      * Used to configure the graphQLHTTP middleware by providing a schema
      * and other configuration options.
      */
-    export type Options = ((req: Request) => OptionsObj) | OptionsObj
+    export type Options = ((req: Request) => OptionsObj) | ((req: Request) => Promise<OptionsObj>) | OptionsObj
     export type OptionsObj = {
         /**
          * A GraphQL schema from graphql-js.

--- a/types/express-graphql/tsconfig.json
+++ b/types/express-graphql/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
+        "target": "es2015",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
From the [documentation of express-graphql](https://github.com/graphql/express-graphql):

> In addition to an object defining each option, options can also be provided as a function (**or async function**) which returns this options object

The `graphqlHTTP` method also accepts `Promise<OptionsObj>` as input.
The definition for async resolution of `OptionsObj` is added with test cases.