### PR TITLE
Add types for stemmer package

### DIFF
--- a/types/stemmer/index.d.ts
+++ b/types/stemmer/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for stemmer 1.0
+// Project: https://github.com/wooorm/stemmer#readme
+// Definitions by: Will Ockmore <https://github.com/will-ockmore>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export default function stemmer(value: string): string;

--- a/types/stemmer/index.d.ts
+++ b/types/stemmer/index.d.ts
@@ -3,4 +3,6 @@
 // Definitions by: Will Ockmore <https://github.com/will-ockmore>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default function stemmer(value: string): string;
+declare function stemmer(value: string): string;
+
+export = stemmer;

--- a/types/stemmer/stemmer-tests.ts
+++ b/types/stemmer/stemmer-tests.ts
@@ -1,3 +1,3 @@
-import * as stemmer from 'stemmer';
+import stemmer = require('stemmer');
 
 stemmer('Working');  // $ExpectType string

--- a/types/stemmer/stemmer-tests.ts
+++ b/types/stemmer/stemmer-tests.ts
@@ -1,0 +1,3 @@
+import * as stemmer from 'stemmer';
+
+stemmer('Working');  // $ExpectType string

--- a/types/stemmer/tsconfig.json
+++ b/types/stemmer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "stemmer-tests.ts"
+    ]
+}

--- a/types/stemmer/tslint.json
+++ b/types/stemmer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Adds type definition for single default function in
package.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.