### PR TITLE
rc-slider: Add definition for createSliderWithTooltip

### DIFF
--- a/types/rc-slider/README.md
+++ b/types/rc-slider/README.md
@@ -5,7 +5,7 @@
 This package contains type definitions for rc-slider (https://github.com/react-component/slider).
 
 Additional Details
- * Last updated: Tue, 24 Feb 2017
+ * Last updated: Tue, 11 Oct 2017
  * Dependencies: react
  * Global values: none
 

--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -163,3 +163,6 @@ export interface HandleProps extends CommonApiProps {
 export default class Slider extends React.Component<SliderProps> { }
 export class Range extends React.Component<RangeProps> { }
 export class Handle extends React.Component<HandleProps> { }
+
+export function createSliderWithTooltip(slider: typeof Slider): new() => Slider;
+export function createSliderWithTooltip(range: typeof Range): new() => Range;

--- a/types/rc-slider/rc-slider-tests.tsx
+++ b/types/rc-slider/rc-slider-tests.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import Slider, { Range, Handle } from 'rc-slider';
+import Slider, { Range, Handle, createSliderWithTooltip } from 'rc-slider';
+
+const SliderWithTooltip = createSliderWithTooltip(Slider);
+const RangeWithTooltip = createSliderWithTooltip(Range);
 
 ReactDOM.render(
     <Slider defaultValue={1} max={2} step={0.01} min={0.01} />,
@@ -43,5 +46,15 @@ ReactDOM.render(
         count={3}
         allowCross={false}
         pushable={true} />,
+    document.querySelector('.app')
+);
+
+ReactDOM.render(
+    <SliderWithTooltip defaultValue={1} max={2} step={0.01} min={0.01} />,
+    document.querySelector('.app')
+);
+
+ReactDOM.render(
+    <RangeWithTooltip defaultValue={1} max={2} step={0.01} min={0.01} />,
     document.querySelector('.app')
 );


### PR DESCRIPTION
Add definition of createSliderWithTooltip as per docs:
createSliderWithTooltip(Slider | Range) => React.Component

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <https://react-component.github.io/slider/>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
