### PR TITLE
Add typings for react-tracking

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -1,0 +1,72 @@
+// Type definitions for react-tracking 4.2
+// Project: https://github.com/NYTimes/react-tracking
+// Definitions by: Eloy Durán <https://github.com/alloy>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as React from "react";
+
+export interface TrackingProp {
+    trackEvent({}): any;
+
+    /**
+     * This method returns all of the contextual tracking data up until this point in the component hierarchy.
+     */
+    getTrackingData(): {};
+}
+
+type Falsy = false | null | undefined | "";
+
+interface Options<T> {
+    /**
+     * By default, data tracking objects are pushed to `window.dataLayer[]`. This is a good default if you use Google
+     * Tag Manager. You can override this by passing in a dispatch function as a second parameter to the tracking
+     * decorator `{ dispatch: fn() }` on some top-level component high up in your app (typically some root-level
+     * component that wraps your entire app).
+     */
+    dispatch?(data: T): any;
+
+    /**
+     * To dispatch tracking data when a component mounts, you can pass in `{ dispatchOnMount: true }` as the second
+     * parameter to `@track()`. This is useful for dispatching tracking data on "Page" components.
+     *
+     * If you pass in a function, the function will be called with all of the tracking data from the app's context when
+     * the component mounts. The return value of this function will be dispatched in `componentDidMount()`. The object
+     * returned from this function call will be merged with the context data and then dispatched. A use case for this
+     * would be that you want to provide extra tracking data without adding it to the context.
+     */
+    dispatchOnMount?: boolean | ((contextData: T) => T);
+
+    /**
+     * When there's a need to implicitly dispatch an event with some data for every component, you can define an
+     * `options.process` function. This function should be declared once, at some top-level component. It will get
+     * called with each component's tracking data as the only argument. The returned object from this function will be
+     * merged with all the tracking context data and dispatched in `componentDidMount()`. If a falsy value is returned
+     * (`false`, `null`, `undefined`, ...), nothing will be dispatched.
+     *
+     * A common use case for this is to dispatch a `pageview` event for every component in the application that has a
+     * `page` property on its `trackingData`.
+     */
+    process?(ownTrackingData: T): T | Falsy;
+}
+
+export type TrackingInfo<T, P> = T | ((props: P) => T);
+
+// Duplicated from ES6 lib to remove the `void` typing, otherwise `track` can’t be used as a HOC function that passes
+// through a JSX component that be used without casting.
+type ClassDecorator = <TFunction extends Function>(target: TFunction) => TFunction;
+type MethodDecorator = <T>(target: object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
+type Decorator = ClassDecorator & MethodDecorator;
+
+/**
+ * This is the type of the `track` function. It’s declared as an interface so that consumers can extend the typing and
+ * specify defaults, such as a global analytics schema for the tracking-info.
+ *
+ * For examples of such extensions see: https://github.com/artsy/reaction/blob/master/src/utils/track.ts
+ */
+export interface Track<T = any, P = any> {
+    (trackingInfo?: TrackingInfo<Partial<T>, P>, options?: Options<Partial<T>>): Decorator;
+}
+
+export const track: Track;
+export default track;

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Track, track as _track, TrackingProp } from 'react-tracking';
+
+function customEventReporter(data: { page?: string }) {}
+
+interface Props {
+    someProp: string;
+    tracking?: TrackingProp;
+}
+
+interface TrackingData {
+    page: string;
+    event: string;
+}
+
+const track: Track<TrackingData, Props> = _track;
+
+@track({ page: "ClassPage" }, {
+    dispatch: customEventReporter,
+    dispatchOnMount: contextData => ({ event: "pageDataReady" }),
+    process: ownTrackingData => ownTrackingData.page ? { event: 'pageview' } : null,
+})
+class ClassPage extends React.Component<Props> {
+    @track({ event: "Clicked" })
+    handleClick() {
+    // ... other stuff
+    }
+
+    @track(props => ({ event: `got ${props.someProp}` }))
+    render() {
+        return (
+            <button onClick={this.handleClick}>
+                Click Me!
+            </button>
+        );
+    }
+}
+
+const FunctionPage: React.SFC<Props> = (props) => {
+  return (
+    <div onClick={() => {
+        props.tracking && props.tracking.trackEvent({ action: 'click' });
+      }}
+    />
+  );
+};
+
+const WrappedFunctionPage = track({
+    page: 'FunctionPage'
+}, {
+    dispatchOnMount: true
+})(FunctionPage);
+
+class Test extends React.Component<any, null> {
+    render() {
+        return (
+            <div>
+                <ClassPage someProp="oh yeah" />
+                <WrappedFunctionPage someProp="oh yeah" />
+            </div>
+        );
+    }
+}

--- a/types/react-tracking/test/react-tracking-without-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-without-types-tests.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Track, track, TrackingProp } from 'react-tracking';
+
+function customEventReporter(data: { page?: string }) {}
+
+@track({ page: "ClassPage" }, {
+    dispatch: customEventReporter,
+    dispatchOnMount: contextData => ({ event: "pageDataReady" }),
+    process: ownTrackingData => ownTrackingData.page ? { event: 'pageview' } : null,
+})
+class ClassPage extends React.Component<any> {
+    @track({ event: "Clicked" })
+    handleClick() {
+    // ... other stuff
+    }
+
+    // Only need to cast this to `any` because the settings for this project is to disallow implicit `any`.
+    @track((props: any) => ({ event: `got ${props.someProp}` }))
+    render() {
+        return (
+            <button onClick={this.handleClick}>
+                Click Me!
+            </button>
+        );
+    }
+}
+
+const FunctionPage: React.SFC<any> = (props) => {
+  return (
+    <div onClick={() => {
+        props.tracking && props.tracking.trackEvent({ action: 'click' });
+      }}
+    />
+  );
+};
+
+const WrappedFunctionPage = track({
+    page: 'FunctionPage'
+}, {
+    dispatchOnMount: true
+})(FunctionPage);
+
+class Test extends React.Component<any, null> {
+    render() {
+        return (
+            <div>
+                <ClassPage someProp="oh yeah" />
+                <WrappedFunctionPage someProp="oh yeah" />
+            </div>
+        );
+    }
+}

--- a/types/react-tracking/tsconfig.json
+++ b/types/react-tracking/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "experimentalDecorators": true,
+        "jsx": "preserve"
+    },
+    "files": [
+        "index.d.ts",
+        "test/react-tracking-with-types-tests.tsx",
+        "test/react-tracking-without-types-tests.tsx"
+    ]
+}

--- a/types/react-tracking/tslint.json
+++ b/types/react-tracking/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "ban-types": false,
+        "callable-types": false
+    }
+}


### PR DESCRIPTION
If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

https://github.com/NYTimes/react-tracking