### PR TITLE
Fix the parameter list of method `blend`, in package chroma-js

### DIFF
--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -109,7 +109,7 @@ declare namespace chroma {
          * Blends two colors using RGB channel-wise blend functions.
          */
         blend(color1: string | Color, color2: string | Color,
-              blendMode: 'multiply' | 'darken' | 'lighten' | 'screen' | 'overlay' | 'burn' | 'dogde'): Color;
+              blendMode: 'multiply' | 'darken' | 'lighten' | 'screen' | 'overlay' | 'burn' | 'dodge'): Color;
 
         /**
          * Returns a random color.


### PR DESCRIPTION
The last blend mode should be `dodge`, otherwise it will throw ``unknown blend mode dogde''. According to <https://en.wikipedia.org/wiki/Blend_modes#Dodge_and_burn>.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/yankaifyyy/DefinitelyTyped/blob/2370b455d317b9e28a37a4b10c3c60b82a0f6b65/types/chroma-js/index.d.ts#L112>>
- [ ] Increase the version number in the header if appropriate. **No need to update the version number.**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.