### PR TITLE
[webmidi] Add Uint8Array to MIDIOutput send

### DIFF
--- a/types/webmidi/index.d.ts
+++ b/types/webmidi/index.d.ts
@@ -145,7 +145,7 @@ declare namespace WebMidi {
      * to zero (or another time in the past), the data is to be sent as soon as
      * possible.
      */
-    send(data: number[], timestamp?: number): void;
+    send(data: number[] | Uint8Array, timestamp?: number): void;
 
     /**
      * Clears any pending send data that has not yet been sent from the MIDIOutput 's

--- a/types/webmidi/webmidi-tests.ts
+++ b/types/webmidi/webmidi-tests.ts
@@ -20,6 +20,7 @@ const onFulfilled = (item: WebMidi.MIDIAccess) => {
     for (const op of outputs) {
         this._outputs.push(op);
         op.send([ 0x90, 0x45, 0x7f ]);
+        op.send(new Uint8Array([ 0x90, 0x45, 0x7f ]));
     }
 
     for (const input of this._inputs) {


### PR DESCRIPTION
The spec for Web MIDI API MIDIOutput.send at:
https://webaudio.github.io/web-midi-api/#dom-midioutput-send
suggests that both number[] and Uint8Array are acceptable types
for sending data on a MIDI output port.

The relevant text that allows for Uint8Array states:
"... while still enabling use of Uint8Arrays for efficiency in large ..."

An obvious use case is to forward MIDI events received on MIDIInputs as
these are already in the form of a Uint8Array types.

Tested with Chrome 60.0.3112.113 on Mac OS 10.12.6.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://webaudio.github.io/web-midi-api/#dom-midioutput-send
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.