### PR TITLE
loglevel: Remove flqw (myself) as an author

### DIFF
--- a/types/loglevel/index.d.ts
+++ b/types/loglevel/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for loglevel 1.5
 // Project: https://github.com/pimterry/loglevel
 // Definitions by: Stefan Profanter <https://github.com/Pro>
-//                 Florian Wagner <https://github.com/flqw>
 //                 Gabor Szmetanko <https://github.com/szmeti>
 //                 Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
I am no longer actively maintaining the loglevel definitions and removed myself as an author.