### PR TITLE
recursive-readdir: Fixes definitions to match reality.

### DIFF
--- a/types/recursive-readdir/index.d.ts
+++ b/types/recursive-readdir/index.d.ts
@@ -1,20 +1,21 @@
-// Type definitions for recursive-readdir v1.2.1
+// Type definitions for recursive-readdir 2.2
 // Project: https://github.com/jergason/recursive-readdir/
-// Definitions by: Elisée Maurer <https://github.com/elisee>
+// Definitions by: Elisée Maurer <https://github.com/elisee>, Micah Zoltu <https://github.com/MicahZoltu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
-
 import * as fs from "fs";
 declare namespace RecursiveReaddir {
-    interface readdir {
-        (path: string, callback: (error: Error, files: string[]) => any): void;
-        // ignorePattern supports glob syntax via https://github.com/isaacs/minimatch
-        (path: string, ignorePattern: (string | ((file: string, stats: fs.Stats) => void))[], callback: (error: Error, files: string[]) => any): void;
-        (path: string, ignoreFunction: (file: string, stats: fs.Stats) => void, callback: (error: Error, files: string[]) => any): void;
+    type IgnoreFunction = (file: string, stats: fs.Stats) => boolean;
+    type Ignores = ReadonlyArray<string|IgnoreFunction>;
+    type Callback = (error: Error, files: string[]) => void;
+    interface readDir {
+        (path: string, ignores?: Ignores): Promise<string[]>;
+        (path: string, callback: Callback): void;
+        (path: string, ignores: Ignores, callback: Callback): void;
     }
 }
 
-declare var r: RecursiveReaddir.readdir;
-export = r;
+declare var recursiveReadDir: RecursiveReaddir.readDir;
+export = recursiveReadDir;

--- a/types/recursive-readdir/recursive-readdir-tests.ts
+++ b/types/recursive-readdir/recursive-readdir-tests.ts
@@ -1,5 +1,13 @@
-
+import * as fs from "fs";
 import recursiveReaddir = require("recursive-readdir");
 
 recursiveReaddir("some/path", (err, files) => {});
 recursiveReaddir("some/path", ["foo.cs", "*.html"], (err, files) => {});
+
+function apple(a: string, b: fs.Stats): boolean {
+    return true;
+}
+
+async function banana(): Promise<string[]> {
+    return recursiveReaddir("some/path", [apple]);
+}

--- a/types/recursive-readdir/tslint.json
+++ b/types/recursive-readdir/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/recursive-readdir/v1/index.d.ts
+++ b/types/recursive-readdir/v1/index.d.ts
@@ -1,0 +1,20 @@
+// Type definitions for recursive-readdir v1.2.1
+// Project: https://github.com/jergason/recursive-readdir/
+// Definitions by: Elisée Maurer <https://github.com/elisee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+
+import * as fs from "fs";
+declare namespace RecursiveReaddir {
+    interface readdir {
+        (path: string, callback: (error: Error, files: string[]) => any): void;
+        // ignorePattern supports glob syntax via https://github.com/isaacs/minimatch
+        (path: string, ignorePattern: (string | ((file: string, stats: fs.Stats) => void))[], callback: (error: Error, files: string[]) => any): void;
+        (path: string, ignoreFunction: (file: string, stats: fs.Stats) => void, callback: (error: Error, files: string[]) => any): void;
+    }
+}
+
+declare var r: RecursiveReaddir.readdir;
+export = r;

--- a/types/recursive-readdir/v1/recursive-readdir-tests.ts
+++ b/types/recursive-readdir/v1/recursive-readdir-tests.ts
@@ -1,0 +1,5 @@
+
+import recursiveReaddir = require("recursive-readdir");
+
+recursiveReaddir("some/path", (err, files) => {});
+recursiveReaddir("some/path", ["foo.cs", "*.html"], (err, files) => {});

--- a/types/recursive-readdir/v1/tsconfig.json
+++ b/types/recursive-readdir/v1/tsconfig.json
@@ -1,17 +1,19 @@
 {
     "compilerOptions": {
-        "target": "es2015",
         "module": "commonjs",
         "lib": [
             "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
-        "baseUrl": "../",
+        "strictNullChecks": false,
+        "baseUrl": "../../",
         "typeRoots": [
-            "../"
+            "../../"
         ],
+        "paths": {
+            "recursive-readdir": [ "recursive-readdir/v1" ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Return type on ignore function was missing and Promise return type was missing from overloads that didn't take a callback.  Also extracts out a helper type definitions and provides slightly better variable naming for the transient `recursiveReadDir`.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jergason/recursive-readdir/blob/master/index.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.