### PR TITLE
three.js - Add Multimaterial support for Mesh

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -4820,8 +4820,8 @@ export class LineSegments extends Line {
 }
 
 export class Mesh extends Object3D {
-    constructor(geometry?: Geometry, material?: Material);
-    constructor(geometry?: BufferGeometry, material?: Material);
+    constructor(geometry?: Geometry, material?: Material | Material[]);
+    constructor(geometry?: BufferGeometry, material?: Material | Material[]);
 
     geometry: Geometry|BufferGeometry;
     material: Material;


### PR DESCRIPTION
In the Mesh class it is also possible to pass in an array of materials instead of only a single material. (=> MultiMaterial)
Check out 
https://github.com/mrdoob/three.js/blob/r87/src/objects/Mesh.js 
Line 297 
var isMultiMaterial = Array.isArray( material );
