### PR TITLE
PDFKit: complete interface of color / winding-rule

### DIFF
--- a/types/pdfkit/index.d.ts
+++ b/types/pdfkit/index.d.ts
@@ -58,9 +58,16 @@ declare namespace PDFKit.Mixins {
         textAnnotation(x: number, y: number, w: number, h: number, text: string, option?: AnnotationOption): TDocument;
     }
 
+    // The color forms accepted by PDFKit:
+    //     example:   "red"                  [R, G, B]                  [C, M, Y, K]
+    type ColorValue = string | PDFGradient | [number, number, number] | [number, number, number, number];
+
+    // The winding / filling rule accepted by PDFKit:
+    type RuleValue = "even-odd" | "evenodd" | "non-zero" | "nonzero";
+
     interface PDFColor<TDocument> {
-        fillColor(color: string|PDFGradient, opacity?: number): TDocument;
-        strokeColor(color: string, opacity?: number): TDocument;
+        fillColor(color: ColorValue, opacity?: number): TDocument;
+        strokeColor(color: ColorValue, opacity?: number): TDocument;
         opacity(opacity: number): TDocument;
         fillOpacity(opacity: number): TDocument;
         strokeOpacity(opacity: number): TDocument;
@@ -166,10 +173,13 @@ declare namespace PDFKit.Mixins {
         circle(x: number, y: number, raduis: number): TDocument;
         polygon(...points: number[][]): TDocument;
         path(path: string): TDocument;
-        fill(color: string|PDFKit.PDFGradient, rule?: string): TDocument;
-        stroke(color?: string|PDFKit.PDFGradient): TDocument;
-        fillAndStroke(fillColor: string, strokeColor?: string, rule?: string): TDocument;
-        clip(rule?: string): TDocument;
+        fill(color?: ColorValue, rule?: RuleValue): TDocument;
+        fill(rule: RuleValue): TDocument;
+        stroke(color?: ColorValue): TDocument;
+        fillAndStroke(fillColor?: ColorValue, strokeColor?: ColorValue, rule?: RuleValue): TDocument;
+        fillAndStroke(fillColor: ColorValue, rule?: RuleValue): TDocument;
+        fillAndStroke(rule: RuleValue): TDocument;
+        clip(rule?: RuleValue): TDocument;
         transform(m11: number, m12: number, m21: number, m22: number, dx: number, dy: number): TDocument;
         translate(x: number, y: number): TDocument;
         rotate(angle: number, options?: { origin?: number[] }): TDocument;

--- a/types/pdfkit/pdfkit-tests.ts
+++ b/types/pdfkit/pdfkit-tests.ts
@@ -44,6 +44,8 @@ doc.moveTo(0,20)
   .lineTo(100,160)
   .quadraticCurveTo(130,200,150,120)
   .lineTo(400,90)
+  .strokeColor([255, 0, 0], 1)
+  .strokeColor([255, 0, 0])
   .stroke();
 
 //SVG Paths
@@ -79,6 +81,9 @@ var grad = doc.linearGradient(50, 0, 150, 100)
 
 doc.rect(50, 0, 100, 100)
 .fill(grad);
+
+doc.rect(150, 0, 25, 25)
+.fill();
 
 doc.circle(100, 50, 50).dash(5, {
   space: 10


### PR DESCRIPTION
- add 2 color forms: [R, G, B] or [C, M, Y, K]
- constrain possible value of winding rule
- add missing overloads of fill / fillAndStroke

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [color.coffee](https://github.com/devongovett/pdfkit/blob/master/lib/mixins/color.coffee) / [vector.coffee](https://github.com/devongovett/pdfkit/blob/master/lib/mixins/vector.coffee)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
