### PR TITLE
Fixes crossfilter bisect method

### DIFF
--- a/types/crossfilter/crossfilter-tests.ts
+++ b/types/crossfilter/crossfilter-tests.ts
@@ -118,7 +118,7 @@ var types = paymentCountByType.all();
 paymentsByTotal.dispose();
 
 crossfilter.bisect([], null, 0, 0);
-var bisectBy = crossfilter.bisect.by<{value: string}>(t => t.value);
+var bisectBy = crossfilter.bisect.by<{value: string}, string>(t => t.value);
 bisectBy([{value: 'a'}, {value: 'b'}], 'c', 0, 0); // 2
 bisectBy.left([], 'string', 0, 0); // 0
 bisectBy.right([], 'string', 0, 0); // 0

--- a/types/crossfilter/crossfilter-tests.ts
+++ b/types/crossfilter/crossfilter-tests.ts
@@ -118,10 +118,10 @@ var types = paymentCountByType.all();
 paymentsByTotal.dispose();
 
 crossfilter.bisect([], null, 0, 0);
-var bisectBy = crossfilter.bisect.by(t => t);
-bisectBy([], null, 0, 0);
-bisectBy.left([], null, 0, 0);
-bisectBy.right([], null, 0, 0);
+var bisectBy = crossfilter.bisect.by<{value: string}>(t => t.value);
+bisectBy([{value: 'a'}, {value: 'b'}], 'c', 0, 0); // 2
+bisectBy.left([], 'string', 0, 0); // 0
+bisectBy.right([], 'string', 0, 0); // 0
 
 crossfilter.heap([], 0, 0);
 var heapBy = crossfilter.heap.by(t => t);

--- a/types/crossfilter/index.d.ts
+++ b/types/crossfilter/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for CrossFilter
 // Project: https://github.com/square/crossfilter
-// Definitions by: Schmulik Raskin <https://github.com/schmuli>, Izaak Baker <https://github.com/iebaker>
+// Definitions by: Schmulik Raskin <https://github.com/schmuli>, Izaak Baker <https://github.com/iebaker>, Einar Norðfjörð <https://github.com/nordfjord>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace CrossFilter {
@@ -15,7 +15,7 @@ declare namespace CrossFilter {
         permute<T>(array: T[], index: number[]): T[];
         bisect: {
             <T>(array: T[], value: T, lo: number, hi: number): number;
-            by<T>(value: Selector<T>): Bisector<T>;
+            by<T,U>(accessor: (x: T)=> U): Bisector<T,U>;
         }
         heap: {
             <T>(array: T[], lo: number, hi: number): T[];
@@ -36,13 +36,13 @@ declare namespace CrossFilter {
         }
     }
 
-    export interface Bisection<T> {
-        (array: T[], value: T, lo: number, hi: number): number;
+    export interface Bisection<T,U> {
+        (array: T[], value: U, lo: number, hi: number): number;
     }
 
-    export interface Bisector<T> extends Bisection<T> {
-        left: Bisection<T>
-        right: Bisection<T>
+    export interface Bisector<T,U> extends Bisection<T,U> {
+        left: Bisection<T,U>
+        right: Bisection<T,U>
     }
 
     export interface Heap<T> {


### PR DESCRIPTION
Crossfilters bisect methods second argument should be of the type returned by the accessor

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/crossfilter/crossfilter/wiki/API-Reference#bisect

It's not really documented but if you look at the code: https://github.com/crossfilter/crossfilter/blob/master/src/bisect.js#L20
The accessor function isn't run on the second argument.

- [ x ] Increase the version number in the header if appropriate.
  Not appropriate
- [ x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
Not required
