### PR TITLE
Update GoogleAuth.grantOfflineAccess

### DIFF
--- a/types/gapi.auth2/index.d.ts
+++ b/types/gapi.auth2/index.d.ts
@@ -42,11 +42,7 @@ declare namespace gapi.auth2 {
     /**
      * Get permission from the user to access the specified scopes offline.
      */
-    grantOfflineAccess(options?: {
-      scope?: string;
-      prompt?: "select_account" | "consent";
-      app_package_name?: string;
-    }): any;
+    grantOfflineAccess(options?: OfflineAccessOptions): Promise<{code: string}>;
 
     /**
      * Attaches the sign-in flow to the specified container's click handler.
@@ -106,6 +102,18 @@ declare namespace gapi.auth2 {
      */
     scope?: string;
   }
+    
+
+  /**
+   * Definitions by: John <https://github.com/jhcao23>
+   * Interface that represents the different configuration parameters for the GoogleAuth.grantOfflineAccess(options) method.
+   * Reference: https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiauth2offlineaccessoptions
+   */
+  interface OfflineAccessOptions {
+    scope?: string;
+    prompt?: "select_account" | "consent";
+    app_package_name?: string;
+  }    
 
   /**
    * Interface that represents the different configuration parameters for the gapi.auth2.init method.

--- a/types/gapi.auth2/index.d.ts
+++ b/types/gapi.auth2/index.d.ts
@@ -102,7 +102,6 @@ declare namespace gapi.auth2 {
      */
     scope?: string;
   }
-    
 
   /**
    * Definitions by: John <https://github.com/jhcao23>
@@ -113,7 +112,7 @@ declare namespace gapi.auth2 {
     scope?: string;
     prompt?: "select_account" | "consent";
     app_package_name?: string;
-  }    
+  }
 
   /**
    * Interface that represents the different configuration parameters for the gapi.auth2.init method.


### PR DESCRIPTION
Update gapi.auth2.GoogleAuth.grantOfflineAccess such that  it should take OfflineAccessOptions as parameter and return a Promise, based on official google docs.