### PR TITLE
Add `react-treeview` type definitions

### DIFF
--- a/types/react-treeview/index.d.ts
+++ b/types/react-treeview/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for react-treeview 0.4
+// Project: https://github.com/chenglou/react-treeview
+// Definitions by: Jay Anslow <https://github.com/janslow>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Component, HTMLAttributes } from 'react';
+
+declare namespace TreeView {
+  interface TreeProps extends HTMLAttributes<HTMLDivElement> {
+    collapsed?: boolean;
+    defaultCollapsed?: boolean;
+    nodeLabel: React.ReactNode;
+    itemClassName?: string;
+    treeViewClassName?: string;
+    childrenClassName?: string;
+  }
+}
+
+declare class TreeView extends Component<TreeView.TreeProps, any> {
+}
+
+export = TreeView;

--- a/types/react-treeview/react-treeview-tests.tsx
+++ b/types/react-treeview/react-treeview-tests.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import TreeView = require("react-treeview");
+
+const label = <div>A label</div>;
+
+const elem1: JSX.Element = <TreeView key='1' nodeLabel={label} collapsed={false} onClick={() => undefined}>
+    <div>Entry</div>
+    <TreeView nodeLabel={label} itemClassName='item' treeViewClassName='tree' childrenClassName='children'>
+        <div>Nested Entry</div>
+    </TreeView>
+</TreeView>;

--- a/types/react-treeview/tsconfig.json
+++ b/types/react-treeview/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-treeview-tests.tsx"
+    ]
+}

--- a/types/react-treeview/tslint.json
+++ b/types/react-treeview/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
  - No response from author (https://github.com/chenglou/react-treeview/pull/54)
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
