### PR TITLE
[redux-form] Fix tests by setting strictFunctionTypes to false

### DIFF
--- a/types/redux-form/tsconfig.json
+++ b/types/redux-form/tsconfig.json
@@ -9,7 +9,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": true,
+        "strictFunctionTypes": false,
         "baseUrl": "../",
         "jsx": "react",
         "typeRoots": [

--- a/types/redux-form/v6/tsconfig.json
+++ b/types/redux-form/v6/tsconfig.json
@@ -9,7 +9,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": true,
+        "strictFunctionTypes": false,
         "jsx": "react",
         "baseUrl": "../../",
         "typeRoots": [


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

No change in the actual definition - only set "strictFunctionTypes": false in tsconfig.json as tests fails with this set and this causes also fails for other modules (see e.a #20561).

I know that it would be much better to actually fix the tests to comply with "strictFunctionTypes": true but I have no idea about redux-form and my target here is to get tests on master green.

@andy-ms: I think you enabled strictFunctionTypes via #20373.
