### PR TITLE
[react-router-config] - add extraProps argument for renderRoutes

### DIFF
--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -28,4 +28,4 @@ export interface MatchedRoute<T> {
 
 export function matchRoutes<T>(routes: RouteConfig[], pathname: string): Array<MatchedRoute<T>>;
 
-export function renderRoutes(routes: RouteConfig[] | undefined): JSX.Element;
+export function renderRoutes(routes: RouteConfig[] | undefined, extraProps?: any): JSX.Element;


### PR DESCRIPTION
Add support for optional extraProps argument to renderRoutes introduced in react-router 4.2.0

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactTraining/react-router/blob/master/CHANGES.md / https://github.com/ReactTraining/react-router/pull/5137
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
