### PR TITLE
[thrift] Remove dependency on node v8

### DIFF
--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -238,6 +238,20 @@ export interface ServerOptions<TProcessor, THandler> extends ServiceOptions<TPro
     tls?: tls.TlsOptions;
 }
 
+export interface RequestOptions {
+    protocol?: string;
+    host?: string;
+    hostname?: string;
+    family?: number;
+    port?: number;
+    localAddress?: string;
+    socketPath?: string;
+    method?: string;
+    path?: string;
+    headers?: HttpHeaders;
+    auth?: string;
+}
+
 export interface ConnectOptions {
     transport?: TTransportConstructor;
     protocol?: TProtocolConstructor;
@@ -249,7 +263,7 @@ export interface ConnectOptions {
     retry_max_delay?: number;
     connect_timeout?: number;
     timeout?: number;
-    nodeOptions?: http.ClientRequestArgs;
+    nodeOptions?: RequestOptions;
 }
 
 export interface WSConnectOptions {


### PR DESCRIPTION
  * Many users may still be on earlier version of node, the requirement
    of node v8 is not necessary

  * ClientRequestArgs is new in the types for node v8. The same types exists in node v6 under a
     different name. Just moving that hash to here as to remove the dependency on a specific
     node version

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/apache/thrift/blob/master/lib/nodejs/lib/thrift/http_connection.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
