### PR TITLE
[thrift] Update Thrift types for completeness and correctness

### DIFF
--- a/types/evernote/index.d.ts
+++ b/types/evernote/index.d.ts
@@ -2,8 +2,9 @@
 // Project: https://www.npmjs.com/package/evernote
 // Definitions by: Zachary Collins <https://github.com/corps>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-import * as Thrift from 'thrift';
+import { Thrift } from 'thrift';
 
 declare namespace Evernote {
     interface Callback<T> {

--- a/types/evernote/tsconfig.json
+++ b/types/evernote/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,

--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -171,6 +171,32 @@ export class XHRConnection extends NodeJS.EventEmitter {
     getSendBuffer(): string;
 }
 
+export interface WSOptions {
+    host: string;
+    port: number;
+    path: string;
+    headers: http.OutgoingHttpHeaders;
+}
+
+export class WSConnection extends NodeJS.EventEmitter {
+    seqId2Service: SeqId2Service;
+    options: ConnectOptions;
+    host: string;
+    port: number;
+    secure: boolean;
+    transport: TTransport;
+    protocol: TProtocol;
+    path: string;
+    send_pending: Buffer[];
+    wsOptions: WSOptions;
+    constructor(host: string, port: number, options?: ConnectOptions);
+    isOpen(): boolean;
+    open(): void;
+    close(): void;
+    uri(): string;
+    write(data: Buffer): void;
+}
+
 export class Multiplexer<TClient> {
     createClient(serviceName: string, client: TClientConstructor<TClient>, connection: Connection): TClient;
 }
@@ -216,6 +242,15 @@ export interface ConnectOptions {
     nodeOptions?: http.ClientRequestArgs;
 }
 
+export interface WSConnectOptions {
+    transport?: TTransportConstructor;
+    protocol?: TProtocolConstructor;
+    path?: string;
+    headers?: http.OutgoingHttpHeaders;
+    secure?: boolean;
+    wsOptions?: WSOptions;
+}
+
 export type TClientConstructor<TClient> =
     { new (output: TTransport, pClass: { new (trans: TTransport): TProtocol }): TClient; } |
     { Client: { new (output: TTransport, pClass: { new (trans: TTransport): TProtocol }): TClient; } };
@@ -237,8 +272,24 @@ export function createConnection(host: string | undefined, port: number, options
 export function createSSLConnection(host: string | undefined, port: number, options?: ConnectOptions): Connection;
 export function createHttpConnection(host: string | undefined, port: number, options?: ConnectOptions): HttpConnection;
 export function createXHRConnection(host: string | undefined, port: number, options?: ConnectOptions): XHRConnection;
+export function createWSConnectin(host: string | undefined, port: number, options?: WSConnectOptions): WSConnection;
 
 export function createXHRClient<TClient>(
+    client: TClientConstructor<TClient>,
+    connection: XHRConnection
+): TClient;
+
+export function createHttpClient<TClient>(
+    client: TClientConstructor<TClient>,
+    connection: HttpConnection
+): TClient;
+
+export function createWSClient<TClient>(
+    client: TClientConstructor<TClient>,
+    connection: WSConnection
+): TClient;
+
+export function createStdIOClient<TClient>(
     client: TClientConstructor<TClient>,
     connection: Connection
 ): TClient;

--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -309,37 +309,195 @@ export function createServer<TProcessor, THandler>(
 // tslint:disable-next-line no-unnecessary-generics
 export function createWebServer<TProcessor, THandler>(options: WebServerOptions<TProcessor, THandler>): http.Server | tls.Server;
 
-export interface TBufferedTransportConstructor {
-    new (buffer: Buffer | undefined, callback: TTransportCallback): TTransport;
+export class TBufferedTransport implements TTransport {
+    constructor(buffer: Buffer | undefined, callback: TTransportCallback);
+    static receiver(callback: (trans: TBufferedTransport, seqid: number) => void, seqid: number): (data: Buffer) => void;
+    commitPosition(): void;
+    rollbackPosition(): void;
+    isOpen(): boolean;
+    open(): boolean;
+    close(): boolean;
+    setCurrSeqId(seqId: number): void;
+    ensureAvailable(len: number): void;
+    read(len: number): Buffer;
+    readByte(): number;
+    readI16(): number;
+    readI32(): number;
+    readDouble(): number;
+    readString(): string;
+    write(buf: Buffer | string): void;
+    flush(): void;
 }
 
-export interface TFramedTransportConstructor {
-    new (buffer: Buffer | undefined, callback: TTransportCallback): TTransport;
+export class TFramedTransport implements TTransport {
+    constructor(buffer: Buffer | undefined, callback: TTransportCallback);
+    static receiver(callback: (trans: TFramedTransport, seqid: number) => void, seqid: number): (data: Buffer) => void;
+    commitPosition(): void;
+    rollbackPosition(): void;
+    isOpen(): boolean;
+    open(): boolean;
+    close(): boolean;
+    setCurrSeqId(seqId: number): void;
+    ensureAvailable(len: number): void;
+    read(len: number): Buffer;
+    readByte(): number;
+    readI16(): number;
+    readI32(): number;
+    readDouble(): number;
+    readString(): string;
+    write(buf: Buffer | string): void;
+    flush(): void;
 }
 
 export type TTransportConstructor =
-    TBufferedTransportConstructor | TFramedTransportConstructor;
+    TBufferedTransport | TFramedTransport;
 
-export interface TBinaryProtocolConstructor {
-    new (trans: TTransport, strictRead?: boolean, strictWrite?: boolean): TProtocol;
+export class TBinaryProtocol implements TProtocol {
+    constructor(trans: TTransport, strictRead?: boolean, strictWrite?: boolean);
+    flush(): void;
+    writeMessageBegin(name: string, type: Thrift.MessageType, seqid: number): void;
+    writeMessageEnd(): void;
+    writeStructBegin(name: string): void;
+    writeStructEnd(): void;
+    writeFieldBegin(name: string, type: Thrift.Type, id: number): void;
+    writeFieldEnd(): void;
+    writeFieldStop(): void;
+    writeMapBegin(ktype: Thrift.Type, vtype: Thrift.Type, size: number): void;
+    writeMapEnd(): void;
+    writeListBegin(etype: Thrift.Type, size: number): void;
+    writeListEnd(): void;
+    writeSetBegin(etype: Thrift.Type, size: number): void;
+    writeSetEnd(): void;
+    writeBool(bool: boolean): void;
+    writeByte(b: number): void;
+    writeI16(i16: number): void;
+    writeI32(i32: number): void;
+    writeI64(i64: number | Int64): void;
+    writeDouble(dbl: number): void;
+    writeString(arg: string | Buffer): void;
+    writeBinary(arg: string | Buffer): void;
+    readMessageBegin(): TMessage;
+    readMessageEnd(): void;
+    readStructBegin(): TStruct;
+    readStructEnd(): void;
+    readFieldBegin(): TField;
+    readFieldEnd(): void;
+    readMapBegin(): TMap;
+    readMapEnd(): void;
+    readListBegin(): TList;
+    readListEnd(): void;
+    readSetBegin(): TSet;
+    readSetEnd(): void;
+    readBool(): boolean;
+    readByte(): number;
+    readI16(): number;
+    readI32(): number;
+    readI64(): Int64;
+    readDouble(): number;
+    readBinary(): Buffer;
+    readString(): string;
+    getTransport(): TTransport;
+    skip(type: Thrift.Type): void;
 }
 
-export interface TJSONProtocolConstructor {
-    new (trans: TTransport): TProtocol;
+export class TJSONProtocol implements TProtocol {
+    constructor(trans: TTransport);
+    flush(): void;
+    writeMessageBegin(name: string, type: Thrift.MessageType, seqid: number): void;
+    writeMessageEnd(): void;
+    writeStructBegin(name: string): void;
+    writeStructEnd(): void;
+    writeFieldBegin(name: string, type: Thrift.Type, id: number): void;
+    writeFieldEnd(): void;
+    writeFieldStop(): void;
+    writeMapBegin(ktype: Thrift.Type, vtype: Thrift.Type, size: number): void;
+    writeMapEnd(): void;
+    writeListBegin(etype: Thrift.Type, size: number): void;
+    writeListEnd(): void;
+    writeSetBegin(etype: Thrift.Type, size: number): void;
+    writeSetEnd(): void;
+    writeBool(bool: boolean): void;
+    writeByte(b: number): void;
+    writeI16(i16: number): void;
+    writeI32(i32: number): void;
+    writeI64(i64: number | Int64): void;
+    writeDouble(dbl: number): void;
+    writeString(arg: string | Buffer): void;
+    writeBinary(arg: string | Buffer): void;
+    readMessageBegin(): TMessage;
+    readMessageEnd(): void;
+    readStructBegin(): TStruct;
+    readStructEnd(): void;
+    readFieldBegin(): TField;
+    readFieldEnd(): void;
+    readMapBegin(): TMap;
+    readMapEnd(): void;
+    readListBegin(): TList;
+    readListEnd(): void;
+    readSetBegin(): TSet;
+    readSetEnd(): void;
+    readBool(): boolean;
+    readByte(): number;
+    readI16(): number;
+    readI32(): number;
+    readI64(): Int64;
+    readDouble(): number;
+    readBinary(): Buffer;
+    readString(): string;
+    getTransport(): TTransport;
+    skip(type: Thrift.Type): void;
 }
 
-export interface TCompactProtocolConstructor {
-    new (trans: TTransport): TProtocol;
+export class TCompactProtocol implements TProtocol {
+    constructor(trans: TTransport);
+    flush(): void;
+    writeMessageBegin(name: string, type: Thrift.MessageType, seqid: number): void;
+    writeMessageEnd(): void;
+    writeStructBegin(name: string): void;
+    writeStructEnd(): void;
+    writeFieldBegin(name: string, type: Thrift.Type, id: number): void;
+    writeFieldEnd(): void;
+    writeFieldStop(): void;
+    writeMapBegin(ktype: Thrift.Type, vtype: Thrift.Type, size: number): void;
+    writeMapEnd(): void;
+    writeListBegin(etype: Thrift.Type, size: number): void;
+    writeListEnd(): void;
+    writeSetBegin(etype: Thrift.Type, size: number): void;
+    writeSetEnd(): void;
+    writeBool(bool: boolean): void;
+    writeByte(b: number): void;
+    writeI16(i16: number): void;
+    writeI32(i32: number): void;
+    writeI64(i64: number | Int64): void;
+    writeDouble(dbl: number): void;
+    writeString(arg: string | Buffer): void;
+    writeBinary(arg: string | Buffer): void;
+    readMessageBegin(): TMessage;
+    readMessageEnd(): void;
+    readStructBegin(): TStruct;
+    readStructEnd(): void;
+    readFieldBegin(): TField;
+    readFieldEnd(): void;
+    readMapBegin(): TMap;
+    readMapEnd(): void;
+    readListBegin(): TList;
+    readListEnd(): void;
+    readSetBegin(): TSet;
+    readSetEnd(): void;
+    readBool(): boolean;
+    readByte(): number;
+    readI16(): number;
+    readI32(): number;
+    readI64(): Int64;
+    readDouble(): number;
+    readBinary(): Buffer;
+    readString(): string;
+    getTransport(): TTransport;
+    skip(type: Thrift.Type): void;
 }
 
 export type TProtocolConstructor =
-    TBinaryProtocolConstructor | TJSONProtocolConstructor | TCompactProtocolConstructor;
-
-export const TBufferedTransport: TBufferedTransportConstructor;
-export const TFramedTransport: TFramedTransportConstructor;
-export const TBinaryProtocol: TBinaryProtocolConstructor;
-export const TJSONProtocol: TJSONProtocolConstructor;
-export const TCompactProtocol: TCompactProtocolConstructor;
+    TBinaryProtocol | TJSONProtocol | TCompactProtocol;
 
 // thrift.js
 export namespace Thrift {

--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -349,8 +349,9 @@ export class TFramedTransport implements TTransport {
     flush(): void;
 }
 
-export type TTransportConstructor =
-    TBufferedTransport | TFramedTransport;
+export interface TTransportConstructor {
+  new (buffer: Buffer | undefined, callback: TTransportCallback): TTransport;
+}
 
 export class TBinaryProtocol implements TProtocol {
     constructor(trans: TTransport, strictRead?: boolean, strictWrite?: boolean);
@@ -496,8 +497,9 @@ export class TCompactProtocol implements TProtocol {
     skip(type: Thrift.Type): void;
 }
 
-export type TProtocolConstructor =
-    TBinaryProtocol | TJSONProtocol | TCompactProtocol;
+export interface TProtocolConstructor {
+    new (trans: TTransport, strictRead?: boolean, strictWrite?: boolean): TProtocol;
+}
 
 // thrift.js
 export namespace Thrift {

--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -310,11 +310,11 @@ export function createServer<TProcessor, THandler>(
 export function createWebServer<TProcessor, THandler>(options: WebServerOptions<TProcessor, THandler>): http.Server | tls.Server;
 
 export interface TBufferedTransportConstructor {
-    new (buffer: Buffer, callback: TTransportCallback): TTransport;
+    new (buffer: Buffer | undefined, callback: TTransportCallback): TTransport;
 }
 
 export interface TFramedTransportConstructor {
-    new (buffer: Buffer, callback: TTransportCallback): TTransport;
+    new (buffer: Buffer | undefined, callback: TTransportCallback): TTransport;
 }
 
 export type TTransportConstructor =

--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -1,42 +1,374 @@
 // Type definitions for thrift 0.10
 // Project: https://www.npmjs.com/package/thrift
 // Definitions by: Kamek <https://github.com/kamek-pf>
+//                 Kevin Greene <https://github.com/kevin-greene-ck>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
-export as namespace Thrift;
+/// <reference types="node" />
 
-export class TException {}
+import * as net from 'net';
+import * as http from 'http';
+import * as tls from 'tls';
 
-/**
- * Protocols and Transports
- */
-export class TBufferedTransport {}
-export class TXHRTransport {}
-export class TJSONProtocol {}
-export class TBinaryProtocol {}
+// Thrift re-exports node-int64 and Q
+import Int64 = require('node-int64');
+export { Int64 as Int64 };
+import Q = require('q');
+export { Q as Q };
 
-/**
- * Server side
- */
-export interface ThriftServer {
-    listen(port: number): any;
+export interface TMap {
+    ktype: Thrift.Type;
+    vtype: Thrift.Type;
+    size: number;
 }
 
-export function createServer(generatedService: any, serviceMethods: any): ThriftServer;
-
-/**
- * Client side
- */
-export type ConnexionEvent = 'open' | 'message' | 'close' | 'error';
-
-export interface ClientConnectionParams {
-    transport: TJSONProtocol | TBinaryProtocol;
-    protocol: TBufferedTransport | TXHRTransport;
+export interface TMessage {
+    fname: string;
+    mtype: Thrift.MessageType;
+    rseqid: number;
 }
 
-export interface ClientConnection {
-    on(event: ConnexionEvent, callback: (...args: any[]) => void): void;
+export interface TField {
+    fname: string;
+    ftype: Thrift.Type;
+    fid: number;
 }
 
-export function createConnection(host: string, port: number, params: ClientConnectionParams): ClientConnection;
-export function createClient(generatedService: any, connection: {}): any;
+export interface TList {
+    etype: Thrift.Type;
+    size: number;
+}
+
+export interface TSet {
+    etype: Thrift.Type;
+    size: number;
+}
+
+export interface TStruct {
+    fname: string;
+}
+
+export interface TTransport {
+    commitPosition(): void;
+    rollbackPosition(): void;
+    isOpen(): boolean;
+    open(): boolean;
+    close(): boolean;
+    setCurrSeqId(seqId: number): void;
+    ensureAvailable(len: number): void;
+    read(len: number): Buffer;
+    readByte(): number;
+    readI16(): number;
+    readI32(): number;
+    readDouble(): number;
+    readString(): string;
+    write(buf: Buffer | string): void;
+    flush(): void;
+}
+
+export interface TProtocol {
+    flush(): void;
+    writeMessageBegin(name: string, type: Thrift.MessageType, seqid: number): void;
+    writeMessageEnd(): void;
+    writeStructBegin(name: string): void;
+    writeStructEnd(): void;
+    writeFieldBegin(name: string, type: Thrift.Type, id: number): void;
+    writeFieldEnd(): void;
+    writeFieldStop(): void;
+    writeMapBegin(ktype: Thrift.Type, vtype: Thrift.Type, size: number): void;
+    writeMapEnd(): void;
+    writeListBegin(etype: Thrift.Type, size: number): void;
+    writeListEnd(): void;
+    writeSetBegin(etype: Thrift.Type, size: number): void;
+    writeSetEnd(): void;
+    writeBool(bool: boolean): void;
+    writeByte(b: number): void;
+    writeI16(i16: number): void;
+    writeI32(i32: number): void;
+    writeI64(i64: number | Int64): void;
+    writeDouble(dbl: number): void;
+    writeString(arg: string | Buffer): void;
+    writeBinary(arg: string | Buffer): void;
+    readMessageBegin(): TMessage;
+    readMessageEnd(): void;
+    readStructBegin(): TStruct;
+    readStructEnd(): void;
+    readFieldBegin(): TField;
+    readFieldEnd(): void;
+    readMapBegin(): TMap;
+    readMapEnd(): void;
+    readListBegin(): TList;
+    readListEnd(): void;
+    readSetBegin(): TSet;
+    readSetEnd(): void;
+    readBool(): boolean;
+    readByte(): number;
+    readI16(): number;
+    readI32(): number;
+    readI64(): Int64;
+    readDouble(): number;
+    readBinary(): Buffer;
+    readString(): string;
+    getTransport(): TTransport;
+    skip(type: Thrift.Type): void;
+}
+
+export interface SeqId2Service {
+    [seqid: number]: string;
+}
+
+export class Connection extends NodeJS.EventEmitter {
+    seqId2Service: SeqId2Service;
+    connection: net.Socket;
+    ssl: boolean;
+    options: ConnectOptions;
+    transport: TTransport;
+    protocol: TProtocol;
+    offline_queue: Buffer[];
+    connected: boolean;
+    constructor(stream: net.Socket, options?: ConnectOptions);
+    end(): void;
+    destroy(): void;
+    initialize_retry_vars(): void;
+    write(data: Buffer): void;
+    connection_gone(): void;
+}
+
+export class HttpConnection extends NodeJS.EventEmitter {
+    options: ConnectOptions;
+    host: string;
+    port: number;
+    https: boolean;
+    transport: TTransport;
+    protocol: TProtocol;
+    constructor(host: string, port: number, options?: ConnectOptions);
+    responseCallback(response: http.IncomingMessage): void;
+    write(data: Buffer): void;
+}
+
+export class XHRConnection extends NodeJS.EventEmitter {
+    seqId2Service: SeqId2Service;
+    options: ConnectOptions;
+    wpos: number;
+    rpos: number;
+    useCORS: boolean;
+    send_buf: string;
+    recv_buf: string;
+    transport: TTransport;
+    protocol: TProtocol;
+    headers: http.OutgoingHttpHeaders;
+    constructor(host: string, port: number, options?: ConnectOptions);
+    getXmlHttpRequestObject(): XMLHttpRequest;
+    flush(): void;
+    setRecvBuffer(buf: string): void;
+    isOpen(): boolean;
+    open(): void;
+    close(): void;
+    read(len: number): string;
+    readAll(): string;
+    write(buf: string): void;
+    getSendBuffer(): string;
+}
+
+export class Multiplexer<TClient> {
+    createClient(serviceName: string, client: TClientConstructor<TClient>, connection: Connection): TClient;
+}
+
+export class MultiplexedProcessor {
+    constructor(stream?: any, options?: any);
+    process(input: TProtocol, output: TProtocol): void;
+}
+
+export type TTransportCallback =
+    (msg?: Buffer, seqid?: number) => void;
+
+export interface ServiceMap<TProcessor, THandler> {
+    [uri: string]: ServerOptions<TProcessor, THandler>;
+}
+
+export interface ServiceOptions<TProcessor, THandler> {
+    transport?: TTransportConstructor;
+    protocol?: TProtocolConstructor;
+    processor?: { new (handler: THandler): TProcessor };
+    handler?: THandler;
+}
+
+export interface ServerOptions<TProcessor, THandler> extends ServiceOptions<TProcessor, THandler> {
+    cors?: string[];
+    files?: string;
+    headers?: http.IncomingHttpHeaders;
+    services?: ServiceMap<TProcessor, THandler>;
+    tls?: tls.TlsOptions;
+}
+
+export interface ConnectOptions {
+    transport?: TTransportConstructor;
+    protocol?: TProtocolConstructor;
+    path?: string;
+    headers?: http.OutgoingHttpHeaders;
+    https?: boolean;
+    debug?: boolean;
+    max_attempts?: number;
+    retry_max_delay?: number;
+    connect_timeout?: number;
+    timeout?: number;
+    nodeOptions?: http.ClientRequestArgs;
+}
+
+export type TClientConstructor<TClient> =
+    { new (output: TTransport, pClass: { new (trans: TTransport): TProtocol }): TClient; } |
+    { Client: { new (output: TTransport, pClass: { new (trans: TTransport): TProtocol }): TClient; } };
+
+export type TProcessorConstructor<TProcessor, THandler> =
+    { new (handler: THandler): TProcessor } |
+    { Processor: { new (handler: THandler): TProcessor }};
+
+export interface WebServerOptions<TProcessor, THandler> {
+    services: {
+        [path: string]: {
+            processor: TProcessorConstructor<TProcessor, THandler>;
+            handler: THandler;
+        }
+    };
+}
+
+export function createConnection(host: string | undefined, port: number, options?: ConnectOptions): Connection;
+export function createSSLConnection(host: string | undefined, port: number, options?: ConnectOptions): Connection;
+export function createHttpConnection(host: string | undefined, port: number, options?: ConnectOptions): HttpConnection;
+export function createXHRConnection(host: string | undefined, port: number, options?: ConnectOptions): XHRConnection;
+
+export function createXHRClient<TClient>(
+    client: TClientConstructor<TClient>,
+    connection: Connection
+): TClient;
+
+export function createClient<TClient>(
+    client: TClientConstructor<TClient>,
+    connection: Connection
+): TClient;
+
+// THandler is going to be a hash of user-defined functions for prcessing RPC calls
+export function createServer<TProcessor, THandler>(
+    processor: TProcessorConstructor<TProcessor, THandler>,
+    handler: THandler,
+    options?: ServerOptions<TProcessor, THandler>
+): http.Server | tls.Server;
+
+// tslint:disable-next-line no-unnecessary-generics
+export function createWebServer<TProcessor, THandler>(options: WebServerOptions<TProcessor, THandler>): http.Server | tls.Server;
+
+export interface TBufferedTransportConstructor {
+    new (buffer: Buffer, callback: TTransportCallback): TTransport;
+}
+
+export interface TFramedTransportConstructor {
+    new (buffer: Buffer, callback: TTransportCallback): TTransport;
+}
+
+export type TTransportConstructor =
+    TBufferedTransportConstructor | TFramedTransportConstructor;
+
+export interface TBinaryProtocolConstructor {
+    new (trans: TTransport, strictRead?: boolean, strictWrite?: boolean): TProtocol;
+}
+
+export interface TJSONProtocolConstructor {
+    new (trans: TTransport): TProtocol;
+}
+
+export interface TCompactProtocolConstructor {
+    new (trans: TTransport): TProtocol;
+}
+
+export type TProtocolConstructor =
+    TBinaryProtocolConstructor | TJSONProtocolConstructor | TCompactProtocolConstructor;
+
+export const TBufferedTransport: TBufferedTransportConstructor;
+export const TFramedTransport: TFramedTransportConstructor;
+export const TBinaryProtocol: TBinaryProtocolConstructor;
+export const TJSONProtocol: TJSONProtocolConstructor;
+export const TCompactProtocol: TCompactProtocolConstructor;
+
+// thrift.js
+export namespace Thrift {
+    enum Type {
+        STOP = 0,
+        VOID = 1,
+        BOOL = 2,
+        BYTE = 3,
+        I08 = 3,
+        DOUBLE = 4,
+        I16 = 6,
+        I32 = 8,
+        I64 = 10,
+        STRING = 11,
+        UTF7 = 11,
+        STRUCT = 12,
+        MAP = 13,
+        SET = 14,
+        LIST = 15,
+        UTF8 = 16,
+        UTF16 = 17
+    }
+
+    enum MessageType {
+        CALL = 1,
+        REPLY = 2,
+        EXCEPTION = 3,
+        ONEWAY = 4
+    }
+
+    class TException extends Error {
+        name: string;
+        message: string;
+
+        constructor(message: string);
+
+        getMessage(): string;
+    }
+
+    enum TApplicationExceptionType {
+        UNKNOWN = 0,
+        UNKNOWN_METHOD = 1,
+        INVALID_MESSAGE_TYPE = 2,
+        WRONG_METHOD_NAME = 3,
+        BAD_SEQUENCE_ID = 4,
+        MISSING_RESULT = 5,
+        INTERNAL_ERROR = 6,
+        PROTOCOL_ERROR = 7,
+        INVALID_TRANSFORM = 8,
+        INVALID_PROTOCOL = 9,
+        UNSUPPORTED_CLIENT_TYPE = 10
+    }
+
+    class TApplicationException extends TException {
+        message: string;
+        code: number;
+
+        constructor(type?: TApplicationExceptionType, message?: string);
+        read(input: TProtocol): void;
+        write(output: TProtocol): void;
+        getCode(): number;
+    }
+
+    enum TProtocolExceptionType {
+        UNKNOWN = 0,
+        INVALID_DATA = 1,
+        NEGATIVE_SIZE = 2,
+        SIZE_LIMIT = 3,
+        BAD_VERSION = 4,
+        NOT_IMPLEMENTED = 5,
+        DEPTH_LIMIT = 6
+    }
+
+    class TProtocolException implements Error {
+        name: string;
+        message: string;
+        type: TProtocolExceptionType;
+
+        constructor(type: TProtocolExceptionType, message: string);
+    }
+
+    function objectLength(obj: any): number;
+}

--- a/types/thrift/thrift-tests.ts
+++ b/types/thrift/thrift-tests.ts
@@ -42,7 +42,10 @@ const mockGeneratedService = {
 
 createServer<MockProcessor, MockServiceHandlers>(mockGeneratedService, mockServiceHandlers);
 
-const clientConnection = createConnection('0.0.0.0', 1234);
+const clientConnection = createConnection('0.0.0.0', 1234, {
+  transport: TBufferedTransport,
+  protocol: TBinaryProtocol
+});
 createClient<MockClient>(mockGeneratedService, clientConnection);
 
 const mockBuffer: Buffer = Buffer.alloc(8);

--- a/types/thrift/thrift-tests.ts
+++ b/types/thrift/thrift-tests.ts
@@ -1,10 +1,125 @@
-import * as Thrift from 'thrift';
+import {
+  createConnection,
+  createServer,
+  createClient,
+  Thrift,
+  TBinaryProtocol,
+  TBufferedTransport,
+  TProtocol,
+  TTransport,
+  TTransportCallback,
+  Int64,
+  TMessage,
+  TStruct,
+  TField,
+  TSet,
+  TList,
+  TMap,
+} from 'thrift';
 
-const fakeGeneratedService: any = {};
-const fakeServiceMethods: any = {};
-const fakeConnectionParams: any = {};
+interface MockServiceHandlers {
+  ping(): string;
+}
 
-Thrift.createServer(fakeGeneratedService, fakeServiceMethods);
+class MockProcessor {
+  constructor() {}
+}
 
-const clientConnection = Thrift.createConnection('0.0.0.0', 1234, fakeConnectionParams);
-Thrift.createClient(fakeGeneratedService, clientConnection);
+class MockClient {
+  constructor() {}
+}
+
+const mockServiceHandlers: MockServiceHandlers = {
+  ping(): string {
+    return 'ok';
+  }
+};
+
+const mockGeneratedService = {
+  Client: MockClient,
+  Processor: MockProcessor
+};
+
+createServer<MockProcessor, MockServiceHandlers>(mockGeneratedService, mockServiceHandlers);
+
+const clientConnection = createConnection('0.0.0.0', 1234);
+createClient<MockClient>(mockGeneratedService, clientConnection);
+
+const mockBuffer: Buffer = Buffer.alloc(8);
+
+const mockCallback: TTransportCallback = (msg: Buffer, seq: number): void => {};
+
+const mockTransport: TTransport = new TBufferedTransport(mockBuffer, mockCallback);
+
+const mockProtocol: TProtocol = new TBinaryProtocol(mockTransport);
+
+// Test utility types
+const len: number = Thrift.objectLength({});
+
+// Test transport types
+const pI16: number = mockTransport.readI16();
+const pI32: number = mockTransport.readI32();
+const pDouble: number = mockTransport.readDouble();
+const pByte: number = mockTransport.readByte();
+const pString: string = mockTransport.readString();
+const isOpen: boolean = mockTransport.isOpen();
+const open: boolean = mockTransport.open();
+const close: boolean = mockTransport.close();
+
+mockTransport.write(mockBuffer);
+mockTransport.write('test');
+mockTransport.flush();
+mockTransport.setCurrSeqId(1);
+mockTransport.ensureAvailable(10);
+mockTransport.commitPosition();
+mockTransport.rollbackPosition();
+
+// Test protocol types
+mockProtocol.flush();
+mockProtocol.writeMessageBegin('test', Thrift.MessageType.CALL, 1);
+mockProtocol.writeMessageEnd();
+mockProtocol.writeStructBegin('test');
+mockProtocol.writeStructEnd();
+mockProtocol.writeFieldBegin('test', Thrift.Type.BOOL, 1);
+mockProtocol.writeFieldEnd();
+mockProtocol.writeFieldStop();
+mockProtocol.writeMapBegin(Thrift.Type.STRING, Thrift.Type.I64, 1);
+mockProtocol.writeMapEnd();
+mockProtocol.writeListBegin(Thrift.Type.STRING, 10);
+mockProtocol.writeListEnd();
+mockProtocol.writeSetBegin(Thrift.Type.I32, 10);
+mockProtocol.writeSetEnd();
+mockProtocol.writeBool(true);
+mockProtocol.writeByte(1);
+mockProtocol.writeI16(16);
+mockProtocol.writeI32(32);
+mockProtocol.writeI64(64);
+mockProtocol.writeI64(new Int64('0xff'));
+mockProtocol.writeDouble(42);
+mockProtocol.writeString('test');
+mockProtocol.writeString(new Buffer('test'));
+mockProtocol.writeBinary('test');
+mockProtocol.writeBinary(new Buffer('test'));
+
+const message: TMessage = mockProtocol.readMessageBegin();
+mockProtocol.readMessageEnd();
+const struct: TStruct = mockProtocol.readStructBegin();
+mockProtocol.readStructEnd();
+const field: TField = mockProtocol.readFieldBegin();
+mockProtocol.readFieldEnd();
+const map: TMap = mockProtocol.readMapBegin();
+mockProtocol.readMapEnd();
+const list: TList = mockProtocol.readListBegin();
+mockProtocol.readListEnd();
+const set: TSet = mockProtocol.readSetBegin();
+mockProtocol.readSetEnd();
+const bool: boolean = mockProtocol.readBool();
+const byte: number = mockProtocol.readByte();
+const tI16: number = mockProtocol.readI16();
+const tI32: number = mockProtocol.readI32();
+const tI64: Int64 = mockProtocol.readI64();
+const tDouble: number = mockProtocol.readDouble();
+const tBinary: Buffer = mockProtocol.readBinary();
+const tString: string = mockProtocol.readString();
+const tTrans: TTransport = mockProtocol.getTransport();
+mockProtocol.skip(Thrift.Type.STRUCT);

--- a/types/thrift/tsconfig.json
+++ b/types/thrift/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
  * The defined types for thrift were very bare
  * This adds all of the missing public exports from "thrift"
  * Correct error in evernote using import * as Thrift from 'thrift'. This should be
    import { Thrift } from 'thrift'. They were using Thrift.TException which is not
    exported from the top level of 'thrift'. It is nested in the Thrift namespace.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apache/thrift/blob/master/lib/nodejs/lib/thrift/index.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
