### PR TITLE
fixed parameter order of getImageSource

### DIFF
--- a/types/react-native-vector-icons/Icon.d.ts
+++ b/types/react-native-vector-icons/Icon.d.ts
@@ -187,8 +187,8 @@ export interface TabBarItemIOSProps extends TabBarItemProperties {
 export class Icon extends React.Component<IconProps, any> {
   static getImageSource(
     name: string,
-    color: string,
-    size?: number
+    size?: number,
+    color?: string,
   ): Promise<ImageSource>;
   static loadFont(
     file?: string


### PR DESCRIPTION
According to [source of getImageSource](https://github.com/oblador/react-native-vector-icons/blob/master/lib/create-icon-set.js#L105) the parameter order in type definition of `Icon.getImageSource` should be `(name: string, size?: number, color?: string)`
