### PR TITLE
Add Missing Config Options in webpack-dev-server

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for webpack-dev-server 2.4
+// Type definitions for webpack-dev-server 2.9
 // Project: https://github.com/webpack/webpack-dev-server
 // Definitions by: maestroh <https://github.com/maestroh>
 //                 Dave Parslow <https://github.com/daveparslow>
+//                 Zheyang Song <https://github.com/ZheyangSong>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import * as webpack from 'webpack';
@@ -9,28 +10,61 @@ import * as core from 'express-serve-static-core';
 import * as serveStatic from 'serve-static';
 import * as http from 'http';
 import * as spdy from 'spdy';
+import * as httpProxyMiddleware from 'http-proxy-middleware';
 
 declare namespace WebpackDevServer {
-    interface Configuration {
-        contentBase?: string;
-        hot?: boolean;
-        https?: boolean | spdy.ServerOptions;
-        historyApiFallback?: boolean;
-        compress?: boolean;
-        proxy?: any;
-        staticOptions?: any;
-        quiet?: boolean;
-        noInfo?: boolean;
-        lazy?: boolean;
-        filename?: string| RegExp;
-        watchOptions?: webpack.WatchOptions;
-        publicPath: string;
-        headers?: any;
-        stats?: webpack.compiler.StatsOptions| webpack.compiler.StatsToStringOptions;
-        public?: string;
-        disableHostCheck?: boolean;
+    interface proxyConfigMap {
+        [url: string]: string | httpProxyMiddleware.Config;
+    }
 
-        setup?(app: core.Express): void;
+    type proxyConfigArrayItem = {
+        path?: string | string[];
+        context?: string | string[]
+    } & httpProxyMiddleware.Config;
+
+    type proxyConfigArray = proxyConfigArrayItem[];
+
+    type expressAppHook = (app: core.Express) => void;
+
+    interface Configuration {
+        after?: expressAppHook;
+        allowedHosts?: string[];
+        before?: expressAppHook;
+        bonjour?: boolean;
+        clientLogLevel?: string;
+        compress?: boolean;
+        contentBase?: string;
+        disableHostCheck?: boolean;
+        filename?: string;
+        headers?: {};
+        historyApiFallback?: boolean | {};
+        host?: string;
+        hot?: boolean;
+        hotOnly?: boolean;
+        https?: boolean | spdy.ServerOptions;
+        inline?: boolean;
+        lazy?: boolean;
+        noInfo?: boolean;
+        open?: boolean;
+        openPage?: string;
+        overlay?: boolean | {
+            warnings: boolean;
+            errors: boolean;
+        };
+        pfx?: string;
+        pfxPassphrase?: string;
+        port?: number;
+        proxy?: proxyConfigMap | proxyConfigArray;
+        public?: string;
+        publicPath?: string;
+        quiet?: boolean;
+        setup?: expressAppHook; // will be depreacted in v3.0.0 and replaced by before
+        socket?: string;
+        staticOptions?: serveStatic.ServeStaticOptions;
+        stats?: webpack.compiler.StatsOptions| webpack.compiler.StatsToStringOptions;
+        useLocalIp?: boolean;
+        watchContentBase?: boolean;
+        watchOptions?: webpack.WatchOptions;
     }
 }
 

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -12,6 +12,9 @@ server.listen(8080);
 // Configuration can be used as a type
 const config: WebpackDevServer.Configuration = {
     // webpack-dev-server options
+    inline: true,
+    // Toggle between the dev-server's two different modes --- inline (default, recommended for HMR) or iframe.
+
     contentBase: "/path/to/directory",
     // or: contentBase: "http://localhost/",
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://webpack.js.org/configuration/dev-server/
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
