### PR TITLE
[React-Router-DOM] Fix exporting types for JetBrains IDE

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -24,33 +24,33 @@ export {
     withRouter,
     RouterChildContext
 } from 'react-router';
-  
+
 export interface BrowserRouterProps {
-  basename?: string;
-  getUserConfirmation?(): void;
-  forceRefresh?: boolean;
-  keyLength?: number;
+    basename?: string;
+    getUserConfirmation?(): void;
+    forceRefresh?: boolean;
+    keyLength?: number;
 }
 export class BrowserRouter extends React.Component<BrowserRouterProps> {}
-  
+
 export interface HashRouterProps {
-  basename?: string;
-  getUserConfirmation?(): void;
-  hashType?: 'slash' | 'noslash' | 'hashbang';
+    basename?: string;
+    getUserConfirmation?(): void;
+    hashType?: 'slash' | 'noslash' | 'hashbang';
 }
 export class HashRouter extends React.Component<HashRouterProps> {}
-  
+
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-  to: H.LocationDescriptor;
-  replace?: boolean;
+    to: H.LocationDescriptor;
+    replace?: boolean;
 }
 export class Link extends React.Component<LinkProps> {}
-  
+
 export interface NavLinkProps extends LinkProps {
-  activeClassName?: string;
-  activeStyle?: React.CSSProperties;
-  exact?: boolean;
-  strict?: boolean;
-  isActive?<P>(match: match<P>, location: H.Location): boolean;
+    activeClassName?: string;
+    activeStyle?: React.CSSProperties;
+    exact?: boolean;
+    strict?: boolean;
+    isActive?<P>(match: match<P>, location: H.Location): boolean;
 }
 export class NavLink extends React.Component<NavLinkProps> {}

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -5,8 +5,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-declare module 'react-router-dom' {
-  import {
+import { match } from "react-router";
+import * as React from 'react';
+import * as H from 'history';
+
+export {
     Prompt,
     MemoryRouter,
     Redirect,
@@ -20,61 +23,34 @@ declare module 'react-router-dom' {
     matchPath,
     withRouter,
     RouterChildContext
-  } from 'react-router';
-  import * as React from 'react';
-  import * as H from 'history';
-
-  interface BrowserRouterProps {
-    basename?: string;
-    getUserConfirmation?(): void;
-    forceRefresh?: boolean;
-    keyLength?: number;
-  }
-  class BrowserRouter extends React.Component<BrowserRouterProps> {}
-
-  interface HashRouterProps {
-    basename?: string;
-    getUserConfirmation?(): void;
-    hashType?: 'slash' | 'noslash' | 'hashbang';
-  }
-  class HashRouter extends React.Component<HashRouterProps> {}
-
-  interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-    to: H.LocationDescriptor;
-    replace?: boolean;
-  }
-  class Link extends React.Component<LinkProps> {}
-
-  interface NavLinkProps extends LinkProps {
-    activeClassName?: string;
-    activeStyle?: React.CSSProperties;
-    exact?: boolean;
-    strict?: boolean;
-    isActive?<P>(match: match<P>, location: H.Location): boolean;
-  }
-  class NavLink extends React.Component<NavLinkProps> {}
-
-  export {
-    BrowserRouter,
-    BrowserRouterProps, // TypeScript specific, not from React Router itself
-    HashRouter,
-    HashRouterProps, // TypeScript specific, not from React Router itself
-    LinkProps, // TypeScript specific, not from React Router itself
-    NavLinkProps, // TypeScript specific, not from React Router itself
-    Link,
-    NavLink,
-    Prompt,
-    MemoryRouter,
-    Redirect,
-    RouteComponentProps, // TypeScript specific, not from React Router itself
-    RouteProps, // TypeScript specific, not from React Router itself
-    Route,
-    Router,
-    StaticRouter,
-    Switch,
-    match, // TypeScript specific, not from React Router itself
-    matchPath,
-    withRouter,
-    RouterChildContext
-  };
+} from 'react-router';
+  
+export interface BrowserRouterProps {
+  basename?: string;
+  getUserConfirmation?(): void;
+  forceRefresh?: boolean;
+  keyLength?: number;
 }
+export class BrowserRouter extends React.Component<BrowserRouterProps> {}
+  
+export interface HashRouterProps {
+  basename?: string;
+  getUserConfirmation?(): void;
+  hashType?: 'slash' | 'noslash' | 'hashbang';
+}
+export class HashRouter extends React.Component<HashRouterProps> {}
+  
+export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  to: H.LocationDescriptor;
+  replace?: boolean;
+}
+export class Link extends React.Component<LinkProps> {}
+  
+export interface NavLinkProps extends LinkProps {
+  activeClassName?: string;
+  activeStyle?: React.CSSProperties;
+  exact?: boolean;
+  strict?: boolean;
+  isActive?<P>(match: match<P>, location: H.Location): boolean;
+}
+export class NavLink extends React.Component<NavLinkProps> {}


### PR DESCRIPTION
Rider always suggest me to use require instead of import because it didn't detect the imported type in the code.
Since this definitions use the declare module and the react-router definitions don't.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>