### PR TITLE
Update Dockerode options types

### DIFF
--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -11,13 +11,30 @@ const docker4 = new Docker({ host: '127.0.0.1', port: 3000 });
 const docker5 = new Docker({
   host: '192.168.1.10',
   port: process.env.DOCKER_PORT || 2375,
+  ca: 'ca',
+  cert: 'cert',
+  key: 'key'
+});
+
+const docker6 = new Docker({
+  protocol: 'https', // you can enforce a protocol
+  host: '192.168.1.10',
+  port: process.env.DOCKER_PORT || 2375,
+  ca: 'ca',
+  cert: 'cert',
+  key: 'key'
+});
+
+const docker7 = new Docker({
+  host: '192.168.1.10',
+  port: process.env.DOCKER_PORT || 2375,
   ca: fs.readFileSync('ca.pem'),
   cert: fs.readFileSync('cert.pem'),
   key: fs.readFileSync('key.pem'),
   version: 'v1.25' // required when Docker >= v1.13, https://docs.docker.com/engine/api/version-history/
 });
 
-const docker6 = new Docker({
+const docker8 = new Docker({
   protocol: 'https', // you can enforce a protocol
   host: '192.168.1.10',
   port: process.env.DOCKER_PORT || 2375,
@@ -26,7 +43,7 @@ const docker6 = new Docker({
   key: fs.readFileSync('key.pem')
 });
 
-const docker7 = new Docker({
+const docker9 = new Docker({
   Promise
 });
 

--- a/types/dockerode/dockerode-tests.ts
+++ b/types/dockerode/dockerode-tests.ts
@@ -1,4 +1,5 @@
 import * as Docker from 'dockerode';
+import * as fs from 'fs';
 
 // Code samples from Dockerode 'Getting started'
 const docker = new Docker();
@@ -10,18 +11,19 @@ const docker4 = new Docker({ host: '127.0.0.1', port: 3000 });
 const docker5 = new Docker({
   host: '192.168.1.10',
   port: process.env.DOCKER_PORT || 2375,
-  ca: 'ca',
-  cert: 'cert',
-  key: 'key'
+  ca: fs.readFileSync('ca.pem'),
+  cert: fs.readFileSync('cert.pem'),
+  key: fs.readFileSync('key.pem'),
+  version: 'v1.25' // required when Docker >= v1.13, https://docs.docker.com/engine/api/version-history/
 });
 
 const docker6 = new Docker({
   protocol: 'https', // you can enforce a protocol
   host: '192.168.1.10',
   port: process.env.DOCKER_PORT || 2375,
-  ca: 'ca',
-  cert: 'cert',
-  key: 'key'
+  ca: fs.readFileSync('ca.pem'),
+  cert: fs.readFileSync('cert.pem'),
+  key: fs.readFileSync('key.pem')
 });
 
 const docker7 = new Docker({

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -659,9 +659,9 @@ declare namespace Dockerode {
     socketPath?: string;
     host?: string;
     port?: number | string;
-    ca?: Buffer;
-    cert?: Buffer;
-    key?: Buffer;
+    ca?: string | string[] | Buffer | Buffer[];
+    cert?: string | string[] | Buffer | Buffer[];
+    key?: string | string[] | Buffer | Buffer[];
     protocol?: "https" | "http";
     timeout?: number;
     version?: string;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -658,11 +658,12 @@ declare namespace Dockerode {
     socketPath?: string;
     host?: string;
     port?: number | string;
-    ca?: string;
-    cert?: string;
-    key?: string;
+    ca?: Buffer;
+    cert?: Buffer;
+    key?: Buffer;
     protocol?: "https" | "http";
     timeout?: number;
+    version?: string;
     Promise?: typeof Promise;
   }
 

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for dockerode 2.4
+// Type definitions for dockerode 2.5
 // Project: https://github.com/apocas/dockerode
 // Definitions by: Carl Winkler <https://github.com/seikho>
 //                 Nicolas Laplante <https://github.com/nlaplante>

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -655,13 +655,18 @@ declare namespace Dockerode {
     };
   }
 
+  interface KeyObject {
+    pem: string | Buffer;
+    passphrase?: string;
+  }
+
   interface DockerOptions {
     socketPath?: string;
     host?: string;
     port?: number | string;
     ca?: string | string[] | Buffer | Buffer[];
     cert?: string | string[] | Buffer | Buffer[];
-    key?: string | string[] | Buffer | Buffer[];
+    key?: string | string[] | Buffer | Buffer[] | KeyObject[];
     protocol?: "https" | "http";
     timeout?: number;
     version?: string;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Carl Winkler <https://github.com/seikho>
 //                 Nicolas Laplante <https://github.com/nlaplante>
 //                 ByeongHun Yoo <https://github.com/isac322>
+//                 Ray Fang <https://github.com/lazarusx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 


### PR DESCRIPTION
According to the [README](https://github.com/apocas/dockerode/blob/master/README.md#getting-started) of Dockerode, `ca`, `cert`, and `key` parameters of `DockerOptions` should be buffers loaded by `fs.readFileSync()`, instead of file name strings.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apocas/dockerode/blob/master/README.md#getting-started
- [x] Increase the version number in the header if appropriate.
- [ ] (N/A) If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.