### PR TITLE
[jest] Added 'stringContaining' property to 'Expect' interface

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -326,7 +326,11 @@ declare namespace jest {
         /**
          * Matches any string that contains the exact provided string
          */
-        stringMatching(str: string | RegExp): any;
+        stringContaining(str: string): any;
+        /**
+         * Matches any string that matches the provided regular expression
+         */
+        stringMatching(str: RegExp): any;
     }
 
     interface Matchers<R> {

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -328,9 +328,9 @@ declare namespace jest {
          */
         stringContaining(str: string): any;
         /**
-         * Matches any string that matches the provided regular expression
+         * Matches any string that matches the provided string or regular expression
          */
-        stringMatching(str: RegExp): any;
+        stringMatching(str: string | RegExp): any;
     }
 
     interface Matchers<R> {

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -199,10 +199,12 @@ describe('Assymetric matchers', () => {
     it('works', () => {
         expect({
             timestamp: 1480807810388,
-            text: 'Some text content, but we care only about *this part*'
+            regex: 'Some text content, but we care only about *this part*',
+            string: 'Some text content, but we care only about *this part*'
         }).toEqual({
             timestamp: expect.any(Number),
-            text: expect.stringMatching('*this part*')
+            regex: expect.stringMatching(/\*this part\*/),
+            string: expect.stringContaining('*this part*')
         });
 
         const callback = jest.fn();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 [Jest repo](https://github.com/facebook/jest/blob/77744a24816d0978b6c478987426c36d615864bd/packages/expect/src/asymmetric_matchers.js#L184)
[Jest documentation](https://facebook.github.io/jest/docs/en/expect.html#expectstringcontainingstring)
