### PR TITLE
[react-native] Add VirtualizedList onLayout event data

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3921,7 +3921,7 @@ export interface VirtualizedListProperties<ItemT> extends ScrollViewProperties {
 
     onEndReachedThreshold?: number | null
 
-    onLayout?: () => void
+    onLayout?: (event: LayoutChangeEvent) => void;
 
     /**
      * If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make


### PR DESCRIPTION
This adds back in the `onLayout` `event` data param. Looks like this was lost in the recent updates to have `FlatListProperties` extend `ScrollViewProperties`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/facebook/react-native/blob/master/Libraries/Lists/VirtualizedList.js#L903
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.