### PR TITLE
Updates hot property in Module interface to optional

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for webpack (module API) 1.13
 // Project: https://github.com/webpack/webpack
 // Definitions by: use-strict <https://github.com/use-strict>
+//                 rhonsby <https://github.com/rhonsby>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
@@ -60,7 +61,7 @@ declare namespace __WebpackModuleApi {
         loaded: boolean;
         parent: any;
         children: any[];
-        hot: Hot;
+        hot?: Hot;
     }
     type ModuleId = string|number;
 


### PR DESCRIPTION
The `hot` property in the `Module` interface is incorrectly typed as a property that always exists. It is only available in the case where HMR is enabled.

Fixes #19601 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: not relevant
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
