### PR TITLE
jquery.cookie: make cookie be no optional

### DIFF
--- a/types/jquery.cookie/index.d.ts
+++ b/types/jquery.cookie/index.d.ts
@@ -92,7 +92,7 @@ interface JQueryStatic {
     /**
      * A simple, lightweight jQuery plugin for reading, writing and deleting cookies.
      */
-    cookie?: JQueryCookieStatic;
+    cookie: JQueryCookieStatic;
     /**
      * Deletes a cookie
      * @param name Name of cookie to delete


### PR DESCRIPTION
Very annoying to check if there is `cookie` in `$`. After you installed plugin properly, you will always have `$.cookie`.
Removes false warnings about this

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/carhartl/jquery-cookie#installation>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
