### PR TITLE
@types/nano Cookie property is missing in nano.Configuration interface

### DIFF
--- a/types/nano/index.d.ts
+++ b/types/nano/index.d.ts
@@ -16,6 +16,7 @@ declare function nano(
 declare namespace nano {
   interface Configuration {
     url: string;
+    cookie?: string;
     requestDefaults?: CoreOptions;
     log?(id: string, args: any): void;
     parseUrl?: boolean;

--- a/types/nano/nano-tests.ts
+++ b/types/nano/nano-tests.ts
@@ -6,6 +6,7 @@ import * as nano from "nano";
  */
 const config: nano.Configuration = {
   url: "http://localhost:5984/foo",
+  cookie: "someAuthSession",
   requestDefaults: { proxy: "http://someproxy" }
 };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apache/couchdb-nano#using-cookie-authentication

Hi there =)

There is a little issue when trying to use session; the actual definitions prevent us to add a "cookie" property which is needed to get user session.
I just added the property in index.d.ts + nano-tests.ts

The docs: https://github.com/apache/couchdb-nano#using-cookie-authentication