### PR TITLE
Add missing cookies property

### DIFF
--- a/types/needle/index.d.ts
+++ b/types/needle/index.d.ts
@@ -15,6 +15,7 @@ declare namespace core {
         body: any;
         raw: Buffer;
         bytes: number;
+        cookies?: Cookies;
     }
 
     type ReadableStream = NodeJS.ReadableStream;


### PR DESCRIPTION
The docs state:
> `parse_cookies`: If parsed, response cookies will be available at resp.cookies.

`NeedleResponse` does not have a cookies property. This PR adds it as an optional property, since ot's only set when whe `parse_cookies` option is set to true.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <no URL needed, docs are in the definition>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.