### PR TITLE
Atom: support v1.21. Remove the Electron dependency.

### DIFF
--- a/types/atom/package.json
+++ b/types/atom/package.json
@@ -1,6 +1,0 @@
-{
-    "private": true,
-    "dependencies": {
-        "electron": "1.6.9"
-    }
-}

--- a/types/pathwatcher/index.d.ts
+++ b/types/pathwatcher/index.d.ts
@@ -7,6 +7,8 @@
 /// <reference types="node" />
 /// <reference types="event-kit" />
 
+import { ReadStream, WriteStream } from "fs";
+
 declare global {
 	namespace PathWatcher {
 		/** Objects that appear as parameters to callbacks. */
@@ -128,13 +130,13 @@ declare global {
 			read(flushCache?: boolean): Promise<string>;
 
 			/** Returns a stream to read the content of the file. */
-			createReadStream(): NodeJS.ReadableStream;
+			createReadStream(): ReadStream;
 
 			/** Overwrites the file with the given text. */
 			write(text: string): Promise<undefined>;
 
 			/** Returns a stream to write content to the file. */
-			createWriteStream(): NodeJS.WritableStream;
+			createWriteStream(): WriteStream;
 
 			/** Overwrites the file with the given text. */
 			writeSync(text: string): undefined;

--- a/types/pathwatcher/pathwatcher-tests.ts
+++ b/types/pathwatcher/pathwatcher-tests.ts
@@ -59,7 +59,8 @@ async function readFile() {
 	str = await file.read();
 }
 
-file.createReadStream();
+const stream = file.createReadStream();
+stream.close();
 
 async function writeFile() {
 	await file.write("Test");

--- a/types/text-buffer/index.d.ts
+++ b/types/text-buffer/index.d.ts
@@ -844,8 +844,11 @@ declare global {
 			onDidChangeEncoding(callback: (encoding: string) => void):
 				EventKit.Disposable;
 
-			/** Invoke the given callback before the buffer is saved to disk. */
-			onWillSave(callback: () => void): EventKit.Disposable;
+			/** Invoke the given callback before the buffer is saved to disk. If the
+			 *  given callback returns a promise, then the buffer will not be saved until
+			 *  the promise resolves.
+			 */
+			onWillSave(callback: () => Promise<void>|void): EventKit.Disposable;
 
 			/** Invoke the given callback after the buffer is saved to disk. */
 			onDidSave(callback: (event: Events.FileSaved) => void):

--- a/types/text-buffer/text-buffer-tests.ts
+++ b/types/text-buffer/text-buffer-tests.ts
@@ -199,7 +199,10 @@ sub = buffer.onDidChangePath((path): void => {
 });
 
 sub = buffer.onDidChangeEncoding(() => void {});
+
 sub = buffer.onWillSave(() => void {});
+sub = buffer.onWillSave(() => Promise.resolve());
+
 sub = buffer.onDidSave(() => void {});
 sub = buffer.onDidDelete(() => void {});
 sub = buffer.onWillReload(() => void {});


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Atom's v1.21 Release](https://github.com/atom/atom/releases/tag/v1.21.0)
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This is the followup to pull request #20240. This simply adds support for Atom v1.21, while removing the Electron dependency from the definitions. This dependency was only present to type one reference within the public Atom API, with the weight of the dependencies outweighing the value of that one type. The alternative was to bundle the electron definitions alone, as we only need the definitions with Atom, but that was denied in the previous PR.