### PR TITLE
passport-github2: added optional state parameter for StrategyOption definition

### DIFF
--- a/types/passport-github2/index.d.ts
+++ b/types/passport-github2/index.d.ts
@@ -19,6 +19,7 @@ export interface StrategyOption {
 
     scope?: string[];
     userAgent?: string;
+    state?: boolean;
 
     authorizationURL?: string;
     tokenURL?: string;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/cfsghost/passport-github/blob/master/lib/strategy.js#L61
https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L102
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`state` option can be used because it is available in passport-oauth2
References:
https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L102
https://github.com/cfsghost/passport-github/blob/master/lib/strategy.js#L61