### PR TITLE
Angular: add $overrideModelOptions

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -392,6 +392,7 @@ declare namespace angular {
         $rollbackViewValue(): void;
         $commitViewValue(): void;
         $isEmpty(value: any): boolean;
+        $overrideModelOptions(options: INgModelOptions): void;
 
         $viewValue: any;
 


### PR DESCRIPTION
Add `$overrideModelOptions` to `INgModelController` as per issue #19136.

**Related links:**
- AngularJS Documentation: https://docs.angularjs.org/api/ng/type/ngModel.NgModelController#$overrideModelOptions
- AngularJS Source: https://github.com/angular/angular.js/blob/master/src/ng/directive/ngModel.js#L863
- AngularJS Issue: https://github.com/angular/angular.js/issues/12884