### PR TITLE
[restify] Correct and tighten type declarations.

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -26,7 +26,7 @@ export interface ServerOptions {
 
     ciphers?: string;
 
-    formatters?: any;
+    formatters?: Formatters;
 
     log?: Logger;
 
@@ -1061,9 +1061,13 @@ export namespace bunyan {
 
 export function createServer(options?: ServerOptions): Server;
 
-export const formatters: {
-    [name: string]: RequestHandler
-};
+export type Formatter = (req: Request, res: Response, body: any) => string | null;
+
+export interface Formatters {
+    [contentType: string]: Formatter;
+}
+
+export const formatters: Formatters;
 
 export namespace plugins {
     namespace pre {

--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -68,16 +68,6 @@ export interface AddressInterface {
     address: string;
 }
 
-export class Server {
-    /**
-     * Creates a new Server.
-     * @public
-     * @class
-     * @param {Object} options an options object
-     */
-    constructor(options?: ServerOptions);
-}
-
 export interface Server extends http.Server {
     /**
      * Returns the server address. Wraps node's address().
@@ -323,10 +313,6 @@ export interface RouterOptions {
     version?: string;
 
     versions?: string[];
-}
-
-export class Router {
-    constructor(options: RouterOptions);
 }
 
 export interface Router {

--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -7,16 +7,18 @@
 /// <reference types="node" />
 
 import http = require('http');
+import https = require('https');
 import Logger = require('bunyan');
 import url = require('url');
+import spdy = require('spdy');
 import stream = require('stream');
 
 export interface ServerOptions {
-    ca?: any;
+    ca?: string | Buffer | ReadonlyArray<string | Buffer>;
 
-    certificate?: any;
+    certificate?: string | Buffer | ReadonlyArray<string | Buffer>;
 
-    key?: any;
+    key?: string | Buffer | ReadonlyArray<string | Buffer>;
 
     passphrase?: string;
 
@@ -30,7 +32,7 @@ export interface ServerOptions {
 
     name?: string;
 
-    spdy?: any;
+    spdy?: spdy.ServerOptions;
 
     version?: string;
 
@@ -38,7 +40,7 @@ export interface ServerOptions {
 
     handleUpgrades?: boolean;
 
-    httpsServerOptions?: any;
+    httpsServerOptions?: https.ServerOptions;
 
     handleUncaughtExceptions?: boolean;
 

--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -3,7 +3,7 @@ import * as url from "url";
 import * as Logger from "bunyan";
 import * as http from "http";
 
-let server = new restify.Server();
+let server: restify.Server;
 
 server = restify.createServer({
     formatters: {
@@ -121,7 +121,6 @@ server.versions = [""];
 server.acceptable = ["test"];
 server.url = "";
 server.server = new http.Server();
-server.router = new restify.Router({});
 
 server.address().port;
 server.address().family;

--- a/types/restify/restify-tests.ts
+++ b/types/restify/restify-tests.ts
@@ -2,6 +2,7 @@ import * as restify from "restify";
 import * as url from "url";
 import * as Logger from "bunyan";
 import * as http from "http";
+import * as stream from "stream";
 
 let server: restify.Server;
 
@@ -164,3 +165,19 @@ server.on('after', (req: restify.Request, res: restify.Response, route: restify.
 (<any> restify).defaultResponseHeaders = function(this: restify.Request, data: any) {
     this.header('Server', 'helloworld');
 };
+
+const loggerStream: Logger.Stream = {};
+
+const requestCaptureOptions: restify.bunyan.RequestCaptureOptions = {};
+requestCaptureOptions.stream = loggerStream;
+requestCaptureOptions.streams = Object.freeze([loggerStream, loggerStream]);
+requestCaptureOptions.level = Logger.DEBUG;
+requestCaptureOptions.level = "info";
+requestCaptureOptions.maxRecords = 50;
+requestCaptureOptions.maxRequestIds = 500;
+requestCaptureOptions.dumpDefault = true;
+
+const requestCaptureStream = new restify.bunyan.RequestCaptureStream(requestCaptureOptions);
+const asStream: stream.Stream = requestCaptureStream;
+
+const logger2: Logger = restify.bunyan.createLogger("horse");


### PR DESCRIPTION
The attached pull request makes multiple improvements to the type declarations for restify:

 * Remove spurious exports: restify does not export the constructors for `Server` or `Router`, so modify the type declarations to export these as interfaces only, not classes. (see [lib/index.js](https://github.com/restify/node-restify/blob/35b078d922f9ae4afafcfce0fe72cc43529bba7b/lib/index.js)).
 * Correct type of `bunyan` export: The previous declaration bore no resemblance to the actual exported object. I have corrected this declaration to be correct as of restify 5.0.1 and 6.0.1. (Probably earlier versions too but those are the ones I checked.) (see [lib/index.js](https://github.com/restify/node-restify/blob/35b078d922f9ae4afafcfce0fe72cc43529bba7b/lib/index.js) and [bunyan_helper.js](https://github.com/restify/node-restify/blob/35b078d922f9ae4afafcfce0fe72cc43529bba7b/lib/bunyan_helper.js)).
 * Specify stricter types for members of `ServerOptions`. (see [lib/server.js](https://github.com/restify/node-restify/blob/35b078d922f9ae4afafcfce0fe72cc43529bba7b/lib/server.js)).
 * Correct type signature for formatters (see files in [lib/formatters](https://github.com/restify/node-restify/tree/35b078d922f9ae4afafcfce0fe72cc43529bba7b/lib/formatters)).
 * I have not bumped the version number because I’ve not made any effort to update the types for restify 6.0. I verified the changes I have made against both restify 5.0.1 and 6.0.1. So these types are still closer to restify 5.0.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/restify/node-restify/tree/35b078d922f9ae4afafcfce0fe72cc43529bba7b/lib
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.