### PR TITLE
[gravatar-url] Fix default function export

### DIFF
--- a/types/gravatar-url/gravatar-url-tests.ts
+++ b/types/gravatar-url/gravatar-url-tests.ts
@@ -1,4 +1,4 @@
-import gravatarUrl = require('gravatar-url');
+import gravatarUrl from 'gravatar-url';
 
 gravatarUrl('sindresorhus@gmail.com'); // $ExpectType string
 gravatarUrl('sindresorhus@gmail.com', { default: 'monsterid' }); // $ExpectType string

--- a/types/gravatar-url/index.d.ts
+++ b/types/gravatar-url/index.d.ts
@@ -3,14 +3,10 @@
 // Definitions by: Ivan Gabriele <https://github.com/ivangabriele>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export = GravatarUrl;
-
-declare function GravatarUrl(email: string, options?: GravatarUrl.Options): string;
-
-declare namespace GravatarUrl {
-    interface Options {
-        default?: string;
-        rating?: 'g' | 'pg' | 'r' | 'x';
-        size?: number;
-    }
+export interface Options {
+    default?: string;
+    rating?: 'g' | 'pg' | 'r' | 'x';
+    size?: number;
 }
+
+export default function GravatarUrl(email: string, options?: Options): string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
It's the classic [CommonJS module exporting a default function](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/12395) issue.

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
