### PR TITLE
Nes socket disconnect typo

### DIFF
--- a/types/nes/index.d.ts
+++ b/types/nes/index.d.ts
@@ -91,7 +91,7 @@ declare module nes {
         id: string;
         app: Object;
         auth: nes.SocketAuthObject;
-        disconect(callback?: () => void): void;
+        disconnect(callback?: () => void): void;
         send(message: any, callback?: (err?: any) => void): void;
         publish(path: string, message: any, callback?: (err?: any) => void): void;
         revoke(path: string, message: any, callback?: (err?: any) => void): void;

--- a/types/nes/test/socket.ts
+++ b/types/nes/test/socket.ts
@@ -1,0 +1,16 @@
+// from https://github.com/hapijs/nes/blob/v6.4.3/lib/socket.js
+
+import Nes = require('nes');
+
+const socket: Nes.Socket = undefined;
+
+const cb = () => { };
+socket.disconnect(cb);
+const s: string = socket.id;
+const o: Object = socket.app;
+const auth: Nes.SocketAuthObject = socket.auth;
+
+const cb2 = (err?: any) => { };
+socket.send('message', (err?: any) => { });
+socket.publish('path', 'message', cb2);
+socket.revoke('path', 'message', cb2);

--- a/types/nes/tsconfig.json
+++ b/types/nes/tsconfig.json
@@ -26,6 +26,7 @@
         "test/route-authentication-server.ts",
         "test/route-invocation-client.ts",
         "test/route-invocation-server.ts",
+        "test/socket.ts",
         "test/subscription-filter-client.ts",
         "test/subscription-filter-server.ts",
         "test/subscriptions-client.ts",


### PR DESCRIPTION
This fix should be quite obvious. There is a typo in hapi-nes' Socket interface.

I also added a small test for the interface.

--

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/nes/blob/v6.4.3/lib/socket.js#L47
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.