### PR TITLE
[Postmark] Make Client constructor "options" param optional

### DIFF
--- a/types/postmark/index.d.ts
+++ b/types/postmark/index.d.ts
@@ -100,7 +100,7 @@ interface Options extends SimpleOptions {
 }
 
 declare class Client {
-    constructor(serverKey: string, options: Partial<Options>);
+    constructor(serverKey: string, options?: Partial<Options>);
     send(message: PostmarkMessage, callback: PostmarkCallback): void;
     sendEmailWithTemplate(
         message: PostmarkMessageWithTemplate,


### PR DESCRIPTION
See the following URL that shows that the options are not mandatory:
http://wildbit.github.io/postmark.js/Client.html#Client
