### PR TITLE
google.visualization: Additional isStacked values

### DIFF
--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -584,7 +584,7 @@ declare namespace google {
             draw(data: DataTable | DataView, options: ColumnChartOptions): void;
         }
 
-        // https://developers.google.com/chart/interactive/docs/gallery/columnchart#Configuration_Options
+        // https://developers.google.com/chart/interactive/docs/gallery/columnchart#configuration-options
         export interface ColumnChartOptions {
             aggregationTarget?: string;
             animation?: TransitionAnimation;
@@ -600,7 +600,7 @@ declare namespace google {
             fontName?: string;
             hAxis?: ChartAxis;
             height?: number;
-            isStacked?: boolean;
+            isStacked?: boolean | 'percent' | 'relative' | 'absolute';
             legend?: ChartLegend | 'none';
             reverseCategories?: boolean;
             selectionMode?: string // single / multiple
@@ -663,7 +663,7 @@ declare namespace google {
         //#endregion
         //#region BarChart
 
-        // https://developers.google.com/chart/interactive/docs/gallery/barchart#Configuration_Options
+        // https://developers.google.com/chart/interactive/docs/gallery/barchart#configuration-options
         export interface BarChartOptions {
             aggregationTarget?: string;
             animation?: TransitionAnimation;
@@ -681,7 +681,7 @@ declare namespace google {
             hAxes?: any;
             hAxis?: ChartAxis;
             height?: number;
-            isStacked?: boolean;
+            isStacked?: boolean | 'percent' | 'relative' | 'absolute';
             legend?: ChartLegend | 'none';
             reverseCategories?: boolean;
             series?: any;
@@ -708,7 +708,7 @@ declare namespace google {
             draw(data: DataTable | DataView, options: HistogramOptions): void;
         }
 
-        // https://developers.google.com/chart/interactive/docs/gallery/histogram#Configuration_Options
+        // https://developers.google.com/chart/interactive/docs/gallery/histogram#configuration-options
         export interface HistogramOptions {
             animation?: TransitionAnimation;
             axisTitlesPosition?: string; // in, out, none
@@ -725,7 +725,7 @@ declare namespace google {
             histogram?: HistogramHistogramOptions;
             height?: number;
             interpolateNulls?: boolean;
-            isStacked?: boolean;
+            isStacked?: boolean | 'percent' | 'relative' | 'absolute';
             legend?: ChartLegend | 'none';
             orientation?: string;
             reverseCategories?: boolean;
@@ -754,7 +754,7 @@ declare namespace google {
             draw(data: DataTable | DataView, options: AreaChartOptions): void;
         }
 
-        // https://developers.google.com/chart/interactive/docs/gallery/areachart#Configuration_Options
+        // https://developers.google.com/chart/interactive/docs/gallery/areachart#configuration-options
         export interface AreaChartOptions {
             aggregationTarget?: string;
             animation?: TransitionAnimation;
@@ -774,7 +774,7 @@ declare namespace google {
             hAxis?: ChartAxis;
             height?: number;
             interpolateNulls?: boolean;
-            isStacked?: boolean;
+            isStacked?: boolean | 'percent' | 'relative' | 'absolute';
             legend?: ChartLegend | 'none';
             lineWidth?: number;
             orientation?: string;
@@ -842,7 +842,7 @@ declare namespace google {
             draw(data: DataTable | DataView, options: SteppedAreaChartOptions): void;
         }
 
-        // https://developers.google.com/chart/interactive/docs/gallery/areachart#Configuration_Options
+        // https://developers.google.com/chart/interactive/docs/gallery/steppedareachart#configuration-options
         export interface SteppedAreaChartOptions {
             aggregationTarget?: string;
             animation?: TransitionAnimation;
@@ -859,7 +859,7 @@ declare namespace google {
             hAxis?: ChartAxis;
             height?: number;
             interpolateNulls?: boolean;
-            isStacked?: boolean;
+            isStacked?: boolean | 'percent' | 'relative' | 'absolute';
             legend?: ChartLegend | 'none';
             reverseCategories?: boolean;
             selectionMode?: string // single / multiple
@@ -882,7 +882,7 @@ declare namespace google {
             draw(data: DataTable | DataView, options: PieChartOptions): void;
         }
 
-        // https://developers.google.com/chart/interactive/docs/gallery/piechart#Configuration_Options
+        // https://developers.google.com/chart/interactive/docs/gallery/piechart#configuration-options
         export interface PieChartOptions {
             backgroundColor?: any;
             chartArea?: ChartArea;


### PR DESCRIPTION
All charts that support `isStacked` except ComboChart also support `'percent' | 'relative' | 'absolute'` as possible values.
