### PR TITLE
Make it possible to extend knockouts builtin extender object

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -5,6 +5,7 @@
 //                 Clément Bourgeois <https://github.com/moonpyk/>
 //                 Matt Brooks <https://github.com/EnableSoftware>
 //                 Benjamin Eckardt <https://github.com/BenjaminEckardt>
+//                 Patrik Storm <https://github.com/stormpat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
@@ -217,6 +218,7 @@ interface KnockoutVirtualElements {
 }
 
 interface KnockoutExtenders {
+    [userland: string]: (target: KnockoutObservable<{}>, ...args) => any;
     throttle(target: any, timeout: number): KnockoutComputed<any>;
     notify(target: any, notifyWhen: string): any;
 


### PR DESCRIPTION
Make it possible to extend knockout extenders object with user land
functions. Docs: http://knockoutjs.com/documentation/extenders.html

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

