### PR TITLE
Update aria props, add missing insertion type

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Draft.js v0.10.1
+// Type definitions for Draft.js v0.10.3
 // Project: https://facebook.github.io/draft-js/
 // Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>
 //                 Eelco Lempsink <https://github.com/eelco>
@@ -111,11 +111,11 @@ declare namespace Draft {
 
                 ariaActiveDescendantID?: string;
                 ariaAutoComplete?: string;
+                ariaControls?: string;
                 ariaDescribedBy?: string;
                 ariaExpanded?: boolean;
-                ariaHasPopup?: boolean;
                 ariaLabel?: string;
-                ariaOwneeID?: string;
+                ariaMultiline?: boolean;
 
                 webDriverTestID?: string;
 
@@ -320,6 +320,12 @@ declare namespace Draft {
              * to indicate whether an event was handled or not.
              */
             type DraftHandleValue = "handled" | "not-handled";
+
+            /**
+             * A type that defines if an fragment shall be inserted before or after
+             * another fragment or if the selected fragment shall be replaced
+             */
+            type DraftInsertionType = "replace" | "before" | "after";
         }
 
         namespace Decorators {
@@ -828,6 +834,7 @@ declare namespace Draft {
 
             class AtomicBlockUtils {
                 static insertAtomicBlock(editorState: EditorState, entityKey: string, character: string): EditorState;
+                static moveAtomicBlock(editorState: EditorState, atomicBlock: ContentBlock, targetRange: SelectionState, insertionMode?: DraftInsertionType): EditorState;
             }
 
             /**
@@ -943,6 +950,7 @@ import DraftDragType = Draft.Model.Constants.DraftDragType;
 import DraftBlockType = Draft.Model.Constants.DraftBlockType;
 import DraftRemovalDirection = Draft.Model.Constants.DraftRemovalDirection;
 import DraftHandleValue = Draft.Model.Constants.DraftHandleValue;
+import DraftInsertionType = Draft.Model.Constants.DraftInsertionType;
 
 export {
     Editor,
@@ -982,5 +990,6 @@ export {
     DraftDragType,
     DraftBlockType,
     DraftRemovalDirection,
-    DraftHandleValue
+    DraftHandleValue,
+    DraftInsertionType,
 };


### PR DESCRIPTION
Updated aria props to reflect 0.10.3, added DraftInsertionType

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [DraftInsertionType](https://github.com/facebook/draft-js/blob/b7fadfffec410b3332e056767f627324ecc5b725/src/model/constants/DraftInsertionType.js), [DraftEditorProps](https://github.com/facebook/draft-js/blob/8ee0449da8f38aeb24b149aef5b397a12a4cb42a/src/component/base/DraftEditorProps.js)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.