### PR TITLE
[react-mdl] Change DOMAttributes generic type from Textfield to HTMLI…

### DIFF
--- a/types/react-mdl/index.d.ts
+++ b/types/react-mdl/index.d.ts
@@ -584,7 +584,7 @@ declare namespace __ReactMDL {
     class Tabs extends __MDLComponent<TabsProps> { }
 
 
-    interface TextfieldProps extends MDLHTMLAttributes, React.DOMAttributes<Textfield> {
+    interface TextfieldProps extends MDLHTMLAttributes, React.DOMAttributes<HTMLInputElement> {
         label: string;
         disabled?: boolean;
         error?: React.ReactNode;
@@ -594,7 +594,7 @@ declare namespace __ReactMDL {
         id?: string;
         inputClassName?: string;
         maxRows?: number;
-        onChange?: React.FormEventHandler<Textfield>;
+        onChange?: React.FormEventHandler<HTMLInputElement>;
         pattern?: string;
         required?: boolean;
         rows?: number;


### PR DESCRIPTION
Textfield redirect all DOMAttributes to the input component inside of it. The typing should match it

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/react-mdl/react-mdl/blob/master/src/Textfield.js#L88>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.