### PR TITLE
[history] Mark Location's key as optional

### DIFF
--- a/types/history/index.d.ts
+++ b/types/history/index.d.ts
@@ -28,7 +28,7 @@ export interface Location {
     search: Search;
     state: LocationState;
     hash: Hash;
-    key: LocationKey;
+    key?: LocationKey;
 }
 
 export interface LocationDescriptorObject {


### PR DESCRIPTION
While the `key` will always be a string value after updating history, it will not be present when the `history` object is first created, at least until the first push/replace state happens.

This behavior is not documented, but is a consequence of https://github.com/ReactTraining/history/blob/master/modules/createBrowserHistory.js#L57 which is fed to https://github.com/ReactTraining/history/blob/master/modules/LocationUtils.js#L49-L50.

It is documented, though, that `key` is only supported for `browser` and `memory` history -- `hash` does not support `key`.