### PR TITLE
Puppeteer: fixing .cookies() method type and other cleanup

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -38,29 +38,29 @@ export interface Dialog {
   defaultValue(): string;
   dismiss(): Promise<void>;
   message(): string;
-  type: 'alert' | 'beforeunload' | 'confirm' | 'prompt';
+  type: "alert" | "beforeunload" | "confirm" | "prompt";
 }
 
 export type PageEvents =
-  | 'console'
-  | 'dialog'
-  | 'error'
-  | 'frameattached'
-  | 'framedetached'
-  | 'framenavigated'
-  | 'load'
-  | 'pageerror'
-  | 'request'
-  | 'requestfailed'
-  | 'requestfinished'
-  | 'response';
+  | "console"
+  | "dialog"
+  | "error"
+  | "frameattached"
+  | "framedetached"
+  | "framenavigated"
+  | "load"
+  | "pageerror"
+  | "request"
+  | "requestfailed"
+  | "requestfinished"
+  | "response";
 
 export interface AuthOptions {
   username: string;
   password: string;
 }
 
-export type MouseButtons = 'left' | 'right' | 'middle';
+export type MouseButtons = "left" | "right" | "middle";
 
 export interface ClickOptions {
   /** defaults to left */
@@ -82,7 +82,7 @@ export interface Cookie {
   expires: number;
   httpOnly: boolean;
   secure: boolean;
-  sameSite: 'Strict' | 'Lax';
+  sameSite: "Strict" | "Lax";
 }
 
 export interface Viewport {
@@ -103,22 +103,22 @@ export type EvaluateFn<T> = (elem?: ElementHandle) => Promise<T>;
 
 export interface NavigationOptions {
   timeout?: number;
-  waitUntil?: 'load' | 'networkidle' | 'networkIdleTimeout';
+  waitUntil?: "load" | "networkidle" | "networkIdleTimeout";
   networkIdleInflight?: number;
   networkIdleTimeout?: number;
 }
 
 export type PDFFormat =
-  | 'Letter'
-  | 'Legal'
-  | 'Tabload'
-  | 'Ledger'
-  | 'A0'
-  | 'A1'
-  | 'A2'
-  | 'A3'
-  | 'A4'
-  | 'A5';
+  | "Letter"
+  | "Legal"
+  | "Tabload"
+  | "Ledger"
+  | "A0"
+  | "A1"
+  | "A2"
+  | "A3"
+  | "A4"
+  | "A5";
 
 export interface PDFOptions {
   /** If no path is provided, the PDF won't be saved to the disk. */
@@ -145,7 +145,7 @@ export interface PDFOptions {
 
 export interface ScreenshotOptions {
   path?: string;
-  type?: 'jpeg' | 'png';
+  type?: "jpeg" | "png";
   /** The quality of the image, between 0-100. Not applicable to png images. */
   quality?: number;
   fullPage?: boolean;
@@ -159,7 +159,7 @@ export interface ScreenshotOptions {
 }
 
 export interface PageFnOptions {
-  polling?: 'raf' | 'mutation' | number;
+  polling?: "raf" | "mutation" | number;
   timeout?: number;
 }
 
@@ -173,27 +173,27 @@ export interface ElementHandle {
 
 export type Headers = Record<string, string>;
 export type HttpMethod =
-  | 'GET'
-  | 'POST'
-  | 'PATCH'
-  | 'PUT'
-  | 'DELETE'
-  | 'OPTIONS';
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE"
+  | "OPTIONS";
 
 export type ResourceType =
-  | 'Document'
-  | 'Stylesheet'
-  | 'Image'
-  | 'Media'
-  | 'Font'
-  | 'Script'
-  | 'TextTrack'
-  | 'XHR'
-  | 'Fetch'
-  | 'EventSource'
-  | 'WebSocket'
-  | 'Manifest'
-  | 'Other';
+  | "Document"
+  | "Stylesheet"
+  | "Image"
+  | "Media"
+  | "Font"
+  | "Script"
+  | "TextTrack"
+  | "XHR"
+  | "Fetch"
+  | "EventSource"
+  | "WebSocket"
+  | "Manifest"
+  | "Other";
 
 export interface Overrides {
   url?: string;
@@ -284,7 +284,7 @@ export interface EventObj {
 }
 
 export interface Page extends FrameBase {
-  on(event: 'console', handler: (...args: any[]) => void): void;
+  on(event: "console", handler: (...args: any[]) => void): void;
   on<K extends keyof EventObj>(
     event: K,
     handler: (e: EventObj[K], ...args: any[]) => void
@@ -311,7 +311,7 @@ export interface Page extends FrameBase {
   ): Promise<void>;
 
   // Argument `fn` can be an arbitrary function
-  exposeFunction(name: string, fn: Function): Promise<void>;
+  exposeFunction(name: string, fn: any): Promise<void>;
 
   focus(selector: string): Promise<void>;
   frames(): Frame[];

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -38,29 +38,29 @@ export interface Dialog {
   defaultValue(): string;
   dismiss(): Promise<void>;
   message(): string;
-  type: "alert" | "beforeunload" | "confirm" | "prompt";
+  type: 'alert' | 'beforeunload' | 'confirm' | 'prompt';
 }
 
 export type PageEvents =
-  | "console"
-  | "dialog"
-  | "error"
-  | "frameattached"
-  | "framedetached"
-  | "framenavigated"
-  | "load"
-  | "pageerror"
-  | "request"
-  | "requestfailed"
-  | "requestfinished"
-  | "response";
+  | 'console'
+  | 'dialog'
+  | 'error'
+  | 'frameattached'
+  | 'framedetached'
+  | 'framenavigated'
+  | 'load'
+  | 'pageerror'
+  | 'request'
+  | 'requestfailed'
+  | 'requestfinished'
+  | 'response';
 
 export interface AuthOptions {
   username: string;
   password: string;
 }
 
-export type MouseButtons = "left" | "right" | "middle";
+export type MouseButtons = 'left' | 'right' | 'middle';
 
 export interface ClickOptions {
   /** defaults to left */
@@ -82,7 +82,7 @@ export interface Cookie {
   expires: number;
   httpOnly: boolean;
   secure: boolean;
-  sameSite: "Strict" | "Lax";
+  sameSite: 'Strict' | 'Lax';
 }
 
 export interface Viewport {
@@ -103,22 +103,22 @@ export type EvaluateFn<T> = (elem?: ElementHandle) => Promise<T>;
 
 export interface NavigationOptions {
   timeout?: number;
-  waitUntil?: "load" | "networkidle" | "networkIdleTimeout";
+  waitUntil?: 'load' | 'networkidle' | 'networkIdleTimeout';
   networkIdleInflight?: number;
   networkIdleTimeout?: number;
 }
 
 export type PDFFormat =
-  | "Letter"
-  | "Legal"
-  | "Tabload"
-  | "Ledger"
-  | "A0"
-  | "A1"
-  | "A2"
-  | "A3"
-  | "A4"
-  | "A5";
+  | 'Letter'
+  | 'Legal'
+  | 'Tabload'
+  | 'Ledger'
+  | 'A0'
+  | 'A1'
+  | 'A2'
+  | 'A3'
+  | 'A4'
+  | 'A5';
 
 export interface PDFOptions {
   /** If no path is provided, the PDF won't be saved to the disk. */
@@ -145,7 +145,7 @@ export interface PDFOptions {
 
 export interface ScreenshotOptions {
   path?: string;
-  type?: "jpeg" | "png";
+  type?: 'jpeg' | 'png';
   /** The quality of the image, between 0-100. Not applicable to png images. */
   quality?: number;
   fullPage?: boolean;
@@ -159,7 +159,7 @@ export interface ScreenshotOptions {
 }
 
 export interface PageFnOptions {
-  polling?: "raf" | "mutation" | number;
+  polling?: 'raf' | 'mutation' | number;
   timeout?: number;
 }
 
@@ -173,27 +173,27 @@ export interface ElementHandle {
 
 export type Headers = Record<string, string>;
 export type HttpMethod =
-  | "GET"
-  | "POST"
-  | "PATCH"
-  | "PUT"
-  | "DELETE"
-  | "OPTIONS";
+  | 'GET'
+  | 'POST'
+  | 'PATCH'
+  | 'PUT'
+  | 'DELETE'
+  | 'OPTIONS';
 
 export type ResourceType =
-  | "Document"
-  | "Stylesheet"
-  | "Image"
-  | "Media"
-  | "Font"
-  | "Script"
-  | "TextTrack"
-  | "XHR"
-  | "Fetch"
-  | "EventSource"
-  | "WebSocket"
-  | "Manifest"
-  | "Other";
+  | 'Document'
+  | 'Stylesheet'
+  | 'Image'
+  | 'Media'
+  | 'Font'
+  | 'Script'
+  | 'TextTrack'
+  | 'XHR'
+  | 'Fetch'
+  | 'EventSource'
+  | 'WebSocket'
+  | 'Manifest'
+  | 'Other';
 
 export interface Overrides {
   url?: string;
@@ -284,7 +284,7 @@ export interface EventObj {
 }
 
 export interface Page extends FrameBase {
-  on(event: "console", handler: (...args: any[]) => void): void;
+  on(event: 'console', handler: (...args: any[]) => void): void;
   on<K extends keyof EventObj>(
     event: K,
     handler: (e: EventObj[K], ...args: any[]) => void
@@ -328,7 +328,7 @@ export interface Page extends FrameBase {
   reload(options?: NavigationOptions): Promise<Response>;
   screenshot(options?: ScreenshotOptions): Promise<Buffer>;
   setContent(html: string): Promise<void>;
-  setCookie(...cookies: Cookie[]): Promise<void>;
+  setCookie(...cookies: Array<Cookie>): Promise<void>;
   setExtraHTTPHeaders(headers: Headers): Promise<void>;
   setJavaScriptEnabled(enabled: boolean): Promise<void>;
   setRequestInterceptionEnabled(value: boolean): Promise<void>;

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -38,29 +38,29 @@ export interface Dialog {
   defaultValue(): string;
   dismiss(): Promise<void>;
   message(): string;
-  type: 'alert' | 'beforeunload' | 'confirm' | 'prompt';
+  type: "alert" | "beforeunload" | "confirm" | "prompt";
 }
 
 export type PageEvents =
-  | 'console'
-  | 'dialog'
-  | 'error'
-  | 'frameattached'
-  | 'framedetached'
-  | 'framenavigated'
-  | 'load'
-  | 'pageerror'
-  | 'request'
-  | 'requestfailed'
-  | 'requestfinished'
-  | 'response';
+  | "console"
+  | "dialog"
+  | "error"
+  | "frameattached"
+  | "framedetached"
+  | "framenavigated"
+  | "load"
+  | "pageerror"
+  | "request"
+  | "requestfailed"
+  | "requestfinished"
+  | "response";
 
 export interface AuthOptions {
   username: string;
   password: string;
 }
 
-export type MouseButtons = 'left' | 'right' | 'middle';
+export type MouseButtons = "left" | "right" | "middle";
 
 export interface ClickOptions {
   /** defaults to left */
@@ -82,7 +82,7 @@ export interface Cookie {
   expires: number;
   httpOnly: boolean;
   secure: boolean;
-  sameSite: 'Strict' | 'Lax';
+  sameSite: "Strict" | "Lax";
 }
 
 export interface Viewport {
@@ -103,22 +103,22 @@ export type EvaluateFn<T> = (elem?: ElementHandle) => Promise<T>;
 
 export interface NavigationOptions {
   timeout?: number;
-  waitUntil?: 'load' | 'networkidle' | 'networkIdleTimeout';
+  waitUntil?: "load" | "networkidle" | "networkIdleTimeout";
   networkIdleInflight?: number;
   networkIdleTimeout?: number;
 }
 
 export type PDFFormat =
-  | 'Letter'
-  | 'Legal'
-  | 'Tabload'
-  | 'Ledger'
-  | 'A0'
-  | 'A1'
-  | 'A2'
-  | 'A3'
-  | 'A4'
-  | 'A5';
+  | "Letter"
+  | "Legal"
+  | "Tabload"
+  | "Ledger"
+  | "A0"
+  | "A1"
+  | "A2"
+  | "A3"
+  | "A4"
+  | "A5";
 
 export interface PDFOptions {
   /** If no path is provided, the PDF won't be saved to the disk. */
@@ -145,7 +145,7 @@ export interface PDFOptions {
 
 export interface ScreenshotOptions {
   path?: string;
-  type?: 'jpeg' | 'png';
+  type?: "jpeg" | "png";
   /** The quality of the image, between 0-100. Not applicable to png images. */
   quality?: number;
   fullPage?: boolean;
@@ -159,7 +159,7 @@ export interface ScreenshotOptions {
 }
 
 export interface PageFnOptions {
-  polling?: 'raf' | 'mutation' | number;
+  polling?: "raf" | "mutation" | number;
   timeout?: number;
 }
 
@@ -173,27 +173,27 @@ export interface ElementHandle {
 
 export type Headers = Record<string, string>;
 export type HttpMethod =
-  | 'GET'
-  | 'POST'
-  | 'PATCH'
-  | 'PUT'
-  | 'DELETE'
-  | 'OPTIONS';
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE"
+  | "OPTIONS";
 
 export type ResourceType =
-  | 'Document'
-  | 'Stylesheet'
-  | 'Image'
-  | 'Media'
-  | 'Font'
-  | 'Script'
-  | 'TextTrack'
-  | 'XHR'
-  | 'Fetch'
-  | 'EventSource'
-  | 'WebSocket'
-  | 'Manifest'
-  | 'Other';
+  | "Document"
+  | "Stylesheet"
+  | "Image"
+  | "Media"
+  | "Font"
+  | "Script"
+  | "TextTrack"
+  | "XHR"
+  | "Fetch"
+  | "EventSource"
+  | "WebSocket"
+  | "Manifest"
+  | "Other";
 
 export interface Overrides {
   url?: string;
@@ -284,7 +284,7 @@ export interface EventObj {
 }
 
 export interface Page extends FrameBase {
-  on(event: 'console', handler: (...args: any[]) => void): void;
+  on(event: "console", handler: (...args: any[]) => void): void;
   on<K extends keyof EventObj>(
     event: K,
     handler: (e: EventObj[K], ...args: any[]) => void
@@ -295,13 +295,13 @@ export interface Page extends FrameBase {
   content(): Promise<string>;
   cookies(...urls: string[]): Promise<Cookie[]>;
   deleteCookie(
-    ...cookies: {
+    ...cookies: Array<{
       name: string;
       url?: string;
       domain?: string;
       path?: string;
       secure?: boolean;
-    }[]
+    }>
   ): Promise<void>;
   emulate(options: Partial<EmulateOptions>): Promise<void>;
   emulateMedia(mediaType: string | null): Promise<void>;
@@ -328,7 +328,7 @@ export interface Page extends FrameBase {
   reload(options?: NavigationOptions): Promise<Response>;
   screenshot(options?: ScreenshotOptions): Promise<Buffer>;
   setContent(html: string): Promise<void>;
-  setCookie(...cookies: Array<Cookie>): Promise<void>;
+  setCookie(...cookies: Cookie[]): Promise<void>;
   setExtraHTTPHeaders(headers: Headers): Promise<void>;
   setJavaScriptEnabled(enabled: boolean): Promise<void>;
   setRequestInterceptionEnabled(value: boolean): Promise<void>;

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -38,29 +38,29 @@ export interface Dialog {
   defaultValue(): string;
   dismiss(): Promise<void>;
   message(): string;
-  type: "alert" | "beforeunload" | "confirm" | "prompt";
+  type: 'alert' | 'beforeunload' | 'confirm' | 'prompt';
 }
 
 export type PageEvents =
-  | "console"
-  | "dialog"
-  | "error"
-  | "frameattached"
-  | "framedetached"
-  | "framenavigated"
-  | "load"
-  | "pageerror"
-  | "request"
-  | "requestfailed"
-  | "requestfinished"
-  | "response";
+  | 'console'
+  | 'dialog'
+  | 'error'
+  | 'frameattached'
+  | 'framedetached'
+  | 'framenavigated'
+  | 'load'
+  | 'pageerror'
+  | 'request'
+  | 'requestfailed'
+  | 'requestfinished'
+  | 'response';
 
 export interface AuthOptions {
   username: string;
   password: string;
 }
 
-export type MouseButtons = "left" | "right" | "middle";
+export type MouseButtons = 'left' | 'right' | 'middle';
 
 export interface ClickOptions {
   /** defaults to left */
@@ -82,7 +82,7 @@ export interface Cookie {
   expires: number;
   httpOnly: boolean;
   secure: boolean;
-  sameSite: "Strict" | "Lax";
+  sameSite: 'Strict' | 'Lax';
 }
 
 export interface Viewport {
@@ -103,22 +103,22 @@ export type EvaluateFn<T> = (elem?: ElementHandle) => Promise<T>;
 
 export interface NavigationOptions {
   timeout?: number;
-  waitUntil?: "load" | "networkidle" | "networkIdleTimeout";
+  waitUntil?: 'load' | 'networkidle' | 'networkIdleTimeout';
   networkIdleInflight?: number;
   networkIdleTimeout?: number;
 }
 
 export type PDFFormat =
-  | "Letter"
-  | "Legal"
-  | "Tabload"
-  | "Ledger"
-  | "A0"
-  | "A1"
-  | "A2"
-  | "A3"
-  | "A4"
-  | "A5";
+  | 'Letter'
+  | 'Legal'
+  | 'Tabload'
+  | 'Ledger'
+  | 'A0'
+  | 'A1'
+  | 'A2'
+  | 'A3'
+  | 'A4'
+  | 'A5';
 
 export interface PDFOptions {
   /** If no path is provided, the PDF won't be saved to the disk. */
@@ -145,7 +145,7 @@ export interface PDFOptions {
 
 export interface ScreenshotOptions {
   path?: string;
-  type?: "jpeg" | "png";
+  type?: 'jpeg' | 'png';
   /** The quality of the image, between 0-100. Not applicable to png images. */
   quality?: number;
   fullPage?: boolean;
@@ -159,7 +159,7 @@ export interface ScreenshotOptions {
 }
 
 export interface PageFnOptions {
-  polling?: "raf" | "mutation" | number;
+  polling?: 'raf' | 'mutation' | number;
   timeout?: number;
 }
 
@@ -173,27 +173,27 @@ export interface ElementHandle {
 
 export type Headers = Record<string, string>;
 export type HttpMethod =
-  | "GET"
-  | "POST"
-  | "PATCH"
-  | "PUT"
-  | "DELETE"
-  | "OPTIONS";
+  | 'GET'
+  | 'POST'
+  | 'PATCH'
+  | 'PUT'
+  | 'DELETE'
+  | 'OPTIONS';
 
 export type ResourceType =
-  | "Document"
-  | "Stylesheet"
-  | "Image"
-  | "Media"
-  | "Font"
-  | "Script"
-  | "TextTrack"
-  | "XHR"
-  | "Fetch"
-  | "EventSource"
-  | "WebSocket"
-  | "Manifest"
-  | "Other";
+  | 'Document'
+  | 'Stylesheet'
+  | 'Image'
+  | 'Media'
+  | 'Font'
+  | 'Script'
+  | 'TextTrack'
+  | 'XHR'
+  | 'Fetch'
+  | 'EventSource'
+  | 'WebSocket'
+  | 'Manifest'
+  | 'Other';
 
 export interface Overrides {
   url?: string;
@@ -224,13 +224,15 @@ export interface Response {
   url: string;
 }
 
+export type Serializable = boolean | number | string | object;
+
 export interface FrameBase {
   $(selector: string): Promise<ElementHandle>;
   $$(selector: string): Promise<ElementHandle[]>;
   $eval(
     selector: string,
-    fn: (...args: Array<object | ElementHandle>) => void
-  ): Promise<object>;
+    fn: (...args: Array<Serializable | ElementHandle>) => void
+  ): Promise<Serializable>;
   addScriptTag(url: string): Promise<void>;
   injectFile(filePath: string): Promise<void>;
   evaluate<T = string>(
@@ -282,7 +284,7 @@ export interface EventObj {
 }
 
 export interface Page extends FrameBase {
-  on(event: "console", handler: (...args: any[]) => void): void;
+  on(event: 'console', handler: (...args: any[]) => void): void;
   on<K extends keyof EventObj>(
     event: K,
     handler: (e: EventObj[K], ...args: any[]) => void
@@ -291,7 +293,16 @@ export interface Page extends FrameBase {
   click(selector: string, options?: ClickOptions): Promise<void>;
   close(): Promise<void>;
   content(): Promise<string>;
-  cookies(...urls: string[]): Cookie;
+  cookies(...urls: string[]): Promise<Cookie[]>;
+  deleteCookie(
+    ...cookies: {
+      name: string;
+      url?: string;
+      domain?: string;
+      path?: string;
+      secure?: boolean;
+    }[]
+  ): Promise<void>;
   emulate(options: Partial<EmulateOptions>): Promise<void>;
   emulateMedia(mediaType: string | null): Promise<void>;
   evaluateOnNewDocument(
@@ -300,7 +311,7 @@ export interface Page extends FrameBase {
   ): Promise<void>;
 
   // Argument `fn` can be an arbitrary function
-  exposeFunction(name: string, fn: any): Promise<void>;
+  exposeFunction(name: string, fn: Function): Promise<void>;
 
   focus(selector: string): Promise<void>;
   frames(): Frame[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagecookiesurls>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

