### PR TITLE
Remove React SVG "values" attribute (because it breaks svg with tsx)

### DIFF
--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -3143,7 +3143,6 @@ declare namespace React {
         unicodeRange?: number | string;
         unitsPerEm?: number | string;
         vAlphabetic?: number | string;
-        values?: string;
         vectorEffect?: number | string;
         version?: string;
         vertAdvY?: number | string;


### PR DESCRIPTION
Related to https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19460

The "values" attribute of SVG tags breaks the usage of SVG tags within TSX. The usage of this attribute is uncommon (see issue for details), and the concerned tags (which are actually **not** all SVG tags) seems to be subjects of a larger refactor.

I propose the suppression of the attribute, before a better solution can be found.