### PR TITLE
[highland] Add the `through` stream method

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -23,6 +23,7 @@ var numArr: string[];
 var funcArr: Function[];
 
 var readable: NodeJS.ReadableStream;
+var readwritable: NodeJS.ReadWriteStream;
 var writable: NodeJS.WritableStream;
 var emitter: NodeJS.EventEmitter;
 
@@ -299,6 +300,9 @@ fooStream = fooStream.parallel(num);
 barStream = fooStream.sequence<Bar>();
 
 barStream = fooStream.series<Bar>();
+
+barStream = fooStream.through(x => bar);
+barStream = fooStream.through(readwritable);
 
 fooStream = fooStream.zip(fooStream);
 fooStream = fooStream.zip([foo, foo]);

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -1137,7 +1137,6 @@ declare namespace Highland {
 		 * });
 		 */
 		through<R, U>(f: (x: R) => U): Stream<U>;
-		//TODO: don't just use `any`, find a way to preserve types with the ReadWriteStream
 		through(thru: NodeJS.ReadWriteStream): Stream<any>;
 
 

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -1078,6 +1078,70 @@ declare namespace Highland {
 		series<U>(): Stream<U>;
 
 		/**
+		 * Transforms a stream using an arbitrary target transform.
+		 *
+		 * If `target` is a function, this transform passes the current Stream to it,
+		 * returning the result.
+		 *
+		 * If `target` is a [Duplex
+		 * Stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex_1),
+		 * this transform pipes the current Stream through it. It will always return a
+		 * Highland Stream (instead of the piped to target directly as in
+		 * [pipe](#pipe)). Any errors emitted will be propagated as Highland errors.
+		 *
+		 * **TIP**: Passing a function to `through` is a good way to implement complex
+		 * reusable stream transforms. You can even construct the function dynamically
+		 * based on certain inputs. See examples below.
+		 *
+		 * @id through
+		 * @section Higher-order Streams
+		 * @name Stream.through(target)
+		 * @param {Function | Duplex Stream} target - the stream to pipe through or a
+		 * function to call.
+		 * @api public
+		 *
+		 * // This is a static complex transform.
+		 * function oddDoubler(s) {
+		 *     return s.filter(function (x) {
+		 *         return x % 2; // odd numbers only
+		 *     })
+		 *     .map(function (x) {
+		 *         return x * 2;
+		 *     });
+		 * }
+		 *
+		 * // This is a dynamically-created complex transform.
+		 * function multiplyEvens(factor) {
+		 *     return function (s) {
+		 *         return s.filter(function (x) {
+		 *             return x % 2 === 0;
+		 *         })
+		 *         .map(function (x) {
+		 *             return x * factor;
+		 *         });
+		 *     };
+		 * }
+		 *
+		 * _([1, 2, 3, 4]).through(oddDoubler); // => 2, 6
+		 *
+		 * _([1, 2, 3, 4]).through(multiplyEvens(5)); // => 10, 20
+		 *
+		 * // Can also be used with Node Through Streams
+		 * _(filenames).through(jsonParser).map(function (obj) {
+		 *     // ...
+		 * });
+		 *
+		 * // All errors will be propagated as Highland errors
+		 * _(['zz{"a": 1}']).through(jsonParser).errors(function (err) {
+		 *   console.log(err); // => SyntaxError: Unexpected token z
+		 * });
+		 */
+		through<R, U>(f: (x: R) => U): Stream<U>;
+		//TODO: don't just use `any`, find a way to preserve types with the ReadWriteStream
+		through(thru: NodeJS.ReadWriteStream): Stream<any>;
+
+
+		/**
 		 * Takes two Streams and returns a Stream of corresponding pairs.
 		 *
 		 * @id zip


### PR DESCRIPTION
The `through` method seems to have been added in caolan/highland@2d616e083873832b4083eab3c19b2a9e0ff5f7b8.

Relates to #17090, and [this PR comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/16523#issuecomment-302863224).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://highlandjs.org/#through>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
