### PR TITLE
Correct type of Node url.query

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2181,7 +2181,7 @@ declare module "url" {
         pathname?: string;
         port?: string | number;
         protocol?: string;
-        query?: string | null | { [key: string]: string };
+        query?: string | null | { [key: string]: string | string[] };
         search?: string;
         slashes?: boolean;
     }

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2181,7 +2181,7 @@ declare module "url" {
         pathname?: string;
         port?: string | number;
         protocol?: string;
-        query?: string | { [key: string]: any; };
+        query?: string | { [key: string]: string };
         search?: string;
         slashes?: boolean;
     }

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -2181,7 +2181,7 @@ declare module "url" {
         pathname?: string;
         port?: string | number;
         protocol?: string;
-        query?: string | { [key: string]: string };
+        query?: string | null | { [key: string]: string };
         search?: string;
         slashes?: boolean;
     }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -557,7 +557,9 @@ namespace url_tests {
 
     {
         var helloUrl = url.parse('http://example.com/?hello=world', true);
-        assert.equal(helloUrl.query.hello, 'world');
+        if (typeof helloUrl.query !== 'string') {
+            assert.equal(helloUrl.query.hello, 'world');
+        }
     }
 
     {


### PR DESCRIPTION
The `any` meant the type was widened, so it was completely useless.

`url.query` can be `string`, `null` when there is no query, or a string dictionary.

https://nodejs.org/api/url.html#url_urlobject_query

```
> require('url').parse('').query
null
> require('url').parse('?foo').query
'foo'
> require('url').parse('?foo', true).query
{ foo: '' }
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.