### PR TITLE
[VError] Update constructor

### DIFF
--- a/types/verror/index.d.ts
+++ b/types/verror/index.d.ts
@@ -31,6 +31,7 @@ declare class VError extends Error {
     cause(): Error | undefined;
     constructor(options: VError.Options | Error, message: string, ...params: any[]);
     constructor(message: string, ...params: any[]);
+    constructor();
 }
 
 declare namespace VError {


### PR DESCRIPTION
VError's constructor supports being called with no arguments (see here https://github.com/joyent/node-verror/blob/master/lib/verror.js#L63)

This is needed to be able to properly subclass a VError, e.g.

```typescript
class MyError extends VError {
    constructor(code: number, ...args) {
        super(...args) // this will not compile w/o this patch
    }
}
```