### PR TITLE
Added the styling props to the ReferenceLine type definitions

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -579,7 +579,7 @@ export interface ReferenceDotProps {
 
 export class ReferenceDot extends React.Component<ReferenceDotProps> { }
 
-export interface ReferenceLineProps {
+export interface ReferenceLineProps extends PartialAndNumber<CSSStyleDeclaration> {
 	xAxisId?: string | number;
 	yAxisId?: string | number;
 	x?: number | string;


### PR DESCRIPTION
Please fill in this template.

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
Following the example here for `ReferenceAreaProps`:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/recharts/index.d.ts#L542
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

