### PR TITLE
Fix dagre types to allow objects to be set as default edge labels

### DIFF
--- a/types/dagre/dagre-tests.ts
+++ b/types/dagre/dagre-tests.ts
@@ -1,6 +1,6 @@
 const gDagre = new dagre.graphlib.Graph();
 gDagre.setGraph({})
-  .setDefaultEdgeLabel(() => {})
+  .setDefaultEdgeLabel(() => ({}))
   .setNode("a", {})
   .setEdge("b", "c")
   .setEdge("c", "d", {class: "class"});

--- a/types/dagre/index.d.ts
+++ b/types/dagre/index.d.ts
@@ -1,7 +1,10 @@
 // Type definitions for dagre 0.7
 // Project: https://github.com/cpettitt/dagre
-// Definitions by: Qinfeng Chen <https://github.com/qinfchen>, Lisa Vallfors <https://github.com/Frankrike>
+// Definitions by: Qinfeng Chen <https://github.com/qinfchen>
+//                 Lisa Vallfors <https://github.com/Frankrike>
+//                 Pete Vilter <https://github.com/vilterp>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 export as namespace dagre;
 
@@ -11,8 +14,8 @@ export namespace graphlib {
         edge(id: any): any;
         nodes(): string[];
         node(id: any): any;
-        setDefaultEdgeLabel(callback: string|(() => string|void)): Graph;
-        setDefaultNodeLabel(callback: string|(() => string|void)): Graph;
+        setDefaultEdgeLabel(callback: string|(() => string|object)): Graph;
+        setDefaultNodeLabel(callback: string|(() => string|object)): Graph;
         setEdge(sourceId: string, targetId: string, options?: { [key: string]: any }, value?: string): Graph;
         setEdge(params: {v: string, w: string, name?: string}, value?: string): Graph;
         setGraph(label: GraphLabel): Graph;


### PR DESCRIPTION
The tests call `.setDefaultEdgeLabel(() => {})` which is a translation to ES6 of something seen in the example in [Dagre's readme](https://github.com/cpettitt/dagre/wiki#an-example-layout): `g.setDefaultEdgeLabel(function() { return {}; });`. However, the translation is botched: `() => {}` doesn't return an empty object, it returns `undefined`, because `{}` is not an object literal, it's a block with 0 statements.

I think this is what motivated the current typing to specify that `void` can be returned by the callback. However, in my experience returning `undefined` from this callback causes the library to crash. Thus I've changed the tests to say `.setDefaultEdgeLabel(() => ({}))` (i.e. actually return an empty object, which is what the author probably intended), and updated the types accordingly. This works in my project.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cpettitt/dagre/wiki#an-example-layout
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.