### PR TITLE
[react-tracking] Update for v5 and use Pick over Partial.

### DIFF
--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-tracking 4.2
+// Type definitions for react-tracking 5.0
 // Project: https://github.com/NYTimes/react-tracking
 // Definitions by: Eloy Durán <https://github.com/alloy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -50,7 +50,7 @@ interface Options<T> {
     process?(ownTrackingData: T): T | Falsy;
 }
 
-export type TrackingInfo<T, P> = T | ((props: P) => T);
+export type TrackingInfo<T, P, S> = T | ((props: P, state: S) => T);
 
 // Duplicated from ES6 lib to remove the `void` typing, otherwise `track` can’t be used as a HOC function that passes
 // through a JSX component that be used without casting.
@@ -64,8 +64,8 @@ type Decorator = ClassDecorator & MethodDecorator;
  *
  * For examples of such extensions see: https://github.com/artsy/reaction/blob/master/src/utils/track.ts
  */
-export interface Track<T = any, P = any> {
-    (trackingInfo?: TrackingInfo<Partial<T>, P>, options?: Options<Partial<T>>): Decorator;
+export interface Track<T = any, P = any, S = any> {
+    <K extends keyof T>(trackingInfo?: TrackingInfo<Pick<T, K>, P, S>, options?: Options<Partial<T>>): Decorator;
 }
 
 export const track: Track;

--- a/types/react-tracking/test/react-tracking-with-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-with-types-tests.tsx
@@ -8,25 +8,29 @@ interface Props {
     tracking?: TrackingProp;
 }
 
+interface State {
+    isClicked: boolean;
+}
+
 interface TrackingData {
     page: string;
     event: string;
 }
 
-const track: Track<TrackingData, Props> = _track;
+const track: Track<TrackingData, Props, State> = _track;
 
 @track({ page: "ClassPage" }, {
     dispatch: customEventReporter,
     dispatchOnMount: contextData => ({ event: "pageDataReady" }),
     process: ownTrackingData => ownTrackingData.page ? { event: 'pageview' } : null,
 })
-class ClassPage extends React.Component<Props> {
+class ClassPage extends React.Component<Props, State> {
     @track({ event: "Clicked" })
     handleClick() {
     // ... other stuff
     }
 
-    @track(props => ({ event: `got ${props.someProp}` }))
+    @track((props, state) => ({ event: `got ${props.someProp} and clicked ${state.isClicked}` }))
     render() {
         return (
             <button onClick={this.handleClick}>

--- a/types/react-tracking/test/react-tracking-without-types-tests.tsx
+++ b/types/react-tracking/test/react-tracking-without-types-tests.tsx
@@ -15,7 +15,7 @@ class ClassPage extends React.Component<any> {
     }
 
     // Only need to cast this to `any` because the settings for this project is to disallow implicit `any`.
-    @track((props: any) => ({ event: `got ${props.someProp}` }))
+    @track((props: any, state: any) => ({ event: `got ${props.someProp} and clicked ${state.isClicked}` }))
     render() {
         return (
             <button onClick={this.handleClick}>

--- a/types/react-tracking/tslint.json
+++ b/types/react-tracking/tslint.json
@@ -2,6 +2,7 @@
     "extends": "dtslint/dt.json",
     "rules": {
         "ban-types": false,
-        "callable-types": false
+        "callable-types": false,
+        "no-unnecessary-generics": false
     }
 }


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NYTimes/react-tracking/pull/45
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
