### PR TITLE
Changed title/label props on components to ReactNode instead HTML props string, per docs

### DIFF
--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -9,6 +9,7 @@
 //                 Kat Busch <https://github.com/katbusch>,
 //                 Vito Samson <https://github.com/vitosamson>
 //                 Karol Janyst <https://github.com/LKay>
+//                 Aaron Beall <https://github.com/aaronbeall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/react-bootstrap/lib/DropdownButton.d.ts
+++ b/types/react-bootstrap/lib/DropdownButton.d.ts
@@ -10,6 +10,7 @@ declare namespace DropdownButton {
         navItem?: boolean;
         noCaret?: boolean;
         pullRight?: boolean;
+        title: React.ReactNode;
     }
 
     export type DropdownButtonProps = DropdownButtonBaseProps & React.HTMLProps<DropdownButton>;

--- a/types/react-bootstrap/lib/Popover.d.ts
+++ b/types/react-bootstrap/lib/Popover.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Sizes } from 'react-bootstrap';
+import { Sizes, Omit } from 'react-bootstrap';
 
 declare namespace Popover {
-    export interface PopoverProps extends React.HTMLProps<Popover> {
+    export interface PopoverProps extends Omit<React.HTMLProps<Popover>, "title"> {
         // Optional
         arrowOffsetLeft?: number | string;
         arrowOffsetTop?: number | string;
@@ -11,6 +11,7 @@ declare namespace Popover {
         placement?: string;
         positionLeft?: number | string; // String support added since v0.30.0
         positionTop?: number | string; // String support added since v0.30.0
+        title?: React.ReactNode;
     }
 }
 declare class Popover extends React.Component<Popover.PopoverProps> { }

--- a/types/react-bootstrap/lib/ProgressBar.d.ts
+++ b/types/react-bootstrap/lib/ProgressBar.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Sizes } from 'react-bootstrap';
+import { Sizes, Omit } from 'react-bootstrap';
 
 declare namespace ProgressBar {
-    export interface ProgressBarProps extends React.HTMLProps<ProgressBar> {
+    export interface ProgressBarProps extends Omit<React.HTMLProps<ProgressBar>, "label"> {
         // Optional
         active?: boolean;
         bsSize?: Sizes;
@@ -13,6 +13,7 @@ declare namespace ProgressBar {
         now?: number;
         srOnly?: boolean;
         striped?: boolean;
+        label?: React.ReactNode;
     }
 }
 declare class ProgressBar extends React.Component<ProgressBar.ProgressBarProps> { }

--- a/types/react-bootstrap/lib/SplitButton.d.ts
+++ b/types/react-bootstrap/lib/SplitButton.d.ts
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { Sizes } from 'react-bootstrap';
+import { Sizes, Omit } from 'react-bootstrap';
 
 declare namespace SplitButton {
-    export interface SplitButtonProps extends React.HTMLProps<SplitButton> {
+    export interface SplitButtonProps extends Omit<React.HTMLProps<SplitButton>, "title"> {
         bsStyle?: string;
         bsSize?: Sizes;
         dropdownTitle?: any; // TODO: Add more specific type
         dropup?: boolean;
         pullRight?: boolean;
+        title: React.ReactNode;
+        id: string;
     }
 }
 declare class SplitButton extends React.Component<SplitButton.SplitButtonProps> { }

--- a/types/react-bootstrap/lib/Tab.d.ts
+++ b/types/react-bootstrap/lib/Tab.d.ts
@@ -1,17 +1,18 @@
 import * as React from 'react';
-import { TransitionCallbacks } from 'react-bootstrap';
+import { TransitionCallbacks, Omit } from 'react-bootstrap';
 import * as TabContainer from './TabContainer';
 import * as TabPane from './TabPane';
 import * as TabContent from './TabContent';
 
 declare namespace Tab {
-    export interface TabProps extends TransitionCallbacks, React.HTMLProps<Tab> {
+    export interface TabProps extends TransitionCallbacks, Omit<React.HTMLProps<Tab>, "title"> {
         animation?: boolean;
         'aria-labelledby'?: string;
         bsClass?: string;
         eventKey?: any; // TODO: Add more specific type
         unmountOnExit?: boolean;
         tabClassName?: string;
+        title?: React.ReactNode; // Override HTMLProps.title to allow nodes not just strings
     }
 }
 declare class Tab extends React.Component<Tab.TabProps> {

--- a/types/react-bootstrap/test/react-bootstrap-individual-components-tests.tsx
+++ b/types/react-bootstrap/test/react-bootstrap-individual-components-tests.tsx
@@ -120,7 +120,7 @@ export class ReactBootstrapIndividualComponentsTest extends React.Component {
         <Collapse />
         <ControlLabel />
         <Dropdown id="foo" />
-        <DropdownButton id="foo" />
+        <DropdownButton id="foo" title="bar" />
         <DropdownMenu />
         <DropdownToggle />
         <Fade />
@@ -178,7 +178,7 @@ export class ReactBootstrapIndividualComponentsTest extends React.Component {
         <ResponsiveEmbed />
         <Row />
         <SafeAnchor />
-        <SplitButton />
+        <SplitButton id="foo" title="bar" />
         <SplitToggle />
         <Tab />
         <TabContainer />


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-bootstrap.github.io/components.html#tabs-props-pane
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

