### PR TITLE
react-sticky: added disableCompensation property

### DIFF
--- a/types/react-sticky/index.d.ts
+++ b/types/react-sticky/index.d.ts
@@ -17,6 +17,7 @@ export interface StickyProps {
     topOffset?: number;
     bottomOffset?: number;
     onStickyStateChange?(isSticky: boolean): void;
+    disableCompensation?: boolean;
 }
 
 export const Sticky: React.ComponentClass<StickyProps>;


### PR DESCRIPTION
Set `disableCompensation` to true if you do not want your `<Sticky />` to apply padding to a hidden placeholder `<div />` to correct "jumpiness" as attachment changes from position:fixed and back.