### PR TITLE
@types/node-red New set of types for Node-RED node creation api.

### DIFF
--- a/types/node-red/index.d.ts
+++ b/types/node-red/index.d.ts
@@ -1,0 +1,192 @@
+// Type definitions for node-red 0.17
+// Project: http://nodered.org
+// Definitions by: Anders E. Andersen <https://github.com/andersea>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="node" />
+
+import EventEmitter = require('events');
+
+/**
+ * Node-RED node creation api.
+ */
+export interface Red {
+    /** Node lifecycle management api. Used by all nodes. */
+    nodes: Nodes;
+    log: any;
+    settings: any;
+    events: any;
+    util: any;
+    /** Returns the version of the running Node-RED environment. */
+    version(): string;
+}
+
+/**
+ * Node base type.
+ *
+ * See the Nodes interfaces registerType() method for information about
+ * declaring node constructors in typescript.
+ */
+export interface Node extends EventEmitter {
+    updateWires(wires: any): void;
+    context(): any;
+    close(removed: any): void;
+    /**
+     * Send one or more messages to multiple downstream nodes.
+     * It is possible to send multiple messages to any
+     * one node by sending an array to the node instead
+     * of a single message.
+     * @param msg - array of messages and/or message bundle arrays.
+     */
+    send(msg: any[]): void;
+    /**
+     * Send a message to the downstream node. If msg is null or
+     * undefined, no message is sent.
+     * @param msg - optional message to send.
+     */
+    send(msg?: any): void;
+    /**
+     * Send a message to this node.
+     * @param msg - optional message to send.
+     */
+    receive(msg: any): void;
+    /**
+     * Log an log-level event. Used for mundane events
+     * that are part of the normal functioning of the
+     * node.
+     * @param msg - message to log.
+     */
+    log(msg: any): void;
+    /**
+     * Log a warn-level event. For important events
+     * that the user should be made aware of.
+     * @param msg - message to log.
+     */
+    warn(msg: any): void;
+    /**
+     * Log an error-level event. To trigger catch nodes on
+     * the workflow call the function with msg set to the
+     * original message.
+     * @param logMessage - description of the error.
+     * @param msg - optional payload that caused the error.
+     */
+    error(logMessage: any, msg?: any): void;
+    /**
+     * Log a debug-level event. Use this is for logging
+     * internal detail not needed for normal operation.
+     * @param msg - message to log.
+     */
+    debug(msg: any): void;
+    /**
+     * Log a trace-level event. Even more internal details than
+     * debug-level.
+     * @param msg - message to log.
+     */
+    trace(msg: any): void;
+    metric(eventname?: any, msg?: any, metricValue?: any): void;
+    /**
+     * Set or clear node status.
+     *
+     * For more info see: https://nodered.org/docs/creating-nodes/status
+     * @param status - the status to set or an empty object to clear the
+     *  node status.
+     */
+    status(status: NodeStatus | {}): void;
+}
+
+/**
+ * Contains the user selected property values
+ * for the node.
+ *
+ * This object is also known as the node's definition
+ * object.
+ */
+export interface NodeProperties {
+    /** This node's unique identifier. */
+    id: NodeId;
+    /** The type name for this node. */
+    type: NodeType;
+}
+
+/** Unique node identifier. */
+export type NodeId = string;
+/** Node type name. */
+export type NodeType = string;
+
+/** Node status icon color choices. */
+export type StatusFill = "red" | "green" | "yellow" | "blue" | "grey";
+/** Node status icon fill choices. */
+export type StatusShape = "ring" | "dot";
+
+/**
+ * Object used to set the nodes status flag.
+ */
+export interface NodeStatus {
+    /** Selects the icon color. */
+    fill: StatusFill;
+    /**
+     *  Selects whether the icon appears as a ring or
+     *  is filled out (dot).
+     */
+    shape: StatusShape;
+    /** Status label. */
+    text: string;
+}
+
+export interface Nodes {
+    /**
+     * Node constructor functions must call this to
+     * finish setting up the node. Among other things
+     * it adds the node credentials, which are stored
+     * outside the flow.
+     *
+     * @param node - the node object under construction.
+     * @param props - the node's properties object, aka.
+     * the node instance definition.
+     */
+    createNode(node: Node, props: NodeProperties): void;
+    /**
+     * Get a node by NodeID.
+     *
+     * If your node uses a configuration
+     * node, this call is used to get access to the running
+     * instance.
+     * @param id - the id of the node.
+     */
+    getNode(id: NodeId): any;
+    eachNode(callback: (node: Node) => any): void;
+    /**
+     * Adds a set of credentials for the given node id.
+     * @param id the node id for the credentials
+     * @param creds an object of credential key/value pairs
+     */
+    addCredentials(id: NodeId, creds: object): void;
+    /**
+     * Gets the credentials for the given node id.
+     * @param id the node id for the credentials
+     * @return the credentials
+     */
+    getCredentials(id: NodeId): object;
+    /**
+     * Deletes the credentials for the given node id.
+     * @param id the node id for the credentials
+     */
+    deleteCredentials(id: NodeId): void;
+    /**
+     * Registers a node constructor.
+     *
+     * Node constructors should be declared as functions with an explicit this
+     * argument of a type descending from the Node interface. You can extend
+     * the NodeProperties interface also, to add your node's properties.
+     *
+     * Example, using in-line declaration:
+     *
+     * RED.nodes.registerType('my-node', function(this: MyNode, props: MyProperties)
+     *  => { RED.nodes.createNode(this, props); ... }, { ... });
+     * @param type - the string type name
+     * @param constructor - the constructor function for this node type
+     * @param opts - optional additional options for the node
+     */
+    registerType(type: string, constructor: (props: NodeProperties) => any, opts?: any): void;
+}

--- a/types/node-red/index.d.ts
+++ b/types/node-red/index.d.ts
@@ -27,8 +27,11 @@ export interface Red {
  *
  * See the Nodes interfaces registerType() method for information about
  * declaring node constructors in typescript.
+ * 
+ * The id, type and name properties are available after the
+ * call to RED.nodes.createNode().
  */
-export interface Node extends EventEmitter {
+export interface Node extends EventEmitter, NodeProperties {
     updateWires(wires: any): void;
     context(): any;
     close(removed: any): void;
@@ -92,7 +95,7 @@ export interface Node extends EventEmitter {
      * @param status - the status to set or an empty object to clear the
      *  node status.
      */
-    status(status: NodeStatus | {}): void;
+    status(status: NodeStatus | ClearNodeStatus): void;
 }
 
 /**
@@ -107,6 +110,12 @@ export interface NodeProperties {
     id: NodeId;
     /** The type name for this node. */
     type: NodeType;
+    /**
+     * The UI visible name for this node. Many nodes
+     * allow the user to pick the name and provide
+     * a fallback name, if they leave it blank.
+     */
+    name: string;
 }
 
 /** Unique node identifier. */
@@ -116,7 +125,7 @@ export type NodeType = string;
 
 /** Node status icon color choices. */
 export type StatusFill = "red" | "green" | "yellow" | "blue" | "grey";
-/** Node status icon fill choices. */
+/** Node status icon shape choices. */
 export type StatusShape = "ring" | "dot";
 
 /**
@@ -125,13 +134,17 @@ export type StatusShape = "ring" | "dot";
 export interface NodeStatus {
     /** Selects the icon color. */
     fill: StatusFill;
-    /**
-     *  Selects whether the icon appears as a ring or
-     *  is filled out (dot).
-     */
+    /** Selects either ring or dot shape. */
     shape: StatusShape;
     /** Status label. */
     text: string;
+}
+
+/** Fancy definition that matches an empty object. */
+export interface ClearNodeStatus {
+    fill?: undefined;
+    shape?: undefined;
+    text?: undefined;
 }
 
 export interface Nodes {
@@ -153,8 +166,9 @@ export interface Nodes {
      * node, this call is used to get access to the running
      * instance.
      * @param id - the id of the node.
+     * @return - the node matching the given id.
      */
-    getNode(id: NodeId): any;
+    getNode(id: NodeId): Node;
     eachNode(callback: (node: Node) => any): void;
     /**
      * Adds a set of credentials for the given node id.

--- a/types/node-red/index.d.ts
+++ b/types/node-red/index.d.ts
@@ -27,7 +27,7 @@ export interface Red {
  *
  * See the Nodes interfaces registerType() method for information about
  * declaring node constructors in typescript.
- * 
+ *
  * The id, type and name properties are available after the
  * call to RED.nodes.createNode().
  */

--- a/types/node-red/node-red-tests.ts
+++ b/types/node-red/node-red-tests.ts
@@ -1,0 +1,33 @@
+import * as nodered from 'node-red';
+
+interface MyFantasticNode extends nodered.Node {
+    myStrProp: string;
+    myNmbProp: number;
+    someResource: any;
+}
+
+interface MyFantasticProps extends nodered.NodeProperties {
+    config: nodered.NodeId;
+}
+
+export = (RED: nodered.Red) => {
+    RED.nodes.registerType('my-fantastic-node', function(this: MyFantasticNode, props: MyFantasticProps) {
+        RED.nodes.createNode(this, props);
+        const config = RED.nodes.getNode(props.config);
+        this.log('Something fantastic happened.');
+        this.warn('Something exceptional happened.');
+        this.error('Something disastrous happened when I tried to process this.', { payload: 'Cookies' });
+        this.debug('A behind the scenes look.');
+        this.trace('A look behind the scenes, under the floor.');
+        this.status({ fill: 'red', shape: 'dot', text: 'status' });
+        this.status({});
+        this.send({ payload: 'Milk' });
+        this.send([[
+            { payload: 'FirstMessageFirstNode' },
+            { payload: 'SecondMessageFirstNode' },
+        ], { payload: "MessageSecondNode" }]);
+        this.on('close', () => {
+            this.someResource.close();
+        });
+    });
+};

--- a/types/node-red/tsconfig.json
+++ b/types/node-red/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "node-red-tests.ts"
+    ]
+}

--- a/types/node-red/tslint.json
+++ b/types/node-red/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

These types only cover node creation. Types for the most commonly used api calls when creating custom Node-RED nodes are provided.