### PR TITLE
Added type definitions for osx-notifier

### DIFF
--- a/types/osx-notifier/osx-notifier-tests.ts
+++ b/types/osx-notifier/osx-notifier-tests.ts
@@ -1,0 +1,18 @@
+// Tests for osx-notifier.d.ts
+// Project: https://www.npmjs.com/package/osx-notifier
+// Definitions by: ZongJing Lu <https://github.com/SONIC3D>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Tests taken from documentation samples.
+
+///<reference path="../osx-notifier/osx-notifier.d.ts" />
+
+import notify = require('osx-notifier');
+
+let duration: number = 45;
+notify({
+    type: 'pass',
+    title: 'Taskdoer Report',
+    subtitle: 'Task completed',
+    message: 'Took ' + duration + ' seconds.',
+    group: 'taskdoer',
+});

--- a/types/osx-notifier/osx-notifier.d.ts
+++ b/types/osx-notifier/osx-notifier.d.ts
@@ -1,0 +1,8 @@
+﻿// Type definitions for osx-notifier 0.2.2
+// Project: https://www.npmjs.com/package/osx-notifier
+// Definitions by: ZongJing Lu <https://github.com/SONIC3D>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = notify;
+
+declare function notify(option: Object): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.
