### PR TITLE
Enzyme getElement and getElements

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -206,6 +206,14 @@ function ShallowWrapperTest() {
         reactElements = shallowWrapper.getNodes();
     }
 
+    function test_getElement() {
+        reactElement = shallowWrapper.getElement();
+    }
+
+    function test_getElements() {
+        reactElements = shallowWrapper.getElements();
+    }
+
     function test_getDOMNode() {
         domElement = shallowWrapper.getDOMNode();
     }
@@ -543,6 +551,14 @@ function ReactWrapperTest() {
 
     function test_getNodes() {
         reactElements = reactWrapper.getNodes();
+    }
+
+    function test_getElement() {
+        reactElement = reactWrapper.getElement();
+    }
+
+    function test_getElements() {
+        reactElements = reactWrapper.getElements();
     }
 
     function test_getDOMNode() {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -149,6 +149,16 @@ export interface CommonWrapper<P = {}, S = {}> {
     getNodes(): Array<ReactElement<any>>;
 
     /**
+     * Returns the wrapper's underlying node.
+     */
+    getElement(): ReactElement<any>;
+
+    /**
+     * Returns the wrapper's underlying node.
+     */
+    getElements(): Array<ReactElement<any>>;
+
+    /**
      * Returns the outer most DOMComponent of the current wrapper.
      */
     getDOMNode(): Element;


### PR DESCRIPTION
When trying to update to Enzyme 3, my tests started failing since `getNode` [is no longer supported](https://github.com/airbnb/enzyme/blob/master/packages/enzyme/src/ShallowWrapper.js#L195-L197). `getElement` and `getElements` now replaces those, but are not in the type definition.

This PR adds the type definition for `getElement` and `getElements`.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/enzyme/blob/master/packages/enzyme/src/ShallowWrapper.js#L170-L209
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
