### PR TITLE
Add missing types on ILoadingBarProvider in @types/angular-loading-bar

### DIFF
--- a/types/angular-loading-bar/angular-loading-bar-tests.ts
+++ b/types/angular-loading-bar/angular-loading-bar-tests.ts
@@ -1,5 +1,4 @@
 
-
 var app = angular.module('testModule', ['angular-loading-bar']);
 
 class TestController {

--- a/types/angular-loading-bar/angular-loading-bar-tests.ts
+++ b/types/angular-loading-bar/angular-loading-bar-tests.ts
@@ -19,5 +19,8 @@ barConfig.push({
     includeSpinner: true,
     includeBar: true,
     spinnerTemplate: 'template',
-    latencyThreshold: 100
+    latencyThreshold: 100,
+    startSize: 0.02,
+    loadingBarTemplate: '',
+    autoIncrement: true
 });

--- a/types/angular-loading-bar/index.d.ts
+++ b/types/angular-loading-bar/index.d.ts
@@ -7,40 +7,38 @@
 
 /// <reference types="angular" />
 
-import * as angular from 'angular';
-
 declare module 'angular' {
-	export namespace loadingBar {
+    export namespace loadingBar {
 
-		interface ILoadingBarProvider {
-			/**
-			* Turn the spinner on or off
-			*/
-			includeSpinner?: boolean;
+        interface ILoadingBarProvider {
+            /**
+             * Turn the spinner on or off
+             */
+            includeSpinner?: boolean;
 
-			/**
-			* Turn the loading bar on or off
-			*/
-			includeBar?: boolean;
+            /**
+             * Turn the loading bar on or off
+             */
+            includeBar?: boolean;
 
-			/**
-			* HTML template
-			*/
-			spinnerTemplate?: string;
+            /**
+             * HTML template
+             */
+            spinnerTemplate?: string;
 
             /**
              * Loading bar template
              */
             loadingBarTemplate?: string;
 
-			/**
-			* Latency Threshold
-			*/
-			latencyThreshold?: number;
-			/**
-			 * HTML element selector of parent
-			 */
-			parentSelector?: string;
+            /**
+             * Latency Threshold
+             */
+            latencyThreshold?: number;
+            /**
+             * HTML element selector of parent
+             */
+            parentSelector?: string;
 
             /**
              * Starting size
@@ -51,14 +49,14 @@ declare module 'angular' {
              * Give illusion that there's always progress
              */
             autoIncrement?: boolean;
-		}
-	}
+        }
+    }
 
-	interface IRequestShortcutConfig {
-		/**
-		 * Indicates that the loading bar should be hidden.
-		 */
-		ignoreLoadingBar?: boolean;
-	}
+    interface IRequestShortcutConfig {
+        /**
+         * Indicates that the loading bar should be hidden.
+         */
+        ignoreLoadingBar?: boolean;
+    }
 
 }

--- a/types/angular-loading-bar/index.d.ts
+++ b/types/angular-loading-bar/index.d.ts
@@ -7,6 +7,8 @@
 
 /// <reference types="angular" />
 
+import * as angular from 'angular';
+
 declare module 'angular' {
     export namespace loadingBar {
 

--- a/types/angular-loading-bar/index.d.ts
+++ b/types/angular-loading-bar/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for angular-loading-bar
 // Project: https://github.com/chieffancypants/angular-loading-bar
-// Definitions by: Stephen Lautier <https://github.com/stephenlautier>
+// Definitions by:  Stephen Lautier <https://github.com/stephenlautier>
+//                  Tyrone Dougherty <https://github.com/tyronedougherty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -27,6 +28,11 @@ declare module 'angular' {
 			*/
 			spinnerTemplate?: string;
 
+            /**
+             * Loading bar template
+             */
+            loadingBarTemplate?: string;
+
 			/**
 			* Latency Threshold
 			*/
@@ -35,6 +41,16 @@ declare module 'angular' {
 			 * HTML element selector of parent
 			 */
 			parentSelector?: string;
+
+            /**
+             * Starting size
+             */
+            startSize?: number;
+
+            /**
+             * Give illusion that there's always progress
+             */
+            autoIncrement?: boolean;
 		}
 	}
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chieffancypants/angular-loading-bar/blob/master/src/loading-bar.js (lines `163` to `170`)

---

There were several properties that were not type def'd, so I've added them.

The properties added are:

- `startSize`
- `loadingBarTemplate`
- `autoIncrement`