### PR TITLE
[passport-jwt] Fix the missing secretOrKeyProvider

### DIFF
--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -14,7 +14,8 @@ export declare class Strategy extends PassportStrategy {
 }
 
 export interface StrategyOptions {
-    secretOrKey: string | Buffer;
+    secretOrKey?: string | Buffer;
+    secretOrKeyProvider?: any;
     jwtFromRequest: JwtFromRequestFunction;
     issuer?: string;
     audience?: string;

--- a/types/passport-jwt/index.d.ts
+++ b/types/passport-jwt/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for passport-jwt 2.0
+// Type definitions for passport-jwt 3.0
 // Project: https://github.com/themikenicholson/passport-jwt
 // Definitions by: TANAKA Koichi <https://github.com/mugeso/>
 //                 Alex Young <https://github.com/alsiola/>
 //                 David Ng <https://github.com/davidNHK/>
+//                 Carlos Eduardo Scheffer <https://github.com/carlosscheffer/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Strategy as PassportStrategy } from 'passport-strategy';


### PR DESCRIPTION
In passport-jwt v3.0.0 it has dynamic secretOrKey support, but has not been implemented so far in DefinitelyTyped. This commit corrects this.
