### PR TITLE
React bootstrap table/remote expansion

### DIFF
--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -87,7 +87,7 @@ export interface BootstrapTableProps extends Props<BootstrapTable> {
 	/**
 	If set, data is remote (use also fetchInfo)
 	*/
-	remote?: (remobeObj: RemoteObjSpec) => RemoteObjSpec | boolean,	// Updated to support ^3.0.0
+	remote?: boolean | (remobeObj: RemoteObjSpec) => RemoteObjSpec,	// Updated to support ^3.0.0
 	/**
 	Use keyField to tell table which column is unique. This is same as isKey in <TableHeaderColumn>
 	Tips: You need choose one configuration to set key field: keyField or isKey in <TableHeaderColumn>

--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -87,7 +87,7 @@ export interface BootstrapTableProps extends Props<BootstrapTable> {
 	/**
 	If set, data is remote (use also fetchInfo)
 	*/
-	remote?: boolean | (remobeObj: RemoteObjSpec) => RemoteObjSpec,	// Updated to support ^3.0.0
+	remote?: ((remobeObj: RemoteObjSpec) => RemoteObjSpec) | boolean; // Updated to support ^3.0.0
 	/**
 	Use keyField to tell table which column is unique. This is same as isKey in <TableHeaderColumn>
 	Tips: You need choose one configuration to set key field: keyField or isKey in <TableHeaderColumn>
@@ -600,6 +600,10 @@ export interface TableHeaderColumnProps extends Props<TableHeaderColumn> {
 	True to hide column.
 	*/
 	hidden?: boolean;
+	/**
+	 * True to hide from insert dialog
+	 */
+	hiddenOnInsert?: boolean;
 	/**
 	True to hide the dropdown for sizePerPage.
 	*/

--- a/types/react-bootstrap-table/react-bootstrap-table-tests.tsx
+++ b/types/react-bootstrap-table/react-bootstrap-table-tests.tsx
@@ -101,6 +101,22 @@ class RemoteProps extends React.Component {
     );
   }
 }
+
+class RemoteBool extends React.Component {
+  render() {
+    return (
+      <BootstrapTable
+        data={products}
+        remote
+      >
+        <TableHeaderColumn dataField='id' isKey>Product ID</TableHeaderColumn>
+        <TableHeaderColumn dataField='name'>Product Name</TableHeaderColumn>
+        <TableHeaderColumn dataField='isInStock' filter={{ type: 'CustomFilter', getElement: getCustomFilter, customFilterParameters: { textOK: 'yes', textNOK: 'no' } }}>Product Is In Stock</TableHeaderColumn>
+      </BootstrapTable>
+    );
+  }
+}
+
 // Adopted from https://github.com/AllenFang/react-bootstrap-table/blob/master/examples/js/column-header-span/column-header-span-complex.js
 export default class ColumnHeaderSpanComplex extends React.Component {
   render() {


### PR DESCRIPTION
Contains fixes suggested by @pocesar. Remote property on table is supposed to be either a boolean or a function. Existing definition is defined in a way that remote property is a function that returns either a remote spec or a boolean. That definition is incorrect.