### PR TITLE
[meteor] Fix meteor/ejson/EJSONableCustomType

### DIFF
--- a/types/meteor/ejson.d.ts
+++ b/types/meteor/ejson.d.ts
@@ -38,8 +38,8 @@ declare module EJSON {
 
 declare module "meteor/ejson" {
     interface EJSONableCustomType {
-        clone(): EJSONableCustomType;
-        equals(other: Object): boolean;
+        clone?(): EJSONableCustomType;
+        equals?(other: Object): boolean;
         toJSONValue(): JSONable;
         typeName(): string;
     }


### PR DESCRIPTION
Fixing commit 7031c869bb0d219864cdede602b2d4b2284c695e

Sorry I made a mistake. In referenced commit the `clone` and `equal` methods in EJSONableCustomType was marked as optional but forgot to update the corresponding interface in `declare module "meteor/ejson"` section.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
