### PR TITLE
react-modal: Remove default export

### DIFF
--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -10,9 +10,8 @@
 
 import * as React from "react";
 
+export = ReactModal
 export as namespace ReactModal;
-
-export default ReactModal;
 
 declare namespace ReactModal {
     interface Styles {

--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -10,7 +10,7 @@
 
 import * as React from "react";
 
-export = ReactModal
+export = ReactModal;
 export as namespace ReactModal;
 
 declare namespace ReactModal {

--- a/types/react-modal/react-modal-tests.tsx
+++ b/types/react-modal/react-modal-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import ReactModal from 'react-modal';
+import * as ReactModal from 'react-modal';
 
 class ExampleOfUsingReactModal extends React.Component {
   render() {

--- a/types/react-modal/react-modal-tests.tsx
+++ b/types/react-modal/react-modal-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as ReactModal from 'react-modal';
+import ReactModal = require('react-modal');
 
 class ExampleOfUsingReactModal extends React.Component {
   render() {


### PR DESCRIPTION
Typescript not working with synthetic default import: https://github.com/reactjs/react-modal/issues/497
