### PR TITLE
Revert "redux-actions: Remove incorrect type assumptions in handleActions"

### DIFF
--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -4,7 +4,6 @@
 //                 Alex Gorbatchev <https://github.com/alexgorbatchev>,
 //                 Alec Hill <https://github.com/alechill>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 export as namespace ReduxActions;
 
@@ -23,12 +22,12 @@ export interface ActionMeta<Payload, Meta> extends Action<Payload> {
     meta: Meta;
 }
 
-export interface ReducerMap<State> {
-    [actionType: string]: Reducer<State, any> | ReducerNextThrow<State, any>;
+export interface ReducerMap<State, Payload> {
+    [actionType: string]: Reducer<State, Payload> | ReducerNextThrow<State, Payload>;
 }
 
-export interface ReducerMapMeta<State, Meta> {
-    [actionType: string]: ReducerMeta<State, any, Meta> | ReducerNextThrowMeta<State, any, Meta>;
+export interface ReducerMapMeta<State, Payload, Meta> {
+    [actionType: string]: ReducerMeta<State, Payload, Meta> | ReducerNextThrowMeta<State, Payload, Meta>;
 }
 
 export interface ReducerNextThrow<State, Payload> {
@@ -41,28 +40,58 @@ export interface ReducerNextThrowMeta<State, Payload, Meta> {
     throw?(state: State, action: ActionMeta<Payload, Meta>): State;
 }
 
-export type ActionFunctions<Payload> = ActionFunctionAny<Action<Payload>>;
+export type ActionFunctions<Payload> =
+    ActionFunction0<Action<Payload>> |
+    ActionFunction1<any, Action<Payload>> |
+    ActionFunction2<any, any, Action<Payload>> |
+    ActionFunction3<any, any, any, Action<Payload>> |
+    ActionFunction4<any, any, any, any, Action<Payload>> |
+    ActionFunctionAny<Action<Payload>>;
 
 export type Reducer<State, Payload> = (state: State, action: Action<Payload>) => State;
 
 export type ReducerMeta<State, Payload, Meta> = (state: State, action: ActionMeta<Payload, Meta>) => State;
 
 /** argument inferring borrowed from lodash definitions */
-export type ActionFunction<R, T1 = undefined, T2 = undefined, T3 = undefined, T4 = undefined> = (t1?: T1, t2?: T2, t3?: T3, t4?: T4) => R;
+export type ActionFunction0<R> = () => R;
+export type ActionFunction1<T1, R> = (t1: T1) => R;
+export type ActionFunction2<T1, T2, R> = (t1: T1, t2: T2) => R;
+export type ActionFunction3<T1, T2, T3, R>  = (t1: T1, t2: T2, t3: T3) => R;
+export type ActionFunction4<T1, T2, T3, T4, R> = (t1: T1, t2: T2, t3: T3, t4: T4) => R;
 export type ActionFunctionAny<R> = (...args: any[]) => R;
 
 export function createAction(
     actionType: string
-): ActionFunction<Action<void>>;
+): ActionFunction0<Action<void>>;
 
-export function createAction<Payload, Arg1 = undefined, Arg2 = undefined, Arg3 = undefined, Arg4 = undefined>(
+export function createAction<Payload>(
     actionType: string,
-    payloadCreator: ActionFunction<Payload, Arg1, Arg2, Arg3, Arg4>
-): ActionFunction<Action<Payload>, Arg1, Arg2, Arg3, Arg4>;
+    payloadCreator: ActionFunction0<Payload>
+): ActionFunction0<Action<Payload>>;
+
+export function createAction<Payload, Arg1>(
+    actionType: string,
+    payloadCreator: ActionFunction1<Arg1, Payload>
+): ActionFunction1<Arg1, Action<Payload>>;
+
+export function createAction<Payload, Arg1, Arg2>(
+    actionType: string,
+    payloadCreator: ActionFunction2<Arg1, Arg2, Payload>
+): ActionFunction2<Arg1, Arg2, Action<Payload>>;
+
+export function createAction<Payload, Arg1, Arg2, Arg3>(
+    actionType: string,
+    payloadCreator: ActionFunction3<Arg1, Arg2, Arg3, Payload>
+): ActionFunction3<Arg1, Arg2, Arg3, Action<Payload>>;
+
+export function createAction<Payload, Arg1, Arg2, Arg3, Arg4>(
+    actionType: string,
+    payloadCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Payload>
+): ActionFunction4<Arg1, Arg2, Arg3, Arg4, Action<Payload>>;
 
 export function createAction<Payload>(
     actionType: string
-): ActionFunction<Action<Payload>, Payload>;
+): ActionFunction1<Payload, Action<Payload>>;
 
 export function createAction<Payload, Meta>(
     actionType: string,
@@ -70,11 +99,29 @@ export function createAction<Payload, Meta>(
     metaCreator: ActionFunctionAny<Meta>
 ): ActionFunctionAny<ActionMeta<Payload, Meta>>;
 
+export function createAction<Payload, Meta, Arg1>(
+    actionType: string,
+    payloadCreator: ActionFunction1<Arg1, Payload>,
+    metaCreator: ActionFunction1<Arg1, Meta>
+): ActionFunction1<Arg1, ActionMeta<Payload, Meta>>;
+
+export function createAction<Payload, Meta, Arg1, Arg2>(
+    actionType: string,
+    payloadCreator: ActionFunction2<Arg1, Arg2, Payload>,
+    metaCreator: ActionFunction2<Arg1, Arg2, Meta>
+): ActionFunction2<Arg1, Arg2, ActionMeta<Payload, Meta>>;
+
+export function createAction<Payload, Meta, Arg1, Arg2, Arg3>(
+    actionType: string,
+    payloadCreator: ActionFunction3<Arg1, Arg2, Arg3, Payload>,
+    metaCreator: ActionFunction3<Arg1, Arg2, Arg3, Meta>
+): ActionFunction3<Arg1, Arg2, Arg3, ActionMeta<Payload, Meta>>;
+
 export function createAction<Payload, Meta, Arg1, Arg2, Arg3, Arg4>(
     actionType: string,
-    payloadCreator: ActionFunction<Payload, Arg1, Arg2, Arg3, Arg4>,
-    metaCreator: ActionFunction<Meta, Arg1, Arg2, Arg3, Arg4>
-): ActionFunction<ActionMeta<Payload, Meta>, Arg1, Arg2, Arg3, Arg4>;
+    payloadCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Payload>,
+    metaCreator: ActionFunction4<Arg1, Arg2, Arg3, Arg4, Meta>
+): ActionFunction4<Arg1, Arg2, Arg3, Arg4, ActionMeta<Payload, Meta>>;
 
 export function handleAction<State, Payload>(
     actionType: string | ActionFunctions<Payload>,
@@ -88,36 +135,34 @@ export function handleAction<State, Payload, Meta>(
     initialState: State
 ): Reducer<State, Payload>;
 
-export function handleActions<State>(
-    reducerMap: ReducerMap<State>,
-    initialState: State
-): Reducer<State, any>;
+export function handleActions<StateAndPayload>(
+    reducerMap: ReducerMap<StateAndPayload, StateAndPayload>,
+    initialState: StateAndPayload
+): Reducer<StateAndPayload, StateAndPayload>;
 
-export function handleActions<State, Meta>(
-    reducerMap: ReducerMapMeta<State, Meta>,
+export function handleActions<State, Payload>(
+    reducerMap: ReducerMap<State, Payload>,
     initialState: State
-): ReducerMeta<State, any, Meta>;
+): Reducer<State, Payload>;
+
+export function handleActions<State, Payload, Meta>(
+    reducerMap: ReducerMapMeta<State, Payload, Meta>,
+    initialState: State
+): ReducerMeta<State, Payload, Meta>;
 
 export function combineActions(...actionTypes: Array<ActionFunctions<any> | string>): string;
 
-export interface ActionMap<Payload, Meta = undefined> {
+export interface ActionMap<Payload, Meta> {
     [actionType: string]:
-    ActionMap<Payload, Meta> |
-    ActionFunctionAny<Payload> |
-    [ActionFunctionAny<Payload>, ActionFunctionAny<Meta>] |
-    undefined;
+        ActionMap<Payload, Meta> |
+        ActionFunctionAny<Payload> |
+        [ActionFunctionAny<Payload>, ActionFunctionAny<Meta>] |
+        undefined;
 }
-
-export function createActions<Payload>(
-    actionMap: ActionMap<Payload>,
-    ...identityActions: string[]
-): {
-    [actionName: string]: ActionFunctionAny<Action<Payload>>
-};
 
 export function createActions<Payload, Meta>(
     actionMap: ActionMap<Payload, Meta>,
     ...identityActions: string[]
 ): {
-    [actionName: string]: ActionFunctionAny<ActionMeta<Payload, Meta>>
+    [actionName: string]: ActionFunctionAny<Action<Payload>>
 };

--- a/types/redux-actions/redux-actions-tests.ts
+++ b/types/redux-actions/redux-actions-tests.ts
@@ -1,4 +1,4 @@
-import * as ReduxActions from 'redux-actions';
+import * as ReduxActions from "redux-actions";
 
 let state: number;
 const minimalAction: ReduxActions.BaseAction = { type: 'INCREMENT' };
@@ -33,14 +33,14 @@ const actionHandlerWithReduceMap = ReduxActions.handleAction<number, number>(
 
 state = actionHandlerWithReduceMap(0, multiplyAction(10));
 
-const actionsHandler = ReduxActions.handleActions({
+const actionsHandler = ReduxActions.handleActions<number, number>({
     INCREMENT: (state: number, action: ReduxActions.Action<number>) => state + action.payload,
     MULTIPLY: (state: number, action: ReduxActions.Action<number>) => state * action.payload
 }, 0);
 
 state = actionsHandler(0, { type: 'INCREMENT' });
 
-const actionsHandlerWithInitialState = ReduxActions.handleActions({
+const actionsHandlerWithInitialState = ReduxActions.handleActions<number, number>({
     INCREMENT: {
         next: (state: number, action: ReduxActions.Action<number>) => state + action.payload,
     },
@@ -112,9 +112,9 @@ ReduxActions.Action<TypedPayload> = ReduxActions.createAction<TypedPayload, numb
 const actionFrom2Args = typedIncrementAction2TypedArgs(10, '100');
 actionFrom1Arg.payload.increase === 110;
 
-const typedActionHandlerReducerMap = ReduxActions.handleActions(
+const typedActionHandlerReducerMap = ReduxActions.handleActions<TypedState, TypedPayload>(
     {
-        INCREMENT: (state: TypedState, action: ReduxActions.Action<any>) => ({ value: state.value + 1 })
+        INCREMENT: (state: TypedState, action: ReduxActions.Action<TypedPayload>) => ({ value: state.value + 1 })
     },
     {value: 1}
 );
@@ -144,7 +144,7 @@ const typedActionHandlerWithMeta = ReduxActions.handleAction<TypedState, TypedPa
 
 typedState = typedActionHandlerWithMeta({ value: 0 }, typedIncrementByActionWithMetaAnyArgs(10));
 
-const typedActionHandlerReducerMetaMap = ReduxActions.handleActions<TypedState, MetaType>(
+const typedActionHandlerReducerMetaMap = ReduxActions.handleActions<TypedState, TypedPayload, MetaType>(
     {
         INCREMENT_BY: {
             next(state: TypedState, action: ReduxActions.ActionMeta<TypedPayload, MetaType>) {
@@ -159,7 +159,7 @@ const typedActionHandlerReducerMetaMap = ReduxActions.handleActions<TypedState, 
 typedState = typedActionHandlerReducerMetaMap({ value: 0 }, actionMetaFromAnyArgs);
 
 const typedActionWithMeta1TypedArg: (value: number) => ReduxActions.ActionMeta<TypedPayload, MetaType> =
-    ReduxActions.createAction(
+    ReduxActions.createAction<TypedPayload, MetaType, number>(
         'INCREMENT_BY',
         amount => ({ increase: amount }),
         amount => ({ remote: true })
@@ -172,7 +172,7 @@ actionMetaFrom1Arg.meta.remote;
 typedState = typedActionHandlerReducerMetaMap({ value: 0 }, actionMetaFrom1Arg);
 
 const typedActionWithMeta2TypedArgs: (value: number, remote: boolean) => ReduxActions.ActionMeta<TypedPayload, MetaType> =
-    ReduxActions.createAction(
+    ReduxActions.createAction<TypedPayload, MetaType, number, boolean>(
         'INCREMENT_BY',
         (amount, remote)  => ({ increase: amount }),
         (amount, remote) => ({ remote })

--- a/types/redux-promise/index.d.ts
+++ b/types/redux-promise/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/acdlite/redux-promise
 // Definitions by: Rogelio Morrell Caballero <https://github.com/molekilla>, Kaur Kuut <https://github.com/xStrom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import * as Redux from 'redux';
 

--- a/types/redux-promise/index.d.ts
+++ b/types/redux-promise/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/acdlite/redux-promise
 // Definitions by: Rogelio Morrell Caballero <https://github.com/molekilla>, Kaur Kuut <https://github.com/xStrom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
 
 import * as Redux from 'redux';
 


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#19693


@florian-richter Sorry I missed the previously merged PR, if I understand you correctly then you were only having issues using a single reducer map that receives actions of differing payload types.

Interestingly I am doing exactly the same as you mention with the previous typings, the key being to simply type the reducer map as having a union of payloads that the map can expect to handle, then at the item reducer level restrict it further:

Heres an actual working production snippet, note its a single reducer map that accepts reducers which expect an action with payload type of either ICardState or string (in reality this reducer map handles 8 different action payload types)

```
export const state = handleActions<List<ICardState>, ICardState | string>({

  [actions.ADD_CARD]: (state, action: ActionMeta<ICardState, ICardActionMeta>) =>
    state.insert(action.meta.position !== undefined ? action.meta.position : state.size, action.payload),

  [actions.REMOVE_CARD]: (state, action: Action<string>) =>
    state.filterNot(card => card.uuid === action.payload).toList()

})
```

Similarly your example above would be possible with `Item | Item[]` as the generic payload type, or if you really want `any` you can add it as your generic, which has the benefit of anyone else still having the ability to keep it strictly typed of they want

Perhaps a common ground would be to keep the generic, but to default it to `any`?

Also by changing all the tests to remove type info from the generics, they now aren't actually testing anything except the completely lenient version. I'm concerned the action creators etc may also now not be type safe any more, as there are more changes than the above and the tests for them have also been altered in the same way - whats the reasoning behind those other changes?

Is there any way we can work together to reach a compromise, as these changes have significantly reduced type safety, and also significantly altered the API for action creators that has been in place for a long time