### PR TITLE
express-serve-static-core: remove redundant definition

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -35,12 +35,10 @@ type PathParams = string | RegExp | (string | RegExp)[];
 type RequestHandlerParams = RequestHandler | ErrorRequestHandler | (RequestHandler | ErrorRequestHandler)[];
 
 interface IRouterMatcher<T> {
-    (path: PathParams, ...handlers: RequestHandler[]): T;
     (path: PathParams, ...handlers: RequestHandlerParams[]): T;
 }
 
 interface IRouterHandler<T> {
-    (...handlers: RequestHandler[]): T;
     (...handlers: RequestHandlerParams[]): T;
 }
 

--- a/types/express/express-tests.ts
+++ b/types/express/express-tests.ts
@@ -18,7 +18,7 @@ namespace express_tests {
     next();
     });
 
-    app.use(function(err: any, req: express.Request, res: express.Response, next: express.NextFunction) {
+    app.use(function(err, req, res, next) {
     console.error(err);
     next(err);
     });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

In express-serve-static-core definition of `IRouterMatcher` and `IRouterHandler`, both `RequestHandler` and `RequestHandlerParams` signature variants are provided, while `RequestHandlerParams` is already an union of types including `RequestHandler`, thus explicitly having a variant with `RequestHandler` is redundant with `RequestHandlerParams`.

For some reason, the fact that this declaration is redundant breaks `ErrorRequestHandler` on  the `use` function (but doesn't break `RequestHandler` for whatever reason), in a way that all its params are assumed `any` instead of being typed as they should be. This bug is only noticeable when using `noImplicitAny`.

Example, before this PR:

```
import express = require('express');

const app = express();

app.use((err, req, res, next) => {
  console.log(req.path);
});
```

Fails with:

```
Parameter 'err' implicitly has an 'any' type. (7006)
Parameter 'req' implicitly has an 'any' type. (7006)
Parameter 'res' implicitly has an 'any' type. (7006)
Parameter 'next' implicitly has an 'any' type. (7006)
```

After this PR, this code compiles properly.

I'm not sure how to run tests for this package, but I could run it successfully with my own code.