### PR TITLE
[swaggerize-express] Add RequestHandler array to RouteSegment i/f

### DIFF
--- a/types/swaggerize-express/index.d.ts
+++ b/types/swaggerize-express/index.d.ts
@@ -224,13 +224,13 @@ declare namespace swaggerize {
     }
 
     export interface RouteSegment {
-        [urlSegment: string]: RouteSegment | express.RequestHandler;
+        [urlSegment: string]: RouteSegment | express.RequestHandler | express.RequestHandler[];
     }
 
     export interface Options {
         api: Swagger.ApiDefinition
-        docspath: String
-        handlers: String | RouteSegment
+        docspath: string
+        handlers: string | RouteSegment
     }
 
     export interface IConfig {

--- a/types/swaggerize-express/swaggerize-express-tests.ts
+++ b/types/swaggerize-express/swaggerize-express-tests.ts
@@ -2,9 +2,8 @@ import http = require('http');
 import express = require('express');
 import swaggerize = require('swaggerize-express');
 
-var app = express();
-app.use(swaggerize(<swaggerize.Options>{
-    api: {
+const api: Partial<swaggerize.Options> = {
+    api:  {
         swagger: "2.0",
         host: "localhost:8080",
         info: {
@@ -12,32 +11,39 @@ app.use(swaggerize(<swaggerize.Options>{
             version: "1"
         },
         paths: {
-
         }
     },
     docspath: '/api-docs',
+};
+
+var app = express();
+app.use(swaggerize(<swaggerize.Options>{
+    ...api,
     handlers: './handlers'
 }));
 
 app.use(swaggerize(<swaggerize.Options>{
-    api: {
-        swagger: "2.0",
-        host: "localhost:8080",
-        info: {
-            title: "swaggerize-express.d.ts test",
-            version: "1"
-        },
-        paths: {
-
-        }
-    },
-    docspath: '/api-docs',
+    ...api,
     handlers: {
         'api': {
             'v1': {
                 'version': {
                     '$get': (req: express.Request, res: express.Response) => res.send('v1')
                 }
+            }
+        }
+    }
+}));
+
+app.use(swaggerize(<swaggerize.Options>{
+    ...api,
+    handlers: {
+        'api': {
+            'authenticated-path': {
+                '$get': [
+                    (req: express.Request, res: express.Response, next: express.NextFunction) => next(),
+                    (req: express.Request, res: express.Response) => res.send('v1'),
+                ]
             }
         }
     }

--- a/types/swaggerize-express/swaggerize-express-tests.ts
+++ b/types/swaggerize-express/swaggerize-express-tests.ts
@@ -2,28 +2,27 @@ import http = require('http');
 import express = require('express');
 import swaggerize = require('swaggerize-express');
 
-const api: Partial<swaggerize.Options> = {
-    api:  {
-        swagger: "2.0",
-        host: "localhost:8080",
-        info: {
-            title: "swaggerize-express.d.ts test",
-            version: "1"
-        },
-        paths: {
-        }
+const api = {
+    swagger: "2.0",
+    host: "localhost:8080",
+    info: {
+        title: "swaggerize-express.d.ts test",
+        version: "1"
     },
-    docspath: '/api-docs',
+    paths: {
+    }
 };
 
 var app = express();
 app.use(swaggerize(<swaggerize.Options>{
-    ...api,
+    api,
+    docspath: '/api-docs',
     handlers: './handlers'
 }));
 
 app.use(swaggerize(<swaggerize.Options>{
-    ...api,
+    api,
+    docspath: '/api-docs',
     handlers: {
         'api': {
             'v1': {
@@ -36,7 +35,8 @@ app.use(swaggerize(<swaggerize.Options>{
 }));
 
 app.use(swaggerize(<swaggerize.Options>{
-    ...api,
+    api,
+    docspath: '/api-docs',
     handlers: {
         'api': {
             'authenticated-path': {


### PR DESCRIPTION
Extended the RouteSegment interface to accept an array of Route Handlers in addition to a single handler or string. This is in-line with the swaggerize-express package.
See the documention link below.
Also replaced a couple of String declarations with string in-line with TypeScript Do's and Don'ts.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/krakenjs/swaggerize-express#handlers-object>>
- [n/a] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
