### PR TITLE
Simplify PouchDB Attachments interfaces (pouchdb-core)

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -107,7 +107,7 @@ declare namespace PouchDB {
         type AttachmentId = string;
         type RevisionId = string;
         type Availability = 'available' | 'compacted' | 'not compacted' | 'missing';
-        type Attachment = string | Blob | Buffer;
+        type AttachmentData = string | Blob | Buffer;
 
         interface Options {
           ajax?: Configuration.RemoteRequesterConfiguration;
@@ -178,28 +178,55 @@ declare namespace PouchDB {
             _attachments?: Attachments;
         }
 
-        interface AttachmentResponse {
+        /**
+         * Stub attachments are returned by PouchDB by default (attachments option set to false)
+         */
+        interface StubAttachment {
+            /**
+             * Mime type of the attachment
+             */
             content_type: string;
 
-            /** MD5 hash, starts with "md5-" prefix */
+            /**
+             * Database digest of the attachment
+             */
             digest: string;
 
-            /** Only present if `attachments` was `false`. */
-            stub?: boolean;
-
-            /** Only present if `attachments` was `false`. */
-            length?: number;
+            /**
+             * Attachment is a stub
+             */
+            stub: true;
 
             /**
-             * Only present if `attachments` was `true`.
+             * Length of the attachment
+             */
+            length: number;
+        }
+
+        /**
+         * Full attachments are used to create new attachments or returned when the attachments option
+         * is true.
+         */
+        interface FullAttachment {
+            /**
+             * Mime type of the attachment
+             */
+            content_type: string;
+
+            /** MD5 hash, starts with "md5-" prefix; populated by PouchDB for new attachments */
+            digest?: string;
+
+            /**
              * {string} if `binary` was `false`
              * {Blob|Buffer} if `binary` was `true`
              */
-            data?: Attachment;
+            data: AttachmentData;
         }
 
+        type Attachment = StubAttachment | FullAttachment;
+
         interface Attachments {
-            [attachmentId: string]: AttachmentResponse;
+            [attachmentId: string]: Attachment;
         }
 
         type NewDocument<Content extends {}> = Content;
@@ -217,17 +244,12 @@ declare namespace PouchDB {
             /** You can update an existing doc using _rev */
             _rev?: RevisionId;
 
-            _attachments?: {[attachmentId: string]: PutAttachment};
+            _attachments?: Attachments;
         };
 
         type PutDocument<Content extends {}> = PostDocument<Content> & ChangesMeta & {
             _id?: DocumentId;
         };
-
-        interface PutAttachment {
-            content_type: string;
-            data: Attachment;
-        }
 
         interface AllDocsOptions extends Options {
             /** Include attachment data for each document.
@@ -725,7 +747,7 @@ declare namespace PouchDB {
         putAttachment(docId: Core.DocumentId,
                       attachmentId: Core.AttachmentId,
                       rev: Core.RevisionId,
-                      attachment: Core.Attachment,
+                      attachment: Core.AttachmentData,
                       type: string,
                       callback: Core.Callback<Core.Response>): void;
 
@@ -737,7 +759,7 @@ declare namespace PouchDB {
         putAttachment(docId: Core.DocumentId,
                       attachmentId: Core.AttachmentId,
                       rev: Core.RevisionId,
-                      attachment: Core.Attachment,
+                      attachment: Core.AttachmentData,
                       type: string): Promise<Core.Response>;
 
          /**
@@ -747,7 +769,7 @@ declare namespace PouchDB {
           */
         putAttachment(docId: Core.DocumentId,
                       attachmentId: Core.AttachmentId,
-                      attachment: Core.Attachment,
+                      attachment: Core.AttachmentData,
                       type: string,
                       callback: Core.Callback<Core.Response>): void;
 
@@ -758,7 +780,7 @@ declare namespace PouchDB {
           */
         putAttachment(docId: Core.DocumentId,
                       attachmentId: Core.AttachmentId,
-                      attachment: Core.Attachment,
+                      attachment: Core.AttachmentData,
                       type: string): Promise<Core.Response>;
 
         /** Get attachment data */

--- a/types/pouchdb-core/pouchdb-core-tests.ts
+++ b/types/pouchdb-core/pouchdb-core-tests.ts
@@ -122,6 +122,9 @@ function testBasics() {
     db.info((error, result) => {
     });
 
+    // "Round-trippable": can put back a document from get
+    db.get('id').then(doc => db.put(doc));
+
     PouchDB.debug.enable('*');
 }
 
@@ -236,11 +239,28 @@ function heterogeneousGenericsDatabase(db: PouchDB.Database) {
         thud: boolean;
     }
 
+    // Attachment test
+    db.put<Cat>({
+        _attachments: {
+            ['meme.gif']: {
+                content_type: 'image/gif',
+                data: new Blob(['fake example'])
+            }
+        },
+        meow: 'roar'
+    });
+
     db.allDocs<Cat>({ startkey: 'cat/', endkey: 'cat/\uffff', include_docs: true })
         .then(cats => {
             for (const row of cats.rows) {
                 if (row.doc) {
                     row.doc.meow; // $ExpectType string
+
+                    // Round-trip test
+                    db.put(row.doc);
+                    db.put<Cat>(row.doc);
+                    // Generic strictness test
+                    db.put<Boot>(row.doc); // $ExpectError
                 }
             }
         });


### PR DESCRIPTION
Make a cleaner separation between Stub attachments and non-Stub attachments (here called FullAttachment). New Attachment is then the union type of StubAttachment and FullAttachment. Renamed the previous Attachment to AttachmentData to better reflect what's it purpose is. (Would love to make it more generic, but there's not a great way to key off of `{ attachment: true, binary: true }` in the options stacks right now.) Remove PutAttachment because it now better handled by FullAttachment. Furthermore, you can db.put StubAttachments when round-tripping documents, so PutAttachment was too strict. Added simple round-trip tests to avoid that strictness problem moving forward.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pouchdb.com/guides/attachments.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

