### PR TITLE
[sequelize] Allow partial TAttribute create and updates.

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3895,7 +3895,7 @@ declare namespace sequelize {
         /**
          * Builds a new model instance and calls save on it.
          */
-        create(values?: TAttributes, options?: CreateOptions): Promise<TInstance>;
+        create(values?: Partial<TAttributes>, options?: CreateOptions): Promise<TInstance>;
 
         /**
          * Find a row that matches the query, or build (but don't save) the row if none is found.
@@ -3980,7 +3980,7 @@ declare namespace sequelize {
          * elements. The first element is always the number of affected rows, while the second element is the actual
          * affected rows (only supported in postgres with `options.returning` true.)
          */
-        update(values: TAttributes, options: UpdateOptions): Promise<[number, TInstance[]]>;
+        update(values: Partial<TAttributes>, options: UpdateOptions): Promise<[number, TInstance[]]>;
 
         /**
          * Run a describe query on the table. The result will be return to the listener as a hash of attributes and

--- a/types/sequelize/v3/index.d.ts
+++ b/types/sequelize/v3/index.d.ts
@@ -3140,7 +3140,7 @@ declare namespace sequelize {
     /**
     * Shortcut for types used in FindOptions.attributes
     */
-    type FindOptionsAttributesArray = Array<string | literal | [string, string] | fn | [fn, string] | cast | [cast, string] | [literal, string]>;    
+    type FindOptionsAttributesArray = Array<string | literal | [string, string] | fn | [fn, string] | cast | [cast, string] | [literal, string]>;
 
     /**
 * Options that are passed to any model creating a SELECT query
@@ -3835,7 +3835,7 @@ declare namespace sequelize {
         /**
          * Builds a new model instance and calls save on it.
          */
-        create(values?: TAttributes, options?: CreateOptions): Promise<TInstance>;
+        create(values?: Partial<TAttributes>, options?: CreateOptions): Promise<TInstance>;
 
         /**
          * Find a row that matches the query, or build (but don't save) the row if none is found.
@@ -3920,7 +3920,7 @@ declare namespace sequelize {
          * elements. The first element is always the number of affected rows, while the second element is the actual
          * affected rows (only supported in postgres with `options.returning` true.)
          */
-        update(values: TAttributes, options: UpdateOptions): Promise<[number, TInstance[]]>;
+        update(values: Partial<TAttributes>, options: UpdateOptions): Promise<[number, TInstance[]]>;
 
         /**
          * Run a describe query on the table. The result will be return to the listener as a hash of attributes and
@@ -6178,7 +6178,7 @@ declare namespace sequelize {
 
         camelizeIf(str: string, condition: boolean): string;
         underscoredIf(str: string, condition: boolean): string;
-                     
+
         _: SequelizeLoDash;
 
         /**


### PR DESCRIPTION
Allows creating and updating models via their `Model`'s static methods using partial keys ([see docs](http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-update) for intended behavior). This enables the use of `--strictNullChecks` without having to define all attributes as optional:

#### before
```ts
interface UserAttrs {
  id?:    number;
  name?:  string;
  email?: string;
}
```

#### after
```ts
interface UserAttrs {
  id:    number;
  name:  string;
  email: string;
}
```

```ts
// ...
await User.update({
  name: 'Bob'
}, {
  where: { id: 1 }
});
```

---


 - [x]  Use a meaningful title for the pull request. Include the name of the package modified.
 - [x]  Test the change in your own code. (Compile and run.)
 - [x]  Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
 - [x]  Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
 - [x]  Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
 - [x]  Provide a URL to documentation or source code which provides context for the suggested changes: <http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-update>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

