### PR TITLE
Change placeholder type from `Node` to `any` (Issue #19599)

### DIFF
--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -15,7 +15,7 @@ export interface LazyLoadProps {
     children?: JSX.Element;
     throttle?: number | boolean;
     debounce?: number | boolean;
-    placeholder?: Node;
+    placeholder?: any;
     unmountIfInvisible?: boolean;
 }
 


### PR DESCRIPTION
- [ ] Package: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-lazyload
- [ ] Issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19599
