### PR TITLE
cheerio: #attr() can be used without arguments

### DIFF
--- a/types/cheerio/cheerio-tests.ts
+++ b/types/cheerio/cheerio-tests.ts
@@ -52,6 +52,7 @@ var $multiEl = $('selector', 'selector', 'selector');
  */
 
 // attr
+$el.attr();
 $el.attr('id');
 $el.attr('id', 'favorite').html();
 

--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -13,6 +13,7 @@ interface Cheerio {
 
     // Attributes
 
+    attr(): {[attr: string]: string};
     attr(name: string): string;
     attr(name: string, value: any): Cheerio;
 


### PR DESCRIPTION
Proof: https://github.com/cheeriojs/cheerio/blob/master/lib/api/attributes.js#L38