### PR TITLE
node: Add _destroy to Readable stream

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5035,6 +5035,7 @@ declare module "stream" {
             unshift(chunk: any): void;
             wrap(oldStream: NodeJS.ReadableStream): Readable;
             push(chunk: any, encoding?: string): boolean;
+            _destroy(err: Error, callback: Function): void;
             destroy(error?: Error): void;
 
             /**


### PR DESCRIPTION
From the docs:
https://nodejs.org/api/stream.html#stream_readable_destroy_err_callback

As specified in
https://nodejs.org/api/stream.html#stream_readable_destroy_error
implementors are recommended to implement this method instead of
`destroy()` and the original method should be available for calling via
`super`.

This change matches the signatures of other Stream subclasses by
annotating `callback` as `Function` instead of `(err: Error) => void`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/stream.html#stream_readable_destroy_err_callback
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

