### PR TITLE
Add typings for tabris-plugin-firebase

### DIFF
--- a/types/tabris-plugin-firebase/index.d.ts
+++ b/types/tabris-plugin-firebase/index.d.ts
@@ -64,7 +64,7 @@ interface EventObject<T> {
  * Base class for all objects with a native implementation.
  */
 declare class NativeObject {
-    protected constructor(properties?: {});
+    protected constructor(properties?: object);
 
     /**
      * Gets the current value of the given *property*.
@@ -84,7 +84,7 @@ declare class NativeObject {
      * Removes all listeners in the given object from the event type indicated by their key.
      * @param listeners A key-value map where the keys are event types and the values are the listeners to deregister from these events, e.g. `{tap: onTap, scroll: onScroll}`.
      */
-    off(listeners: {}): this;
+    off(listeners: object): this;
 
     /**
      * Registers a *listener* function to be notified of events of the given *type*.
@@ -98,7 +98,7 @@ declare class NativeObject {
      * Registers all listeners in the given object for the event type indicated by their key.
      * @param listeners A key-value map where the keys are event types and the values are the listeners to register for these events, e.g. `{tap: onTap, scroll: onScroll}`.
      */
-    on(listeners: {}): this;
+    on(listeners: object): this;
 
     /**
      * Same as `on`, but removes the listener after it has been invoked by an event.
@@ -112,7 +112,7 @@ declare class NativeObject {
      * Same as `on`, but removes the listener after it has been invoked by an event.
      * @param listeners A key-value map where the keys are event types and the values are the listeners to register for these events, e.g. `{tap: onTap, scroll: onScroll}`.
      */
-    once(listeners: {}): this;
+    once(listeners: object): this;
 
     /**
      * Sets the given property.
@@ -125,7 +125,7 @@ declare class NativeObject {
      * Sets all key-value pairs in the properties object as widget properties.
      * @param properties
      */
-    set(properties: {}): this;
+    set(properties: object): this;
 
     /**
      * Notifies all registered listeners for the given *type* and passes the *event* object to the

--- a/types/tabris-plugin-firebase/index.d.ts
+++ b/types/tabris-plugin-firebase/index.d.ts
@@ -1,0 +1,152 @@
+// Type definitions for tabris-plugin-firebase 1.0
+// Project: https://github.com/eclipsesource/tabris-plugin-firebase/
+// Definitions by: EclipseSource <https://github.com/eclipsesource>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+declare global {
+    namespace firebase {
+        const Analytics: Analytics;
+        const Messaging: Messaging;
+        const MessagingEvents: MessagingEvents;
+        const MessageEvent: MessageEvent;
+        type AnalyticsProperties = Partial<PropertyMixins.Analytics>;
+
+        interface Analytics extends NativeObject, PropertyMixins.Analytics {
+            logEvent(eventName: string, parameters?: {[key: string]: string}): void;
+            setUserProperty(propertyName: string, value: string): void;
+            set(properties: AnalyticsProperties): this;
+            set(property: string, value: any): this;
+        }
+
+        interface Messaging extends NativeObject {
+            readonly instanceId: string;
+            readonly token: string;
+            readonly launchData: object;
+            resetInstanceId(): void;
+            on(type: string, listener: (event: any) => void, context?: object): this;
+            on(listeners: MessagingEvents): this;
+            off(type: string, listener: (event: any) => void, context?: object): this;
+            off(listeners: MessagingEvents): this;
+            once(type: string, listener: (event: any) => void, context?: object): this;
+            once(listeners: MessagingEvents): this;
+        }
+
+        interface MessagingEvents {
+            instanceIdChanged?(event: PropertyChangedEvent<Messaging, string>): void;
+            tokenChanged?(event: PropertyChangedEvent<Messaging, string>): void;
+            message?(event: MessageEvent): void;
+        }
+
+        interface MessageEvent extends EventObject<Messaging> {
+            data: any;
+        }
+
+        namespace PropertyMixins {
+            interface Analytics {
+                analyticsCollectionEnabled: boolean;
+                screenName: string;
+                userId: string;
+            }
+        }
+    }
+}
+
+// Tabris.js interfaces
+
+interface EventObject<T> {
+    readonly target: T;
+    readonly timeStamp: number;
+    readonly type: string;
+}
+
+/**
+ * Base class for all objects with a native implementation.
+ */
+declare class NativeObject {
+    protected constructor(properties?: {});
+
+    /**
+     * Gets the current value of the given *property*.
+     * @param property
+     */
+    get(property: string): any;
+
+    /**
+     * Removes all occurrences of *listener* that are bound to *type* and *context* from this widget.
+     * @param type The type of events to remove listeners for.
+     * @param listener The listener function to remove.
+     * @param context The context of the bound listener to remove.
+     */
+    off(type: string, listener: (event: any) => void, context?: object): this;
+
+    /**
+     * Removes all listeners in the given object from the event type indicated by their key.
+     * @param listeners A key-value map where the keys are event types and the values are the listeners to deregister from these events, e.g. `{tap: onTap, scroll: onScroll}`.
+     */
+    off(listeners: {}): this;
+
+    /**
+     * Registers a *listener* function to be notified of events of the given *type*.
+     * @param type The type of events to listen for.
+     * @param listener The listener function to register. This function will be called with an event object.
+     * @param context In the listener function, `this` will point to this object. If not present, the listener will be called in the context of this object.
+     */
+    on(type: string, listener: (event: any) => void, context?: object): this;
+
+    /**
+     * Registers all listeners in the given object for the event type indicated by their key.
+     * @param listeners A key-value map where the keys are event types and the values are the listeners to register for these events, e.g. `{tap: onTap, scroll: onScroll}`.
+     */
+    on(listeners: {}): this;
+
+    /**
+     * Same as `on`, but removes the listener after it has been invoked by an event.
+     * @param type The type of the event to listen for.
+     * @param listener The listener function to register. This function will be called with an event object.
+     * @param context In the listener function, `this` will point to this object. If not present, the listener will be called in the context of this object.
+     */
+    once(type: string, listener: (event: any) => void, context?: object): this;
+
+    /**
+     * Same as `on`, but removes the listener after it has been invoked by an event.
+     * @param listeners A key-value map where the keys are event types and the values are the listeners to register for these events, e.g. `{tap: onTap, scroll: onScroll}`.
+     */
+    once(listeners: {}): this;
+
+    /**
+     * Sets the given property.
+     * @param property
+     * @param value
+     */
+    set(property: string, value: any): this;
+
+    /**
+     * Sets all key-value pairs in the properties object as widget properties.
+     * @param properties
+     */
+    set(properties: {}): this;
+
+    /**
+     * Notifies all registered listeners for the given *type* and passes the *event* object to the
+     * listeners.
+     * @param type The type of event to trigger
+     * @param event The event object to pass to listener functions.
+     */
+    trigger(type: string, event: EventObject<this>): this;
+
+    /**
+     * An application-wide unique identifier automatically assigned to all native objects on creation.
+     * @static
+     */
+    readonly cid: string;
+}
+
+interface PropertyChangedEvent<T, U> {
+    readonly target: T;
+    readonly timeStamp: number;
+    readonly type: string;
+    readonly value: U;
+}
+
+export {};

--- a/types/tabris-plugin-firebase/tabris-plugin-firebase-tests.ts
+++ b/types/tabris-plugin-firebase/tabris-plugin-firebase-tests.ts
@@ -1,0 +1,67 @@
+function testAnalytics() {
+    // Properties
+    let analyticsCollectionEnabled: boolean;
+    let screenName: string;
+    let userId: string;
+
+    analyticsCollectionEnabled = firebase.Analytics.analyticsCollectionEnabled;
+    screenName = firebase.Analytics.screenName;
+    userId = firebase.Analytics.userId;
+
+    firebase.Analytics.analyticsCollectionEnabled = analyticsCollectionEnabled;
+    firebase.Analytics.screenName = screenName;
+    firebase.Analytics.userId = userId;
+
+    const properties: firebase.AnalyticsProperties = {analyticsCollectionEnabled, screenName, userId};
+    const partialProperties: firebase.AnalyticsProperties = {};
+    firebase.Analytics.set(properties);
+    firebase.Analytics.set(partialProperties);
+
+    // Methods
+    let thisReturnValue: firebase.Analytics;
+    const name = '';
+    const property = '';
+
+    thisReturnValue = firebase.Analytics.set({analyticsCollectionEnabled, screenName, userId});
+    firebase.Analytics.logEvent(name, {foo: property});
+    firebase.Analytics.logEvent(name);
+    firebase.Analytics.setUserProperty(name, property);
+}
+
+function testMessaging() {
+    // Properties
+    let instanceId: string;
+    let token: string;
+    let launchData: object;
+
+    instanceId = firebase.Messaging.instanceId;
+    token = firebase.Messaging.token;
+    launchData = firebase.Messaging.launchData;
+
+    // Methods
+    firebase.Messaging.resetInstanceId();
+
+    // Events
+    const target: firebase.Messaging = firebase.Messaging;
+    const timeStamp = 0;
+    const type = 'foo';
+    const value = 'bar';
+    const data: any = {};
+
+    const instanceIdChangedEvent: PropertyChangedEvent<firebase.Messaging, string> = {target, timeStamp, type, value};
+    const tokenChangedEvent: PropertyChangedEvent<firebase.Messaging, string> = {target, timeStamp, type, value};
+    const messageEvent: firebase.MessageEvent = {target, timeStamp, type, data};
+
+    firebase.Messaging.on({
+        instanceIdChanged: (event: PropertyChangedEvent<firebase.Messaging, string>) => {},
+        tokenChanged: (event: PropertyChangedEvent<firebase.Messaging, string>) => {},
+        message: (event: firebase.MessageEvent) => {}
+    });
+}
+
+interface PropertyChangedEvent<T, U> {
+    readonly target: T;
+    readonly timeStamp: number;
+    readonly type: string;
+    readonly value: U;
+}

--- a/types/tabris-plugin-firebase/tsconfig.json
+++ b/types/tabris-plugin-firebase/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "tabris-plugin-firebase-tests.ts"
+    ]
+}

--- a/types/tabris-plugin-firebase/tslint.json
+++ b/types/tabris-plugin-firebase/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "strict-export-declare-modifiers": false
+    }
+}


### PR DESCRIPTION
tabris-plugin-firebase is a plugin for the framework for mobile app
development Tabris.js [1]. The plugin is made available by the Cordova
ecosystem and can thus only be consumed through a global variable.

Disable linter rule "strict-export-declare-modifiers" since using
"export {};" is the recommended way of exporting nothing when the module
is only to be used through a global variable [2].

Include missing Tabris.js interfaces due to the lack of support for the
"peerDependencies" field in package.json. Remove trivial types, i.e.
the interfaces NativeObjectEvents and NativeObjectProperties which were
essentially of type object. Linter rules disallow empty interfaces.

[1]: https://tabrisjs.com
[2]: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
