### PR TITLE
Update Ssh2 sftp client type definition to v1.1.0

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ssh2-sftp-client v1.0.5
+// Type definitions for ssh2-sftp-client v1.1.0
 // Project: https://www.npmjs.com/package/ssh2-sftp-client
 // Definitions by: igrayson <https://github.com/igrayson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -29,10 +29,8 @@ declare module "ssh2-sftp-client" {
       new():Client;
       connect(options:ssh2.ConnectConfig):Promise<void>;
       list(remoteFilePath:string):Promise<Array<FileInfo>>;
-      get(remoteFilePath:string, useCompression?:boolean):Promise<NodeJS.ReadableStream>;
-      put(localFilePath:string, remoteFilePath:string, useCompression?:boolean):Promise<void>;
-      put(buffer:Buffer, remoteFilePath:string, useCompression?:boolean):Promise<void>;
-      put(stream:NodeJS.ReadableStream, remoteFilePath:string, useCompression?:boolean):Promise<void>;
+      get(remoteFilePath:string, useCompression?:boolean, encoding?: string):Promise<NodeJS.ReadableStream>;
+      put(input:string|Buffer|NodeJS.ReadableStream, remoteFilePath:string, useCompression?:boolean, encoding?:string):Promise<void>;
       mkdir(remoteFilePath:string, recursive?:boolean):Promise<void>;
       delete(remoteFilePath:string):Promise<void>;
       rename(remoteSourcePath:string, remoteDestPath:string):Promise<void>;

--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for ssh2-sftp-client v1.1.0
 // Project: https://www.npmjs.com/package/ssh2-sftp-client
-// Definitions by: igrayson <https://github.com/igrayson>
+// Definitions by: igrayson <https://github.com/igrayson>, Ascari Andrea <https://github.com/ascariandrea>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="ssh2"/>

--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -1,45 +1,36 @@
-// Type definitions for ssh2-sftp-client v1.1.0
+// Type definitions for ssh2-sftp-client 1.1
 // Project: https://www.npmjs.com/package/ssh2-sftp-client
 // Definitions by: igrayson <https://github.com/igrayson>, Ascari Andrea <https://github.com/ascariandrea>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="ssh2"/>
+import * as ssh2 from 'ssh2';
 
-declare module "ssh2-sftp-client" {
-  import * as ssh2 from 'ssh2';
-
-  namespace sftp {
-
-    interface FileInfo {
-      type:string;
-      name:string;
-      size:number;
-      modifyTime:number;
-      accessTime:number;
-      rights:{
-        user:string;
-        group:string;
-        other:string;
-      };
-      owner:number;
-      group:number;
-    }
-
-    interface Client {
-      new():Client;
-      connect(options:ssh2.ConnectConfig):Promise<void>;
-      list(remoteFilePath:string):Promise<Array<FileInfo>>;
-      get(remoteFilePath:string, useCompression?:boolean, encoding?: string):Promise<NodeJS.ReadableStream>;
-      put(input:string|Buffer|NodeJS.ReadableStream, remoteFilePath:string, useCompression?:boolean, encoding?:string):Promise<void>;
-      mkdir(remoteFilePath:string, recursive?:boolean):Promise<void>;
-      delete(remoteFilePath:string):Promise<void>;
-      rename(remoteSourcePath:string, remoteDestPath:string):Promise<void>;
-      end():Promise<void>;
-    }
+declare namespace sftp {
+  interface FileInfo {
+    type: string;
+    name: string;
+    size: number;
+    modifyTime: number;
+    accessTime: number;
+    rights: {
+      user: string;
+      group: string;
+      other: string;
+    };
+    owner: number;
+    group: number;
   }
 
-  var sftp:sftp.Client;
-
-  export = sftp;
+  class Client {
+    connect(options: ssh2.ConnectConfig): Promise<void>;
+    list(remoteFilePath: string): Promise<FileInfo[]>;
+    get(remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<NodeJS.ReadableStream>;
+    put(input: string | Buffer | NodeJS.ReadableStream, remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<void>;
+    mkdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
+    delete(remoteFilePath: string): Promise<void>;
+    rename(remoteSourcePath: string, remoteDestPath: string): Promise<void>;
+    end(): Promise<void>;
+  }
 }
 
+export default sftp.Client;

--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -5,6 +5,18 @@
 
 import * as ssh2 from 'ssh2';
 
+export = sftp;
+
+declare class sftp {
+  connect(options: ssh2.ConnectConfig): Promise<void>;
+  list(remoteFilePath: string): Promise<sftp.FileInfo[]>;
+  get(remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<NodeJS.ReadableStream>;
+  put(input: string | Buffer | NodeJS.ReadableStream, remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<void>;
+  mkdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
+  delete(remoteFilePath: string): Promise<void>;
+  rename(remoteSourcePath: string, remoteDestPath: string): Promise<void>;
+  end(): Promise<void>;
+}
 declare namespace sftp {
   interface FileInfo {
     type: string;
@@ -20,17 +32,4 @@ declare namespace sftp {
     owner: number;
     group: number;
   }
-
-  class Client {
-    connect(options: ssh2.ConnectConfig): Promise<void>;
-    list(remoteFilePath: string): Promise<FileInfo[]>;
-    get(remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<NodeJS.ReadableStream>;
-    put(input: string | Buffer | NodeJS.ReadableStream, remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<void>;
-    mkdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
-    delete(remoteFilePath: string): Promise<void>;
-    rename(remoteSourcePath: string, remoteDestPath: string): Promise<void>;
-    end(): Promise<void>;
-  }
 }
-
-export default sftp.Client;

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -1,4 +1,5 @@
 import * as Client from 'ssh2-sftp-client';
+import * as fs from 'fs';
 var client = new Client();
 
 client.connect({
@@ -11,10 +12,11 @@ client.connect({
 client.list('/remote/path').then(() => null);
 
 client.get('/remote/path').then(stream => stream.read(0));
+client.get('/remote/path', true, 'binary').then(stream => stream.read(0));
 
 client.put('/local/path', '/remote/path').then(() => null);
-
 client.put(new Buffer('content'), '/remote/path').then(() => null);
+client.put(fs.createReadStream('Hello World'), '/remote/path').then(() => null);
 
 client.mkdir('/remote/path/dir', true).then(() => null);
 

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -1,6 +1,6 @@
-import * as Client from 'ssh2-sftp-client';
+import Client from 'ssh2-sftp-client';
 import * as fs from 'fs';
-var client = new Client();
+const client = new Client();
 
 client.connect({
     host: 'asdb',

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -1,4 +1,4 @@
-import Client from 'ssh2-sftp-client';
+import * as Client from 'ssh2-sftp-client';
 import * as fs from 'fs';
 const client = new Client();
 

--- a/types/ssh2-sftp-client/tslint.json
+++ b/types/ssh2-sftp-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ssh2-sftp-client](https://github.com/jyu213/ssh2-sftp-client/blob/master/src/index.js#L63)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
