### PR TITLE
Allow @types/angular-loading-bar to export a string name for angular

### DIFF
--- a/types/angular-loading-bar/index.d.ts
+++ b/types/angular-loading-bar/index.d.ts
@@ -7,6 +7,9 @@
 
 /// <reference types="angular" />
 
+declare var _: string;
+export = _;
+
 import * as angular from 'angular';
 
 declare module 'angular' {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

When importing the `angular-loading-bar` module, you generally want to use it directly as a dependency on your angular app. In order to do so, the module must export it's `name` property.

![image](https://user-images.githubusercontent.com/4608024/30620785-d261d4c6-9dea-11e7-8d57-2485b65b9611.png)

`angular-loading-bar`'s export is it's name property, which follows the convention set out by many other angular modules. These lines let TS know that the export is a string.