### PR TITLE
fix: do not make use of es6's Map and Set

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -395,26 +395,34 @@ declare namespace Sinon {
         contains(expected: any[]): SinonMatcher;
     }
 
+    interface SimplifiedSet {
+        has(el: any): boolean;
+    }
+
+    interface SimplifiedMap extends SimplifiedSet {
+        get(key: any): any;
+    }
+
     interface SinonMapMatcher extends SinonMatcher {
         /**
          * Requires a Map to be deep equal another one.
          */
-        deepEquals(expected: Map<any, any>): SinonMatcher;
+        deepEquals(expected: SimplifiedMap): SinonMatcher;
         /**
          * Requires a Map to contain each one of the items the given map has.
          */
-        contains(expected: Map<any, any>): SinonMatcher;
+        contains(expected: SimplifiedMap): SinonMatcher;
     }
 
     interface SinonSetMatcher extends SinonMatcher {
         /**
          *  Requires a Set to be deep equal another one.
          */
-        deepEquals(expected: Set<any>): SinonMatcher;
+        deepEquals(expected: SimplifiedSet): SinonMatcher;
         /**
          * Requires a Set to contain each one of the items the given set has.
          */
-        contains(expected: Set<any>): SinonMatcher;
+        contains(expected: SimplifiedSet): SinonMatcher;
     }
 
     interface SinonMatch {


### PR DESCRIPTION
This is a partial fix for #16587. I do make use of a custom Map/Set interface in order to allow sinon be es6 free. Sinon's implementation does not rely on es6, so it's definition on tsconfig.json is wrong. In my opinion it is only there to easy the tests where you need Promise/Map/Set types.

I believe that to properly fix this, tsconfig.json should only target `es5` and make use of es6 only for testing. I do not know though if something like that is possible. Is there a way to have 2 tsconfig files? 