### PR TITLE
Mapbox-gl fix: stops are optional in StyleFunction

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -395,7 +395,7 @@ declare namespace mapboxgl {
 		timeout?: number;
 		maximumAge?: number;
 	}
-	
+
 	export class FitBoundsOptions {
 		maxZoom?: number;
 	}
@@ -723,7 +723,7 @@ declare namespace mapboxgl {
 		angleWidth(p: Point): number;
 
 		angleWithSep(x: number, y: number): number;
-	
+
 		static convert(a: PointLike): Point;
 	}
 
@@ -920,7 +920,7 @@ declare namespace mapboxgl {
 	}
 
 	export interface StyleFunction {
-		stops: any[][];
+		stops?: any[][];
 		property?: string;
 		base?: number;
 		type?: "identity" | "exponential" | "interval" | "categorical";


### PR DESCRIPTION
Fixed an optional property in Mapbox-gl stylefunction as requested here https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19834#issuecomment-330405022