### PR TITLE
[react-table] Make ReactTable the default export

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-table 6.5
 // Project: https://github.com/react-tools/react-table
-// Definitions by: Roy Xue <https://github.com/royxue>
+// Definitions by: Roy Xue <https://github.com/royxue>, Dylan Stewart <https://github.com/dyst5422>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 import * as React from 'react';

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-table 6.5
+// Type definitions for react-table 6.6.0
 // Project: https://github.com/react-tools/react-table
 // Definitions by: Roy Xue <https://github.com/royxue>, Dylan Stewart <https://github.com/dyst5422>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -506,4 +506,4 @@ export interface FinalState extends TableProps {
     rowMinWidth: number;
 }
 
-export class ReactTable extends React.Component<Partial<TableProps>> {}
+export default class ReactTable extends React.Component<Partial<TableProps>> {}


### PR DESCRIPTION
The only way the previous typings worked was if synthetic default exports were turned on.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/react-tools/react-table/blob/master/src/index.js>>
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
