### PR TITLE
bugfix sinon map and set for browser-less environments.

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -16,6 +16,12 @@ interface Event { }
 interface Document { }
 // tslint:enable no-empty-interface
 
+// see more details in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16587
+// tslint:disable no-empty-interface
+interface Map<v, k> { }
+interface Set<T> { }
+// tslint:enable no-empty-interface
+
 declare namespace Sinon {
     interface SinonSpyCallApi {
         // Properties


### PR DESCRIPTION
This fixes [#16587](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/16587).

e.g.

```
.../node_modules/@types/sinon/index.d.ts
(402,30): error TS2304: Cannot find name 'Map'.
.../node_modules/@types/sinon/index.d.ts
(413,30): error TS2304: Cannot find name 'Set'.
```

N.B. I'm concerned there is a deeper issue this is working around.