### PR TITLE
[chrome] Add and utilize ColorArray type

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -448,16 +448,7 @@ declare namespace chrome.browserAction {
         tabId?: number;
     }
 
-    interface ColorArray extends Array<number> {
-        /** Red */
-        0: number;
-        /** Green */
-        1: number;
-        /** Blue */
-        2: number;
-        /** Alpha */
-        3: number;
-    }
+    type ColorArray = [number, number, number, number];
 
     interface TitleDetails {
         /** The string the browser action should display when moused over. */

--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -436,7 +436,7 @@ declare namespace chrome.bookmarks {
 declare namespace chrome.browserAction {
     interface BadgeBackgroundColorDetails {
         /** An array of four integers in the range [0,255] that make up the RGBA color of the badge. For example, opaque red is [255, 0, 0, 255]. Can also be a string with a CSS value, with opaque red being #FF0000 or #F00. */
-        color: any;
+        color: string | ColorArray;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
         tabId?: number;
     }
@@ -446,6 +446,17 @@ declare namespace chrome.browserAction {
         text: string;
         /** Optional. Limits the change to when a particular tab is selected. Automatically resets when the tab is closed.  */
         tabId?: number;
+    }
+
+    interface ColorArray extends Array<number> {
+        /** Red */
+        0: number;
+        /** Green */
+        1: number;
+        /** Blue */
+        2: number;
+        /** Alpha */
+        3: number;
     }
 
     interface TitleDetails {
@@ -518,7 +529,7 @@ declare namespace chrome.browserAction {
      * @param callback The callback parameter should be a function that looks like this:
      * function( ColorArray result) {...};
      */
-    export function getBadgeBackgroundColor(details: TabDetails, callback: (result: number[]) => void): void;
+    export function getBadgeBackgroundColor(details: TabDetails, callback: (result: ColorArray) => void): void;
     /**
      * Since Chrome 19.
      * Gets the html document set as the popup for this browser action.


### PR DESCRIPTION
Added a declaration for `ColorArray` type, which is [documented here](https://developer.chrome.com/extensions/browserAction#type-ColorArray), and updated some typings with it.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/extensions/browserAction#type-ColorArray https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.