### PR TITLE
[express / express-serve-static-core] Fix req.is() return type

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -351,7 +351,7 @@ interface Request extends http.IncomingMessage, Express.Request {
         *
         * @param type
         */
-    is(type: string): boolean;
+    is(type: string): string | false;
 
     /**
         * Return the protocol string "http" or "https"


### PR DESCRIPTION
The Express docs are somewhat misleading about this method. The documentation says that [`req.is()` returns `boolean`](https://expressjs.com/en/4x/api.html#req.is), but in reality, this method simply delegates to the `type-is` package, [whose return is `string | false`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/type-is/index.d.ts#L12). I assume the Express docs are simplifying things, leaning on the fact that non-empty strings are truthy.

I've filed expressjs/expressjs.com#858 to get the Express docs fixed as well.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - Express `req.is()`: https://expressjs.com/en/4x/api.html#req.is
  - Delegates to `typeis()`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/type-is/index.d.ts#L12
- [ ] Increase the version number in the header if appropriate. _Not sure what this means_
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ 0"extends": "dtslint/dt.json" }`.
