### PR TITLE
webpack: improve loader context typings

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -1162,13 +1162,13 @@ declare namespace webpack {
              * Emit a warning.
              * @param message
              */
-            emitWarning(message: string): void;
+            emitWarning(message: string | Error): void;
 
             /**
              * Emit a error.
              * @param message
              */
-            emitError(message: string): void;
+            emitError(message: string | Error): void;
 
             /**
              * Execute some code fragment like a module.

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -611,7 +611,11 @@ function loader(this: webpack.loader.LoaderContext, source: string, sourcemap: s
 
     this.resolve('context', 'request', ( err: Error, result: string) => {});
 
-    this.emitError('warning');
+    this.emitWarning('warning message');
+    this.emitWarning(new Error('warning message'));
+
+    this.emitError('error message');
+    this.emitError(new Error('error message'));
 
     this.callback(null, source);
 }


### PR DESCRIPTION
emitError() and emitWarning() can both accept an Error, for exposing already caught Errors.
See: https://github.com/webpack/webpack/blob/master/lib/NormalModule.js#L115

Added relevant type tests.