### PR TITLE
[redux-form] - Added missing error property for FIeldState in v6

### DIFF
--- a/types/redux-form/v6/index.d.ts
+++ b/types/redux-form/v6/index.d.ts
@@ -16,6 +16,7 @@ export type FieldState = {
     active?: boolean;
     touched?: boolean;
     visited?: boolean;
+    error?: string;
 }
 
 export type FieldType = "Field" | "FieldArray";

--- a/types/redux-form/v6/index.d.ts
+++ b/types/redux-form/v6/index.d.ts
@@ -16,7 +16,7 @@ export type FieldState = {
     active?: boolean;
     touched?: boolean;
     visited?: boolean;
-    error?: string;
+    error?: any;
 }
 
 export type FieldType = "Field" | "FieldArray";


### PR DESCRIPTION
redux-form in version 6 is missing the optional error property in the FieldState type.