### PR TITLE
[redux-logger] Allowing color configuration to be false

### DIFF
--- a/types/redux-logger/index.d.ts
+++ b/types/redux-logger/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for redux-logger v3.0.0
 // Project: https://github.com/fcomb/redux-logger
 // Definitions by: Alexander Rusakov <https://github.com/arusakov>
+//                 Kevin Groat <https://github.com/kgroat>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace ReduxLogger;
@@ -34,7 +35,7 @@ export interface ReduxLoggerOptions {
   level?: string | ActionToString | LevelObject;
   duration?: boolean;
   timestamp?: boolean;
-  colors?: ColorsObject;
+  colors?: ColorsObject | false;
   logger?: any;
   logErrors?: boolean;
   collapsed?: boolean | LoggerPredicate;

--- a/types/redux-logger/redux-logger-tests.ts
+++ b/types/redux-logger/redux-logger-tests.ts
@@ -26,6 +26,10 @@ let loggerCollapsedPredicate = createLogger({
   collapsed: (getAction, action) => true
 });
 
+let loggerColorsOverallBoolean = createLogger({
+  colors: false
+});
+
 let loggerColorsBoolean = createLogger({
   colors: {
     title: false,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [redux-logger v2.1.1 release notes](https://github.com/evgenyrodionov/redux-logger/releases/tag/2.1.1) to allow logger [to not use color formatting](https://github.com/evgenyrodionov/redux-logger/issues/92)
- [x] Increase the version number in the header if appropriate. (N/A)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (N/A)
