### PR TITLE
[node-zookeeper-client] fix event type, should be number

### DIFF
--- a/types/node-zookeeper-client/index.d.ts
+++ b/types/node-zookeeper-client/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for node-zookeeper-client 0.2
 // Project: https://github.com/alexguan/node-zookeeper-client
 // Definitions by: York Yao <https://github.com/plantain-00>
+//                 Jesse Zhang <https://github.com/jessezhang91>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -62,12 +63,12 @@ export class Event {
     static NODE_DELETED: number;
     static NODE_DATA_CHANGED: number;
     static NODE_CHILDREN_CHANGED: number;
-    type: string;
+    type: number;
     name: string;
     path: string;
-    constructor(type: string, name: string, path: string);
+    constructor(type: number, name: string, path: string);
     toString(): string;
-    getType(): string;
+    getType(): number;
     getName(): string;
     getPath(): string;
 }

--- a/types/node-zookeeper-client/node-zookeeper-client-tests.ts
+++ b/types/node-zookeeper-client/node-zookeeper-client-tests.ts
@@ -251,3 +251,7 @@ const client = zookeeper.createClient(
         console.log('Node: %s is created.', path);
     });
 }
+
+{
+    new zookeeper.Event(zookeeper.Event.NODE_CREATED, 'test', '/test');
+}


### PR DESCRIPTION
`zookeeper.Event#type` should be of type `number` not `string`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/alexguan/node-zookeeper-client/blob/master/lib/Event.js#L43 and https://github.com/alexguan/node-zookeeper-client/blob/master/lib/Event.js#L25-L35
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
