### PR TITLE
[GraphQL] Overloading of 'graphql' and 'execute' functions

### DIFF
--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -36,6 +36,16 @@ export interface ExecutionResult {
     errors?: GraphQLError[];
 }
 
+export type ExecutionArgs = {
+  schema: GraphQLSchema,
+  document: DocumentNode,
+  rootValue?: any,
+  contextValue?: any,
+  variableValues?: {[key: string]: any},
+  operationName?: string,
+  fieldResolver?: GraphQLFieldResolver<any, any>
+};
+
 /**
  * Implements the "Evaluating requests" section of the GraphQL specification.
  *
@@ -43,7 +53,10 @@ export interface ExecutionResult {
  *
  * If the arguments to this function do not result in a legal execution context,
  * a GraphQLError will be thrown immediately explaining the invalid input.
+ *
+ * Accepts either an object with named arguments, or individual arguments.
  */
+export function execute(args: ExecutionArgs): Promise<ExecutionResult>;
 export function execute(
     schema: GraphQLSchema,
     document: DocumentNode,

--- a/types/graphql/execution/index.d.ts
+++ b/types/graphql/execution/index.d.ts
@@ -2,6 +2,7 @@ export {
     execute,
     defaultFieldResolver,
     responsePathAsArray,
+    ExecutionArgs,
     ExecutionResult
 } from './execute';
 

--- a/types/graphql/graphql.d.ts
+++ b/types/graphql/graphql.d.ts
@@ -1,3 +1,5 @@
+import { Source } from './language/source';
+import { GraphQLFieldResolver } from './type/definition';
 import { GraphQLSchema } from './type/schema';
 import { ExecutionResult } from './execution/execute';
 
@@ -10,9 +12,11 @@ import { ExecutionResult } from './execution/execute';
  * may wish to separate the validation and execution phases to a static time
  * tooling step, and a server runtime step.
  *
+ * Accepts either an object with named arguments, or individual arguments:
+ *
  * schema:
  *    The GraphQL type system to use when validating and executing a query.
- * requestString:
+ * source:
  *    A GraphQL language formatted string representing the requested operation.
  * rootValue:
  *    The value provided as the first argument to resolver functions on the top
@@ -24,14 +28,30 @@ import { ExecutionResult } from './execution/execute';
  *    The name of the operation to use if requestString contains multiple
  *    possible operations. Can be omitted if requestString contains only
  *    one operation.
+ * fieldResolver:
+ *    A resolver function to use when one is not provided by the schema.
+ *    If not provided, the default field resolver is used (which looks for a
+ *    value or method on the source value with the field's name).
  */
-export function graphql(
+export function graphql(args: {
     schema: GraphQLSchema,
-    requestString: string,
+    source: string | Source,
     rootValue?: any,
     contextValue?: any,
     variableValues?: {
         [key: string]: any
     },
-    operationName?: string
+    operationName?: string,
+    fieldResolver?: GraphQLFieldResolver<any, any>
+}): Promise<ExecutionResult>;
+export function graphql(
+    schema: GraphQLSchema,
+    source: string | Source,
+    rootValue?: any,
+    contextValue?: any,
+    variableValues?: {
+        [key: string]: any
+    },
+    operationName?: string,
+    fieldResolver?: GraphQLFieldResolver<any, any>
 ): Promise<ExecutionResult>;

--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -29,6 +29,7 @@ export {
     defaultFieldResolver,
     responsePathAsArray,
     getDirectiveValues,
+    ExecutionArgs,
     ExecutionResult,
 } from './execution';
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/graphql/graphql-js/blob/master/src/graphql.js#L49-L67
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.