### PR TITLE
d3-scale-chromatic - Adding missing schemes

### DIFF
--- a/types/d3-scale-chromatic/d3-scale-chromatic-tests.ts
+++ b/types/d3-scale-chromatic/d3-scale-chromatic-tests.ts
@@ -33,6 +33,16 @@ const RdYlBu: string = d3ScaleChromatic.interpolateRdYlBu(0); // rgb(103, 0, 31)
 const RdYlGn: string = d3ScaleChromatic.interpolateRdYlGn(0); // rgb(103, 0, 31)
 const Spectral: string = d3ScaleChromatic.interpolateSpectral(0); // rgb(158, 1, 66)
 
+const schemeBrBG: string = d3ScaleChromatic.schemeBrBG[3][0]; // #d8b365
+const schemePRGn: string = d3ScaleChromatic.schemePRGn[3][0]; // #af8dc3
+const schemePiYG: string = d3ScaleChromatic.schemePiYG[3][0]; // #e9a3c9
+const schemePuOr: string = d3ScaleChromatic.schemePuOr[3][0]; // #998ec3
+const schemeRdBu: string = d3ScaleChromatic.schemeRdBu[3][0]; // #ef8a62
+const schemeRdGy: string = d3ScaleChromatic.schemeRdGy[3][0]; // #ef8a62
+const schemeRdYlBu: string = d3ScaleChromatic.schemeRdYlBu[3][0]; // #fc8d59
+const schemeRdYlGn: string = d3ScaleChromatic.schemeRdYlGn[3][0]; // #fc8d59
+const schemeSpectral: string = d3ScaleChromatic.schemeSpectral[3][0]; // #fc8d59
+
 // -----------------------------------------------------------------------
 // Sequential
 // -----------------------------------------------------------------------
@@ -42,6 +52,13 @@ const Grey: string = d3ScaleChromatic.interpolateGreys(1); // rgb(0, 0, 0)
 const Orange: string = d3ScaleChromatic.interpolateOranges(1); // rgb(127, 39, 4)
 const Purple: string = d3ScaleChromatic.interpolatePurples(1); // rgb(63, 0, 125)
 const Red: string = d3ScaleChromatic.interpolateReds(1); // rgb(103, 0, 13)
+
+const schemeBlues: string = d3ScaleChromatic.schemeBlues[3][0]; // #deebf7
+const schemeGreens: string = d3ScaleChromatic.schemeGreens[3][0]; // #e5f5e0
+const schemeGreys: string = d3ScaleChromatic.schemeGreys[3][0]; // #f0f0f0
+const schemeOranges: string = d3ScaleChromatic.schemeOranges[3][0]; // #fee6ce
+const schemePurples: string = d3ScaleChromatic.schemePurples[3][0]; // #efedf5
+const schemeReds: string = d3ScaleChromatic.schemeReds[3][0]; // #fee0d2
 
 // -----------------------------------------------------------------------
 // Sequential(Multi-Hue)
@@ -58,3 +75,16 @@ const YlGnBu: string = d3ScaleChromatic.interpolateYlGnBu(1); // rgb(8, 29, 88)
 const YlGn: string = d3ScaleChromatic.interpolateYlGn(1); // rgb(0, 69, 41)
 const YlOrBr: string = d3ScaleChromatic.interpolateYlOrBr(1); // rgb(102, 37, 6)
 const YlOrRd: string = d3ScaleChromatic.interpolateYlOrRd(1); // rgb(128, 0, 38)
+
+const schemeBuGn: string = d3ScaleChromatic.schemeBuGn[3][0]; // #e5f5f9
+const schemeBuPu: string = d3ScaleChromatic.schemeBuPu[3][0]; // #e0ecf4
+const schemeGnBu: string = d3ScaleChromatic.schemeGnBu[3][0]; // #e0f3db
+const schemeOrRd: string = d3ScaleChromatic.schemeOrRd[3][0]; // #fee8c8
+const schemePuBuGn: string = d3ScaleChromatic.schemePuBuGn[3][0]; // #ece2f0
+const schemePuBu: string = d3ScaleChromatic.schemePuBu[3][0]; // #ece7f2
+const schemePuRd: string = d3ScaleChromatic.schemePuRd[3][0]; // #e7e1ef
+const schemeRdPu: string = d3ScaleChromatic.schemeRdPu[3][0]; // #fde0dd
+const schemeYlGnBu: string = d3ScaleChromatic.schemeYlGnBu[3][0]; // #edf8b1
+const schemeYlGn: string = d3ScaleChromatic.schemeYlGn[3][0]; // #f7fcb9
+const schemeYlOrBr: string = d3ScaleChromatic.schemeYlOrBr[3][0]; // #fff7bc
+const schemeYlOrRd: string = d3ScaleChromatic.schemeYlOrRd[3][0]; // #ffeda0

--- a/types/d3-scale-chromatic/index.d.ts
+++ b/types/d3-scale-chromatic/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3-scale-chromatic module 1.0
 // Project: https://github.com/d3/d3-scale-chromatic/
-// Definitions by: Hugues Stefanski <https://github.com/Ledragon>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Hugues Stefanski <https://github.com/Ledragon>,
+//                 Alex Ford <https://github.com/gustavderdrache>,
+//                 Boris Yankov <https://github.com/borisyankov>,
+//                 Henrique Machado <https://github.com/henriquefm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 1.0.2
@@ -45,53 +48,83 @@ export const schemeSet3: string[];
 // Diverging
 // -----------------------------------------------------------------------
 /**
+ * Diverging color schemes are available as continuous interpolators (often used with d3.scaleSequential) and as discrete schemes
+ *  (often used with d3.scaleOrdinal). Each discrete scheme, such as d3.schemeBrBG, is represented as an array of arrays of hexadecimal
+ *  color strings. The kth element of this array contains the color scheme of size k; for example, d3.schemeBrBG[9] contains an array
+ *  of nine strings representing the nine colors of the brown-blue-green diverging color scheme. Diverging color schemes support
+ *  a size k ranging from 3 to 11.
+ *
  * Given a number value in the range [0,1], returns the corresponding color from the “BrBG” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateBrBG(value: number): string;
+
+export const schemeBrBG: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PRGn” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolatePRGn(value: number): string;
+
+export const schemePRGn: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PiYG” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolatePiYG(value: number): string;
+
+export const schemePiYG: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PuOr” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolatePuOr(value: number): string;
+
+export const schemePuOr: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdBu” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateRdBu(value: number): string;
+
+export const schemeRdBu: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdGy” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateRdGy(value: number): string;
+
+export const schemeRdGy: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdYlBu” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateRdYlBu(value: number): string;
+
+export const schemeRdYlBu: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdYlGn” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateRdYlGn(value: number): string;
+
+export const schemeRdYlGn: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Spectral” diverging color scheme represented as an RGB string.
  *
@@ -99,39 +132,62 @@ export function interpolateRdYlGn(value: number): string;
  */
 export function interpolateSpectral(value: number): string;
 
+export const schemeSpectral: string[][];
+
 // -----------------------------------------------------------------------
 // Sequential
 // -----------------------------------------------------------------------
 /**
+ * Sequential, single-hue color schemes are available as continuous interpolators (often used with d3.scaleSequential) and
+ *  as discrete schemes (often used with d3.scaleOrdinal). Each discrete scheme, such as d3.schemeBlues, is represented as
+ *  an array of arrays of hexadecimal color strings. The kth element of this array contains the color scheme of size k; for example,
+ *  d3.schemeBlues[9] contains an array of nine strings representing the nine colors of the blue sequential color scheme.
+ *  Sequential, single-hue color schemes support a size k ranging from 3 to 9.
+ *
  * Given a number t in the range [0,1], returns the corresponding color from the “Blues” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateBlues(value: number): string;
+
+export const schemeBlues: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Greens” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateGreens(value: number): string;
+
+export const schemeGreens: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Greys” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateGreys(value: number): string;
+
+export const schemeGreys: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Oranges” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateOranges(value: number): string;
+
+export const schemeOranges: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Purples” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolatePurples(value: number): string;
+
+export const schemePurples: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Reds” sequential color scheme represented as an RGB string.
  *
@@ -139,79 +195,122 @@ export function interpolatePurples(value: number): string;
  */
 export function interpolateReds(value: number): string;
 
+export const schemeReds: string[][];
+
 // -----------------------------------------------------------------------
 // Sequential(Multi-Hue)
 // -----------------------------------------------------------------------
 
 /**
+ * Sequential, multi-hue color schemes are available as continuous interpolators (often used with d3.scaleSequential) and
+ *  as discrete schemes (often used with d3.scaleOrdinal). Each discrete scheme, such as d3.schemeBuGn, is represented as
+ *  an array of arrays of hexadecimal color strings. The kth element of this array contains the color scheme of size k; for example,
+ *  d3.schemeBuGn[9] contains an array of nine strings representing the nine colors of the blue-green sequential color scheme.
+ *  Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ *
  * Given a number t in the range [0,1], returns the corresponding color from the “BuGn” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateBuGn(value: number): string;
+
+export const schemeBuGn: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “BuPu” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateBuPu(value: number): string;
+
+export const schemeBuPu: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “GnBu” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateGnBu(value: number): string;
+
+export const schemeGnBu: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “OrRd” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateOrRd(value: number): string;
+
+export const schemeOrRd: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PuBuGn” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolatePuBuGn(value: number): string;
+
+export const schemePuBuGn: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PuBu” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolatePuBu(value: number): string;
+
+export const schemePuBu: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PuRd” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolatePuRd(value: number): string;
+
+export const schemePuRd: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdPu” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateRdPu(value: number): string;
+
+export const schemeRdPu: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “YlGnBu” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateYlGnBu(value: number): string;
+
+export const schemeYlGnBu: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “YlGn” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateYlGn(value: number): string;
+
+export const schemeYlGn: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “YlOrBr” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateYlOrBr(value: number): string;
+
+export const schemeYlOrBr: string[][];
+
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “YlOrRd” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateYlOrRd(value: number): string;
+
+export const schemeYlOrRd: string[][];

--- a/types/d3-scale-chromatic/index.d.ts
+++ b/types/d3-scale-chromatic/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for D3JS d3-scale-chromatic module 1.0
+// Type definitions for D3JS d3-scale-chromatic module 1.1
 // Project: https://github.com/d3/d3-scale-chromatic/
 // Definitions by: Hugues Stefanski <https://github.com/Ledragon>,
 //                 Alex Ford <https://github.com/gustavderdrache>,
@@ -14,53 +14,52 @@
 /**
  * An array of eight categorical colors represented as RGB hexadecimal strings.
  */
-export const schemeAccent: string[];
+export const schemeAccent: ReadonlyArray<string>;
 /**
  * An array of eight categorical colors represented as RGB hexadecimal strings.
  */
-export const schemeDark2: string[];
+export const schemeDark2: ReadonlyArray<string>;
 /**
  * An array of twelve categorical colors represented as RGB hexadecimal strings.
  */
-export const schemePaired: string[];
+export const schemePaired: ReadonlyArray<string>;
 /**
  * An array of nine categorical colors represented as RGB hexadecimal strings.
  */
-export const schemePastel1: string[];
+export const schemePastel1: ReadonlyArray<string>;
 /**
  * An array of eight categorical colors represented as RGB hexadecimal strings.
  */
-export const schemePastel2: string[];
+export const schemePastel2: ReadonlyArray<string>;
 /**
  * An array of nine categorical colors represented as RGB hexadecimal strings.
  */
-export const schemeSet1: string[];
+export const schemeSet1: ReadonlyArray<string>;
 /**
  * An array of eight categorical colors represented as RGB hexadecimal strings.
  */
-export const schemeSet2: string[];
+export const schemeSet2: ReadonlyArray<string>;
 /**
  * An array of twelve categorical colors represented as RGB hexadecimal strings.
  */
-export const schemeSet3: string[];
+export const schemeSet3: ReadonlyArray<string>;
 
 // -----------------------------------------------------------------------
 // Diverging
 // -----------------------------------------------------------------------
 /**
- * Diverging color schemes are available as continuous interpolators (often used with d3.scaleSequential) and as discrete schemes
- *  (often used with d3.scaleOrdinal). Each discrete scheme, such as d3.schemeBrBG, is represented as an array of arrays of hexadecimal
- *  color strings. The kth element of this array contains the color scheme of size k; for example, d3.schemeBrBG[9] contains an array
- *  of nine strings representing the nine colors of the brown-blue-green diverging color scheme. Diverging color schemes support
- *  a size k ranging from 3 to 11.
- *
  * Given a number value in the range [0,1], returns the corresponding color from the “BrBG” diverging color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateBrBG(value: number): string;
 
-export const schemeBrBG: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “BrBG” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeBrBG[9] contains an array of nine strings representing the nine colors of the
+ *  brown-blue-green diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemeBrBG: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PRGn” diverging color scheme represented as an RGB string.
@@ -69,7 +68,12 @@ export const schemeBrBG: string[][];
  */
 export function interpolatePRGn(value: number): string;
 
-export const schemePRGn: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “PRGn” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemePRGn[9] contains an array of nine strings representing the nine colors of the
+ *  purple-green diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemePRGn: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PiYG” diverging color scheme represented as an RGB string.
@@ -78,7 +82,12 @@ export const schemePRGn: string[][];
  */
 export function interpolatePiYG(value: number): string;
 
-export const schemePiYG: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “PiYG” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemePiYG[9] contains an array of nine strings representing the nine colors of the
+ *  pink-yellow-green diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemePiYG: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PuOr” diverging color scheme represented as an RGB string.
@@ -87,7 +96,12 @@ export const schemePiYG: string[][];
  */
 export function interpolatePuOr(value: number): string;
 
-export const schemePuOr: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “PuOr” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemePuOr[9] contains an array of nine strings representing the nine colors of the
+ *  purple-orange diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemePuOr: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdBu” diverging color scheme represented as an RGB string.
@@ -96,7 +110,12 @@ export const schemePuOr: string[][];
  */
 export function interpolateRdBu(value: number): string;
 
-export const schemeRdBu: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “RdBu” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeRdBu[9] contains an array of nine strings representing the nine colors of the
+ *  red-blue diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemeRdBu: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdGy” diverging color scheme represented as an RGB string.
@@ -105,7 +124,12 @@ export const schemeRdBu: string[][];
  */
 export function interpolateRdGy(value: number): string;
 
-export const schemeRdGy: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “RdGy” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeRdGy[9] contains an array of nine strings representing the nine colors of the
+ *  red-grey diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemeRdGy: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdYlBu” diverging color scheme represented as an RGB string.
@@ -114,7 +138,12 @@ export const schemeRdGy: string[][];
  */
 export function interpolateRdYlBu(value: number): string;
 
-export const schemeRdYlBu: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “RdYlBu” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeRdYlBu[9] contains an array of nine strings representing the nine colors of the
+ *  red-yellow-blue diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemeRdYlBu: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdYlGn” diverging color scheme represented as an RGB string.
@@ -123,7 +152,12 @@ export const schemeRdYlBu: string[][];
  */
 export function interpolateRdYlGn(value: number): string;
 
-export const schemeRdYlGn: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “RdYlGn” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeRdYlGn[9] contains an array of nine strings representing the nine colors of the
+ *  red-yellow-green diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemeRdYlGn: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Spectral” diverging color scheme represented as an RGB string.
@@ -132,25 +166,29 @@ export const schemeRdYlGn: string[][];
  */
 export function interpolateSpectral(value: number): string;
 
-export const schemeSpectral: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “Spectral” diverging color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeSpectral[9] contains an array of nine strings representing the nine colors of the
+ *  spectral diverging color scheme. Diverging color schemes support a size k ranging from 3 to 11.
+ */
+export const schemeSpectral: ReadonlyArray<ReadonlyArray<string>>;
 
 // -----------------------------------------------------------------------
 // Sequential
 // -----------------------------------------------------------------------
 /**
- * Sequential, single-hue color schemes are available as continuous interpolators (often used with d3.scaleSequential) and
- *  as discrete schemes (often used with d3.scaleOrdinal). Each discrete scheme, such as d3.schemeBlues, is represented as
- *  an array of arrays of hexadecimal color strings. The kth element of this array contains the color scheme of size k; for example,
- *  d3.schemeBlues[9] contains an array of nine strings representing the nine colors of the blue sequential color scheme.
- *  Sequential, single-hue color schemes support a size k ranging from 3 to 9.
- *
  * Given a number t in the range [0,1], returns the corresponding color from the “Blues” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateBlues(value: number): string;
 
-export const schemeBlues: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “Blues” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeBlues[9] contains an array of nine strings representing the nine colors of the
+ *  blue sequential color scheme. Sequential, single-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeBlues: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Greens” sequential color scheme represented as an RGB string.
@@ -159,7 +197,12 @@ export const schemeBlues: string[][];
  */
 export function interpolateGreens(value: number): string;
 
-export const schemeGreens: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “Greens” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeGreens[9] contains an array of nine strings representing the nine colors of the
+ *  green sequential color scheme. Sequential, single-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeGreens: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Greys” sequential color scheme represented as an RGB string.
@@ -168,7 +211,12 @@ export const schemeGreens: string[][];
  */
 export function interpolateGreys(value: number): string;
 
-export const schemeGreys: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “Greys” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeGreys[9] contains an array of nine strings representing the nine colors of the
+ *  grey sequential color scheme. Sequential, single-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeGreys: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Oranges” sequential color scheme represented as an RGB string.
@@ -177,7 +225,12 @@ export const schemeGreys: string[][];
  */
 export function interpolateOranges(value: number): string;
 
-export const schemeOranges: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “Oranges” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeOranges[9] contains an array of nine strings representing the nine colors of the
+ *  orange sequential color scheme. Sequential, single-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeOranges: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Purples” sequential color scheme represented as an RGB string.
@@ -186,7 +239,12 @@ export const schemeOranges: string[][];
  */
 export function interpolatePurples(value: number): string;
 
-export const schemePurples: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “Purples” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemePurples[9] contains an array of nine strings representing the nine colors of the
+ *  purple sequential color scheme. Sequential, single-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemePurples: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “Reds” sequential color scheme represented as an RGB string.
@@ -195,26 +253,30 @@ export const schemePurples: string[][];
  */
 export function interpolateReds(value: number): string;
 
-export const schemeReds: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “Reds” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeReds[9] contains an array of nine strings representing the nine colors of the
+ *  red sequential color scheme. Sequential, single-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeReds: ReadonlyArray<ReadonlyArray<string>>;
 
 // -----------------------------------------------------------------------
 // Sequential(Multi-Hue)
 // -----------------------------------------------------------------------
 
 /**
- * Sequential, multi-hue color schemes are available as continuous interpolators (often used with d3.scaleSequential) and
- *  as discrete schemes (often used with d3.scaleOrdinal). Each discrete scheme, such as d3.schemeBuGn, is represented as
- *  an array of arrays of hexadecimal color strings. The kth element of this array contains the color scheme of size k; for example,
- *  d3.schemeBuGn[9] contains an array of nine strings representing the nine colors of the blue-green sequential color scheme.
- *  Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
- *
  * Given a number t in the range [0,1], returns the corresponding color from the “BuGn” sequential color scheme represented as an RGB string.
  *
  * @param value Number in the range [0, 1].
  */
 export function interpolateBuGn(value: number): string;
 
-export const schemeBuGn: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “BuGn” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeBuGn[9] contains an array of nine strings representing the nine colors of the
+ *  blue-green sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeBuGn: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “BuPu” sequential color scheme represented as an RGB string.
@@ -223,7 +285,12 @@ export const schemeBuGn: string[][];
  */
 export function interpolateBuPu(value: number): string;
 
-export const schemeBuPu: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “BuPu” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeBuPu[9] contains an array of nine strings representing the nine colors of the
+ *  blue-purple sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeBuPu: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “GnBu” sequential color scheme represented as an RGB string.
@@ -232,7 +299,12 @@ export const schemeBuPu: string[][];
  */
 export function interpolateGnBu(value: number): string;
 
-export const schemeGnBu: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “GnBu” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeGnBu[9] contains an array of nine strings representing the nine colors of the
+ *  green-blue sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeGnBu: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “OrRd” sequential color scheme represented as an RGB string.
@@ -241,7 +313,12 @@ export const schemeGnBu: string[][];
  */
 export function interpolateOrRd(value: number): string;
 
-export const schemeOrRd: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “OrRd” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeOrRd[9] contains an array of nine strings representing the nine colors of the
+ *  orange-red sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeOrRd: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PuBuGn” sequential color scheme represented as an RGB string.
@@ -250,7 +327,12 @@ export const schemeOrRd: string[][];
  */
 export function interpolatePuBuGn(value: number): string;
 
-export const schemePuBuGn: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “PuBuGn” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemePuBuGn[9] contains an array of nine strings representing the nine colors of the
+ *  purple-blue-green sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemePuBuGn: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PuBu” sequential color scheme represented as an RGB string.
@@ -259,7 +341,12 @@ export const schemePuBuGn: string[][];
  */
 export function interpolatePuBu(value: number): string;
 
-export const schemePuBu: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “PuBu” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemePuBu[9] contains an array of nine strings representing the nine colors of the
+ *  purple-blue sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemePuBu: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “PuRd” sequential color scheme represented as an RGB string.
@@ -268,7 +355,12 @@ export const schemePuBu: string[][];
  */
 export function interpolatePuRd(value: number): string;
 
-export const schemePuRd: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “PuRd” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemePuRd[9] contains an array of nine strings representing the nine colors of the
+ *  purple-red sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemePuRd: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “RdPu” sequential color scheme represented as an RGB string.
@@ -277,7 +369,12 @@ export const schemePuRd: string[][];
  */
 export function interpolateRdPu(value: number): string;
 
-export const schemeRdPu: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “RdPu” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeRdPu[9] contains an array of nine strings representing the nine colors of the
+ *  red-purple sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeRdPu: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “YlGnBu” sequential color scheme represented as an RGB string.
@@ -286,7 +383,12 @@ export const schemeRdPu: string[][];
  */
 export function interpolateYlGnBu(value: number): string;
 
-export const schemeYlGnBu: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “YlGnBu” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeYlGnBu[9] contains an array of nine strings representing the nine colors of the
+ *  yellow-green-blue sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeYlGnBu: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “YlGn” sequential color scheme represented as an RGB string.
@@ -295,7 +397,12 @@ export const schemeYlGnBu: string[][];
  */
 export function interpolateYlGn(value: number): string;
 
-export const schemeYlGn: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “YlGn” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeYlGn[9] contains an array of nine strings representing the nine colors of the
+ *  yellow-green sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeYlGn: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “YlOrBr” sequential color scheme represented as an RGB string.
@@ -304,7 +411,12 @@ export const schemeYlGn: string[][];
  */
 export function interpolateYlOrBr(value: number): string;
 
-export const schemeYlOrBr: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “YlOrBr” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeYlOrBr[9] contains an array of nine strings representing the nine colors of the
+ *  yellow-orange-brown sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeYlOrBr: ReadonlyArray<ReadonlyArray<string>>;
 
 /**
  * Given a number t in the range [0,1], returns the corresponding color from the “YlOrRd” sequential color scheme represented as an RGB string.
@@ -313,4 +425,9 @@ export const schemeYlOrBr: string[][];
  */
 export function interpolateYlOrRd(value: number): string;
 
-export const schemeYlOrRd: string[][];
+/**
+ * An array of arrays of hexadecimal color strings from the “YlOrRd” sequential color scheme. The kth element of this array contains
+ *  the color scheme of size k; for example, d3.schemeYlOrRd[9] contains an array of nine strings representing the nine colors of the
+ *  yellow-orange-red sequential color scheme. Sequential, multi-hue color schemes support a size k ranging from 3 to 9.
+ */
+export const schemeYlOrRd: ReadonlyArray<ReadonlyArray<string>>;


### PR DESCRIPTION
Library documentation:
https://github.com/d3/d3-scale-chromatic

Commit that added the missing schemes:
https://github.com/d3/d3-scale-chromatic/commit/ade54c13e8dfdb9807801a794eaec1a37f926b8a

Adding the schemes:
// Diverging
schemeBrBG
schemePRGn
schemePiYG
schemePuOr
schemeRdBu
schemeRdGy
schemeRdYlBu
schemeRdYlGn
schemeSpectral
// Sequential
schemeBlues
schemeGreens
schemeGreys
schemeOranges
schemePurples
schemeReds
// Sequential(Multi-Hue)
schemeBuGn
schemeBuPu
schemeGnBu
schemeOrRd
schemePuBuGn
schemePuBu
schemePuRd
schemeRdPu
schemeYlGnBu
schemeYlGn
schemeYlOrBr
schemeYlOrRd