### PR TITLE
ramda: fix prop function definition

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1438,7 +1438,7 @@ declare namespace R {
          * Note: TS1.9 # replace any by dictionary
          */
         prop<T>(p: string, obj: any): T;
-        prop<T>(p: string): <T>(obj: any) => T;
+        prop<T>(p: string): (obj: any) => T;
 
         /**
          * Determines whether the given property of an object has a specific


### PR DESCRIPTION
```js
const foo = R.prop<number>('foo')({ foo: 4 });
```

Before change the `foo` is of type `{}`, after change the `foo` is of type `number` (as it should be).


