### PR TITLE
Fix some mapbox-gl mismatching typings

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Mapbox GL JS v0.39.1
+// Type definitions for Mapbox GL JS v0.40.1
 // Project: https://github.com/mapbox/mapbox-gl-js
 // Definitions by: Dominik Bruderer <https://github.com/dobrud>, Patrick Reames <https://github.com/patrickr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -87,7 +87,7 @@ declare namespace mapboxgl {
 
 		getLayer(id: string): mapboxgl.Layer;
 
-		setFilter(layer: string, filter: any[]): this;
+		setFilter(layer: string, filter?: any[]): this;
 
 		setLayerZoomRange(layerId: string, minzoom: number, maxzoom: number): this;
 
@@ -224,7 +224,7 @@ declare namespace mapboxgl {
 		/** If true, enable keyboard shortcuts (see KeyboardHandler). */
 		keyboard?: boolean;
 
-		logoPosition?: boolean;
+		logoPosition?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 		/** If set, the map is constrained to the given bounds. */
 		maxBounds?: LngLatBoundsLike;

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -944,7 +944,7 @@ declare namespace mapboxgl {
 		"fill-antialias"?: boolean;
 		"fill-opacity"?: number | StyleFunction;
 		"fill-color"?: string | StyleFunction;
-		"fill-outline-color": string | StyleFunction;
+		"fill-outline-color"?: string | StyleFunction;
 		"fill-translate"?: number[];
 		"fill-translate-anchor"?: "map" | "viewport";
 		"fill-pattern"?: "string";

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -958,9 +958,9 @@ declare namespace mapboxgl {
 		"fill-extrusion-color"?: string | StyleFunction;
 		"fill-extrusion-translate"?: number[];
 		"fill-extrusion-translate-anchor"?: "map" | "viewport";
-		"fill-extrusion-pattern": string;
+		"fill-extrusion-pattern"?: string;
 		"fill-extrusion-height"?: number | StyleFunction;
-		"fill-extrusion-base"?: number;
+		"fill-extrusion-base"?: number | StyleFunction;
 	}
 
 	export interface LineLayout {

--- a/types/mapbox-gl/mapbox-gl-tests.ts
+++ b/types/mapbox-gl/mapbox-gl-tests.ts
@@ -303,16 +303,6 @@ var mapStyle = {
 	]
 };
 
-map = new mapboxgl.Map({
-	container: 'map',
-	minZoom: 14,
-	zoom: 17,
-	center: [-122.514426, 37.562984],
-	bearing: -96,
-	style: videoStyle,
-	hash: false
-});
-
 /**
  * Add video
  */
@@ -362,10 +352,20 @@ map = new mapboxgl.Map({
 	hash: false
 });
 
+map = new mapboxgl.Map({
+	container: 'map',
+	minZoom: 14,
+	zoom: 17,
+	center: [-122.514426, 37.562984],
+	bearing: -96,
+	style: videoStyle,
+	hash: false
+});
+
 /**
  * Marker
  */
-let marker = new mapboxgl.Marker(null,{offset: [10, 0]})
+let marker = new mapboxgl.Marker(undefined, {offset: [10, 0]})
 	.setLngLat([-50,50])
 	.addTo(map);
 

--- a/types/mapbox-gl/tsconfig.json
+++ b/types/mapbox-gl/tsconfig.json
@@ -5,10 +5,7 @@
             "es6",
             "dom"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": false,
-        "strictFunctionTypes": true,
+        "strict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/mapbox-gl/tsconfig.json
+++ b/types/mapbox-gl/tsconfig.json
@@ -8,6 +8,7 @@
         "strictNullChecks": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/mapbox-gl/tsconfig.json
+++ b/types/mapbox-gl/tsconfig.json
@@ -8,7 +8,6 @@
         "strictNullChecks": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "alwaysStrict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/mapbox-gl/tsconfig.json
+++ b/types/mapbox-gl/tsconfig.json
@@ -5,7 +5,10 @@
             "es6",
             "dom"
         ],
-        "strict": true,
+        "strictNullChecks": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see [doc](https://www.mapbox.com/mapbox-gl-js/api/#map)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

