### PR TITLE
[karma] Fix tests by removing dependency to log4js

### DIFF
--- a/types/karma/index.d.ts
+++ b/types/karma/index.d.ts
@@ -9,7 +9,6 @@
 // See Karma public API https://karma-runner.github.io/0.13/dev/public-api.html
 import Promise = require('bluebird');
 import https = require('https');
-import log4js = require('log4js');
 
 declare namespace karma {
     interface Karma {
@@ -142,6 +141,16 @@ declare namespace karma {
 
     interface ConfigFile {
         configFile: string;
+    }
+
+    // taken from log4js 1.x typings which are gone...
+    interface Log4jsAppenderConfigBase {
+        type: string;
+        category?: string;
+        layout?: {
+            type: string;
+            [key: string]: any
+        }
     }
 
     interface ConfigOptions {
@@ -283,7 +292,7 @@ declare namespace karma {
          * @default [{type: 'console'}]
          * @description A list of log appenders to be used. See the documentation for [log4js] for more information.
          */
-        loggers?: log4js.AppenderConfigBase[];
+        loggers?: Log4jsAppenderConfigBase[];
         /**
          * @default {}
          * @description Redefine default mapping from file extensions to MIME-type.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nomiddlename/log4js-node/blob/master/index.d.ts
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

log4js typings have been removed via #20518 and the typings exported
by log4js 2.x don't exporte the relevant type.

Created a local type to fix build.

fixes #20534
