### PR TITLE
Defining Node-Config's `setModuleDefaults`

### DIFF
--- a/types/config/config-tests.ts
+++ b/types/config/config-tests.ts
@@ -34,3 +34,5 @@ var configSources: config.IConfigSource[] = config.util.getConfigSources();
 var configSource: config.IConfigSource = configSources[0];
 var configSourceName: string = configSource.name;
 var configSourceOriginal: string | undefined = configSource.original;
+
+var moduleDefaults: any = config.util.setModuleDefaults("moduleName", {});

--- a/types/config/index.d.ts
+++ b/types/config/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for node-config
 // Project: https://github.com/lorenwest/node-config
 // Definitions by: Roman Korneev <https://github.com/RWander>
+//                 Forrest Bice <https://github.com/forrestbice>
+//                 James Donald <https://github.com/jndonald3>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
@@ -31,12 +33,19 @@ declare namespace c {
 
         // Get the current value of a config environment variable
         getEnv(varName: string): string;
-        
+
         // Return the config for the project based on directory param if not directory then return default one (config).
         loadFileConfigs(configDir: string): any;
 
         // Return the sources for the configurations
         getConfigSources(): IConfigSource[];
+
+        /**
+         * This allows module developers to attach their configurations onto
+         * the 6 years agoInitial 0.4 checkin default configuration object so
+         * they can be configured by the consumers of the module.
+         */
+        setModuleDefaults(moduleName:string, defaults:any): any;
     }
 
     interface IConfig {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lorenwest/node-config/blob/083a783daa5e2426d679890ae7e3fb3149100d13/lib/config.js#L358
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc @jndonald3