### PR TITLE
[vis] timeline: add types for custom ordering functions

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -6,6 +6,7 @@
 //                 Severin <https://github.com/seveves>
 //                 kaktus40 <https://github.com/kaktus40>
 //                 Matthieu Maitre <https://github.com/mmaitre314>
+//                 Adam Lewis <https://github.com/supercargo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export type IdType = string | number;
@@ -135,11 +136,12 @@ export type TimelineOptionsConfigureType = boolean | TimelineOptionsConfigureFun
 export type TimelineOptionsDataAttributesType = boolean | string | string[];
 export type TimelineOptionsEditableType = boolean | TimelineEditableOption;
 export type TimelineOptionsGroupEditableType = boolean | TimelineGroupEditableOption;
-export type TimelineOptionsGroupOrderType = string | (() => void); // TODO
+export type TimelineOptionsGroupOrderType = string | TimelineOptionsComparisonFunction; 
 export type TimelineOptionsGroupOrderSwapFunction = (fromGroup: any, toGroup: any, groups: DataSet<DataGroup>) => void;
 export type TimelineOptionsMarginType = number | TimelineMarginOption;
 export type TimelineOptionsOrientationType = string | TimelineOrientationOption;
 export type TimelineOptionsSnapFunction = (date: Date, scale: string, step: number) => Date | number;
+export type TimelineOptionsComparisonFunction = (a: any, b: any) => number;
 
 export interface TimelineOptions {
   align?: string;
@@ -178,7 +180,7 @@ export interface TimelineOptions {
   onMoving?(): void; // TODO
   onRemove?(): void; // TODO
   onRemoveGroup?(): void; // TODO
-  order?(): void; // TODO
+  order?: TimelineOptionsComparisonFunction;
   orientation?: TimelineOptionsOrientationType;
   rollingMode?: any;
   selectable?: boolean;

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -136,7 +136,7 @@ export type TimelineOptionsConfigureType = boolean | TimelineOptionsConfigureFun
 export type TimelineOptionsDataAttributesType = boolean | string | string[];
 export type TimelineOptionsEditableType = boolean | TimelineEditableOption;
 export type TimelineOptionsGroupEditableType = boolean | TimelineGroupEditableOption;
-export type TimelineOptionsGroupOrderType = string | TimelineOptionsComparisonFunction; 
+export type TimelineOptionsGroupOrderType = string | TimelineOptionsComparisonFunction;
 export type TimelineOptionsGroupOrderSwapFunction = (fromGroup: any, toGroup: any, groups: DataSet<DataGroup>) => void;
 export type TimelineOptionsMarginType = number | TimelineMarginOption;
 export type TimelineOptionsOrientationType = string | TimelineOrientationOption;

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -9,6 +9,14 @@
 //                 Adam Lewis <https://github.com/supercargo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+import { MomentInput, MomentFormatSpecification, Moment } from 'moment';
+export type MomentConstructor1 =
+    (inp?: MomentInput, format?: MomentFormatSpecification, strict?: boolean) => Moment;
+export type MomentConstructor2 =
+    (inp?: MomentInput, format?: MomentFormatSpecification, language?: string, strict?: boolean) => Moment;
+
+export type MomentConstructor = MomentConstructor1 | MomentConstructor2;
+
 export type IdType = string | number;
 export type SubgroupType = IdType;
 export type DateType = Date | number | string;
@@ -162,7 +170,7 @@ export interface TimelineOptions {
   itemsAlwaysDraggable?: boolean;
   locale?: string;
   locales?: any; // TODO
-  moment?(): void; // TODO
+  moment?: MomentConstructor;
   margin?: TimelineOptionsMarginType;
   max?: DateType;
   maxHeight?: HeightWidthType;
@@ -642,7 +650,7 @@ export interface Graph2dOptions {
   legend?: Graph2dLegendOption;
   locale?: string;
   locales?: any; // TODO
-  moment?(): void; // TODO
+  moment?: MomentConstructor;
   max?: DateType;
   maxHeight?: HeightWidthType;
   maxMinorChars?: number;

--- a/types/vis/package.json
+++ b/types/vis/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "moment": ">=2.13.0"
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://visjs.org/docs/timeline/#Configuration_Options (see `order` and `groupOrder` properties)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.