### PR TITLE
[hapi] Fix type definitions for Hapi load configuration property

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -724,11 +724,11 @@ export interface ConnectionConfigurationServerDefaults {
     /** connection load limits configuration where:  */
     load?: {
         /** maximum V8 heap size over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-        maxHeapUsedBytes: number;
+        maxHeapUsedBytes?: number;
         /** maximum process RSS size over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-        maxRssBytes: number;
+        maxRssBytes?: number;
         /** maximum event loop delay duration in milliseconds over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-        maxEventLoopDelay: number;
+        maxEventLoopDelay?: number;
     };
     /** plugin-specific configuration which can later be accessed via connection.settings.plugins. Provides a place to store and pass connection-specific plugin configuration. plugins is an object where each key is a plugin name and the value is the configuration. Note the difference between connection.settings.plugins which is used to store configuration values and connection.plugins which is meant for storing run-time state. */
     plugins?: PluginSpecificConfiguration;

--- a/types/hapi/v12/index.d.ts
+++ b/types/hapi/v12/index.d.ts
@@ -102,11 +102,11 @@ declare module "hapi" {
         /**  connection load limits configuration where:  */
         load?: {
             /**  maximum V8 heap size over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-            maxHeapUsedBytes: number;
+            maxHeapUsedBytes?: number;
             /**  maximum process RSS size over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-            maxRssBytes: number;
+            maxRssBytes?: number;
             /**  maximum event loop delay duration in milliseconds over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-            maxEventLoopDelay: number;
+            maxEventLoopDelay?: number;
         };
         /**  plugin-specific configuration which can later be accessed via connection.settings.plugins. Provides a place to store and pass connection-specific plugin configuration. plugins is an object where each key is a plugin name and the value is the configuration. Note the difference between connection.settings.plugins which is used to store configuration values and connection.plugins which is meant for storing run-time state. */
         plugins?: any;

--- a/types/hapi/v15/index.d.ts
+++ b/types/hapi/v15/index.d.ts
@@ -125,11 +125,11 @@ export interface IConnectionConfigurationServerDefaults {
 	/**  connection load limits configuration where:  */
 	load?: {
 		/**  maximum V8 heap size over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-		maxHeapUsedBytes: number;
+		maxHeapUsedBytes?: number;
 		/**  maximum process RSS size over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-		maxRssBytes: number;
+		maxRssBytes?: number;
 		/**  maximum event loop delay duration in milliseconds over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-		maxEventLoopDelay: number;
+		maxEventLoopDelay?: number;
 	};
 	/**  plugin-specific configuration which can later be accessed via connection.settings.plugins. Provides a place to store and pass connection-specific plugin configuration. plugins is an object where each key is a plugin name and the value is the configuration. Note the difference between connection.settings.plugins which is used to store configuration values and connection.plugins which is meant for storing run-time state. */
 	plugins?: any;

--- a/types/hapi/v8/index.d.ts
+++ b/types/hapi/v8/index.d.ts
@@ -88,11 +88,11 @@ export interface IConnectionConfigurationServerDefaults {
     /**  connection load limits configuration where:  */
     load?: {
         /**  maximum V8 heap size over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-        maxHeapUsedBytes: number;
+        maxHeapUsedBytes?: number;
         /**  maximum process RSS size over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-        maxRssBytes: number;
+        maxRssBytes?: number;
         /**  maximum event loop delay duration in milliseconds over which incoming requests are rejected with an HTTP Server Timeout (503) response. Defaults to 0 (no limit).  */
-        maxEventLoopDelay: number;
+        maxEventLoopDelay?: number;
     };
     /**  plugin-specific configuration which can later be accessed via connection.settings.plugins. Provides a place to store and pass connection-specific plugin configuration. plugins is an object where each key is a plugin name and the value is the configuration. Note the difference between connection.settings.plugins which is used to store configuration values and connection.plugins which is meant for storing run-time state. */
     plugins?: any;


### PR DESCRIPTION
Any or all of the properties in the load configuration object can be defined.