### PR TITLE
Use inherited `writeHead` method signature

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -919,15 +919,6 @@ export interface Response extends http.ServerResponse {
      */
     toString(): string;
 
-    /**
-     * pass through to native response.writeHead().
-     * @public
-     * @function writeHead
-     * @emits    header
-     * @returns  {undefined}
-     */
-    writeHead(): void;
-
     /** redirect is sugar method for redirecting.
      * res.redirect(301, 'www.foo.com', next);
      * `next` is mandatory, to complete the response and trigger audit logger.

--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -95,7 +95,10 @@ function send(req: restify.Request, res: restify.Response, next: restify.Next) {
     res.id === 'test';
 
     res.send('hello ' + req.params.name);
-    res.writeHead();
+    res.writeHead(200);
+    res.writeHead(200, {
+        "Content-Type": "application/json"
+    });
     return next();
 }
 


### PR DESCRIPTION
The `writeHead` method gets passed through to the native `response.writeHead`. The `Response` interface extends `http.ServerResponse` which defined the `writeHead` method with different arguments. For maintainability reasons, we should just use the inherited method. Also, the current definition makes this method useless (`writeHead` expects at lease one argument).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/restify/node-restify/blob/master/lib/response.js#L512-L530
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
