### PR TITLE
[react-intl] Allow booleans and dates when formatting a message

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -138,7 +138,7 @@ declare namespace ReactIntl {
         }
 
         interface Props extends MessageDescriptor {
-            values?: {[key: string]: string | number | JSX.Element};
+            values?: {[key: string]: string | number | boolean | Date | JSX.Element};
             tagName?: string;
         }
     }

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -118,6 +118,20 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
             <FormattedMessage
                 id="test"
                 description="Test"
+                defaultMessage="Hi {bool}!"
+                values={{ bool: false }}
+                tagName="div" />
+
+            <FormattedMessage
+                id="test"
+                description="Test"
+                defaultMessage="Hi {date}!"
+                values={{ date: new Date() }}
+                tagName="div" />
+
+            <FormattedMessage
+                id="test"
+                description="Test"
                 defaultMessage="Hi plurals: {valueOne, number} {valueOne, plural, one {plural} other {plurals}} {valueTen, number} {valueTen, plural, one {plural} other {plurals}} !"
                 values={{ valueOne: 1, valueTen: 10 }}
                 tagName="div" />
@@ -134,6 +148,27 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 description="Test"
                 defaultMessage="Hi, {name}!"
                 values={{ name: "bob" }}
+                tagName="div" />
+
+            <FormattedHTMLMessage
+                id="test"
+                description="Test"
+                defaultMessage="Hi numbers {count}!"
+                values={{ count: 123 }}
+                tagName="div" />
+
+            <FormattedHTMLMessage
+                id="test"
+                description="Test"
+                defaultMessage="Hi {bool}!"
+                values={{ bool: false }}
+                tagName="div" />
+
+            <FormattedHTMLMessage
+                id="test"
+                description="Test"
+                defaultMessage="Hi {date}!"
+                values={{ date: new Date() }}
                 tagName="div" />
 
             <FormattedNumber


### PR DESCRIPTION
This is the same change that I did previously in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17133, but for react-intl's React components instead of the injectable methods.

Currently only strings and numbers are allowed as values when using react-intl's `<FormattedMessage>` and `<FormattedHTMLMessage>` components.

react-intl's API Wiki defines the value for values property as object (https://github.com/yahoo/react-intl/wiki/Components#formattedmessage), which means that you should be able to pass the method any kind of data inside of an object.

Using object seems to be banned by tslint in this project, so changed the code to allow `boolean`, `Date`, `number` and `string` as usable values.

# Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
