### PR TITLE
[express-serve-static-core / express]  Fix header() return type

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -197,9 +197,11 @@ interface Request extends http.IncomingMessage, Express.Request {
         *
         * @param name
         */
-    get(name: string): string | string[] | undefined;
+    get(name: "set-cookie"): string[] | undefined;
+    get(name: string): string | undefined;
 
-    header(name: string): string | string[] | undefined;
+    header(name: "set-cookie"): string[] | undefined;
+    header(name: string): string | undefined;
 
     /**
         * Check if the given `type(s)` is acceptable, returning

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -70,14 +70,26 @@ namespace express_tests {
         language = req.acceptsLanguages(['en', 'ja']);
         language = req.acceptsLanguages('en', 'ja');
 
-        let existingHeader1 = req.get('existingHeader') as string;
-        let nonExistingHeader1 = req.get('nonExistingHeader') as undefined;
+        // downcasting
+        req.get('set-cookie') as undefined;
+        req.get('set-cookie') as string[];
+        const setCookieHeader1 = req.get('set-cookie');
+        if (setCookieHeader1 !== undefined) {
+            const setCookieHeader2: string[] = setCookieHeader1;
+        }
+        req.get('header') as undefined;
+        req.get('header') as string;
+        const header1 = req.get('header');
+        if (header1 !== undefined) {
+            const header2: string = header1;
+        }
 
-        let existingHeader2 = req.header('existingHeader') as string;
-        let nonExistingHeader2 = req.header('nonExistingHeader') as undefined;
+        // upcasting
+        const setCookieHeader3: string[] | undefined = req.get('set-cookie');
+        const header3: string | undefined = req.header('header');
 
-        let existingHeader3 = req.headers.existingHeader as string;
-        let nonExistingHeader3 = req.headers.nonExistingHeader as any as undefined;
+        req.headers.existingHeader as string;
+        req.headers.nonExistingHeader as any as undefined;
 
         res.send(req.query['token']);
     });


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/19575 is not good change for almost all users.
req.header() returns an array of strings if and only if "set-cookie".
See: https://nodejs.org/api/http.html#http_message_headers

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/DefinitelyTyped/DefinitelyTyped/pull/19575
  - https://nodejs.org/api/http.html#http_message_headers
- [ ] Increase the version number in the header if appropriate. <- ???
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
