### PR TITLE
Add O_DSYNC flag to fs constants

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -4179,6 +4179,9 @@ declare module "fs" {
         /** Constant for fs.open(). Flag indicating that the file is opened for synchronous I/O. */
         export const O_SYNC: number;
 
+        /** Constant for fs.open(). Flag indicating that the file is opened for synchronous I/O with write operations waiting for data integrity. */
+        export const O_DSYNC: number;
+
         /** Constant for fs.open(). Flag indicating to open the symbolic link itself rather than the resource it is pointing to. */
         export const O_SYMLINK: number;
 
@@ -5673,6 +5676,7 @@ declare module "constants" {
     export var O_NOATIME: number;
     export var O_NOFOLLOW: number;
     export var O_SYNC: number;
+    export var O_DSYNC: number;
     export var O_SYMLINK: number;
     export var O_DIRECT: number;
     export var O_NONBLOCK: number;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2896,6 +2896,7 @@ namespace constants_tests {
     num = constants.O_NOATIME;
     num = constants.O_NOFOLLOW;
     num = constants.O_SYNC;
+    num = constants.O_DSYNC;
     num = constants.O_DIRECT;
     num = constants.O_NONBLOCK;
     num = constants.S_IRWXU;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v8.x/docs/api/fs.html#fs_file_open_constants
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
