### PR TITLE
Use generics to improve @types/rosie safety

### DIFF
--- a/types/rosie/index.d.ts
+++ b/types/rosie/index.d.ts
@@ -1,12 +1,11 @@
 // Type definitions for rosie
 // Project: https://github.com/rosiejs/rosie
-// Definitions by: Abner Oliveira <https://github.com/abner>
+// Definitions by: Abner Oliveira <https://github.com/abner>, Chris Grigg <https://github.com/subvertallchris>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 declare namespace rosie {
   interface IFactoryStatic {
-
-
     /**
      * Defines a factory by name and constructor function. Call #attr and #option
      * on the result to define the properties of this factory.
@@ -15,7 +14,7 @@ declare namespace rosie {
      * @param {function(object): *=} constructor
      * @return {Factory}
      */
-    define(name: String, constructor?: Function):  IFactory;
+    define<T = any>(name: string, constructor?: (opts?: any) => any): IFactory<T>;
 
     /**
      * Locates a factory by name and calls #build on it.
@@ -25,7 +24,7 @@ declare namespace rosie {
      * @param {object=} options
      * @return {*}
      */
-    build(name: string, attributes?: any, options?: Object): Object;
+    build<T>(name: string, attributes?: { [k in keyof T]?: T[k] }, options?: any): T;
 
     /**
      * Builds a collection of objects using the named factory.
@@ -36,7 +35,7 @@ declare namespace rosie {
      * @param {object=} options
      * @return {Array.<*>}
      */
-    buildList(name: string, size: number, attributes?: any, options?: Object): Object[];
+    buildList(name: string, size: number, attributes?: any, options?: any): any[];
 
     /**
      * Locates a factory by name and calls #attributes on it.
@@ -46,10 +45,10 @@ declare namespace rosie {
      * @param {object} options
      * @return {object}
      */
-    attributes(name: string, attributes: Object, options?: Object): Object;
+    attributes(name: string, attributes: any, options?: any): any;
   }
 
-  interface IFactory {
+  interface IFactory<T = any> {
     /**
       * Define an attribute on this factory. Attributes can optionally define a
       * default value, either as a value (e.g. a string or number) or as a builder
@@ -89,7 +88,24 @@ declare namespace rosie {
       * @param any
       * @return {Factory}
       */
-    attr(name: string, dependenciesOrValue: any | string[], value?: any): IFactory;
+    attr<K extends keyof T>(name: K, dependenciesOrValue?: [keyof T] | T[K] | ((opts?: any) => T[K]), value?: T[K] | ((opts?: any) => T[K]) ): IFactory<T>;
+
+      /**
+      * Convenience function for defining a set of attributes on this object as
+      * builder functions or static values. If you need to specify dependencies,
+      * use #attr instead.
+      *
+      * For example:
+      *
+      *   Factory.define('Person').attrs({
+      *     name: 'Michael',
+      *     age: function() { return Math.random() * 100; }
+      *   });
+      *
+      * @param {object} attributes
+      * @return {Factory}
+      */
+    attrs(attributes: { [k in keyof T]: T[k] | ((opts?: any) => T[k]) }): IFactory<T>;
 
     /**
      * Define an option for this factory. Options are values that may inform
@@ -119,7 +135,7 @@ declare namespace rosie {
      * @param {*=} value
      * @return {Factory}
      */
-    option(name: string, dependenciesOrValue?: any | string[], value?: any): IFactory;
+    option(name: string, dependenciesOrValue?: any | string[], value?: any): IFactory<T>;
 
     /**
      * Defines an attribute that, by default, simply has an auto-incrementing
@@ -138,7 +154,7 @@ declare namespace rosie {
      * @param {function(number): *=} builder
      * @return {Factory}
      */
-    sequence(name: string, dependenciesOrBuilder?: Function | string[], builder?: Function) : IFactory;
+    sequence(name: keyof T, dependenciesOrBuilder?: () => any | keyof T[], builder?: Function) : IFactory<T>;
 
     /**
      * Sets a post-processor callback that will receive built objects and the
@@ -148,7 +164,7 @@ declare namespace rosie {
      * @param {function(object, ?object)} callback
      * @return {Factory}
      */
-    after(functionArg: Function): IFactory;
+    after(functionArg: (obj: T, opts?: any) => void): IFactory<T>;
 
     /**
      * Sets the constructor for this factory to be another factory. This can be
@@ -157,7 +173,7 @@ declare namespace rosie {
      * @param {Factory} parentFactory
      * @return {Factory}
      */
-    inherits(functionArg: Function): IFactory;
+    inherits(functionArg: (parentFactory: IFactory<T>) => void): IFactory<T>;
 
     /**
      * Builds a plain object containing values for each of the declared
@@ -168,7 +184,7 @@ declare namespace rosie {
      * @param {object=} options
      * @return {object}
      */
-    attributes(attributes:Object, options: Object): Object;
+    attributes(attributes: string, options?: { [k in keyof T]: T[k] }): T;
 
     /**
      * Generates values for all the registered options using the values given.
@@ -177,7 +193,7 @@ declare namespace rosie {
      * @param {object} options
      * @return {object}
      */
-    options(options: Object): Object;
+    options(options: any): any;
 
     /**
      * Builds objects by getting values for all attributes and optionally passing
@@ -187,9 +203,9 @@ declare namespace rosie {
      * @param {object=} options
      * @return {*}
      */
-    build(attributes: Object, options: Object): Object;
+    build(attributes: { [k in keyof T]?: T[k] }, options?: any): T;
 
-    buildList(size: number, attributes: Object, options: Object): Object[];
+    buildList(size: number, attributes: { [k in keyof T]?: T[k] }, options: any): T[];
 
     /**
      * Extends a given factory by copying over its attributes, options,
@@ -199,7 +215,7 @@ declare namespace rosie {
      * @param {string|Factory} name The factory to extend.
      * @return {Factory}
      */
-    extend(name: String | IFactory): IFactory;
+    extend<K extends T, T>(name: String | IFactory<T>): IFactory<K>;
   }
 
 }

--- a/types/rosie/index.d.ts
+++ b/types/rosie/index.d.ts
@@ -88,7 +88,13 @@ declare namespace rosie {
       * @param any
       * @return {Factory}
       */
-    attr<K extends keyof T>(name: K, dependenciesOrValue?: [keyof T] | T[K] | ((opts?: any) => T[K]), value?: T[K] | ((opts?: any) => T[K]) ): IFactory<T>;
+    attr<K extends keyof T>(name: K, defaultValue: T[K]): IFactory<T>;
+    attr<K extends keyof T>(name: K, generatorFunction: () => T[K]): IFactory<T>
+    attr<K extends keyof T, D1 extends keyof T, D2 extends keyof T, D3 extends keyof T, D4 extends keyof T, D5 extends keyof T>(name: K, dependencies: [D1, D2, D3, D4, D5], generatorFunction: (value1: T[D1], value2: T[D2], value3: T[D3], value4: T[D4], value5: T[D5]) => T[K]): IFactory<T>;
+    attr<K extends keyof T, D1 extends keyof T, D2 extends keyof T, D3 extends keyof T, D4 extends keyof T>(name: K, dependencies: [D1, D2, D3, D4], generatorFunction: (value1: T[D1], value2: T[D2], value3: T[D3], value4: T[D4]) => T[K]): IFactory<T>;
+    attr<K extends keyof T, D1 extends keyof T, D2 extends keyof T, D3 extends keyof T>(name: K, dependencies: [D1, D2, D3], generatorFunction: (value1: T[D1], value2: T[D2], value3: T[D3]) => T[K]): IFactory<T>;
+    attr<K extends keyof T, D1 extends keyof T, D2 extends keyof T>(name: K, dependencies: [D1, D2], generatorFunction: (value1: T[D1], value2: T[D2]) => T[K]): IFactory<T>;
+    attr<K extends keyof T, D extends keyof T>(name: K, dependencies: D[], generatorFunction: (value: T[D]) => T[K]): IFactory<T>;
 
       /**
       * Convenience function for defining a set of attributes on this object as
@@ -105,7 +111,7 @@ declare namespace rosie {
       * @param {object} attributes
       * @return {Factory}
       */
-    attrs(attributes: { [k in keyof T]: T[k] | ((opts?: any) => T[k]) }): IFactory<T>;
+    attrs(attributes: { [K in keyof T]: T[K] | ((opts?: any) => T[K]) }): IFactory<T>;
 
     /**
      * Define an option for this factory. Options are values that may inform

--- a/types/rosie/index.d.ts
+++ b/types/rosie/index.d.ts
@@ -95,6 +95,7 @@ declare namespace rosie {
     attr<K extends keyof T, D1 extends keyof T, D2 extends keyof T, D3 extends keyof T>(name: K, dependencies: [D1, D2, D3], generatorFunction: (value1: T[D1], value2: T[D2], value3: T[D3]) => T[K]): IFactory<T>;
     attr<K extends keyof T, D1 extends keyof T, D2 extends keyof T>(name: K, dependencies: [D1, D2], generatorFunction: (value1: T[D1], value2: T[D2]) => T[K]): IFactory<T>;
     attr<K extends keyof T, D extends keyof T>(name: K, dependencies: D[], generatorFunction: (value: T[D]) => T[K]): IFactory<T>;
+    attr<K extends keyof T, D extends keyof T>(name: K, dependencies: D[], generatorFunction: any): IFactory<T>;
 
       /**
       * Convenience function for defining a set of attributes on this object as

--- a/types/rosie/rosie-tests.ts
+++ b/types/rosie/rosie-tests.ts
@@ -1,10 +1,14 @@
-let resultObj: Object;
+let resultObj: any;
 let resultFactory: rosie.IFactory;
 
 declare var Factory:rosie.IFactoryStatic;
 
 resultFactory = Factory.define('person').attr('name', 'John').sequence('id');
 resultObj = Factory.build('person');
+if (resultObj.name !== 'John') { throw new Error('incorrect build'); };
+
+/// resultObj, as any, will allow this
+resultObj.name = 1;
 
 resultFactory = Factory.define('some').sequence('id').attr('name', ['id'], (id: number) => { return 'Name ' + id.toString() });
 resultObj = Factory.build('some');
@@ -24,6 +28,15 @@ Factory.define('coach')
   });
 
 Factory.build('coach', {}, {buildPlayer: true});
+
+interface Person {
+  name: string;
+  id: number;
+}
+
+const personFactory = Factory.define<Person>('Person').attr('name', 'John').sequence('id');
+const personObj = Factory.build<Person>('Person');
+if (personObj.name !== 'John') { throw new Error('incorrect Person build'); }
 
 import rosie = require('rosie');
 

--- a/types/rosie/rosie-tests.ts
+++ b/types/rosie/rosie-tests.ts
@@ -30,13 +30,24 @@ Factory.define('coach')
 Factory.build('coach', {}, {buildPlayer: true});
 
 interface Person {
-  name: string;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+  age: number;
+  secretNumber: number;
+  secretCode: { name: string; value: number };
   id: number;
 }
 
-const personFactory = Factory.define<Person>('Person').attr('name', 'John').sequence('id');
+const personFactory = Factory.define<Person>('Person').attr('firstName', 'John').sequence('id');
+personFactory.attr('fullName', ['firstName'], firstName => firstName);
+personFactory.attr('fullName', ['firstName', 'lastName'], (firstName, lastName) => lastName);
+personFactory.attr('secretNumber', ['firstName', 'lastName', 'age'], (firstName, lastName, age) => age + 1);
+personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age'], (firstName, lastName, age1, age2) => ({ name: `${firstName} + ${lastName}`, value: age1 + age2 }));
+personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age', 'firstName'], (firstName, lastName, age1, age2, firstNameAgain) => ({ name: firstNameAgain, value: age1 + age2 }));
+
 const personObj = Factory.build<Person>('Person');
-if (personObj.name !== 'John') { throw new Error('incorrect Person build'); }
+if (personObj.firstName !== 'John') { throw new Error('incorrect Person build'); }
 
 import rosie = require('rosie');
 

--- a/types/rosie/rosie-tests.ts
+++ b/types/rosie/rosie-tests.ts
@@ -10,7 +10,10 @@ if (resultObj.name !== 'John') { throw new Error('incorrect build'); };
 /// resultObj, as any, will allow this
 resultObj.name = 1;
 
-resultFactory = Factory.define('some').sequence('id').attr('name', ['id'], (id: number) => { return 'Name ' + id.toString() });
+// When you do not provide an interface for your factory, you'll get lots of `any`
+resultFactory = Factory.define('some').sequence('id');
+resultFactory.attr('name', ['id'], (id: number) => { return 'Name ' + id.toString() });
+resultFactory.attr('name', ['id', 'id2', 'id3', 'id4', 'id5', 'id6'], (id: number, id2: number, id3: number, id4: number, id5: number, id6: number) => { return 'Name ' + id.toString() });
 resultObj = Factory.build('some');
 
 Factory.define('coach')
@@ -40,11 +43,16 @@ interface Person {
 }
 
 const personFactory = Factory.define<Person>('Person').attr('firstName', 'John').sequence('id');
+
+// It will automatically type up to five dependencies
 personFactory.attr('fullName', ['firstName'], firstName => firstName);
 personFactory.attr('fullName', ['firstName', 'lastName'], (firstName, lastName) => lastName);
 personFactory.attr('secretNumber', ['firstName', 'lastName', 'age'], (firstName, lastName, age) => age + 1);
 personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age'], (firstName, lastName, age1, age2) => ({ name: `${firstName} + ${lastName}`, value: age1 + age2 }));
 personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age', 'firstName'], (firstName, lastName, age1, age2, firstNameAgain) => ({ name: firstNameAgain, value: age1 + age2 }));
+
+// You can go past five dependencies, but you need to specify types
+personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age', 'firstName', 'firstName'], (firstName: string, lastName: string, age1: number, age2: number, firstNameAgain: string, firstNameThisIsTooMuch: string) => ({ name: firstNameAgain, value: age1 + age2 }));
 
 const personObj = Factory.build<Person>('Person');
 if (personObj.firstName !== 'John') { throw new Error('incorrect Person build'); }


### PR DESCRIPTION
This uses generics to help ensure your factory objects are compliant with established interfaces.

```typescript
interface MyCoolInterface {
  name: string;
  really: boolean;
  id?: number;
}

// Will error on `'nope'` because it's not boolean
Factory.define<MyCoolInterface>('MyCoolInterface').attr<'really'>('really', 'nope')

// Give give an error because required key `really` is missing
Factory.define<MyCoolInterface>('MyCoolInterface').attrs({ name: 'Cool Thing' });

// myThing will be of the correct type
const myThing = Factory.build<MyCoolInterface>('MyCoolInterface');

interface PersistedCoolInterface extends MyCoolInterface {
  id: number;
}

// Will give an error if the ExtendedCoolInterface does not actually extended MyCoolInterface
Factory.define('PersistedCoolInterface').extend<PersistedCoolInterface, MyCoolInterface>('MyCoolInterface').sequence('id')
```

I still have not personally tested some of the methods, so it could use some more review. The core functionality (class method `define`, `build`, instance method `extend`, `attr`, `attrs`) is working for me. 

I corrected the tests and added an additional case demonstrating `define` with a generic argument. I added some default generics but it also now requires >= TS 2.3, so I'm not sure how to safely merge this without messing up folks relying on the current behavior.

Appreciate any advice or input.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rosiejs/rosie/blob/master/src/rosie.js

Previously open under #19966. Tests are passing locally now.