### PR TITLE
Allow access to custom GeoJSON properties @types/geojson

### DIFF
--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -205,3 +205,20 @@ featureCollection = {
         }
     }
 };
+
+// Allow access to custom properties
+const pt: GeoJSON.Feature<GeoJSON.Point> = {
+    type: 'Feature',
+    properties: {
+        foo: 'bar',
+        hello: 'world',
+        1: 2
+    },
+    geometry: {
+        type: 'Point',
+        coordinates: [0, 0]
+    }
+};
+pt.properties.foo;
+pt.properties.hello;
+pt.properties[1];

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://geojson.org/
 // Definitions by: Jacob Bruun <https://github.com/cobster>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 export as namespace GeoJSON;
 

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -92,7 +92,7 @@ export interface GeometryCollection extends GeoJsonObject {
 export interface Feature<T extends GeometryObject> extends GeoJsonObject {
     type: 'Feature';
     geometry: T;
-    properties: {} | null;
+    properties: {[key: string]: any} | null;
     id?: string;
 }
 

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -2,7 +2,6 @@
 // Project: http://geojson.org/
 // Definitions by: Jacob Bruun <https://github.com/cobster>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 export as namespace GeoJSON;
 
@@ -93,7 +92,7 @@ export interface GeometryCollection extends GeoJsonObject {
 export interface Feature<T extends GeometryObject> extends GeoJsonObject {
     type: 'Feature';
     geometry: T;
-    properties: {[key: string]: any} | null;
+    properties: any;
     id?: string;
 }
 


### PR DESCRIPTION
Ref: https://tools.ietf.org/html/rfc7946#section-3.2
A Feature object has a member with the name "properties".  The value of the properties member is an object (any JSON object or a JSON null value).

Could possibly change `{[key: string]: any} | null` to `any` to make things simpler.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://tools.ietf.org/html/rfc7946#section-3.2
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
