### PR TITLE
Fix restify declarations to comply with standard lint rules.

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/restify/node-restify
 // Definitions by: Bret Little <https://github.com/blittle>, Steve Hipwell <https://github.com/stevehipwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.2
 
 /// <reference types="node" />
 
@@ -942,7 +942,7 @@ export interface Response extends http.ServerResponse {
      * @function redirect
      * @return   {undefined}
      */
-    redirect(options: string | any, next: Next): void;
+    redirect(options: object | string, next: Next): void;
 
     /** HTTP status code. */
     code: number;

--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -99,7 +99,7 @@ function send(req: restify.Request, res: restify.Response, next: restify.Next) {
     res.writeHead(200, {
         "Content-Type": "application/json"
     });
-    return next();
+    next();
 }
 
 server.post('/hello', send);
@@ -149,7 +149,9 @@ server.use(restify.plugins.throttle({
     }
 }));
 
-server.on('after', restify.plugins.auditLogger({ event: 'after', log: {} as Logger }));
+const logger = Logger.createLogger({ name: "test" });
+
+server.on('after', restify.plugins.auditLogger({ event: 'after', log: logger }));
 
 server.on('after', (req: restify.Request, res: restify.Response, route: restify.Route, err: any) => {
     route.spec.method === 'GET';
@@ -157,7 +159,7 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
     route.spec.path === '/some/path';
     route.spec.path === /\/some\/path\/.*/;
     route.spec.versions === ['v1'];
-    restify.plugins.auditLogger({ event: 'after', log: {} as Logger })(req, res, route, err);
+    restify.plugins.auditLogger({ event: 'after', log: logger })(req, res, route, err);
 });
 
 (<any> restify).defaultResponseHeaders = function(this: restify.Request, data: any) {

--- a/types/restify/tslint.json
+++ b/types/restify/tslint.json
@@ -1,9 +1,3 @@
 {
-	"extends": "dtslint/dt.json",
-	"rules": {
-		// TODOs
-		"no-any-union": false,
-		"no-object-literal-type-assertion": false,
-		"no-void-expression": false
-	}
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
This change fixes the declarations and tests for "restify" to comply with the standard lint rules. Previously existing exceptions to the rules are removed from tslint.json.

The only change to the types themselves is for `Response#redirect(...)`. The first argument was previously typed as `string | any`, which violated the linting rules. The [restify documentation](http://restify.com/docs/response-api/#redirectcode-url-next) makes it clear that the type should be `object | string`.

(Actually this could be improved further by defining a proper interface for options passed to `redirect(...)`, but `object` is an improvement over `any`, at least.)

This change requires TypeScript 2.2 because the type `object` did not exist in 2.1. Earlier versions could use `Object` but that is discouraged by the TypeScript handbook.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://restify.com/docs/response-api/#redirectcode-url-next
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.