### PR TITLE
Added typings for redux-first-router-link

### DIFF
--- a/types/redux-first-router-link/index.d.ts
+++ b/types/redux-first-router-link/index.d.ts
@@ -1,0 +1,56 @@
+// Type definitions for redux-first-router-link 1.4
+// Project: https://github.com/faceyspacey/redux-first-router-link#readme
+// Definitions by: janb87 <https://github.com/janb87>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import * as React from "react";
+import { Location } from 'redux-first-router';
+
+export type To = string | string[] | object;
+
+export type OnClick = false | ((e: React.SyntheticEvent<HTMLElement>) => boolean | undefined);
+
+export interface Match<P> {
+    params: P;
+    isExact: boolean;
+    path: string;
+    url: string;
+}
+
+export interface LinkProps {
+    to: To;
+    redirect?: boolean;
+    replace?: boolean;
+    tagName?: string;
+    children?: React.ReactNode;
+    onPress?: OnClick;
+    onClick?: OnClick;
+    down?: boolean;
+    shouldDispatch?: boolean;
+    target?: string;
+}
+
+export default class Link extends React.Component<LinkProps> {}
+
+export interface NavLinkProps {
+    to: To;
+    redirect?: boolean;
+    replace?: boolean;
+    children?: React.ReactNode;
+    onPress?: OnClick;
+    onClick?: OnClick;
+    down?: boolean;
+    shouldDispatch?: boolean;
+    target?: string;
+    className?: string;
+    style?: React.CSSProperties;
+    activeClassName?: string;
+    activeStyle?: React.CSSProperties;
+    ariaCurrent?: string;
+    exact?: boolean;
+    strict?: boolean;
+    isActive?(match: Match<object>, location: Location): boolean;
+}
+
+export class NavLink extends React.Component<NavLinkProps> {}

--- a/types/redux-first-router-link/redux-first-router-link-tests.tsx
+++ b/types/redux-first-router-link/redux-first-router-link-tests.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import Link, { NavLink } from "redux-first-router-link";
+
+interface Payload {
+    category: string;
+}
+
+export default () => {
+    return (
+        <div>
+            { /* as a standard href path string: */ }
+            <Link to='/list/db-graphql'>DB & GRAPHQL</Link>
+
+            { /* as an array of path segments: */ }
+            <Link to={['list', 'react-redux']}>REACT & REDUX</Link>
+
+            { /* as an action object (RECOMMENDED APPROACH SO YOU CAN CHANGE ALL URLs FROM YOUR ROUTESMAP): */ }
+            <Link to={{type: 'LIST', payload: { category: 'fp' }}}>FP</Link>
+
+            <NavLink
+                to={{ type: 'LIST', payload: { category: 'redux-first-router' } }}
+                activeClassName='active'
+                activeStyle={{ color: 'purple' }}
+                exact={true}
+                strict={true}
+                isActive={(match, location) => (location.payload as Payload).category === 'redux-first-router'} >
+                Redux First Router
+            </NavLink>
+        </div>
+    );
+};

--- a/types/redux-first-router-link/tsconfig.json
+++ b/types/redux-first-router-link/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "redux-first-router-link-tests.tsx"
+    ]
+}

--- a/types/redux-first-router-link/tslint.json
+++ b/types/redux-first-router-link/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
