### PR TITLE
Fix type of createPushResponse() in node http2.

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6454,7 +6454,7 @@ declare module "http2" {
         writeContinue(): void;
         writeHead(statusCode: number, headers?: OutgoingHttpHeaders): void;
         writeHead(statusCode: number, statusMessage?: string, headers?: OutgoingHttpHeaders): void;
-        createPushResponse(headers: OutgoingHttpHeaders, callback: (err: Error, res: Http2ServerResponse) => void): void;
+        createPushResponse(headers: OutgoingHttpHeaders, callback: (err: Error | null, res: Http2ServerResponse) => void): void;
 
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6454,7 +6454,7 @@ declare module "http2" {
         writeContinue(): void;
         writeHead(statusCode: number, headers?: OutgoingHttpHeaders): void;
         writeHead(statusCode: number, statusMessage?: string, headers?: OutgoingHttpHeaders): void;
-        createPushResponse(headers: OutgoingHttpHeaders, callback?: (err: Error) => void): void;
+        createPushResponse(headers: OutgoingHttpHeaders, callback: (err: Error, res: Http2ServerResponse) => void): void;
 
         addListener(event: string, listener: (...args: any[]) => void): this;
         addListener(event: "aborted", listener: (hadError: boolean, code: number) => void): this;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3199,8 +3199,8 @@ namespace http2_tests {
 
             response.setTimeout(0, () => {});
             response.createPushResponse(outgoingHeaders, () => {});
-            response.createPushResponse(outgoingHeaders, (err: Error) => {});
-            response.createPushResponse(outgoingHeaders, (err: Error, res: http2.Http2ServerResponse) => {});
+            response.createPushResponse(outgoingHeaders, (err: Error | null) => {});
+            response.createPushResponse(outgoingHeaders, (err: Error | null, res: http2.Http2ServerResponse) => {});
 
             response.writeContinue();
             response.writeHead(200);

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3198,8 +3198,6 @@ namespace http2_tests {
             let headersSent: boolean = response.headersSent;
 
             response.setTimeout(0, () => {});
-            response.createPushResponse(outgoingHeaders, () => {});
-            response.createPushResponse(outgoingHeaders, (err: Error | null) => {});
             response.createPushResponse(outgoingHeaders, (err: Error | null, res: http2.Http2ServerResponse) => {});
 
             response.writeContinue();

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3198,8 +3198,9 @@ namespace http2_tests {
             let headersSent: boolean = response.headersSent;
 
             response.setTimeout(0, () => {});
-            response.createPushResponse(outgoingHeaders);
+            response.createPushResponse(outgoingHeaders, () => {});
             response.createPushResponse(outgoingHeaders, (err: Error) => {});
+            response.createPushResponse(outgoingHeaders, (err: Error, res: http2.Http2ServerResponse) => {});
 
             response.writeContinue();
             response.writeHead(200);


### PR DESCRIPTION
From https://github.com/nodejs/node/blob/master/lib/internal/http2/compat.js#L628:
`callback` is required to be a function. And its second argument is an `Http2ServerResponse`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
