### PR TITLE
Set more specific types for Backbone Model and Collection url propert…

### DIFF
--- a/types/backbone/backbone-tests.ts
+++ b/types/backbone/backbone-tests.ts
@@ -115,6 +115,8 @@ class Employee extends Backbone.Model {
         super(options);
         this.reports = new EmployeeCollection();
         this.reports.url = '../api/employees/' + this.id + '/reports';
+        // Test that collection url property can be set as a function returning a string.
+        this.reports.url = () => { return ""; };
     }
 
     more() {

--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -100,7 +100,6 @@ declare namespace Backbone {
     }
 
     class ModelBase extends Events {
-        url: any;
         parse(response: any, options?: any): any;
         toJSON(options?: any): any;
         sync(...arg: any[]): JQueryXHR;
@@ -133,6 +132,13 @@ declare namespace Backbone {
         id: any;
         idAttribute: string;
         validationError: any;
+
+        /**
+         * Returns the relative URL where the model's resource would be located on the server.
+         * @memberof Model
+         */
+        url: () => string;
+
         urlRoot: any;
 
         constructor(attributes?: any, options?: any);
@@ -314,6 +320,14 @@ declare namespace Backbone {
         take(): TModel;
         take(n: number): TModel[];
         toArray(): TModel[];
+
+        /**
+         * Sets the url property (or function) on a collection to reference its location on the server.
+         *
+         * @memberof Collection
+         */
+        url: string | (() => string);
+
         without(...values: TModel[]): TModel[];
     }
 


### PR DESCRIPTION
…ies.  Addresses issue #529 

Per Backbone docs for Model and Collection set their respective url properties to respect the intended types:

Model.url should be a function returning a string: http://backbonejs.org/#Model-url

Collection.url should be a string or a function returning a string: http://backbonejs.org/#Collection-url
