### PR TITLE
Fix incorrect rdf-data-model DataFactory interface

### DIFF
--- a/types/rdf-data-model/index.d.ts
+++ b/types/rdf-data-model/index.d.ts
@@ -5,62 +5,11 @@
 
 import * as RDF from "rdf-js";
 
-export class NamedNode implements RDF.NamedNode {
-    termType: "NamedNode";
-    value: string;
-    constructor(iri: string);
-    equals(other: RDF.Term): boolean;
-}
-
-export class BlankNode implements RDF.BlankNode {
-    static nextId: number;
-    termType: "BlankNode";
-    value: string;
-    constructor(id?: string);
-    equals(other: RDF.Term): boolean;
-}
-
-export class Literal implements RDF.Literal {
-    static readonly langStringDatatype: NamedNode;
-    termType: "Literal";
-    value: string;
-    language: string;
-    datatype: RDF.NamedNode;
-    constructor(value: string, language?: string, datatype?: RDF.NamedNode);
-    equals(other: RDF.Term): boolean;
-}
-
-export class Variable implements RDF.Variable {
-    termType: "Variable";
-    value: string;
-    constructor(name: string);
-    equals(other: RDF.Term): boolean;
-}
-
-export class DefaultGraph implements RDF.DefaultGraph {
-    termType: "DefaultGraph";
-    value: "";
-    constructor();
-    equals(other: RDF.Term): boolean;
-}
-
-export class Quad implements RDF.Quad {
-    subject: RDF.Term;
-    predicate: RDF.Term;
-    object: RDF.Term;
-    graph: RDF.Term;
-    constructor(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph?: RDF.Term);
-    equals(other: RDF.Quad): boolean;
-}
-
-export class DataFactory implements RDF.DataFactory {
-    static defaultGraphInstance: RDF.DefaultGraph;
-    constructor();
-    namedNode(value: string): NamedNode;
-    blankNode(value?: string): BlankNode;
-    literal(value: string, languageOrDatatype?: string | RDF.NamedNode): Literal;
-    variable(value: string): Variable;
-    defaultGraph(): DefaultGraph;
-    triple(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term): Quad;
-    quad(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph?: RDF.Term): Quad;
-}
+export const defaultGraphInstance: RDF.DefaultGraph;
+export function namedNode(value: string): RDF.NamedNode;
+export function blankNode(value?: string): RDF.BlankNode;
+export function literal(value: string, languageOrDatatype?: string | RDF.NamedNode): RDF.Literal;
+export function variable(value: string): RDF.Variable;
+export function defaultGraph(): RDF.DefaultGraph;
+export function triple(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term): RDF.Quad;
+export function quad(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph?: RDF.Term): RDF.Quad;

--- a/types/rdf-data-model/rdf-data-model-tests.ts
+++ b/types/rdf-data-model/rdf-data-model-tests.ts
@@ -1,65 +1,22 @@
 import * as RDF from "rdf-js";
-import { BlankNode, DataFactory, DefaultGraph, Literal, NamedNode, Quad, Variable } from "rdf-data-model";
-import { EventEmitter } from "events";
-
-function test_terms() {
-    // Only types are checked in this tests,
-    // so this does not have to be functional.
-    const someTerm: RDF.Term = <any> {};
-
-    const namedNode: RDF.NamedNode = new NamedNode('http://example.org');
-    const tt1: string = namedNode.termType;
-    const v1: string = namedNode.value;
-    const b1: boolean = namedNode.equals(someTerm);
-
-    const blankNode1: RDF.BlankNode = new BlankNode();
-    const blankNode2: RDF.BlankNode = new BlankNode('b100');
-    const tt2: string = blankNode1.termType;
-    const v2: string = blankNode1.value;
-    const b2: boolean = blankNode1.equals(someTerm);
-
-    const literal1: RDF.Literal = new Literal('abc', 'en-us');
-    const literal2: RDF.Literal = new Literal('abc', 'en-us', namedNode);
-    const literal3: RDF.Literal = new Literal('abc', undefined, namedNode);
-    const tt3: string = literal1.termType;
-    const v3: string = literal1.value;
-    const lang: string = literal1.language;
-    const datatype: RDF.NamedNode = literal1.datatype;
-    const b3: boolean = literal1.equals(someTerm);
-
-    const variable: RDF.Variable = new Variable('myvar');
-    const tt4: string = variable.termType;
-    const v4: string = variable.value;
-    const b4: boolean = variable.equals(someTerm);
-
-    const defaultGraph: RDF.DefaultGraph = new DefaultGraph();
-    const tt5: string = defaultGraph.termType;
-    const v5: string = defaultGraph.value;
-    const b5: boolean = defaultGraph.equals(someTerm);
-
-    const quad: RDF.Quad = new Quad(namedNode, namedNode, namedNode, namedNode);
-    const s: RDF.Term = quad.subject;
-    const p: RDF.Term = quad.predicate;
-    const o: RDF.Term = quad.object;
-    const g: RDF.Term = quad.graph;
-    const b: boolean = quad.equals(new Quad(namedNode, namedNode, namedNode));
-}
+import * as DataFactory from "rdf-data-model";
 
 function test_datafactory() {
-    const dataFactory: RDF.DataFactory = new DataFactory();
+    const namedNode: RDF.NamedNode = DataFactory.namedNode('http://example.org');
 
-    const namedNode: RDF.NamedNode = dataFactory.namedNode('http://example.org');
+    const blankNode1: RDF.BlankNode = DataFactory.blankNode('b1');
+    const blankNode2: RDF.BlankNode = DataFactory.blankNode();
 
-    const blankNode1: RDF.BlankNode = dataFactory.blankNode('b1');
-    const blankNode2: RDF.BlankNode = dataFactory.blankNode();
+    const literal1: RDF.Literal = DataFactory.literal('abc');
+    const literal2: RDF.Literal = DataFactory.literal('abc', 'en-us');
+    const literal3: RDF.Literal = DataFactory.literal('abc', namedNode);
 
-    const literal1: RDF.Literal = dataFactory.literal('abc');
-    const literal2: RDF.Literal = dataFactory.literal('abc', 'en-us');
-    const literal3: RDF.Literal = dataFactory.literal('abc', namedNode);
+    const variable: RDF.Variable = DataFactory.variable('v1');
 
-    const variable: RDF.Variable = dataFactory.variable ? dataFactory.variable('v1') : new Variable('myvar');
+    const defaultGraph1: RDF.DefaultGraph = DataFactory.defaultGraphInstance;
+    const defaultGraph2: RDF.DefaultGraph = DataFactory.defaultGraph();
 
     const term: RDF.Term = <any> {};
-    const triple: RDF.Quad = dataFactory.triple(term, term, term);
-    const quad: RDF.Quad = dataFactory.quad(term, term, term, term);
+    const triple: RDF.Quad = DataFactory.triple(term, term, term);
+    const quad: RDF.Quad = DataFactory.quad(term, term, term, term);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rdf-ext/rdf-data-model/blob/master/index.js#L5 https://github.com/rdf-ext/rdf-data-model/blob/master/lib/data-factory.js#L12-L48
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Summary of changes:
* Remove incorrectly exported classes, as rdf-data-model does not export these.
* Change `DataFactory` methods to default exported functions, as how these are exposed by rdf-data-model.
* Update tests