### PR TITLE
react: update list of types that can be returned from Component.render()

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -284,7 +284,7 @@ declare namespace React {
         // tslint:enable:unified-signatures
 
         forceUpdate(callBack?: () => any): void;
-        render(): JSX.Element | null | false;
+        render(): JSX.Element | JSX.Element[] | boolean | string | null | false;
 
         // React.Props<T> is now deprecated, which means that the `children`
         // property is not available on `P` by default, even though you can
@@ -3453,7 +3453,7 @@ declare global {
         // tslint:disable:no-empty-interface
         interface Element extends React.ReactElement<any> { }
         interface ElementClass extends React.Component<any> {
-            render(): Element | null | false;
+            render(): Element | Element[] | boolean | string | null | false;
         }
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }


### PR DESCRIPTION
This updates definition for Component.render() to match the one in https://reactjs.org/docs/react-component.html#render. In particular support for returning of `JSX.Element[]`, `string` and `boolean` types was added.