### PR TITLE
@types/vis separated Node color into it's own interface and added it to the Node

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -1850,16 +1850,19 @@ export interface Options {
 }
 
 export interface Color {
-  border?: string,
-  background?: string,
+  border?: string;
+
+  background?: string;
+
   highlight?: string | {
-    border?: string,
-    background?: string,
-  },
+    border?: string;
+    background?: string;
+  };
+
   hover?: string | {
-    border?: string,
-    background?: string,
-  }
+    border?: string;
+    background?: string;
+  };
 }
 
 export interface NodeOptions {

--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -1783,6 +1783,7 @@ export interface Node {
   fixed?: boolean;
   image?: string;
   shape?: string;
+  color?: string | Color;
 }
 
 export interface Edge {
@@ -1848,6 +1849,19 @@ export interface Options {
   physics?: any; // http://visjs.org/docs/network/physics.html#
 }
 
+export interface Color {
+  border?: string,
+  background?: string,
+  highlight?: string | {
+    border?: string,
+    background?: string,
+  },
+  hover?: string | {
+    border?: string,
+    background?: string,
+  }
+}
+
 export interface NodeOptions {
   borderWidth?: number;
 
@@ -1855,18 +1869,7 @@ export interface NodeOptions {
 
   brokenImage?: string;
 
-  color?: {
-    border?: string,
-    background?: string,
-    highlight?: string | {
-      border?: string,
-      background?: string,
-    },
-    hover?: string | {
-      border?: string,
-      background?: string,
-    }
-  };
+  color?: Color;
 
   fixed?: boolean | {
     x?: boolean,


### PR DESCRIPTION
The Vis library supports specifying colors in a Node object either as a string or as a Color object, currently the type defs allow it in a NodeOptions object but not in the Node type itself. This PR separates the color definition into it's own type and uses it from both places.

Vis api docs are here:

http://visjs.org/docs/network/nodes.html


- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
