### PR TITLE
visible property added in IndividualSeriesOptions interface.

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -5372,6 +5372,10 @@ declare namespace Highcharts {
          */
         stack?: any;
         /**
+         * The series' visibility state as set by series.show(), series.hide(), or the initial configuration.
+         */
+        visible?: boolean;
+        /**
          * When using dual or multiple x axes, this number defines which xAxis the particular series is connected to. It
          * refers to either the axis id or the index of the axis in the xAxis array, with 0 being the first.
          * @default 0


### PR DESCRIPTION
In IndividualSeriesOptions interface "visible?:boolean" is not available due to which whenever I use:

```
series: [{
        name: 'Tokyo',
        data: [49.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1, 95.6, 54.4],
        visible: false
    }]
```
due to which I got error: 

```
Types of property 'series' are incompatible.
    Type '{ name: string; data: number[]; visible: boolean; }[]' is not assignable to type 'IndividualSeriesOptions[]'.
      Type '{ name: string; data: number[]; visible: boolean; }' is not assignable to type 'IndividualSeriesOptions'.
        Object literal may only specify known properties, and 'visible' does not exist in type 'IndividualSeriesOptions'. 
```
have to add visible property in IndividualSeriesOptions interface.