### PR TITLE
cucumber: define overridable World interface

### DIFF
--- a/types/cucumber/cucumber-tests.ts
+++ b/types/cucumber/cucumber-tests.ts
@@ -1,6 +1,13 @@
 import * as assert from "power-assert";
 import cucumber = require("cucumber");
 
+// You can optionally declare your own world properties
+declare module "cucumber" {
+    interface World {
+        visit(url: string, callback: CallbackStepDefinition): void;
+    }
+}
+
 function StepSample() {
     type Callback = cucumber.CallbackStepDefinition;
     type Table = cucumber.TableDefinition;

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -7,6 +7,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+export interface World {
+    [key: string]: any;
+}
+
 export interface CallbackStepDefinition {
     pending(): PromiseLike<any>;
     (error?: any, pending?: string): void;
@@ -21,7 +25,7 @@ export interface TableDefinition {
 
 export type StepDefinitionParam = string | number | CallbackStepDefinition | TableDefinition;
 
-export type StepDefinitionCode = (this: {[key: string]: any}, ...stepArgs: StepDefinitionParam[]) => PromiseLike<any> | any | void;
+export type StepDefinitionCode = (this: World, ...stepArgs: StepDefinitionParam[]) => PromiseLike<any> | any | void;
 
 export interface StepDefinitionOptions {
     timeout?: number;
@@ -45,7 +49,7 @@ export interface HookScenarioResult {
     stepsResults: any;
 }
 
-export type HookCode = (this: { [key: string]: any }, scenario: HookScenarioResult, callback?: CallbackStepDefinition) => void;
+export type HookCode = (this: World, scenario: HookScenarioResult, callback?: CallbackStepDefinition) => void;
 
 // tslint:disable-next-line ban-types
 export type AroundCode = (scenario: HookScenarioResult, runScenario?: (error: string, callback?: Function) => void) => void;
@@ -69,7 +73,7 @@ export interface Hooks {
     Around(code: AroundCode): void;
     setDefaultTimeout(time: number): void;
     // tslint:disable-next-line ban-types
-    setWorldConstructor(world: ((this: {[key: string]: any}, init: {attach: Function, parameters: {[key: string]: any}}) => void) | {}): void;
+    setWorldConstructor(world: ((this: World, init: {attach: Function, parameters: {[key: string]: any}}) => void) | {}): void;
     registerHandler(handlerOption: string, code: (event: any, callback: CallbackStepDefinition) => void): void;
     registerListener(listener: EventListener): void;
     defineParameterType(transform: Transform): void;


### PR DESCRIPTION
By implementing World as an interface, it can be extended in projects by using declaration merging.

Example:

```ts
import {defineSupportCode} from "cucumber";

declare module "cucumber" {
    interface World {
        cleanup: Function[];
    }
}

defineSupportCode(function({After, Before}) {
	Before(function() {
		this.cleanup = [];
	})

	After(function() {
		while (this.cleanup.length > 0) {
			const job = this.cleanup.shift()!;
			job();
		}
	});
});
```

Now world property `cleanup` will be checked and autocompleted in all step definitions.