### PR TITLE
Update CryptoJS-definition to include lib.WordArray.create and allow the output as input to any Hash

### DIFF
--- a/types/crypto-js/crypto-js-tests.ts
+++ b/types/crypto-js/crypto-js-tests.ts
@@ -11,6 +11,10 @@ wordArray = CryptoJS.SHA1('some message', 'some key', { any: true });
 wordArray = CryptoJS.format.OpenSSL('some message');
 wordArray = CryptoJS.format.OpenSSL('some message', 'some key');
 
+var FR = new FileReader();
+FR.onloadend = () => {
+    var hash = CryptoJS.SHA1(CryptoJS.lib.WordArray.create(FR.result)).toString()
+}
 
 // Ciphers
 var encrypted: CryptoJS.WordArray;

--- a/types/crypto-js/crypto-js-tests.ts
+++ b/types/crypto-js/crypto-js-tests.ts
@@ -13,7 +13,7 @@ wordArray = CryptoJS.format.OpenSSL('some message', 'some key');
 
 var FR = new FileReader();
 FR.onloadend = () => {
-    var hash = CryptoJS.SHA1(CryptoJS.lib.WordArray.create(FR.result)).toString()
+	var hash = CryptoJS.SHA1(CryptoJS.lib.WordArray.create(FR.result)).toString()
 }
 
 // Ciphers

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -8,7 +8,7 @@ export as namespace CryptoJS;
 
 declare var CryptoJS: CryptoJS.Hashes;
 declare namespace CryptoJS {
-	type Hash = (message: string, key?: string, ...options: any[]) => WordArray;
+	type Hash = (message: string | LibWordArray, key?: string, ...options: any[]) => WordArray;
 	interface Cipher {
 		encrypt(message: string, secretPassphrase: string, option?: CipherOption): WordArray;
 		decrypt(encryptedMessage: string | WordArray, secretPassphrase: string, option?: CipherOption): DecryptedMessage;
@@ -25,6 +25,10 @@ declare namespace CryptoJS {
 		process(messagePart: string): string;
 		finalize(): string;
 	}
+	interface LibWordArray {
+        sigBytes: number,
+        words: number[],
+    }
 	export interface WordArray {
 		iv: string;
 		salt: string;
@@ -96,6 +100,11 @@ declare namespace CryptoJS {
 			Utf16: Encoder;
 			Utf16LE: Encoder;
 			Base64: Encoder;
+		};
+		lib: {
+			WordArray: {
+				create: (v: any) => LibWordArray;
+			};
 		};
 		mode: {
 			CBC: Mode;

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -26,9 +26,9 @@ declare namespace CryptoJS {
 		finalize(): string;
 	}
 	interface LibWordArray {
-        sigBytes: number,
-        words: number[],
-    }
+		sigBytes: number,
+		words: number[],
+	}
 	export interface WordArray {
 		iv: string;
 		salt: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gist.github.com/npcode/11282867
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
