### PR TITLE
@types/webpack - output.library should allow both string and string[]

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -148,7 +148,7 @@ declare namespace webpack {
         /** Include comments with information about the modules. */
         pathinfo?: boolean;
         /** If set, export the bundle as library. output.library is the name. */
-        library?: string;
+        library?: string | string[];
         /**
          * Which format to export the library:
          * <ul>


### PR DESCRIPTION
output.library allows for string array like this
    output: {
        filename: './dist/dist.js',
        library: ['namespaceA', 'solutionA']
    }
