### PR TITLE
request: response request always have an URI

### DIFF
--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -176,8 +176,12 @@ declare namespace request {
         (error: any, response: RequestResponse, body: any): void;
     }
 
+    export type ResponseRequest = CoreOptions & {
+      uri: Url;
+    }
+
 	export interface RequestResponse extends http.IncomingMessage {
-		request: Options;
+		request: ResponseRequest;
 		body: any;
 		timingStart?: number;
 		timings?: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/request/request/blob/b12a6245d9acdb1e13c6486d427801e123fdafae/request.js#L195
  - https://github.com/request/request/blob/b12a6245d9acdb1e13c6486d427801e123fdafae/request.js#L237
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Issue

Accessing `res.request.uri.href` fails with the following error:

```
Property 'uri' does not exist on type 'Options'.
  Property 'uri' does not exist on type 'OptionsWithUrl'.
```

According to the code (see `request` source code links above), `uri` is always present on the `request` object, and it's parsed with `url.parse`, so it's always gonna be an `Url` and not a string.

I'm not sure of the best way to reflect that. I added a type `ResponseRequest` that's basically `CoreOptions` plus a prop `uri` that's always an `Url`.

Technically, the `request` property of a response is actually the `Request` object itself (https://github.com/request/request/blob/b12a6245d9acdb1e13c6486d427801e123fdafae/request.js#L940) but the current type definition for `Request` doesn't include any of those either, and I don't want to change the current types too much.