### PR TITLE
@types/auth0 add full typedef for ManagementClientOptions Issue #20210

### DIFF
--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -7,8 +7,18 @@
 import * as Promise from 'bluebird';
 
 export interface ManagementClientOptions {
-  token: string;
+  token?: string;
   domain?: string;
+  clientId?: string;
+  clientSecret?: string;
+  audience?: string;
+  scope?: string;
+  tokenProvider?: TokenProvider
+}
+
+export interface TokenProvider {
+  enableCache: boolean
+  cacheTTLInSeconds?: number
 }
 
 export interface UserMetadata { }

--- a/types/auth0/index.d.ts
+++ b/types/auth0/index.d.ts
@@ -8,17 +8,17 @@ import * as Promise from 'bluebird';
 
 export interface ManagementClientOptions {
   token?: string;
-  domain?: string;
+  domain: string;
   clientId?: string;
   clientSecret?: string;
   audience?: string;
   scope?: string;
-  tokenProvider?: TokenProvider
+  tokenProvider?: TokenProvider;
 }
 
 export interface TokenProvider {
-  enableCache: boolean
-  cacheTTLInSeconds?: number
+  enableCache: boolean;
+  cacheTTLInSeconds?: number;
 }
 
 export interface UserMetadata { }


### PR DESCRIPTION
See auth0 ManagemntClient implementation here:
https://github.com/auth0/node-auth0/blob/master/src/management/index.js#L72

The DefinitelyTyped library only specifies domain and token, however:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/auth0-js/index.d.ts#L456
