### PR TITLE
@types/react-native fix type of options argument for ShareActionSheetIOSOptions interface

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6559,7 +6559,7 @@ export type ShareContent = {
 
 export type ShareOptions = {
     dialogTitle?: string
-    excludeActivityTypes?: Array<string>
+    excludedActivityTypes?: Array<string>
     tintColor?: string
 }
 


### PR DESCRIPTION
Options argument contains excludeActivityTypes property.
But in [documentation](https://facebook.github.io/react-native/docs/share.html) and in [source code](https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/Libraries/ActionSheetIOS/RCTActionSheetManager.m) (line 164) the name of this property is excludedActivityTypes