### PR TITLE
socket.io: added local and volatile flag for socket.io SocketIO.Server interface

### DIFF
--- a/types/socket.io/index.d.ts
+++ b/types/socket.io/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for socket.io 1.4.4
 // Project: http://socket.io/
-// Definitions by: PROGRE <https://github.com/progre>, Damian Connolly <https://github.com/divillysausages>, Florent Poujol <https://github.com/florentpoujol>, KentarouTakeda <https://github.com/KentarouTakeda>
+// Definitions by: PROGRE <https://github.com/progre>, Damian Connolly <https://github.com/divillysausages>, Florent Poujol <https://github.com/florentpoujol>, KentarouTakeda <https://github.com/KentarouTakeda>, Alexey Snigirev <https://github.com/gigi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///<reference types="node" />
@@ -63,6 +63,16 @@ declare namespace SocketIO {
 		 * Sets the 'json' flag when emitting an event
 		 */
 		json: Server;
+
+		/**
+		 * Sets a modifier for a subsequent event emission that the event data may be lost if the clients are not ready to receive messages
+		 */
+		volatile: Server;
+
+		/**
+		 * Sets a modifier for a subsequent event emission that the event data will only be broadcast to the current node
+		 */
+		local: Server;
 
 		/**
 		 * Server request verification function, that checks for allowed origins

--- a/types/socket.io/socket.io-tests.ts
+++ b/types/socket.io/socket.io-tests.ts
@@ -170,3 +170,13 @@ function testClosingServerWithoutCallback() {
     var io = socketIO.listen(80);
     io.close();
 }
+
+function testLocalServerMessages() {
+    var io = socketIO.listen(80);
+    io.local.emit('local', 'Local data');
+}
+
+function testVolatileServerMessages() {
+    var io = socketIO.listen(80);
+    io.volatile.emit('volatile', 'Lost data');
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://socket.io/docs/server-api/#flag-local, https://socket.io/docs/server-api/#flag-volatile
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.