### PR TITLE
[extend] More expressive type definitions

### DIFF
--- a/types/extend/extend-tests.ts
+++ b/types/extend/extend-tests.ts
@@ -1,38 +1,43 @@
-import extend = require('extend');
-declare function assert(cond: boolean): void;
+/// <reference types="node" />
+import * as assert from 'assert';
+import * as extend from 'extend';
 
-var objectBase = {
+const objectBase = {
     test: 'base'
 };
 
-var objectOne = {
+const objectOne = {
     test: 'one',
     iamone: true
 };
 
-var objectTwo = {
+const objectTwo = {
     test: 2,
     iamtwo: true
 };
 
-var objectThree = {
+const objectThree = {
     iamthree: true,
     depth: {
         innerType: 'deep'
     }
 };
 
-var extended = extend(objectBase, objectOne);
+type ExtendedType = typeof objectBase & typeof objectOne;
+const extended: ExtendedType = extend(objectBase, objectOne);
 assert(extended.test === 'one');
-assert(extended.iamone === true);
+assert(extended.iamone);
 
-var moreExtended = extend(objectBase, objectOne, objectTwo);
+type MoreExtendedType = typeof objectBase & typeof objectOne & typeof objectTwo;
+const moreExtended: MoreExtendedType = extend(objectBase, objectOne, objectTwo);
 assert(moreExtended.test === 2);
-assert(moreExtended.iamone === true);
-assert(moreExtended.iamtwo === true);
+assert(moreExtended.iamone);
+assert(moreExtended.iamtwo);
 
-var deepExtended = extend(true, objectBase, objectOne, objectTwo, objectThree);
-assert(deepExtended.iamone === true);
-assert(moreExtended.iamtwo === true);
-assert(deepExtended.iamthree === true);
-assert(deepExtended.depth.innerType === 'one');
+type DeepExtendedType = typeof objectBase & typeof objectOne &
+  typeof objectTwo & typeof objectThree;
+const deepExtended = extend(true, objectBase, objectOne, objectTwo, objectThree);
+assert(deepExtended.iamone);
+assert(deepExtended.iamtwo);
+assert(deepExtended.iamthree);
+assert(deepExtended.depth.innerType === 'deep');

--- a/types/extend/index.d.ts
+++ b/types/extend/index.d.ts
@@ -1,9 +1,20 @@
-// Type definitions for extend v2.0.0
+// Type definitions for extend 3.0
 // Project: https://www.npmjs.com/package/extend
 // Definitions by: Stefan Steinhart <https://github.com/reppners>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
-declare function extend(deepOrObject: boolean | Object, ...objectN: Object[]): any;
-declare namespace extend { }
+declare function extend<T, U>(deep: boolean, target: T, source: U): T & U;
+declare function extend<T, U, V>(deep: boolean, target: T, source1: U, source2: V): T & U & V;
+declare function extend<T, U, V, W>(deep: boolean, target: T, source1: U, source2: V,
+  source3: W): T & U & V & W;
+declare function extend<T, U, V, W, X>(deep: boolean, target: T, source1: U, source2: V,
+  source3: W, source4: X): T & U & V & W & X;
+declare function extend<T, U>(target: T, source: U): T & U;
+declare function extend<T, U, V>(target: T, source1: U, source2: V): T & U & V;
+declare function extend<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+declare function extend<T, U, V, W, X>(target: T, source1: U, source2: V,
+  source3: W, source4: X): T & U & V & W & X;
+declare function extend(deep: boolean, target: any, ...sources: any[]): any;
+declare function extend(target: any, ...sources: any[]): any;
+declare namespace extend {}
 export = extend;

--- a/types/extend/tslint.json
+++ b/types/extend/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This change makes the return type of `extend` more useful. I've done up to five levels of arg lengths, since the code I am writing requires that much.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/extend (it says it's equivalent to `Object.assign`)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
