### PR TITLE
Fixing react-ga .ga() signature

### DIFF
--- a/types/react-ga/index.d.ts
+++ b/types/react-ga/index.d.ts
@@ -54,6 +54,7 @@ export interface OutboundLinkArgs {
 }
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
+export function ga(): (...args: any[]) => any;
 export function ga(...args: any[]): any;
 export function set(fieldsObject: FieldsObject): void;
 export function send(fieldsObject: FieldsObject): void;

--- a/types/react-ga/index.d.ts
+++ b/types/react-ga/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-ga 2.1
 // Project: https://github.com/react-ga/react-ga
-// Definitions by: Tim Aldridge <https://github.com/telshin>
+// Definitions by: Tim Aldridge <https://github.com/telshin>, Vasya Aksyonov <https://github.com/outring>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface EventArgs {
@@ -54,7 +54,7 @@ export interface OutboundLinkArgs {
 }
 
 export function initialize(trackingCode: string, options?: InitializeOptions): void;
-export function ga(): any;
+export function ga(...args: any[]): any;
 export function set(fieldsObject: FieldsObject): void;
 export function send(fieldsObject: FieldsObject): void;
 export function pageview(path: string): void;

--- a/types/react-ga/react-ga-tests.ts
+++ b/types/react-ga/react-ga-tests.ts
@@ -63,6 +63,9 @@ describe("Testing react-ga v2.1.2", () => {
     it("Able to make ga calls", () => {
         ga.ga();
     });
+    it("Able to make ga calls with any arguments", () => {
+        ga.ga("create", "UA-65432-1", "auto", "trackerName");
+    });
     it("Able to make send calls", () => {
         const fieldObject: ga.FieldsObject = {
             page: '/users'

--- a/types/react-ga/react-ga-tests.ts
+++ b/types/react-ga/react-ga-tests.ts
@@ -66,6 +66,9 @@ describe("Testing react-ga v2.1.2", () => {
     it("Able to make ga calls with any arguments", () => {
         ga.ga("create", "UA-65432-1", "auto", "trackerName");
     });
+    it("Able to make returned ga calls with any arguments", () => {
+        ga.ga()("create", "UA-65432-1", "auto", "trackerName");
+    });
     it("Able to make send calls", () => {
         const fieldObject: ga.FieldsObject = {
             page: '/users'


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: according to [README](https://github.com/react-ga/react-ga#reactgaga) and source, `.ga()` function could be called with any arguments, now typings restrict arguments at all.