### PR TITLE
Add definitions for angular-file-upload

### DIFF
--- a/types/angular-file-upload/angular-file-upload-tests.ts
+++ b/types/angular-file-upload/angular-file-upload-tests.ts
@@ -1,0 +1,77 @@
+import { FileUploaderFactory, FileUploader, FileItem } from 'angular-file-upload';
+import * as angular from 'angular';
+
+angular.module('app', ['angularFileUpload'])
+
+	.controller('AppController', ['$scope', 'FileUploader', (
+		$scope: any,
+		FileUploader: FileUploaderFactory
+	) => {
+		const uploader: FileUploader = $scope.uploader = new FileUploader({
+			url: 'upload.php'
+		});
+
+		uploader.onAfterAddingFile = (fileItem: FileItem) => {
+			console.log(fileItem);
+		};
+		
+		// FILTERS
+
+		// a sync filter
+		const syncFilter = (item: File, options: {}) => {
+			console.log('syncFilter');
+			return $scope.queue.length < 10;
+		};
+		uploader.filters.push({
+			name: 'syncFilter',
+			fn: syncFilter
+		});
+
+		// an async filter
+		const asyncFilter = (item: File, options: {}, deferred: angular.IDeferred<any>) => {
+			console.log('asyncFilter');
+			setTimeout(deferred.resolve, 1e3);
+		};
+		uploader.filters.push({
+			name: 'asyncFilter',
+			fn: asyncFilter
+		});
+
+		// CALLBACKS
+
+		uploader.onWhenAddingFileFailed = (item /*{File|FileLikeObject}*/, filter, options) => {
+			console.info('onWhenAddingFileFailed', item, filter, options);
+		};
+		uploader.onAfterAddingFile = (fileItem) => {
+			console.info('onAfterAddingFile', fileItem);
+		};
+		uploader.onAfterAddingAll = (addedFileItems) => {
+			console.info('onAfterAddingAll', addedFileItems);
+		};
+		uploader.onBeforeUploadItem = (item) => {
+			console.info('onBeforeUploadItem', item);
+		};
+		uploader.onProgressItem = (fileItem, progress) => {
+			console.info('onProgressItem', fileItem, progress);
+		};
+		uploader.onProgressAll = (progress) => {
+			console.info('onProgressAll', progress);
+		};
+		uploader.onSuccessItem = (fileItem, response, status, headers) => {
+			console.info('onSuccessItem', fileItem, response, status, headers);
+		};
+		uploader.onErrorItem = (fileItem, response, status, headers) => {
+			console.info('onErrorItem', fileItem, response, status, headers);
+		};
+		uploader.onCancelItem = (fileItem, response, status, headers) => {
+			console.info('onCancelItem', fileItem, response, status, headers);
+		};
+		uploader.onCompleteItem = (fileItem, response, status, headers) => {
+			console.info('onCompleteItem', fileItem, response, status, headers);
+		};
+		uploader.onCompleteAll = () => {
+			console.info('onCompleteAll');
+		};
+
+		console.info('uploader', uploader);
+	}]);

--- a/types/angular-file-upload/angular-file-upload-tests.ts
+++ b/types/angular-file-upload/angular-file-upload-tests.ts
@@ -3,24 +3,23 @@ import * as angular from 'angular';
 
 angular.module('app', ['angularFileUpload'])
 
-	.controller('AppController', ['$scope', 'FileUploader', (
-		$scope: any,
+	.controller('AppController', ['FileUploader', (
 		FileUploader: FileUploaderFactory
 	) => {
-		const uploader: FileUploader = $scope.uploader = new FileUploader({
+		const uploader: FileUploader = new FileUploader({
 			url: 'upload.php'
 		});
 
 		uploader.onAfterAddingFile = (fileItem: FileItem) => {
 			console.log(fileItem);
 		};
-		
+
 		// FILTERS
 
 		// a sync filter
 		const syncFilter = (item: File, options: {}) => {
 			console.log('syncFilter');
-			return $scope.queue.length < 10;
+			return true;
 		};
 		uploader.filters.push({
 			name: 'syncFilter',

--- a/types/angular-file-upload/index.d.ts
+++ b/types/angular-file-upload/index.d.ts
@@ -1,314 +1,301 @@
-// Type definitions for angular-file-upload 2.5.0
+// Type definitions for angular-file-upload 2.5
 // Project: https://github.com/nervgh/angular-file-upload
 // Definitions by: Cyril Gandon <https://github.com/cyrilgandon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.2
 
 import * as angular from 'angular';
 
-export as namespace fileUploaderLib;
+export interface FileUploaderFactory {
+    new(options?: {}): FileUploader;
+}
+export interface FileUploader {
+    // **Properties**
 
-export = FileUploader;
+    /**
+     * Path on the server to upload files
+     */
+    url: string;
+    /**
+     * Name of the field which will contain the file, default is file
+     */
+    alias: string;
+    /**
+     * Items to be uploaded
+     */
+    queue: FileItem[];
+    /**
+     * Upload queue progress percentage. Read only.
+     */
+    progress: number;
+    /**
+     * Headers to be sent along with the files. HTML5 browsers only.
+     */
+    headers: {};
+    /**
+     * Data to be sent along with the files
+     */
+    formData: any[];
+    /**
+     * Filters to be applied to the files before adding them to the queue. If the filter returns true the file will be added to the queue
+     */
+    filters: UploaderFilter[];
+    /**
+     * Automatically upload files after adding them to the queue
+     */
+    autoUpload: boolean;
+    /**
+     * It's a request method. By default POST. HTML5 browsers only.
+     */
+    method: string;
+    /**
+     * Remove files from the queue after uploading
+     */
+    removeAfterUpload: boolean;
+    /**
+     * true if uploader is html5-uploader. Read only.
+     */
+    isHTML5: boolean;
+    /**
+     * true if an upload is in progress. Read only.
+     */
+    isUploading: boolean;
+    /**
+     * maximum count of files
+     */
+    queueLimit: number;
+    /**
+     * enable CORS. HTML5 browsers only.
+     */
+    withCredentials: boolean;
 
-declare function MyFunction(): FileUploader.FileUploader;
+    // **Methods**
 
-declare namespace FileUploader {
+    /**
+     * Add items to the queue
+     */
+    addToQueue(files: FileList | File | HTMLInputElement, options: {}, filters: string): void;
+    /**
+     * Remove an item from the queue, where value is {FileItem} or index of item.
+     */
+    removeFromQueue(value: FileItem | number): void;
+    /**
+     * Removes all elements from the queue.
+     */
+    clearQueue(): void;
+    /**
+     * Uploads an item, where value is {FileItem} or index of item.
+     */
+    uploadItem(value: FileItem | number): void;
+    /**
+     * Cancels uploading of item, where value is {FileItem} or index of item.
+     */
+    cancelItem(value: FileItem | number): void;
+    /**
+     * Upload all pending items on the queue.
+     */
+    uploadAll(): void;
+    /**
+     * Cancels all current uploads.
+     */
+    cancelAll(): void;
+    /**
+     * Destroys a uploader.
+     */
+    destroy(): void;
+    /**
+     * Returns true if value is {File}.
+     */
+    isFile(value: any): boolean;
+    /**
+     * Returns true if value is {FileLikeObject}.
+     */
+    isFileLikeObject(value: any): boolean;
+    /**
+     * Returns the index of the {FileItem} queue element.
+     */
+    getIndexOfItem(fileItem: FileItem): number;
+    /**
+     * Return items are ready to upload.
+     */
+    getReadyItems(): FileItem[];
+    /**
+     * Return an array of all pending items on the queue
+     */
+    getNotUploadedItems(): FileItem[];
 
-    export interface FileUploaderFactory {
-        new(options?: {}): FileUploader;
-    }
-    export interface FileUploader {
-        // **Properties**
+    // **Callbacks**
 
-        /**
-         * Path on the server to upload files
-         */
-        url: string;
-        /**
-         * Name of the field which will contain the file, default is file
-         */
-        alias: string;
-        /**
-         * Items to be uploaded
-         */
-        queue: FileItem[];
-        /**
-         * Upload queue progress percentage. Read only.
-         */
-        progress: number;
-        /**
-         * Headers to be sent along with the files. HTML5 browsers only.
-         */
-        headers: {};
-        /**
-         * Data to be sent along with the files
-         */
-        formData: any[];
-        /**
-         * Filters to be applied to the files before adding them to the queue. If the filter returns true the file will be added to the queue
-         */
-        filters: IUploaderFilter[];
-        /**
-         * Automatically upload files after adding them to the queue
-         */
-        autoUpload: boolean;
-        /**
-         * It's a request method. By default POST. HTML5 browsers only.
-         */
-        method: string;
-        /**
-         * Remove files from the queue after uploading
-         */
-        removeAfterUpload: boolean;
-        /**
-         * true if uploader is html5-uploader. Read only.
-         */
-        isHTML5: boolean;
-        /**
-         * true if an upload is in progress. Read only.
-         */
-        isUploading: boolean;
-        /**
-         * maximum count of files
-         */
-        queueLimit: number;
-        /**
-         * enable CORS. HTML5 browsers only.
-         */
-        withCredentials: boolean;
+    /**
+     * Fires after adding all the dragged or selected files to the queue.
+     */
+    onAfterAddingAll(addedItems: FileItem[]): void;
+    /**
+     * When adding a file failed
+     */
+    onWhenAddingFileFailed(item: FileItem, filter: any, options: any): void;
+    /**
+     * Fires after adding a single file to the queue.
+     */
+    onAfterAddingFile(item: FileItem): void;
+    /**
+     * Fires before uploading an item.
+     */
+    onBeforeUploadItem(item: FileItem): void;
+    /**
+     * On file upload progress.
+     */
+    onProgressItem(item: FileItem, progress: number): void;
+    /**
+     * On file successfully uploaded
+     */
+    onSuccessItem(item: FileItem, response: Response, status: number, headers: Headers): void;
+    /**
+     * On upload error
+     */
+    onErrorItem(item: FileItem, response: Response, status: number, headers: Headers): void;
+    /**
+     * On cancel uploading
+     */
+    onCancelItem(item: FileItem, response: Response, status: number, headers: Headers): void;
+    /**
+     * On file upload complete (independently of the sucess of the operation)
+     */
+    onCompleteItem(item: FileItem, response: Response, status: number, headers: Headers): void;
+    /**
+     * On upload queue progress
+     */
+    onProgressAll(progress: number): void;
+    /**
+     * On all loaded when uploading an entire queue, or on file loaded when uploading a single independent file
+     */
+    onCompleteAll(): void;
+}
+export interface FileLikeObject {
+    lastModifiedDate: Date;
+    name: string;
 
-        // **Methods**
+    /**
+     * Size of object in octet
+     */
+    size: number;
+    type: string;
+}
+export interface FileItem {
+    // **Properties**
+    file: FileLikeObject;
+    /**
+     * Path on the server in which this file will be uploaded
+     */
+    url: string;
+    /**
+     * Name of the field which will contain the file, default is file
+     */
+    alias: string;
+    /**
+     * Headers to be sent along with this file. HTML5 browsers only.
+     */
+    headers: {};
+    /**
+     * Data to be sent along with this file
+     */
+    formData: any[];
+    /**
+     * It's a request method. By default POST. HTML5 browsers only.
+     */
+    method: string;
+    /**
+     * enable CORS. HTML5 browsers only.
+     */
+    withCredentials: boolean;
+    /**
+     * Remove this file from the queue after uploading
+     */
+    removeAfterUpload: boolean;
+    /**
+     * A sequence number upload. Read only.
+     */
+    index: number;
+    /**
+     * File upload progress percentage. Read only.
+     */
+    progress: number;
+    /**
+     * File is ready to upload. Read only.
+     */
+    isReady: boolean;
+    /**
+     * true if the file is being uploaded. Read only.
+     */
+    isUploading: boolean;
+    /**
+     * true if the file was uploaded. Read only.
+     */
+    isUploaded: boolean;
+    /**
+     * true if the file was uploaded successfully. Read only.
+     */
+    isSuccess: boolean;
+    /**
+     * true if uploading was canceled. Read only.
+     */
+    isCancel: boolean;
+    /**
+     * true if occurred error while file uploading. Read only.
+     */
+    isError: boolean;
+    /**
+     * Reference to the parent Uploader object for this file. Read only.
+     */
+    uploader: FileUploader;
 
-        /**
-         * Add items to the queue
-         */
-        addToQueue(files: FileList | File | HTMLInputElement, options: {}, filters: string): void;
-        /**
-         * Remove an item from the queue, where value is {FileItem} or index of item.
-         */
-        removeFromQueue(value: FileItem | number): void;
-        /**
-         * Removes all elements from the queue.
-         */
-        clearQueue(): void;
-        /**
-         * Uploads an item, where value is {FileItem} or index of item.
-         */
-        uploadItem(value: FileItem | number): void;
-        /**
-         * Cancels uploading of item, where value is {FileItem} or index of item.
-         */
-        cancelItem(value: FileItem | number): void;
-        /**
-         * Upload all pending items on the queue.
-         */
-        uploadAll(): void;
-        /**
-         * Cancels all current uploads.
-         */
-        cancelAll(): void;
-        /**
-         * Destroys a uploader.
-         */
-        destroy(): void;
-        /**
-         * Returns true if value is {File}.
-         */
-        isFile(value: any): boolean;
-        /**
-         * Returns true if value is {FileLikeObject}.
-         */
-        isFileLikeObject(value: any): boolean;
-        /**
-         * Returns the index of the {FileItem} queue element.
-         */
-        getIndexOfItem(fileItem: FileItem): number;
-        /**
-         * Return items are ready to upload.
-         */
-        getReadyItems(): FileItem[];
-        /**
-         * Return an array of all pending items on the queue
-         */
-        getNotUploadedItems(): FileItem[];
+    // **Methods**
 
-        // **Callbacks**
+    /**
+     * Cancels uploading of this file
+     */
+    cancel(): void;
 
-        /**
-         * Fires after adding all the dragged or selected files to the queue.
-         */
-        onAfterAddingAll(addedItems: FileItem[]): void;
-        /**
-         * When adding a file failed
-         */
-        onWhenAddingFileFailed(item: FileItem, filter: any, options: any): void;
-        /**
-         * Fires after adding a single file to the queue.
-         */
-        onAfterAddingFile(item: FileItem): void;
-        /**
-         * Fires before uploading an item.
-         */
-        onBeforeUploadItem(item: FileItem): void;
-        /**
-         * On file upload progress.
-         */
-        onProgressItem(item: FileItem, progress: number): void;
-        /**
-         * On file successfully uploaded
-         */
-        onSuccessItem(item: FileItem, response: Response, status: number, headers: Headers): void;
-        /**
-         * On upload error
-         */
-        onErrorItem(item: FileItem, response: Response, status: number, headers: Headers): void;
-        /**
-         * On cancel uploading
-         */
-        onCancelItem(item: FileItem, response: Response, status: number, headers: Headers): void;
-        /**
-         * On file upload complete (independently of the sucess of the operation)
-         */
-        onCompleteItem(item: FileItem, response: Response, status: number, headers: Headers): void;
-        /**
-         * On upload queue progress
-         */
-        onProgressAll(progress: number): void;
-        /**
-         * On all loaded when uploading an entire queue, or on file loaded when uploading a single independent file
-         */
-        onCompleteAll(): void;
-    }
-    export interface FileLikeObject {
-        lastModifiedDate: Date;
-        name: string;
+    /**
+     * Remove this file from the queue
+     */
+    remove(): void;
 
-        /**
-         * Size of object in octet
-         */
-        size: number;
-        type: string;
-    }
-    export interface FileItem {
+    /**
+     * Upload this file
+     */
+    upload(): void;
 
-        // **Properties**
-        file: FileLikeObject;
-        /**
-         * Path on the server in which this file will be uploaded
-         */
-        url: string;
-        /**
-         * Name of the field which will contain the file, default is file
-         */
-        alias: string;
-        /**
-         * Headers to be sent along with this file. HTML5 browsers only.
-         */
-        headers: {};
-        /**
-         * Data to be sent along with this file
-         */
-        formData: any[];
-        /**
-         * It's a request method. By default POST. HTML5 browsers only.
-         */
-        method: string;
-        /**
-         * enable CORS. HTML5 browsers only.
-         */
-        withCredentials: boolean;
-        /**
-         * Remove this file from the queue after uploading
-         */
-        removeAfterUpload: boolean;
-        /**
-         * A sequence number upload. Read only.
-         */
-        index: number;
-        /**
-         * File upload progress percentage. Read only.
-         */
-        progress: number;
-        /**
-         * File is ready to upload. Read only.
-         */
-        isReady: boolean;
-        /**
-         * true if the file is being uploaded. Read only.
-         */
-        isUploading: boolean;
-        /**
-         * true if the file was uploaded. Read only.
-         */
-        isUploaded: boolean;
-        /**
-         * true if the file was uploaded successfully. Read only.
-         */
-        isSuccess: boolean;
-        /**
-         * true if uploading was canceled. Read only.
-         */
-        isCancel: boolean;
-        /**
-         * true if occurred error while file uploading. Read only.
-         */
-        isError: boolean;
-        /**
-         * Reference to the parent Uploader object for this file. Read only.
-         */
-        uploader: FileUploader;
+    // **Callbacks**
 
-        // **Methods**
-
-        /**
-         * Cancels uploading of this file
-         */
-        cancel(): void;
-
-        /**
-         * Remove this file from the queue
-         */
-        remove(): void;
-
-        /**
-         * Upload this file
-         */
-        upload(): void;
-
-        // **Callbacks**
-
-        /**
-         *  Fires before uploading an item.
-         */
-        onBeforeUpload(): void;
-        /**
-         * On file upload progress.
-         */
-        onProgress(progress: number): void;
-        /**
-         * On file successfully uploaded
-         */
-        onSuccess(response: Response, status: number, headers: Headers): void;
-        /**
-         * On upload error
-         */
-        onError(response: Response, status: number, headers: Headers): void;
-        /**
-         * On cancel uploading
-         */
-        onCancel(response: Response, status: number, headers: Headers): void;
-        /**
-         * On file upload complete (independently of the sucess of the operation)
-         */
-        onComplete(response: Response, status: number, headers: Headers): void;
-
-    }
-
-    type SyncFilter = (item: File | FileLikeObject, options?: {}) => boolean;
-    type AsyncFilter = (item: File | FileLikeObject, options?: {}, deferred?: angular.IDeferred<any>) => void;
-
-    export interface IUploaderFilter {
-        name: string;
-        fn: SyncFilter | AsyncFilter;
-    }
+    /**
+     *  Fires before uploading an item.
+     */
+    onBeforeUpload(): void;
+    /**
+     * On file upload progress.
+     */
+    onProgress(progress: number): void;
+    /**
+     * On file successfully uploaded
+     */
+    onSuccess(response: Response, status: number, headers: Headers): void;
+    /**
+     * On upload error
+     */
+    onError(response: Response, status: number, headers: Headers): void;
+    /**
+     * On cancel uploading
+     */
+    onCancel(response: Response, status: number, headers: Headers): void;
+    /**
+     * On file upload complete (independently of the sucess of the operation)
+     */
+    onComplete(response: Response, status: number, headers: Headers): void;
+}
+export type SyncFilter = (item: File | FileLikeObject, options?: {}) => boolean;
+export type AsyncFilter = (item: File | FileLikeObject, options?: {}, deferred?: angular.IDeferred<any>) => void;
+export interface UploaderFilter {
+    name: string;
+    fn: SyncFilter | AsyncFilter;
 }

--- a/types/angular-file-upload/index.d.ts
+++ b/types/angular-file-upload/index.d.ts
@@ -35,11 +35,11 @@ export interface FileUploader {
     /**
      * Data to be sent along with the files
      */
-    formData: any[];
+    formData: FormData[];
     /**
      * Filters to be applied to the files before adding them to the queue. If the filter returns true the file will be added to the queue
      */
-    filters: UploaderFilter[];
+    filters: Filter[];
     /**
      * Automatically upload files after adding them to the queue
      */
@@ -74,7 +74,7 @@ export interface FileUploader {
     /**
      * Add items to the queue
      */
-    addToQueue(files: FileList | File | HTMLInputElement, options: {}, filters: string): void;
+    addToQueue(files: File | HTMLInputElement | {} | FileList | object[], options: {}, filters: Filter[] | string): void;
     /**
      * Remove an item from the queue, where value is {FileItem} or index of item.
      */
@@ -133,7 +133,7 @@ export interface FileUploader {
     /**
      * When adding a file failed
      */
-    onWhenAddingFileFailed(item: FileItem, filter: any, options: any): void;
+    onWhenAddingFileFailed(item: FileItem, filter: Filter, options: {}): void;
     /**
      * Fires after adding a single file to the queue.
      */
@@ -172,13 +172,21 @@ export interface FileUploader {
     onCompleteAll(): void;
 }
 export interface FileLikeObject {
-    lastModifiedDate: Date;
-    name: string;
-
     /**
-     * Size of object in octet
+     * Equals File.lastModifiedDate
+     */
+    lastModifiedDate: any;
+    /**
+     * Equals File.name
+     */
+    name: string;
+    /**
+     * Equals Blob.size, in octet
      */
     size: number;
+    /**
+     * Equals Blob.type, in octet
+     */
     type: string;
 }
 export interface FileItem {
@@ -199,7 +207,7 @@ export interface FileItem {
     /**
      * Data to be sent along with this file
      */
-    formData: any[];
+    formData: FormData[];
     /**
      * It's a request method. By default POST. HTML5 browsers only.
      */
@@ -294,8 +302,8 @@ export interface FileItem {
     onComplete(response: Response, status: number, headers: Headers): void;
 }
 export type SyncFilter = (item: File | FileLikeObject, options?: {}) => boolean;
-export type AsyncFilter = (item: File | FileLikeObject, options?: {}, deferred?: angular.IDeferred<any>) => void;
-export interface UploaderFilter {
+export type AsyncFilter = (item: File | FileLikeObject, options: {}, deferred: angular.IDeferred<any>) => void;
+export interface Filter {
     name: string;
     fn: SyncFilter | AsyncFilter;
 }

--- a/types/angular-file-upload/index.d.ts
+++ b/types/angular-file-upload/index.d.ts
@@ -7,51 +7,77 @@
 import * as angular from 'angular';
 
 export interface FileUploaderFactory {
-    new(options?: {}): FileUploader;
+    new(options?: Partial<FileUploaderOptions>): FileUploader;
 }
-export interface FileUploader {
-    // **Properties**
 
+export interface FileUploaderOptions {
     /**
      * Path on the server to upload files
+     * @default /
      */
     url: string;
     /**
      * Name of the field which will contain the file, default is file
+     * @default file
      */
     alias: string;
     /**
+     * Headers to be sent along with the files. HTML5 browsers only.
+     * @default {}
+     */
+    headers: Headers;
+    /**
      * Items to be uploaded
+     * @default []
      */
     queue: FileItem[];
+    /**
+     * Automatically upload files after adding them to the queue
+     * @default false
+     */
+    autoUpload: boolean;
+    /**
+     * Remove files from the queue after uploading
+     * @default false
+     */
+    removeAfterUpload: boolean;
+    /**
+     * It's a request method. HTML5 browsers only.
+     * @default POST
+     */
+    method: string;
+    /**
+     * Filters to be applied to the files before adding them to the queue. If the filter returns true the file will be added to the queue
+     * @default []
+     */
+    filters: Filter[];
+    /**
+     * Data to be sent along with the files
+     * @default []
+     */
+    formData: FormData[];
+    /**
+     * Maximum count of files.
+     * @default Number.MAX_VALUE
+     */
+    queueLimit: number;
+    /**
+     * enable CORS. HTML5 browsers only.
+     * @default false
+     */
+    withCredentials: boolean;
+    /**
+     * Disable multipart.
+     * @default false
+     */
+    disableMultipart: boolean;
+}
+
+export interface FileUploader extends FileUploaderOptions {
     /**
      * Upload queue progress percentage. Read only.
      */
     progress: number;
-    /**
-     * Headers to be sent along with the files. HTML5 browsers only.
-     */
-    headers: {};
-    /**
-     * Data to be sent along with the files
-     */
-    formData: FormData[];
-    /**
-     * Filters to be applied to the files before adding them to the queue. If the filter returns true the file will be added to the queue
-     */
-    filters: Filter[];
-    /**
-     * Automatically upload files after adding them to the queue
-     */
-    autoUpload: boolean;
-    /**
-     * It's a request method. By default POST. HTML5 browsers only.
-     */
-    method: string;
-    /**
-     * Remove files from the queue after uploading
-     */
-    removeAfterUpload: boolean;
     /**
      * true if uploader is html5-uploader. Read only.
      */
@@ -60,21 +86,13 @@ export interface FileUploader {
      * true if an upload is in progress. Read only.
      */
     isUploading: boolean;
-    /**
-     * maximum count of files
-     */
-    queueLimit: number;
-    /**
-     * enable CORS. HTML5 browsers only.
-     */
-    withCredentials: boolean;
 
     // **Methods**
 
     /**
      * Add items to the queue
      */
-    addToQueue(files: File | HTMLInputElement | {} | FileList | object[], options: {}, filters: Filter[] | string): void;
+    addToQueue(files: File | HTMLInputElement | object | FileList | object[], options: object, filters: Filter[] | string): void;
     /**
      * Remove an item from the queue, where value is {FileItem} or index of item.
      */
@@ -133,7 +151,7 @@ export interface FileUploader {
     /**
      * When adding a file failed
      */
-    onWhenAddingFileFailed(item: FileItem, filter: Filter, options: {}): void;
+    onWhenAddingFileFailed(item: FileItem, filter: Filter, options: object): void;
     /**
      * Fires after adding a single file to the queue.
      */
@@ -203,7 +221,7 @@ export interface FileItem {
     /**
      * Headers to be sent along with this file. HTML5 browsers only.
      */
-    headers: {};
+    headers: Headers;
     /**
      * Data to be sent along with this file
      */
@@ -301,8 +319,8 @@ export interface FileItem {
      */
     onComplete(response: Response, status: number, headers: Headers): void;
 }
-export type SyncFilter = (item: File | FileLikeObject, options?: {}) => boolean;
-export type AsyncFilter = (item: File | FileLikeObject, options: {}, deferred: angular.IDeferred<any>) => void;
+export type SyncFilter = (item: File | FileLikeObject, options?: object) => boolean;
+export type AsyncFilter = (item: File | FileLikeObject, options: object | undefined, deferred: angular.IDeferred<any>) => void;
 export interface Filter {
     name: string;
     fn: SyncFilter | AsyncFilter;

--- a/types/angular-file-upload/index.d.ts
+++ b/types/angular-file-upload/index.d.ts
@@ -48,7 +48,7 @@ export interface FileUploaderOptions {
     method: string;
     /**
      * Filters to be applied to the files before adding them to the queue. If the filter returns true the file will be added to the queue
-     * @default []
+     * @default [folderFilter, queueLimitFilter]
      */
     filters: Filter[];
     /**

--- a/types/angular-file-upload/index.d.ts
+++ b/types/angular-file-upload/index.d.ts
@@ -1,0 +1,313 @@
+// Type definitions for angular-file-upload 2.5.0
+// Project: https://github.com/nervgh/angular-file-upload
+// Definitions by: Cyril Gandon <https://github.com/cyrilgandon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as angular from 'angular';
+
+export as namespace fileUploaderLib;
+
+export = FileUploader;
+
+declare function MyFunction(): FileUploader.FileUploader;
+
+declare namespace FileUploader {
+
+    export interface FileUploaderFactory {
+        new(options?: {}): FileUploader;
+    }
+    export interface FileUploader {
+        // **Properties**
+
+        /**
+         * Path on the server to upload files
+         */
+        url: string;
+        /**
+         * Name of the field which will contain the file, default is file
+         */
+        alias: string;
+        /**
+         * Items to be uploaded
+         */
+        queue: FileItem[];
+        /**
+         * Upload queue progress percentage. Read only.
+         */
+        progress: number;
+        /**
+         * Headers to be sent along with the files. HTML5 browsers only.
+         */
+        headers: {};
+        /**
+         * Data to be sent along with the files
+         */
+        formData: any[];
+        /**
+         * Filters to be applied to the files before adding them to the queue. If the filter returns true the file will be added to the queue
+         */
+        filters: IUploaderFilter[];
+        /**
+         * Automatically upload files after adding them to the queue
+         */
+        autoUpload: boolean;
+        /**
+         * It's a request method. By default POST. HTML5 browsers only.
+         */
+        method: string;
+        /**
+         * Remove files from the queue after uploading
+         */
+        removeAfterUpload: boolean;
+        /**
+         * true if uploader is html5-uploader. Read only.
+         */
+        isHTML5: boolean;
+        /**
+         * true if an upload is in progress. Read only.
+         */
+        isUploading: boolean;
+        /**
+         * maximum count of files
+         */
+        queueLimit: number;
+        /**
+         * enable CORS. HTML5 browsers only.
+         */
+        withCredentials: boolean;
+
+        // **Methods**
+
+        /**
+         * Add items to the queue
+         */
+        addToQueue(files: FileList | File | HTMLInputElement, options: {}, filters: string): void;
+        /**
+         * Remove an item from the queue, where value is {FileItem} or index of item.
+         */
+        removeFromQueue(value: FileItem | number): void;
+        /**
+         * Removes all elements from the queue.
+         */
+        clearQueue(): void;
+        /**
+         * Uploads an item, where value is {FileItem} or index of item.
+         */
+        uploadItem(value: FileItem | number): void;
+        /**
+         * Cancels uploading of item, where value is {FileItem} or index of item.
+         */
+        cancelItem(value: FileItem | number): void;
+        /**
+         * Upload all pending items on the queue.
+         */
+        uploadAll(): void;
+        /**
+         * Cancels all current uploads.
+         */
+        cancelAll(): void;
+        /**
+         * Destroys a uploader.
+         */
+        destroy(): void;
+        /**
+         * Returns true if value is {File}.
+         */
+        isFile(value: any): boolean;
+        /**
+         * Returns true if value is {FileLikeObject}.
+         */
+        isFileLikeObject(value: any): boolean;
+        /**
+         * Returns the index of the {FileItem} queue element.
+         */
+        getIndexOfItem(fileItem: FileItem): number;
+        /**
+         * Return items are ready to upload.
+         */
+        getReadyItems(): FileItem[];
+        /**
+         * Return an array of all pending items on the queue
+         */
+        getNotUploadedItems(): FileItem[];
+
+        // **Callbacks**
+
+        /**
+         * Fires after adding all the dragged or selected files to the queue.
+         */
+        onAfterAddingAll(addedItems: FileItem[]): void;
+        /**
+         * When adding a file failed
+         */
+        onWhenAddingFileFailed(item: FileItem, filter: any, options: any): void;
+        /**
+         * Fires after adding a single file to the queue.
+         */
+        onAfterAddingFile(item: FileItem): void;
+        /**
+         * Fires before uploading an item.
+         */
+        onBeforeUploadItem(item: FileItem): void;
+        /**
+         * On file upload progress.
+         */
+        onProgressItem(item: FileItem, progress: number): void;
+        /**
+         * On file successfully uploaded
+         */
+        onSuccessItem(item: FileItem, response: Response, status: number, headers: Headers): void;
+        /**
+         * On upload error
+         */
+        onErrorItem(item: FileItem, response: Response, status: number, headers: Headers): void;
+        /**
+         * On cancel uploading
+         */
+        onCancelItem(item: FileItem, response: Response, status: number, headers: Headers): void;
+        /**
+         * On file upload complete (independently of the sucess of the operation)
+         */
+        onCompleteItem(item: FileItem, response: Response, status: number, headers: Headers): void;
+        /**
+         * On upload queue progress
+         */
+        onProgressAll(progress: number): void;
+        /**
+         * On all loaded when uploading an entire queue, or on file loaded when uploading a single independent file
+         */
+        onCompleteAll(): void;
+    }
+    export interface FileLikeObject {
+        lastModifiedDate: Date;
+        name: string;
+
+        /**
+         * Size of object in octet
+         */
+        size: number;
+        type: string;
+    }
+    export interface FileItem {
+
+        // **Properties**
+        file: FileLikeObject;
+        /**
+         * Path on the server in which this file will be uploaded
+         */
+        url: string;
+        /**
+         * Name of the field which will contain the file, default is file
+         */
+        alias: string;
+        /**
+         * Headers to be sent along with this file. HTML5 browsers only.
+         */
+        headers: {};
+        /**
+         * Data to be sent along with this file
+         */
+        formData: any[];
+        /**
+         * It's a request method. By default POST. HTML5 browsers only.
+         */
+        method: string;
+        /**
+         * enable CORS. HTML5 browsers only.
+         */
+        withCredentials: boolean;
+        /**
+         * Remove this file from the queue after uploading
+         */
+        removeAfterUpload: boolean;
+        /**
+         * A sequence number upload. Read only.
+         */
+        index: number;
+        /**
+         * File upload progress percentage. Read only.
+         */
+        progress: number;
+        /**
+         * File is ready to upload. Read only.
+         */
+        isReady: boolean;
+        /**
+         * true if the file is being uploaded. Read only.
+         */
+        isUploading: boolean;
+        /**
+         * true if the file was uploaded. Read only.
+         */
+        isUploaded: boolean;
+        /**
+         * true if the file was uploaded successfully. Read only.
+         */
+        isSuccess: boolean;
+        /**
+         * true if uploading was canceled. Read only.
+         */
+        isCancel: boolean;
+        /**
+         * true if occurred error while file uploading. Read only.
+         */
+        isError: boolean;
+        /**
+         * Reference to the parent Uploader object for this file. Read only.
+         */
+        uploader: FileUploader;
+
+        // **Methods**
+
+        /**
+         * Cancels uploading of this file
+         */
+        cancel(): void;
+
+        /**
+         * Remove this file from the queue
+         */
+        remove(): void;
+
+        /**
+         * Upload this file
+         */
+        upload(): void;
+
+        // **Callbacks**
+
+        /**
+         *  Fires before uploading an item.
+         */
+        onBeforeUpload(): void;
+        /**
+         * On file upload progress.
+         */
+        onProgress(progress: number): void;
+        /**
+         * On file successfully uploaded
+         */
+        onSuccess(response: Response, status: number, headers: Headers): void;
+        /**
+         * On upload error
+         */
+        onError(response: Response, status: number, headers: Headers): void;
+        /**
+         * On cancel uploading
+         */
+        onCancel(response: Response, status: number, headers: Headers): void;
+        /**
+         * On file upload complete (independently of the sucess of the operation)
+         */
+        onComplete(response: Response, status: number, headers: Headers): void;
+
+    }
+
+    type SyncFilter = (item: File | FileLikeObject, options?: {}) => boolean;
+    type AsyncFilter = (item: File | FileLikeObject, options?: {}, deferred?: angular.IDeferred<any>) => void;
+
+    export interface IUploaderFilter {
+        name: string;
+        fn: SyncFilter | AsyncFilter;
+    }
+}

--- a/types/angular-file-upload/index.d.ts
+++ b/types/angular-file-upload/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/nervgh/angular-file-upload
 // Definitions by: Cyril Gandon <https://github.com/cyrilgandon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.5
 
 import * as angular from 'angular';
 

--- a/types/angular-file-upload/index.d.ts
+++ b/types/angular-file-upload/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nervgh/angular-file-upload
 // Definitions by: Cyril Gandon <https://github.com/cyrilgandon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.5
+// TypeScript Version: 2.1
 
 import * as angular from 'angular';
 

--- a/types/angular-file-upload/tsconfig.json
+++ b/types/angular-file-upload/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "lib": [
+            "es6",
+            "dom"
+        ],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,

--- a/types/angular-file-upload/tsconfig.json
+++ b/types/angular-file-upload/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "angular-file-upload-tests.ts"
+    ]
+}

--- a/types/angular-file-upload/tslint.json
+++ b/types/angular-file-upload/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Add the right typings for [angular-file-upload](https://github.com/nervgh/angular-file-upload) (previously, this declaration files was referencing the [ng-file-upload](https://github.com/danialfarid/ng-file-upload) library, which is not the same).

Fix https://github.com/DefinitelyTyped/DefinitelyTyped/issues/5322.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
