### PR TITLE
react-select: Fix minor issues

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -17,9 +17,9 @@ export = ReactSelectClass;
 
 declare namespace ReactSelectClass {
     // Other components
-    class Creatable<TValue = OptionValues> extends React.Component<ReactCreatableSelectProps<TValue>> { }
-    class Async<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue>> { }
-    class AsyncCreatable<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue> & ReactCreatableSelectProps<TValue>> { }
+    class Creatable<TValue = OptionValues> extends React.Component<ReactCreatableSelectProps<TValue>, {}> { }
+    class Async<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue>, {}> { }
+    class AsyncCreatable<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue> & ReactCreatableSelectProps<TValue>, {}> { }
 
     type HandlerRendererResult = JSX.Element | null | false;
 
@@ -346,7 +346,7 @@ declare namespace ReactSelectClass {
         /**
          * option component to render in dropdown
          */
-        optionComponent?: React.ComponentType;
+        optionComponent?: JSX.Element;
         /**
          * function which returns a custom way to render the options in the menu
          */
@@ -411,7 +411,7 @@ declare namespace ReactSelectClass {
         /**
          *  value component to render
          */
-        valueComponent?: React.ComponentType;
+        valueComponent?: JSX.Element;
 
         /**
          *  optional style to apply to the component wrapper
@@ -524,6 +524,6 @@ declare namespace ReactSelectClass {
     }
 }
 
-declare class ReactSelectClass<TValue = ReactSelectClass.OptionValues> extends React.Component<ReactSelectClass.ReactSelectProps<TValue>> {
+declare class ReactSelectClass<TValue = ReactSelectClass.OptionValues> extends React.Component<ReactSelectClass.ReactSelectProps<TValue>, void> {
     focus(): void;
 }


### PR DESCRIPTION
Hi. I had problems using these typings, because `React.Component` requires a second parameter & there's no such thing as a `React.ReactComponent`.

So I added `void` as a second parameter & made the `React.ReactComponent`s into `JSX.Elements`.

It _works on my machine_. Not sure, if I missed something though.