### PR TITLE
Add more types for "repl" and "module" modules in Node

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -93,8 +93,15 @@ interface NodeRequireFunction {
 interface NodeRequire extends NodeRequireFunction {
     resolve(id: string): string;
     cache: any;
-    extensions: any;
+    extensions: NodeExtensions;
     main: NodeModule | undefined;
+}
+
+interface NodeExtensions {
+  '.js': (m: NodeModule, filename: string) => any;
+  '.json': (m: NodeModule, filename: string) => any;
+  '.node': (m: NodeModule, filename: string) => any;
+  [ext: string]: (m: NodeModule, filename: string) => any;
 }
 
 declare var require: NodeRequire;
@@ -1632,6 +1639,9 @@ declare module "repl" {
 
     export interface REPLServer extends readline.ReadLine {
         context: any;
+        inputStream: NodeJS.ReadableStream;
+        outputStream: NodeJS.WritableStream;
+
         defineCommand(keyword: string, cmd: Function | { help: string, action: Function }): void;
         displayPrompt(preserveCursor?: boolean): void;
 
@@ -1667,6 +1677,12 @@ declare module "repl" {
     }
 
     export function start(options?: string | ReplOptions): REPLServer;
+
+    export class Recoverable extends SyntaxError {
+        err: Error;
+
+        constructor(err: Error);
+    }
 }
 
 declare module "readline" {
@@ -5590,6 +5606,26 @@ declare module "constants" {
     export var defaultCipherList: string;
     export var ENGINE_METHOD_RSA: number;
     export var ALPN_ENABLED: number;
+}
+
+declare module "module" {
+    class Module implements NodeModule {
+        static runMain(): void;
+        static wrap(code: string): string;
+
+        exports: any;
+        require: NodeRequireFunction;
+        id: string;
+        filename: string;
+        loaded: boolean;
+        parent: NodeModule | null;
+        children: NodeModule[];
+        paths: string[];
+
+        constructor(id: string, parent?: Module);
+    }
+
+    export = Module;
 }
 
 declare module "process" {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -28,6 +28,7 @@ import * as v8 from "v8";
 import * as dns from "dns";
 import * as async_hooks from "async_hooks";
 import * as http2 from "http2";
+import Module = require("module");
 
 // Specifically test buffer module regression.
 import { Buffer as ImportedBuffer, SlowBuffer as ImportedSlowBuffer } from "buffer";
@@ -2532,6 +2533,11 @@ namespace repl_tests {
 
         _server = _server.prependOnceListener("exit", () => { });
         _server = _server.prependOnceListener("reset", () => { });
+
+        _server.outputStream.write("test");
+        let line = _server.inputStream.read();
+
+        throw new repl.Recoverable(new Error("test"));
     }
 }
 
@@ -3379,4 +3385,17 @@ namespace http2_tests {
         str = constants.HTTP2_METHOD_UPDATEREDIRECTREF;
         str = constants.HTTP2_METHOD_VERSION_CONTROL;
     }
+}
+
+////////////////////////////////////////////////////
+/// module tests : http://nodejs.org/api/modules.html
+////////////////////////////////////////////////////
+
+namespace module_tests {
+    require.extensions[".ts"] = () => "";
+
+    Module.runMain();
+    Module.wrap("some code");
+
+    const m1 = new Module("moduleId");
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    Added APIs are used by [ts-node](https://github.com/TypeStrong/ts-node), but mostly not mentioned in the documentation pages.
    [ouputStream/inputStream](https://github.com/nodejs/node/blob/a80b1621b034b6bcd920805681db22e1f6c5a282/lib/repl.js#L326)
    [Recoverable](https://github.com/nodejs/node/blob/a80b1621b034b6bcd920805681db22e1f6c5a282/lib/repl.js#L1388)
    ["module" module, Module class](https://github.com/nodejs/node/blob/a80b1621b034b6bcd920805681db22e1f6c5a282/lib/module.js#L55).
    `require.extensions` can be checked by running `require.extensions['.js'].toString()` and they are used by `ts-node` this way.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.