### PR TITLE
extending the flatten type definition. Adding tests.

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -10,6 +10,7 @@
 //                 Jordan Quagliatini <https://github.com/1M0reBug>
 //                 Simon Højberg <https://github.com/hojberg>
 //                 Charles-Philippe Clermont <https://github.com/charlespwd>
+//                 Iheatu Wogu <https://github.com/iha2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -626,6 +627,9 @@ declare namespace R {
          * them in a new array, depth-first.
          */
         flatten<T>(x: T[] | T[][]): T[];
+        flatten<T>(x: T[][] | T[][][]): T[];
+        flatten<T>(x: T[][][] | T[][][][]): T[];
+        flatten<T>(x: T[][][][]| T[][][][][]): T[];
 
         /**
          * Returns a new function much like the supplied one, except that the first two arguments'

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -626,10 +626,11 @@ declare namespace R {
          * Returns a new list by pulling every item out of it (and all its sub-arrays) and putting
          * them in a new array, depth-first.
          */
-        flatten<T>(x: T[] | T[][]): T[];
-        flatten<T>(x: T[][] | T[][][]): T[];
-        flatten<T>(x: T[][][] | T[][][][]): T[];
-        flatten<T>(x: T[][][][]| T[][][][][]): T[];
+        flatten<T>(x: T[]): T[];
+        flatten<T>(x: T[][]): T[];
+        flatten<T>(x: T[][][]): T[]
+        flatten<T>(x: T[][][][]): T[]
+        flatten<T>(x: T[][][][][]): T[]
 
         /**
          * Returns a new function much like the supplied one, except that the first two arguments'

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -621,7 +621,7 @@ interface Obj {
     // => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     // ensuring flatten infers properly during a composition. known inference issues under this condition
-    R.compose<Obj[][][], Obj[]>(R.flatten)([[[xs, xs], [xs, xs]], [[xs, xs], [xs, xs]], [[xs, xs], [xs, xs]]]);
+    const result = R.compose<Obj[][][], Obj[]>(R.flatten)([[[xs, xs], [xs, xs]], [[xs, xs], [xs, xs]], [[xs, xs], [xs, xs]]]);
     // => [xs, xs, xs, xs, xs, xs, xs, xs, xs, xs, xs, xs]
 };
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -614,8 +614,15 @@ interface Obj {
 };
 
 () => {
+    const xs: Obj = {a: 1, b: 3};
+    R.flatten([[[xs, xs], [xs, xs]], [[xs, xs], [xs, xs]], [[xs, xs], [xs, xs]]]);
+    // => [xs, xs, xs, xs, xs, xs, xs, xs, xs, xs, xs, xs]
     R.flatten([1, 2, [3, 4], 5, [6, [7, 8, [9, [10, 11], 12]]]]);
     // => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
+    // ensuring flatten infers properly during a composition. known inference issues under this condition
+    R.compose<Obj[][][], Obj[]>(R.flatten)([[[xs, xs], [xs, xs]], [[xs, xs], [xs, xs]], [[xs, xs], [xs, xs]]]);
+    // => [xs, xs, xs, xs, xs, xs, xs, xs, xs, xs, xs, xs]
 };
 
 () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



The flatten function has issues when used to compose with other functions. After a certain depth of arrays the composition cannot be inferred. Extending the type definition allows to flatten 3 and 4 dimensional arrays. 