### PR TITLE
[superagent] Improving the typing of the #field method

### DIFF
--- a/types/superagent/index.d.ts
+++ b/types/superagent/index.d.ts
@@ -16,6 +16,10 @@ type CallbackHandler = (err: any, res: request.Response) => void;
 
 type Serializer = (obj: any) => string;
 
+type MultipartValueSingle = Blob | Buffer | fs.ReadStream | string | boolean | number;
+
+type MultipartValue = MultipartValueSingle | MultipartValueSingle[];
+
 declare const request: request.SuperAgentStatic;
 
 declare namespace request {
@@ -103,14 +107,15 @@ declare namespace request {
     interface Request extends Promise<Response> {
         abort(): void;
         accept(type: string): this;
-        attach(field: string, file: Blob | Buffer | fs.ReadStream | string, filename?: string): this;
+        attach(field: string, file: MultipartValueSingle, options?: string | { filename?: string; contentType?: string }): this;
         auth(user: string, name: string): this;
         buffer(val?: boolean): this;
         ca(cert: Buffer): this;
         cert(cert: Buffer | string): this;
         clearTimeout(): this;
         end(callback?: CallbackHandler): this;
-        field(name: string, val: string): this;
+        field(name: string, val: MultipartValue): this;
+        field(fields: { [fieldName: string]: MultipartValue }): this;
         get(field: string): string;
         key(cert: Buffer | string): this;
         ok(callback: (res: Response) => boolean): this;

--- a/types/superagent/superagent-tests.ts
+++ b/types/superagent/superagent-tests.ts
@@ -285,6 +285,7 @@ request
     .attach('avatar', 'path/to/tobi.png', 'user.png')
     .attach('image', 'path/to/loki.png')
     .attach('file', 'path/to/jane.png')
+    .attach('fileWithOptions', 'path/to/file.png', { filename: 'filename', contentType: 'contentType' })
     .attach('blob', blob)
     .end(callback);
 
@@ -293,6 +294,12 @@ request
     .post('/upload')
     .field('user[name]', 'Tobi')
     .field('user[email]', 'tobi@learnboost.com')
+    .field({
+        field1: 'value1',
+        field2: Buffer.from([ 10, 20 ]),
+        field3: [ 'value1', 'value2' ],
+        field4: true,
+    })
     .attach('image', 'path/to/tobi.png')
     .end(callback);
 


### PR DESCRIPTION
There are two major changes here:

1) The value of a field no longer needs to be a string. It also
accepts arrays, buffers, blobs, and streams.

2) You may pass in an object, which sets all of the field values,
instead of calling once for each field.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
