### PR TITLE
use union type for GeocoderGeometry location field

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1200,7 +1200,7 @@ declare namespace google.maps {
 
     export interface GeocoderGeometry {
         bounds: LatLngBounds;
-        location: LatLng;
+        location: LatLng | LatLngLiteral;
         location_type: GeocoderLocationType;
         viewport: LatLngBounds;
     }


### PR DESCRIPTION
When calling google api directly, the `location` it returns inside the `GeocoderGeometry` is a `LatLngLiteral` instead of a `LatLng`. 
Example: 
>http://maps.googleapis.com/maps/api/geocode/json?address=20874

```
{
   "results" : [
      {
         "address_components" : [
            {
               "long_name" : "20874",
               "short_name" : "20874",
               "types" : [ "postal_code" ]
            },
            {
               "long_name" : "Germantown",
               "short_name" : "Germantown",
               "types" : [ "locality", "political" ]
            },
            {
               "long_name" : "Montgomery County",
               "short_name" : "Montgomery County",
               "types" : [ "administrative_area_level_2", "political" ]
            },
            {
               "long_name" : "Maryland",
               "short_name" : "MD",
               "types" : [ "administrative_area_level_1", "political" ]
            },
            {
               "long_name" : "United States",
               "short_name" : "US",
               "types" : [ "country", "political" ]
            }
         ],
         "formatted_address" : "Germantown, MD 20874, USA",
         "geometry" : {
            "bounds" : {
               "northeast" : {
                  "lat" : 39.2067559,
                  "lng" : -77.23240609999999
               },
               "southwest" : {
                  "lat" : 39.0477769,
                  "lng" : -77.343778
               }
            },
            "location" : {
               "lat" : 39.1348627,
               "lng" : -77.2922332
            },
            "location_type" : "APPROXIMATE",
            "viewport" : {
               "northeast" : {
                  "lat" : 39.2067559,
                  "lng" : -77.23240609999999
               },
               "southwest" : {
                  "lat" : 39.0477769,
                  "lng" : -77.343778
               }
            }
         },
         "place_id" : "ChIJ5diWhQoutokREKKJg28YyzI",
         "postcode_localities" : [ "Darnestown", "Germantown" ],
         "types" : [ "postal_code" ]
      }
   ],
   "status" : "OK"
}
```

