### PR TITLE
react-virtualized: add missing properties to GridCellRangeProps, fix incorrect type for overscanIndicesGetter in Grid.defaultProps

### DIFF
--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -126,7 +126,14 @@ export type GridCellRangeProps = {
     rowStartIndex: number,
     rowStopIndex: number,
     scrollLeft: number,
-    scrollTop: number
+    scrollTop: number,
+    deferredMeasurementCache: CellMeasurerCache,
+    horizontalOffsetAdjustment: number,
+    parent: Grid | List | Table,
+    styleCache: Map<React.CSSProperties>,
+    verticalOffsetAdjustment: number,
+    visibleColumnIndices: VisibleCellRange,
+    visibleRowIndices: VisibleCellRange
 }
 export type GridCellRangeRenderer = (params: GridCellRangeProps) => React.ReactNode[];
 

--- a/types/react-virtualized/dist/es/Grid.d.ts
+++ b/types/react-virtualized/dist/es/Grid.d.ts
@@ -382,7 +382,7 @@ export class Grid extends PureComponent<GridProps, GridState> {
         onScroll: () => null,
         onSectionRendered: () => null,
         overscanColumnCount: 0,
-        overscanIndicesGetter: OverscanIndicesGetterParams,
+        overscanIndicesGetter: OverscanIndicesGetter,
         overscanRowCount: 10,
         role: 'grid',
         scrollingResetTimeInterval: typeof DEFAULT_SCROLLING_RESET_TIME_INTERVAL,

--- a/types/react-virtualized/index.d.ts
+++ b/types/react-virtualized/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 //                 John Gunther <https://github.com/guntherjh>
 //                 Konstantin Nesterov <https://github.com/wasd171>
+//                 Szőke Szabolcs <https://github.com/szabolcsx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized/blob/master/source/Grid/defaultCellRangeRenderer.js#L27

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fix for #20411 