### PR TITLE
Fix for TextMetrics bug in pixi.js

### DIFF
--- a/types/pixi.js/index.d.ts
+++ b/types/pixi.js/index.d.ts
@@ -1417,7 +1417,7 @@ declare namespace PIXI {
         width: number;
         height: number;
         lines: number[];
-        lineWidgets: number[];
+        lineWidths: number[];
         lineHeight: number;
         maxLineWidth: number;
         fontProperties: any;


### PR DESCRIPTION
In pixi.js the field lineWidgets in TextMetrics should be lineWidths according to the pixi js documentation found here http://pixijs.download/dev/docs/PIXI.TextMetrics.html.