### PR TITLE
[auth0-js] Make options optional in WebAuth.authorize

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -187,7 +187,7 @@ export class WebAuth {
      *
      * @param {AuthorizeOptions} options: https://auth0.com/docs/api/authentication#!#get--authorize_db
      */
-    authorize(options: AuthorizeOptions): void;
+    authorize(options?: AuthorizeOptions): void;
 
     /**
      * Parse the url hash and extract the returned tokens depending on the transaction.


### PR DESCRIPTION
Since everything in `AuthorizeOptions` is optional and in the docs they are using authorize from `WebAuth` without any options, it should be possible to leave them out.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.com/docs/quickstart/spa/vanillajs
