### PR TITLE
mithril - Add other component types for onmatch return type

### DIFF
--- a/types/mithril/index.d.ts
+++ b/types/mithril/index.d.ts
@@ -65,7 +65,7 @@ declare namespace Mithril {
 
 	interface RouteResolver<Attrs, State> {
 		/** The onmatch hook is called when the router needs to find a component to render. */
-		onmatch?(this: this, args: Attrs, requestedPath: string): Component<any, any> | Promise<any> | void;
+		onmatch?(this: this, args: Attrs, requestedPath: string): ComponentTypes<any, any> | Promise<any> | void;
 		/** The render method is called on every redraw for a matching route. */
 		render?(this: this, vnode: Vnode<Attrs, State>): Children;
 	}

--- a/types/mithril/test/test-route.ts
+++ b/types/mithril/test/test-route.ts
@@ -1,4 +1,4 @@
-import { Component, Comp, RouteResolver } from 'mithril';
+import { Vnode, Component, Comp, ClassComponent, FactoryComponent, RouteResolver } from 'mithril';
 import * as h from 'mithril/hyperscript';
 import * as route from 'mithril/route';
 
@@ -22,6 +22,7 @@ interface State {
 	text: string;
 }
 
+// Test various component types with router
 const component3: Comp<Attrs, State> = {
 	text: "Uninitialized",
 	oninit({state}) {
@@ -30,6 +31,20 @@ const component3: Comp<Attrs, State> = {
 	view({attrs}) {
 		return h('p', 'id: ' + attrs.id);
 	}
+};
+
+class Component4 implements ClassComponent<Attrs> {
+	view({attrs}: Vnode<Attrs, {}>) {
+		return h('p', 'id: ' + attrs.id);
+	}
+}
+
+const component5: FactoryComponent<Attrs> = () => {
+	return {
+		view({attrs}) {
+			return h('p', 'id: ' + attrs.id);
+		}
+	};
 };
 
 // RouteResolver example using Attrs type and this context
@@ -75,7 +90,22 @@ route(document.body, '/', {
 			});
 		}
 	},
-	'test5/:id': routeResolver
+	'test5/:id': routeResolver,
+	test6: {
+		onmatch(args, path) {
+			// Can return ClassComponent from onmatch
+			return Component4;
+		}
+	},
+	test7: {
+		onmatch(args, path) {
+			// Can return FactoryComponent from onmatch
+			return component5;
+		}
+	},
+	// Can use other component types for routes
+	test8: Component4,
+	test9: component5
 });
 
 route.prefix('/app');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/MithrilJS/mithril.js/pull/1640#issuecomment-334904416

All component types can be returned from the `RouteResolver`'s `onmatch` method.