### PR TITLE
[joi] - Add Hoek.reach options to ReferenceOptions interface

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -127,6 +127,9 @@ export interface WhenOptions<T> {
 export interface ReferenceOptions {
     separator?: string;
     contextPrefix?: string;
+    default?: any;
+    strict?: boolean;
+    functions?: boolean;
 }
 
 export interface IPOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/joi/blob/v13.0.0/API.md#refkey-options
https://github.com/hapijs/hoek/blob/master/API.md#reachobj-chain-options

The [Joi documentation](https://github.com/hapijs/joi/blob/v13.0.0/API.md#refkey-options) makes it clear that [`Hoek.reach` options](https://github.com/hapijs/hoek/blob/master/API.md#reachobj-chain-options) are valid `ref` options, but these do not appear in the current typings, leading to type errors if they're used.
