### PR TITLE
fix export issue for cytoscape

### DIFF
--- a/types/cytoscape/cytoscape-tests.ts
+++ b/types/cytoscape/cytoscape-tests.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { cytoscape } from 'cytoscape';
+import cytoscape = require('cytoscape');
 
 const parentCSS = {
   'padding-top': '10px',

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -58,19 +58,18 @@
  * A number of interfaces contain nothing as they server to collect interfaces.
  *
  */
-// export as namespace Cy
-// export = cytoscape;
+export = cytoscape;
+export as namespace cytoscape;
 
-export function cytoscape(options?: cytoscape.CytoscapeOptions): cytoscape.Core;
-export function cytoscape(extensionName: string, foo: string, bar: any): cytoscape.Core;
+declare function cytoscape(options?: cytoscape.CytoscapeOptions): cytoscape.Core;
+declare function cytoscape(extensionName: string, foo: string, bar: any): cytoscape.Core;
 
-export namespace cytoscape {
+declare namespace cytoscape {
     interface Position {
         x: number;
         y: number;
     }
 
-    type HtmlElement = any;
     type CssStyleDeclaration = any;
 
     interface ElementDefinition {


### PR DESCRIPTION

cytoscape could be imported as 
```typescript
import cytoscape = require('cytoscape');
```
or
```typescript
import cytoscape from 'cytoscape'; // --allowSyntheticDefaultImports true
```