### PR TITLE
lodash: CloneDeepWithCustomizer accepts and returns "any" value

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -11608,7 +11608,7 @@ declare namespace _ {
     }
 
     //_.cloneDeepWith
-    type CloneDeepWithCustomizer<TValue, TResult> = (value: TValue, key?: number|string, object?: any, stack?: any) => TResult;
+    type CloneDeepWithCustomizer = (value: any, key?: number|string, object?: any, stack?: any) => any;
 
     interface LoDashStatic {
         /**
@@ -11620,7 +11620,7 @@ declare namespace _ {
          */
         cloneDeepWith<TResult>(
             value: any,
-            customizer?: CloneDeepWithCustomizer<any, TResult>
+            customizer?: CloneDeepWithCustomizer
         ): TResult;
 
         /**
@@ -11628,7 +11628,7 @@ declare namespace _ {
          */
         cloneDeepWith<T, TResult>(
             value: T,
-            customizer?: CloneDeepWithCustomizer<T, TResult>
+            customizer?: CloneDeepWithCustomizer
         ): TResult;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lodash/lodash/blob/bcd2c356049988f4910653fb52fb620a36541d01/.internal/baseClone.js#L157
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`cloneDeep` will call customizer recursively so you can't specify value of it argument.
Here is a simple example:
```sh
$ node
> var cloneDeepWith = require('lodash').cloneDeepWith
undefined
> cloneDeepWith([1,true, false, null], (value) => { console.log(typeof value); })
object
number
boolean
boolean
object
[ 1, true, false, null ]
>
```
Moreover as [seen here](https://github.com/lodash/lodash/blob/bcd2c356049988f4910653fb52fb620a36541d01/.internal/baseClone.js#L166) returning `undefined` from customizer has a special meaning.