### PR TITLE
nano - add missing db.attachment.get signature that returns a ReadableStream

### DIFF
--- a/types/nano/index.d.ts
+++ b/types/nano/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for nano 6.2
+// Type definitions for nano 6.4
 // Project: https://github.com/apache/couchdb-nano
 // Definitions by: Tim Jacobi <https://github.com/timjacobi>
 //                 Kovács Vince <https://github.com/vincekovacs>

--- a/types/nano/index.d.ts
+++ b/types/nano/index.d.ts
@@ -282,6 +282,7 @@ declare namespace nano {
       params: any,
       callback?: Callback<any>
     ): Request;
+    get(docname: string, attname: string): NodeJS.ReadableStream;
     get(docname: string, attname: string, callback?: Callback<any>): Request;
     get(
       docname: string,

--- a/types/nano/nano-tests.ts
+++ b/types/nano/nano-tests.ts
@@ -127,8 +127,15 @@ mydb.attachment.insert(
   "text/plain",
   (error: any, att: any) => {}
 );
+const attInsert: NodeJS.WritableStream = mydb.attachment.insert(
+  "new",
+  "att",
+  null,
+  "text/plain"
+);
 mydb.attachment.destroy("new", "att", { rev: "123" }, (err, response) => {});
 mydb.attachment.get("new_string", "att", (error: any, helloWorld: any) => {});
+const attGet: NodeJS.ReadableStream = mydb.attachment.get("new_string", "att");
 
 /*
  * Multipart


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apache/couchdb-nano#dbattachmentgetdocname-attname-params-callback
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
