### PR TITLE
[moment-timezone] Add Zone population field

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for moment-timezone.js 0.2
+// Type definitions for moment-timezone.js 0.5
 // Project: http://momentjs.com/timezone/
 // Definitions by: Michel Salib <https://github.com/michelsalib>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -14,6 +14,7 @@ declare module "moment" {
         abbrs: string[];
         untils: number[];
         offsets: number[];
+        population: number;
 
         abbr(timestamp: number): string;
         offset(timestamp: number): number;


### PR DESCRIPTION
Population information was added in moment-timezone 0.5.0:
https://github.com/moment/moment-timezone/commit/dab50e8bcbf2d98ae92e5c688f6849c830a0a791

Zone objects have a population field as seen here:
https://github.com/moment/moment-timezone/blob/0.5.0/moment-timezone.js#L149

Its type is a number. If a timezone doesn't have a population, it defaults to 0, as seen here:
https://github.com/moment/moment-timezone/blob/0.5.0/moment-timezone.js#L129

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Increase the version number in the header if appropriate.
