### PR TITLE
Add missing tls.connect lookup option for node 8.x

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -4709,7 +4709,7 @@ declare module "tls" {
         secureContext?: Object;
         session?: Buffer;
         minDHSize?: number;
-        lookup?: (hostname: string, options: dns.LookupOptions, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void;
+        lookup?: (hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void;
     }
 
     export interface Server extends net.Server {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -4414,6 +4414,7 @@ declare module "string_decoder" {
 
 declare module "tls" {
     import * as crypto from "crypto";
+    import * as dns from "dns";
     import * as net from "net";
     import * as stream from "stream";
 
@@ -4708,6 +4709,7 @@ declare module "tls" {
         secureContext?: Object;
         session?: Buffer;
         minDHSize?: number;
+        lookup?: (hostname: string, options: dns.LookupOptions, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void;
     }
 
     export interface Server extends net.Server {


### PR DESCRIPTION
This PR addresses [issue 19776](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19776).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
