### PR TITLE
Add possible definition to Response.send for Express

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -476,6 +476,7 @@ interface MediaType {
 
 interface Send {
     (body?: any): Response;
+    (code: number, body: any): Response;
 }
 
 interface Response extends http.ServerResponse, Express.Response {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [src](https://github.com/expressjs/express/blob/master/lib/response.js#L117)

This is a bit of a hairy one, the [official documentation](http://expressjs.com/en/api.html#res.send) doesn't list this use case, but the source code certainly has it explicitly supported. My team is moving old `js` over to `ts` and we use this pattern: `res.send(200, 'some message')` consistently.
