### PR TITLE
Cookie interface don't inherit from RawResult, only the Cookie responses

### DIFF
--- a/types/webdriverio/index.d.ts
+++ b/types/webdriverio/index.d.ts
@@ -309,13 +309,13 @@ declare namespace WebdriverIO {
         ensureCleanSession?: boolean;
     }
 
-    interface Cookie extends RawResult<string> {
+    interface Cookie {
         name: string;
         value: string;
         path?: string;
         httpOnly?: boolean;
         expiry?: number;
-        secure: boolean;
+        secure?: boolean;
     }
 
     interface Suite {
@@ -769,8 +769,8 @@ declare namespace WebdriverIO {
         deleteCookie(name?: string): Client<RawResult<null>> & RawResult<null>;
         deleteCookie<P>(name?: string): Client<P>;
 
-        getCookie(): Client<Cookie[]> & Cookie[];
-        getCookie(name: string): Client<Cookie> & Cookie;
+        getCookie(): Client<Cookie & Array<RawResult<string>>> & Cookie[] & Array<RawResult<string>>;
+        getCookie(name: string): Client<Cookie & RawResult<string>> & Cookie & RawResult<string>;
         getCookie<P>(name?: string): Client<P>;
 
         setCookie(cookie: Cookie): Client<RawResult<null>> & RawResult<null>;
@@ -1033,12 +1033,12 @@ declare namespace WebdriverIO {
         /** @deprecated in favour of Actions.pointerUp */
         buttonUp<P>(button?: string | Button): Client<P>;
 
-        cookie(): Client<RawResult<Cookie[]>> & RawResult<Cookie[]>;
+        cookie(): Client<RawResult<Cookie[] & Array<RawResult<string>>>> & RawResult<Cookie[] & Array<RawResult<string>>>;
 
         cookie(
             method: Method,
-            key?: Cookie | string
-        ): Client<RawResult<Cookie[]>> & RawResult<Cookie[]>;
+            key?: (Cookie & RawResult<string>) | string
+        ): Client<RawResult<Cookie[] & Array<RawResult<string>>>> & RawResult<Cookie[] & Array<RawResult<string>>>;
 
         /** @deprecated in favour of Actions.pointerDown(0) + Actions.pointerMove */
         doDoubleClick(): Client<RawResult<null>> & RawResult<null> & never;


### PR DESCRIPTION
Cookie interface don't inherit from RawResult, only the Cookie responses
http://webdriver.io/api/cookie/setCookie.html
https://github.com/SeleniumHQ/selenium/blob/master/cpp/iedriver/BrowserCookie.cpp#L23

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
http://webdriver.io/api/cookie/setCookie.html
https://github.com/SeleniumHQ/selenium/blob/master/cpp/iedriver/BrowserCookie.cpp#L23
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
