### PR TITLE
 @types/socket.io-client -Add missing "managers" property to SocketIOClientStatic

### DIFF
--- a/types/socket.io-client/index.d.ts
+++ b/types/socket.io-client/index.d.ts
@@ -58,6 +58,11 @@ interface SocketIOClientStatic {
 	 * Manager constructor - exposed for the standalone build
 	 */
 	Manager: SocketIOClient.ManagerStatic;
+
+    /**
+     * Managers cache
+     */
+    managers: { [key: string]: SocketIOClient.Manager }
 }
 
 declare namespace SocketIOClient {

--- a/types/socket.io-client/index.d.ts
+++ b/types/socket.io-client/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for socket.io-client 1.4.4
+// Type definitions for socket.io-client 1.4.5
 // Project: http://socket.io/
 // Definitions by: PROGRE <https://github.com/progre>, Damian Connolly <https://github.com/divillysausages>, Florent Poujol <https://github.com/florentpoujol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
add managers property to SocketIOClientStatic for
which is exposed in lib/index.js

```
/**
* Managers cache.
*/
var cache = exports.managers = {};
```