### PR TITLE
camelizeIf and underscoredIf moved from SequelizeLoDash to Utils

### DIFF
--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -6158,8 +6158,6 @@ declare namespace sequelize {
 
     interface SequelizeLoDash extends _.LoDashStatic {
 
-        camelizeIf(str: string, condition: boolean): string;
-        underscoredIf(str: string, condition: boolean): string;
         /**
          * * Returns an array with some falsy values removed. The values null, "", undefined and NaN are considered
          * falsey.
@@ -6173,6 +6171,9 @@ declare namespace sequelize {
 
     interface Utils {
 
+        camelizeIf(str: string, condition: boolean): string;
+        underscoredIf(str: string, condition: boolean): string;
+                     
         _: SequelizeLoDash;
 
         /**


### PR DESCRIPTION
The type definition defines that `underscoredIf` and `camelizeIf` is accessable via `Utils._.underscoredIf`
The correct path would be `Utils.underscoredIf` for a sequelize version '>=3.0.0'

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:   https://github.com/sequelize/sequelize/blob/13427d4937daa811b628b5f6dfcbbebba6d25608/lib/utils.js#L24 