### PR TITLE
[JSForce] large cleanups and refactor for greater type-safety

### DIFF
--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -5,15 +5,15 @@ import { RecordResult } from './record-result';
 import { SObject } from './salesforce-object';
 
 // These are pulled out because according to http://jsforce.github.io/jsforce/doc/connection.js.html#line49
-//the oauth options can either be in the `oauth2` proeprty OR spread across the main connection
-interface OAuth2Options {
-    clientId: string;
-    clientSecret: string;
-    loginUrl: string;
+// the oauth options can either be in the `oauth2` proeprty OR spread across the main connection
+export interface OAuth2Options {
+    clientId?: string;
+    clientSecret?: string;
+    loginUrl?: string;
     redirectUri?: string;
 }
 
-export interface ConnectionOptions extends Partial<OAuth2Options> {
+export interface ConnectionOptions extends OAuth2Options {
     accessToken?: string;
     callOptions?: Object;
     instanceUrl?: string;

--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -1,21 +1,26 @@
 import { SObjectCreateOptions } from './create-options';
 import { DescribeSObjectResult } from './describe-result';
-import { Query } from './query';
+import { Query, QueryResult } from './query';
 import { RecordResult } from './record-result';
 import { SObject } from './salesforce-object';
 
-export interface ConnectionOptions {
+// These are pulled out because according to http://jsforce.github.io/jsforce/doc/connection.js.html#line49
+//the oauth options can either be in the `oauth2` proeprty OR spread across the main connection
+interface OAuth2Options {
+    clientId: string;
+    clientSecret: string;
+    loginUrl: string;
+    redirectUri?: string;
+}
+
+export interface ConnectionOptions extends Partial<OAuth2Options> {
     accessToken?: string;
     callOptions?: Object;
     instanceUrl?: string;
     loginUrl?: string;
     logLevel?: string;
     maxRequest?: number;
-    oauth2?: {
-        clientId: string,
-        clientSecret: string,
-        redirectUri?: string,
-    };
+    oauth2?: OAuth2Options;
     proxyUrl?: string;
     redirectUri?: string;
     refreshToken?: string;
@@ -37,6 +42,7 @@ export class Connection {
     constructor(params: ConnectionOptions)
 
     accessToken: string;
+    query<T>(soql: string, callback?: (err: Error, result: QueryResult<T>) => void): QueryResult<T>;
     sobject(resource: string): SObject;
     login(user: string, password: string, callback?: (err: Error, res: UserInfo) => void): Promise<UserInfo>;
     loginByOAuth2(user: string, password: string, callback?: (err: Error, res: UserInfo) => void): Promise<UserInfo>;

--- a/types/jsforce/connection.d.ts
+++ b/types/jsforce/connection.d.ts
@@ -20,7 +20,7 @@ export interface ConnectionOptions extends Partial<OAuth2Options> {
     loginUrl?: string;
     logLevel?: string;
     maxRequest?: number;
-    oauth2?: OAuth2Options;
+    oauth2?: Partial<OAuth2Options>;
     proxyUrl?: string;
     redirectUri?: string;
     refreshToken?: string;
@@ -38,12 +38,33 @@ export interface UserInfo {
 
 export type ConnectionEvent = "refresh";
 
-export class Connection {
-    constructor(params: ConnectionOptions)
-
-    accessToken: string;
+/**
+ * the methods exposed here are done so that a client can use 'declaration augmentation' to get intellisense on their own projects.
+ * for example, given a type
+ *
+ * interface Foo {
+ *  thing: string;
+ *  yes: boolean;
+ * }
+ *
+ * you can write
+ *
+ * declare module "jsforce" {
+ *  interface Connection {
+ *    sobject(type: 'Foo'): SObject<Foo>
+ *  }
+ * }
+ *
+ * to ensure that you have the correct data types for the various collection names.
+ */
+export interface Connection {
     query<T>(soql: string, callback?: (err: Error, result: QueryResult<T>) => void): QueryResult<T>;
-    sobject(resource: string): SObject;
+    sobject<T>(resource: string): SObject<T>;
+}
+
+export class Connection implements Connection {
+    constructor(params: ConnectionOptions)
+    accessToken: string;
     login(user: string, password: string, callback?: (err: Error, res: UserInfo) => void): Promise<UserInfo>;
     loginByOAuth2(user: string, password: string, callback?: (err: Error, res: UserInfo) => void): Promise<UserInfo>;
     loginBySoap(user: string, password: string, callback?: (err: Error, res: UserInfo) => void): Promise<UserInfo>;

--- a/types/jsforce/index.d.ts
+++ b/types/jsforce/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Dolan Miu <https://github.com/dolanmiu>
 //                 Kamil Ejsymont <https://github.com/netes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 import * as fs from 'fs';
 import * as stream from 'stream';

--- a/types/jsforce/jsforce-tests.ts
+++ b/types/jsforce/jsforce-tests.ts
@@ -1,5 +1,11 @@
 import * as sf from 'jsforce';
 
+export interface DummyRecord {
+    thing: boolean;
+    other: number;
+    person: string;
+}
+
 const salesforceConnection: sf.Connection = new sf.Connection({
     instanceUrl: '',
     refreshToken: '',
@@ -8,6 +14,11 @@ const salesforceConnection: sf.Connection = new sf.Connection({
         clientSecret: '',
     },
 });
+
+salesforceConnection.sobject<DummyRecord>("Dummy").select(["thing", "other"]);
+
+// note the following should never compile:
+// salesforceConnection.sobject<DummyRecord>("Dummy").select(["lol"]);
 
 salesforceConnection.sobject("Account").create({
     Name: "Test Acc 2",
@@ -30,9 +41,9 @@ salesforceConnection.sobject("ContentVersion").create({
     }
 });
 
-salesforceConnection.sobject("ContentVersion").retrieve("world", {
+salesforceConnection.sobject<any>("ContentVersion").retrieve("world", {
     test: "test"
-}, (err: Error, ret: sf.Record) => {
+}, (err: Error, ret) => {
     if (err) {
         return;
     }

--- a/types/jsforce/query.d.ts
+++ b/types/jsforce/query.d.ts
@@ -7,7 +7,14 @@ export interface ExecuteOptions {
     scanAll?: number;
 }
 
-export class Query<T> {
+export interface QueryResult<T> {
+    done: boolean;
+    nextRecordsUrl?: string;
+    totalSize: number;
+    records: T[];
+}
+
+export class Query<T> extends Promise<T> {
     end(): Query<T>;
     filter(filter: Object): Query<T>;
     include(include: string): Query<T>;
@@ -27,7 +34,6 @@ export class Query<T> {
     map(callback: (currentValue: Object) => void): Promise<any>;
     scanAll(value: boolean): Query<T>;
     select(fields: Object | string[] | string): Query<T>;
-    then(onSuccess?: Function, onRejected?: Function): Promise<any>;
     thenCall(callback?: (err: Error, records: T) => void): Query<T>;
     toSOQL(callback: (err: Error, soql: string) => void): Promise<string>;
     update(mapping: any, type: string, callback: (err: Error, records: RecordResult[]) => void): Promise<RecordResult[]>;

--- a/types/jsforce/record-result.d.ts
+++ b/types/jsforce/record-result.d.ts
@@ -1,7 +1,13 @@
 import { SalesforceId } from './salesforce-id';
 
-export interface RecordResult {
-    id: SalesforceId;
-    success: boolean;
-    anys: Object[];
+interface ErrorResult {
+    errors: string[];
+    success: false;
 }
+
+interface SuccessResult {
+    id: SalesforceId;
+    success: true;
+}
+
+export type RecordResult = SuccessResult | ErrorResult;

--- a/types/jsforce/record.d.ts
+++ b/types/jsforce/record.d.ts
@@ -1,6 +1,16 @@
+import { RecordResult } from './record-result';
+import { Connection } from './connection';
 import { SalesforceId } from './salesforce-id';
+import { Stream } from 'stream';
 
-export interface Record {
-    Id: SalesforceId;
-    attributes: Object[];
+export class RecordReference<T> {
+    constructor(conn: Connection, type: string, id: SalesforceId);
+    blob(fieldName: string): Stream;
+    del(options?: Object, callback?: (err: Error, result: RecordResult) => void): Promise<RecordResult>;
+    delete(options?: Object, callback?: (err: Error, result: RecordResult) => void): Promise<RecordResult>;
+    destroy(options?: Object, callback?: (err: Error, result: RecordResult) => void): Promise<RecordResult>;
+    retrieve(options?: Object, callback?: (err: Error, record: Record<T>) => void): Promise<Record<T>>;
+    update(record: Partial<T>, options?: Object, callback?: (err: Error, result: RecordResult) => void): Promise<RecordResult>;
 }
+
+export type Record<T> = {Id: SalesforceId } & T;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -3,19 +3,20 @@ import * as stream from 'stream';
 import { SObjectCreateOptions } from './create-options';
 import { DescribeSObjectResult } from './describe-result';
 import { Query } from './query';
-import { Record } from './record';
+import { Record, RecordReference } from './record';
 import { RecordResult } from './record-result';
 import { Connection } from './connection';
 import { SalesforceId } from './salesforce-id';
 
-export class SObject {
-    record(options: any, callback?: (err: Error, ret: any) => void): void;
-    update<T>(record: Partial<T>, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    update<T>(records: Partial<T>[], options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
-    retrieve(ids: string | string[], callback?: (err: Error, ret: Record | Record[]) => void): Promise<Record | Record[]>;
-    retrieve(ids: string | string[], options?: Object, callback?: (err: Error, ret: Record | Record[]) => void): Promise<Record | Record[]>;
-    upsert(records: Record | Record[], extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult | RecordResult[]>;
-    upsertBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+export class SObject<T> {
+    record(id: SalesforceId): RecordReference<T>;
+    retrieve(id: SalesforceId, options?: Object, callback?:(err: Error, record: Record<T>) => void): Promise<Record<T>>;
+    retrieve(ids: SalesforceId[], options?: Object, callback?: (err: Error, ret: Record<T>[]) => void): Promise<Record<T>[]>;
+    update(record: Partial<T>, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
+    update(records: Partial<T>[], options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
+    upsert(records: Record<T>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
+    upsert(records: Record<T>[], extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult[]>;
+    upsertBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult[] | BatchResultInfo[]) => void): Batch;
     describeGlobal(callback: (err: Error, res: any) => void): void;
     describe$(callback: (err: Error, ret: DescribeSObjectResult) => void): void;
     describeGlobal$(callback: (err: Error, res: any) => void): void;
@@ -29,37 +30,35 @@ export class SObject {
     findOne<T>(query?: any, fields?: Object | string[] | string, options?: Object, callback?: (err: Error, ret: T) => void): void;
 
     approvalLayouts(callback?: (layoutInfo: ApprovalLayoutInfo) => void): Promise<ApprovalLayoutInfo>;
-    bulkload(operation: string, options?: { extIdField?: string }, input?: Record[] | stream.Stream[] | string[], callback?: (err: Error, ret: RecordResult) => void): Batch;
+    bulkload(operation: string, options?: { extIdField?: string }, input?: Record<T>[] | stream.Stream[] | string[], callback?: (err: Error, ret: RecordResult) => void): Batch;
     compactLayouts(callback?: CompactLayoutInfo): Promise<CompactLayoutInfo>;
     count(conditions?: Object | string, callback?: (err: Error, num: number) => void): Promise<number>;
     create(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
-    createBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    createBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     del(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
     destroy(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
     delete(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
-    deleteBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    destroyBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    destroyHardBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    deleteBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    destroyBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    destroyHardBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     deleted(start: Date | string, end: Date | string, callback?: (info: DeletedRecordsInfo) => void): Promise<DeletedRecordsInfo>;
-    deleteHardBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    deleteHardBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     describe(callback?: (err: Error, ret: DescribeSObjectResult) => void): Promise<DescribeSObjectResult>;
     insert(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
-    insertBulk(input?: Record[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    insertBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     layouts(layoutName?: string, callback?: (err: Error, info: LayoutInfo) => void): Promise<LayoutInfo>;
     listview(id: string): ListView;
     listviews(callback?: (err: Error, info: ListViewsInfo) => void): Promise<ListViewsInfo>;
     quickAction(actionName: string): QuickAction;
     quickActions(callback?: (err: Error, info: any) => void): Promise<any>;
     recent(callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    select<T>(field?: Object | string[] | string, callback?: (err: Error, ret: T[]) => void): Query<T[]>;
+    select(callback?: (err: Error, ret: T[]) => void): Promise<T[]>;
+    //TODO:use a typed pluck to turn `fields` into a subset of T's fields so that the output is slimmed down appropriately
+    select(fields?: (keyof T)[] | (keyof T), callback?: (err: Error, ret: Partial<T>[]) => void): Promise<Partial<T>[]>;
 }
 
 export interface ApprovalLayoutInfo {
     approvalLayouts: Object[];
-}
-
-export class Record extends Object {
-    constructor(connection: Connection, type: SObject, id: SalesforceId)
 }
 
 export class Batch extends stream.Writable {
@@ -86,7 +85,20 @@ export interface LayoutInfo {
 }
 
 export class ListView {
-    constructor(connection: Connection, type: SObject, id: SalesforceId)
+    constructor(connection: Connection, type: string, id: SalesforceId)
+}
+
+export interface BatchInfo {
+    id: string;
+    jobId: string;
+    state: string;
+    stateMessage: string;
+}
+
+export interface BatchResultInfo {
+    id: string;
+    batchId: string;
+    jobId: string;
 }
 
 export class ListViewsInfo { }

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -10,7 +10,8 @@ import { SalesforceId } from './salesforce-id';
 
 export class SObject {
     record(options: any, callback?: (err: Error, ret: any) => void): void;
-    update(options: SObjectCreateOptions, callback?: (err: Error, ret: any) => void): void;
+    update<T>(record: Partial<T>, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
+    update<T>(records: Partial<T>[], options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
     retrieve(ids: string | string[], callback?: (err: Error, ret: Record | Record[]) => void): Promise<Record | Record[]>;
     retrieve(ids: string | string[], options?: Object, callback?: (err: Error, ret: Record | Record[]) => void): Promise<Record | Record[]>;
     upsert(records: Record | Record[], extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult | RecordResult[]>;

--- a/types/jsforce/salesforce-object.d.ts
+++ b/types/jsforce/salesforce-object.d.ts
@@ -10,13 +10,13 @@ import { SalesforceId } from './salesforce-id';
 
 export class SObject<T> {
     record(id: SalesforceId): RecordReference<T>;
-    retrieve(id: SalesforceId, options?: Object, callback?:(err: Error, record: Record<T>) => void): Promise<Record<T>>;
-    retrieve(ids: SalesforceId[], options?: Object, callback?: (err: Error, ret: Record<T>[]) => void): Promise<Record<T>[]>;
+    retrieve(id: SalesforceId, options?: Object, callback?: (err: Error, record: Record<T>) => void): Promise<Record<T>>;
+    retrieve(ids: SalesforceId[], options?: Object, callback?: (err: Error, ret: Array<Record<T>>) => void): Promise<Array<Record<T>>>;
     update(record: Partial<T>, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    update(records: Partial<T>[], options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
+    update(records: Array<Partial<T>>, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
     upsert(records: Record<T>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
-    upsert(records: Record<T>[], extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult[]>;
-    upsertBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult[] | BatchResultInfo[]) => void): Batch;
+    upsert(records: Array<Record<T>>, extIdField: SalesforceId, options?: Object, callback?: (err: Error, ret: RecordResult[]) => void): Promise<RecordResult[]>;
+    upsertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult[] | BatchResultInfo[]) => void): Batch;
     describeGlobal(callback: (err: Error, res: any) => void): void;
     describe$(callback: (err: Error, ret: DescribeSObjectResult) => void): void;
     describeGlobal$(callback: (err: Error, res: any) => void): void;
@@ -30,22 +30,22 @@ export class SObject<T> {
     findOne<T>(query?: any, fields?: Object | string[] | string, options?: Object, callback?: (err: Error, ret: T) => void): void;
 
     approvalLayouts(callback?: (layoutInfo: ApprovalLayoutInfo) => void): Promise<ApprovalLayoutInfo>;
-    bulkload(operation: string, options?: { extIdField?: string }, input?: Record<T>[] | stream.Stream[] | string[], callback?: (err: Error, ret: RecordResult) => void): Batch;
+    bulkload(operation: string, options?: { extIdField?: string }, input?: Array<Record<T>> | stream.Stream[] | string[], callback?: (err: Error, ret: RecordResult) => void): Batch;
     compactLayouts(callback?: CompactLayoutInfo): Promise<CompactLayoutInfo>;
     count(conditions?: Object | string, callback?: (err: Error, num: number) => void): Promise<number>;
     create(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
-    createBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    createBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     del(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
     destroy(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
     delete(ids: string | string[], callback?: (err: Error, ret: any) => void): void;
-    deleteBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    destroyBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
-    destroyHardBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    deleteBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    destroyBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    destroyHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     deleted(start: Date | string, end: Date | string, callback?: (info: DeletedRecordsInfo) => void): Promise<DeletedRecordsInfo>;
-    deleteHardBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    deleteHardBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     describe(callback?: (err: Error, ret: DescribeSObjectResult) => void): Promise<DescribeSObjectResult>;
     insert(options: any | any[], callback?: (err: Error, ret: RecordResult | RecordResult[]) => void): Promise<RecordResult | RecordResult[]>;
-    insertBulk(input?: Record<T>[] | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
+    insertBulk(input?: Array<Record<T>> | stream.Stream | string, callback?: (err: Error, ret: RecordResult) => void): Batch;
     layouts(layoutName?: string, callback?: (err: Error, info: LayoutInfo) => void): Promise<LayoutInfo>;
     listview(id: string): ListView;
     listviews(callback?: (err: Error, info: ListViewsInfo) => void): Promise<ListViewsInfo>;
@@ -53,8 +53,8 @@ export class SObject<T> {
     quickActions(callback?: (err: Error, info: any) => void): Promise<any>;
     recent(callback?: (err: Error, ret: RecordResult) => void): Promise<RecordResult>;
     select(callback?: (err: Error, ret: T[]) => void): Promise<T[]>;
-    //TODO:use a typed pluck to turn `fields` into a subset of T's fields so that the output is slimmed down appropriately
-    select(fields?: (keyof T)[] | (keyof T), callback?: (err: Error, ret: Partial<T>[]) => void): Promise<Partial<T>[]>;
+    // TODO:use a typed pluck to turn `fields` into a subset of T's fields so that the output is slimmed down appropriately
+    select(fields?: {[P in keyof T]: boolean}  | Array<(keyof T)> | (keyof T), callback?: (err: Error, ret: Array<Partial<T>>) => void): Promise<Array<Partial<T>>>;
 }
 
 export interface ApprovalLayoutInfo {


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: In lieu of this I'll comment on changes inline to this PR as appropriate
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

These changes are inspired by change my company has in our own local jsforce typings that we'd like to subsume into these typings.  They are oriented around greater type safety and auto-completeable updates, because we often have nicely-typed models for the data types in salesforce.
