### PR TITLE
[prosemirror-commands] Add export for selectNodeBackward

### DIFF
--- a/types/prosemirror-commands/index.d.ts
+++ b/types/prosemirror-commands/index.d.ts
@@ -12,6 +12,7 @@ import { EditorView } from 'prosemirror-view';
 export function deleteSelection(state: EditorState, dispatch?: (tr: Transaction) => void): boolean;
 export function joinBackward(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView): boolean;
 export function selectNodeBackward(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView): boolean;
+export function selectNodeForward(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView): boolean;
 export function joinForward(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView): boolean;
 export function joinUp(state: EditorState, dispatch?: (tr: Transaction) => void): boolean;
 export function joinDown(state: EditorState, dispatch?: (tr: Transaction) => void): boolean;

--- a/types/prosemirror-commands/index.d.ts
+++ b/types/prosemirror-commands/index.d.ts
@@ -11,6 +11,7 @@ import { EditorView } from 'prosemirror-view';
 
 export function deleteSelection(state: EditorState, dispatch?: (tr: Transaction) => void): boolean;
 export function joinBackward(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView): boolean;
+export function selectNodeBackward(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView): boolean;
 export function joinForward(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView): boolean;
 export function joinUp(state: EditorState, dispatch?: (tr: Transaction) => void): boolean;
 export function joinDown(state: EditorState, dispatch?: (tr: Transaction) => void): boolean;

--- a/types/prosemirror-commands/index.d.ts
+++ b/types/prosemirror-commands/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for prosemirror-commands 0.21
+// Type definitions for prosemirror-commands 0.22
 // Project: https://github.com/ProseMirror/prosemirror-commands
 // Definitions by: Bradley Ayers <https://github.com/bradleyayers>
 //                 David Hahn <https://github.com/davidka>


### PR DESCRIPTION
Recent changes to the library have added a `selectNodeBackward`. I have added this to the typescript definition.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.js#L68
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
