### PR TITLE
reactstrap: add missing prop on Modal.d.ts

### DIFF
--- a/types/reactstrap/lib/Modal.d.ts
+++ b/types/reactstrap/lib/Modal.d.ts
@@ -1,6 +1,7 @@
 import { CSSModule } from '../index';
 
 interface Props {
+  autoFocus?: boolean;
   isOpen?: boolean;
   autoFocus?: boolean;
   size?: string;


### PR DESCRIPTION
Add missing prop to `reactstrap`

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://reactstrap.github.io/components/modals/>