### PR TITLE
Add types for pngjs 3.3

### DIFF
--- a/types/pngjs/index.d.ts
+++ b/types/pngjs/index.d.ts
@@ -1,0 +1,100 @@
+// Type definitions for pngjs 3.3
+// Project: https://github.com/lukeapage/pngjs
+// Definitions by: Jason Cheatham <https://github.com/jason0x43>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import { Duplex } from 'stream';
+import { createDeflate } from 'zlib';
+
+export class PNG extends Duplex {
+	static adjustGamma(src: PNG): void;
+
+	static bitblt(
+		src: PNG,
+		dst: PNG,
+		srcX?: number,
+		srcY?: number,
+		width?: number,
+		height?: number,
+		deltaX?: number,
+		deltaY?: number
+	): void;
+
+	static sync: {
+		read(buffer: Buffer, options?: ParserOptions): PNG;
+		write(buffer: Buffer, options?: PackerOptions): PNG;
+	};
+
+	constructor(options?: PNGOptions);
+
+	data: Buffer;
+	gamma: number;
+	height: number;
+	width: number;
+
+	adjustGamma(): void;
+
+	bitblt(
+		dst: PNG,
+		srcX?: number,
+		srcY?: number,
+		width?: number,
+		height?: number,
+		deltaX?: number,
+		deltaY?: number
+	): PNG;
+
+	on(event: 'metadata', callback: (metadata: Metadata) => void): this;
+	on(event: 'parsed', callback: (data: Buffer) => void): this;
+	on(event: 'error', callback: (error: Error) => void): this;
+	on(event: string, callback: (...args: any[]) => void): this;
+
+	pack(): PNG;
+
+	parse(data: string | Buffer, callback?: (error: Error, data: PNG) => void): PNG;
+}
+
+export interface BaseOptions {
+	width?: number;
+	height?: number;
+	fill?: boolean;
+}
+
+export interface ParserOptions {
+	checkCRC?: boolean;
+}
+
+export interface PackerOptions {
+	deflateChunkSize?: number;
+	deflateLevel?: number;
+	deflateStrategy?: number;
+	deflateFactory?: typeof createDeflate;
+	colorType?: ColorType;
+	bitDepth?: 8 | 16;
+	bgColor?: {
+		red: number;
+		green: number;
+		blue: number;
+	};
+	inputHasAlpha?: boolean;
+	inputColorType?: ColorType;
+	filterType?: number | number[];
+}
+
+export type PNGOptions = BaseOptions & ParserOptions & PackerOptions;
+
+export type ColorType = 0 | 1 | 2 | 4;
+
+export interface Metadata {
+	width: number;
+	height: number;
+	depth: 1 | 2 | 4 | 8 | 16;
+	interlace: boolean;
+	palette: boolean;
+	color: boolean;
+	alpha: boolean;
+	bpp: 1 | 2 | 3 | 4;
+	colorType: ColorType;
+}

--- a/types/pngjs/pngjs-tests.ts
+++ b/types/pngjs/pngjs-tests.ts
@@ -1,0 +1,64 @@
+import { PNG } from 'pngjs';
+import { createDeflate } from 'zlib';
+
+const pngs = [
+	new PNG(),
+	new PNG({}),
+	new PNG({ width: 1 }),
+	new PNG({ checkCRC: false }),
+	new PNG({ deflateChunkSize: 3 }),
+	new PNG({
+		width: 1,
+		height: 1,
+		fill: false,
+		checkCRC: true,
+		deflateChunkSize: 1,
+		deflateLevel: 1,
+		deflateStrategy: 1,
+		deflateFactory: createDeflate,
+		colorType: 4,
+		bitDepth: 8,
+		inputHasAlpha: false,
+		filterType: 4
+	}),
+	new PNG({ filterType: [1, 2, 3] })
+];
+
+const png = pngs[0];
+
+png.readable === true;
+png.writable === true;
+png.width === 1;
+png.height === 1;
+png.gamma === 1;
+png.adjustGamma();
+
+png.bitblt(pngs[1]);
+png.bitblt(pngs[1], 1);
+png.bitblt(pngs[1], 1, 1);
+png.bitblt(pngs[1], 1, 1, 1, 1, 1, 1);
+
+png.on('metadata', metadata => {
+	metadata.bpp === 1;
+});
+png.on('parsed', data => {
+	data.byteLength === 1;
+});
+png.on('error', error => {
+	error === new Error('testing');
+});
+png.on('foo', () => {});
+
+png.pack().adjustGamma();
+
+png.parse('foo').adjustGamma();
+png.parse(Buffer.from('foo')).adjustGamma();
+png.parse('foo', (error, data) => {
+	error.stack;
+	data.adjustGamma();
+}).adjustGamma();
+
+PNG.adjustGamma(png);
+
+PNG.bitblt(png, pngs[1]);
+PNG.bitblt(png, pngs[1], 1, 1, 1, 1, 1, 1);

--- a/types/pngjs/pngjs-tests.ts
+++ b/types/pngjs/pngjs-tests.ts
@@ -26,8 +26,12 @@ const pngs = [
 
 const png = pngs[0];
 
-png.readable === true;
-png.writable === true;
+if (png.readable === true) {
+	console.log('readable');
+}
+if (png.writable === true) {
+	console.log('writable');
+}
 png.width === 1;
 png.height === 1;
 png.gamma === 1;

--- a/types/pngjs/pngjs-tests.ts
+++ b/types/pngjs/pngjs-tests.ts
@@ -26,10 +26,10 @@ const pngs = [
 
 const png = pngs[0];
 
-if (png.readable === true) {
+if (png.readable) {
 	console.log('readable');
 }
-if (png.writable === true) {
+if (png.writable) {
 	console.log('writable');
 }
 png.width === 1;

--- a/types/pngjs/tsconfig.json
+++ b/types/pngjs/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "pngjs-tests.ts"
+    ]
+}

--- a/types/pngjs/tslint.json
+++ b/types/pngjs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

---

These types are somewhere in between a new definition and an update. They're for the same library as the existing pngjs2 types (the library changed its published name to "pngjs" after version pngjs2@2.0.0.) However, I implemented them as a new set of types rather than taking over the pngjs2 types because pngjs2 does still exist.