### PR TITLE
[thrift] Fix thrift multiplexer type, moved generic to createClient

### DIFF
--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://www.npmjs.com/package/thrift
 // Definitions by: Kamek <https://github.com/kamek-pf>
 //                 Kevin Greene <https://github.com/kevin-greene-ck>
+//                 Jesse Zhang <https://github.com/jessezhang91>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -197,8 +198,8 @@ export class WSConnection extends NodeJS.EventEmitter {
     write(data: Buffer): void;
 }
 
-export class Multiplexer<TClient> {
-    createClient(serviceName: string, client: TClientConstructor<TClient>, connection: Connection): TClient;
+export class Multiplexer {
+    createClient<TClient>(serviceName: string, client: TClientConstructor<TClient>, connection: Connection): TClient;
 }
 
 export class MultiplexedProcessor {

--- a/types/thrift/thrift-tests.ts
+++ b/types/thrift/thrift-tests.ts
@@ -2,6 +2,7 @@ import {
   createConnection,
   createServer,
   createClient,
+  Multiplexer,
   Thrift,
   TBinaryProtocol,
   TBufferedTransport,
@@ -126,3 +127,6 @@ const tBinary: Buffer = mockProtocol.readBinary();
 const tString: string = mockProtocol.readString();
 const tTrans: TTransport = mockProtocol.getTransport();
 mockProtocol.skip(Thrift.Type.STRUCT);
+
+const multiplexer = new Multiplexer();
+multiplexer.createClient("mock-service", mockGeneratedService, clientConnection);


### PR DESCRIPTION
Moved generic from `thrift.Multiplexer` to `thrift.Multiplexer#createClient`. The multiplexer should be able to create multiple different client types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apache/thrift/blob/master/lib/nodejs/lib/thrift/multiplexed_protocol.js#L51
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
