### PR TITLE
Updated typings and tests for Navigation 4.0.1

### DIFF
--- a/types/navigation/index.d.ts
+++ b/types/navigation/index.d.ts
@@ -348,6 +348,10 @@ export class StateContext {
      */
     oldData: any;
     /**
+     * Gets the Url for the last displayed State
+     */
+    oldUrl: string;
+    /**
      * Gets the State of the last Crumb in the crumb trail
      */
     previousState: State;
@@ -355,6 +359,10 @@ export class StateContext {
      * Gets the NavigationData of the last Crumb in the crumb trail
      */
     previousData: any;
+    /**
+     * Gets the Url of the last Crumb in the crumb trail
+     */
+    previousUrl: string;
     /**
      * Gets the current State
      */

--- a/types/navigation/navigation-tests.ts
+++ b/types/navigation/navigation-tests.ts
@@ -83,12 +83,14 @@ link = stateNavigator.fluent()
 
 // State Context
 let state: State = stateNavigator.stateContext.state;
-const url: string = stateNavigator.stateContext.url;
+let url: string = stateNavigator.stateContext.url;
 const title: string = stateNavigator.stateContext.title;
 let page: number = stateNavigator.stateContext.data.page;
 state = stateNavigator.stateContext.oldState;
+url = stateNavigator.stateContext.oldUrl;
 page = stateNavigator.stateContext.oldData.page;
 state = stateNavigator.stateContext.previousState;
+url = stateNavigator.stateContext.previousUrl;
 page = stateNavigator.stateContext.previousData.page;
 
 // Navigation Data


### PR DESCRIPTION
Updated typings and tests to match the new version [4.0.1 of the Navigation Router](https://github.com/grahammendick/navigation/releases/tag/v4.0.1-Navigation)