### PR TITLE
[highland] add `ratelimit` method for streams

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -231,6 +231,8 @@ barStream = fooStream.map((x: Foo) => {
 
 barStream = fooStream.pluck<Bar>(str);
 
+barStream = fooStream.ratelimit(3, 1000);
+
 barStream = fooStream.reduce(bar, (memo: Bar, x: Foo) => {
 	return memo;
 });

--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -231,7 +231,7 @@ barStream = fooStream.map((x: Foo) => {
 
 barStream = fooStream.pluck<Bar>(str);
 
-barStream = fooStream.ratelimit(3, 1000);
+fooStream = fooStream.ratelimit(3, 1000);
 
 barStream = fooStream.reduce(bar, (memo: Bar, x: Foo) => {
 	return memo;

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -783,7 +783,7 @@ declare namespace Highland {
 		 * // after 100ms => 1, 2, 3, 4
 		 * // after 200ms => 1, 2, 3, 4, 5
 		 */
-		ratelimit<U>(num: number, ms: number): Stream<U>;
+		ratelimit<R>(num: number, ms: number): Stream<R>;
 
 		/**
 		 * Boils down a Stream to a single value. The memo is the initial state

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -783,7 +783,7 @@ declare namespace Highland {
 		 * // after 100ms => 1, 2, 3, 4
 		 * // after 200ms => 1, 2, 3, 4, 5
 		 */
-		ratelimit<R>(num: number, ms: number): Stream<R>;
+		ratelimit(num: number, ms: number): Stream<R>;
 
 		/**
 		 * Boils down a Stream to a single value. The memo is the initial state

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -766,6 +766,26 @@ declare namespace Highland {
 		pluck<U>(prop: string): Stream<U>;
 
 		/**
+		 * Limits number of values through the stream to a maximum of number of values
+		 * per window. Errors are not limited but allowed to pass through as soon as
+		 * they are read from the source.
+		 *
+		 * @id ratelimit
+		 * @section Transforms
+		 * @name Stream.ratelimit(num, ms)
+		 * @param {Number} num - the number of operations to perform per window
+		 * @param {Number} ms - the window of time to limit the operations in (in ms)
+		 * @api public
+		 *
+		 * _([1, 2, 3, 4, 5]).ratelimit(2, 100);
+		 *
+		 * // after 0ms => 1, 2
+		 * // after 100ms => 1, 2, 3, 4
+		 * // after 200ms => 1, 2, 3, 4, 5
+		 */
+		ratelimit<U>(num: number, ms: number): Stream<U>;
+
+		/**
 		 * Boils down a Stream to a single value. The memo is the initial state
 		 * of the reduction, and each successive step of it should be returned by
 		 * the iterator function. The iterator is passed two arguments:


### PR DESCRIPTION
`ratelimit()` method was missing, so here it is.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://highlandjs.org/#ratelimit>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. _(n/a)_
