### PR TITLE
Add undefined type to ol.Overlay.setPosition

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for OpenLayers v4.3.0
 // Project: http://openlayers.org/
-// Definitions by: Olivier Sechet <https://github.com/osechet>, Guilhem Brouat <https://github.com/ganlhi>
+// Definitions by: Olivier Sechet <https://github.com/osechet>
+//                 Guilhem Brouat <https://github.com/ganlhi>
+//                 Bin Wang <https://github.com/wb14123>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Definitions partially generated using tsd-jsdoc (https://github.com/englercj/tsd-jsdoc)
 
@@ -7597,7 +7599,7 @@ declare module ol {
          * @observable
          * @api stable
          */
-        setPosition(position: (ol.Coordinate)): void;
+        setPosition(position: (ol.Coordinate | undefined)): void;
 
         /**
          * Set the positioning for this overlay.

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -590,6 +590,7 @@ voidValue = popup.setElement(popupElement);
 voidValue = popup.setMap(popupMap);
 voidValue = popup.setOffset(popupOffset);
 voidValue = popup.setPosition(coordinate);
+voidValue = popup.setPosition(undefined);
 voidValue = popup.setPositioning(popupPositioning);
 
 


### PR DESCRIPTION
According to the [document of ol.Overlay.setPosition](http://openlayers.org/en/latest/apidoc/ol.Overlay.html#setPosition), set it to undefined makes the popup disappear. However, in the current definition, it doesn't allow to be set to undefined.