### PR TITLE
@types/gm Use union types instead of overloaded functions 

### DIFF
--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for gm 1.17
 // Project: https://github.com/aheckmann/gm
-// Definitions by: Joel Spadin <https://github.com/ChaosinaCan>
+// Definitions by: Joel Spadin <https://github.com/ChaosinaCan>, Maarten van Vliet <https://github.com/maartenvanvliet>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>

--- a/types/gm/index.d.ts
+++ b/types/gm/index.d.ts
@@ -7,9 +7,7 @@
 
 import stream = require('stream');
 
-declare function m(image: string): m.State;
-declare function m(stream: NodeJS.ReadableStream, image?: string): m.State;
-declare function m(buffer: Buffer, image?: string): m.State;
+declare function m(stream: NodeJS.ReadableStream | Buffer | string, image?: string): m.State;
 declare function m(width: number, height: number, color?: string): m.State;
 
 declare namespace m {
@@ -27,7 +25,7 @@ declare namespace m {
     interface CompareOptions {
         file?: string;
         highlightColor?: string;
-        highlightStyle?: string;
+        highlightStyle?: HighlightStyle;
         tolerance?: number;
     }
 
@@ -108,78 +106,17 @@ declare namespace m {
         border(width: number, height: number): State;
         borderColor(color: string): State;
         box(color: string): State;
-        channel(type: 'Red'): State;
-        channel(type: 'Green'): State;
-        channel(type: 'Blue'): State;
-        channel(type: 'Opacity'): State;
-        channel(type: 'Matte'): State;
-        channel(type: 'Cyan'): State;
-        channel(type: 'Magenta'): State;
-        channel(type: 'Yellow'): State;
-        channel(type: 'Black'): State;
-        channel(type: 'Gray'): State;
-        channel(type: string): State;
+        channel(type: NamedColor | string): State;
         charcoal(factor: number): State;
         chop(width: number, height: number, x?: number, y?: number): State;
         clip(): State;
         coalesce(): State;
         colorize(red: number, green: number, blue: number): State;
-        colorMap(type: 'shared'): State;
-        colorMap(type: 'private'): State;
-        colorMap(type: string): State;
+        colorMap(type: 'shared' | 'private' | string): State;
         colors(colors: number): State;
-        colorspace(space: 'CineonLog'): State;
-        colorspace(space: 'CMYK'): State;
-        colorspace(space: 'GRAY'): State;
-        colorspace(space: 'HSL'): State;
-        colorspace(space: 'HSB'): State;
-        colorspace(space: 'OHTA'): State;
-        colorspace(space: 'RGB'): State;
-        colorspace(space: 'Rec601Luma'): State;
-        colorspace(space: 'Rec709Luma'): State;
-        colorspace(space: 'Rec601YCbCr'): State;
-        colorspace(space: 'Rec709YCbCr'): State;
-        colorspace(space: 'Transparent'): State;
-        colorspace(space: 'XYZ'): State;
-        colorspace(space: 'YCbCr'): State;
-        colorspace(space: 'YIQ'): State;
-        colorspace(space: 'YPbPr'): State;
-        colorspace(space: 'YUV'): State;
-        colorspace(space: string): State;
-        compose(operator: 'Over'): State;
-        compose(operator: 'In'): State;
-        compose(operator: 'Out'): State;
-        compose(operator: 'Atop'): State;
-        compose(operator: 'Xor'): State;
-        compose(operator: 'Plus'): State;
-        compose(operator: 'Minus'): State;
-        compose(operator: 'Add'): State;
-        compose(operator: 'Subtract'): State;
-        compose(operator: 'Difference'): State;
-        compose(operator: 'Divide'): State;
-        compose(operator: 'Multiply'): State;
-        compose(operator: 'Bumpmap'): State;
-        compose(operator: 'Copy'): State;
-        compose(operator: 'CopyRed'): State;
-        compose(operator: 'CopyGreen'): State;
-        compose(operator: 'CopyBlue'): State;
-        compose(operator: 'CopyOpacity'): State;
-        compose(operator: 'CopyCyan'): State;
-        compose(operator: 'CopyMagenta'): State;
-        compose(operator: 'CopyYellow'): State;
-        compose(operator: 'CopyBlack'): State;
-        compose(operator: string): State;
-        compress(type: 'None'): State;
-        compress(type: 'BZip'): State;
-        compress(type: 'Fax'): State;
-        compress(type: 'Group4'): State;
-        compress(type: 'JPEG'): State;
-        compress(type: 'Lossless'): State;
-        compress(type: 'LZW'): State;
-        compress(type: 'RLE'): State;
-        compress(type: 'Zip'): State;
-        compress(type: 'LZMA'): State;
-        compress(type: string): State;
+        colorspace(space: ColorSpace | string): State;
+        compose(operator: ComposeOperator | string): State;
+        compress(type: CompressionType | string): State;
         contrast(multiplier: number): State;
         convolve(kernel: string): State;
         createDirectories(): State;
@@ -192,52 +129,18 @@ declare namespace m {
         despeckle(): State;
         displace(horizontal: number, vertical: number): State;
         display(xServer: string): State;
-        dispose(method: 'Undefined'): State;
-        dispose(method: 'None'): State;
-        dispose(method: 'Background'): State;
-        dispose(method: 'Previous'): State;
-        dispose(method: string): State;
+        dispose(method: DisposeMethod | string): State;
         dissolve(percent: number): State;
         dither(enable?: boolean): State;
         edge(radius?: number): State;
         emboss(radius?: number): State;
-        encoding(encoding: 'AdobeCustom'): State;
-        encoding(encoding: 'AdobeExpert'): State;
-        encoding(encoding: 'AdobeStandard'): State;
-        encoding(encoding: 'AppleRoman'): State;
-        encoding(encoding: 'BIG5'): State;
-        encoding(encoding: 'GB2312'): State;
-        encoding(encoding: 'Latin 2'): State;
-        encoding(encoding: 'None'): State;
-        encoding(encoding: 'SJIScode'): State;
-        encoding(encoding: 'Symbol'): State;
-        encoding(encoding: 'Unicode'): State;
-        encoding(encoding: 'Wansung'): State;
-        encoding(encoding: string): State;
-        endian(type: 'MSB'): State;
-        endian(type: 'LSB'): State;
-        endian(type: 'Native'): State;
-        endian(type: string): State;
+        encoding(encoding: Encoding | string): State;
+        endian(type: EndianType | string): State;
         enhance(): State;
         equalize(): State;
         extent(width: number, height: number, options?: string): State;
         file(filename: string): State;
-        filter(type: 'Point'): State;
-        filter(type: 'Box'): State;
-        filter(type: 'Triangle'): State;
-        filter(type: 'Hermite'): State;
-        filter(type: 'Hanning'): State;
-        filter(type: 'Hamming'): State;
-        filter(type: 'Blackman'): State;
-        filter(type: 'Gaussian'): State;
-        filter(type: 'Quadratic'): State;
-        filter(type: 'Cubic'): State;
-        filter(type: 'Catrom'): State;
-        filter(type: 'Mitchell'): State;
-        filter(type: 'Lanczos'): State;
-        filter(type: 'Bessel'): State;
-        filter(type: 'Sinc'): State;
-        filter(type: string): State;
+        filter(type: FilterType | string): State;
         flatten(): State;
         flip(): State;
         flop(): State;
@@ -249,52 +152,18 @@ declare namespace m {
         geometry(width: number, height?: number, option?: ResizeOption): State;
         geometry(geometry: string): State;
         greenPrimary(x: number, y: number): State;
-        gravity(direction: 'NorthWest'): State;
-        gravity(direction: 'North'): State;
-        gravity(direction: 'NorthEast'): State;
-        gravity(direction: 'West'): State;
-        gravity(direction: 'Center'): State;
-        gravity(direction: 'East'): State;
-        gravity(direction: 'SouthWest'): State;
-        gravity(direction: 'South'): State;
-        gravity(direction: 'SouthEast'): State;
-        gravity(direction: string): State;
+        gravity(direction: GravityDirection | string): State;
         highlightColor(color: string): State;
-        highlightStyle(style: 'Assign'): State;
-        highlightStyle(style: 'Threshold'): State;
-        highlightStyle(style: 'Tint'): State;
-        highlightStyle(style: 'XOR'): State;
-        highlightStyle(style: string): State;
+        highlightStyle(style: HighlightStyle | string): State;
         iconGeometry(geometry: string): State;
         implode(factor?: number): State;
-        intent(type: 'Absolute'): State;
-        intent(type: 'Perceptual'): State;
-        intent(type: 'Relative'): State;
-        intent(type: 'Saturation'): State;
-        intent(type: string): State;
-        interlace(type: 'None'): State;
-        interlace(type: 'Line'): State;
-        interlace(type: 'Plane'): State;
-        interlace(type: 'Partition'): State;
-        interlace(type: string): State;
+        intent(type: IntentType | string): State;
+        interlace(type: InterlaceType | string): State;
         label(name: string): State;
         lat(width: number, height: number, offset: number, percent?: boolean): State;
         level(blackPoint: number, gamma: number, whitePoint: number, percent?: boolean): State;
-        limit(type: 'disk', val: string): State;
-        limit(type: 'file', val: string): State;
-        limit(type: 'map', val: string): State;
-        limit(type: 'memory', val: string): State;
-        limit(type: 'pixels', val: string): State;
-        limit(type: 'threads', val: string): State;
-        limit(type: string, val: string): State;
-        list(type: string): State;
-        list(type: 'Color'): State;
-        list(type: 'Delegate'): State;
-        list(type: 'Format'): State;
-        list(type: 'Magic'): State;
-        list(type: 'Module'): State;
-        list(type: 'Resource'): State;
-        list(type: 'Type'): State;
+        limit(type: LimitType | string, val: string): State;
+        list(type: ListType | string): State;
         log(format: string): State;
         loop(iterations: number): State;
         lower(width: number, height: number): State;
@@ -306,112 +175,29 @@ declare namespace m {
         maximumError(limit: number): State;
         median(radius?: number): State;
         minify(factor: number): State;
-        mode(mode: 'frame'): State;
-        mode(mode: 'unframe'): State;
-        mode(mode: 'concatenate'): State;
-        mode(mode: string): State;
+        mode(mode: OperationMode | string): State;
         modulate(b: number, s: number, h: number): State;
         monitor(): State;
         monochrome(): State;
-        morph(otherImg: string, outName: string, callback?: WriteCallback): State;
-        morph(otherImg: string[], outName: string, callback?: WriteCallback): State;
+        morph(otherImg: string | string[], outName: string, callback?: WriteCallback): State;
         mosaic(): State;
         motionBlur(radius: number, sigma?: number, angle?: number): State;
         name(): State;
         negative(): State;
-        noise(type: 'uniform'): State;
-        noise(type: 'gaussian'): State;
-        noise(type: 'multiplicative'): State;
-        noise(type: 'impulse'): State;
-        noise(type: 'laplacian'): State;
-        noise(type: 'poisson'): State;
-        noise(type: string): State;
-        noise(radius: number): State;
+        noise(type: NoiseType | string | number): State;
         noop(): State;
         normalize(): State;
         opaque(color: string): State;
-        operator(channel: string, operator: 'Add', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'And', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Assign', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Depth', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Divide', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Gamma', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Negate', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'LShift', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Log', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Max', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Min', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Multiply', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Or', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Pow', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'RShift', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Subtract', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Threshold', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Threshold-White', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Threshold-White-Negate', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Threshold-Black', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Threshold-Black-Negate', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Xor', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Noise-Gaussian', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Noise-Impulse', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Noise-Laplacian', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Noise-Multiplicative', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Noise-Poisson', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Noise-Random', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: 'Noise-Uniform', rvalue: number, percent?: boolean): State;
-        operator(channel: string, operator: string, rvalue: number, percent?: boolean): State;
-        orderedDither(channelType: 'All', NxN: string): State;
-        orderedDither(channelType: 'Intensity', NxN: string): State;
-        orderedDither(channelType: 'Red', NxN: string): State;
-        orderedDither(channelType: 'Green', NxN: string): State;
-        orderedDither(channelType: 'Blue', NxN: string): State;
-        orderedDither(channelType: 'Cyan', NxN: string): State;
-        orderedDither(channelType: 'Magenta', NxN: string): State;
-        orderedDither(channelType: 'Yellow', NxN: string): State;
-        orderedDither(channelType: 'Black', NxN: string): State;
-        orderedDither(channelType: 'Opacity', NxN: string): State;
-        orderedDither(channelType: string, NxN: string): State;
+        operator(channel: string, operator: ChannelOperator | string, rvalue: number, percent?: boolean): State;
+        orderedDither(channelType: ChannelType | string, NxN: string): State;
         outputDirectory(directory: string): State;
-        page(width: number, height: number, arg?: '%'): State;
-        page(width: number, height: number, arg?: '!'): State;
-        page(width: number, height: number, arg?: '<'): State;
-        page(width: number, height: number, arg?: '>'): State;
-        page(width: number, height: number, arg?: string): State;
+        page(width: number, height: number, arg?: '%' | '!' | '<' | '>' |string): State;
         pause(seconds: number): State;
         pen(color: string): State;
         ping(): State;
         pointSize(size: number): State;
         noProfile(): State;
-        preview(type: 'Rotate'): State;
-        preview(type: 'Shear'): State;
-        preview(type: 'Roll'): State;
-        preview(type: 'Hue'): State;
-        preview(type: 'Saturation'): State;
-        preview(type: 'Brightness'): State;
-        preview(type: 'Gamma'): State;
-        preview(type: 'Spiff'): State;
-        preview(type: 'Dull'): State;
-        preview(type: 'Grayscale'): State;
-        preview(type: 'Quantize'): State;
-        preview(type: 'Despeckle'): State;
-        preview(type: 'ReduceNoise'): State;
-        preview(type: 'AddNoise'): State;
-        preview(type: 'Sharpen'): State;
-        preview(type: 'Blur'): State;
-        preview(type: 'Threshold'): State;
-        preview(type: 'EdgeDetect'): State;
-        preview(type: 'Spread'): State;
-        preview(type: 'Shade'): State;
-        preview(type: 'Raise'): State;
-        preview(type: 'Segment'): State;
-        preview(type: 'Solarize'): State;
-        preview(type: 'Swirl'): State;
-        preview(type: 'Implode'): State;
-        preview(type: 'Wave'): State;
-        preview(type: 'OilPaint'): State;
-        preview(type: 'CharcoalDrawing'): State;
-        preview(type: 'JPEG'): State;
-        preview(type: string): State;
+        preview(type: PreviewType | string): State;
         paint(radius: number): State;
         process(command: string): State;
         profile(filename: string): State;
@@ -424,8 +210,7 @@ declare namespace m {
         region(width: number, height: number, x?: number, y?: number): State;
         remote(): State;
         render(): State;
-        repage(reset: '+'): State;
-        repage(reset: string): State;
+        repage(reset: '+' | string): State;
         repage(width: number, height: number, xoff: number, yoff: number, arg?: string): State;
         sample(geometry: string): State;
         samplingFactor(horizontalFactor: number, verticalFactor: number): State;
@@ -461,46 +246,21 @@ declare namespace m {
         threshold(value: number, percent?: boolean): State;
         thumb(width: number, height: number, outName: string, callback: WriteCallback): State;
         thumb(width: number, height: number, outName: string, quality: number, callback: WriteCallback): State;
-        thumb(width: number, height: number, outName: string, quality: number, align: 'topleft', callback: WriteCallback): State;
-        thumb(width: number, height: number, outName: string, quality: number, align: 'center', callback: WriteCallback): State;
-        thumb(width: number, height: number, outName: string, quality: number, align: string, callback: WriteCallback): State;
+        thumb(width: number, height: number, outName: string, quality: number, align: 'topleft' | 'center' | string, callback: WriteCallback): State;
         tile(filename: string): State;
         title(title: string): State;
         transform(color: string): State;
         transparent(color: string): State;
         treeDepth(depth: number): State;
         trim(): State;
-        type(type: 'Bilevel'): State;
-        type(type: 'Grayscale'): State;
-        type(type: 'Palette'): State;
-        type(type: 'PaletteMatte'): State;
-        type(type: 'TrueColor'): State;
-        type(type: 'TrueColorMatte'): State;
-        type(type: 'ColorSeparation'): State;
-        type(type: 'ColorSeparationMatte'): State;
-        type(type: 'Optimize'): State;
-        type(type: string): State;
+        type(type: ImageType | string): State;
         update(seconds: number): State;
-        units(type: 'Undefined'): State;
-        units(type: 'PixelsPerInch'): State;
-        units(type: 'PixelsPerCentimeter'): State;
-        units(type: string): State;
+        units(type: UnitType | string): State;
         unsharp(radius: number, sigma?: number, amount?: number, threshold?: number): State;
         usePixmap(): State;
         view(): State;
-        virtualPixel(method: 'Constant'): State;
-        virtualPixel(method: 'Edge'): State;
-        virtualPixel(method: 'Mirror'): State;
-        virtualPixel(method: 'Tile'): State;
-        virtualPixel(method: string): State;
-        visual(type: 'StaticGray'): State;
-        visual(type: 'GrayScale'): State;
-        visual(type: 'StaticColor'): State;
-        visual(type: 'PseudoColor'): State;
-        visual(type: 'TrueColor'): State;
-        visual(type: 'DirectColor'): State;
-        visual(type: 'default'): State;
-        visual(type: string): State;
+        virtualPixel(method: VirtualPixelMethod | string): State;
+        visual(type: VisualType | string): State;
         watermark(brightness: number, saturation: number): State;
         wave(amplitude: number, wavelength: number): State;
         whitePoint(x: number, y: number): State;
@@ -530,46 +290,21 @@ declare namespace m {
         // Drawing Operations
         draw(args: string): State;
         drawArc(x0: number, y0: number, x1: number, y1: number, r0: number, r1: number): State;
-        drawBezier(x0: number, y0: number, x1: number, y1: number): State;
-        drawBezier(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): State;
-        drawBezier(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, ...coords: number[]): State;
+        drawBezier(x0: number, y0: number, x1: number, y1: number, x2?: number, y2?: number, ...coords: number[]): State;
         drawCircle(x0: number, y0: number, x1: number, y1: number): State;
         drawEllipse(x0: number, y0: number, rx: number, ry: number, a0: number, a1: number): State;
         drawLine(x0: number, y0: number, x1: number, y1: number): State;
         drawPoint(x: number, y: number): State;
-        drawPolygon(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): State;
         drawPolygon(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, ...coords: number[]): State;
-        drawPolyline(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number): State;
         drawPolyline(x0: number, y0: number, x1: number, y1: number, x2: number, y2: number, ...coords: number[]): State;
-        drawRectangle(x0: number, y0: number, x1: number, y1: number): State;
-        drawRectangle(x0: number, y0: number, x1: number, y1: number, rc: number): State;
-        drawRectangle(x0: number, y0: number, x1: number, y1: number, wc: number, hc: number): State;
-        drawText(x: number, y: number, text: string, gravity: 'NorthWest'): State;
-        drawText(x: number, y: number, text: string, gravity: 'North'): State;
-        drawText(x: number, y: number, text: string, gravity: 'NorthEast'): State;
-        drawText(x: number, y: number, text: string, gravity: 'West'): State;
-        drawText(x: number, y: number, text: string, gravity: 'Center'): State;
-        drawText(x: number, y: number, text: string, gravity: 'East'): State;
-        drawText(x: number, y: number, text: string, gravity: 'SouthWest'): State;
-        drawText(x: number, y: number, text: string, gravity: 'South'): State;
-        drawText(x: number, y: number, text: string, gravity: 'SouthEast'): State;
-        drawText(x: number, y: number, text: string, gravity?: string): State;
+        drawRectangle(x0: number, y0: number, x1: number, y1: number, wc?: number, hc?: number): State;
+        drawText(x: number, y: number, text: string, gravity?: GravityDirection | string): State;
         fill(color: string): State;
         font(name: string, size?: number): State;
         fontSize(size: number): State;
         stroke(color: string, width?: number): State;
         strokeWidth(width: number): State;
-        setDraw(property: 'color', x: number, y: number, method: 'point'): State;
-        setDraw(property: 'color', x: number, y: number, method: 'replace'): State;
-        setDraw(property: 'color', x: number, y: number, method: 'floodfill'): State;
-        setDraw(property: 'color', x: number, y: number, method: 'filltoborder'): State;
-        setDraw(property: 'color', x: number, y: number, method: 'reset'): State;
-        setDraw(property: 'matte', x: number, y: number, method: 'point'): State;
-        setDraw(property: 'matte', x: number, y: number, method: 'replace'): State;
-        setDraw(property: 'matte', x: number, y: number, method: 'floodfill'): State;
-        setDraw(property: 'matte', x: number, y: number, method: 'filltoborder'): State;
-        setDraw(property: 'matte', x: number, y: number, method: 'reset'): State;
-        setDraw(property: string, x: number, y: number, method: string): State;
+        setDraw(property: SetDrawProperty | string, x: number, y: number, method: SetDrawMethod | string): State;
 
         // Commands
         stream(callback?: WriteCallback): stream.PassThrough;
@@ -581,16 +316,44 @@ declare namespace m {
 
     interface SubClass {
         (image: string): State;
-        (stream: NodeJS.ReadableStream, image?: string): State;
-        (buffer: Buffer, image?: string): State;
+        (stream: NodeJS.ReadableStream | Buffer, image?: string): State;
         (width: number, height: number, color?: string): State;
     }
 
     function compare(filename1: string, filename2: string, callback: CompareCallback): void;
-    function compare(filename1: string, filename2: string, tolerance: number, callback: CompareCallback): void;
-    function compare(filename1: string, filename2: string, options: CompareOptions, callback: CompareCallback): void;
+    function compare(filename1: string, filename2: string, options: CompareOptions | number, callback: CompareCallback): void;
 
     function subClass(options: ClassOptions): SubClass;
+
+    type ChannelOperator = 'Add'
+        | 'And'
+        | 'Assign'
+        | 'Depth'
+        | 'Divide'
+        | 'Gamma'
+        | 'Negate'
+        | 'LShift'
+        | 'Log'
+        | 'Max'
+        | 'Min'
+        | 'Multiply'
+        | 'Or'
+        | 'Pow'
+        | 'RShift'
+        | 'Subtract'
+        | 'Threshold'
+        | 'Threshold-White'
+        | 'Threshold-White-Negate'
+        | 'Threshold-Black'
+        | 'Threshold-Black-Negate'
+        | 'Xor'
+        | 'Noise-Gaussian'
+        | 'Noise-Impulse'
+        | 'Noise-Laplacian'
+        | 'Noise-Multiplicative'
+        | 'Noise-Poisson'
+        | 'Noise-Random'
+        | 'Noise-Uniform';
 
     type ChannelType = 'All'
         | 'Intensity'
@@ -603,9 +366,201 @@ declare namespace m {
         | 'Black'
         | 'Opacity';
 
+    type ColorSpace = 'CineonLog'
+        | 'CMYK'
+        | 'GRAY'
+        | 'HSL'
+        | 'HSB'
+        | 'OHTA'
+        | 'RGB'
+        | 'Rec601Luma'
+        | 'Rec709Luma'
+        | 'Rec601YCbCr'
+        | 'Rec709YCbCr'
+        | 'Transparent'
+        | 'XYZ'
+        | 'YCbCr'
+        | 'YIQ'
+        | 'YPbPr'
+        | 'YUV';
+
     type CompareCallback = (err: Error, isEqual: boolean, equality: number, raw: number) => any;
 
+    type ComposeOperator = 'Over'
+        | 'In'
+        | 'Out'
+        | 'Atop'
+        | 'Xor'
+        | 'Plus'
+        | 'Minus'
+        | 'Add'
+        | 'Subtract'
+        | 'Difference'
+        | 'Divide'
+        | 'Multiply'
+        | 'Bumpmap'
+        | 'Copy'
+        | 'CopyRed'
+        | 'CopyGreen'
+        | 'CopyBlue'
+        | 'CopyOpacity'
+        | 'CopyCyan'
+        | 'CopyMagenta'
+        | 'CopyYellow'
+        | 'CopyBlack';
+
+    type CompressionType = 'None'
+        | 'BZip'
+        | 'Fax'
+        | 'Group4'
+        | 'JPEG'
+        | 'Lossless'
+        | 'LZW'
+        | 'RLE'
+        | 'Zip'
+        | 'LZMA';
+
+    type DisposeMethod = 'Undefined'
+        | 'None'
+        | 'Background'
+        | 'Previous';
+
+    type Encoding = 'AdobeCustom'
+        | 'AdobeExpert'
+        | 'AdobeStandard'
+        | 'AppleRoman'
+        | 'BIG5'
+        | 'GB2312'
+        | 'Latin 2'
+        | 'None'
+        | 'SJIScode'
+        | 'Symbol'
+        | 'Unicode'
+        | 'Wansung';
+
+    type EndianType = 'MSB'
+        | 'LSB'
+        | 'Native';
+
+    type FilterType = 'Point'
+        | 'Box'
+        | 'Triangle'
+        | 'Hermite'
+        | 'Hanning'
+        | 'Hamming'
+        | 'Blackman'
+        | 'Gaussian'
+        | 'Quadratic'
+        | 'Cubic'
+        | 'Catrom'
+        | 'Mitchell'
+        | 'Lanczos'
+        | 'Bessel'
+        | 'Sinc';
+
     type GetterCallback<T> = (err: Error, value: T) => any;
+
+    type GravityDirection = 'NorthWest'
+        | 'North'
+        | 'NorthEast'
+        | 'West'
+        | 'Center'
+        | 'East'
+        | 'SouthWest'
+        | 'South'
+        | 'SouthEast';
+
+    type HighlightStyle = 'Assign'
+        | 'Threshold'
+        | 'Tint'
+        | 'XOR';
+
+    type ImageType = 'Bilevel'
+        | 'Grayscale'
+        | 'Palette'
+        | 'PaletteMatte'
+        | 'TrueColor'
+        | 'TrueColorMatte'
+        | 'ColorSeparation'
+        | 'ColorSeparationMatte'
+        | 'Optimize';
+
+    type IntentType = 'Absolute'
+        | 'Perceptual'
+        | 'Relative'
+        | 'Saturation';
+
+    type InterlaceType = 'None'
+        | 'Line'
+        | 'Plane'
+        | 'Partition';
+
+    type LimitType = 'disk'
+        | 'file'
+        | 'map'
+        | 'memory'
+        | 'pixels'
+        | 'threads';
+
+    type ListType = 'Color'
+        | 'Delegate'
+        | 'Format'
+        | 'Magic'
+        | 'Module'
+        | 'Resource'
+        | 'Type';
+
+    type NamedColor = 'Red'
+        | 'Green'
+        | 'Blue'
+        | 'Opacity'
+        | 'Matte'
+        | 'Cyan'
+        | 'Magenta'
+        | 'Yellow'
+        | 'Black'
+        | 'Gray';
+
+    type NoiseType = 'uniform'
+        | 'gaussian'
+        | 'multiplicative'
+        | 'impulse'
+        | 'laplacian'
+        | 'poisson';
+
+    type OperationMode = 'frame'
+        | 'unframe'
+        | 'concatenate';
+
+    type PreviewType = 'Rotate'
+        | 'Shear'
+        | 'Roll'
+        | 'Hue'
+        | 'Saturation'
+        | 'Brightness'
+        | 'Gamma'
+        | 'Spiff'
+        | 'Dull'
+        | 'Grayscale'
+        | 'Quantize'
+        | 'Despeckle'
+        | 'ReduceNoise'
+        | 'AddNoise'
+        | 'Sharpen'
+        | 'Blur'
+        | 'Threshold'
+        | 'EdgeDetect'
+        | 'Spread'
+        | 'Shade'
+        | 'Raise'
+        | 'Segment'
+        | 'Solarize'
+        | 'Swirl'
+        | 'Implode'
+        | 'Wave'
+        | 'OilPaint'
+        | 'CharcoalDrawing'
+        | 'JPEG';
 
     type ResizeOption = '%' /** Width and height are specified in percents */
         | '@' /** Specify maximum area in pixels */
@@ -613,6 +568,31 @@ declare namespace m {
         | '^' /** Width and height are minimum values */
         | '<' /** Change dimensions only if image is smaller than width or height */
         | '>'; /** Change dimensions only if image is larger than width or height */
+
+    type SetDrawMethod = 'point'
+        | 'replace'
+        | 'floodfill'
+        | 'filltoborder'
+        | 'reset';
+
+    type SetDrawProperty = 'color' | 'matte';
+
+    type UnitType = 'Undefined'
+        | 'PixelsPerInch'
+        | 'PixelsPerCentimeter';
+
+    type VirtualPixelMethod = 'Constant'
+        | 'Edge'
+        | 'Mirror'
+        | 'Tile';
+
+    type VisualType = 'StaticGray'
+        | 'GrayScale'
+        | 'StaticColor'
+        | 'PseudoColor'
+        | 'TrueColor'
+        | 'DirectColor'
+        | 'default';
 
     type WriteCallback = (err: Error, stdout: string, stderr: string, cmd: string) => any;
 }

--- a/types/gm/tslint.json
+++ b/types/gm/tslint.json
@@ -1,7 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        // This package unifiable overloaded functions, lot of effort to fix
-        "unified-signatures": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Many functions used overloading to add types to different values the arguments could be. This PR converts those to use union types. 

The tslint rule that warns for using overloading functions therefore could be turned on.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://aheckmann.github.io/gm/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
