### PR TITLE
Change hostname to host

### DIFF
--- a/types/webdriverio/index.d.ts
+++ b/types/webdriverio/index.d.ts
@@ -406,7 +406,7 @@ declare namespace WebdriverIO {
         desiredCapabilities?: DesiredCapabilities;
         exclude?: string[];
         framework?: string;
-        hostname?: string;
+        host?: string;
         isWDIO?: boolean;
         protocol?: string;
         port?: number;


### PR DESCRIPTION
hostname must be host in Options interface.
https://github.com/webdriverio/webdriverio/blob/master/lib/cli.js#L72

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webdriverio/webdriverio/blob/master/lib/cli.js#L72
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

