### PR TITLE
Ramda: Tighten type signature for `append`

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -225,9 +225,8 @@ declare namespace R {
         /**
          * Returns a new list containing the contents of the given list, followed by the given element.
          */
-        append<U>(el: U): <T>(list: T[]) => Array<(T & U)>;
-        append<T, U>(el: U, list: T[]): Array<(T & U)>;
-        append<T>(el: T, list: string): Array<T & string>;
+        append<T>(el: T, list: T[]): T[];
+        append<T>(el: T): <T>(list: T[]) => T[];
 
         /**
          * Applies function fn to the argument list args. This is useful for creating a fixed-arity function from

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -442,10 +442,6 @@ R.times(i, 5);
     R.append("tests", ["write", "more"]); // => ['write', 'more', 'tests']
     R.append("tests")(["write", "more"]); // => ['write', 'more', 'tests']
     R.append("tests", []); // => ['tests']
-    R.append<string, string[]>(["tests"], ["write", "more"]); // => ['write', 'more', ['tests']]
-    R.append(["tests"], ["write", "more"]); // => ['write', 'more', ['tests']]
-    R.append<string[]>(["tests"])(["write", "more"]); // => ['write', 'more', ['tests']]
-    R.append(["tests"])(["write", "more"]); // => ['write', 'more', ['tests']]
 };
 
 () => {


### PR DESCRIPTION
[The Ramda documentation clearly states](http://ramdajs.com/docs/#append) that the element to append an the elements in the list should have the same type.
The previous type definition unnecessarily weakened type safety. For example this error could not be detected by TypeScript:

```typescript
interface A {
    id: number
}
const list: A[] = []
R.append({idd: 2}, list)
```

Which seems ridiculous. If one wanted an intersection type, one could explicity define it to be used for the list/element type. Additionally, the function `prepend` already is as strict as this proposal, that should probably be consistent.

I also deleted a redundant line.