### PR TITLE
[express-serve-static-core / express] Fix header() return type

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -197,9 +197,9 @@ interface Request extends http.IncomingMessage, Express.Request {
         *
         * @param name
         */
-    get(name: string): string | undefined;
+    get(name: string): string | string[] | undefined;
 
-    header(name: string): string | undefined;
+    header(name: string): string | string[] | undefined;
 
     /**
         * Check if the given `type(s)` is acceptable, returning


### PR DESCRIPTION
req.header() can return an array of strings

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Express's `header` method](https://github.com/expressjs/express/blob/master/lib/request.js#L82)
  - [Express's Request class gets `headers` from http.IncomingMessage](https://github.com/expressjs/express/blob/master/lib/request.js#L31)
  - [http.IncomingMessage.headers is `[header: string]: string | string[]`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L791)
- [ ] Increase the version number in the header if appropriate. _Not sure what this is referring to_
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
