### PR TITLE
Add null as a type for bsStyle in ButtonProps to allow for custom cla…

### DIFF
--- a/types/react-bootstrap/lib/Button.d.ts
+++ b/types/react-bootstrap/lib/Button.d.ts
@@ -6,7 +6,7 @@ declare namespace Button {
         bsClass?: string;
         active?: boolean;
         block?: boolean;
-        bsStyle?: string;
+        bsStyle?: string | null;
         bsSize?: Sizes;
         componentClass?: React.ReactType;
         disabled?: boolean;


### PR DESCRIPTION
Add null as a type for bsStyle in ButtonProps to allow for custom classes

When adding a new bsStyle, the react-bootstrap propTypes linter issues warnings. To avoid this issue, definining bsStyle as null and giving it your custom className will allow for customizability without propTypes warning from react-bootstrap.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
