### PR TITLE
ember: Added Ember.computed methods

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -2381,6 +2381,18 @@ declare namespace Ember {
         oneWay(dependentKey: string): ComputedProperty;
         or(...args: string[]): ComputedProperty;
         readOnly(dependentString: string): ComputedProperty;
+
+        /** A computed property which returns a new array with all the unique
+            elements from one or more dependent arrays. Alias for uniq. */
+        union(...propertyKeys: string[]): ComputedProperty;
+
+        /** A computed property which returns a new array with all the unique
+            elements from one or more dependent arrays. */
+        uniq(...propertyKeys: string[]): ComputedProperty;
+
+        /** A computed property which returns a new array with all the unique
+            elements from an array, with uniqueness determined by specific key. */
+        uniqBy(dependentKey: string, propertyKey: string): ComputedProperty;
     };
     // ReSharper restore DuplicatingLocalDeclaration
     function controllerFor(


### PR DESCRIPTION
This PR adds some of the missing definitions from here: https://www.emberjs.com/api/ember/2.15/namespaces/Ember.computed/methods/union?anchor=union

Note: the documentation there suggests that propertyKey is a single parameter, which is incorrect/unclear per the discussion in https://github.com/emberjs/ember.js/pull/14904. Hence, I added them as ... arguments instead.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.): Tried, `yarn test` worked fine but `yarn lint` ran into errors. `npm run lint` on the individual package worked though.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present). tried, but returned error.

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember/2.15/namespaces/Ember.computed/methods/union?anchor=union
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
