### PR TITLE
Add type definitions for webpack-node-externals

### DIFF
--- a/types/webpack-node-externals/index.d.ts
+++ b/types/webpack-node-externals/index.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for webpack-node-externals 1.6
+// Project: https://github.com/liady/webpack-node-externals
+// Definitions by: Matt Traynham <https://github.com/mtraynham>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import webpack = require('webpack');
+
+export = webpackNodeExternals;
+
+declare function webpackNodeExternals(options?: webpackNodeExternals.Options): webpack.ExternalsFunctionElement;
+
+declare namespace webpackNodeExternals {
+    type WhitelistOption = string | RegExp;
+
+    interface Options {
+        /**
+         * An array for the externals to whitelist, so they will be included in the bundle.
+         * Can accept exact strings ('module_name'), regex patterns (/^module_name/), or a
+         * function that accepts the module name and returns whether it should be included.
+         * Important - if you have set aliases in your webpack config with the exact
+         * same names as modules in node_modules, you need to whitelist them so Webpack will know
+         * they should be bundled.
+         * @default []
+         */
+        whitelist?: WhitelistOption[];
+        /**
+         * @default ['.bin']
+         */
+        binaryDirs?: string[];
+        /**
+         * The method in which unbundled modules will be required in the code. Best to leave as
+         * 'commonjs' for node modules.
+         * @default 'commonjs'
+         */
+        importType?: 'var' | 'this' | 'commonjs' | 'amd' | 'umd';
+        /**
+         * The folder in which to search for the node modules.
+         * @default 'node_modules'
+         */
+        modulesDir?: string;
+        /**
+         * Read the modules from the package.json file instead of the node_modules folder.
+         * @default false
+         */
+        modulesFromFile?: boolean;
+        /**
+         * @default false
+         */
+        includeAbsolutePaths?: boolean;
+    }
+}

--- a/types/webpack-node-externals/tsconfig.json
+++ b/types/webpack-node-externals/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-node-externals-tests.ts"
+    ]
+}

--- a/types/webpack-node-externals/tslint.json
+++ b/types/webpack-node-externals/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-node-externals/webpack-node-externals-tests.ts
+++ b/types/webpack-node-externals/webpack-node-externals-tests.ts
@@ -1,0 +1,21 @@
+import webpack = require('webpack');
+import webpackNodeExternals = require('webpack-node-externals');
+
+const a: webpack.Configuration = {
+    entry: 'test.js',
+    externals: [
+        webpackNodeExternals()
+    ]
+};
+const b: webpack.Configuration = {
+    entry: 'test.js',
+    externals: webpackNodeExternals()
+};
+const c: webpack.Configuration = {
+    entry: 'test.js',
+    externals: [
+        webpackNodeExternals({
+            whitelist: ['jquery', 'webpack/hot/dev-server', /^lodash/]
+        })
+    ]
+};


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
