### PR TITLE
[openlayers] Adding missing options on PinchZoom and MouseWheelZoom

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -12578,11 +12578,15 @@ declare module olx {
 
 
         /**
-         * @typedef {{duration: (number|undefined),
+         * @typedef {{constrainResolution: (boolean|undefined),
+         *     duration: (number|undefined),
+         *     timeout: (number|undefined),
          *     useAnchor: (boolean|undefined)}}
          */
         interface MouseWheelZoomOptions {
+            constrainResolution?: boolean;
             duration?: number;
+            timeout?: number;
             useAnchor?: boolean;
         }
 
@@ -12598,9 +12602,11 @@ declare module olx {
 
 
         /**
-         * @typedef {{duration: (number|undefined)}}
+         * @typedef {{constrainResolution: (boolean|undefined)
+         *     duration: (number|undefined)}}
          */
         interface PinchZoomOptions {
+            constrainResolution?: boolean;
             duration?: number;
         }
 

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -717,6 +717,17 @@ const select: ol.interaction.Select = new ol.interaction.Select({
     layers: (layer: ol.layer.Layer) => true,
 });
 
+let pinchZoom: ol.interaction.PinchZoom = new ol.interaction.PinchZoom({
+    constrainResolution: booleanValue,
+    duration: numberValue
+});
+
+let mouseWheelZoom: ol.interaction.MouseWheelZoom = new ol.interaction.MouseWheelZoom({
+    constrainResolution: booleanValue,
+    duration: numberValue,
+    timeout: numberValue,
+    useAnchor: booleanValue
+});
 //
 // ol.style.RegularShape
 //


### PR DESCRIPTION
Several options on olx.interaction.PinchZoomOptions and olx.interaction.MouseWheelZoomOptions were missing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/openlayers/openlayers/blob/master/src/ol/interaction/mousewheelzoom.js
https://github.com/openlayers/openlayers/blob/master/src/ol/interaction/pinchzoom.js
- [ ] Increase the version number in the header if appropriate.
N/A
