### PR TITLE
@types/react: Adding "type" to AnchorHTMLAttributes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2578,6 +2578,7 @@ declare namespace React {
         media?: string;
         rel?: string;
         target?: string;
+        type?: string;
     }
 
     // tslint:disable-next-line:no-empty-interface


### PR DESCRIPTION
Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
Broken by: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/a24aee6125213ba20a5bda15a5d4fce8b60b2f57
React documentation for the supported "type" attribute: https://reactjs.org/docs/dom-elements.html
