### PR TITLE
Add `export as namespace` on markdown-it

### DIFF
--- a/types/markdown-it/index.d.ts
+++ b/types/markdown-it/index.d.ts
@@ -14,6 +14,7 @@ interface MarkdownItStatic {
 
 declare var MarkdownIt: MarkdownItStatic;
 export = MarkdownIt;
+export as namespace markdownit;
 
 declare module MarkdownIt {
     interface MarkdownIt {


### PR DESCRIPTION
...as markdown-it supports exposing as a global namespace. (See https://github.com/markdown-it/markdown-it)