### PR TITLE
@types/node: Asynchooks promiseResolve and AsyncResource

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5886,6 +5886,13 @@ declare module "async_hooks" {
         after?(asyncId: number): void;
 
         /**
+         * Called when a promise has resolve() called. This may not be in the same execution id
+         * as the promise itself.
+         * @param asyncId the unique id for the promise that was resolve()d.
+         */
+        promiseResolve?(asyncId: number): void;
+
+        /**
          * Called after the resource corresponding to asyncId is destroyed
          * @param asyncId a unique ID for the async resource
          */

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5917,6 +5917,46 @@ declare module "async_hooks" {
      * @return an AsyncHooks instance used for disabling and enabling hooks
      */
     export function createHook(options: HookCallbacks): AsyncHook;
+
+    /**
+     * The class AsyncResource was designed to be extended by the embedder's async resources.
+     * Using this users can easily trigger the lifetime events of their own resources.
+     */
+    export class AsyncResource {
+        /**
+         * AsyncResource() is meant to be extended. Instantiating a
+         * new AsyncResource() also triggers init. If triggerAsyncId is omitted then
+         * async_hook.executionAsyncId() is used.
+         * @param type the name of this async resource type
+         * @param triggerAsyncId the unique ID of the async resource in whose execution context this async resource was created
+         */
+        constructor(type: string, triggerAsyncId?: number)
+
+        /**
+         * Call AsyncHooks before callbacks.
+         */
+        emitBefore(): void;
+
+        /**
+         * Call AsyncHooks after callbacks
+         */
+        emitAfter(): void;
+
+        /**
+         * Call AsyncHooks destroy callbacks.
+         */
+        emitDestroy(): void;
+
+        /**
+         * Return the unique ID assigned to the AsyncResource instance.
+         */
+        asyncId(): number;
+
+        /**
+         * Return the trigger ID for the AsyncResource instance.
+         */
+        triggerAsyncId(): number;
+    }
 }
 
 declare module "http2" {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -5948,12 +5948,12 @@ declare module "async_hooks" {
         emitDestroy(): void;
 
         /**
-         * Return the unique ID assigned to the AsyncResource instance.
+         * @return the unique ID assigned to this AsyncResource instance.
          */
         asyncId(): number;
 
         /**
-         * Return the trigger ID for the AsyncResource instance.
+         * @return the trigger ID for this AsyncResource instance.
          */
         triggerAsyncId(): number;
     }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2939,6 +2939,8 @@ namespace async_hooks_tests {
     class AnotherTestResource extends async_hooks.AsyncResource {
         constructor() {
             super('TEST_RESOURCE', 42);
+            const aId: number = this.asyncId();
+            const tId: number = this.triggerAsyncId();
         }
         run() {
             this.emitBefore();

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2919,7 +2919,8 @@ namespace async_hooks_tests {
         init: (asyncId: number, type: string, triggerAsyncId: number, resource: object) => void {},
         before: (asyncId: number) => void {},
         after: (asyncId: number) => void {},
-        destroy: (asyncId: number) => void {}
+        destroy: (asyncId: number) => void {},
+        promiseResolve: (asyncId: number) => void {}
     };
 
     const asyncHook = async_hooks.createHook(hooks);

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2929,6 +2929,25 @@ namespace async_hooks_tests {
 
     const tId: number = async_hooks.triggerAsyncId();
     const eId: number = async_hooks.executionAsyncId();
+
+    class TestResource extends async_hooks.AsyncResource {
+        constructor() {
+            super('TEST_RESOURCE');
+        }
+    }
+
+    class AnotherTestResource extends async_hooks.AsyncResource {
+        constructor() {
+            super('TEST_RESOURCE', 42);
+        }
+        run() {
+            this.emitBefore();
+            this.emitAfter();
+        }
+        destroy() {
+            this.emitDestroy();
+        }
+    }
 }
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
   - https://nodejs.org/api/async_hooks.html#async_hooks_promiseresolve_asyncid
   - https://nodejs.org/api/async_hooks.html#async_hooks_class_asyncresource
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Adds `promiseResolve` hook to async_hooks library. Added in Node 8.6, documented at url above, discussed at https://github.com/nodejs/node/pull/15296 .
If a user specifies this in Node < 8.6, there will be no runtime error, however obviously their callback will not run.

Adds `AsyncResource` to async_hooks library. This has been present since node 8.0.

- Jarrad