### PR TITLE
[@types/three] Adds morphTargetInfluences and morphTargetDictionary to mesh on three-core.d.ts

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -4837,6 +4837,8 @@ export class Mesh extends Object3D {
     geometry: Geometry|BufferGeometry;
     material: Material | Material[];
     drawMode: TrianglesDrawModes;
+    morphTargetInfluences?: number[];
+    morphTargetDictionary?: {};
 
     setDrawMode(drawMode: TrianglesDrawModes): void;
     updateMorphTargets(): void;

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -4838,7 +4838,7 @@ export class Mesh extends Object3D {
     material: Material | Material[];
     drawMode: TrianglesDrawModes;
     morphTargetInfluences?: number[];
-    morphTargetDictionary?: {};
+    morphTargetDictionary?: { [key: string]: number; };
 
     setDrawMode(drawMode: TrianglesDrawModes): void;
     updateMorphTargets(): void;


### PR DESCRIPTION
Very minimal change. Solving issue #20468

**Checklist:**
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**If changing an existing definition:**
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [ThreeJS Mesh Docs](https://threejs.org/docs/#api/objects/Mesh.morphTargetInfluences)