### PR TITLE
[types/node] Change Buffer.from to accept SharedArrayBuffer

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -178,7 +178,7 @@ declare var Buffer: {
      *
      * @param arrayBuffer The ArrayBuffer with which to share memory.
      */
-    new(arrayBuffer: ArrayBuffer): Buffer;
+    new(arrayBuffer: ArrayBuffer | SharedArrayBuffer): Buffer;
     /**
      * Allocates a new buffer containing the given {array} of octets.
      *
@@ -208,7 +208,7 @@ declare var Buffer: {
      * @param byteOffset
      * @param length
      */
-    from(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;
+    from(arrayBuffer: ArrayBuffer | SharedArrayBuffer, byteOffset?: number, length?: number): Buffer;
     /**
      * Copies the passed {buffer} data onto a new Buffer instance.
      *

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -66,6 +66,10 @@ interface IteratorResult<T> { }
 interface SymbolConstructor {
     readonly iterator: symbol;
 }
+
+// Forward-declare SharedArrayBuffer (available starting es2017)
+interface SharedArrayBuffer {}
+
 declare var Symbol: SymbolConstructor;
 
 /************************************************


### PR DESCRIPTION
@andy-ms

This changes the the definition of Buffer to accept a SharedArrayBuffer as well. There have been mentions of this in #16860.