### PR TITLE
Fix parse_response type and use lookup type

### DIFF
--- a/types/needle/index.d.ts
+++ b/types/needle/index.d.ts
@@ -42,7 +42,7 @@ declare namespace core {
         /**
          * Alias for open_timeout
          */
-        timeout?: number;
+        timeout?: RequestOptions['open_timeout'];
 
         /**
          * Returns error if data transfer takes longer than X milisecs,
@@ -56,7 +56,7 @@ declare namespace core {
         /**
          * Alias for follow_max
          */
-        follow?: number;
+        follow?: RequestOptions['follow_max'];
 
         /**
          * Enables multipart/form-data encoding. Defaults to false.
@@ -155,7 +155,7 @@ declare namespace core {
         /**
          * Alias for decode_response
          */
-        decode?: boolean;
+        decode?: ResponseOptions['decode_response'];
 
         /**
          * Whether to parse XML or JSON response bodies automagically.
@@ -163,11 +163,11 @@ declare namespace core {
          * You can also set this to 'xml' or 'json' in which case Needle
          * will only parse the response if the content type matches.
          */
-        parse_response?: boolean;
+        parse_response?: boolean | 'json' | 'xml';
         /**
          * Alias for parse_response
          */
-        parse?: boolean;
+        parse?: ResponseOptions['parse_response'];
 
         /**
          * Whether to parse response’s Set-Cookie header.


### PR DESCRIPTION
The type of parse_response/parse is missing two options. This PR fixes this.

Also, aliases no use the exact type of the property they are an alias for.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: no url needed, the docs are right in the code
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.