### PR TITLE
DraftJS: add editorState param to event handlers

### DIFF
--- a/types/draft-js/draft-js-tests.tsx
+++ b/types/draft-js/draft-js-tests.tsx
@@ -68,13 +68,12 @@ class RichEditorExample extends React.Component<{}, { editorState: EditorState }
     return getDefaultKeyBinding(e);
   }
 
-  handleKeyCommand = (command: string) => {
+  handleKeyCommand = (command: string, editorState: EditorState) => {
     if (command === SPLIT_HEADER_BLOCK) {
       this.onChange(this.splitHeaderToNewBlock());
       return 'handled';
     }
 
-    const {editorState} = this.state;
     const newState = RichUtils.handleKeyCommand(editorState, command);
 
     if (newState) {

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Draft.js v0.10.0
+// Type definitions for Draft.js v0.10.1
 // Project: https://facebook.github.io/draft-js/
 // Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>
 //                 Eelco Lempsink <https://github.com/eelco>
@@ -6,6 +6,7 @@
 //                 Ryan Schwers <https://github.com/schwers>
 //                 Michael Wu <https://github.com/michael-yx-wu>
 //                 Willis Plummer <https://github.com/willisplummer>
+//                 Santiago Vilar <https://github.com/smvilar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -125,20 +126,20 @@ declare namespace Draft {
 
                 // Useful for managing special behavior for pressing the `Return` key. E.g.
                 // removing the style from an empty list item.
-                handleReturn?(e: SyntheticKeyboardEvent): DraftHandleValue,
+                handleReturn?(e: SyntheticKeyboardEvent, editorState: EditorState): DraftHandleValue,
 
                 // Map a key command string provided by your key binding function to a
                 // specified behavior.
-                handleKeyCommand?(command: EditorCommand): DraftHandleValue,
+                handleKeyCommand?(command: EditorCommand, editorState: EditorState): DraftHandleValue,
 
                 // Handle intended text insertion before the insertion occurs. This may be
                 // useful in cases where the user has entered characters that you would like
                 // to trigger some special behavior. E.g. immediately converting `:)` to an
                 // emoji Unicode character, or replacing ASCII quote characters with smart
                 // quotes.
-                handleBeforeInput?(chars: string): DraftHandleValue,
+                handleBeforeInput?(chars: string, editorState: EditorState): DraftHandleValue,
 
-                handlePastedText?(text: string, html?: string): DraftHandleValue,
+                handlePastedText?(text: string, html: string|undefined, editorState: EditorState): DraftHandleValue,
 
                 handlePastedFiles?(files: Array<Blob>): DraftHandleValue,
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://draftjs.org/docs/api-reference-editor.html#cancelable-handlers-optional
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
