### PR TITLE
Fix up URL iteration

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2125,21 +2125,21 @@ declare module "url" {
         unicode?: boolean;
     }
 
-    export class URLSearchParams implements Iterable<string[]> {
-        constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<string[]>);
+    export class URLSearchParams implements Iterable<[string, string]> {
+        constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]>);
         append(name: string, value: string): void;
         delete(name: string): void;
-        entries(): Iterator<string[]>;
+        entries(): IterableIterator<[string, string]>;
         forEach(callback: (value: string, name: string) => void): void;
         get(name: string): string | null;
         getAll(name: string): string[];
         has(name: string): boolean;
-        keys(): Iterator<string>;
+        keys(): IterableIterator<string>;
         set(name: string, value: string): void;
         sort(): void;
         toString(): string;
-        values(): Iterator<string>;
-        [Symbol.iterator](): Iterator<string[]>;
+        values(): IterableIterator<string>;
+        [Symbol.iterator](): IterableIterator<[string,string]>;
     }
 
     export class URL {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2125,7 +2125,7 @@ declare module "url" {
         unicode?: boolean;
     }
 
-    export class URLSearchParams implements Iterable<[string, string]> {
+    export class URLSearchParams {
         constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]>);
         append(name: string, value: string): void;
         delete(name: string): void;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2125,8 +2125,8 @@ declare module "url" {
         unicode?: boolean;
     }
 
-    export class URLSearchParams {
-        constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]>);
+    export class URLSearchParams implements Iterable<[string, string]> {
+        constructor(init?: URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]> | Array<[string, string]>);
         append(name: string, value: string): void;
         delete(name: string): void;
         entries(): IterableIterator<[string, string]>;
@@ -2139,7 +2139,7 @@ declare module "url" {
         sort(): void;
         toString(): string;
         values(): IterableIterator<string>;
-        [Symbol.iterator](): IterableIterator<[string,string]>;
+        [Symbol.iterator](): IterableIterator<[string, string]>;
     }
 
     export class URL {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v8.x/docs/api/url.html#url_urlsearchparams_iterator

This fix then ensures that `global.URL` and `url.URL` interfaces are fully compatible and interchangeable.