### PR TITLE
[url-parse] Add missing boolean parameter type and update tests to include this case

### DIFF
--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -21,7 +21,7 @@ declare class URL {
     readonly protocol: string;
     query: { [key: string]: string | undefined };
     readonly search: string;
-    set(property: string, value: string | object | number | undefined): URL;
+    set(property: string, value: string | object | number | boolean | undefined): URL;
     readonly slashes: boolean;
     readonly username: string;
     readonly searchParams: URLSearchParams;

--- a/types/url-parse/index.d.ts
+++ b/types/url-parse/index.d.ts
@@ -6,9 +6,11 @@
 
 import URLSearchParams = require("url-search-params");
 
-type UrlQueryParamsParser = (url: string) => string;
+export type UrlQueryParamsParser = (url: string) => string;
 
-declare class URL {
+export class URL {
+    constructor(url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean);
+    constructor(url: string, baseURL?: object | string, parser?: boolean | UrlQueryParamsParser);
     readonly auth: string;
     readonly hash: string;
     readonly host: string;
@@ -28,25 +30,23 @@ declare class URL {
     toString(): string;
 }
 
-type ParseFunctionNodeType = (url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean) => URL;
-type ParseFunctionType = (url: string, baseURL?: object | string, parser?: boolean | UrlQueryParamsParser) => URL;
+export type ParseFunctionNodeType = (url: string, parseQueryString?: boolean, slashesDenoteHost?: boolean) => URL;
+export type ParseFunctionType = (url: string, baseURL?: object | string, parser?: boolean | UrlQueryParamsParser) => URL;
 
-interface Protocol {
+export interface Protocol {
     slashes: boolean;
     protocol: string;
     rest: string;
 }
 
-type ExtractProtocolFunctionType = (url: string) => Protocol;
+export type ExtractProtocolFunctionType = (url: string) => Protocol;
 
-type LocationFunctionType = (url: string) => string;
+export type LocationFunctionType = (url: string) => string;
 
-interface ExtendedParseFunctionType extends ParseFunctionNodeType, ParseFunctionType {
+export interface ExtendedParseFunctionType extends ParseFunctionNodeType, ParseFunctionType {
     extractProtocol: ExtractProtocolFunctionType;
     location: LocationFunctionType;
     qs: any;
 }
 
-declare const parse: ExtendedParseFunctionType;
-
-export = parse;
+export const parse: ExtendedParseFunctionType;

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -12,6 +12,7 @@ url2.query.baz;
 
 url3.slashes;
 url3.set("protocol", "http://");
+url3.set("slashed", false);
 
 parse.extractProtocol("https://github.com/foo/bar");
 parse.location("https://github.com/foo/bar");

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -1,5 +1,6 @@
-import parse = require("url-parse");
+import { URL, parse } from "url-parse";
 
+const url0 = new URL("foo/bar", true, true);
 const url1 = new URL("foo/bar", "https://github.com/");
 const url2 = parse("https://github.com/foo/bar?baz=true");
 const url3 = parse("https://github.com/foo/bar", true, true);

--- a/types/url-parse/url-parse-tests.ts
+++ b/types/url-parse/url-parse-tests.ts
@@ -12,7 +12,7 @@ url2.query.baz;
 
 url3.slashes;
 url3.set("protocol", "http://");
-url3.set("slashed", false);
+url3.set("slashes", false);
 
 parse.extractProtocol("https://github.com/foo/bar");
 parse.location("https://github.com/foo/bar");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**Changing an existing definition**:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: The issue solved is described here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20402 
Original package's tests do not include this case: https://github.com/unshiftio/url-parse/blob/master/test/test.js 
- [-] Increase the version number in the header if appropriate.
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.