### PR TITLE
Minor fixes/adjustments to ESTree

### DIFF
--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -42,7 +42,7 @@ export type Node =
     ClassBody | Class | MethodDefinition | ModuleDeclaration | ModuleSpecifier;
 
 export interface Comment extends BaseNodeWithoutComments {
-  type: 'Line' | 'Block';
+  type: "Line" | "Block";
   value: string;
 }
 
@@ -349,7 +349,7 @@ export type Literal = SimpleLiteral | RegExpLiteral;
 export interface SimpleLiteral extends BaseNode, BaseExpression {
   type: "Literal";
   value: string | boolean | number | null;
-  raw: string;
+  raw?: string;
 }
 
 export interface RegExpLiteral extends BaseNode, BaseExpression {

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -21,23 +21,28 @@
 // but it has the notable advantage of making ESTree much easier to use as
 // an end user.
 
-interface BaseNode {
+interface BaseNodeWithoutComments {
   // Every leaf interface that extends BaseNode must specify a type property.
   // The type property should be a string literal. For example, Identifier
   // has: `type: "Identifier"`
-
-  leadingComments?: Array<Comment>;
-  trailingComments?: Array<Comment>;
+  type: string;
   loc?: SourceLocation | null;
   range?: [number, number];
 }
+
+interface BaseNode extends BaseNodeWithoutComments {
+  leadingComments?: Array<Comment>;
+  trailingComments?: Array<Comment>;
+}
+
 export type Node =
     Identifier | Literal | Program | Function | SwitchCase | CatchClause |
     VariableDeclarator | Statement | Expression | Property |
     AssignmentProperty | Super | TemplateElement | SpreadElement | Pattern |
     ClassBody | Class | MethodDefinition | ModuleDeclaration | ModuleSpecifier;
 
-export interface Comment {
+export interface Comment extends BaseNodeWithoutComments {
+  type: 'Line' | 'Block';
   value: string;
 }
 
@@ -74,13 +79,13 @@ interface BaseFunction extends BaseNode {
 export type Function =
     FunctionDeclaration | FunctionExpression | ArrowFunctionExpression;
 
-
 export type Statement =
     ExpressionStatement | BlockStatement | EmptyStatement |
     DebuggerStatement | WithStatement | ReturnStatement | LabeledStatement |
     BreakStatement | ContinueStatement | IfStatement | SwitchStatement |
     ThrowStatement | TryStatement | WhileStatement | DoWhileStatement |
     ForStatement | ForInStatement | ForOfStatement | Declaration;
+
 interface BaseStatement extends BaseNode { }
 
 export interface EmptyStatement extends BaseStatement {
@@ -186,6 +191,7 @@ export interface DebuggerStatement extends BaseStatement {
 
 export type Declaration =
       FunctionDeclaration | VariableDeclaration | ClassDeclaration;
+
 interface BaseDeclaration extends BaseStatement { }
 
 export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
@@ -214,6 +220,7 @@ type Expression =
     CallExpression | NewExpression | SequenceExpression | TemplateLiteral |
     TaggedTemplateExpression | ClassExpression | MetaProperty | Identifier |
     AwaitExpression;
+
 export interface BaseExpression extends BaseNode { }
 
 export interface ThisExpression extends BaseExpression {
@@ -254,7 +261,7 @@ export interface SequenceExpression extends BaseExpression {
 export interface UnaryExpression extends BaseExpression {
   type: "UnaryExpression";
   operator: UnaryOperator;
-  prefix: boolean;
+  prefix: true;
   argument: Expression;
 }
 
@@ -317,6 +324,7 @@ export interface MemberExpression extends BaseExpression, BasePattern {
 export type Pattern =
     Identifier | ObjectPattern | ArrayPattern | RestElement |
     AssignmentPattern | MemberExpression;
+
 interface BasePattern extends BaseNode { }
 
 export interface SwitchCase extends BaseNode {
@@ -346,12 +354,12 @@ export interface SimpleLiteral extends BaseNode, BaseExpression {
 
 export interface RegExpLiteral extends BaseNode, BaseExpression {
   type: "Literal";
-  value: RegExp;
+  value?: RegExp | null;
   regex: {
     pattern: string;
     flags: string;
   };
-  raw: string;
+  raw?: string;
 }
 
 export type UnaryOperator =


### PR DESCRIPTION
 - Add `type: string` to base interface to allow only strings for `type` in any descendants.
 - Change `UnaryExpression::prefix` to `true` (since it can never be false and is just a backwards compatibility artefact).
 - Add absent / `null` as a valid `RegexpLiteral::value` (it's used by compliant parsers/tools when RegExp can't be natively represented).
 - Make `Literal::raw` optional to allow creating nodes without one.
 - Add missing `type` and location properties to `Comment` node.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/estree/estree/blob/master/es5.md
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.