### PR TITLE
@types/jest - add type definition for expect.stringContaining

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -7,6 +7,7 @@
 //                 Alex Jover Morales <https://github.com/alexjoverm>
 //                 Allan Lukwago <https://github.com/epicallan>
 //                 Ika <https://github.com/ikatyang>
+//                 Waseem Dahman <https://github.com/wsmd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -327,6 +328,10 @@ declare namespace jest {
          * Matches any string that contains the exact provided string
          */
         stringMatching(str: string | RegExp): any;
+        /**
+         * Matches any received string that contains the exact expected string
+         */
+        stringContaining(str: string): any;
     }
 
     interface Matchers<R> {

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -199,10 +199,14 @@ describe('Assymetric matchers', () => {
     it('works', () => {
         expect({
             timestamp: 1480807810388,
-            text: 'Some text content, but we care only about *this part*'
+            text: 'Some text content, but we care only about *this part*',
+            color: '#bada55',
+            greeting: 'hello, world!',
         }).toEqual({
             timestamp: expect.any(Number),
-            text: expect.stringMatching('*this part*')
+            text: expect.stringMatching('*this part*'),
+            color: expect.stringMatching(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i),
+            greeting: expect.stringContaining('hello'),
         });
 
         const callback = jest.fn();


### PR DESCRIPTION
Earlier this year, the asymmetric matcher `stringContaining` was added to Jest 19.0.0+ in https://github.com/facebook/jest/pull/2701 but I noticed that it's missing from `@types/jest`.

I've added the appropriate type definition and the necessary test.

**Before**

![screen shot 2017-09-30 at 10 30 33 pm](https://user-images.githubusercontent.com/2100222/31051167-0acebc38-a62f-11e7-9d2d-91e092199ebc.png)

```
Error: /Users/waseem/DefinitelyTyped/types/jest/jest-tests.ts
ERROR: 209:30  expect  TypeScript@next compile error:
Property 'stringContaining' does not exist on type 'Expect'.

    at /Users/waseem/DefinitelyTyped/node_modules/dtslint/bin/index.js:76:19
    at Generator.next (<anonymous>)
    at fulfilled (/Users/waseem/DefinitelyTyped/node_modules/dtslint/bin/index.js:5:58)
    at <anonymous>
The following packages had errors: jest
```

**After**
![screen shot 2017-09-30 at 10 15 48 pm](https://user-images.githubusercontent.com/2100222/31051081-f6885c90-a62c-11e7-90b2-a39885e9604d.png)

It's worth mentioning that `stringMatching` also accepts a `RegExp` (which is the only difference between this matcher and `stringContaining`) so I've included a test for that as well.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/facebook/jest/pull/2701
  - https://facebook.github.io/jest/docs/en/expect.html#expectstringcontainingstring