### PR TITLE
material-ui: Tighten type definition

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1724,7 +1724,7 @@ declare namespace __MaterialUI {
             onCellHoverExit?(row: number, column: number): void;
             onRowHover?(row: number): void;
             onRowHoverExit?(row: number): void;
-            onRowSelection?(selectedRows: number[] | string): void;
+            onRowSelection?(selectedRows: number[] | 'all'): void;
             selectable?: boolean;
             style?: React.CSSProperties;
             wrapperStyle?: React.CSSProperties;


### PR DESCRIPTION
If Table.onRowSelection returns a string, it should always be 'all'

See http://www.material-ui.com/#/components/table