### PR TITLE
Meteor: Fix bug from different definition of ObjectID from previous PR

### DIFF
--- a/types/meteor/mongo.d.ts
+++ b/types/meteor/mongo.d.ts
@@ -103,7 +103,10 @@ declare module Mongo {
     interface ObjectIDStatic {
         new (hexString?: string): ObjectID;
     }
-    interface ObjectID { }
+    interface ObjectID {
+        toHexString(): string;
+        equals(otherID: ObjectID): boolean;
+    }
 
     function setConnectionOptions(options: any): void;
 }


### PR DESCRIPTION
PR #19475 add two methods to one definition of ObjectID. However, there're two definitions of ObjectID in mongo.d.ts, so that PR introduce error for some. This PR fix that by updating the other definition of ObjectID.

@barbatus @fullflavedave @birkskyum @ardatan @stefanholzapfel
@kombadzomba