### PR TITLE
Package: Twit. Fixed incorrect type for Twit.stream

### DIFF
--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -8,6 +8,7 @@
 
 declare module 'twit' {
   import { IncomingMessage } from 'http';
+  import { EventEmitter } from 'events';
 
   namespace Twit {
     export type StreamEndpoint = 'statuses/filter' | 'statuses/sample' | 'statuses/firehose' | 'user' | 'site';
@@ -264,6 +265,10 @@ declare module 'twit' {
       timeout_ms?: number,
       trusted_cert_fingerprints?: string[],
     }
+    export interface Stream extends EventEmitter {
+      start(): void;
+      stop(): void;
+    }
   }
 
   class Twit {
@@ -304,7 +309,7 @@ declare module 'twit' {
     /**
      * @see https://github.com/ttezel/twit#tstreampath-params
      */
-    stream(path: Twit.StreamEndpoint, params?: Twit.Params): NodeJS.ReadableStream;
+    stream(path: Twit.StreamEndpoint, params?: Twit.Params): Twit.Stream;
   }
 
   export = Twit;


### PR DESCRIPTION
The Twit docs [specifically says](https://github.com/ttezel/twit#using-the-streaming-api) that the `stream` method returns an `EventEmitter`. It also says that the `EventEmitter` has [two methods - `start()` and `stop()`](https://github.com/ttezel/twit#streamstop) to start and stop the Twitter stream.

The return type was incorrectly specified as a `NodeJS.ReadableStream`. This fixes that.