### PR TITLE
Set default export to Polylabel

### DIFF
--- a/types/polylabel/index.d.ts
+++ b/types/polylabel/index.d.ts
@@ -1,34 +1,18 @@
-// Type definitions for polylabel 1.0.0
+// Type definitions for polylabel 1.0
 // Project: https://github.com/mapbox/polylabel
 // Definitions by: Denis Carriere <https://github.com/DenisCarriere>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**
- * polylabel
- * 
- * A fast algorithm for finding polygon pole of inaccessibility, the most distant internal point from
- * the polygon outline (not to be confused with centroid), implemented as a JavaScript library.
- * Useful for optimal placement of a text label on a polygon.
- * It's an iterative grid algorithm, inspired by paper by Garcia-Castellanos & Lombardo, 2007.
- * Unlike the one in the paper, this algorithm:
+ * Polylabel returns the pole of inaccessibility coordinate in [x, y] format.
  *
- * - guarantees finding global optimum within the given precision
- * - is many times faster (10-40x)
+ * @param {Array<number>} polygon - Given polygon coordinates in GeoJSON-like format
+ * @param {number} precision - Precision (1.0 by default)
+ * @param {boolean} debug - Debugging for Console
+ * @return {Array<number>}
+ * @example
+ * var p = polylabel(polygon, 1.0);
  */
-declare module "polylabel" {
-    /**
-     * Polylabel returns the pole of inaccessibility coordinate in [x, y] format.
-     * 
-     * @name polylabel
-     * @function
-     * @param {Array<number>} polygon - Given polygon coordinates in GeoJSON-like format
-     * @param {number} precision - Precision (1.0 by default)
-     * @param {boolean} debug - Debugging for Console 
-     * @return {Array<number>}
-     * @example
-     * var p = polylabel(polygon, 1.0);
-     */
-    function polylabel(polygon: number[][][], precision?: number, debug?: boolean): number[];
-    namespace polylabel {}
-    export = polylabel;
-}
+declare function polylabel(polygon: number[][][], precision?: number, debug?: boolean): number[];
+declare namespace polylabel {}
+export default polylabel;

--- a/types/polylabel/polylabel-tests.ts
+++ b/types/polylabel/polylabel-tests.ts
@@ -1,7 +1,7 @@
-import * as polylabel from 'polylabel';
+import polylabel from 'polylabel';
 
-const polygon = [[[3116,3071],[3118,3068],[3108,3102],[3751,927]]]
-polylabel(polygon)
-polylabel(polygon, 1.0)
-polylabel(polygon, 1.0, true)
-polylabel(polygon, 1.0, false)
+const polygon = [[[3116, 3071], [3118, 3068], [3108, 3102], [3751, 927]]];
+polylabel(polygon);
+polylabel(polygon, 1.0);
+polylabel(polygon, 1.0, true);
+polylabel(polygon, 1.0, false);

--- a/types/polylabel/tslint.json
+++ b/types/polylabel/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
- [x] Removed declare module in favor of export default.
- [x] Added linting

https://github.com/mapbox/polylabel/blob/master/polylabel.js#L6

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mapbox/polylabel/blob/master/polylabel.js#L6
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
