### PR TITLE
bull: added missing method "promote" from bull v3 to typings

### DIFF
--- a/types/bull/index.d.ts
+++ b/types/bull/index.d.ts
@@ -104,6 +104,11 @@ declare namespace Bull {
          * since pubsub does not give any guarantees.
          */
         finished(): Promise<void>;
+
+        /**
+         * Promotes a job that is currently "delayed" to the "waiting" state and executed as soon as possible.
+         */
+        promote(): Promise<void>;
     }
 
     type JobStatus = 'completed' | 'waiting' | 'active' | 'delayed' | 'failed';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/OptimalBits/bull/blob/master/REFERENCE.md#jobpromote
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.