### PR TITLE
@types/sinon: Added sinon.createSandbox and sinon.defaultConfig

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -494,13 +494,11 @@ declare namespace Sinon {
     }
 
     interface SinonSandboxStatic {
-        create(): SinonSandbox;
-        create(config: SinonSandboxConfig): SinonSandbox;
+        create(config?: SinonSandboxConfig): SinonSandbox;
     }
 
     interface SinonStatic {
-        createSandbox(): SinonSandbox;
-        createSandbox(config: SinonSandboxConfig): SinonSandbox;
+        createSandbox(config?: SinonSandboxConfig): SinonSandbox;
         defaultConfig: SinonSandboxConfig;
         sandbox: SinonSandboxStatic;
     }

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -499,6 +499,9 @@ declare namespace Sinon {
     }
 
     interface SinonStatic {
+        createSandbox(): SinonSandbox;
+        createSandbox(config: SinonSandboxConfig): SinonSandbox;
+        defaultConfig: SinonSandboxConfig;
         sandbox: SinonSandboxStatic;
     }
 

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -97,7 +97,21 @@ function testAssert() {
 }
 
 function testSandbox() {
+    const config = {
+        injectInto: null,
+        properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+        useFakeServer: true,
+        useFakeTimers: true,
+    };
+
     let sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox.create(config);
+    sandbox = sinon.sandbox.create(sinon.defaultConfig);
+
+    sandbox = sinon.createSandbox();
+    sandbox = sinon.createSandbox(config);
+    sandbox = sinon.createSandbox(sinon.defaultConfig);
+
     sandbox = sandbox.usingPromise(Promise);
 
     sandbox.assert.notCalled(sinon.spy());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://sinonjs.org/releases/v4.0.1/sandbox
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I'm not sure about the version number. I noticed in `index.d.ts` that the version is still only v2.3. The alias I'm adding was added to Sinon library in v3.2.1 and the're now at v4.0.1.

Strictly speaking my additon doesn't belong to v2.3 but since it doesn't change any existing definitions it does help users of the latest Sinon versions because the docs now only mention the new `sinon.createSandbox` alias and not the old `sinon.defaultConfig` way. So having this change added is still a benefit. 

My suggestion would be to leave the version on v2.3 but still add my change (if approved). Let me know what you think.

Authors: @MrBigDog2U @rationull @lumaxis @nicojs @43081j

