### PR TITLE
Remove tslint rule linebreak-style as it forces erros on windows

### DIFF
--- a/types/atom-keymap/tslint.json
+++ b/types/atom-keymap/tslint.json
@@ -5,7 +5,6 @@
         "class-name": true,
         "indent": [true, "tabs"],
         "jsdoc-format": true,
-        "linebreak-style": [true, "LF"],
         "max-line-length": [true, 100],
         "quotemark": [true, "double", "avoid-escape"],
         "trailing-comma": [true, {

--- a/types/atom/tslint.json
+++ b/types/atom/tslint.json
@@ -6,7 +6,6 @@
         "class-name": true,
         "indent": [true, "tabs"],
         "jsdoc-format": true,
-        "linebreak-style": [true, "LF"],
         "max-line-length": [true, 100],
         "no-any": false,
         "quotemark": [true, "double", "avoid-escape"],

--- a/types/event-kit/tslint.json
+++ b/types/event-kit/tslint.json
@@ -5,7 +5,6 @@
         "class-name": true,
         "indent": [true, "tabs"],
         "jsdoc-format": true,
-        "linebreak-style": [true, "LF"],
         "max-line-length": [true, 100],
         "no-any": false,
         "quotemark": [true, "double", "avoid-escape"],

--- a/types/first-mate/tslint.json
+++ b/types/first-mate/tslint.json
@@ -5,7 +5,6 @@
         "class-name": true,
         "indent": [true, "tabs"],
         "jsdoc-format": true,
-        "linebreak-style": [true, "LF"],
         "max-line-length": [true, 100],
         "quotemark": [true, "double", "avoid-escape"],
         "trailing-comma": [true, {

--- a/types/pathwatcher/tslint.json
+++ b/types/pathwatcher/tslint.json
@@ -5,7 +5,6 @@
         "class-name": true,
         "indent": [true, "tabs"],
         "jsdoc-format": true,
-        "linebreak-style": [true, "LF"],
         "max-line-length": [true, 100],
         "quotemark": [true, "double", "avoid-escape"],
         "trailing-comma": [true, {

--- a/types/text-buffer/tslint.json
+++ b/types/text-buffer/tslint.json
@@ -5,7 +5,6 @@
         "class-name": true,
         "indent": [true, "tabs"],
         "jsdoc-format": true,
-        "linebreak-style": [true, "LF"],
         "max-line-length": [true, 100],
         "quotemark": [true, "double", "avoid-escape"],
         "trailing-comma": [true, {


### PR DESCRIPTION
The .gitattributes file specifies `* text=auto` resulting in files with CRLF on windows and LF on linux during clone.

Therefore the lint rule checking on LF will always fail on windows but never on linux.

No change in the definition itself was done.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
