### PR TITLE
Chrome debugger type patch

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1274,104 +1274,106 @@ declare namespace chrome.cookies {
  * Availability: Since Chrome 18.
  * Permissions:  "debugger"
  */
-// TODO: Uncomment when Microsoft/TypeScript#8312 is merged in
-// declare module chrome.debugger {
-//     /** Debuggee identifier. Either tabId or extensionId must be specified */
-//     interface Debuggee {
-//         /** Optional. The id of the tab which you intend to debug.  */
-//         tabId?: number;
-//         /**
-//          * Optional.
-//           * Since Chrome 27.
-//          * The id of the extension which you intend to debug. Attaching to an extension background page is only possible when 'silent-debugger-extension-api' flag is enabled on the target browser.
-//          */
-//         extensionId?: string;
-//         /**
-//          * Optional.
-//           * Since Chrome 28.
-//          * The opaque id of the debug target.
-//          */
-//         targetId?: string;
-//     }
-//
-//     /**
-//      * Since Chrome 28.
-//      * Debug target information
-//      */
-//     interface TargetInfo {
-//         /** Target type. */
-//         type: string;
-//         /** Target id. */
-//         id: string;
-//         /**
-//          * Optional.
-//           * Since Chrome 30.
-//          * The tab id, defined if type == 'page'.
-//          */
-//         tabId?: number;
-//         /**
-//          * Optional.
-//           * Since Chrome 30.
-//          * The extension id, defined if type = 'background_page'.
-//          */
-//         extensionId?: string;
-//         /** True if debugger is already attached. */
-//         attached: boolean;
-//         /** Target page title. */
-//         title: string;
-//         /** Target URL. */
-//         url: string;
-//         /** Optional. Target favicon URL.  */
-//         faviconUrl?: string;
-//     }
-//
-//     interface DebuggerDetachedEvent extends chrome.events.Event<(source: Debuggee, reason: string) => void> {}
-//
-//     interface DebuggerEventEvent extends chrome.events.Event<(source: Debuggee, method: string, params?: Object) => void> {}
-//
-//     /**
-//      * Attaches debugger to the given target.
-//      * @param target Debugging target to which you want to attach.
-//      * @param requiredVersion Required debugging protocol version ("0.1"). One can only attach to the debuggee with matching major version and greater or equal minor version. List of the protocol versions can be obtained in the documentation pages.
-//      * @param callback Called once the attach operation succeeds or fails. Callback receives no arguments. If the attach fails, runtime.lastError will be set to the error message.
-//      * If you specify the callback parameter, it should be a function that looks like this:
-//      * function() {...};
-//      */
-//     export function attach(target: Debuggee, requiredVersion: string, callback?: () => void): void;
-//     /**
-//      * Detaches debugger from the given target.
-//      * @param target Debugging target from which you want to detach.
-//      * @param callback Called once the detach operation succeeds or fails. Callback receives no arguments. If the detach fails, runtime.lastError will be set to the error message.
-//      * If you specify the callback parameter, it should be a function that looks like this:
-//      * function() {...};
-//      */
-//     export function detach(target: Debuggee, callback?: () => void): void;
-//     /**
-//      * Sends given command to the debugging target.
-//      * @param target Debugging target to which you want to send the command.
-//      * @param method Method name. Should be one of the methods defined by the remote debugging protocol.
-//      * @param commandParams Since Chrome 22.
-//      * JSON object with request parameters. This object must conform to the remote debugging params scheme for given method.
-//      * @param callback Response body. If an error occurs while posting the message, the callback will be called with no arguments and runtime.lastError will be set to the error message.
-//      * If you specify the callback parameter, it should be a function that looks like this:
-//      * function(object result) {...};
-//      */
-//     export function sendCommand(target: Debuggee, method: string, commandParams?: Object, callback?: (result?: Object) => void): void;
-//     /**
-//      * Since Chrome 28.
-//      * Returns the list of available debug targets.
-//      * @param callback The callback parameter should be a function that looks like this:
-//      * function(array of TargetInfo result) {...};
-//      * Parameter result: Array of TargetInfo objects corresponding to the available debug targets.
-//      */
-//     export function getTargets(callback: (result: TargetInfo[]) => void): void;
-//
-//     /** Fired when browser terminates debugging session for the tab. This happens when either the tab is being closed or Chrome DevTools is being invoked for the attached tab. */
-//     var onDetach: DebuggerDetachedEvent;
-//     /** Fired whenever debugging target issues instrumentation event. */
-//     var onEvent: DebuggerEventEvent;
-// }
+declare module chrome {
+    namespace _debugger {
+        /** Debuggee identifier. Either tabId or extensionId must be specified */
+        interface Debuggee {
+            /** Optional. The id of the tab which you intend to debug.  */
+            tabId?: number;
+            /**
+             * Optional.
+             * Since Chrome 27.
+             * The id of the extension which you intend to debug. Attaching to an extension background page is only possible when 'silent-debugger-extension-api' flag is enabled on the target browser.
+             */
+            extensionId?: string;
+            /**
+             * Optional.
+             * Since Chrome 28.
+             * The opaque id of the debug target.
+             */
+            targetId?: string;
+        }
 
+        /**
+         * Since Chrome 28.
+         * Debug target information
+         */
+        interface TargetInfo {
+            /** Target type. */
+            type: string;
+            /** Target id. */
+            id: string;
+            /**
+             * Optional.
+             * Since Chrome 30.
+             * The tab id, defined if type == 'page'.
+             */
+            tabId?: number;
+            /**
+             * Optional.
+             * Since Chrome 30.
+             * The extension id, defined if type = 'background_page'.
+             */
+            extensionId?: string;
+            /** True if debugger is already attached. */
+            attached: boolean;
+            /** Target page title. */
+            title: string;
+            /** Target URL. */
+            url: string;
+            /** Optional. Target favicon URL.  */
+            faviconUrl?: string;
+        }
+
+        interface DebuggerDetachedEvent extends chrome.events.Event<(source: Debuggee, reason: string) => void> {}
+
+        interface DebuggerEventEvent extends chrome.events.Event<(source: Debuggee, method: string, params?: Object) => void> {}
+
+        /**
+         * Attaches debugger to the given target.
+         * @param target Debugging target to which you want to attach.
+         * @param requiredVersion Required debugging protocol version ("0.1"). One can only attach to the debuggee with matching major version and greater or equal minor version. List of the protocol versions can be obtained in the documentation pages.
+         * @param callback Called once the attach operation succeeds or fails. Callback receives no arguments. If the attach fails, runtime.lastError will be set to the error message.
+         * If you specify the callback parameter, it should be a function that looks like this:
+         * function() {...};
+         */
+        export function attach(target: Debuggee, requiredVersion: string, callback?: () => void): void;
+        /**
+         * Detaches debugger from the given target.
+         * @param target Debugging target from which you want to detach.
+         * @param callback Called once the detach operation succeeds or fails. Callback receives no arguments. If the detach fails, runtime.lastError will be set to the error message.
+         * If you specify the callback parameter, it should be a function that looks like this:
+         * function() {...};
+         */
+        export function detach(target: Debuggee, callback?: () => void): void;
+        /**
+         * Sends given command to the debugging target.
+         * @param target Debugging target to which you want to send the command.
+         * @param method Method name. Should be one of the methods defined by the remote debugging protocol.
+         * @param commandParams Since Chrome 22.
+         * JSON object with request parameters. This object must conform to the remote debugging params scheme for given method.
+         * @param callback Response body. If an error occurs while posting the message, the callback will be called with no arguments and runtime.lastError will be set to the error message.
+         * If you specify the callback parameter, it should be a function that looks like this:
+         * function(object result) {...};
+         */
+        export function sendCommand(target: Debuggee, method: string, commandParams?: Object, callback?: (result?: Object) => void): void;
+        /**
+         * Since Chrome 28.
+         * Returns the list of available debug targets.
+         * @param callback The callback parameter should be a function that looks like this:
+         * function(array of TargetInfo result) {...};
+         * Parameter result: Array of TargetInfo objects corresponding to the available debug targets.
+         */
+        export function getTargets(callback: (result: TargetInfo[]) => void): void;
+
+        /** Fired when browser terminates debugging session for the tab. This happens when either the tab is being closed or Chrome DevTools is being invoked for the attached tab. */
+        var onDetach: DebuggerDetachedEvent;
+        /** Fired whenever debugging target issues instrumentation event. */
+        var onEvent: DebuggerEventEvent;
+    }
+
+    export {_debugger as debugger}
+}
 ////////////////////
 // Declarative Content
 ////////////////////
@@ -3311,13 +3313,13 @@ declare namespace chrome.history {
 declare namespace chrome.i18n {
     /** Holds detected ISO language code and its percentage in the input string */
     interface DetectedLanguage {
-        /** An ISO language code such as 'en' or 'fr'. 
-         * For a complete list of languages supported by this method, see  [kLanguageInfoTable]{@link https://src.chromium.org/viewvc/chrome/trunk/src/third_party/cld/languages/internal/languages.cc}. 
+        /** An ISO language code such as 'en' or 'fr'.
+         * For a complete list of languages supported by this method, see  [kLanguageInfoTable]{@link https://src.chromium.org/viewvc/chrome/trunk/src/third_party/cld/languages/internal/languages.cc}.
          * For an unknown language, 'und' will be returned, which means that [percentage] of the text is unknown to CLD */
         language: string;
 
         /** The percentage of the detected language */
-        percentage: number; 
+        percentage: number;
     }
 
     /** Holds detected language reliability and array of DetectedLanguage */
@@ -3328,7 +3330,7 @@ declare namespace chrome.i18n {
         /** Array of detectedLanguage */
         languages: DetectedLanguage[];
     }
-    
+
     /**
      * Gets the accept-languages of the browser. This is different from the locale used by the browser; to get the locale, use i18n.getUILanguage.
      * @param callback The callback parameter should be a function that looks like this:
@@ -3347,7 +3349,7 @@ declare namespace chrome.i18n {
      * @since Chrome 35.
      */
     export function getUILanguage(): string;
-    
+
     /** Detects the language of the provided text using CLD.
      * @param text User input string to be translated.
      * @param callback The callback parameter should be a function that looks like this: function(object result) {...};
@@ -6598,7 +6600,7 @@ declare namespace chrome.tabs {
      * @since Chrome 38.
      */
     var onZoomChange: TabZoomChangeEvent;
-    
+
     /**
      * An ID which represents the absence of a browser tab.
      * @since Chrome 46.
@@ -7226,7 +7228,7 @@ declare namespace chrome.webRequest {
         types?: string[];
         /** A list of URLs or URL patterns. Requests that cannot match any of the URLs will be filtered out. */
         urls: string[];
- 
+
         /** Optional. */
         windowId?: number;
     }

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -300,38 +300,38 @@ function testOptionsPage() {
 
 // https://developer.chrome.com/extensions/debugger
 function testDebugger() {
-  chrome.debugger.attach({tabId: 123}, '1.23', () => {
-    console.log('This is a callback!');
-  });
+	chrome.debugger.attach({tabId: 123}, '1.23', () => {
+		console.log('This is a callback!');
+	});
 
-  chrome.debugger.detach({tabId: 123}, () => {
-    console.log('This is a callback!');
-  });
+	chrome.debugger.detach({tabId: 123}, () => {
+		console.log('This is a callback!');
+	});
 
-  chrome.debugger.sendCommand(
-      {targetId: 'abc'}, 'Debugger.Cmd', {param1: 'x'}, (result) => {
-    console.log('Do something with the result.' + result);
-  });
+	chrome.debugger.sendCommand(
+		{targetId: 'abc'}, 'Debugger.Cmd', {param1: 'x'}, (result) => {
+			console.log('Do something with the result.' + result);
+	});
 
-  chrome.debugger.getTargets((results) => {
-    for (let result of results) {
-      if (result.tabId == 123) {
-        // Do Something.
-      }
-    }
-  });
+	chrome.debugger.getTargets((results) => {
+		for (let result of results) {
+			if (result.tabId == 123) {
+			// Do Something.
+			}
+		}
+	});
 
-  chrome.debugger.onEvent.addListener((source, methodName, params) => {
-    if (source.tabId == 123) {
-      console.log('Hello World.');
-    }
-  });
+	chrome.debugger.onEvent.addListener((source, methodName, params) => {
+		if (source.tabId == 123) {
+			console.log('Hello World.');
+		}
+	});
 
-  chrome.debugger.onDetach.addListener((source, reason) => {
-    if (source.tabId == 123) {
-      console.log('Hello World.');
-    }
-  });
+	chrome.debugger.onDetach.addListener((source, reason) => {
+		if (source.tabId == 123) {
+			console.log('Hello World.');
+		}
+	});
 }
 
 // https://developer.chrome.com/extensions/storage#type-StorageArea

--- a/types/chrome/test/index.ts
+++ b/types/chrome/test/index.ts
@@ -188,18 +188,18 @@ function beforeRedditNavigation() {
 
 // for chrome.tabs.InjectDetails.frameId
 function executeScriptFramed () {
-    
+
     const tabId = 123;
     const frameId = 0;
-    
+
     const code = "alert('hi');";
-    
+
     chrome.tabs.executeScript({frameId, code});
     chrome.tabs.insertCSS({frameId, code});
-    
+
     chrome.tabs.executeScript(tabId, {frameId, code});
     chrome.tabs.insertCSS(tabId, {frameId, code});
-    
+
 }
 
 // for chrome.tabs.TAB_ID_NONE
@@ -295,6 +295,42 @@ function testOptionsPage() {
   chrome.runtime.openOptionsPage();
   chrome.runtime.openOptionsPage(function() {
     // Do a thing ...
+  });
+}
+
+// https://developer.chrome.com/extensions/debugger
+function testDebugger() {
+  chrome.debugger.attach({tabId: 123}, '1.23', () => {
+    console.log('This is a callback!');
+  });
+
+  chrome.debugger.detach({tabId: 123}, () => {
+    console.log('This is a callback!');
+  });
+
+  chrome.debugger.sendCommand(
+      {targetId: 'abc'}, 'Debugger.Cmd', {param1: 'x'}, (result) => {
+    console.log('Do something with the result.' + result);
+  });
+
+  chrome.debugger.getTargets((results) => {
+    for (let result of results) {
+      if (result.tabId == 123) {
+        // Do Something.
+      }
+    }
+  });
+
+  chrome.debugger.onEvent.addListener((source, methodName, params) => {
+    if (source.tabId == 123) {
+      console.log('Hello World.');
+    }
+  });
+
+  chrome.debugger.onDetach.addListener((source, reason) => {
+    if (source.tabId == 123) {
+      console.log('Hello World.');
+    }
   });
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [?] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
(Not sure what I pass to tsc)


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

We can't have chrome.debugger as a type because debugger is a reserved keyword. However, it is possible to do a workaround. Here is the context:
https://github.com/Microsoft/TypeScript/issues/7840
(and) https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14385

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
