### PR TITLE
[fluent-ffmpeg] Added static ffprobe and fixed ffprobe.

### DIFF
--- a/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
+++ b/types/fluent-ffmpeg/fluent-ffmpeg-tests.ts
@@ -50,3 +50,7 @@ command.clone()
 
 // Save a converted version with the original size
 command.save('/path/to/output-original-size.mp4');
+
+ffmpeg.ffprobe('/path/to/file.avi', (err, metadata) => {
+    console.dir(metadata);
+});

--- a/types/fluent-ffmpeg/index.d.ts
+++ b/types/fluent-ffmpeg/index.d.ts
@@ -277,10 +277,10 @@ declare namespace Ffmpeg {
 
         // ffprobe
         /* tslint:disable:unified-signatures */
-        ffprobe(callback: (err: any, data: FfprobeData) => void): (err: any, data: FfprobeData) => void;
-        ffprobe(index: number, callback: (err: any, data: FfprobeData) => void): (err: any, data: FfprobeData) => void;
-        ffprobe(options: string[], callback: (err: any, data: FfprobeData) => void): (err: any, data: FfprobeData) => void;
-        ffprobe(index: number, options: string[], callback: (err: any, data: FfprobeData) => void): (err: any, data: FfprobeData) => void;
+        ffprobe(callback: (err: any, data: FfprobeData) => void): void;
+        ffprobe(index: number, callback: (err: any, data: FfprobeData) => void): void;
+        ffprobe(options: string[], callback: (err: any, data: FfprobeData) => void): void;
+        ffprobe(index: number, options: string[], callback: (err: any, data: FfprobeData) => void): void;
         /* tslint:enable:unified-signatures */
 
         // recipes
@@ -300,6 +300,13 @@ declare namespace Ffmpeg {
         clone(): FfmpegCommand;
         run(): void;
     }
+
+    /* tslint:disable:unified-signatures */
+    function ffprobe(file: string, callback: (err: any, data: FfprobeData) => void): void;
+    function ffprobe(file: string, index: number, callback: (err: any, data: FfprobeData) => void): void;
+    function ffprobe(file: string, options: string[], callback: (err: any, data: FfprobeData) => void): void;
+    function ffprobe(file: string, index: number, options: string[], callback: (err: any, data: FfprobeData) => void): void;
+    /* tslint:enable:unified-signatures */
 }
 declare function Ffmpeg(options?: Ffmpeg.FfmpegCommandOptions): Ffmpeg.FfmpegCommand;
 declare function Ffmpeg(input?: string | stream.Readable, options?: Ffmpeg.FfmpegCommandOptions): Ffmpeg.FfmpegCommand;


### PR DESCRIPTION
usage: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg#reading-video-metadata
impl: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/blob/master/lib/fluent-ffmpeg.js#L219
ffprobe returns void: https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/blob/master/lib/ffprobe.js#L86

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.) see test and docs
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: see above
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
