### PR TITLE
[thrift] Update with an interface for struct-like classes

### DIFF
--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -49,6 +49,11 @@ export interface TStruct {
     fname: string;
 }
 
+export interface TStructLike {
+    read(input: TProtocol): void;
+    write(output: TProtocol): void;
+}
+
 export interface TTransport {
     commitPosition(): void;
     rollbackPosition(): void;
@@ -310,7 +315,7 @@ export function createServer<TProcessor, THandler>(
 export function createWebServer<TProcessor, THandler>(options: WebServerOptions<TProcessor, THandler>): http.Server | tls.Server;
 
 export class TBufferedTransport implements TTransport {
-    constructor(buffer: Buffer | undefined, callback: TTransportCallback);
+    constructor(buffer?: Buffer, callback?: TTransportCallback);
     static receiver(callback: (trans: TBufferedTransport, seqid: number) => void, seqid: number): (data: Buffer) => void;
     commitPosition(): void;
     rollbackPosition(): void;
@@ -330,7 +335,7 @@ export class TBufferedTransport implements TTransport {
 }
 
 export class TFramedTransport implements TTransport {
-    constructor(buffer: Buffer | undefined, callback: TTransportCallback);
+    constructor(buffer?: Buffer, callback?: TTransportCallback);
     static receiver(callback: (trans: TFramedTransport, seqid: number) => void, seqid: number): (data: Buffer) => void;
     commitPosition(): void;
     rollbackPosition(): void;
@@ -350,7 +355,7 @@ export class TFramedTransport implements TTransport {
 }
 
 export interface TTransportConstructor {
-  new (buffer: Buffer | undefined, callback: TTransportCallback): TTransport;
+  new (buffer?: Buffer, callback?: TTransportCallback): TTransport;
 }
 
 export class TBinaryProtocol implements TProtocol {

--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -119,6 +119,10 @@ export interface TProtocol {
     skip(type: Thrift.Type): void;
 }
 
+export interface HttpHeaders {
+    [name: string]: number | string | string[] | undefined
+}
+
 export interface SeqId2Service {
     [seqid: number]: string;
 }
@@ -162,7 +166,7 @@ export class XHRConnection extends NodeJS.EventEmitter {
     recv_buf: string;
     transport: TTransport;
     protocol: TProtocol;
-    headers: http.OutgoingHttpHeaders;
+    headers: HttpHeaders;
     constructor(host: string, port: number, options?: ConnectOptions);
     getXmlHttpRequestObject(): XMLHttpRequest;
     flush(): void;
@@ -180,7 +184,7 @@ export interface WSOptions {
     host: string;
     port: number;
     path: string;
-    headers: http.OutgoingHttpHeaders;
+    headers: HttpHeaders;
 }
 
 export class WSConnection extends NodeJS.EventEmitter {
@@ -228,7 +232,7 @@ export interface ServiceOptions<TProcessor, THandler> {
 export interface ServerOptions<TProcessor, THandler> extends ServiceOptions<TProcessor, THandler> {
     cors?: string[];
     files?: string;
-    headers?: http.IncomingHttpHeaders;
+    headers?: HttpHeaders;
     services?: ServiceMap<TProcessor, THandler>;
     tls?: tls.TlsOptions;
 }
@@ -237,7 +241,7 @@ export interface ConnectOptions {
     transport?: TTransportConstructor;
     protocol?: TProtocolConstructor;
     path?: string;
-    headers?: http.OutgoingHttpHeaders;
+    headers?: HttpHeaders;
     https?: boolean;
     debug?: boolean;
     max_attempts?: number;
@@ -251,7 +255,7 @@ export interface WSConnectOptions {
     transport?: TTransportConstructor;
     protocol?: TProtocolConstructor;
     path?: string;
-    headers?: http.OutgoingHttpHeaders;
+    headers?: HttpHeaders;
     secure?: boolean;
     wsOptions?: WSOptions;
 }

--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -120,7 +120,7 @@ export interface TProtocol {
 }
 
 export interface HttpHeaders {
-    [name: string]: number | string | string[] | undefined
+    [name: string]: number | string | string[] | undefined;
 }
 
 export interface SeqId2Service {


### PR DESCRIPTION
The thrift generated code for JS uses a consistent interface for all struct-like objects (structs, unions and exceptions). This change exports an interface to match any of these types.

  * Additionally, mark Transport constructor args as optional

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apache/thrift/tree/master/lib/nodejs/lib/thrift
- [x] Increase the version number in the header if appropriate.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


