### PR TITLE
[gl-matrix] Change vec2.cross out from vec2 to vec3

### DIFF
--- a/types/gl-matrix/index.d.ts
+++ b/types/gl-matrix/index.d.ts
@@ -343,7 +343,7 @@ declare module 'gl-matrix' {
          * @param b the second operand
          * @returns out
          */
-        public static cross(out: vec2, a: vec2 | number[], b: vec2 | number[]): vec2;
+        public static cross(out: vec3, a: vec2 | number[], b: vec2 | number[]): vec2;
 
         /**
          * Performs a linear interpolation between two vec2's


### PR DESCRIPTION
There is a mathematical reasoning behind it but I'm in a bit o a hurry to explain. Anyway, it works like this and it's documented like this. http://glmatrix.net/docs/module-vec2.html

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://glmatrix.net/docs/module-vec2.html
- [?] Increase the version number in the header if appropriate.

Should I increase the version? gl-matrix has been updated but I don't know what changed since then.
I just want to fix this bug :)