### PR TITLE
jest: restoreAllMocks()

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 20.0
+// Type definitions for Jest 21.1
 // Project: http://facebook.github.io/jest/
 // Definitions by: Asana <https://asana.com>
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -61,7 +61,7 @@ declare namespace jest {
      */
     function resetAllMocks(): typeof jest;
     /**
-     * available in Jest 20.1.0+
+     * available since Jest 21.1.0
      * Restores all mocks back to their original value.
      * Equivalent to calling .mockRestore on every mocked function.
      * Beware that jest.restoreAllMocks() only works when mock was created with

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -61,6 +61,12 @@ declare namespace jest {
      */
     function resetAllMocks(): typeof jest;
     /**
+     * available in Jest 20.1.0+
+     * Restores all mocks back to their original value. Equivalent to calling .mockRestore on every mocked function.
+     * Beware that jest.restoreAllMocks() only works when mock was created with jest.spyOn; other mocks will require you to manually restore them.
+     */
+    function restoreAllMocks(): typeof jest;
+    /**
      * Removes any pending timers from the timer system. If any timers have
      * been scheduled, they will be cleared and will never have the opportunity
      * to execute in the future.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -62,8 +62,10 @@ declare namespace jest {
     function resetAllMocks(): typeof jest;
     /**
      * available in Jest 20.1.0+
-     * Restores all mocks back to their original value. Equivalent to calling .mockRestore on every mocked function.
-     * Beware that jest.restoreAllMocks() only works when mock was created with jest.spyOn; other mocks will require you to manually restore them.
+     * Restores all mocks back to their original value.
+     * Equivalent to calling .mockRestore on every mocked function.
+     * Beware that jest.restoreAllMocks() only works when mock was created with
+     * jest.spyOn; other mocks will require you to manually restore them.
      */
     function restoreAllMocks(): typeof jest;
     /**

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -17,6 +17,12 @@ describe('sum', () => {
     });
 });
 
+describe('restoreAllMocks', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+});
+
 describe('fetchCurrentUser', () => {
     it('calls the callback when $.ajax requests are finished', () => {
         const fetchCurrentUser = require('../fetchCurrentUser');


### PR DESCRIPTION
Hello,
this would add restoreAllMocks() to Jest definition.
restoreAllMocks is available since Jest 20.1.0+
https://facebook.github.io/jest/docs/en/jest-object.html#jestrestoreallmocks

Template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/jest/docs/en/jest-object.html#jestrestoreallmocks
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
