### PR TITLE
[@types/three] Added missing definitions to Matrix3 on three-core.d.ts

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -3625,6 +3625,18 @@ export class Matrix3 implements Matrix {
     transposeIntoArray(r: number[]): number[];
     fromArray(array: number[], offset?: number): Matrix3;
     toArray(): number[];
+	
+	/**
+     * Multiplies this matrix by m.
+     */
+    multiply(m: Matrix3): Matrix3;
+
+    premultiply(m: Matrix3): Matrix3;
+
+    /**
+     * Sets this matrix to a x b.
+     */
+    multiplyMatrices(a: Matrix3, b: Matrix3): Matrix3;
 
     /**
      * @deprecated


### PR DESCRIPTION
# Description 

Very minimal change. Solving issue #20251

Added multiply, premultiply and multiplyMatrices to Matrix3 class on three-core.d.ts. These were already present on Matrix4, just copied over and adapted code.

**Checklist:**

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**Changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Matrix3 docs](https://threejs.org/docs/index.html#api/math/Matrix3)

