### PR TITLE
Widened 'koa'.Context.session type3 in order to enable strict null ch…

### DIFF
--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -108,7 +108,7 @@ declare function session(app: Koa): Koa.Middleware;
 
 declare module 'koa' {
     interface Context {
-        session: session.sessionProps;
+        session: session.sessionProps | null;
     }
 }
 


### PR DESCRIPTION
@kerol2r20 

The current definition for the `'koa'.Context.session` property does not specify that it can be set to `null` when resetting the session. This makes it difficult or impossible to enable strict null checks in the compiler.

The correct definition, included in the pull request, is:
```typescript
declare module 'koa' {
    interface Context {
        session: session.sessionProps | null;
    }
}
```