### PR TITLE
[accepts] Fix accepts.types()

### DIFF
--- a/types/accepts/index.d.ts
+++ b/types/accepts/index.d.ts
@@ -44,16 +44,14 @@ declare namespace accepts {
 
         /**
          * Return the first accepted type (and it is returned as the same text as what appears in the `types` array). If nothing in `types` is accepted, then `false` is returned.
+         * If no types are supplied, return the entire set of acceptable types.
          *
          * The `types` array can contain full MIME types or file extensions. Any value that is not a full MIME types is passed to `require('mime-types').lookup`.
          */
-        type(types: string[]): string | false;
-        type(...types: string[]): string | false;
-
-        /**
-         * Return the types that the request accepts, in the order of the client's preference (most preferred first).
-         */
-        types(): string[];
+        type(types: string[]): string[] | string | false;
+        type(...types: string[]): string[] | string | false;
+        types(types: string[]): string[] | string | false;
+        types(...types: string[]): string[] | string | false;
     }
 }
 


### PR DESCRIPTION
Despite the documentation for `accepts` [that appears to say otherwise](https://github.com/jshttp/accepts#typetypes), `.types()` and `.type()` are [simple aliases](https://github.com/jshttp/accepts/blob/master/index.js#L83) for each other.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see above)
- [?] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
