### PR TITLE
[http-errors] don't return never from HttpError constructor

### DIFF
--- a/types/http-errors/http-errors-tests.ts
+++ b/types/http-errors/http-errors-tests.ts
@@ -71,10 +71,6 @@ err = create(404, 'LOL', {id: 1});
 // create(status, msg, { expose: false })
 err = create(404, 'LOL', {expose: false});
 
-// new create.HttpError() should throw: cannot construct abstract class
-// $ExpectType never
-new create.HttpError();
-
 err = new create.NotFound();
 err = new create.InternalServerError();
 err = new create[404]();
@@ -91,8 +87,15 @@ err = new create[404]('This might be a problem');
 err = new create.MisdirectedRequest();
 err = new create.MisdirectedRequest('Where should this go?');
 
+// $ExpectType HttpError
+new create.HttpError();
+
 // $ExpectType boolean
 new Error() instanceof create.HttpError;
+
+if (err instanceof create.HttpError) {
+    err.statusCode;
+}
 
 // should support err instanceof Error
 create(404) instanceof Error;

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.2
 
 export = createHttpError;
 
@@ -26,7 +26,7 @@ declare namespace createHttpError {
 
     type NamedConstructors = {
         [code: string]: HttpErrorConstructor;
-        HttpError: new (msg?: string) => never;
+        HttpError: HttpErrorConstructor;
     } & Record<'BadRequest' |
         'Unauthorized' |
         'PaymentRequired' |


### PR DESCRIPTION
Fixes #19458.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jshttp/http-errors
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.