### PR TITLE
mapValues can accept a single param and output entire object

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -16222,7 +16222,7 @@ declare namespace _ {
         */
         mapValues<T, TResult>(obj: Dictionary<T> | null | undefined, callback: ObjectIterator<T, TResult>): Dictionary<TResult>;
         mapValues<T>(obj: Dictionary<T> | null | undefined, where: Dictionary<T>): Dictionary<boolean>;
-        mapValues<T, TMapped>(obj: T | null | undefined, pluck: string): TMapped;
+        mapValues<T, TMapped>(obj: T | null | undefined, pluck?: string): TMapped;
         mapValues<T>(obj: T | null | undefined, callback: ObjectIterator<any, any>): T;
     }
 
@@ -16239,7 +16239,7 @@ declare namespace _ {
          * TResult is the type of the property specified by pluck.
          * T should be a Dictionary<Dictionary<TResult>>
          */
-        mapValues<TResult>(pluck: string): LoDashImplicitObjectWrapper<Dictionary<TResult>>;
+        mapValues<TResult>(pluck?: string): LoDashImplicitObjectWrapper<Dictionary<TResult>>;
 
         /**
          * @see _.mapValues
@@ -16262,7 +16262,7 @@ declare namespace _ {
          * TResult is the type of the property specified by pluck.
          * T should be a Dictionary<Dictionary<TResult>>
          */
-        mapValues<TResult>(pluck: string): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
+        mapValues<TResult>(pluck?: string): LoDashExplicitObjectWrapper<Dictionary<TResult>>;
 
         /**
          * @see _.mapValues


### PR DESCRIPTION
This makes the pluck string optional in the mapValues function. If string is omitted then the result will be the entire object

http://jsbin.com/zonetoq/1/edit?html,js,console
```javascript
const data = [
  {id: 1, photo:'api/photo/1'},
  {id: 2, photo:'api/photo/2'},
]

let result = _.mapValues(_.keyBy(data, 'id'))
console.log(result)
/*
[object Object] {
  1: [object Object] {
    id: 1,
    photo: "api/photo/1"
  },
  2: [object Object] {
    id: 2,
    photo: "api/photo/2"
  }
*/
```