### PR TITLE
node: process.stdin is a stream.Readable and process.stdout is a stream.Writable

### DIFF
--- a/types/firebird/firebird-tests.ts
+++ b/types/firebird/firebird-tests.ts
@@ -119,4 +119,4 @@ blob._write(buffer, 10);
 blob._write(buffer, 10, (err: Error | null) => {});
 
 /* Stream */
-const strm: NodeJS.ReadWriteStream = new fb.Stream(blob);
+const strm = new fb.Stream(blob);

--- a/types/firebird/index.d.ts
+++ b/types/firebird/index.d.ts
@@ -457,6 +457,7 @@ declare module 'firebird' {
      */
     class Stream extends stream.Stream {
         constructor(blob: FBBlob);
+        /* tslint:disable */
 
         /* NodeJS.ReadStream */
         readable: boolean;
@@ -473,6 +474,7 @@ declare module 'firebird' {
         end(str: string, encoding?: string, cb?: Function): void;
         destroy(error?: Error): void;
 
+        /* tslint:enable */
         check_destroyed(): void;
     }
 }

--- a/types/firebird/index.d.ts
+++ b/types/firebird/index.d.ts
@@ -12,6 +12,8 @@
  * Original document is [here](https://www.npmjs.com/package/firebird).
  */
 declare module 'firebird' {
+    import * as stream from 'stream';
+
     /**
      * @see createConnection() method will create Firebird Connection object for you
      */
@@ -453,24 +455,13 @@ declare module 'firebird' {
      * You may pipe strm to/from NodeJS Stream objects (fs or socket).
      * You may also look at [NodeJS Streams reference](https://nodejs.org/api/stream.html).
      */
-    class Stream implements NodeJS.ReadWriteStream {
+    class Stream extends stream.Stream {
         constructor(blob: FBBlob);
-
-        /* Following lines is JUST AS NodeJS.ReadStream, NodeJS.WriteStream, and NodeJS.Emmiter */
-        /* tslint:disable */
 
         /* NodeJS.ReadStream */
         readable: boolean;
-        read(size?: number): string | Buffer;
-        setEncoding(encoding: string | null): this;
         pause(): this;
         resume(): this;
-        isPaused(): boolean;
-        pipe<T extends NodeJS.WritableStream>(destination: T, options?: { end?: boolean; }): T;
-        unpipe<T extends NodeJS.WritableStream>(destination?: T): this;
-        unshift(chunk: string): void;
-        unshift(chunk: Buffer): void;
-        wrap(oldStream: NodeJS.ReadableStream): this;
 
         /* NodeJS.WriteStream */
         writable: boolean;
@@ -480,22 +471,8 @@ declare module 'firebird' {
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
+        destroy(error?: Error): void;
 
-        /* EventEmitter */
-        addListener(event: string | symbol, listener: Function): this;
-        on(event: string | symbol, listener: Function): this;
-        once(event: string | symbol, listener: Function): this;
-        removeListener(event: string | symbol, listener: Function): this;
-        removeAllListeners(event?: string | symbol): this;
-        setMaxListeners(n: number): this;
-        getMaxListeners(): number;
-        listeners(event: string | symbol): Function[];
-        emit(event: string | symbol, ...args: any[]): boolean;
-        listenerCount(type: string | symbol): number;
-        prependListener(event: string | symbol, listener: Function): this;
-        prependOnceListener(event: string | symbol, listener: Function): this;
-        eventNames(): (string | symbol)[];
-
-        /* tslint:enable */
+        check_destroyed(): void;
     }
 }

--- a/types/firebird/index.d.ts
+++ b/types/firebird/index.d.ts
@@ -470,7 +470,7 @@ declare module 'firebird' {
         unpipe<T extends NodeJS.WritableStream>(destination?: T): this;
         unshift(chunk: string): void;
         unshift(chunk: Buffer): void;
-        wrap(oldStream: NodeJS.ReadableStream): NodeJS.ReadableStream;
+        wrap(oldStream: NodeJS.ReadableStream): this;
 
         /* NodeJS.WriteStream */
         writable: boolean;

--- a/types/hexo-fs/index.d.ts
+++ b/types/hexo-fs/index.d.ts
@@ -426,11 +426,6 @@ export function writeFile(
  */
 export function writeFileSync(path: string, data: any, options?: string | { encoding?: string | null; mode?: string | number; flag?: string }): void;
 
-// Static classes
-export let Stats: Stats;
-export let ReadStream: ReadStream;
-export let WriteStream: WriteStream;
-
 // util
 export function escapeEOL(str: string): string;
 export function escapeBOM(str: string): string;

--- a/types/hexo-fs/index.d.ts
+++ b/types/hexo-fs/index.d.ts
@@ -426,6 +426,9 @@ export function writeFile(
  */
 export function writeFileSync(path: string, data: any, options?: string | { encoding?: string | null; mode?: string | number; flag?: string }): void;
 
+// Static classes
+export { Stats, ReadStream, WriteStream } from 'graceful-fs';
+
 // util
 export function escapeEOL(str: string): string;
 export function escapeBOM(str: string): string;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -450,6 +450,7 @@ declare namespace NodeJS {
         isRaw?: boolean;
         setRawMode?(mode: boolean): void;
         _read(size: number): void;
+        _destroy(err: Error, callback: Function): void;
         push(chunk: any, encoding?: string): boolean;
         destroy(error?: Error): void;
     }

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -345,7 +345,7 @@ declare namespace NodeJS {
         unpipe<T extends WritableStream>(destination?: T): this;
         unshift(chunk: string): void;
         unshift(chunk: Buffer): void;
-        wrap(oldStream: ReadableStream): ReadableStream;
+        wrap(oldStream: ReadableStream): this;
     }
 
     export interface WritableStream extends EventEmitter {
@@ -5084,7 +5084,7 @@ declare module "stream" {
             isPaused(): boolean;
             unpipe<T extends NodeJS.WritableStream>(destination?: T): this;
             unshift(chunk: any): void;
-            wrap(oldStream: NodeJS.ReadableStream): Readable;
+            wrap(oldStream: NodeJS.ReadableStream): this;
             push(chunk: any, encoding?: string): boolean;
             _destroy(err: Error, callback: Function): void;
             destroy(error?: Error): void;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -336,6 +336,7 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
+        _read(size: number): void;
         read(size?: number): string | Buffer;
         setEncoding(encoding: string): this;
         pause(): this;
@@ -346,17 +347,26 @@ declare namespace NodeJS {
         unshift(chunk: string): void;
         unshift(chunk: Buffer): void;
         wrap(oldStream: ReadableStream): this;
+        push(chunk: any, encoding?: string): boolean;
+        destroy(error?: Error): void;
     }
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
+        _write(chunk: any, encoding: string, callback: Function): void;
+        _destroy(err: Error, callback: Function): void;
+        _final(callback: Function): void;
         write(buffer: Buffer | string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
+        setDefaultEncoding(encoding: string): this;
         end(): void;
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
-    }
+        cork(): void;
+        uncork(): void;
+        destroy(error?: Error): void;
+}
 
     export interface ReadWriteStream extends ReadableStream, WritableStream { }
 
@@ -2430,7 +2440,9 @@ declare module "net" {
 
     export type SocketConnectOpts = TcpSocketConnectOpts | IpcSocketConnectOpts;
 
-    export interface Socket extends stream.Duplex {
+    export class Socket extends stream.Duplex {
+        constructor(options?: { fd?: number; allowHalfOpen?: boolean; readable?: boolean; writable?: boolean; });
+
         // Extended base methods
         write(buffer: Buffer): boolean;
         write(buffer: Buffer, cb?: Function): boolean;
@@ -2543,10 +2555,6 @@ declare module "net" {
         prependOnceListener(event: "lookup", listener: (err: Error, address: string, family: string | number, host: string) => void): this;
         prependOnceListener(event: "timeout", listener: () => void): this;
     }
-
-    export var Socket: {
-        new(options?: SocketConstructorOpts): Socket;
-    };
 
     export interface ListenOptions {
         port?: number;
@@ -2679,7 +2687,7 @@ declare module "dgram" {
     export function createSocket(type: SocketType, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
     export function createSocket(options: SocketOptions, callback?: (msg: Buffer, rinfo: RemoteInfo) => void): Socket;
 
-    export interface Socket extends events.EventEmitter {
+    export class Socket extends events.EventEmitter {
         send(msg: Buffer | String | any[], port: number, address: string, callback?: (error: Error | null, bytes: number) => void): void;
         send(msg: Buffer | String | any[], offset: number, length: number, port: number, address: string, callback?: (error: Error | null, bytes: number) => void): void;
         bind(port?: number, address?: string, callback?: () => void): void;
@@ -2757,7 +2765,7 @@ declare module "fs" {
      */
     export type PathLike = string | Buffer | URL;
 
-    export interface Stats {
+    export class Stats {
         isFile(): boolean;
         isDirectory(): boolean;
         isBlockDevice(): boolean;
@@ -2814,7 +2822,7 @@ declare module "fs" {
         prependOnceListener(event: "error", listener: (error: Error) => void): this;
     }
 
-    export interface ReadStream extends stream.Readable {
+    export class ReadStream extends stream.Readable {
         close(): void;
         destroy(): void;
         bytesRead: number;
@@ -2846,7 +2854,7 @@ declare module "fs" {
         prependOnceListener(event: "close", listener: () => void): this;
     }
 
-    export interface WriteStream extends stream.Writable {
+    export class WriteStream extends stream.Writable {
         close(): void;
         bytesWritten: number;
         path: string | Buffer;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -336,7 +336,6 @@ declare namespace NodeJS {
 
     export interface ReadableStream extends EventEmitter {
         readable: boolean;
-        _read(size: number): void;
         read(size?: number): string | Buffer;
         setEncoding(encoding: string): this;
         pause(): this;
@@ -347,26 +346,17 @@ declare namespace NodeJS {
         unshift(chunk: string): void;
         unshift(chunk: Buffer): void;
         wrap(oldStream: ReadableStream): this;
-        push(chunk: any, encoding?: string): boolean;
-        destroy(error?: Error): void;
     }
 
     export interface WritableStream extends EventEmitter {
         writable: boolean;
-        _write(chunk: any, encoding: string, callback: Function): void;
-        _destroy(err: Error, callback: Function): void;
-        _final(callback: Function): void;
         write(buffer: Buffer | string, cb?: Function): boolean;
         write(str: string, encoding?: string, cb?: Function): boolean;
-        setDefaultEncoding(encoding: string): this;
         end(): void;
         end(buffer: Buffer, cb?: Function): void;
         end(str: string, cb?: Function): void;
         end(str: string, encoding?: string, cb?: Function): void;
-        cork(): void;
-        uncork(): void;
-        destroy(error?: Error): void;
-}
+    }
 
     export interface ReadWriteStream extends ReadableStream, WritableStream { }
 
@@ -448,10 +438,20 @@ declare namespace NodeJS {
     export interface WriteStream extends Socket {
         columns?: number;
         rows?: number;
+        _write(chunk: any, encoding: string, callback: Function): void;
+        _destroy(err: Error, callback: Function): void;
+        _final(callback: Function): void;
+        setDefaultEncoding(encoding: string): this;
+        cork(): void;
+        uncork(): void;
+        destroy(error?: Error): void;
     }
     export interface ReadStream extends Socket {
         isRaw?: boolean;
         setRawMode?(mode: boolean): void;
+        _read(size: number): void;
+        push(chunk: any, encoding?: string): boolean;
+        destroy(error?: Error): void;
     }
 
     export interface Process extends EventEmitter {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2066,6 +2066,36 @@ namespace child_process_tests {
             let _sendHandle: net.Socket | net.Server = sendHandle;
         });
     }
+    {
+        process.stdin.setEncoding('utf8');
+
+        process.stdin.on('readable', () => {
+            const chunk = process.stdin.read();
+            if (chunk !== null) {
+              process.stdout.write(`data: ${chunk}`);
+            }
+        });
+
+        process.stdin.on('end', () => {
+            process.stdout.write('end');
+        });
+
+        process.stdin.pipe(process.stdout);
+
+        console.log(process.stdin.isTTY);
+        console.log(process.stdout.isTTY);
+
+        console.log(process.stdin instanceof net.Socket);
+        console.log(process.stdout instanceof fs.ReadStream);
+
+        var stdin: stream.Readable = process.stdin;
+        console.log(stdin instanceof net.Socket);
+        console.log(stdin instanceof fs.ReadStream);
+
+        var stdout: stream.Writable = process.stdout;
+        console.log(stdout instanceof net.Socket);
+        console.log(stdout instanceof fs.WriteStream);
+    }
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/types/vinyl/vinyl-tests.ts
+++ b/types/vinyl/vinyl-tests.ts
@@ -24,10 +24,6 @@ interface TestFile extends File {
 	_base?: string;
 }
 
-declare module 'fs' {
-	class Stats { }
-}
-
 var pipe: (streams: [NodeJS.ReadableStream, NodeJS.WritableStream], cb: (err?: Error) => void) => void = miss.pipe;
 var from: (values: any[]) => NodeJS.ReadableStream = miss.from;
 var concat: (fn: (d: Buffer) => void) => NodeJS.WritableStream = miss.concat;


### PR DESCRIPTION
New interfaces `NodeJS.Readable` and `NodeJS.Writable` have the same properties
as in `stream.Readable` and `stream.Writable` classes.

Interface `NodeJS.Socket` is just a `NodeJS.ReadWriteStream`. But new
interface `NodeJS.TtyStream` (`TtyWriteStream` and `TtyReadStream`) has
extra properties as in `tty.ReadStream` and `tty.WriteStream`.

`process.stdin` implements `NodeJS.TtyReadStream` and
`process.stdout` implements `NodeJS.TtyWriteStream`.

`net.Socket`, `dgram.Socket`, `fs.Stats`, `fs.ReadStream` and `fs.WriteStream`
are classes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
