### PR TITLE
knex: allow calling .join() with a closure as the second argument

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -180,6 +180,7 @@ declare namespace Knex {
     interface Join {
         (raw: Raw): QueryBuilder;
         (tableName: TableName, clause: (this: JoinClause) => void): QueryBuilder;
+        (tableName: TableName, clause: (join: JoinClause) => void): QueryBuilder;
         (tableName: TableName, columns: { [key: string]: string | number | Raw }): QueryBuilder;
         (tableName: TableName, raw: Raw): QueryBuilder;
         (tableName: TableName, column1: string, column2: string): QueryBuilder;

--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -179,7 +179,6 @@ declare namespace Knex {
 
     interface Join {
         (raw: Raw): QueryBuilder;
-        (tableName: TableName, clause: (this: JoinClause) => void): QueryBuilder;
         (tableName: TableName, clause: (this: JoinClause, join: JoinClause) => void): QueryBuilder;
         (tableName: TableName, columns: { [key: string]: string | number | Raw }): QueryBuilder;
         (tableName: TableName, raw: Raw): QueryBuilder;

--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -180,7 +180,7 @@ declare namespace Knex {
     interface Join {
         (raw: Raw): QueryBuilder;
         (tableName: TableName, clause: (this: JoinClause) => void): QueryBuilder;
-        (tableName: TableName, clause: (join: JoinClause) => void): QueryBuilder;
+        (tableName: TableName, clause: (this: JoinClause, join: JoinClause) => void): QueryBuilder;
         (tableName: TableName, columns: { [key: string]: string | number | Raw }): QueryBuilder;
         (tableName: TableName, raw: Raw): QueryBuilder;
         (tableName: TableName, column1: string, column2: string): QueryBuilder;

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -228,8 +228,17 @@ knex.select('*').from('users').join('accounts', function() {
   this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
+knex.select('*').from('users').join('accounts', function(join: Knex.JoinClause) {
+  if (this !== join) {
+    throw new Error("join() callback call semantics wrong");
+  }
+  this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id');
+  join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id');
+});
+
+
 knex.select('*').from('users').join('accounts', (join: Knex.JoinClause) => {
-    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+  join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
 knex.select('*').from('users').join('accounts', 'accounts.type', knex.raw('?', ['admin']));
@@ -245,7 +254,7 @@ knex('users').innerJoin('accounts', function() {
 });
 
 knex('users').innerJoin('accounts', (join: Knex.JoinClause) => {
-    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+  join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id');
 });
 
 knex.select('*').from('users').leftJoin('accounts', 'users.id', 'accounts.user_id');
@@ -255,7 +264,7 @@ knex.select('*').from('users').leftJoin('accounts', function() {
 });
 
 knex.select('*').from('users').leftJoin('accounts', (join: Knex.JoinClause) => {
-    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+  join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
 knex.select('*').from('users').leftOuterJoin('accounts', 'users.id', 'accounts.user_id');
@@ -271,7 +280,7 @@ knex.select('*').from('users').rightJoin('accounts', function() {
 });
 
 knex.select('*').from('users').rightJoin('accounts', (join: Knex.JoinClause) => {
-    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+  join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
 knex.select('*').from('users').rightOuterJoin('accounts', 'users.id', 'accounts.user_id');
@@ -287,7 +296,7 @@ knex.select('*').from('users').outerJoin('accounts', function() {
 });
 
 knex.select('*').from('users').outerJoin('accounts', (join: Knex.JoinClause) => {
-    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+  join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
 knex.select('*').from('users').fullOuterJoin('accounts', 'users.id', 'accounts.user_id');
@@ -297,7 +306,7 @@ knex.select('*').from('users').fullOuterJoin('accounts', function() {
 });
 
 knex.select('*').from('users').fullOuterJoin('accounts', (join: Knex.JoinClause) => {
-    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+  join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
 knex.select('*').from('users').crossJoin('accounts', 'users.id', 'accounts.user_id');

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -228,6 +228,10 @@ knex.select('*').from('users').join('accounts', function() {
   this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
+knex.select('*').from('users').join('accounts', (join: Knex.JoinClause) => {
+    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+});
+
 knex.select('*').from('users').join('accounts', 'accounts.type', knex.raw('?', ['admin']));
 
 knex.raw('select * from users where id = :user_id', { user_id: 1 });
@@ -240,10 +244,18 @@ knex('users').innerJoin('accounts', function() {
   this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
+knex('users').innerJoin('accounts', (join: Knex.JoinClause) => {
+    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+});
+
 knex.select('*').from('users').leftJoin('accounts', 'users.id', 'accounts.user_id');
 
 knex.select('*').from('users').leftJoin('accounts', function() {
   this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+});
+
+knex.select('*').from('users').leftJoin('accounts', (join: Knex.JoinClause) => {
+    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
 knex.select('*').from('users').leftOuterJoin('accounts', 'users.id', 'accounts.user_id');
@@ -258,6 +270,10 @@ knex.select('*').from('users').rightJoin('accounts', function() {
   this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
+knex.select('*').from('users').rightJoin('accounts', (join: Knex.JoinClause) => {
+    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+});
+
 knex.select('*').from('users').rightOuterJoin('accounts', 'users.id', 'accounts.user_id');
 
 knex.select('*').from('users').rightOuterJoin('accounts', function() {
@@ -270,10 +286,18 @@ knex.select('*').from('users').outerJoin('accounts', function() {
   this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
+knex.select('*').from('users').outerJoin('accounts', (join: Knex.JoinClause) => {
+    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+});
+
 knex.select('*').from('users').fullOuterJoin('accounts', 'users.id', 'accounts.user_id');
 
 knex.select('*').from('users').fullOuterJoin('accounts', function() {
   this.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
+});
+
+knex.select('*').from('users').fullOuterJoin('accounts', (join: Knex.JoinClause) => {
+    join.on('accounts.id', '=', 'users.account_id').orOn('accounts.owner_id', '=', 'users.id')
 });
 
 knex.select('*').from('users').crossJoin('accounts', 'users.id', 'accounts.user_id');


### PR DESCRIPTION
Allow calling .join() with a closure as the second argument that takes the JoinClause as its first argument, not just a function w/o arguments with the JoinClause passed as this.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tgriesser/knex/blob/master/src/query/builder.js#L169
