### PR TITLE
(webpack): add missing possible 'entry' types

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -6,6 +6,7 @@
 //                 Tommy Troy Lin <https://github.com/tommytroylin>
 //                 Mohsen Azimi <https://github.com/mohsen1>
 //                 Jonathan Creamer <https://github.com/jcreamer898>
+//                 Ahmed T. Ali <https://github.com/ahmed-taj>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -36,7 +37,7 @@ declare namespace webpack {
          * If `output.pathinfo` is set, the included pathinfo is shortened to this directory.
          */
         context?: string;
-        entry?: string | string[] | Entry;
+        entry?: string | string[] | Entry | EntryFunc;
         /** Choose a style of source mapping to enhance the debugging process. These values can affect build and rebuild speed dramatically. */
         devtool?: Options.Devtool;
         /** Options affecting the output. */
@@ -102,6 +103,8 @@ declare namespace webpack {
     interface Entry {
         [name: string]: string | string[];
     }
+
+    type EntryFunc = () => string | string[] | Promise<string | string[]>;
 
     interface DevtoolModuleFilenameTemplateInfo {
         identifier: string;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -104,7 +104,7 @@ declare namespace webpack {
         [name: string]: string | string[];
     }
 
-    type EntryFunc = () => string | string[] | Promise<string | string[]>;
+    type EntryFunc = () => (string | string[] | Promise<string | string[]>);
 
     interface DevtoolModuleFilenameTemplateInfo {
         identifier: string;

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -559,46 +559,46 @@ configuration = {
     module: {
         rules: [
             { oneOf: [
-                    {
-                        test: {
-                            and: [
-                                /a.\.js$/,
-                                /b\.js$/
-                            ]
-                        },
-                        loader: "./loader?first"
-                    },
-                    {
-                        test: [
-                            require.resolve("./a"),
-                            require.resolve("./c"),
-                        ],
-                        issuer: require.resolve("./b"),
-                        use: [
-                            "./loader?second-1",
-                            {
-                                loader: "./loader",
-                                options: "second-2"
-                            },
-                            {
-                                loader: "./loader",
-                                options: {
-                                    get: () => "second-3"
-                                }
-                            }
+                {
+                    test: {
+                        and: [
+                            /a.\.js$/,
+                            /b\.js$/
                         ]
                     },
-                    {
-                        test: {
-                            or: [
-                                require.resolve("./a"),
-                                require.resolve("./c"),
-                            ]
+                    loader: "./loader?first"
+                },
+                {
+                    test: [
+                        require.resolve("./a"),
+                        require.resolve("./c"),
+                    ],
+                    issuer: require.resolve("./b"),
+                    use: [
+                        "./loader?second-1",
+                        {
+                            loader: "./loader",
+                            options: "second-2"
                         },
-                        loader: "./loader",
-                        options: "third"
-                    }
-                ]}
+                        {
+                            loader: "./loader",
+                            options: {
+                                get: () => "second-3"
+                            }
+                        }
+                    ]
+                },
+                {
+                    test: {
+                        or: [
+                            require.resolve("./a"),
+                            require.resolve("./c"),
+                        ]
+                    },
+                    loader: "./loader",
+                    options: "third"
+                }
+            ]}
         ]
     }
 };

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -77,6 +77,26 @@ configuration = {
 };
 
 //
+// https://webpack.js.org/configuration/entry-context/#dynamic-entry
+//
+
+configuration = {
+    entry: () => './demo'
+};
+
+configuration = {
+    entry: () => ['./demo', './demo2']
+};
+
+configuration = {
+    entry: () => new Promise((resolve) => resolve('./demo'))
+};
+
+configuration = {
+    entry: () => new Promise((resolve) => resolve(['./demo', './demo2']))
+};
+
+//
 // https://webpack.github.io/docs/code-splitting.html
 //
 
@@ -539,46 +559,46 @@ configuration = {
     module: {
         rules: [
             { oneOf: [
-                {
-                    test: {
-                        and: [
-                            /a.\.js$/,
-                            /b\.js$/
-                        ]
-                    },
-                    loader: "./loader?first"
-                },
-                {
-                    test: [
-                        require.resolve("./a"),
-                        require.resolve("./c"),
-                    ],
-                    issuer: require.resolve("./b"),
-                    use: [
-                        "./loader?second-1",
-                        {
-                            loader: "./loader",
-                            options: "second-2"
+                    {
+                        test: {
+                            and: [
+                                /a.\.js$/,
+                                /b\.js$/
+                            ]
                         },
-                        {
-                            loader: "./loader",
-                            options: {
-                                get: () => "second-3"
-                            }
-                        }
-                    ]
-                },
-                {
-                    test: {
-                        or: [
+                        loader: "./loader?first"
+                    },
+                    {
+                        test: [
                             require.resolve("./a"),
                             require.resolve("./c"),
+                        ],
+                        issuer: require.resolve("./b"),
+                        use: [
+                            "./loader?second-1",
+                            {
+                                loader: "./loader",
+                                options: "second-2"
+                            },
+                            {
+                                loader: "./loader",
+                                options: {
+                                    get: () => "second-3"
+                                }
+                            }
                         ]
                     },
-                    loader: "./loader",
-                    options: "third"
-                }
-            ]}
+                    {
+                        test: {
+                            or: [
+                                require.resolve("./a"),
+                                require.resolve("./c"),
+                            ]
+                        },
+                        loader: "./loader",
+                        options: "third"
+                    }
+                ]}
         ]
     }
 };


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/entry-context/#dynamic-entry
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

resolves #19972