### PR TITLE
Removed implements NodeModule clause from Module class

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5612,7 +5612,7 @@ declare module "constants" {
 }
 
 declare module "module" {
-    class Module implements NodeModule {
+    class Module {
         static runMain(): void;
         static wrap(code: string): string;
 


### PR DESCRIPTION
This causes type errors, when people augment NodeModule intefrace by
adding more properties to it. Which seems to be pretty common in a wild.

Fixes #19601

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: not relevant
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
