### PR TITLE
Move axe call back to axe from scales

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -432,20 +432,6 @@ declare namespace Chart {
         type?: ScaleType | string;
         display?: boolean;
         position?: PositionType | string;
-        beforeUpdate?(scale?: any): void;
-        beforeSetDimension?(scale?: any): void;
-        beforeDataLimits?(scale?: any): void;
-        beforeBuildTicks?(scale?: any): void;
-        beforeTickToLabelConversion?(scale?: any): void;
-        beforeCalculateTickRotation?(scale?: any): void;
-        beforeFit?(scale?: any): void;
-        afterUpdate?(scale?: any): void;
-        afterSetDimension?(scale?: any): void;
-        afterDataLimits?(scale?: any): void;
-        afterBuildTicks?(scale?: any): void;
-        afterTickToLabelConversion?(scale?: any): void;
-        afterCalculateTickRotation?(scale?: any): void;
-        afterFit?(scale?: any): void;
         gridLines?: GridLineOptions;
         scaleLabel?: ScaleTitleOptions;
         ticks?: TickOptions;
@@ -463,6 +449,20 @@ declare namespace Chart {
         gridLines?: GridLineOptions;
         barThickness?: number;
         scaleLabel?: ScaleTitleOptions;
+        beforeUpdate?(scale?: any): void;
+        beforeSetDimension?(scale?: any): void;
+        beforeDataLimits?(scale?: any): void;
+        beforeBuildTicks?(scale?: any): void;
+        beforeTickToLabelConversion?(scale?: any): void;
+        beforeCalculateTickRotation?(scale?: any): void;
+        beforeFit?(scale?: any): void;
+        afterUpdate?(scale?: any): void;
+        afterSetDimension?(scale?: any): void;
+        afterDataLimits?(scale?: any): void;
+        afterBuildTicks?(scale?: any): void;
+        afterTickToLabelConversion?(scale?: any): void;
+        afterCalculateTickRotation?(scale?: any): void;
+        afterFit?(scale?: any): void;
     }
 
     interface ChartXAxe extends CommonAxe {


### PR DESCRIPTION
These callbacks do not exist on scales, but exist instead on the axe.
This is not well described in the documentation, but adding them to the scales
they are never called while they are called if they are added to the axe.