### PR TITLE
angular-ui-router: fix IStateService.reload() arguments

### DIFF
--- a/types/angular-ui-router/index.d.ts
+++ b/types/angular-ui-router/index.d.ts
@@ -281,7 +281,7 @@ declare module 'angular' {
             current: IState;
             /** A param object, e.g. {sectionId: section.id)}, that you'd like to test against the current active state. */
             params: IStateParamsService;
-            reload(): angular.IPromise<any>;
+            reload(reloadState?: string | IState): angular.IPromise<any>;
 
             /** Currently pending transition. A promise that'll resolve or reject. */
             transition: angular.IPromise<{}>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: < https://ui-router.github.io/ng1/docs/1.0.0/classes/state.stateservice.html#reload >
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.