### PR TITLE
loopback: Middleware functions have to return RequestHandler

### DIFF
--- a/types/loopback/index.d.ts
+++ b/types/loopback/index.d.ts
@@ -14,7 +14,7 @@
 ************************************************/
 
 import * as core from "express-serve-static-core";
-import { NextFunction } from "express";
+import { NextFunction, RequestHandler } from "express";
 
 declare function l(): l.LoopBackApplication;
 declare namespace l {
@@ -1693,7 +1693,7 @@ declare namespace l {
        * Serve the LoopBack favicon.
        * @header loopback.favicon(
        */
-      function favicon(): void;
+      function favicon(): RequestHandler;
 
       /**
        * Expose models over REST
@@ -1704,7 +1704,7 @@ declare namespace l {
        * For more information, see [Exposing models over a REST API](docs.strongloop.com/display/DOC/Exposing+models+over+a+REST+API).
        * @header loopback.rest(
        */
-      function rest(): void;
+      function rest(): RequestHandler;
 
       /**
        * Serve static assets of a LoopBack application
@@ -1715,7 +1715,7 @@ declare namespace l {
        *   for the full list of available options.
        * @header loopback.static(root, [options])
        */
-      function static(root: string, options: any): void;
+      function static(root: string, options?: any): RequestHandler;
 
       /**
        * Return HTTP response with basic application status information:
@@ -1727,12 +1727,12 @@ declare namespace l {
        * }
        * ```
        */
-      function status(): void;
+      function status(): RequestHandler;
 
       /**
        * Rewrite the url to replace current user literal with the logged in user id
        */
-      function rewriteUserLiteral(): void;
+      function rewriteUserLiteral(): RequestHandler;
 
       /**
        * Check for an access token in cookies, headers, and query string parameters.
@@ -1775,14 +1775,14 @@ declare namespace l {
                   overwriteExistingToken?: boolean,
                   model?(): void|string,
                   currentUserLiteral?: string
-            }): void;
+            }): RequestHandler;
 
       /**
        * Convert any request not handled so far to a 404 error
        * to be handled by error-handling middleware.
        * @header loopback.urlNotFound(
        */
-      function urlNotFound(): void;
+      function urlNotFound(): RequestHandler;
 
       /**
        * Token based authentication and access control

--- a/types/loopback/loopback-tests.ts
+++ b/types/loopback/loopback-tests.ts
@@ -17,6 +17,14 @@ class Server {
 
         this.app.use(cookieParser());
 
+        this.app.use(loopback.favicon());
+        this.app.use(loopback.rest());
+        this.app.use(loopback.static('.'));
+        this.app.use(loopback.status());
+        this.app.use(loopback.rewriteUserLiteral());
+        this.app.use(loopback.token());
+        this.app.use(loopback.urlNotFound());
+
         this.app.start = async () => {
             // start the web server
             const models = this.app.models();


### PR DESCRIPTION
Functions that are using as express middleware have to return RequestHandler interface.
Otherwise you not allow to use them in app.use function.

Example:
```
app.use(loopback.token());
```

Here is a list of loopback middlewares:
http://apidocs.loopback.io/loopback/#middleware

And this is a proof that these functions return (req, res, next) => ...:
https://github.com/strongloop/loopback/blob/master/server/middleware/token.js#L116