### PR TITLE
[net-keepalive] Remove tslint rule linebreak-style as it forces erros on windows

### DIFF
--- a/types/net-keepalive/tslint.json
+++ b/types/net-keepalive/tslint.json
@@ -3,7 +3,6 @@
     "rules": {
         "semicolon": [true, "never"],
         "eofline": false,
-        "indent": [true, "spaces", 4],
-        "linebreak-style": [true, "LF"]
+        "indent": [true, "spaces", 4]
     }
 }


### PR DESCRIPTION
The .gitattributes file specifies * text=auto resulting in files with CRLF on windows and LF on linux during clone.

Therefore the lint rule checking on LF will always fail on windows but never on linux.

No change in the definition itself was done.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
