### PR TITLE
update angular-ui-router state get to use union type

### DIFF
--- a/types/angular-ui-router/angular-ui-router-tests.ts
+++ b/types/angular-ui-router/angular-ui-router-tests.ts
@@ -197,6 +197,11 @@ class UrlLocatorTestService implements IUrlLocatorTestService {
         this.$state.get(this.$state.current);
         this.$state.get(this.$state.current, "yourState");
         this.$state.get(this.$state.current, this.$state.current);
+
+        // make sure get() accepts a discriminated union type as well
+        let myState: string | ng.ui.IState;
+        this.$state.get(myState);
+
         this.$state.reload();
 
         // http://angular-ui.github.io/ui-router/site/#/api/ui.router.state.$state#properties

--- a/types/angular-ui-router/index.d.ts
+++ b/types/angular-ui-router/index.d.ts
@@ -1,6 +1,8 @@
-// Type definitions for Angular JS (ui.router module) 1.1.5
+// Type definitions for Angular JS (ui.router module) 1.1.38
 // Project: https://github.com/angular-ui/ui-router
-// Definitions by: Michel Salib <https://github.com/michelsalib>, Ivan Matiishyn <https://github.com/matiishyn>
+// Definitions by: Michel Salib <https://github.com/michelsalib>
+//                 Ivan Matiishyn <https://github.com/matiishyn>
+//                 Mike Haas <https://github.com/mikehaas763>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -272,10 +274,7 @@ declare module 'angular' {
             is(state: IState, params?: {}): boolean;
             href(state: IState, params?: {}, options?: IHrefOptions): string;
             href(state: string, params?: {}, options?: IHrefOptions): string;
-            get(state: string, context?: string): IState;
-            get(state: IState, context?: string): IState;
-            get(state: string, context?: IState): IState;
-            get(state: IState, context?: IState): IState;
+            get(state: string | IState, context?: string | IState): IState;
             get(): IState[];
             /** A reference to the state's config object. However you passed it in. Useful for accessing custom data. */
             current: IState;


### PR DESCRIPTION
This enables the use of passing to get() a discriminated union type, while still covering the previous overloads.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).