### PR TITLE
add getSupportedRegions() in class PhoneNumberUtil

### DIFF
--- a/types/google-libphonenumber/index.d.ts
+++ b/types/google-libphonenumber/index.d.ts
@@ -109,6 +109,7 @@ declare namespace libphonenumber {
         getNumberType(phoneNumber: PhoneNumber): PhoneNumberType;
         getRegionCodeForCountryCode(countryCallingCode: number): string;
         getRegionCodeForNumber(phoneNumber: PhoneNumber): string | undefined;
+        getSupportedRegions():string [];
         isAlphaNumber(number: string): boolean;
         isLeadingZeroPossible(countryCallingCode: number): boolean;
         isNANPACountry(regionCode?: string): boolean;


### PR DESCRIPTION
`getSupportedRegions() `was not included in Interface of `PhoneNumberUtil`
