### PR TITLE
three: BufferGeometry.setIndex accepts number[]

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -835,7 +835,7 @@ export class BufferGeometry extends EventDispatcher {
     drawRange: { start: number, count: number };
 
     getIndex(): BufferAttribute;
-    setIndex( index: BufferAttribute ): void;
+    setIndex( index: BufferAttribute|number[] ): void;
 
     addAttribute(name: string, attribute: BufferAttribute|InterleavedBufferAttribute): BufferGeometry;
 


### PR DESCRIPTION
This PR includes the suggestions recommended (by myself) in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/19577.
If we merge this, please close the other.
Thanks @assafcw for identifying the original fix.