### PR TITLE
Add type definition for react-truncate

### DIFF
--- a/types/react-truncate/index.d.ts
+++ b/types/react-truncate/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for react-truncate 2.1
+// Project: https://github.com/One-com/react-truncate
+// Definitions by: Matt Perry <https://github.com/mattvperry>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as React from 'react';
+
+export interface TruncateProps extends React.HTMLProps<Truncate> {
+    lines?: number | false;
+    ellipsis?: React.ReactNode;
+    onTruncate?(isTruncated: boolean): void;
+}
+
+declare class Truncate extends React.Component<TruncateProps> { }
+export default Truncate;

--- a/types/react-truncate/react-truncate-tests.tsx
+++ b/types/react-truncate/react-truncate-tests.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import Truncate from 'react-truncate';
+
+const TruncateTest: React.SFC = _ => (
+    <div>
+        <Truncate>
+            Test string
+        </Truncate>
+
+        <Truncate lines={2} ellipsis="..." onTruncate={(isTruncated) => isTruncated} className="testClass">
+            <div>Test string</div>
+        </Truncate>
+
+        <Truncate lines={false} ellipsis={<span>Read more</span>} id="identifier">
+            <div>Test string</div>
+        </Truncate>
+    </div>
+);

--- a/types/react-truncate/tsconfig.json
+++ b/types/react-truncate/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "jsx": "react",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-truncate-tests.tsx"
+    ]
+}

--- a/types/react-truncate/tslint.json
+++ b/types/react-truncate/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
