### PR TITLE
[jquery.fancytree] added enableUpdate method

### DIFF
--- a/types/jquery.fancytree/index.d.ts
+++ b/types/jquery.fancytree/index.d.ts
@@ -190,6 +190,13 @@ declare namespace Fancytree {
 
         /** Write warning to browser console (prepending tree info) */
         warn(msg: any): void;
+
+        /** Temporarily suppress rendering to improve performance on bulk-updates.
+        *
+        * @param {boolean} flag
+        * @returns {boolean} previous status
+        * @since 2.19 */
+        enableUpdate(enabled: boolean): void;
     }
 
     /** A FancytreeNode represents the hierarchical data model and operations. */


### PR DESCRIPTION
Added missing `Fancytree.enableUpdate` method declaration.
reference: http://www.wwwendt.de/tech/fancytree/doc/jsdoc/Fancytree.html#enableUpdate
