### PR TITLE
Add missing ReactDOM Simulate event methods

### DIFF
--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -119,9 +119,9 @@ export namespace Simulate {
     const keyPress: EventSimulator;
     const keyUp: EventSimulator;
     const load: EventSimulator;
+    const loadStart: EventSimulator;
     const loadedData: EventSimulator;
     const loadedMetadata: EventSimulator;
-    const loadStart: EventSimulator;
     const mouseDown: EventSimulator;
     const mouseEnter: EventSimulator;
     const mouseLeave: EventSimulator;

--- a/types/react-dom/test-utils/index.d.ts
+++ b/types/react-dom/test-utils/index.d.ts
@@ -83,9 +83,19 @@ export interface ShallowRenderer {
  * `Simulate` has a method for every event that React understands.
  */
 export namespace Simulate {
+    const abort: EventSimulator;
+    const animationEnd: EventSimulator;
+    const animationIteration: EventSimulator;
+    const animationStart: EventSimulator;
     const blur: EventSimulator;
+    const canPlay: EventSimulator;
+    const canPlayThrough: EventSimulator;
     const change: EventSimulator;
     const click: EventSimulator;
+    const compositionEnd: EventSimulator;
+    const compositionStart: EventSimulator;
+    const compositionUpdate: EventSimulator;
+    const contextMenu: EventSimulator;
     const copy: EventSimulator;
     const cut: EventSimulator;
     const doubleClick: EventSimulator;
@@ -97,11 +107,21 @@ export namespace Simulate {
     const dragOver: EventSimulator;
     const dragStart: EventSimulator;
     const drop: EventSimulator;
+    const durationChange: EventSimulator;
+    const emptied: EventSimulator;
+    const encrypted: EventSimulator;
+    const ended: EventSimulator;
+    const error: EventSimulator;
     const focus: EventSimulator;
     const input: EventSimulator;
+    const invalid: EventSimulator;
     const keyDown: EventSimulator;
     const keyPress: EventSimulator;
     const keyUp: EventSimulator;
+    const load: EventSimulator;
+    const loadedData: EventSimulator;
+    const loadedMetadata: EventSimulator;
+    const loadStart: EventSimulator;
     const mouseDown: EventSimulator;
     const mouseEnter: EventSimulator;
     const mouseLeave: EventSimulator;
@@ -110,12 +130,26 @@ export namespace Simulate {
     const mouseOver: EventSimulator;
     const mouseUp: EventSimulator;
     const paste: EventSimulator;
+    const pause: EventSimulator;
+    const play: EventSimulator;
+    const playing: EventSimulator;
+    const progress: EventSimulator;
+    const rateChange: EventSimulator;
     const scroll: EventSimulator;
+    const seeked: EventSimulator;
+    const seeking: EventSimulator;
+    const select: EventSimulator;
+    const stalled: EventSimulator;
     const submit: EventSimulator;
+    const suspend: EventSimulator;
+    const timeUpdate: EventSimulator;
     const touchCancel: EventSimulator;
     const touchEnd: EventSimulator;
     const touchMove: EventSimulator;
     const touchStart: EventSimulator;
+    const transitionEnd: EventSimulator;
+    const volumeChange: EventSimulator;
+    const waiting: EventSimulator;
     const wheel: EventSimulator;
 }
 


### PR DESCRIPTION
Simulate has a method for every event that React understands.

Source: https://facebook.github.io/react/docs/test-utils.html#simulate