### PR TITLE
noImplicitAny can be turned back on now.

### DIFF
--- a/types/rethinkdb/tsconfig.json
+++ b/types/rethinkdb/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": [
             "es6"
         ],
-        "noImplicitAny": false,
+        "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": false,
         "baseUrl": "../",


### PR DESCRIPTION
Please fill in this template.

Simply fixed a missing typing that causes a compile error when noImplicitAny is enabled.