### PR TITLE
Fix docopt export format

### DIFF
--- a/types/docopt/docopt-tests.ts
+++ b/types/docopt/docopt-tests.ts
@@ -1,4 +1,4 @@
-import docopt = require("docopt");
+import { docopt } from "docopt";
 
 var doc = `
 Usage:

--- a/types/docopt/index.d.ts
+++ b/types/docopt/index.d.ts
@@ -6,9 +6,7 @@
 /**
  * @param doc should be a string with the help message, written according to rules of the docopt language.
  */
-declare function docopt(doc: string, options: DocoptOption): any;
-
-export = docopt;
+export function docopt(doc: string, options: DocoptOption): any;
 
 interface DocoptOption {
     /** is an optional argument vector. It defaults to the arguments passed to your program (process.argv[2..]). You can also supply it with an array of strings, as with process.argv. For example: ['--verbose', '-o', 'hai.txt'] */

--- a/types/docopt/index.d.ts
+++ b/types/docopt/index.d.ts
@@ -8,7 +8,7 @@
  */
 export function docopt(doc: string, options: DocoptOption): any;
 
-interface DocoptOption {
+export interface DocoptOption {
     /** is an optional argument vector. It defaults to the arguments passed to your program (process.argv[2..]). You can also supply it with an array of strings, as with process.argv. For example: ['--verbose', '-o', 'hai.txt'] */
     argv?: Array<string>,
     /** (default:true) specifies whether the parser should automatically print the help message (supplied as doc) in case -h or --help options are encountered. After showing the usage-message, the program will terminate. If you want to handle -h or --help options manually (the same as other options), set help=false. */


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This type was meant for version 0.6.2 but I couldn't use it with that version (published 2 years ago on npm).

It expects the module to do `module.exports = function docopt () {}` while in reality it does `exports.docopt = function docopt () {}`.

This PR updates the type to reflect this.

Before this patch:

```
➜  docopt git:(master) ✗ ts-node docopt-tests.ts

/DefinitelyTyped/types/docopt/docopt-tests.ts:9
docopt(doc, { version: '0.1.1rc' });
^
TypeError: docopt is not a function
```

And after this patch:

```
➜  docopt git:(master) ✗ ts-node docopt-tests.ts
Usage:
  quick_example.coffee tcp <host> <port> [--timeout=<seconds>]
  quick_example.coffee serial <port> [--baud=9600] [--timeout=<seconds>]
  quick_example.coffee -h | --help | --version
```