### PR TITLE
Node http2: statCheck() may also return `false`.

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6112,7 +6112,7 @@ declare module "http2" {
     }
 
     export interface ServerStreamFileResponseOptions {
-        statCheck?: (stats: fs.Stats, headers: IncomingHttpHeaders, statOptions: StatOptions) => void;
+        statCheck?: (stats: fs.Stats, headers: IncomingHttpHeaders, statOptions: StatOptions) => void|false;
         getTrailers?: (trailers: IncomingHttpHeaders) => void;
         offset?: number;
         length?: number;

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6112,7 +6112,7 @@ declare module "http2" {
     }
 
     export interface ServerStreamFileResponseOptions {
-        statCheck?: (stats: fs.Stats, headers: IncomingHttpHeaders, statOptions: StatOptions) => void|false;
+        statCheck?: (stats: fs.Stats, headers: IncomingHttpHeaders, statOptions: StatOptions) => void|boolean;
         getTrailers?: (trailers: IncomingHttpHeaders) => void;
         offset?: number;
         length?: number;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3288,7 +3288,7 @@ namespace http2_tests {
         serverHttp2Stream.respondWithFD(0);
         serverHttp2Stream.respondWithFD(0, headers);
         serverHttp2Stream.respondWithFD(0, headers, options2);
-        serverHttp2Stream.respondWithFD(0, headers, {statCheck: () => { return false; }});
+        serverHttp2Stream.respondWithFD(0, headers, {statCheck: () => false});
         let options3: http2.ServerStreamFileResponseOptionsWithError = {
             onError: (err: NodeJS.ErrnoException) => {},
             statCheck: (stats: fs.Stats, headers: http2.IncomingHttpHeaders, statOptions: http2.StatOptions) => {},
@@ -3299,7 +3299,7 @@ namespace http2_tests {
         serverHttp2Stream.respondWithFile('');
         serverHttp2Stream.respondWithFile('', headers);
         serverHttp2Stream.respondWithFile('', headers, options3);
-        serverHttp2Stream.respondWithFile('', headers, {statCheck: () => { return false; }});
+        serverHttp2Stream.respondWithFile('', headers, {statCheck: () => false});
     }
 
     // Http2Server / Http2SecureServer

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -3288,6 +3288,7 @@ namespace http2_tests {
         serverHttp2Stream.respondWithFD(0);
         serverHttp2Stream.respondWithFD(0, headers);
         serverHttp2Stream.respondWithFD(0, headers, options2);
+        serverHttp2Stream.respondWithFD(0, headers, {statCheck: () => { return false; }});
         let options3: http2.ServerStreamFileResponseOptionsWithError = {
             onError: (err: NodeJS.ErrnoException) => {},
             statCheck: (stats: fs.Stats, headers: http2.IncomingHttpHeaders, statOptions: http2.StatOptions) => {},
@@ -3298,6 +3299,7 @@ namespace http2_tests {
         serverHttp2Stream.respondWithFile('');
         serverHttp2Stream.respondWithFile('', headers);
         serverHttp2Stream.respondWithFile('', headers, options3);
+        serverHttp2Stream.respondWithFile('', headers, {statCheck: () => { return false; }});
     }
 
     // Http2Server / Http2SecureServer


### PR DESCRIPTION
https://nodejs.org/dist/latest-v8.x/docs/api/http2.html#http2_http2stream_respondwithfile_path_headers_options
says:
The options.statCheck function may also be used to cancel the send operation by
returning false

Related node code:
  - https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js#L1621
  - https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js#L1671

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v8.x/docs/api/http2.html#http2_http2stream_respondwithfile_path_headers_options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
