### PR TITLE
Added styling options to ReferenceArea element

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -24,6 +24,10 @@ export type ScaleType = 'auto' | 'linear' | 'pow' | 'sqrt' | 'log' | 'identity' 
 export type PositionType = 'top' | 'left' | 'right' | 'bottom' | 'inside' | 'outside'| 'insideLeft' | 'insideRight' |
 	'insideTop' | 'insideBottom' | 'insideTopLeft' | 'insideBottomLeft' | 'insideTopRight' | 'insideBottomRight' | 'insideStart' | 'insideEnd' | 'end' | 'center';
 
+type PartialAndNumber<T> = {
+   [P in keyof T]?: number | T[P];
+};
+
 export interface Margin {
 	top: number;
 	right: number;
@@ -535,7 +539,7 @@ export interface RectangleProps extends Partial<CSSStyleDeclaration> {
 
 export class Rectangle extends React.Component<RectangleProps> { }
 
-export interface ReferenceAreaProps extends Partial<CSSStyleDeclaration> {
+export interface ReferenceAreaProps extends PartialAndNumber<CSSStyleDeclaration> {
 	xAxisId?: string | number;
 	yAxisId?: string | number;
 	x1?: number | string;

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -178,7 +178,9 @@ export class CartesianGrid extends React.Component<CartesianGridProps> { }
 
 export interface CellProps {
 	fill?: string;
+	fillOpacity?: number;
 	stroke?: string;
+	strokeOpacity?: number;
 }
 
 export class Cell extends React.Component<CellProps> { }
@@ -535,7 +537,7 @@ export interface RectangleProps extends Partial<CSSStyleDeclaration> {
 
 export class Rectangle extends React.Component<RectangleProps> { }
 
-export interface ReferenceAreaProps {
+export interface ReferenceAreaProps extends CellProps {
 	xAxisId?: string | number;
 	yAxisId?: string | number;
 	x1?: number | string;

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -24,7 +24,7 @@ export type ScaleType = 'auto' | 'linear' | 'pow' | 'sqrt' | 'log' | 'identity' 
 export type PositionType = 'top' | 'left' | 'right' | 'bottom' | 'inside' | 'outside'| 'insideLeft' | 'insideRight' |
 	'insideTop' | 'insideBottom' | 'insideTopLeft' | 'insideBottomLeft' | 'insideTopRight' | 'insideBottomRight' | 'insideStart' | 'insideEnd' | 'end' | 'center';
 
-type PartialAndNumber<T> = {
+export type PartialAndNumber<T> = {
    [P in keyof T]?: number | T[P];
 };
 

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -178,9 +178,7 @@ export class CartesianGrid extends React.Component<CartesianGridProps> { }
 
 export interface CellProps {
 	fill?: string;
-	fillOpacity?: number;
 	stroke?: string;
-	strokeOpacity?: number;
 }
 
 export class Cell extends React.Component<CellProps> { }
@@ -537,7 +535,7 @@ export interface RectangleProps extends Partial<CSSStyleDeclaration> {
 
 export class Rectangle extends React.Component<RectangleProps> { }
 
-export interface ReferenceAreaProps extends CellProps {
+export interface ReferenceAreaProps extends Partial<CSSStyleDeclaration> {
 	xAxisId?: string | number;
 	yAxisId?: string | number;
 	x1?: number | string;

--- a/types/recharts/recharts-tests.tsx
+++ b/types/recharts/recharts-tests.tsx
@@ -23,7 +23,13 @@ const Component = (props: {}) => {
             <Line type="monotone" dataKey="pv" stroke="#82ca9d" />
             <Tooltip />
             <ReferenceLine />
-            <ReferenceArea />
+            <ReferenceArea
+                stroke="red"
+                fill="red"
+                y2={1}
+                strokeOpacity={0.2}
+                fillOpacity={0.1}
+            />
         </LineChart>
     );
 };


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See code example at http://recharts.org/#/en-US/api/ReferenceArea
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.



