### PR TITLE
Type definitions for `picturefill`

### DIFF
--- a/types/picturefill/index.d.ts
+++ b/types/picturefill/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for picturefill 3.0
+// Project: https://scottjehl.github.io/picturefill/
+// Definitions by: Alexander Azarov <https://github.com/alaz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace Picturefill {
+  type ElementNullable = Element | null;
+
+  interface EvaluateArg {
+    reevaluate?: boolean;
+    elements: NodeList | ElementNullable[];
+  }
+}
+
+declare function picturefill(arg?: Picturefill.EvaluateArg): void;
+
+declare module 'picturefill' {
+  export = picturefill;
+}

--- a/types/picturefill/index.d.ts
+++ b/types/picturefill/index.d.ts
@@ -14,6 +14,5 @@ declare namespace Picturefill {
 
 declare function picturefill(arg?: Picturefill.EvaluateArg): void;
 
-declare module 'picturefill' {
-  export = picturefill;
-}
+export = picturefill;
+export as namespace picturefill;

--- a/types/picturefill/picturefill-tests.ts
+++ b/types/picturefill/picturefill-tests.ts
@@ -1,0 +1,17 @@
+function test_elements() {
+  // no args
+  picturefill();
+
+  // Element[]
+  picturefill({elements: [ document.getElementById('#id') ]});
+
+  // NodeList
+  picturefill({elements: document.querySelectorAll('img')});
+}
+
+function test_optional() {
+  picturefill({
+    elements: [],
+    reevaluate: true
+  });
+}

--- a/types/picturefill/tsconfig.json
+++ b/types/picturefill/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "dom",
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "picturefill-tests.ts"
+    ]
+}

--- a/types/picturefill/tslint.json
+++ b/types/picturefill/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "dtslint/dt.json",
+  "rules": {
+    "no-single-declare-module": false
+  }
+}

--- a/types/picturefill/tslint.json
+++ b/types/picturefill/tslint.json
@@ -1,6 +1,3 @@
 {
-  "extends": "dtslint/dt.json",
-  "rules": {
-    "no-single-declare-module": false
-  }
+  "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
I've submitted a [PR](https://github.com/scottjehl/picturefill/pull/686) to `picturefill` with type definitions, but it still remains unattended since July 18.

Links for `picturefill` library for reference:
* https://github.com/scottjehl/picturefill
* http://scottjehl.github.io/picturefill/
* https://www.npmjs.com/package/picturefill