### PR TITLE
rss: Fix item enclosure optional property

### DIFF
--- a/types/rss/index.d.ts
+++ b/types/rss/index.d.ts
@@ -90,7 +90,7 @@ declare namespace NodeRSS {
         /**
          * Path to binary file (or URL).
          */
-        file: string;
+        file?: string;
         /**
          * Size of the file.
          */


### PR DESCRIPTION
For item enclosures, it's _either_ a file _or_ a URL. The docs specify that one of the two is always optional, and the source code only mandates the `url`, and may ignore the `file`.

https://www.npmjs.com/package/rss
https://github.com/dylang/node-rss/blob/master/lib/index.js#L83