### PR TITLE
Correct spelling of parsers

### DIFF
--- a/types/serialport/index.d.ts
+++ b/types/serialport/index.d.ts
@@ -62,10 +62,10 @@ declare namespace SerialPort {
 	type callback = (error: any) => void;
 
 	interface parsers {
-		raw: serialParser;
-		readline: readlineParser;
-		byteLength: byteLengthParser;
-		byteDelimiter: byteDelimiterParser;
+		Raw: serialParser;
+		Readline: readlineParser;
+		ByteLength: byteLengthParser;
+		ByteDelimiter: byteDelimiterParser;
 	}
 
 	// https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/4.0.7/README.md#user-content-serialport-path-options-opencallback

--- a/types/serialport/serialport-tests.ts
+++ b/types/serialport/serialport-tests.ts
@@ -9,22 +9,22 @@ function test_basic_connect() {
 function test_connect_config() {
     const port1 = new SerialPort('', {
             baudRate: 0,
-            parser: SerialPort.parsers.raw
+            parser: SerialPort.parsers.Raw
         }, (err: any) => {});
 
     const port2 = new SerialPort('', {
             baudRate: 0,
-            parser: SerialPort.parsers.readline('\n', 'ascii')
+            parser: SerialPort.parsers.Readline('\n', 'ascii')
         }, (err: any) => {});
 
     const port3 = new SerialPort('', {
             baudRate: 0,
-            parser: SerialPort.parsers.byteLength(7)
+            parser: SerialPort.parsers.ByteLength(7)
         }, (err: any) => {});
 
     const port4 = new SerialPort('', {
             baudRate: 0,
-            parser: SerialPort.parsers.byteDelimiter([3, 4, 5])
+            parser: SerialPort.parsers.ByteDelimiter([3, 4, 5])
         }, (err: any) => {});
 
     const port5 = new SerialPort('', {


### PR DESCRIPTION
```
C:\Throwaway\spp>node
> require('serialport').parsers
{ ByteLength: [Function: ByteLengthParser],
  Delimiter: [Function: DelimiterParser],
  Readline: [Function: ReadLineParser],
  Ready: [Function: ReadyParser],
  Regex: [Function: RegexParser] }
```
