### PR TITLE
[highcharts] Add textOverflow and whiteSpace properties to CSSObject

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -1994,6 +1994,8 @@ declare namespace Highcharts {
         position?: string;
         top?: string;
         textOutline?: string;
+        textOverflow?: string;
+        whiteSpace?: string;
     }
 
     interface CreditsOptions {


### PR DESCRIPTION
[xAxis.labels.style](http://api.highcharts.com/highcharts/xAxis.labels.style) describes these properties:

> Use `whiteSpace: 'nowrap'` to prevent wrapping of category labels
>  Use `textOverflow: 'none'` to prevent ellipsis (dots).

These have now been added to the CSSObject definition.

Another option would be to create a sub-type of CSSObject with just these two properties, to be used in xAxis.labels.style, but the Highcharts documentation uses CSSObject itself to describe the type so I think it's better to keep it consistent.

--------------------------


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://api.highcharts.com/highcharts/xAxis.labels.style
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
