### PR TITLE
Default export and removing namespace

### DIFF
--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -14,8 +14,9 @@
 
 import * as React from 'react';
 
-export default ReactSelectClass;
-
+export default class ReactSelectClass<TValue = OptionValues> extends React.Component<ReactSelectProps<TValue>> {
+    focus(): void;
+}
 // Other components
 export class Creatable<TValue = OptionValues> extends React.Component<ReactCreatableSelectProps<TValue>> { }
 export class Async<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue>> { }
@@ -526,9 +527,4 @@ export interface ReactAsyncSelectProps<TValue = OptionValues> extends ReactSelec
      *  message to display while options are loading
      */
     searchingText?: string;
-}
-
-
-declare class ReactSelectClass<TValue = OptionValues> extends React.Component<ReactSelectProps<TValue>> {
-    focus(): void;
 }

--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -14,522 +14,521 @@
 
 import * as React from 'react';
 
-export = ReactSelectClass;
+export default ReactSelectClass;
 
-declare namespace ReactSelectClass {
-    // Other components
-    class Creatable<TValue = OptionValues> extends React.Component<ReactCreatableSelectProps<TValue>> { }
-    class Async<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue>> { }
-    class AsyncCreatable<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue> & ReactCreatableSelectProps<TValue>> { }
+// Other components
+export class Creatable<TValue = OptionValues> extends React.Component<ReactCreatableSelectProps<TValue>> { }
+export class Async<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue>> { }
+export class AsyncCreatable<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue> & ReactCreatableSelectProps<TValue>> { }
 
-    type HandlerRendererResult = JSX.Element | null | false;
+export type HandlerRendererResult = JSX.Element | null | false;
 
-    // Handlers
-    type FocusOptionHandler<TValue = OptionValues> = (option: Option<TValue>) => void;
-    type SelectValueHandler<TValue = OptionValues> = (option: Option<TValue>) => void;
-    type ArrowRendererHandler = (props: ArrowRendererProps) => HandlerRendererResult;
-    type FilterOptionHandler<TValue = OptionValues> = (option: Option<TValue>, filter: string) => boolean;
-    type FilterOptionsHandler<TValue = OptionValues> = (options: Options<TValue>, filter: string, currentValues: Options<TValue>) => Options<TValue>;
-    type InputRendererHandler = (props: { [key: string]: any }) => HandlerRendererResult;
-    type MenuRendererHandler<TValue = OptionValues> = (props: MenuRendererProps<TValue>) => HandlerRendererResult;
-    type OnCloseHandler = () => void;
-    type OnInputChangeHandler = (inputValue: string) => void;
-    type OnInputKeyDownHandler = React.KeyboardEventHandler<HTMLDivElement | HTMLInputElement>;
-    type OnMenuScrollToBottomHandler = () => void;
-    type OnOpenHandler = () => void;
-    type OnFocusHandler = React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
-    type OnBlurHandler = React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
-    type OptionRendererHandler<TValue = OptionValues> = (option: Option<TValue>) => HandlerRendererResult;
-    type ValueRendererHandler<TValue = OptionValues> = (option: Option<TValue>) => HandlerRendererResult;
-    type OnValueClickHandler<TValue = OptionValues> = (option: Option<TValue>, event: React.MouseEvent<HTMLAnchorElement>) => void;
-    type IsOptionUniqueHandler<TValue = OptionValues> = (arg: { option: Option<TValue>, options: Options<TValue>, labelKey: string, valueKey: string }) => boolean;
-    type IsValidNewOptionHandler = (arg: { label: string }) => boolean;
-    type NewOptionCreatorHandler<TValue = OptionValues> = (arg: { label: string, labelKey: string, valueKey: string }) => Option<TValue>;
-    type PromptTextCreatorHandler = (filterText: string) => string;
-    type ShouldKeyDownEventCreateNewOptionHandler = (arg: { keyCode: number }) => boolean;
+// Handlers
+export type FocusOptionHandler<TValue = OptionValues> = (option: Option<TValue>) => void;
+export type SelectValueHandler<TValue = OptionValues> = (option: Option<TValue>) => void;
+export type ArrowRendererHandler = (props: ArrowRendererProps) => HandlerRendererResult;
+export type FilterOptionHandler<TValue = OptionValues> = (option: Option<TValue>, filter: string) => boolean;
+export type FilterOptionsHandler<TValue = OptionValues> = (options: Options<TValue>, filter: string, currentValues: Options<TValue>) => Options<TValue>;
+export type InputRendererHandler = (props: { [key: string]: any }) => HandlerRendererResult;
+export type MenuRendererHandler<TValue = OptionValues> = (props: MenuRendererProps<TValue>) => HandlerRendererResult;
+export type OnCloseHandler = () => void;
+export type OnInputChangeHandler = (inputValue: string) => void;
+export type OnInputKeyDownHandler = React.KeyboardEventHandler<HTMLDivElement | HTMLInputElement>;
+export type OnMenuScrollToBottomHandler = () => void;
+export type OnOpenHandler = () => void;
+export type OnFocusHandler = React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
+export type OnBlurHandler = React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
+export type OptionRendererHandler<TValue = OptionValues> = (option: Option<TValue>) => HandlerRendererResult;
+export type ValueRendererHandler<TValue = OptionValues> = (option: Option<TValue>) => HandlerRendererResult;
+export type OnValueClickHandler<TValue = OptionValues> = (option: Option<TValue>, event: React.MouseEvent<HTMLAnchorElement>) => void;
+export type IsOptionUniqueHandler<TValue = OptionValues> = (arg: { option: Option<TValue>, options: Options<TValue>, labelKey: string, valueKey: string }) => boolean;
+export type IsValidNewOptionHandler = (arg: { label: string }) => boolean;
+export type NewOptionCreatorHandler<TValue = OptionValues> = (arg: { label: string, labelKey: string, valueKey: string }) => Option<TValue>;
+export type PromptTextCreatorHandler = (filterText: string) => string;
+export type ShouldKeyDownEventCreateNewOptionHandler = (arg: { keyCode: number }) => boolean;
 
-    type OnChangeSingleHandler<TValue = OptionValues> = OnChangeHandler<TValue, Option<TValue>>;
-    type OnChangeMultipleHandler<TValue = OptionValues> = OnChangeHandler<TValue, Options<TValue>>;
-    type OnChangeHandler<TValue = OptionValues, TOption = Option<TValue> | Options<TValue>> = (newValue: TOption | null) => void;
-    type OnNewOptionClickHandler<TValue = OptionValues> = (option: Option<TValue>) => void;
+export type OnChangeSingleHandler<TValue = OptionValues> = OnChangeHandler<TValue, Option<TValue>>;
+export type OnChangeMultipleHandler<TValue = OptionValues> = OnChangeHandler<TValue, Options<TValue>>;
+export type OnChangeHandler<TValue = OptionValues, TOption = Option<TValue> | Options<TValue>> = (newValue: TOption | null) => void;
+export type OnNewOptionClickHandler<TValue = OptionValues> = (option: Option<TValue>) => void;
 
-    type LoadOptionsHandler<TValue = OptionValues> = LoadOptionsAsyncHandler<TValue> | LoadOptionsLegacyHandler<TValue>;
-    type LoadOptionsAsyncHandler<TValue = OptionValues> = (input: string) => Promise<AutocompleteResult<TValue>>;
-    type LoadOptionsLegacyHandler<TValue = OptionValues> = (input: string, callback: (err: any, result: AutocompleteResult<TValue>) => void) => void;
+export type LoadOptionsHandler<TValue = OptionValues> = LoadOptionsAsyncHandler<TValue> | LoadOptionsLegacyHandler<TValue>;
+export type LoadOptionsAsyncHandler<TValue = OptionValues> = (input: string) => Promise<AutocompleteResult<TValue>>;
+export type LoadOptionsLegacyHandler<TValue = OptionValues> = (input: string, callback: (err: any, result: AutocompleteResult<TValue>) => void) => void;
 
-    interface AutocompleteResult<TValue = OptionValues> {
-        /** The search-results to be displayed  */
-        options: Options<TValue>;
-        /**
-         * Should be set to true, if and only if a longer query with the same prefix
-         * would return a subset of the results
-         * If set to true, more specific queries will not be sent to the server.
-         */
-        complete: boolean;
-    }
-
-    type Options<TValue = OptionValues> = Array<Option<TValue>>;
-
-    interface Option<TValue = OptionValues> {
-        /** Text for rendering */
-        label?: string;
-        /** Value for searching */
-        value?: TValue;
-        /**
-         * Allow this option to be cleared
-         * @default true
-         */
-        clearableValue?: boolean;
-        /**
-         * Do not allow this option to be selected
-         * @default false
-         */
-        disabled?: boolean;
-        /**
-         * In the event that a custom menuRenderer is provided, Option should be able
-         * to accept arbitrary key-value pairs. See react-virtualized-select.
-         */
-        [property: string]: any;
-    }
-
-    type OptionValues = string | number | boolean;
-
-    interface MenuRendererProps<TValue = OptionValues> {
-        /**
-         * The currently focused option; should be visible in the menu by default.
-         * default {}
-         */
-        focusedOption: Option<TValue>;
-
-        /**
-         * Callback to focus a new option; receives the option as a parameter.
-         */
-        focusOption: FocusOptionHandler<TValue>;
-
-        /**
-         * Option labels are accessible with this string key.
-         */
-        labelKey: string;
-
-        /**
-         * Ordered array of options to render.
-         */
-        options: Options<TValue>;
-
-        /**
-         * Callback to select a new option; receives the option as a parameter.
-         */
-        selectValue: SelectValueHandler<TValue>;
-
-        /**
-         * Array of currently selected options.
-         */
-        valueArray: Options<TValue>;
-    }
-
-    interface ArrowRendererProps {
-        /**
-         * Arrow mouse down event handler.
-         */
-        onMouseDown: React.MouseEventHandler<any>;
-    }
-
-    interface ReactSelectProps<TValue = OptionValues> extends React.Props<ReactSelectClass<TValue>> {
-        /**
-         * text to display when `allowCreate` is true.
-         * @default 'Add "{label}"?'
-         */
-        addLabelText?: string;
-        /**
-         * renders a custom drop-down arrow to be shown in the right-hand side of the select.
-         * @default undefined
-         */
-        arrowRenderer?: ArrowRendererHandler;
-        /**
-         * blurs the input element after a selection has been made. Handy for lowering the keyboard on mobile devices.
-         * @default false
-         */
-        autoBlur?: boolean;
-        /**
-         * autofocus the component on mount
-         * @default false
-         */
-        autofocus?: boolean;
-        /**
-         *  If enabled, the input will expand as the length of its value increases
-         */
-        autosize?: boolean;
-        /**
-         * whether pressing backspace removes the last item when there is no input value
-         * @default true
-         */
-        backspaceRemoves?: boolean;
-        /**
-         * Message to use for screenreaders to press backspace to remove the current item
-         * {label} is replaced with the item label
-         * @default "Press backspace to remove..."
-         */
-        backspaceToRemoveMessage?: string;
-        /**
-         * CSS className for the outer element
-         */
-        className?: string;
-        /**
-         * title for the "clear" control when `multi` is true
-         * @default "Clear all"
-         */
-        clearAllText?: string;
-        /**
-         * title for the "clear" control
-         * @default "Clear value"
-         */
-        clearValueText?: string;
-        /**
-         * whether it is possible to reset value. if enabled, an X button will appear at the right side.
-         * @default true
-         */
-        clearable?: boolean;
-        /**
-         * whether backspace removes an item if there is no text input
-         * @default true
-         */
-        deleteRemoves?: boolean;
-        /**
-         * delimiter to use to join multiple values
-         * @default ","
-         */
-        delimiter?: string;
-        /**
-         * whether the Select is disabled or not
-         * @default false
-         */
-        disabled?: boolean;
-        /**
-         * whether escape clears the value when the menu is closed
-         * @default true
-         */
-        escapeClearsValue?: boolean;
-        /**
-         * method to filter a single option
-         */
-        filterOption?: FilterOptionHandler<TValue>;
-        /**
-         * method to filter the options array
-         */
-        filterOptions?: FilterOptionsHandler<TValue>;
-        /**
-         * whether to strip diacritics when filtering
-         * @default true
-         */
-        ignoreAccents?: boolean;
-        /**
-         * whether to perform case-insensitive filtering
-         * @default true
-         */
-        ignoreCase?: boolean;
-        /**
-         * custom attributes for the Input (in the Select-control) e.g: {'data-foo': 'bar'}
-         * @default {}
-         */
-        inputProps?: { [key: string]: any };
-        /**
-         * renders a custom input
-         */
-        inputRenderer?: InputRendererHandler;
-        /**
-         * allows for synchronization of component id's on server and client.
-         * @see https://github.com/JedWatson/react-select/pull/1105
-         */
-        instanceId?: string;
-        /**
-         * whether the Select is loading externally or not (such as options being loaded).
-         * if true, a loading spinner will be shown at the right side.
-         * @default false
-         */
-        isLoading?: boolean;
-        /**
-         * (legacy mode) joins multiple values into a single form field with the delimiter
-         * @default false
-         */
-        joinValues?: boolean;
-        /**
-         * the option property to use for the label
-         * @default "label"
-         */
-        labelKey?: string;
-        /**
-         * (any, start) match the start or entire string when filtering
-         * @default "any"
-         */
-        matchPos?: string;
-        /**
-         * (any, label, value) which option property to filter on
-         * @default "any"
-         */
-        matchProp?: string;
-        /**
-         * buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport
-         * @default 0
-         */
-        menuBuffer?: number;
-        /**
-         * optional style to apply to the menu container
-         */
-        menuContainerStyle?: React.CSSProperties;
-        /**
-         * renders a custom menu with options
-         */
-        menuRenderer?: MenuRendererHandler<TValue>;
-        /**
-         * optional style to apply to the menu
-         */
-        menuStyle?: React.CSSProperties;
-        /**
-         * multi-value input
-         * @default false
-         */
-        multi?: boolean;
-        /**
-         * field name, for hidden `<input>` tag
-         */
-        name?: string;
-        /**
-         * placeholder displayed when there are no matching search results or a falsy value to hide it
-         * @default "No results found"
-         */
-        noResultsText?: string | JSX.Element;
-        /**
-         * onBlur handler: function (event) {}
-         */
-        onBlur?: OnBlurHandler;
-        /**
-         * whether to clear input on blur or not
-         * @default true
-         */
-        onBlurResetsInput?: boolean;
-        /**
-         * onChange handler: function (newValue) {}
-         */
-        onChange?: OnChangeHandler<TValue>;
-        /**
-         * fires when the menu is closed
-         */
-        onClose?: OnCloseHandler;
-        /**
-         * onFocus handler: function (event) {}
-         */
-        onFocus?: OnFocusHandler;
-        /**
-         * onInputChange handler: function (inputValue) {}
-         */
-        onInputChange?: OnInputChangeHandler;
-        /**
-         * onInputKeyDown handler: function (keyboardEvent) {}
-         */
-        onInputKeyDown?: OnInputKeyDownHandler;
-        /**
-         * fires when the menu is scrolled to the bottom; can be used to paginate options
-         */
-        onMenuScrollToBottom?: OnMenuScrollToBottomHandler;
-        /**
-         * fires when the menu is opened
-         */
-        onOpen?: OnOpenHandler;
-        /**
-         * boolean to enable opening dropdown when focused
-         * @default false
-         */
-        openAfterFocus?: boolean;
-        /**
-         * open the options menu when the input gets focus (requires searchable = true)
-         * @default false
-         */
-        openOnFocus?: boolean;
-        /**
-         * className to add to each option component
-         */
-        optionClassName?: string;
-        /**
-         * option component to render in dropdown
-         */
-        optionComponent?: React.ComponentType;
-        /**
-         * function which returns a custom way to render the options in the menu
-         */
-        optionRenderer?: OptionRendererHandler<TValue>;
-        /**
-         * array of Select options
-         * @default false
-         */
-        options?: Options<TValue>;
-        /**
-         * field placeholder, displayed when there's no value
-         * @default "Select..."
-         */
-        placeholder?: string | JSX.Element;
-        /**
-         * applies HTML5 required attribute when needed
-         * @default false
-         */
-        required?: boolean;
-        /**
-         * value to use when you clear the control
-         */
-        resetValue?: any;
-        /**
-         * whether the viewport will shift to display the entire menu when engaged
-         * @default true
-         */
-        scrollMenuIntoView?: boolean;
-        /**
-         * whether to enable searching feature or not
-         * @default true;
-         */
-        searchable?: boolean;
-        /**
-         * whether to select the currently focused value when the  [tab]  key is pressed
-         */
-        tabSelectsValue?: boolean;
-        /**
-         * initial field value
-         */
-        value?: Option<TValue> | Options<TValue> | string | string[] | number | number[] | boolean;
-        /**
-         * the option property to use for the value
-         * @default "value"
-         */
-        valueKey?: string;
-        /**
-         * function which returns a custom way to render the value selected
-         * @default false
-         */
-        valueRenderer?: ValueRendererHandler<TValue>;
-        /**
-         *  optional style to apply to the control
-         */
-        style?: React.CSSProperties;
-
-        /**
-         *  optional tab index of the control
-         */
-        tabIndex?: string;
-
-        /**
-         *  value component to render
-         */
-        valueComponent?: React.ComponentType;
-
-        /**
-         *  optional style to apply to the component wrapper
-         */
-        wrapperStyle?: React.CSSProperties;
-
-        /**
-         * onClick handler for value labels: function (value, event) {}
-         */
-        onValueClick?: OnValueClickHandler<TValue>;
-
-        /**
-         *  pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
-         */
-        simpleValue?: boolean;
-    }
-
-    interface ReactCreatableSelectProps<TValue = OptionValues> extends ReactSelectProps<TValue> {
-        /**
-         * Searches for any matching option within the set of options. This function prevents
-         * duplicate options from being created.
-         */
-        isOptionUnique?: IsOptionUniqueHandler<TValue>;
-
-        /**
-         * Determines if the current input text represents a valid option.
-         */
-        isValidNewOption?: IsValidNewOptionHandler;
-
-        /**
-         * factory to create new options
-         */
-        newOptionCreator?: NewOptionCreatorHandler<TValue>;
-
-        /**
-         * Creates prompt/placeholder for option text.
-         */
-        promptTextCreator?: PromptTextCreatorHandler;
-
-        /**
-         * Decides if a keyDown event (eg its 'keyCode') should result in the creation of a new option.
-         */
-        shouldKeyDownEventCreateNewOption?: ShouldKeyDownEventCreateNewOptionHandler;
-
-        /**
-         * new option click handler: function (option) {}
-         */
-        onNewOptionClick?: OnNewOptionClickHandler<TValue>;
-    }
-
-    interface ReactAsyncSelectProps<TValue = OptionValues> extends ReactSelectProps<TValue> {
-        /**
-         * Whether to auto-load the default async options set.
-         */
-        autoload?: boolean;
-
-        /**
-         *  object to use to cache results; can be null to disable cache
-         */
-        cache?: { [key: string]: any } | boolean;
-
-        /**
-         *  whether to strip diacritics when filtering (shared with Select)
-         */
-        ignoreAccents?: boolean;
-
-        /**
-         *  whether to perform case-insensitive filtering (shared with Select)
-         */
-        ignoreCase?: boolean;
-
-        /**
-         *  overrides the isLoading state when set to true
-         */
-        isLoading?: boolean;
-
-        /**
-         *  function to call to load options asynchronously
-         */
-        loadOptions: LoadOptionsHandler<TValue>;
-
-        /**
-         *  replaces the placeholder while options are loading
-         */
-        loadingPlaceholder?: string;
-
-        /**
-         *  the minimum number of characters that trigger loadOptions
-         */
-        minimumInput?: number;
-
-        /**
-         *  placeholder displayed when there are no matching search results (shared with Select)
-         */
-        noResultsText?: string | JSX.Element;
-        /**
-         *  field placeholder; displayed when there's no value (shared with Select)
-         */
-        placeholder?: string;
-
-        /**
-         *  label to prompt for search input
-         */
-        searchPromptText?: string;
-
-        /**
-         *  message to display while options are loading
-         */
-        searchingText?: string;
-    }
+export interface AutocompleteResult<TValue = OptionValues> {
+    /** The search-results to be displayed  */
+    options: Options<TValue>;
+    /**
+     * Should be set to true, if and only if a longer query with the same prefix
+     * would return a subset of the results
+     * If set to true, more specific queries will not be sent to the server.
+     */
+    complete: boolean;
 }
 
-declare class ReactSelectClass<TValue = ReactSelectClass.OptionValues> extends React.Component<ReactSelectClass.ReactSelectProps<TValue>> {
+export type Options<TValue = OptionValues> = Array<Option<TValue>>;
+
+export interface Option<TValue = OptionValues> {
+    /** Text for rendering */
+    label?: string;
+    /** Value for searching */
+    value?: TValue;
+    /**
+     * Allow this option to be cleared
+     * @default true
+     */
+    clearableValue?: boolean;
+    /**
+     * Do not allow this option to be selected
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * In the event that a custom menuRenderer is provided, Option should be able
+     * to accept arbitrary key-value pairs. See react-virtualized-select.
+     */
+    [property: string]: any;
+}
+
+export type OptionValues = string | number | boolean;
+
+export interface MenuRendererProps<TValue = OptionValues> {
+    /**
+     * The currently focused option; should be visible in the menu by default.
+     * default {}
+     */
+    focusedOption: Option<TValue>;
+
+    /**
+     * Callback to focus a new option; receives the option as a parameter.
+     */
+    focusOption: FocusOptionHandler<TValue>;
+
+    /**
+     * Option labels are accessible with this string key.
+     */
+    labelKey: string;
+
+    /**
+     * Ordered array of options to render.
+     */
+    options: Options<TValue>;
+
+    /**
+     * Callback to select a new option; receives the option as a parameter.
+     */
+    selectValue: SelectValueHandler<TValue>;
+
+    /**
+     * Array of currently selected options.
+     */
+    valueArray: Options<TValue>;
+}
+
+export interface ArrowRendererProps {
+    /**
+     * Arrow mouse down event handler.
+     */
+    onMouseDown: React.MouseEventHandler<any>;
+}
+
+export interface ReactSelectProps<TValue = OptionValues> extends React.Props<ReactSelectClass<TValue>> {
+    /**
+     * text to display when `allowCreate` is true.
+     * @default 'Add "{label}"?'
+     */
+    addLabelText?: string;
+    /**
+     * renders a custom drop-down arrow to be shown in the right-hand side of the select.
+     * @default undefined
+     */
+    arrowRenderer?: ArrowRendererHandler;
+    /**
+     * blurs the input element after a selection has been made. Handy for lowering the keyboard on mobile devices.
+     * @default false
+     */
+    autoBlur?: boolean;
+    /**
+     * autofocus the component on mount
+     * @default false
+     */
+    autofocus?: boolean;
+    /**
+     *  If enabled, the input will expand as the length of its value increases
+     */
+    autosize?: boolean;
+    /**
+     * whether pressing backspace removes the last item when there is no input value
+     * @default true
+     */
+    backspaceRemoves?: boolean;
+    /**
+     * Message to use for screenreaders to press backspace to remove the current item
+     * {label} is replaced with the item label
+     * @default "Press backspace to remove..."
+     */
+    backspaceToRemoveMessage?: string;
+    /**
+     * CSS className for the outer element
+     */
+    className?: string;
+    /**
+     * title for the "clear" control when `multi` is true
+     * @default "Clear all"
+     */
+    clearAllText?: string;
+    /**
+     * title for the "clear" control
+     * @default "Clear value"
+     */
+    clearValueText?: string;
+    /**
+     * whether it is possible to reset value. if enabled, an X button will appear at the right side.
+     * @default true
+     */
+    clearable?: boolean;
+    /**
+     * whether backspace removes an item if there is no text input
+     * @default true
+     */
+    deleteRemoves?: boolean;
+    /**
+     * delimiter to use to join multiple values
+     * @default ","
+     */
+    delimiter?: string;
+    /**
+     * whether the Select is disabled or not
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * whether escape clears the value when the menu is closed
+     * @default true
+     */
+    escapeClearsValue?: boolean;
+    /**
+     * method to filter a single option
+     */
+    filterOption?: FilterOptionHandler<TValue>;
+    /**
+     * method to filter the options array
+     */
+    filterOptions?: FilterOptionsHandler<TValue>;
+    /**
+     * whether to strip diacritics when filtering
+     * @default true
+     */
+    ignoreAccents?: boolean;
+    /**
+     * whether to perform case-insensitive filtering
+     * @default true
+     */
+    ignoreCase?: boolean;
+    /**
+     * custom attributes for the Input (in the Select-control) e.g: {'data-foo': 'bar'}
+     * @default {}
+     */
+    inputProps?: { [key: string]: any };
+    /**
+     * renders a custom input
+     */
+    inputRenderer?: InputRendererHandler;
+    /**
+     * allows for synchronization of component id's on server and client.
+     * @see https://github.com/JedWatson/react-select/pull/1105
+     */
+    instanceId?: string;
+    /**
+     * whether the Select is loading externally or not (such as options being loaded).
+     * if true, a loading spinner will be shown at the right side.
+     * @default false
+     */
+    isLoading?: boolean;
+    /**
+     * (legacy mode) joins multiple values into a single form field with the delimiter
+     * @default false
+     */
+    joinValues?: boolean;
+    /**
+     * the option property to use for the label
+     * @default "label"
+     */
+    labelKey?: string;
+    /**
+     * (any, start) match the start or entire string when filtering
+     * @default "any"
+     */
+    matchPos?: string;
+    /**
+     * (any, label, value) which option property to filter on
+     * @default "any"
+     */
+    matchProp?: string;
+    /**
+     * buffer of px between the base of the dropdown and the viewport to shift if menu doesnt fit in viewport
+     * @default 0
+     */
+    menuBuffer?: number;
+    /**
+     * optional style to apply to the menu container
+     */
+    menuContainerStyle?: React.CSSProperties;
+    /**
+     * renders a custom menu with options
+     */
+    menuRenderer?: MenuRendererHandler<TValue>;
+    /**
+     * optional style to apply to the menu
+     */
+    menuStyle?: React.CSSProperties;
+    /**
+     * multi-value input
+     * @default false
+     */
+    multi?: boolean;
+    /**
+     * field name, for hidden `<input>` tag
+     */
+    name?: string;
+    /**
+     * placeholder displayed when there are no matching search results or a falsy value to hide it
+     * @default "No results found"
+     */
+    noResultsText?: string | JSX.Element;
+    /**
+     * onBlur handler: function (event) {}
+     */
+    onBlur?: OnBlurHandler;
+    /**
+     * whether to clear input on blur or not
+     * @default true
+     */
+    onBlurResetsInput?: boolean;
+    /**
+     * onChange handler: function (newValue) {}
+     */
+    onChange?: OnChangeHandler<TValue>;
+    /**
+     * fires when the menu is closed
+     */
+    onClose?: OnCloseHandler;
+    /**
+     * onFocus handler: function (event) {}
+     */
+    onFocus?: OnFocusHandler;
+    /**
+     * onInputChange handler: function (inputValue) {}
+     */
+    onInputChange?: OnInputChangeHandler;
+    /**
+     * onInputKeyDown handler: function (keyboardEvent) {}
+     */
+    onInputKeyDown?: OnInputKeyDownHandler;
+    /**
+     * fires when the menu is scrolled to the bottom; can be used to paginate options
+     */
+    onMenuScrollToBottom?: OnMenuScrollToBottomHandler;
+    /**
+     * fires when the menu is opened
+     */
+    onOpen?: OnOpenHandler;
+    /**
+     * boolean to enable opening dropdown when focused
+     * @default false
+     */
+    openAfterFocus?: boolean;
+    /**
+     * open the options menu when the input gets focus (requires searchable = true)
+     * @default false
+     */
+    openOnFocus?: boolean;
+    /**
+     * className to add to each option component
+     */
+    optionClassName?: string;
+    /**
+     * option component to render in dropdown
+     */
+    optionComponent?: React.ComponentType;
+    /**
+     * function which returns a custom way to render the options in the menu
+     */
+    optionRenderer?: OptionRendererHandler<TValue>;
+    /**
+     * array of Select options
+     * @default false
+     */
+    options?: Options<TValue>;
+    /**
+     * field placeholder, displayed when there's no value
+     * @default "Select..."
+     */
+    placeholder?: string | JSX.Element;
+    /**
+     * applies HTML5 required attribute when needed
+     * @default false
+     */
+    required?: boolean;
+    /**
+     * value to use when you clear the control
+     */
+    resetValue?: any;
+    /**
+     * whether the viewport will shift to display the entire menu when engaged
+     * @default true
+     */
+    scrollMenuIntoView?: boolean;
+    /**
+     * whether to enable searching feature or not
+     * @default true;
+     */
+    searchable?: boolean;
+    /**
+     * whether to select the currently focused value when the  [tab]  key is pressed
+     */
+    tabSelectsValue?: boolean;
+    /**
+     * initial field value
+     */
+    value?: Option<TValue> | Options<TValue> | string | string[] | number | number[] | boolean;
+    /**
+     * the option property to use for the value
+     * @default "value"
+     */
+    valueKey?: string;
+    /**
+     * function which returns a custom way to render the value selected
+     * @default false
+     */
+    valueRenderer?: ValueRendererHandler<TValue>;
+    /**
+     *  optional style to apply to the control
+     */
+    style?: React.CSSProperties;
+
+    /**
+     *  optional tab index of the control
+     */
+    tabIndex?: string;
+
+    /**
+     *  value component to render
+     */
+    valueComponent?: React.ComponentType;
+
+    /**
+     *  optional style to apply to the component wrapper
+     */
+    wrapperStyle?: React.CSSProperties;
+
+    /**
+     * onClick handler for value labels: function (value, event) {}
+     */
+    onValueClick?: OnValueClickHandler<TValue>;
+
+    /**
+     *  pass the value to onChange as a simple value (legacy pre 1.0 mode), defaults to false
+     */
+    simpleValue?: boolean;
+}
+
+export interface ReactCreatableSelectProps<TValue = OptionValues> extends ReactSelectProps<TValue> {
+    /**
+     * Searches for any matching option within the set of options. This function prevents
+     * duplicate options from being created.
+     */
+    isOptionUnique?: IsOptionUniqueHandler<TValue>;
+
+    /**
+     * Determines if the current input text represents a valid option.
+     */
+    isValidNewOption?: IsValidNewOptionHandler;
+
+    /**
+     * factory to create new options
+     */
+    newOptionCreator?: NewOptionCreatorHandler<TValue>;
+
+    /**
+     * Creates prompt/placeholder for option text.
+     */
+    promptTextCreator?: PromptTextCreatorHandler;
+
+    /**
+     * Decides if a keyDown event (eg its 'keyCode') should result in the creation of a new option.
+     */
+    shouldKeyDownEventCreateNewOption?: ShouldKeyDownEventCreateNewOptionHandler;
+
+    /**
+     * new option click handler: function (option) {}
+     */
+    onNewOptionClick?: OnNewOptionClickHandler<TValue>;
+}
+
+export interface ReactAsyncSelectProps<TValue = OptionValues> extends ReactSelectProps<TValue> {
+    /**
+     * Whether to auto-load the default async options set.
+     */
+    autoload?: boolean;
+
+    /**
+     *  object to use to cache results; can be null to disable cache
+     */
+    cache?: { [key: string]: any } | boolean;
+
+    /**
+     *  whether to strip diacritics when filtering (shared with Select)
+     */
+    ignoreAccents?: boolean;
+
+    /**
+     *  whether to perform case-insensitive filtering (shared with Select)
+     */
+    ignoreCase?: boolean;
+
+    /**
+     *  overrides the isLoading state when set to true
+     */
+    isLoading?: boolean;
+
+    /**
+     *  function to call to load options asynchronously
+     */
+    loadOptions: LoadOptionsHandler<TValue>;
+
+    /**
+     *  replaces the placeholder while options are loading
+     */
+    loadingPlaceholder?: string;
+
+    /**
+     *  the minimum number of characters that trigger loadOptions
+     */
+    minimumInput?: number;
+
+    /**
+     *  placeholder displayed when there are no matching search results (shared with Select)
+     */
+    noResultsText?: string | JSX.Element;
+    /**
+     *  field placeholder; displayed when there's no value (shared with Select)
+     */
+    placeholder?: string;
+
+    /**
+     *  label to prompt for search input
+     */
+    searchPromptText?: string;
+
+    /**
+     *  message to display while options are loading
+     */
+    searchingText?: string;
+}
+
+
+declare class ReactSelectClass<TValue = OptionValues> extends React.Component<ReactSelectProps<TValue>> {
     focus(): void;
 }

--- a/types/react-select/react-select-tests.tsx
+++ b/types/react-select/react-select-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import * as ReactSelect from "react-select";
-const { Creatable } = ReactSelect;
-
+import ReactSelect from "react-select";
+import {Creatable} from "react-select";
+import * as ReactSelectModule from "react-select";
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
 
@@ -30,7 +30,7 @@ const EXAMPLE_CUSTOM_OPTIONS: ReactSelect.Options<CustomValueType> = [
 ];
 
 const EXAMPLE_CUSTOM_VALUE: ReactSelect.Option<CustomValueType> = {
-  value: { prop1: "ThreeProp1", prop2: 3 }, label: "Three"
+    value: { prop1: "ThreeProp1", prop2: 3 }, label: "Three"
 };
 
 describe("react-select", () => {
@@ -270,8 +270,8 @@ describe("Examples", () => {
                 const options = props.options.map(option => {
                     return (
                         <div className="option" data-value1={option.value.prop1}
-                             data-value2={option.value.prop2}
-                             onClick={() => props.selectValue(option)}>
+                            data-value2={option.value.prop2}
+                            onClick={() => props.selectValue(option)}>
                             {option.label}
                         </div>);
                 });
@@ -333,7 +333,7 @@ describe("Examples", () => {
 
     it("Option render with custom value option", () => {
         const optionRenderer = (option: ReactSelect.Option<CustomValueType>): ReactSelect.HandlerRendererResult =>
-          null;
+            null;
 
         <CustomValueReactSelect
             optionRenderer={optionRenderer}
@@ -342,7 +342,7 @@ describe("Examples", () => {
 
     it("Value render with custom value option", () => {
         const valueRenderer = (option: ReactSelect.Option<CustomValueType>): ReactSelect.HandlerRendererResult =>
-          null;
+            null;
 
         <CustomValueReactSelect
             valueRenderer={valueRenderer}

--- a/types/react-select/react-select-tests.tsx
+++ b/types/react-select/react-select-tests.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
-import ReactSelect from "react-select";
-import {Creatable} from "react-select";
-import * as ReactSelectModule from "react-select";
+import ReactSelect, * as ReactSelectModule from "react-select";
+
 declare function describe(desc: string, f: () => void): void;
 declare function it(desc: string, f: () => void): void;
 
-const EXAMPLE_OPTIONS: ReactSelect.Options = [
+const EXAMPLE_OPTIONS: ReactSelectModule.Options = [
     { value: "one", label: "One" },
     { value: "two", label: "Two" }
 ];
@@ -21,38 +20,38 @@ interface CustomValueType {
  * If https://github.com/Microsoft/TypeScript/issues/6395 ever lands, this
  * workaround may become redundant.
  */
-type CustomValueReactSelect = new (props: ReactSelect.ReactSelectProps<CustomValueType>) => ReactSelect<CustomValueType>;
+type CustomValueReactSelect = new (props: ReactSelectModule.ReactSelectProps<CustomValueType>) => ReactSelect<CustomValueType>;
 const CustomValueReactSelect = ReactSelect as CustomValueReactSelect;
 
-const EXAMPLE_CUSTOM_OPTIONS: ReactSelect.Options<CustomValueType> = [
+const EXAMPLE_CUSTOM_OPTIONS: ReactSelectModule.Options<CustomValueType> = [
     { value: { prop1: "OneProp1", prop2: 1 }, label: "One" },
     { value: { prop1: "TwoProp2", prop2: 2 }, label: "Two" }
 ];
 
-const EXAMPLE_CUSTOM_VALUE: ReactSelect.Option<CustomValueType> = {
+const EXAMPLE_CUSTOM_VALUE: ReactSelectModule.Option<CustomValueType> = {
     value: { prop1: "ThreeProp1", prop2: 3 }, label: "Three"
 };
 
 describe("react-select", () => {
     it("options", () => {
-        const optionsString: ReactSelect.Options<string> = [
+        const optionsString: ReactSelectModule.Options<string> = [
             { value: "one", label: "One" },
             { value: "two", label: "Two", clearableValue: false }
         ];
 
-        const optionsNumber: ReactSelect.Options<number> = [
+        const optionsNumber: ReactSelectModule.Options<number> = [
             { value: 1, label: "One" },
             { value: 2, label: "Two", clearableValue: false }
         ];
 
-        const optionsMixed: ReactSelect.Options = [
+        const optionsMixed: ReactSelectModule.Options = [
             { value: "one", label: "One" },
             { value: 2, label: "Two", clearableValue: false }
         ];
     });
 
     it("async options", () => {
-        const getAsyncLegacyOptions: ReactSelect.LoadOptionsLegacyHandler = (input, callback) => {
+        const getAsyncLegacyOptions: ReactSelectModule.LoadOptionsLegacyHandler = (input, callback) => {
             setTimeout(() => {
                 callback(null, {
                     options: [
@@ -64,12 +63,12 @@ describe("react-select", () => {
         };
 
         const dummyRequest = async () => {
-            return new Promise<ReactSelect.Options>(resolve => {
+            return new Promise<ReactSelectModule.Options>(resolve => {
                 resolve(EXAMPLE_OPTIONS);
             });
         };
 
-        const getAsyncOptions: ReactSelect.LoadOptionsAsyncHandler = async input => {
+        const getAsyncOptions: ReactSelectModule.LoadOptionsAsyncHandler = async input => {
             const result = await dummyRequest();
 
             return {
@@ -80,7 +79,7 @@ describe("react-select", () => {
     });
 
     it("Custom value async options", () => {
-        const getAsyncLegacyOptions: ReactSelect.LoadOptionsLegacyHandler<CustomValueType> = (input, callback) => {
+        const getAsyncLegacyOptions: ReactSelectModule.LoadOptionsLegacyHandler<CustomValueType> = (input, callback) => {
             setTimeout(() => {
                 callback(null, {
                     options: [
@@ -92,12 +91,12 @@ describe("react-select", () => {
         };
 
         const dummyRequest = async () => {
-            return new Promise<ReactSelect.Options<CustomValueType>>(resolve => {
+            return new Promise<ReactSelectModule.Options<CustomValueType>>(resolve => {
                 resolve(EXAMPLE_CUSTOM_OPTIONS);
             });
         };
 
-        const getAsyncOptions: ReactSelect.LoadOptionsAsyncHandler<CustomValueType> = async input => {
+        const getAsyncOptions: ReactSelectModule.LoadOptionsAsyncHandler<CustomValueType> = async input => {
             const result = await dummyRequest();
 
             return {
@@ -109,7 +108,7 @@ describe("react-select", () => {
 
     it("creatable", () => {
         function Component(props: {}): JSX.Element {
-            return <Creatable name="creatable" options={EXAMPLE_OPTIONS} />;
+            return <ReactSelectModule.Creatable name="creatable" options={EXAMPLE_OPTIONS} />;
         }
     });
 
@@ -128,14 +127,14 @@ describe("react-select", () => {
     });
 
     it("Overriding default key-down behavior with onInputKeyDown", () => {
-        const keyDownHandler: ReactSelect.OnInputKeyDownHandler = (event => {
+        const keyDownHandler: ReactSelectModule.OnInputKeyDownHandler = (event => {
             const divEvent = event as React.KeyboardEvent<HTMLDivElement>;
             const inputEvent = event as React.KeyboardEvent<HTMLInputElement>;
         });
     });
 
     it("Updating input values with onInputChange", () => {
-        const cleanInput: ReactSelect.OnInputChangeHandler = inputValue => {
+        const cleanInput: ReactSelectModule.OnInputChangeHandler = inputValue => {
             return inputValue.replace(/[^0-9]/g, "");
         };
     });
@@ -172,7 +171,7 @@ describe("Focus events", () => {
 describe("Examples", () => {
     it("Simple example", () => {
         class Component extends React.Component {
-            private onSelectChange: ReactSelect.OnChangeSingleHandler<string> = (option) => {
+            private onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = (option) => {
                 const optionValue: string = option.value;
             }
 
@@ -188,7 +187,7 @@ describe("Examples", () => {
 
     it("onValueClick", () => {
         class Component extends React.Component {
-            private onValueClick: ReactSelect.OnValueClickHandler<number> = (option) => {
+            private onValueClick: ReactSelectModule.OnValueClickHandler<number> = (option) => {
                 const optionValue: number = option.value;
             }
 
@@ -209,7 +208,7 @@ describe("Examples", () => {
 
     it("Custom value onValueClick", () => {
         class Component extends React.Component {
-            private onValueClick: ReactSelect.OnValueClickHandler<CustomValueType> = (option) => {
+            private onValueClick: ReactSelectModule.OnValueClickHandler<CustomValueType> = (option) => {
                 const optionValue: CustomValueType = option.value;
             }
 
@@ -225,7 +224,7 @@ describe("Examples", () => {
 
     it("Custom value onChange", () => {
         class Component extends React.Component {
-            private onSelectChange: ReactSelect.OnChangeSingleHandler<CustomValueType> = (option) => {
+            private onSelectChange: ReactSelectModule.OnChangeSingleHandler<CustomValueType> = (option) => {
                 const optionValue: CustomValueType = option.value;
             }
 
@@ -241,11 +240,11 @@ describe("Examples", () => {
 
     it("Menu renderer example", () => {
         class Component extends React.Component {
-            private onSelectChange: ReactSelect.OnChangeSingleHandler<string> = option => {
+            private onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = option => {
                 const optionValue: string = option.value;
             }
 
-            private menuRenderer: ReactSelect.MenuRendererHandler = props => {
+            private menuRenderer: ReactSelectModule.MenuRendererHandler = props => {
                 const options = props.options.map(option => {
                     return <div className="option">{option.label}</div>;
                 });
@@ -266,7 +265,7 @@ describe("Examples", () => {
 
     it("Menu renderer with custom value type example", () => {
         class Component extends React.Component {
-            private menuRenderer: ReactSelect.MenuRendererHandler<CustomValueType> = props => {
+            private menuRenderer: ReactSelectModule.MenuRendererHandler<CustomValueType> = props => {
                 const options = props.options.map(option => {
                     return (
                         <div className="option" data-value1={option.value.prop1}
@@ -292,11 +291,11 @@ describe("Examples", () => {
 
     it("Input render example", () => {
         class Component extends React.Component {
-            private onSelectChange: ReactSelect.OnChangeSingleHandler<string> = option => {
+            private onSelectChange: ReactSelectModule.OnChangeSingleHandler<string> = option => {
                 const optionValue: string = option.value;
             }
 
-            private inputRenderer: ReactSelect.InputRendererHandler = props => {
+            private inputRenderer: ReactSelectModule.InputRendererHandler = props => {
                 return <input {...props} />;
             }
 
@@ -332,7 +331,7 @@ describe("Examples", () => {
     });
 
     it("Option render with custom value option", () => {
-        const optionRenderer = (option: ReactSelect.Option<CustomValueType>): ReactSelect.HandlerRendererResult =>
+        const optionRenderer = (option: ReactSelectModule.Option<CustomValueType>): ReactSelectModule.HandlerRendererResult =>
             null;
 
         <CustomValueReactSelect
@@ -341,7 +340,7 @@ describe("Examples", () => {
     });
 
     it("Value render with custom value option", () => {
-        const valueRenderer = (option: ReactSelect.Option<CustomValueType>): ReactSelect.HandlerRendererResult =>
+        const valueRenderer = (option: ReactSelectModule.Option<CustomValueType>): ReactSelectModule.HandlerRendererResult =>
             null;
 
         <CustomValueReactSelect

--- a/types/react-virtualized-select/react-virtualized-select-tests.tsx
+++ b/types/react-virtualized-select/react-virtualized-select-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Select = require("react-select");
+import Select from "react-select";
 import VirtualizedSelect from "react-virtualized-select";
 
 <VirtualizedSelect


### PR DESCRIPTION
Removed namespace since this is in a "module" file the namespace is not needed (used with import). 
https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html

[The webpack rebuild](https://github.com/JedWatson/react-select/commit/27462611929254d91a82b6b7b8cbdec6b9ca80a1#diff-04191649796841200b33375bdff7c78f) introduced a default exports instead of exports = ReactSelect. 

Im still seeing examples all over using the old `import * as ReactSelect from "react-select"` syntax but i can't get it to work since the export no longer contains the Select class iteself (its only on the default, [#1855](https://github.com/JedWatson/react-select/pull/1855)). So using from source (not the UMD) i need to `import ReactSelect from "react-select"`.

Perhaps im using it wrong but with the default exports and removing the legacy namespace all my local tests works and my own projects seems happy again. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/JedWatson/react-select/commit/27462611929254d91a82b6b7b8cbdec6b9ca80a1#diff-04191649796841200b33375bdff7c78f
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
