### PR TITLE
minor: add "playsinline" attribute to <video/>

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2778,6 +2778,7 @@ declare namespace React {
         loop?: boolean;
         mediaGroup?: string;
         muted?: boolean;
+        playsinline?: boolean;
         preload?: string;
         src?: string;
     }

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -2744,6 +2744,7 @@ declare namespace React {
         loop?: boolean;
         mediaGroup?: string;
         muted?: boolean;
+        playsinline?: boolean;
         preload?: string;
         src?: string;
     }


### PR DESCRIPTION
(new PR to replace https://github.com/DefinitelyTyped/DefinitelyTyped/pull/19403)

`<video />` accepts a `playsinline` attribute now in WebKit: https://webkit.org/blog/6784/new-video-policies-for-ios/

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webkit.org/blog/6784/new-video-policies-for-ios/
