### PR TITLE
@types/mongoose: done-callback supports a optional error parameter

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -628,7 +628,7 @@ declare module "mongoose" {
     /**
      * Defines a pre hook for the document.
      */
-    pre(method: string, parallel: boolean, fn: (next: (err?: NativeError) => void, done: () => void) => void,
+    pre(method: string, parallel: boolean, fn: (next: (err?: NativeError) => void, done: (err?: NativeError) => void) => void,
       errorCb?: (err: Error) => void): this;
     pre(method: string, fn: (next: (err?: NativeError) => void) => void,
       errorCb?: (err: Error) => void): this;


### PR DESCRIPTION
Please fill in this template.

- [✓] Use a meaningful title for the pull request. Include the name of the package modified.
- [✓] Test the change in your own code. (Compile and run.)
- [✓] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [✓] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [✓] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [✓] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bnoguchi/hooks-js/blob/master/hooks.js#L96-L102
- [✓] Increase the version number in the header if appropriate.
- [✗] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The done()-callback - too - supports a error parameter: http://mongoosejs.com/docs/middleware.html#error-handling
