### PR TITLE
[react] Fix `isValidElement` to accept `any` type

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -256,7 +256,7 @@ declare namespace React {
         props?: Q, // should be Q & Attributes
         ...children: ReactNode[]): ReactElement<P>;
 
-    function isValidElement<P>(object: {}): object is ReactElement<P>;
+    function isValidElement<P>(object: any): object is ReactElement<P>;
 
     const Children: ReactChildren;
     const version: string;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -256,7 +256,7 @@ declare namespace React {
         props?: Q, // should be Q & Attributes
         ...children: ReactNode[]): ReactElement<P>;
 
-    function isValidElement<P>(object: any): object is ReactElement<P>;
+    function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 
     const Children: ReactChildren;
     const version: string;


### PR DESCRIPTION
`isValidElement` function should accept `any` type of object. It is not clear from the documentation, but according to a source code, it can handle any type. It makes much more sense to accept any, e.g. if I need to check possibly `string` value.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://reactjs.org/docs/react-api.html#isvalidelement
    - https://github.com/facebook/react/blob/0344f7ad5542ff068708e51ede3a08c8039cfe54/src/isomorphic/classic/element/ReactElement.js#L373
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.