### PR TITLE
Fix google.visualization ChartArea backgroundColor

### DIFF
--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -410,7 +410,7 @@ declare namespace google {
         }
 
         export interface ChartArea {
-            backgroundColor: string | { stroke: string; strokeWidth?: number };
+            backgroundColor?: string | { stroke: string; strokeWidth?: number };
             top?: number | string;
             left?: number | string;
             right?: number | string;


### PR DESCRIPTION
Changes `backgroundColor:` to `backgroundColor?:` because this field is optional