### PR TITLE
[react-native-video] Add `onProgress` data

### DIFF
--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-native-video 1.0
+// Type definitions for react-native-video 2.0
 // Project: https://github.com/react-native-community/react-native-video
 // Definitions by: HuHuanming <https://github.com/huhuanming>
+//                 abrahambotros <https://github.com/abrahambotros>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -48,7 +49,10 @@ export interface VideoProperties extends ViewProperties {
     onLoad?(): void;
     onBuffer?(): void;
     onError?(): void;
-    onProgress?(): void;
+    onProgress?(data: {
+        currentTime: number,
+        playableDuration: number,
+    }): void;
     onSeek?(): void;
     onEnd?(): void;
     onFullscreenPlayerWillPresent?(): void;

--- a/types/react-native-video/react-native-video-tests.tsx
+++ b/types/react-native-video/react-native-video-tests.tsx
@@ -27,7 +27,6 @@ class VideoTest extends React.Component {
     }): void => {
         console.log(data.currentTime, data.playableDuration);
     }
-
 }
 
 const styles = StyleSheet.create({

--- a/types/react-native-video/react-native-video-tests.tsx
+++ b/types/react-native-video/react-native-video-tests.tsx
@@ -7,16 +7,27 @@ import {
 } from 'react-native';
 import Video from 'react-native-video';
 
-class SwiperTest extends React.Component {
+class VideoTest extends React.Component {
     constructor(props: {}) {
         super(props);
     }
 
     render(): React.ReactElement<any> {
         return (
-            <Video source={{uri: '//:example.com/test.mp4'}}/>
+            <Video
+                source={{ uri: '//:example.com/test.mp4' }}
+                onProgress={this.onProgress}
+            />
         );
     }
+
+    onProgress = (data: {
+        currentTime: number,
+        playableDuration: number,
+    }): void => {
+        console.log(data.currentTime, data.playableDuration);
+    }
+
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
These changes add `onProgress` data typing to match up with the data returned from native code on progress updates. Only includes the fields in common between all 3 platforms (iOS includes some additional information, but seems not too important to be required to put here and to break platform agnosticism).

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [android](https://github.com/react-native-community/react-native-video/blob/master/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java#L144) [ios](https://github.com/react-native-community/react-native-video/blob/master/ios/RCTVideo.m#L192) [windows](https://github.com/react-native-community/react-native-video/blob/master/windows/ReactNativeVideo/ReactVideoView.cs#L215)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.