### PR TITLE
[redux-actions] Type defs for action meta creators, and reducer map f…

### DIFF
--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -1,6 +1,8 @@
-// Type definitions for redux-actions 1.2
+// Type definitions for redux-actions 2.2
 // Project: https://github.com/acdlite/redux-actions
-// Definitions by: Jack Hsu <https://github.com/jaysoo>, Alex Gorbatchev <https://github.com/alexgorbatchev>
+// Definitions by: Jack Hsu <https://github.com/jaysoo>,
+//                 Alex Gorbatchev <https://github.com/alexgorbatchev>,
+//                 Alec Hill <https://github.com/alechill>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace ReduxActions;
@@ -25,7 +27,7 @@ export interface ReducerMap<State, Payload> {
 }
 
 export interface ReducerMapMeta<State, Payload, Meta> {
-    [actionType: string]: Reducer<State, Payload> | ReducerNextThrow<State, Payload>;
+    [actionType: string]: ReducerMeta<State, Payload, Meta> | ReducerNextThrowMeta<State, Payload, Meta>;
 }
 
 export interface ReducerNextThrow<State, Payload> {
@@ -93,9 +95,33 @@ export function createAction<Payload>(
 
 export function createAction<Payload, Meta>(
     actionType: string,
-    payloadCreator: (...args: any[]) => Payload,
-    metaCreator: (...args: any[]) => Meta
-): (...args: any[]) => ActionMeta<Payload, Meta>;
+    payloadCreator: ActionFunctionAny<Payload>,
+    metaCreator: ActionFunctionAny<Meta>
+): ActionFunctionAny<ActionMeta<Payload, Meta>>;
+
+export function createAction<Payload, Meta, Arg1>(
+    actionType: string,
+    payloadCreator: ActionFunction1<Arg1, Payload>,
+    metaCreator: ActionFunction1<Arg1, Meta>
+): ActionFunction1<Arg1, ActionMeta<Payload, Meta>>;
+
+export function createAction<Payload, Meta, Arg1, Arg2>(
+    actionType: string,
+    payloadCreator: ActionFunction2<Arg1, Arg2, Payload>,
+    metaCreator: ActionFunction2<Arg1, Arg2, Meta>
+): ActionFunction2<Arg1, Arg2, ActionMeta<Payload, Meta>>;
+
+export function createAction<Payload, Meta, Arg1, Arg2, Arg3>(
+    actionType: string,
+    payloadCreator: ActionFunction3<Arg1, Arg2, Arg3, Payload>,
+    metaCreator: ActionFunction3<Arg1, Arg2, Arg3, Meta>
+): ActionFunction3<Arg1, Arg2, Arg3, ActionMeta<Payload, Meta>>;
+
+export function createAction<Payload, Meta, Arg1, Arg2, Arg3, Arg4>(
+    actionType: string,
+    payloadCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Payload>,
+    metaCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Meta>
+): ActionFunction4<Arg1, Arg2, Arg3, Arg4, ActionMeta<Payload, Meta>>;
 
 export function handleAction<State, Payload>(
     actionType: string | ActionFunctions<Payload>,
@@ -118,6 +144,11 @@ export function handleActions<State, Payload>(
     reducerMap: ReducerMap<State, Payload>,
     initialState: State
 ): Reducer<State, Payload>;
+
+export function handleActions<State, Payload, Meta>(
+    reducerMap: ReducerMapMeta<State, Payload, Meta>,
+    initialState: State
+): ReducerMeta<State, Payload, Meta>;
 
 export function combineActions(...actionTypes: Array<ActionFunctions<any> | string>): string;
 

--- a/types/redux-actions/redux-actions-tests.ts
+++ b/types/redux-actions/redux-actions-tests.ts
@@ -89,26 +89,100 @@ const typedActionHandler = ReduxActions.handleAction<TypedState, TypedPayload>(
     {value: 1}
 );
 
-typedState = typedActionHandler({ value: 0 }, typedIncrementAction());
+const actionNoArgs = typedIncrementAction();
+actionNoArgs.payload.increase = 1;
 
-const typedIncrementByActionWithMeta: (value: number) => ReduxActions.ActionMeta<TypedPayload, MetaType> =
-    ReduxActions.createAction<TypedPayload, MetaType>(
-    'INCREMENT_BY',
-        amount => ({ increase: amount }),
-        amount => ({ remote: true })
+typedState = typedActionHandler({ value: 0 }, actionNoArgs);
+
+const typedIncrementAction1TypedArg: (value: number) =>
+    ReduxActions.Action<TypedPayload> = ReduxActions.createAction<TypedPayload, number>(
+        'INCREMENT',
+        amount => ({ increase: amount })
     );
 
-const typedActionHandlerWithReduceMap = ReduxActions.handleAction<TypedState, TypedPayload>(
+const actionFrom1Arg = typedIncrementAction1TypedArg(10);
+actionFrom1Arg.payload.increase === 10;
+
+const typedIncrementAction2TypedArgs: (numericAmount: number, stringAmount: string) =>
+ReduxActions.Action<TypedPayload> = ReduxActions.createAction<TypedPayload, number, string>(
+    'INCREMENT',
+    (numericAmount, stringAmount) => ({ increase: numericAmount + parseInt(stringAmount, 10) })
+);
+
+const actionFrom2Args = typedIncrementAction2TypedArgs(10, '100');
+actionFrom1Arg.payload.increase === 110;
+
+const typedActionHandlerReducerMap = ReduxActions.handleActions<TypedState, TypedPayload>(
+    {
+        INCREMENT: (state: TypedState, action: ReduxActions.Action<TypedPayload>) => ({ value: state.value + 1 })
+    },
+    {value: 1}
+);
+
+typedState = typedActionHandlerReducerMap({ value: 0 }, actionFrom1Arg);
+
+const typedIncrementByActionWithMetaAnyArgs: (...args: any[]) => ReduxActions.ActionMeta<TypedPayload, MetaType> =
+    ReduxActions.createAction<TypedPayload, MetaType>(
+        'INCREMENT_BY',
+        amount => ({ increase: amount }),
+        (_, remote) => ({ remote })
+    );
+
+const actionMetaFromAnyArgs = typedIncrementByActionWithMetaAnyArgs(10, true, 'nic', 'cage');
+actionMetaFromAnyArgs.payload.increase === 10;
+actionMetaFromAnyArgs.meta.remote;
+
+const typedActionHandlerWithMeta = ReduxActions.handleAction<TypedState, TypedPayload, MetaType>(
     'INCREMENT_BY', {
-        next(state: TypedState, action: ReduxActions.Action<TypedPayload>) {
-            return { value: state.value + action.payload.increase };
+        next(state: TypedState, action: ReduxActions.ActionMeta<TypedPayload, MetaType>) {
+            return action.meta.remote ? state : { value: state.value + action.payload.increase };
         },
         throw(state: TypedState) { return state; }
     },
     {value: 1}
 );
 
-typedState = typedActionHandlerWithReduceMap({ value: 0 }, typedIncrementByActionWithMeta(10));
+typedState = typedActionHandlerWithMeta({ value: 0 }, typedIncrementByActionWithMetaAnyArgs(10));
+
+const typedActionHandlerReducerMetaMap = ReduxActions.handleActions<TypedState, TypedPayload, MetaType>(
+    {
+        INCREMENT_BY: {
+            next(state: TypedState, action: ReduxActions.ActionMeta<TypedPayload, MetaType>) {
+                return action.meta.remote ? state : { value: state.value + action.payload.increase };
+            },
+            throw(state: TypedState) { return state; }
+        }
+    },
+    {value: 1}
+);
+
+typedState = typedActionHandlerReducerMetaMap({ value: 0 }, actionMetaFromAnyArgs);
+
+const typedActionWithMeta1TypedArg: (value: number) => ReduxActions.ActionMeta<TypedPayload, MetaType> =
+    ReduxActions.createAction<TypedPayload, MetaType, number>(
+        'INCREMENT_BY',
+        amount => ({ increase: amount }),
+        amount => ({ remote: true })
+    );
+
+const actionMetaFrom1Arg = typedActionWithMeta1TypedArg(10);
+actionMetaFrom1Arg.payload.increase === 10;
+actionMetaFrom1Arg.meta.remote;
+
+typedState = typedActionHandlerReducerMetaMap({ value: 0 }, actionMetaFrom1Arg);
+
+const typedActionWithMeta2TypedArgs: (value: number, remote: boolean) => ReduxActions.ActionMeta<TypedPayload, MetaType> =
+    ReduxActions.createAction<TypedPayload, MetaType, number, boolean>(
+        'INCREMENT_BY',
+        (amount, remote)  => ({ increase: amount }),
+        (amount, remote) => ({ remote })
+    );
+
+const actionMetaFrom2Args = typedActionWithMeta2TypedArgs(10, true);
+actionMetaFrom2Args.payload.increase === 10;
+actionMetaFrom2Args.meta.remote;
+
+typedState = typedActionHandlerReducerMetaMap({ value: 0 }, actionMetaFrom2Args);
 
 const act0 = ReduxActions.createAction('ACTION0');
 act0().payload === null;


### PR DESCRIPTION
…or action meta. Were previously unsafe as could only use the ActionFunctionAny creator for anything that needed a meta. Added missing tests for action function creators, reducer maps, and the new action meta creators

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://redux-actions.js.org/docs/api/createAction.html#createactiontype-payloadcreator-metacreator
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

