### PR TITLE
JQueryUI ResizableEvents interface, incorrect "create" event type

### DIFF
--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -618,7 +618,7 @@ declare namespace JQueryUI {
         resize?: ResizableEvent;
         start?: ResizableEvent;
         stop?: ResizableEvent;
-        create?: ResizableEvents;
+        create?: ResizableEvent;
     }
 
     interface Resizable extends Widget, ResizableOptions {


### PR DESCRIPTION
This fixes #19901

According to JQueryUI docs, resizable "create" event is the same as the other events `create( event, ui )` which is enough to conclude that the mistake in the interface is a typo.

Reference: https://api.jqueryui.com/resizable/#event-create