### PR TITLE
Revert PouchDB module changes from #18519

### DIFF
--- a/types/pouch-redux-middleware/index.d.ts
+++ b/types/pouch-redux-middleware/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.3
 
 import { Dispatch, Action, Middleware } from 'redux';
-import PouchDB from 'pouchdb';
+import * as PouchDB from 'pouchdb';
 
 export interface Document {
   _id: any;

--- a/types/pouch-redux-middleware/pouch-redux-middleware-tests.ts
+++ b/types/pouch-redux-middleware/pouch-redux-middleware-tests.ts
@@ -1,6 +1,6 @@
 import * as redux from 'redux';
 import makePouchMiddleware, { Document, Path } from 'pouch-redux-middleware';
-import PouchDB from 'pouchdb';
+import * as PouchDB from 'pouchdb';
 
 const types = {
     DELETE_TODO: 'delete-todo',

--- a/types/pouchdb/index.d.ts
+++ b/types/pouchdb/index.d.ts
@@ -24,5 +24,5 @@
 
 declare module 'pouchdb' {
     const plugin: PouchDB.Static;
-    export default plugin;
+    export = plugin;
 }

--- a/types/pouchdb/pouchdb-tests.ts
+++ b/types/pouchdb/pouchdb-tests.ts
@@ -1,4 +1,4 @@
-import PouchDB from 'pouchdb';
+import * as PouchDB from 'pouchdb';
 
 function isString(someString: string) {
 }


### PR DESCRIPTION
Per the README, and with research prompted by #19691, the shape of PouchDB export should reflect what is currently the node package's package.json main export shape (not jsnext:main).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#a-package-uses-export--but-i-prefer-to-use-default-imports-can-i-change-export--to-export-default
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

