### PR TITLE
Material-ui: fix Stepper import/export statements

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -111,7 +111,7 @@ declare module "material-ui" {
     export import StepContentProps = __MaterialUI.Stepper.StepContentProps;
     export import StepLabel = __MaterialUI.Stepper.StepLabel;
     export import StepLabelProps = __MaterialUI.Stepper.StepLabelProps;
-    export import Stepper = __MaterialUI.Stepper;
+    export import Stepper = __MaterialUI.Stepper.Stepper;
     export import StepperProps = __MaterialUI.Stepper.StepperProps;
     export import Snackbar = __MaterialUI.Snackbar;
     export import SnackbarProps = __MaterialUI.SnackbarProps;


### PR DESCRIPTION
Currently Stepper is exported as a `namespace`, not as a React Component, what produce `JSX element type 'Stepper' does not have any construct or call signatures` TS error.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://www.material-ui.com/#/components/stepper>>
- [x] Increase the version number in the header if appropriate. (not appropriate - too small changes)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (not substantial changes)
