### PR TITLE
memory-cache: Add type parameters and expose constructor to instantiate new caches

### DIFF
--- a/types/memory-cache/index.d.ts
+++ b/types/memory-cache/index.d.ts
@@ -1,12 +1,29 @@
 // Type definitions for memory-cache
 // Project: https://github.com/ptarjan/node-cache
 // Definitions by: Jeff Goddard <https://github.com/jedigo>
+//                 Travis Thieman <https://github.com/thieman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Imported from: https://github.com/soywiz/typescript-node-definitions/memory-cache.d.ts
+// Originally imported from: https://github.com/soywiz/typescript-node-definitions/memory-cache.d.ts
 
+declare class CacheClass<K, V> {
+    public put(key: K, value: V, time?: number, timeoutCallback?: (key: K, value: V) => void): V;
+    public get(key: K): V;
+    public del(key: K): void;
+    public clear(): void;
 
-export declare function put(key: any, value: any, time?: number, timeoutCallback?: (key: any, value: any) => void): void;
+    public size(): number;
+    public memsize(): number;
+
+    public debug(bool: boolean): void;
+    public hits(): number;
+    public misses(): number;
+    public keys(): any;
+}
+
+export declare let Cache: typeof CacheClass;
+
+export declare function put<V>(key: any, value: V, time?: number, timeoutCallback?: (key: any, value: any) => void): V;
 export declare function get(key: any): any;
 export declare function del(key: any): void;
 export declare function clear(): void;

--- a/types/memory-cache/index.d.ts
+++ b/types/memory-cache/index.d.ts
@@ -6,32 +6,32 @@
 
 // Originally imported from: https://github.com/soywiz/typescript-node-definitions/memory-cache.d.ts
 
-declare class CacheClass<K, V> {
-    public put(key: K, value: V, time?: number, timeoutCallback?: (key: K, value: V) => void): V;
-    public get(key: K): V;
-    public del(key: K): void;
-    public clear(): void;
+export class CacheClass<K, V> {
+    put(key: K, value: V, time?: number, timeoutCallback?: (key: K, value: V) => void): V;
+    get(key: K): V;
+    del(key: K): void;
+    clear(): void;
 
-    public size(): number;
-    public memsize(): number;
+    size(): number;
+    memsize(): number;
 
-    public debug(bool: boolean): void;
-    public hits(): number;
-    public misses(): number;
-    public keys(): K[];
+    debug(bool: boolean): void;
+    hits(): number;
+    misses(): number;
+    keys(): K[];
 }
 
-export declare let Cache: typeof CacheClass;
+export const Cache: typeof CacheClass;
 
-export declare function put<V>(key: any, value: V, time?: number, timeoutCallback?: (key: any, value: any) => void): V;
-export declare function get(key: any): any;
-export declare function del(key: any): void;
-export declare function clear(): void;
+export function put<V>(key: any, value: V, time?: number, timeoutCallback?: (key: any, value: any) => void): V;
+export function get(key: any): any;
+export function del(key: any): void;
+export function clear(): void;
 
-export declare function size(): number;
-export declare function memsize(): number;
+export function size(): number;
+export function memsize(): number;
 
-export declare function debug(bool: boolean): void;
-export declare function hits(): number;
-export declare function misses(): number;
-export declare function keys(): any[];
+export function debug(bool: boolean): void;
+export function hits(): number;
+export function misses(): number;
+export function keys(): any[];

--- a/types/memory-cache/index.d.ts
+++ b/types/memory-cache/index.d.ts
@@ -18,7 +18,7 @@ declare class CacheClass<K, V> {
     public debug(bool: boolean): void;
     public hits(): number;
     public misses(): number;
-    public keys(): any;
+    public keys(): K[];
 }
 
 export declare let Cache: typeof CacheClass;
@@ -34,4 +34,4 @@ export declare function memsize(): number;
 export declare function debug(bool: boolean): void;
 export declare function hits(): number;
 export declare function misses(): number;
-export declare function keys(): any;
+export declare function keys(): any[];

--- a/types/memory-cache/index.d.ts
+++ b/types/memory-cache/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for memory-cache
+// Type definitions for memory-cache 0.2
 // Project: https://github.com/ptarjan/node-cache
 // Definitions by: Jeff Goddard <https://github.com/jedigo>
 //                 Travis Thieman <https://github.com/thieman>

--- a/types/memory-cache/memory-cache-tests.ts
+++ b/types/memory-cache/memory-cache-tests.ts
@@ -1,19 +1,21 @@
-
 import memoryCache = require('memory-cache');
 
 var key: any;
-var value: any;
+var value: string;
 var bool: boolean;
 var num: number;
 
-memoryCache.put(key, value);
-memoryCache.put(key, value, num);
-memoryCache.put(key, value, num, (key) => {
+var returnedValue: string;
+
+returnedValue = memoryCache.put(key, value);
+returnedValue = memoryCache.put(key, value, num);
+returnedValue = memoryCache.put(key, value, num, (key) => {
 
 });
-memoryCache.put(key, value, num, (key, value) => {
+returnedValue = memoryCache.put(key, value, num, (key, value) => {
 
 });
+
 value = memoryCache.get(key);
 memoryCache.del(key);
 memoryCache.clear();
@@ -24,3 +26,12 @@ num = memoryCache.memsize();
 memoryCache.debug(bool);
 num = memoryCache.hits();
 num = memoryCache.misses();
+
+var customCache = new memoryCache.Cache<string, boolean>();
+
+var customKey: string;
+var customValue: boolean;
+
+customValue = customCache.put(customKey, customValue);
+customCache.get(customKey);
+customCache.del(customKey);

--- a/types/memory-cache/memory-cache-tests.ts
+++ b/types/memory-cache/memory-cache-tests.ts
@@ -1,19 +1,15 @@
 import memoryCache = require('memory-cache');
 
-var key: any;
-var value: string;
-var bool: boolean;
-var num: number;
-var returnedValue: string;
+const key: any = 'sampleKey';
+let value: string;
+const bool = false;
+let num: number;
+let returnedValue: string;
 
 returnedValue = memoryCache.put(key, value);
 returnedValue = memoryCache.put(key, value, num);
-returnedValue = memoryCache.put(key, value, num, (key) => {
-
-});
-returnedValue = memoryCache.put(key, value, num, (key, value) => {
-
-});
+returnedValue = memoryCache.put(key, value, num, (key) => { });
+returnedValue = memoryCache.put(key, value, num, (key, value) => { });
 
 value = memoryCache.get(key);
 memoryCache.del(key);
@@ -26,11 +22,11 @@ memoryCache.debug(bool);
 num = memoryCache.hits();
 num = memoryCache.misses();
 
-var customCache = new memoryCache.Cache<string, boolean>();
+const customCache = new memoryCache.Cache<string, boolean>();
 
-var customKey: string;
-var customValue: boolean;
-var customKeys: string[];
+const customKey = 'customKey';
+let customValue: boolean;
+let customKeys: string[];
 
 customValue = customCache.put(customKey, customValue);
 customCache.get(customKey);

--- a/types/memory-cache/memory-cache-tests.ts
+++ b/types/memory-cache/memory-cache-tests.ts
@@ -4,7 +4,6 @@ var key: any;
 var value: string;
 var bool: boolean;
 var num: number;
-
 var returnedValue: string;
 
 returnedValue = memoryCache.put(key, value);
@@ -31,7 +30,9 @@ var customCache = new memoryCache.Cache<string, boolean>();
 
 var customKey: string;
 var customValue: boolean;
+var customKeys: string[];
 
 customValue = customCache.put(customKey, customValue);
 customCache.get(customKey);
 customCache.del(customKey);
+customKeys = customCache.keys();

--- a/types/memory-cache/tslint.json
+++ b/types/memory-cache/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>

This PR does a few things (my apologies, I thought it was small enough a single PR was justified):

1. Expose the constructor to create new Cache instances. `memory-cache` provides a singleton cache instance at the module-level, which was already exposed through types, as well as the ability to create new instances. This is shown at [the bottom of this code block in its README](https://github.com/ptarjan/node-cache#usage).

2. For custom caches, add type parameters for the keys `K` and values `V` in each cache, affecting most functions.

3. Fixes the declaration of `put` to reflect that the `value` is returned. [Docs](https://github.com/ptarjan/node-cache#put--functionkey-value-time-timeoutcallback)

4. For the global cache, keep using `any` with the exception of `put` which now knows that its return type is the same as the type of `value`.

- [ ] Increase the version number in the header if appropriate.

I do not see a version number anywhere in the `memory-cache` dir, please let me know if I missed it

- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Did not seem substantial enough to warrant adding linting