### PR TITLE
Recharts (ReferenceLineProps): Viewbox rendered internally, not required

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -574,9 +574,9 @@ export interface ReferenceLineProps {
 	x?: number | string;
 	y?: number | string;
 	alwaysShow?: boolean;
-	viewBox: any;
-	xAxis: any;
-	yAxis: any;
+	viewBox?: any;
+	xAxis?: any;
+	yAxis?: any;
 	label?: string | number | React.ReactElement<any> | RechartsFunction;
 	isFront?: boolean;
 }


### PR DESCRIPTION
The viewbox on referenceLine is rendered internally, and is an optional prop. 
The Recharts website shows different examples of ReferenceLine, with none specifying viewBox. 
Tested without viewbox personally and line renders fine. 
http://recharts.org/#/en-US/api/ReferenceLine

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://recharts.org/#/en-US/api/ReferenceLine
