### PR TITLE
Fix types for Recharts, optional properties were incorrectly marked required

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -146,7 +146,7 @@ export interface CartesianAxisProps {
 	width?: number;
 	height?: number;
 	orientation?: 'top' | 'bottom' | 'left' | 'right';
-	viewBox?: any;
+	viewBox?: ViewBox;
 	axisLine?: boolean | any;
 	tickLine?: boolean | any;
 	minTickGap?: number;
@@ -537,9 +537,9 @@ export interface ReferenceAreaProps {
 	y1?: number | string;
 	y2?: number | string;
 	alwaysShow?: boolean;
-	viewBox: any;
-	xAxis: any;
-	yAxis: any;
+	viewBox?: ViewBox;
+	xAxis?: any;
+	yAxis?: any;
 	label?: string | number | React.ReactElement<any> | RechartsFunction;
 	isFront?: boolean;
 }
@@ -574,9 +574,9 @@ export interface ReferenceLineProps {
 	x?: number | string;
 	y?: number | string;
 	alwaysShow?: boolean;
-	viewBox: any;
-	xAxis: any;
-	yAxis: any;
+	viewBox?: ViewBox;
+	xAxis?: any;
+	yAxis?: any;
 	label?: string | number | React.ReactElement<any> | RechartsFunction;
 	isFront?: boolean;
 }
@@ -685,7 +685,7 @@ export interface TooltipProps {
 	wrapperStyle?: any;
 	labelStyle?: any;
 	cursor?: boolean | any | React.ReactElement<any> | React.StatelessComponent<any>;
-	viewBox: ViewBox;
+	viewBox?: ViewBox;
 	active?: boolean;
 	coordinate?: Coordinate;
 	payload?: TooltipPayload[];
@@ -713,7 +713,7 @@ export interface TreemapProps {
 }
 
 export interface Label {
-	viewBox?: any;
+	viewBox?: ViewBox;
 	formatter?: RechartsFunction;
 	value: string | number;
 	position?: PositionType;

--- a/types/recharts/recharts-tests.tsx
+++ b/types/recharts/recharts-tests.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts';
+import { CartesianGrid, Line, LineChart, XAxis, YAxis, Tooltip, ReferenceLine, ReferenceArea } from 'recharts';
 
 const Component = (props: {}) => {
     const data = [
@@ -21,6 +21,9 @@ const Component = (props: {}) => {
             <CartesianGrid stroke="#eee" strokeDasharray="5 5"/>
             <Line type="monotone" dataKey="uv" stroke="#8884d8" />
             <Line type="monotone" dataKey="pv" stroke="#82ca9d" />
+            <Tooltip />
+            <ReferenceLine />
+            <ReferenceArea />
         </LineChart>
     );
 };


### PR DESCRIPTION
Correctly mark viewBox, xAxis, yAxis as optional and add some more shapes to the test

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://recharts.org/#/en-US/api>>

