### PR TITLE
React. Partial state support for setState method

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -278,7 +278,7 @@ declare namespace React {
         // Disabling unified-signatures to have separate overloads. It's easier to understand this way.
         // tslint:disable:unified-signatures
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
-        setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
+        setState<S>(state: Partial<S>, callback?: () => any): void;
         // tslint:enable:unified-signatures
 
         forceUpdate(callBack?: () => any): void;

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -285,7 +285,7 @@ declare namespace React {
         // Disabling unified-signatures to have separate overloads. It's easier to understand this way.
         // tslint:disable:unified-signatures
         setState<K extends keyof S>(f: (prevState: S, props: P) => Pick<S, K>, callback?: () => any): void;
-        setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
+        setState<S>(state: Partial<S>, callback?: () => any): void;
         // tslint:enable:unified-signatures
 
         forceUpdate(callBack?: () => any): void;


### PR DESCRIPTION
React allows passing of partial states.
With current definitions, it's hard to use strict null checks and there are many limitations for setState usage.
For backward compatibility, I'm leaving both old and new definitions as there is no way to convert  Partial<S> to Pick<S>.

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ x ] Increase the version number in the header if appropriate. The same version.
- [ x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


