### PR TITLE
[prop-types] Added missing definition of PropTypes.symbol

### DIFF
--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -21,6 +21,7 @@ export const object: Requireable<any>;
 export const string: Requireable<any>;
 export const node: Requireable<any>;
 export const element: Requireable<any>;
+export const symbol: Requireable<any>;
 export function instanceOf(expectedClass: {}): Requireable<any>;
 export function oneOf(types: any[]): Requireable<any>;
 export function oneOfType(types: Array<Validator<any>>): Requireable<any>;

--- a/types/prop-types/prop-types-tests.ts
+++ b/types/prop-types/prop-types-tests.ts
@@ -7,6 +7,7 @@ interface Props {
     func: any;
     string: string;
     number: number;
+    symbol: symbol;
     object: {};
     node: any;
     element: any;
@@ -20,6 +21,7 @@ let propTypes: PropTypes.ValidationMap<Props> = {
     number: PropTypes.number.isRequired,
     object: PropTypes.object.isRequired,
     string: PropTypes.string.isRequired,
+    symbol: PropTypes.symbol.isRequired,
     node: PropTypes.node.isRequired,
     element: PropTypes.element.isRequired
 };


### PR DESCRIPTION
In this commit I've added missing definition of PropTypes.symbol.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://facebook.github.io/react/docs/typechecking-with-proptypes.html>

