### PR TITLE
Update type definition for angularjs/$injector.invoke

### DIFF
--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -509,7 +509,13 @@ namespace TestInjector {
         }
 
         const anyFunction: Function = foobar;
-        const anyResult: string = $injector.invoke(anyFunction);
+        let anyResult: string = $injector.invoke(anyFunction);
+
+        const inlineAnnotatedFunction: any[] = [false, foobar];
+        anyResult = $injector.invoke(inlineAnnotatedFunction);
+        anyResult = $injector.invoke(inlineAnnotatedFunction, 'anyContext', 'anyLocals');
+        anyResult = $injector.invoke(inlineAnnotatedFunction, 'anyContext');
+        anyResult = $injector.invoke(inlineAnnotatedFunction, undefined, 'anyLocals');
     }
 }
 

--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -2078,7 +2078,7 @@ declare namespace angular {
             get<T>(name: '$xhrFactory'): IXhrFactory<T>;
             has(name: string): boolean;
             instantiate<T>(typeConstructor: {new(...args: any[]): T}, locals?: any): T;
-            invoke(inlineAnnotatedFunction: any[]): any;
+            invoke(inlineAnnotatedFunction: any[], context?: any, locals?: any): any;
             invoke<T>(func: (...args: any[]) => T, context?: any, locals?: any): T;
             invoke(func: Function, context?: any, locals?: any): any;
             strictDi: boolean;


### PR DESCRIPTION
- $inject.invoke also accepts optional context and locals arguments when function is an array annotation format.
- Also added tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/auto/service/$injector
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
