### PR TITLE
[node-int64] Updating for missing methods, props and constructors

### DIFF
--- a/types/node-int64/index.d.ts
+++ b/types/node-int64/index.d.ts
@@ -1,25 +1,35 @@
 // Type definitions for node-int64 v0.4.0
 // Project: https://github.com/broofa/node-int64
 // Definitions by: Benno Dreissig <https://github.com/x3cion>
+//                 Kevin Greene <https://github.com/kevin-greene-ck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
 
 declare class Int64 {
-
     static MAX_INT: number;
     static MIN_INT: number;
+
+    public buffer: Buffer;
+    public offset: number;
 
     constructor(buffer: Buffer, offset?: number);
     constructor(array: Uint8Array, offset?: number);
     constructor(str: string);
+    constructor(num: number);
     constructor(hi: number, lo: number);
 
 
     _2scomp(): void;
 
+    // setValue(string) - A hexidecimal string
     setValue(str: string): void;
+    // setValue(number) - Number (throws if n is outside int64 range)
+    setValue(num: number): void;
+    // setValue(hi, lo) - Raw bits as two 32-bit values
+    setValue(hi: number, lo: number): void;
+
     toNumber(allowImprecise?: boolean): number;
     valueOf(): number;
     toString(radix?: number): string;
@@ -29,7 +39,6 @@ declare class Int64 {
     compare(other: Int64): number;
     equals(other: Int64): boolean;
     inspect(): string;
-
 }
 
 export = Int64;

--- a/types/node-int64/node-int64-tests.ts
+++ b/types/node-int64/node-int64-tests.ts
@@ -9,11 +9,17 @@
 // So let's create a couple Int64s using the above values ...
 
 // Require, of course
-let Int64 = require('node-int64');
+import Int64 = require('node-int64');
 
 // x's value is what we expect (the decimal value of 0x123456789)
 let x = new Int64(0x123456789);
 //!! 	[Int64 value:4886718345 octets:00 00 00 01 23 45 67 89]
+
+// We can set the value as a number
+let a: Int64 = new Int64(64);
+
+// We can set the value as two numbers representing raw bits
+let b: Int64 = new Int64(73876293, 827235);
 
 // y's value is Infinity because it's outside the range of integer
 // precision.  But that's okay - it's still useful because it's internal
@@ -21,18 +27,21 @@ let x = new Int64(0x123456789);
 let y = new Int64('123456789abcdef0');
 //!! 	[Int64 value:Infinity octets:12 34 56 78 9a bc de f0]
 
+// Get the underlying Buffer object
+let buffer: Buffer = y.buffer;
+
 // Let's do some math.  Int64's behave like Numbers.  (Sorry, Int64 isn't
 // for doing 64-bit integer arithmetic (yet) - it's just for carrying
 // around int64 values
-x + 1;
+x.toNumber() + 1;
 //!! 4886718346
-y + 1;
+y.toNumber() + 1;
 //!! Infinity
 
 // Int64 string operations ...
-'value: ' + x;
+'value: ' + x.toString();
 //!! 'value: 4886718345'
-'value: ' + y;
+'value: ' + y.toString();
 //!! 'value: Infinity'
 x.toString(2);
 //!! '100100011010001010110011110001001'
@@ -41,9 +50,9 @@ y.toString(2);
 
 // Use JS's isFinite() method to see if the Int64 value is in the
 // integer-precise range of JS values
-isFinite(x);
+isFinite(x.toNumber());
 //!! true
-isFinite(y);
+isFinite(y.toNumber());
 //!! false
 
 // Get an octet string representation.  (Yay, y is what we put in!)


### PR DESCRIPTION
The existing types for node-int64 has a coupe of omissions. The version of the supported library remains the same.

  * Supports constructing from number
  * Support the public buffer and offset properties
  * Support all method signatures of the setValue method

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/broofa/node-int64/blob/master/Int64.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


