### PR TITLE
paho-mqtt: fix Message.{payloadBytes, qos, constructor} & add `export =` to module declaration

### DIFF
--- a/types/paho-mqtt/index.d.ts
+++ b/types/paho-mqtt/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/eclipse/paho.mqtt.javascript#readme
 // Definitions by: Alex Mikhalev <https://github.com/amikhalev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 declare namespace Paho {
     /**
@@ -388,6 +389,17 @@ declare namespace Paho {
             unsubscribe(filter: string, unsubcribeOptions?: UnsubscribeOptions): void;
         }
 
+        type TypedArray =
+            | Int8Array
+            | Uint8Array
+            | Uint8ClampedArray
+            | Int16Array
+            | Uint16Array
+            | Int32Array
+            | Uint32Array
+            | Float32Array
+            | Float64Array;
+
         /**
          * An application message, sent or received.
          */
@@ -405,8 +417,10 @@ declare namespace Paho {
              */
             readonly duplicate: boolean;
 
-            /** <i>read only</i> The payload as an ArrayBuffer. */
-            readonly payloadBytes: ArrayBuffer;
+            /** <i>read only</i> The payload.
+             * @return Uint8Array if payload is a string. Return the original otherwise.
+             */
+            readonly payloadBytes: ArrayBuffer | TypedArray;
 
             /**
              *  <i>read only</i> The payload as a string if the payload consists of valid UTF-8 characters.
@@ -439,7 +453,7 @@ declare namespace Paho {
             /**
              * @param {String|ArrayBuffer} payload The message data to be sent.
              */
-            constructor(payload: string | ArrayBuffer);
+            constructor(payload: string | ArrayBuffer | TypedArray);
         }
     }
 }

--- a/types/paho-mqtt/index.d.ts
+++ b/types/paho-mqtt/index.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
+/// <reference path="module.d.ts"/>
+
 declare namespace Paho {
     /**
      * Send and receive messages using web browsers.
@@ -438,7 +440,7 @@ declare namespace Paho {
              *
              * @default 0
              */
-            qos: number;
+            qos: Qos;
 
             /**
              * If true, the message is to be retained by the server and delivered to both current and future

--- a/types/paho-mqtt/module.d.ts
+++ b/types/paho-mqtt/module.d.ts
@@ -1,0 +1,10 @@
+// Type definitions for paho-mqtt 1.0
+// Project: https://github.com/eclipse/paho.mqtt.javascript#readme
+// Definitions by: Alex Mikhalev <https://github.com/amikhalev>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference path="index.d.ts"/>
+
+declare module 'paho-mqtt' {
+    export = Paho.MQTT;
+}

--- a/types/paho-mqtt/paho-mqtt-tests.ts
+++ b/types/paho-mqtt/paho-mqtt-tests.ts
@@ -85,3 +85,7 @@ msg.destinationName = "test/topic5";
 msg.qos = 2;
 
 client.disconnect();
+
+import { Message, Client, Qos } from "paho-mqtt";
+new Message("some string").destinationName = "test/topic6";
+const qos: Qos = new Message(new Uint8Array(4)).qos = 0;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
    + [export =](https://github.com/eclipse/paho.mqtt.javascript/blob/v1.0.3/src/paho-mqtt.js#L86), 
    + `Message`'s constructor param type & `Message.payloadBytes`: [this](https://github.com/eclipse/paho.mqtt.javascript/blob/v1.0.3/src/paho-mqtt.js#L2317) & [this](https://github.com/eclipse/paho.mqtt.javascript/blob/develop/src/paho-mqtt.js#L2302)

- [x] Increase the version number in the header if appropriate.
`export =` is only added in paho-mqtt version 1.0.3
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
