### PR TITLE
[accept-language-parser] Add new types for accept-language-parser

### DIFF
--- a/types/accept-language-parser/accept-language-parser-tests.ts
+++ b/types/accept-language-parser/accept-language-parser-tests.ts
@@ -20,6 +20,6 @@ const l3: AcceptLanguageParser.Language = {
     quality: 0.9
 };
 
-AcceptLanguageParser.parse('');
-AcceptLanguageParser.pick([''], '');
-AcceptLanguageParser.pick([''], [l1, l2, l3]);
+const parsed1: AcceptLanguageParser.Language[] = AcceptLanguageParser.parse('');
+const pick1: string | null = AcceptLanguageParser.pick([''], '');
+const pick2: string | null = AcceptLanguageParser.pick([''], [l1, l2, l3]);

--- a/types/accept-language-parser/accept-language-parser-tests.ts
+++ b/types/accept-language-parser/accept-language-parser-tests.ts
@@ -1,0 +1,25 @@
+// https://github.com/opentable/accept-language-parser/blob/v1.4.1/index.js
+
+import * as AcceptLanguageParser from '.';
+
+const l1: AcceptLanguageParser.Language = {
+    code: 'en',
+    script: 'Latn',
+    region: 'GB',
+    quality: 0.9
+};
+
+const l2: AcceptLanguageParser.Language = {
+    code: 'en',
+    quality: 0.9
+};
+
+const l3: AcceptLanguageParser.Language = {
+    code: 'en',
+    script: null,
+    quality: 0.9
+};
+
+AcceptLanguageParser.parse('');
+AcceptLanguageParser.pick([''], '');
+AcceptLanguageParser.pick([''], [l1, l2, l3]);

--- a/types/accept-language-parser/accept-language-parser-tests.ts
+++ b/types/accept-language-parser/accept-language-parser-tests.ts
@@ -1,6 +1,6 @@
 // https://github.com/opentable/accept-language-parser/blob/v1.4.1/index.js
 
-import * as AcceptLanguageParser from '.';
+import * as AcceptLanguageParser from 'accept-language-parser';
 
 const l1: AcceptLanguageParser.Language = {
     code: 'en',

--- a/types/accept-language-parser/index.d.ts
+++ b/types/accept-language-parser/index.d.ts
@@ -7,7 +7,7 @@
 // https://github.com/opentable/accept-language-parser/blob/v1.4.1/index.js
 
 export function parse(acceptLanguage: string): Language[];
-export function pick(supportedLanguages: string[], acceptLanguage: string | Language[]): Language | null;
+export function pick(supportedLanguages: string[], acceptLanguage: string | Language[]): string | null;
 
 export interface Language {
     code: string;

--- a/types/accept-language-parser/index.d.ts
+++ b/types/accept-language-parser/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/opentable/accept-language-parser
 // Definitions by: Niklas Wulf <https://github.com/kampfgnom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 // https://github.com/opentable/accept-language-parser/blob/v1.4.1/index.js
 

--- a/types/accept-language-parser/index.d.ts
+++ b/types/accept-language-parser/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for accept-language-parser 1.4
+// Project: https://github.com/opentable/accept-language-parser
+// Definitions by: Niklas Wulf <https://github.com/kampfgnom>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// https://github.com/opentable/accept-language-parser/blob/v1.4.1/index.js
+
+export function parse(acceptLanguage: string): Language[];
+export function pick(supportedLanguages: string[], acceptLanguage: string | Language[]): Language | null;
+
+export interface Language {
+    code: string;
+    script?: string | null;
+    region?: string;
+    quality: number;
+}

--- a/types/accept-language-parser/tsconfig.json
+++ b/types/accept-language-parser/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "accept-language-parser-tests.ts"]
+}

--- a/types/accept-language-parser/tslint.json
+++ b/types/accept-language-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This commit adds initial support for the accept-language-parser module which is currently at version 1.4.1

I am not in any way related to the module. The current maintainer seems to be @matteofigus.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

