### PR TITLE
@types/rosie: allow factory.build with class constructor

### DIFF
--- a/types/rosie/index.d.ts
+++ b/types/rosie/index.d.ts
@@ -14,7 +14,7 @@ declare namespace rosie {
      * @param {function(object): *=} constructor
      * @return {Factory}
      */
-    define<T = any>(name: string, constructor?: (opts?: any) => any): IFactory<T>;
+    define<T = any>(name: string, constructor?: any): IFactory<T>;
 
     /**
      * Locates a factory by name and calls #build on it.

--- a/types/rosie/index.d.ts
+++ b/types/rosie/index.d.ts
@@ -14,7 +14,7 @@ declare namespace rosie {
      * @param {function(object): *=} constructor
      * @return {Factory}
      */
-    define<T = any>(name: string, constructor?: any): IFactory<T>;
+    define<T = any>(name: string, constructor?: ((...opts: any[]) => any) | (new<T>(...opts: any[]) => any)): IFactory<T>;
 
     /**
      * Locates a factory by name and calls #build on it.

--- a/types/rosie/rosie-tests.ts
+++ b/types/rosie/rosie-tests.ts
@@ -65,6 +65,18 @@ personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age', 'firstN
 const personObj = Factory.build<Person>('Person');
 if (personObj.firstName !== 'John') { throw new Error('incorrect Person build'); }
 
+class CustomClass {
+  type: string;
+
+  constructor(props: { type: string }) {
+    this.type = props.type;
+  }
+}
+
+const customTestFactory = Factory.define<CustomClass>('test', CustomClass);
+const output = customTestFactory.build({ type: 'foo' });
+if (output.type !== 'foo') { throw new Error('constructor did not receive args'); }
+
 import rosie = require('rosie');
 
 var Factory = rosie.Factory;

--- a/types/rosie/rosie-tests.ts
+++ b/types/rosie/rosie-tests.ts
@@ -62,8 +62,10 @@ personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age', 'firstN
 // You can go past five dependencies, but you need to specify types
 personFactory.attr('secretCode', ['firstName', 'lastName', 'age', 'age', 'firstName', 'firstName'], (firstName: string, lastName: string, age1: number, age2: number, firstNameAgain: string, firstNameThisIsTooMuch: string) => ({ name: firstNameAgain, value: age1 + age2 }));
 
-const personObj = Factory.build<Person>('Person');
-if (personObj.firstName !== 'John') { throw new Error('incorrect Person build'); }
+// Having defined 'Person', `build` will return an object of type Person, using the generic type.
+const person = Factory.build<Person>('Person');
+let aString = '';
+aString = person.firstName;
 
 class CustomClass {
   type: string;
@@ -73,9 +75,22 @@ class CustomClass {
   }
 }
 
-const customTestFactory = Factory.define<CustomClass>('test', CustomClass);
-const output = customTestFactory.build({ type: 'foo' });
-if (output.type !== 'foo') { throw new Error('constructor did not receive args'); }
+Factory.define<CustomClass>('CustomClass', CustomClass);
+
+class CustomClass2 {
+  constructor(prop1: string, prop2: string, prop3: string) {
+  }
+}
+
+Factory.define<CustomClass2>('CustomClass2', CustomClass2);
+
+class CustomClassWithoutConstructor {
+  constructor() {
+    // set some state
+  }
+}
+
+Factory.define<CustomClassWithoutConstructor>('CustomClassWithoutConstructor', CustomClassWithoutConstructor);
 
 import rosie = require('rosie');
 


### PR DESCRIPTION
The existing definition wasn't quite right. I'm not sure how to write the definition to make this type safe, but this will at least let it compile until we can get a better fix. Having trouble running tests locally but I think this should work. I'll remove the error that's thrown, if not.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/rosiejs/rosie#associate-a-factory-with-an-existing-class>>
