### PR TITLE
highland: add missing definitions & correct some others

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -288,7 +288,7 @@ barStream = fooStream.flatten<Bar>();
 
 fooStream = fooStream.fork();
 
-fooStream = fooStream.merge(fooStreamStream);
+fooStream = _<Foo>([fooStream, fooStream]).merge();
 
 fooStream = fooStream.observe();
 

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -904,6 +904,28 @@ declare namespace Highland {
 		 */
 		throttle(ms: number): Stream<R>;
 
+    /**
+     * Filters out all duplicate values from the stream and keeps only the first
+     * occurence of each value, using === to define equality.
+     *
+     * @id uniq
+     * @section Streams
+     * @name Stream.uniq()
+     * @api public
+     */
+    uniq(): Stream<R>;
+
+    /**
+     * Filters out all duplicate values from the stream and keeps only the first
+     * occurence of each value, using the provided function to define equality.
+     *
+     * @id uniqBy
+     * @section Streams
+     * @name Stream.uniqBy()
+     * @api public
+     */
+    uniqBy(f: (a: R, b: R) => boolean): Stream<R>;
+
 		/**
 		 * A convenient form of filter, which returns all objects from a Stream
 		 * match a set of property values.

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -73,7 +73,7 @@ interface HighlandStatic {
 	 */
 	<R>(): Highland.Stream<R>;
 	<R>(xs: R[]): Highland.Stream<R>;
-	<R>(xs: (push: (err: Error, x?: R) => void, next: () => void) => void): Highland.Stream<R>;
+	<R>(xs: (push: (err: Error | null, x?: R) => void, next: () => void) => void): Highland.Stream<R>;
 
 	<R>(xs: Highland.Stream<R>): Highland.Stream<R>;
 	<R>(xs: NodeJS.ReadableStream): Highland.Stream<R>;
@@ -561,7 +561,7 @@ declare namespace Highland {
 		 * @param {Function} f - the function to handle errors and values
 		 * @api public
 		 */
-		consume<U>(f: (err: Error, x: R, push: (err: Error, value?: U) => void, next: () => void) => void): Stream<U>;
+		consume<U>(f: (err: Error, x: R, push: (err: Error | null, value?: U) => void, next: () => void) => void): Stream<U>;
 
 		/**
 		 * Holds off pushing data events downstream until there has been no more
@@ -626,7 +626,7 @@ declare namespace Highland {
 		 * @param {Function} f - the function to pass all errors to
 		 * @api public
 		 */
-		errors(f: (err: Error, push: (err: Error, x?: R) => void) => void): Stream<R>;
+		errors(f: (err: Error, push: (err: Error | null, x?: R) => void) => void): Stream<R>;
 
 		/**
 		 * Creates a new Stream including only the values which pass a truth test.

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 Hugo Wood <https://github.com/hgwood>
 //                 William Yu <https://github.com/iwllyu>
+//                 Alvis HT Tang <https://github.com/alvis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -1167,7 +1167,7 @@ declare namespace Highland {
 		 * @param {Function} f - the iterator function
 		 * @api public
 		 */
-		each(f: (x: R) => void): void;
+		each(f: (x: R) => void): Pick<Stream<R>, 'done'>;
 
 		/**
 		 * Pipes a Highland Stream to a [Node Writable Stream](http://nodejs.org/api/stream.html#stream_class_stream_writable)

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -72,6 +72,7 @@ interface HighlandStatic {
 	 * @api public
 	 */
 	<R>(): Highland.Stream<R>;
+  <R>(xs: Highland.Stream<R>[]): Highland.Stream<R>;
 	<R>(xs: R[]): Highland.Stream<R>;
 	<R>(xs: (push: (err: Error | null, x?: R) => void, next: () => void) => void): Highland.Stream<R>;
 
@@ -1035,7 +1036,7 @@ declare namespace Highland {
 		 * _([txt, md]).merge();
 		 * // => contents of foo.txt, bar.txt and baz.txt in the order they were read
 		 */
-		merge (ys: Stream<Stream<R>>): Stream<R>;
+	  merge(): Stream<R>;
 
 		/**
 		 * Observes a stream, allowing you to handle values as they are emitted, without

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -1243,6 +1243,29 @@ declare namespace Highland {
 		 * });
 		 */
 		toCallback(cb: (err?: Error, x?: R) => void): void;
+
+    /**
+     * Converts the result of a stream to Promise.
+     *
+     * If the stream contains a single value, it will return
+     * with the single item emitted by the stream (if present).
+     * If the stream is empty, `undefined` will be returned.
+     * If an error is encountered in the stream, this function will stop
+     * consumption and call `cb` with the error.
+     * If the stream contains more than one item, it will stop consumption
+     * and reject with an error.
+     *
+     * @id toPromise
+     * @section Consumption
+     * @name Stream.toPromise(PromiseCtor)
+     * @param {Function} PromiseCtor - Promises/A+ compliant constructor
+     * @api public
+     *
+     * _([1, 2, 3, 4]).collect().toPromise(Promise).then(function (result) {
+     *     // parameter result will be [1,2,3,4]
+     * });
+     */
+    toPromise(promiseConstructor: PromiseConstructor): PromiseLike<R>;
 	}
 
 	interface PipeableStream<T, R> extends Stream<R> {}


### PR DESCRIPTION
What changed in this PR:
* added several missing function definitions, including `toPromise`, `uniq` and `uniqBy`
* corrected several definitions, including `each`, `merge` and `push`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://highlandjs.org
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.