### PR TITLE
Corrected parameter "stream" in interface Options of @types/simple-peer

### DIFF
--- a/types/simple-peer/index.d.ts
+++ b/types/simple-peer/index.d.ts
@@ -20,7 +20,7 @@ declare namespace SimplePeer {
         answerConstraints?: {}; // custom answer constraints (used by createAnswer method)
         reconnectTimer?: boolean | number; // wait __ milliseconds after ICE 'disconnect' for reconnect attempt before emitting 'close'
         sdpTransform?<T extends any>(sdp: T): T; // function to transform the generated SDP signaling data (for advanced users)
-        stream?: boolean; // if video/voice is desired, pass stream returned from getUserMedia
+        stream?: MediaStream; // if video/voice is desired, pass stream returned from getUserMedia
         trickle?: boolean; // set to false to disable trickle ICE and get a single 'signal' event (slower)
         wrtc?: {}; // RTCPeerConnection/RTCSessionDescription/RTCIceCandidate
         objectMode?: boolean; // set to true to create the stream in Object Mode. In this mode, incoming string data is not automatically converted to Buffer objects.


### PR DESCRIPTION
Parameter "stream" must be of type "MediaStream" and not "boolean"

Docs : https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
https://github.com/feross/simple-peer#videovoice