### PR TITLE
Adding type definitions for url-parse npm package

### DIFF
--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -3,9 +3,13 @@
 // Definitions by: Pavlo Chernenko <https://github.com/ChernenkoPaul/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="url-search-params" />
+
+import URLSearchParams = require("url-search-params");
+
 declare module "url-parse" {
     export default class URL {
-        constructor(url: string, baseURL?: object | string, parser?: boolean | Function);
+        constructor(url: string, baseURL?: Object | string, parser?: boolean | Function);
         hash: string;
         host: string;
         hostname: string;

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -29,7 +29,8 @@ declare class URL {
     toString(): string;
 }
 
-type ParseFunctionType = (url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean) => URL;
+type ParseFunctionNodeType = (url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean) => URL;
+type ParseFunctionType = (url: string, baseURL?: object | string, parser?: boolean | UrlQueryParamsParser) => URL;
 
 interface Protocol {
     slashes: boolean;
@@ -41,7 +42,7 @@ type ExtractProtocolFunctionType = (url: string) => Protocol;
 
 type LocationFunctionType = (url: string) => string;
 
-interface ExtendedParseFunctionType extends ParseFunctionType {
+interface ExtendedParseFunctionType extends ParseFunctionNodeType, ParseFunctionType {
     extractProtocol: ExtractProtocolFunctionType;
     location: LocationFunctionType;
     qs: any;
@@ -49,4 +50,4 @@ interface ExtendedParseFunctionType extends ParseFunctionType {
 
 declare const parse: ExtendedParseFunctionType;
 
-export default parse;
+export = parse;

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for url-parse v1.1.9
+// Project: https://github.com/unshiftio/url-parse
+// Definitions by: Pavlo Chernenko <https://github.com/ChernenkoPaul/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "url-parse" {
+    export default class URL {
+        constructor(url: string, baseURL?: object | string, parser?: boolean | Function);
+        hash: string;
+        host: string;
+        hostname: string;
+        href: string;
+        readonly origin: string;
+        password: string;
+        pathname: string;
+        port: string;
+        protocol: string;
+        query: { [key: string]: string | undefined };
+        search: string;
+        set(key: string, value: string): void;
+        username: string;
+        readonly searchParams: URLSearchParams;
+        toString(): string;
+    }
+
+    export function parse(url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): URL;
+}

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -1,52 +1,52 @@
-// Type definitions for url-parse v1.1.9
+// Type definitions for url-parse 1.1
 // Project: https://github.com/unshiftio/url-parse
-// Definitions by: Pavlo Chernenko <https://github.com/ChernenkoPaul/>
+// Definitions by: Pavlo Chernenko https://github.com/ChernenkoPaul/
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-/// <reference types="url-search-params" />
+// TypeScript Version: 2.2
 
 import URLSearchParams = require("url-search-params");
 
-declare module "url-parse" {
-    export type UrlQueryParamsParser = (url: string) => string;
+type UrlQueryParamsParser = (url: string) => string;
 
-    export interface Protocol {
-        slashes: boolean;
-        protocol: string;
-        rest: string;
-    }
-    
-    export class URL {
-        constructor(url: string, baseURL?: object | string, parser?: boolean | UrlQueryParamsParser);
-        readonly auth: string;
-        readonly hash: string;
-        readonly host: string;
-        readonly hostname: string;
-        readonly href: string;
-        readonly origin: string;
-        readonly password: string;
-        readonly pathname: string;
-        readonly port: string;
-        readonly protocol: string;
-        query: { [key: string]: string | undefined };
-        readonly search: string;
-        set(property: string, value: string | object | number | undefined): URL;
-        readonly slashes: boolean;
-        readonly username: string;
-        readonly searchParams: URLSearchParams;
-        toString(): string;
-    }
-    
-    type ParseFunctionType = (url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean) => URL;
-    
-    interface ExtendedParseFunctionType extends ParseFunctionType {
-        extractProtocol: (url: string) => Protocol;
-        location: (url: string) => string;
-        qs: any;
-    }
-    
-    var parse: ExtendedParseFunctionType;
-    
+declare class URL {
+    constructor(url: string, baseURL?: object | string, parser?: boolean | UrlQueryParamsParser);
+    readonly auth: string;
+    readonly hash: string;
+    readonly host: string;
+    readonly hostname: string;
+    readonly href: string;
+    readonly origin: string;
+    readonly password: string;
+    readonly pathname: string;
+    readonly port: string;
+    readonly protocol: string;
+    query: { [key: string]: string | undefined };
+    readonly search: string;
+    set(property: string, value: string | object | number | undefined): URL;
+    readonly slashes: boolean;
+    readonly username: string;
+    readonly searchParams: URLSearchParams;
+    toString(): string;
 }
+
+type ParseFunctionType = (url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean) => URL;
+
+interface Protocol {
+    slashes: boolean;
+    protocol: string;
+    rest: string;
+}
+
+type ExtractProtocolFunctionType = (url: string) => Protocol;
+
+type LocationFunctionType = (url: string) => string;
+
+interface ExtendedParseFunctionType extends ParseFunctionType {
+    extractProtocol: ExtractProtocolFunctionType;
+    location: LocationFunctionType;
+    qs: any;
+}
+
+declare const parse: ExtendedParseFunctionType;
 
 export default parse;

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -8,24 +8,45 @@
 import URLSearchParams = require("url-search-params");
 
 declare module "url-parse" {
-    export default class URL {
-        constructor(url: string, baseURL?: Object | string, parser?: boolean | Function);
-        hash: string;
-        host: string;
-        hostname: string;
-        href: string;
-        readonly origin: string;
-        password: string;
-        pathname: string;
-        port: string;
+    export type UrlQueryParamsParser = (url: string) => string;
+
+    export interface Protocol {
+        slashes: boolean;
         protocol: string;
+        rest: string;
+    }
+    
+    export class URL {
+        constructor(url: string, baseURL?: object | string, parser?: boolean | UrlQueryParamsParser);
+        readonly auth: string;
+        readonly hash: string;
+        readonly host: string;
+        readonly hostname: string;
+        readonly href: string;
+        readonly origin: string;
+        readonly password: string;
+        readonly pathname: string;
+        readonly port: string;
+        readonly protocol: string;
         query: { [key: string]: string | undefined };
-        search: string;
-        set(key: string, value: string): void;
-        username: string;
+        readonly search: string;
+        set(property: string, value: string | object | number | undefined): URL;
+        readonly slashes: boolean;
+        readonly username: string;
         readonly searchParams: URLSearchParams;
         toString(): string;
     }
-
-    export function parse(url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean): URL;
+    
+    type ParseFunctionType = (url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean) => URL;
+    
+    interface ExtendedParseFunctionType extends ParseFunctionType {
+        extractProtocol: (url: string) => Protocol;
+        location: (url: string) => string;
+        qs: any;
+    }
+    
+    var parse: ExtendedParseFunctionType;
+    
 }
+
+export default parse;

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -9,7 +9,6 @@ import URLSearchParams = require("url-search-params");
 type UrlQueryParamsParser = (url: string) => string;
 
 declare class URL {
-    constructor(url: string, baseURL?: object | string, parser?: boolean | UrlQueryParamsParser);
     readonly auth: string;
     readonly hash: string;
     readonly host: string;

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for url-parse 1.1
 // Project: https://github.com/unshiftio/url-parse
-// Definitions by: Pavlo Chernenko https://github.com/ChernenkoPaul/
+// Definitions by: Pavlo Chernenko <https://github.com/ChernenkoPaul>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/url-parse/tsconfig.json
+++ b/types/url-parse/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/url-parse/tsconfig.json
+++ b/types/url-parse/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "url-parse-tests.ts"
+    ]
+}

--- a/types/url-parse/tslint.json
+++ b/types/url-parse/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -1,0 +1,10 @@
+import UrlParse = require("url-parse");
+
+const URL = UrlParse.default;
+const parse = UrlParse.parse;
+
+const url1 = new URL('https://github.com/foo/bar');
+const url2 = new URL('foo/bar', "https://github.com/", true);
+const url3 = new URL('foo/bar', {}, function() {});
+
+const url4 = parse('https://github.com/foo/bar', true);

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -1,10 +1,14 @@
 import UrlParse = require("url-parse");
 
-const URL = UrlParse.default;
-const parse = UrlParse.parse;
+const URL = UrlParse.URL;
+const parse = UrlParse.default;
 
 const url1 = new URL('https://github.com/foo/bar');
 const url2 = new URL('foo/bar', "https://github.com/", true);
-const url3 = new URL('foo/bar', {}, function() {});
+const url3 = new URL('foo/bar', {}, function() { return "1337"; });
 
 const url4 = parse('https://github.com/foo/bar', true);
+
+parse.extractProtocol("");
+parse.location("");
+parse.qs;

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -1,10 +1,18 @@
-import UrlParse = require("url-parse");
+import parse = require("url-parse");
 
-const parse = UrlParse.default;
+const url1 = new URL("foo/bar", "https://github.com/");
+const url2 = parse("https://github.com/foo/bar?baz=true");
+const url3 = parse("https://github.com/foo/bar", true, true);
+const url4 = parse("foo/bar", "https://github.com/");
+const url5 = parse("foo/bar", "https://github.com/", () => "queryParserOverride");
 
-const url = new URL('https://github.com/foo/bar');
-const url2 = parse('https://github.com/foo/bar', true);
+url2.hash;
+url2.hostname;
+url2.query.baz;
 
-parse.extractProtocol("");
-parse.location("");
+url3.slashes;
+url3.set("protocol", "http://");
+
+parse.extractProtocol("https://github.com/foo/bar");
+parse.location("https://github.com/foo/bar");
 parse.qs;

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -1,13 +1,9 @@
 import UrlParse = require("url-parse");
 
-const URL = UrlParse.URL;
 const parse = UrlParse.default;
 
-const url1 = new URL('https://github.com/foo/bar');
-const url2 = new URL('foo/bar', "https://github.com/", true);
-const url3 = new URL('foo/bar', {}, function() { return "1337"; });
-
-const url4 = parse('https://github.com/foo/bar', true);
+const url = new URL('https://github.com/foo/bar');
+const url2 = parse('https://github.com/foo/bar', true);
 
 parse.extractProtocol("");
 parse.location("");


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them: there's a [PR with incomplete typings](https://github.com/unshiftio/url-parse/pull/67)
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.