### PR TITLE
Meteor:  allow strictNullChecks, add 2 methods to ObjectID

### DIFF
--- a/types/meteor/ejson.d.ts
+++ b/types/meteor/ejson.d.ts
@@ -5,10 +5,10 @@ interface EJSONableCustomType {
     typeName(): string;
 }
 interface EJSONable {
-    [key: string]: number | string | boolean | Object | number[] | string[] | Object[] | Date | Uint8Array | EJSONableCustomType;
+    [key: string]: number | string | boolean | Object | number[] | string[] | Object[] | Date | Uint8Array | EJSONableCustomType | undefined | null;
 }
 interface JSONable {
-    [key: string]: number | string | boolean | Object | number[] | string[] | Object[];
+    [key: string]: number | string | boolean | Object | number[] | string[] | Object[] | undefined | null;
 }
 interface EJSON extends EJSONable { }
 
@@ -44,10 +44,10 @@ declare module "meteor/ejson" {
         typeName(): string;
     }
     interface EJSONable {
-        [key: string]: number | string | boolean | Object | number[] | string[] | Object[] | Date | Uint8Array | EJSONableCustomType;
+        [key: string]: number | string | boolean | Object | number[] | string[] | Object[] | Date | Uint8Array | EJSONableCustomType | undefined | null;
     }
     interface JSONable {
-        [key: string]: number | string | boolean | Object | number[] | string[] | Object[];
+        [key: string]: number | string | boolean | Object | number[] | string[] | Object[] | undefined | null;
     }
     interface EJSON extends EJSONable { }
 

--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -214,7 +214,10 @@ declare module "meteor/mongo" {
         interface ObjectIDStatic {
             new (hexString?: string): ObjectID;
         }
-        interface ObjectID { }
+        interface ObjectID {
+            toHexString(): string;
+            equals(otherID: ObjectID): boolean;
+         }
 
         function setConnectionOptions(options: any): void;
     }


### PR DESCRIPTION
ejson.d.ts: Includes undefined and null to enable strictNullChecks.

mongo.d.ts: add 2 methods to Mongo.ObjectID

These method are accessible from meteor Mongo.ObjectID but missing.

Per https://docs.meteor.com/api/collections.html#Mongo-ObjectID :
"Mongo.ObjectID follows the same API as the Node MongoDB driver ObjectID class"

When I check the Node.js MongoDB Driver API, only these two methods
are interesting. (getTimestamp() doesn't make sense in Meteor).

I've a test that call both methods successfully.

@barbatus @fullflavedave @birkskyum @ardatan @stefanholzapfel 

