### PR TITLE
Handy imports for angular-toastr

### DIFF
--- a/types/angular-toastr/index.d.ts
+++ b/types/angular-toastr/index.d.ts
@@ -8,6 +8,15 @@
 
 import * as angular from 'angular';
 
+export type IToastBaseConfig = angular.toastr.IToastBaseConfig;
+export type IToastContainerConfig = angular.toastr.IToastContainerConfig;
+export type IToastConfig = angular.toastr.IToastConfig;
+export type IToastrConfig = angular.toastr.IToastrConfig;
+export type IToastScope = angular.toastr.IToastScope;
+export type IToast = angular.toastr.IToast;
+export type IToastOptions = angular.toastr.IToastOptions;
+export type IToastrService = angular.toastr.IToastrService;
+
 declare module 'angular' {
     export namespace toastr {
         interface IToastBaseConfig {


### PR DESCRIPTION
This change to the module definition allows ES6 style imports, e.g. import { IToastBaseConfig } from 'angular-toastr';

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
