### PR TITLE
[meteor] EJSONableCustomType shloud have `clone` and `equal` method optional

### DIFF
--- a/types/meteor/ejson.d.ts
+++ b/types/meteor/ejson.d.ts
@@ -1,6 +1,6 @@
 interface EJSONableCustomType {
-    clone(): EJSONableCustomType;
-    equals(other: Object): boolean;
+    clone?(): EJSONableCustomType;
+    equals?(other: Object): boolean;
     toJSONValue(): JSONable;
     typeName(): string;
 }


### PR DESCRIPTION
According to meteor docs a custom type registered to EJSON is allowed to omit the `clone` and `equals` methods. See https://docs.meteor.com/api/ejson.html#EJSON-addType

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.meteor.com/api/ejson.html#EJSON-addType
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
