### PR TITLE
Added missing method to PhoneNumberUtil in google-libphonenumber

### DIFF
--- a/types/google-libphonenumber/index.d.ts
+++ b/types/google-libphonenumber/index.d.ts
@@ -100,6 +100,14 @@ declare namespace libphonenumber {
             TOO_SHORT,
             TOO_LONG
         }
+
+        export enum MatchType {
+            EXACT_MATCH,
+            NO_MATCH,
+            NOT_A_NUMBER,
+            NSN_MATCH,
+            SHORT_NSN_MATCH
+        }
     }
 
     export class PhoneNumberUtil {
@@ -124,6 +132,7 @@ declare namespace libphonenumber {
         parse(number?: string, region?: string): PhoneNumber;
         parseAndKeepRawInput(number: string, regionCode?: string): PhoneNumber;
         truncateTooLongNumber(number: PhoneNumber): boolean;
+        isNumberMatch(firstNumber: string, secondNumber: string): PhoneNumberUtil.MatchType;
     }
 
     export class AsYouTypeFormatter {

--- a/types/google-libphonenumber/index.d.ts
+++ b/types/google-libphonenumber/index.d.ts
@@ -132,7 +132,7 @@ declare namespace libphonenumber {
         parse(number?: string, region?: string): PhoneNumber;
         parseAndKeepRawInput(number: string, regionCode?: string): PhoneNumber;
         truncateTooLongNumber(number: PhoneNumber): boolean;
-        isNumberMatch(firstNumber: string, secondNumber: string): PhoneNumberUtil.MatchType;
+        isNumberMatch(firstNumber: string | PhoneNumber, secondNumber: string | PhoneNumber): PhoneNumberUtil.MatchType;
     }
 
     export class AsYouTypeFormatter {


### PR DESCRIPTION
I only found Javadoc for the library but you can look at [the source](https://github.com/googlei18n/libphonenumber/blob/98cb04aced00f7cb1b2af7993edbc0e7610141ed/javascript/i18n/phonenumbers/phonenumberutil.js#L4376) and see that it's the right parameters