### PR TITLE
react-chartjs-2: remove invalid options

### DIFF
--- a/types/react-chartjs-2/test/mix.tsx
+++ b/types/react-chartjs-2/test/mix.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Bar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
 
-const data = {
+const data: ChartData = {
   labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
   datasets: [{
     label: 'Sales',
@@ -22,13 +23,11 @@ const data = {
     fill: false,
     backgroundColor: '#71B37C',
     borderColor: '#71B37C',
-    hoverBackgroundColor: '#71B37C',
-    hoverBorderColor: '#71B37C',
     yAxisID: 'y-axis-1'
   }]
 };
 
-const options = {
+const options: ChartOptions = {
   responsive: true,
   tooltips: {
     mode: 'label'
@@ -44,9 +43,6 @@ const options = {
         display: true,
         gridLines: {
           display: false
-        },
-        labels: {
-          show: true
         }
       }
     ],
@@ -58,9 +54,6 @@ const options = {
         id: 'y-axis-1',
         gridLines: {
           display: false
-        },
-        labels: {
-          show: true
         }
       },
       {
@@ -70,9 +63,6 @@ const options = {
         id: 'y-axis-2',
         gridLines: {
           display: false
-        },
-        labels: {
-          show: true
         }
       }
     ]


### PR DESCRIPTION
*Note: this PR only changes the test case*

`labels` is not a valid option for axes in Chart.js 2.

Also, since the current Chart.js definitions don’t declare `hoverBackgroundColor` and `hoverBorderColor`, I’m removing these, at least temporarily, or else both packages are stuck in a CI deadlock.

(This is blocking #19525, a chart.js update)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://www.chartjs.org/docs/latest/axes/labelling.html>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.