### PR TITLE
[react-bootstrap-table] csvFileName also accepts function returning string

### DIFF
--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -177,7 +177,7 @@ export interface BootstrapTableProps extends Props<BootstrapTable> {
 	/**
 	 * Set CSV filename (e.g. items.csv). Default is spreadsheet.csv
 	 */
-	csvFileName?: string;
+	csvFileName?: () => string | string;
 	/**
 	 * Enable row selection on table. selectRow accept an object which have the following properties
 	 */


### PR DESCRIPTION
The `csvFileName` prop on the `BootstrapTable` component also accepts a function that returns a string.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/AllenFang/react-bootstrap-table/blob/fdaa91a3a763918bd0f0723ec433811b4223e857/src/BootstrapTable.js#L1133
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.