### PR TITLE
Added CurrentUserIsSiteAdmin To ContextInfo

### DIFF
--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -332,6 +332,7 @@ interface ContextInfo extends SPClientTemplates.RenderContext {
     LastSelectedItemIID: number;
     LastRowIndexSelected: number;
     RowFocusTimerID: number;
+    ListTitle: string;
     ListData: any; // SPClientTemplates.ListData_InView | SPClientTemplates.ListData_InForm
     ListSchema: SPClientTemplates.ListSchema;
     ModerationStatus: number;
@@ -340,6 +341,7 @@ interface ContextInfo extends SPClientTemplates.RenderContext {
     SelectAllCbx: HTMLElement;
     SendToLocationName: string;
     SendToLocationUrl: string;
+    SiteTitle: string;
     StateInitDone: boolean;
     TableCbxFocusHandler(instance: any, eventArgs: any): void;
     TableMouseoverHandler(instance: any, eventArgs: any): void;
@@ -1178,6 +1180,7 @@ declare namespace SPClientTemplates {
         ctxType: any; // not in View
         CurrentUserId: number;
         CurrentUserIsSiteAdmin: boolean;
+        LastSelectedItemIID: any;
         dictSel: any;
         /** Absolute path for the list display form */
         displayFormUrl: string;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -346,6 +346,7 @@ interface ContextInfo extends SPClientTemplates.RenderContext {
     TableCbxFocusHandler(instance: any, eventArgs: any): void;
     TableMouseoverHandler(instance: any, eventArgs: any): void;
     TotalListItems: number;
+    CurrentUserIsSiteAdmin: boolean;
     WorkflowsAssociated: boolean;
     clvp: any;
     ctxId: number;


### PR DESCRIPTION
Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ X] Provide a URL to documentation or source code which provides context for the suggested changes: 
     N/A
- [X ] Increase the version number in the header if appropriate.
- [X ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Similar to my previous pull request (20533), I found another property that was missing on ContextInfo, CurrentUserIsSiteAdmin. I have added it here, as this is a blocker of my company moving forward with using the NPM version.

Thanks!

Brandon

