### PR TITLE
[@types/knex] adjust MySqlConnectionConfig.typeCast

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -563,7 +563,7 @@ declare namespace Knex {
         connectTimeout?: number;
         stringifyObjects?: boolean;
         insecureAuth?: boolean;
-        typeCast?: boolean;
+        typeCast?: any;
         queryFormat?: (query: string, values: any) => string;
         supportBigNumbers?: boolean;
         bigNumberStrings?: boolean;


### PR DESCRIPTION
The underlying node-mysql package supports a function as typeCast value (alternative to a boolean), thus its type has been set to any in the respective types package (@types/mysql). https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mysql/index.d.ts#L217

I have tested this with knex 0.13.0 and mysql2 1.4.2 and can confirm that knex and mysql2 correctly forward the option to mysql.

Note on the following template: As I just want to inform about a tiny thing and not migrate to Australia I'll leave some of the bureaucracy to others. After all, you're free to ignore this request. I'll be honest about the things I didn't do.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mysql/index.d.ts#L217
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.