### PR TITLE
Yeoman-generator: add error function to base type

### DIFF
--- a/types/yeoman-generator/index.d.ts
+++ b/types/yeoman-generator/index.d.ts
@@ -61,7 +61,11 @@ declare class Base extends EventEmitter {
 
     constructor(args: string|string[], options: {});
 
-    env: {};
+    env: {
+        error: {
+            (...e: Error[]): void
+        }
+    };
     args: {};
     resolved: string;
     description: string;

--- a/types/yeoman-generator/index.d.ts
+++ b/types/yeoman-generator/index.d.ts
@@ -62,9 +62,7 @@ declare class Base extends EventEmitter {
     constructor(args: string|string[], options: {});
 
     env: {
-        error: {
-            (...e: Error[]): void
-        }
+        error: (...e: Error[]) => void
     };
     args: {};
     resolved: string;

--- a/types/yeoman-generator/index.d.ts
+++ b/types/yeoman-generator/index.d.ts
@@ -62,7 +62,7 @@ declare class Base extends EventEmitter {
     constructor(args: string|string[], options: {});
 
     env: {
-        error: (...e: Error[]) => void
+        error(...e: Error[]): void
     };
     args: {};
     resolved: string;


### PR DESCRIPTION
this function is the recommended method for raising errors.
http://yeoman.io/environment/Environment.html#error
https://stackoverflow.com/questions/27616689/how-to-gracefully-abort-yeoman-generator-on-error

Please fill in this template.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
