### PR TITLE
Fix DropdownButton title type to include JSX.Element

### DIFF
--- a/types/react-bootstrap/lib/DropdownButton.d.ts
+++ b/types/react-bootstrap/lib/DropdownButton.d.ts
@@ -10,10 +10,11 @@ declare namespace DropdownButton {
         navItem?: boolean;
         noCaret?: boolean;
         pullRight?: boolean;
+        title?: JSX.Element | string;
     }
 
-    export type DropdownButtonProps = DropdownButtonBaseProps & React.HTMLProps<DropdownButton>;
+    export type DropdownButtonProps = DropdownButtonBaseProps | React.HTMLProps<DropdownButton>;
 
 }
-declare class DropdownButton extends React.Component<DropdownButton.DropdownButtonProps> { }
+declare class DropdownButton extends React.Component<DropdownButton.DropdownButtonProps, any> { }
 export = DropdownButton;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-bootstrap.github.io/components.html#btn-dropdowns-props-dropdown-button
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

