### PR TITLE
Support multiple colors / styles

### DIFF
--- a/types/winston/index.d.ts
+++ b/types/winston/index.d.ts
@@ -15,7 +15,7 @@ declare namespace winston {
     }
 
     interface AbstractConfigSetColors {
-        [key: string]: string;
+        [key: string]: string | string[];
     }
 
     interface AbstractConfigSet {
@@ -37,16 +37,16 @@ declare namespace winston {
     }
 
     interface CliConfigSetColors extends AbstractConfigSetColors {
-        error: string;
-        warn: string;
-        help: string;
-        data: string;
-        info: string;
-        debug: string;
-        prompt: string;
-        verbose: string;
-        input: string;
-        silly: string;
+        error: string | string[];
+        warn: string | string[];
+        help: string | string[];
+        data: string | string[];
+        info: string | string[];
+        debug: string | string[];
+        prompt: string | string[];
+        verbose: string | string[];
+        input: string | string[];
+        silly: string | string[];
     }
     interface NpmConfigSetLevels extends AbstractConfigSetLevels {
         error: number;
@@ -57,12 +57,12 @@ declare namespace winston {
         silly: number;
     }
     interface NpmConfigSetColors extends AbstractConfigSetColors {
-        error: string;
-        warn: string;
-        info: string;
-        verbose: string;
-        debug: string;
-        silly: string;
+        error: string | string[];
+        warn: string | string[];
+        info: string | string[];
+        verbose: string | string[];
+        debug: string | string[];
+        silly: string | string[];
     }
     interface SyslogConfigSetLevels extends AbstractConfigSetLevels {
         emerg: number;
@@ -75,14 +75,14 @@ declare namespace winston {
         debug: number;
     }
     interface SyslogConfigSetColors extends AbstractConfigSetColors {
-        emerg: string;
-        alert: string;
-        crit: string;
-        error: string;
-        warning: string;
-        notice: string;
-        info: string;
-        debug: string;
+        emerg: string | string[];
+        alert: string | string[];
+        crit: string | string[];
+        error: string | string[];
+        warning: string | string[];
+        notice: string | string[];
+        info: string | string[];
+        debug: string | string[];
     }
 
     interface Winston {


### PR DESCRIPTION
Winston supports configuring multiple styles rather than a single color.  For example you could winston.addColors( { error: ['white', 'underline', 'bgRed'] });

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: winston uses colors.js for all coloring.  See `https://github.com/Marak/colors.js` "combining colors" at the very bottom.
- [x] Increase the version number in the header if appropriate.  (Not needed, fix to existing version)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.  (N/A)
