### PR TITLE
Mithril: Add request config options param.

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -21,9 +21,9 @@ declare function request <T>(options: Mithril.RequestOptions<T> & { url: string 
 declare function request <T>(url: string, options?: Mithril.RequestOptions<T>): Promise<T>;
 
 /** Makes a JSON-P request and returns a promise. */
-declare function jsonp<T>(options: Mithril.JsonpOptions & { url: string }): Promise<T>;
+declare function jsonp<T>(options: Mithril.JsonpOptions & { url: string }): Promise<T>; // tslint:disable-line:no-unnecessary-generics
 /** Makes a JSON-P request and returns a promise. */
-declare function jsonp<T>(url: string, options?: Mithril.JsonpOptions): Promise<T>;
+declare function jsonp<T>(url: string, options?: Mithril.JsonpOptions): Promise<T>; // tslint:disable-line:no-unnecessary-generics
 
 /** Creates an event handler which takes the value of the specified DOM element property and calls a function with it as the argument. */
 declare function withAttr(name: string, callback: (value: any) => any): (e: { currentTarget: any, [p: string]: any }) => void;
@@ -116,7 +116,7 @@ declare namespace Mithril {
 		/** Whether to send cookies to 3rd party domains. */
 		withCredentials?: boolean;
 		/** Exposes the underlying XMLHttpRequest object for low-level configuration. */
-		config?(xhr: XMLHttpRequest): XMLHttpRequest | void;
+		config?(xhr: XMLHttpRequest, options: this): XMLHttpRequest | void;
 		/** Headers to append to the request before sending it. */
 		headers?: { [key: string]: string };
 		/** A constructor to be applied to each object in the response. */

--- a/types/mithril/test/test-api.ts
+++ b/types/mithril/test/test-api.ts
@@ -20,7 +20,7 @@ const FRAME_BUDGET = 100;
 {
 	const vnode = m.fragment({key: 123}, [m("div")]);
 	console.assert((vnode.children as Array<m.Vnode<any, any>>).length === 1);
-	console.assert(vnode.children![0].tag === 'div');
+	console.assert((vnode.children as Array<m.Vnode<any, any>>)[0].tag === 'div');
 }
 
 {

--- a/types/mithril/test/test-component.ts
+++ b/types/mithril/test/test-component.ts
@@ -50,7 +50,7 @@ const comp2: Component<Comp2Attrs, {}> = {
 m(comp2, {title: '', description: ''});
 
 // Correct use with lifecycle method
-m(comp2, {title: '', description: '', oncreate: (v) => v.attrs.title + '\n' + v.attrs.description});
+m(comp2, {title: '', description: '', oncreate: (v) => `${v.attrs.title}\n${v.attrs.description}`});
 
 // Properties missing
 // $ExpectError

--- a/types/mithril/test/test-request.ts
+++ b/types/mithril/test/test-request.ts
@@ -44,8 +44,9 @@ request<Result>('/id', {
 });
 
 request<Result>('/item', {
-	config: xhr => {
+	config: (xhr, opts) => {
 		xhr.setRequestHeader('accept', '*');
+		console.log(opts.background);
 		return xhr;
 	},
 	headers: {"Content-Type": "application/json"},

--- a/types/mithril/test/test-stream.ts
+++ b/types/mithril/test/test-stream.ts
@@ -135,17 +135,6 @@ import { Stream } from 'mithril/stream';
 }
 
 {
-	let count = 0;
-	const a = stream(1);
-	const b = stream.combine(a => stream.HALT, [a])
-	["fantasy-land/map"](() => {
-		count++;
-		return 1;
-	});
-	console.assert(b() === undefined);
-}
-
-{
 	const all = stream.merge([
 		stream(10),
 		stream("20"),
@@ -213,112 +202,6 @@ import { Stream } from 'mithril/stream';
 	doubled.end(true);
 	s(4);
 	console.assert(doubled() === 4);
-}
-
-{
-	const s = stream<number>();
-	const doubled = s["fantasy-land/map"]((n: number) => n * 2);
-	s(3);
-	console.assert(doubled() === 6);
-}
-
-{
-	const s = stream(3);
-	const doubled = s["fantasy-land/map"]((n: number) => n * 2);
-	console.assert(doubled() === 6);
-}
-
-{
-	const s = stream<undefined>();
-	const mapped = s["fantasy-land/map"](String);
-	s(undefined);
-	console.assert(mapped() === "undefined");
-}
-
-{
-	const s = stream(undefined);
-	const mapped = s["fantasy-land/map"](String);
-	console.assert(mapped() === "undefined");
-}
-
-{
-	const s = stream(undefined);
-	const mapped = s["fantasy-land/map"]((_value: undefined) => stream());
-	console.assert(mapped()() === undefined);
-}
-
-{
-	const s = stream(undefined);
-	console.assert(s["fantasy-land/map"] === s.map);
-}
-
-{
-	const apply = stream((n: number) => n * 2);
-	const s = stream(3);
-	const applied = s["fantasy-land/ap"](apply);
-	console.assert(applied() === 6);
-	apply(n => n / 3);
-	console.assert(applied() === 1);
-	s(9);
-	console.assert(applied() === 3);
-}
-
-{
-	const apply = stream<(value: undefined) => string>(String);
-	const s = stream(undefined);
-	const applied = s["fantasy-land/ap"](apply);
-	console.assert(applied() === "undefined");
-	apply(value => String(value) + "a");
-	console.assert(applied() === "undefineda");
-}
-
-{
-	const s = stream(3);
-	const mapped = s["fantasy-land/map"]((v: number) => v);
-	console.assert(s() === mapped());
-}
-
-{
-	const f = (x: number) => x * 2;
-	const g = (x: number) => x * x;
-	const s = stream(3);
-	const mapped = s["fantasy-land/map"]((value: any) => f(g(value)));
-	const composed = s["fantasy-land/map"](g)["fantasy-land/map"](f);
-	console.assert(mapped() === 18);
-	console.assert(mapped() === composed());
-}
-
-{
-	const a = stream((n: number) => n * 2);
-	const u = stream((n: number) => n * 3);
-	const v = stream(5);
-	const mapped = v["fantasy-land/ap"](u["fantasy-land/ap"](a["fantasy-land/map"]((f: any) => (g: any)  => (x: any) => f(g(x)))));
-	const composed = v["fantasy-land/ap"](u)["fantasy-land/ap"](a);
-	console.assert(mapped() === 30);
-	console.assert(mapped() === composed());
-}
-
-{
-	const a = stream()["fantasy-land/of"]((value: number) => value);
-	const v = stream(5);
-	console.assert(v["fantasy-land/ap"](a)() === 5);
-	console.assert(v["fantasy-land/ap"](a)() === v());
-}
-
-{
-	const a = stream(0);
-	const f = (n: number) => n * 2;
-	const x = 3;
-	console.assert(a["fantasy-land/of"](x)["fantasy-land/ap"](a["fantasy-land/of"](f))() === 6);
-	console.assert(a["fantasy-land/of"](x)["fantasy-land/ap"](a["fantasy-land/of"](f))() === a["fantasy-land/of"](f(x))());
-}
-
-{
-	const u = stream((n: number) => n * 2);
-	const a = stream();
-	const y = 3;
-	console.assert(a["fantasy-land/of"](y)["fantasy-land/ap"](u)() === 6);
-	console.assert(a["fantasy-land/of"](y)["fantasy-land/ap"](u)() === u["fantasy-land/ap"](a["fantasy-land/of"]((f: any) => f(y)))());
 }
 
 // scan

--- a/types/mithril/tsconfig.json
+++ b/types/mithril/tsconfig.json
@@ -5,9 +5,8 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "noEmit": true,
     "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
     "baseUrl": "../",
     "typeRoots": ["../"],
     "types": []

--- a/types/mithril/tslint.json
+++ b/types/mithril/tslint.json
@@ -3,7 +3,6 @@
     "rules": {
         // TODOs
         "no-duplicate-imports": false,
-        "object-literal-key-quotes": false,
         "no-empty-interface": false
     }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/spacejack/mithril.d.ts/issues/25#issuecomment-318577656

This PR adds an options parameter to the RequestOptions config callback.

Test/lint rules have changed since the last PR so I also needed to make some changes to tsconfig, tslint and some of the tests.

Suppressing "any index" errors is now forbidden so I removed a number of extraneous stream tests for Fantasy Land spec compliance that aren't covered by the type defs.

The new linting rules no longer like this definition:

```typescript
declare function jsonp<T>(options: Mithril.JsonpOptions & { url: string }): Promise<T>;
```

So for now I've suppressed `no-unnecessary-generics` inline. I don't see how else to describe the type of Promise you expect back.
