### PR TITLE
Increase allowed mixin params to Component.extend in Ember

### DIFF
--- a/types/ember/ember-tests.ts
+++ b/types/ember/ember-tests.ts
@@ -182,7 +182,27 @@ const mix2 = Ember.Mixin.create({
     bar: 2,
 });
 
-const component1 = Ember.Component.extend(mix1, mix2, {
+const mix3 = Ember.Mixin.create({
+    foo: 3,
+});
+
+const mix4 = Ember.Mixin.create({
+    bar: 4,
+});
+
+const mix5 = Ember.Mixin.create({
+    foo: 5,
+});
+
+const mix6 = Ember.Mixin.create({
+    bar: 6,
+});
+
+const mix7 = Ember.Mixin.create({
+    foo: 7,
+});
+
+const component1 = Ember.Component.extend(mix1, mix2, mix3, mix4, mix5, mix6, mix7, {
     lyft: Ember.inject.service(),
     cars: Ember.computed.readOnly('lyft.cars'),
 });

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -913,6 +913,11 @@ declare namespace Ember {
         static extend<T>(args?: CoreObjectArguments): T;
         static extend<T>(mixin1: Mixin, args?: CoreObjectArguments): T;
         static extend<T>(mixin1: Mixin, mixin2: Mixin, args?: CoreObjectArguments): T;
+        static extend<T>(mixin1: Mixin, mixin2: Mixin, mixin3: Mixin, args?: CoreObjectArguments): T;
+        static extend<T>(mixin1: Mixin, mixin2: Mixin, mixin3: Mixin, mixin4: Mixin, args?: CoreObjectArguments): T;
+        static extend<T>(mixin1: Mixin, mixin2: Mixin, mixin3: Mixin, mixin4: Mixin, mixin5: Mixin, args?: CoreObjectArguments): T;
+        static extend<T>(mixin1: Mixin, mixin2: Mixin, mixin3: Mixin, mixin4: Mixin, mixin5: Mixin, mixin6: Mixin, args?: CoreObjectArguments): T;
+        static extend<T>(mixin1: Mixin, mixin2: Mixin, mixin3: Mixin, mixin4: Mixin, mixin5: Mixin, mixin6: Mixin, mixin7: Mixin, args?: CoreObjectArguments): T;
 
         /**
         Creates a new subclass.


### PR DESCRIPTION
Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [*] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: `
export default Ember.Controller.extend(FlashSupport, MobileSupport, LiveValidatedMixin, DeprecatedEventTrackingSupport, {
    indexRoute: 'locations_list'
});
`
- [*] Increase the version number in the header if appropriate. Does not seem appropriate.
- [*] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. Change is not substantial.
