### PR TITLE
angular-hotkeys: expose interfaces to allow ES6-style import

### DIFF
--- a/types/angular-hotkeys/index.d.ts
+++ b/types/angular-hotkeys/index.d.ts
@@ -10,6 +10,10 @@
 
 import * as ng from 'angular';
 
+export type HotkeysProvider = ng.hotkeys.HotkeysProvider;
+export type HotkeysProviderChained = ng.hotkeys.HotkeysProviderChained;
+export type Hotkey = ng.hotkeys.Hotkey;
+
 declare module 'angular' {
     export namespace hotkeys {
 


### PR DESCRIPTION
This change to the module definition allows ES6 style imports, e.g. `import { HotkeysProvider } from 'angular-hotkeys';`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.



Changes are pretty simple and the idea was taken from

angular-ui-router:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/55feb7cdecb1b164655e10b4c1d5e5d58be22c0c/types/angular-ui-router/index.d.ts#L14-L25

angular-ui-bootstrap:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/55feb7cdecb1b164655e10b4c1d5e5d58be22c0c/types/angular-ui-bootstrap/index.d.ts#L11-L34