### PR TITLE
Puppeteer: Change page.url() return type

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for puppeteer 0.13
+// Type definitions for puppeteer 0.12
 // Project: https://github.com/GoogleChrome/puppeteer#readme
 // Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for puppeteer 0.10.1
+// Type definitions for puppeteer 0.13
 // Project: https://github.com/GoogleChrome/puppeteer#readme
 // Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for puppeteer 0.10
+// Type definitions for puppeteer 0.10.1
 // Project: https://github.com/GoogleChrome/puppeteer#readme
 // Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -238,7 +238,7 @@ export interface FrameBase {
     ...args: Array<object | ElementHandle>
   ): Promise<T>;
   title(): Promise<string>;
-  url(): Promise<string>;
+  url(): string;
   waitFor(
     // fn can be an abritary function
     // tslint:disable-next-line ban-types


### PR DESCRIPTION
According to docs frame.url() as well as page.url() returns just string, not promise.

source: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#frameurl