### PR TITLE
Fix immutability-helper

### DIFF
--- a/types/immutability-helper/immutability-helper-tests.ts
+++ b/types/immutability-helper/immutability-helper-tests.ts
@@ -1,22 +1,6 @@
 import * as update from 'immutability-helper';
 import { newContext } from 'immutability-helper';
 
-namespace TestObjectUpdate {
-  update({}, {
-    foo: {
-      bar: { $set: 'baz' }
-    }
-  });
-}
-
-namespace TestArrayUpdate {
-  update([], {
-    foo: {
-      bar: { $set: 'baz' }
-    }
-  });
-}
-
 namespace TestExtend {
   update.extend('$command', (specValue, originalValue) => originalValue);
 }
@@ -24,25 +8,30 @@ namespace TestExtend {
 namespace TestNewContext {
   update.newContext().extend('$command', (specValue, originalValue) => originalValue);
   newContext().extend('$command', (specValue, originalValue) => originalValue);
-
-  // This shouldn't compile, but we can't test negatives.
-  // newContext().newContext();
 }
 
 namespace TestFromReactDocs {
-  // These are copied from https://facebook.github.io/react/docs/update.html
-  let initialArray = [1, 2, 3];
-  let newArray = update(initialArray, { $push: [4] }); // => [1, 2, 3, 4]
 
-  let collection = [1, 2, { a: [12, 17, 15] }];
-  let newCollection = update(collection, { 2: { a: { $splice: [[1, 1, 13, 14]] } } });
-  // => [1, 2, {a: [12, 13, 14, 15]}]
+    interface TestFoo {
+        bar: number,
+        baz: string,
+        qux: boolean[],
+    }
 
-  let obj = { a: 5, b: 3 };
-  let newObj = update(obj, { b: { $apply: function(x: number) { return x * 2; } } });
-  // => {a: 5, b: 6}
-  let newObj2 = update(obj, { b: { $set: obj.b * 2 } });
+    // Test array type coherence
+    let initialArray: number[] = [1, 2, 3];
+    initialArray = update(initialArray, {$push: [4]}); // => [1, 2, 3, 4]
 
-  let objShallow = { a: 5, b: 3 };
-  let newObjShallow = update(obj, { $merge: { b: 6, c: 7 } }); // => {a: 5, b: 6, c: 7}
+    // Test Object type coherence
+    let foo: TestFoo = {bar: 5, baz: 'Hello World', qux: [false, false, true]};
+    foo = update(foo, {
+        bar: {
+            $apply: function (x: number) {
+                return x * 2;
+            }
+        },
+        qux: {
+            $set: []
+        }
+    });
 }

--- a/types/immutability-helper/immutability-helper-tests.ts
+++ b/types/immutability-helper/immutability-helper-tests.ts
@@ -10,7 +10,7 @@ namespace TestNewContext {
   newContext().extend('$command', (specValue, originalValue) => originalValue);
 }
 
-namespace TestFromReactDocs {
+namespace TestTypeCoherence {
 
     interface TestFoo {
         bar: number,

--- a/types/immutability-helper/index.d.ts
+++ b/types/immutability-helper/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for immutability-helper v2.0.0
 // Project: https://github.com/kolodny/immutability-helper
 // Definitions by: Sean Kelley <https://github.com/seansfkelley>
+// Definitions by: Adam Gordon <https://github.com/xmrwhite>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
@@ -27,8 +28,8 @@ interface UpdateArraySpec extends UpdateSpecCommand {
 type CommandHandler = (specValue: any, originalValue: any) => any;
 
 interface UpdateFunction {
-    (value: any[], spec: UpdateArraySpec): any[];
-    (value: {}, spec: UpdateSpec): any;
+    <K extends Array<T>, T>(value: T[], spec: UpdateArraySpec): T[];
+    <T>(value: T, spec: UpdateSpec): T;
     extend: (commandName: string, handler: CommandHandler) => any;
 }
 

--- a/types/immutability-helper/index.d.ts
+++ b/types/immutability-helper/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for immutability-helper v2.0.0
 // Project: https://github.com/kolodny/immutability-helper
-// Definitions by: Sean Kelley <https://github.com/seansfkelley>
-// Definitions by: Adam Gordon <https://github.com/xmrwhite>
+// Definitions by: Sean Kelley <https://github.com/seansfkelley>, Adam Gordon <https://github.com/xmrwhite>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 


### PR DESCRIPTION
It no longer defaults to any[] as the return value of update

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, and `strictNullChecks` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
