### PR TITLE
Added a definition for projection in mat3 class in gl-Matrix

### DIFF
--- a/types/gl-matrix/gl-matrix-tests.ts
+++ b/types/gl-matrix/gl-matrix-tests.ts
@@ -267,6 +267,7 @@ outMat3 = mat3.multiplyScalar (outMat3, mat3A, 2);
 outMat3 = mat3.multiplyScalarAndAdd (outMat3, mat3A, mat3B, 2);
 outBool = mat3.exactEquals(mat3A, mat3B);
 outBool = mat3.equals(mat3A, mat3B);
+outMat3 = mat3.projection(outMat3, 100, 100);
 
 //mat4
 outMat4 = mat4.create();

--- a/types/gl-matrix/index.d.ts
+++ b/types/gl-matrix/index.d.ts
@@ -1950,6 +1950,16 @@ declare module 'gl-matrix' {
          * @returns out
          */
         public static transpose(out: mat3, a: mat3): mat3;
+        
+         /**
+         * Generates a 2D projection matrix with the given bounds
+         *
+         * @param out the receiving matrix
+         * @param width width of your gl context
+         * @param height height of gl context 
+         * @returns out
+         */
+        public static projection(out: mat3, width: number, height: number): mat3
 
         /**
          * Inverts a mat3

--- a/types/gl-matrix/index.d.ts
+++ b/types/gl-matrix/index.d.ts
@@ -1959,7 +1959,7 @@ declare module 'gl-matrix' {
          * @param height height of gl context 
          * @returns out
          */
-        public static projection(out: mat3, width: number, height: number): mat3
+        public static projection(out: mat3, width: number, height: number): mat3;
 
         /**
          * Inverts a mat3


### PR DESCRIPTION
Added the missing definition for projection function in the `mat3` class for [`gl-Matrix`](https://github.com/toji/gl-matrix) types