### PR TITLE
Add jsonfile types

### DIFF
--- a/types/jsonfile/index.d.ts
+++ b/types/jsonfile/index.d.ts
@@ -1,0 +1,60 @@
+// Type definitions for jsonfile 4.0
+// Project: https://github.com/jprichardson/node-jsonfile#readme
+// Definitions by: Daniel Bowring <https://github.com/dbowring>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node"/>
+
+import { Url } from 'url';
+
+export type FSReadOptions = {
+    encoding?: null | undefined;
+    flag?: string | undefined;
+    } | null | undefined;
+export type FSWriteOptions = string | {
+    encoding?: string | null | undefined;
+    mode?: string | number | undefined;
+    flag?: string | undefined;
+    } | null | undefined;
+
+export type ReadCallback = (err: NodeJS.ErrnoException | null, data: Buffer) => void;
+export type WriteCallback = (err: NodeJS.ErrnoException) => void;
+export type Path = string | number | Buffer | Url;
+
+export interface FS {
+    readFile(path: Path, options: FSReadOptions, callback: ReadCallback): void;
+    readFileSync(path: Path, options?: FSReadOptions): Buffer;
+    writeFile(path: Path, data: any, options: FSWriteOptions, callback: WriteCallback): void;
+    writeFileSync(path: Path, data: any, options?: FSWriteOptions): void;
+}
+
+export type JFReadOptions = {
+    encoding?: null | undefined;
+    flag?: string | undefined;
+    throws?: boolean;
+    fs?: FS;
+    reviver?: ((key: any, value: any) => any) | undefined;
+    } | null | undefined;
+
+export type JFWriteOptions = string | {
+    encoding?: string | null | undefined;
+    mode?: string | number | undefined;
+    flag?: string | undefined;
+    throws?: boolean;
+    fs?: FS;
+    EOL?: string;
+    spaces?: string | number | undefined;
+    replacer?: ((key: string, value: any) => any) | undefined;
+    } | null | undefined;
+
+export type JFReadCallback = (err: NodeJS.ErrnoException | null, data: any) => void;
+
+export function readFile(file: Path, options?: JFReadOptions, callback?: JFReadCallback): void;
+export function readFile(file: Path, callback: JFReadCallback): void;
+
+export function readFileSync(file: Path, options?: JFReadOptions): any;
+
+export function writeFile(file: Path, obj: any, options?: JFWriteOptions, callback?: WriteCallback): void;
+export function writeFile(file: Path, obj: any, callback: WriteCallback): void;
+
+export function writeFileSync(file: Path, obj: any, options?: JFWriteOptions): void;

--- a/types/jsonfile/jsonfile-tests.ts
+++ b/types/jsonfile/jsonfile-tests.ts
@@ -1,0 +1,34 @@
+// Following are lifted from the samples on the NPM page, modified to pass
+//  the linter
+
+import * as jsonfile from 'jsonfile';
+
+const file = '/tmp/data.json';
+const obj = {name: 'JP'};
+
+jsonfile.readFile(file, (err: NodeJS.ErrnoException | null, obj: any) => {
+  console.dir(obj);
+});
+
+console.dir(jsonfile.readFileSync(file));
+
+jsonfile.writeFile(file, obj, (err: NodeJS.ErrnoException) => {
+  console.error(err);
+});
+
+jsonfile.writeFile(file, obj, {spaces: 2}, (err: NodeJS.ErrnoException) => {
+  console.error(err);
+});
+
+jsonfile.writeFile(file, obj, {spaces: 2, EOL: '\r\n'}, (err: NodeJS.ErrnoException) => {
+  console.error(err);
+});
+
+jsonfile.writeFile(file, obj, {flag: 'a'}, (err: NodeJS.ErrnoException) => {
+  console.error(err);
+});
+
+jsonfile.writeFileSync(file, obj);
+jsonfile.writeFileSync(file, obj, {spaces: 2});
+jsonfile.writeFileSync(file, obj, {spaces: 2, EOL: '\r\n'});
+jsonfile.writeFileSync(file, obj, {flag: 'a'});

--- a/types/jsonfile/tsconfig.json
+++ b/types/jsonfile/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsonfile-tests.ts"
+    ]
+}

--- a/types/jsonfile/tslint.json
+++ b/types/jsonfile/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
[jsonfile on npm](https://www.npmjs.com/package/jsonfile)

Alternate, more verbose version [here](https://github.com/DefinitelyTyped/DefinitelyTyped/compare/master...dbowring:jsonfile-verbose?expand=1) that doesn't add types to the module.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
