### PR TITLE
Updated Enzyme typings

### DIFF
--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -23,7 +23,7 @@ export class ElementClass extends Component<any, any> {
  * all specified in the implementation. TS chooses the EnzymePropSelector overload and loses the generics
  */
 export interface ComponentClass<Props> {
-    new (props?: Props, context?: any): Component<Props, any>;
+    new(props?: Props, context?: any): Component<Props, any>;
 }
 
 export type StatelessComponent<Props> = (props: Props, context?: any) => JSX.Element;
@@ -612,3 +612,10 @@ export function mount<P, S>(node: ReactElement<P>, options?: MountRendererProps)
  * @param [options]
  */
 export function render<P, S>(node: ReactElement<P>, options?: any): Cheerio;
+
+/**
+ * Configure enzyme to use the correct adapter for the react verstion
+ * This is enabling the Enzyme configuration with adapters in TS
+ * @param options
+ */
+export function configure(options: { adapter: any }): void;


### PR DESCRIPTION
**Updated Enzyme typings**

./enzyme package is modified to allow TS users to follow the documentation here:
http://airbnb.io/enzyme/docs/installation/react-16.html

Added "configure" method so now this setup will compile and work safely:
```
import { configure } from 'enzyme';
import Adapter from 'enzyme-adapter-react-16';

configure({ adapter: new Adapter() });
```