### PR TITLE
[archiver] fix bugs in archiver types around destpath/data parameters

### DIFF
--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -1,5 +1,6 @@
 import * as Archiver from 'archiver';
 import * as fs from 'fs';
+import { EntryData } from 'archiver';
 
 const options: Archiver.ArchiverOptions = {
     statConcurrency: 1,
@@ -37,8 +38,11 @@ archiver.append(readStream, {name: 'archiver.d.ts'})
 archiver.directory('./path', './someOtherPath');
 archiver.directory('./', "", {});
 archiver.directory('./', false, { name: 'test' });
-archiver.directory('./', false, entry => ({ ...entry, name : "foobar" }));
-archiver.directory('./', false, entry => false);
+archiver.directory('./', false, (entry: EntryData) => {
+    entry.name = "foobar";
+    return entry;
+});
+archiver.directory('./', false, (entry: EntryData) => false);
 
 archiver.append(readStream, {
     name: "sub/folder.xml"

--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -1,6 +1,5 @@
 import * as Archiver from 'archiver';
 import * as fs from 'fs';
-import { EntryData } from 'archiver';
 
 const options: Archiver.ArchiverOptions = {
     statConcurrency: 1,
@@ -38,11 +37,11 @@ archiver.append(readStream, {name: 'archiver.d.ts'})
 archiver.directory('./path', './someOtherPath');
 archiver.directory('./', "", {});
 archiver.directory('./', false, { name: 'test' });
-archiver.directory('./', false, (entry: EntryData) => {
+archiver.directory('./', false, (entry: Archiver.EntryData) => {
     entry.name = "foobar";
     return entry;
 });
-archiver.directory('./', false, (entry: EntryData) => false);
+archiver.directory('./', false, (entry: Archiver.EntryData) => false);
 
 archiver.append(readStream, {
     name: "sub/folder.xml"

--- a/types/archiver/archiver-tests.ts
+++ b/types/archiver/archiver-tests.ts
@@ -35,9 +35,10 @@ archiver.append(readStream, {name: 'archiver.d.ts'})
 .append(readStream, {name: 'archiver.d.ts'});
 
 archiver.directory('./path', './someOtherPath');
-archiver.directory('./path', { name: "testName" });
 archiver.directory('./', "", {});
-archiver.directory('./', { name: 'test' }, {});
+archiver.directory('./', false, { name: 'test' });
+archiver.directory('./', false, entry => ({ ...entry, name : "foobar" }));
+archiver.directory('./', false, entry => false);
 
 archiver.append(readStream, {
     name: "sub/folder.xml"

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -22,7 +22,7 @@ declare namespace archiver {
     }
 
     /** A function that lets you either opt out of including an entry (by returning false), or modify the contents of an entry as it is added (by returning an EntryData) */
-    type EntryDataFunction = (entry: EntryData) => false | EntryData
+    type EntryDataFunction = (entry: EntryData) => false | EntryData;
 
     interface Archiver extends stream.Transform {
         abort(): this;

--- a/types/archiver/index.d.ts
+++ b/types/archiver/index.d.ts
@@ -21,12 +21,15 @@ declare namespace archiver {
         stats?: string;
     }
 
+    /** A function that lets you either opt out of including an entry (by returning false), or modify the contents of an entry as it is added (by returning an EntryData) */
+    type EntryDataFunction = (entry: EntryData) => false | EntryData
+
     interface Archiver extends stream.Transform {
         abort(): this;
         append(source: stream.Readable | Buffer | string, name?: EntryData): this;
 
-        directory(dirpath: string, options: EntryData | string, data?: EntryData): this;
-
+        /** if false is passed for destpath, the path of a chunk of data in the archive is set to the root */
+        directory(dirpath: string, destpath: false | string, data?: EntryData | EntryDataFunction): this;
         file(filename: string, data: EntryData): this;
         glob(pattern: string, options?: glob.IOptions, data?: EntryData): this;
         finalize(): Promise<void>;


### PR DESCRIPTION
Per the url link below, the second parameter is either a `false` or a string. if it is not a string it's replaced by the dirPath on line 615, so it makes no sense to allow anyone to put non-false-or-string values there.

For the data parameter, a function can also be applied here. That function is used on line 649 from the link, and must either return false or an object.  In this case the intent is to mutate and return the EntryData.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/archiverjs/node-archiver/blob/master/lib/core.js#L599
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
