### PR TITLE
[react-data-grid] Added missing draggable flag to column

### DIFF
--- a/types/react-data-grid/index.d.ts
+++ b/types/react-data-grid/index.d.ts
@@ -277,6 +277,11 @@ declare namespace AdazzleReactDataGrid {
          * A class name to be applied to the cells in the column
          */
         cellClass?: string;
+        /**
+         * Whether this column can be dragged (re-arranged).
+         * @default false
+         */
+        draggable?: boolean;
     }
 
     interface ColumnEventCallback {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[Ref in source](https://github.com/adazzle/react-data-grid/blob/e63b058b75dffa6a91335f6544eb7b74735a1586/packages/react-data-grid/src/HeaderRow.js#L125)
[Example from documentation](http://adazzle.github.io/react-data-grid/examples.html#/draggable-header)
[Example source](http://adazzle.github.io/react-data-grid/scripts/example24-draggable-header.js)
- [] Increase the version number in the header if appropriate.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
