### PR TITLE
react-relay — fixes for compat library definitions

### DIFF
--- a/types/react-relay/compat.d.ts
+++ b/types/react-relay/compat.d.ts
@@ -33,7 +33,6 @@ export type ReactFragmentComponent<T> = ComponentWithFragment<T> | StatelessWith
 export type ReactBaseComponent<T> = React.ComponentClass<T> | React.StatelessComponent<T>;
 export type RelayClassicEnvironment = RelayEnvironmentInterface;
 
-
 // ~~~~~~~~~~~~~~~~~~~~~
 // RelayCompatTypes
 // ~~~~~~~~~~~~~~~~~~~~~

--- a/types/react-relay/compat.d.ts
+++ b/types/react-relay/compat.d.ts
@@ -1,13 +1,13 @@
 export {
     QueryRenderer,
-    commitMutation,
-    createFragmentContainer,
-    createPaginationContainer,
-    createRefetchContainer,
     fetchQuery,
     graphql,
 } from "./index";
-
+import {
+    ConnectionConfig,
+    RelayPaginationProp as RelayModernPaginationProp,
+    RelayRefetchProp as RelayModernRefetchProp
+} from "./index";
 import * as RelayRuntimeTypes from "relay-runtime";
 import { RelayEnvironmentInterface } from "./classic";
 
@@ -33,32 +33,56 @@ export type ReactFragmentComponent<T> = ComponentWithFragment<T> | StatelessWith
 export type ReactBaseComponent<T> = React.ComponentClass<T> | React.StatelessComponent<T>;
 export type RelayClassicEnvironment = RelayEnvironmentInterface;
 
+
 // ~~~~~~~~~~~~~~~~~~~~~
 // RelayCompatTypes
 // ~~~~~~~~~~~~~~~~~~~~~
 export type CompatEnvironment = RelayRuntimeTypes.Environment | RelayClassicEnvironment;
 
 // ~~~~~~~~~~~~~~~~~~~~~
+// RelayProps
+// ~~~~~~~~~~~~~~~~~~~~~
+export interface RelayProp {
+    environment: CompatEnvironment;
+}
+
+export type RelayPaginationProp = RelayModernPaginationProp & RelayProp;
+export type RelayRefetchProp = RelayModernRefetchProp & RelayProp;
+
+// ~~~~~~~~~~~~~~~~~~~~~
 // RelayCompatMutations
 // ~~~~~~~~~~~~~~~~~~~~~
-export function commitUpdate(
+export function commitMutation(
     environment: CompatEnvironment,
     config: RelayRuntimeTypes.MutationConfig<any>
 ): RelayRuntimeTypes.Disposable;
-export function applyUpdate(
+export function applyOptimisticMutation(
     environment: CompatEnvironment,
     config: RelayRuntimeTypes.OptimisticMutationConfig
 ): RelayRuntimeTypes.Disposable;
 
 // ~~~~~~~~~~~~~~~~~~~~~
-// RelayCompatContainer
+// RelayCompatContainers
 // ~~~~~~~~~~~~~~~~~~~~~
 export interface GeneratedNodeMap {
     [key: string]: RelayRuntimeTypes.GraphQLTaggedNode;
 }
-export function createContainer<T>(
+
+export function createFragmentContainer<T>(
     Component: ReactBaseComponent<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap
+): ReactFragmentComponent<T>;
+
+export function createRefetchContainer<T>(
+    Component: ReactBaseComponent<T>,
+    fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
+    taggedNode: RelayRuntimeTypes.GraphQLTaggedNode
+): ReactFragmentComponent<T>;
+
+export function createPaginationContainer<T>(
+    Component: ReactBaseComponent<T>,
+    fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
+    connectionConfig: ConnectionConfig<T>
 ): ReactFragmentComponent<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -332,9 +332,53 @@ requestSubscription(
 import {
     QueryRenderer as CompatQueryRenderer,
     createFragmentContainer as createFragmentContainerCompat,
+    commitMutation as commitMutationCompat,
+    CompatEnvironment,
+    RelayPaginationProp as RelayPaginationPropCompat,
 } from "react-relay/compat";
 
-// TODO? This is all more or less identical to modern...
+// testting compat mutation with classic environment
+function markNotificationAsReadCompat(environment: CompatEnvironment, source: string, storyID: string) {
+    const variables = {
+        input: {
+            source,
+            storyID,
+        },
+    };
+
+    commitMutationCompat(environment, {
+        configs,
+        mutation,
+        optimisticResponse,
+        variables,
+        onCompleted: (response, errors) => {
+            console.log("Response received from server.");
+        },
+        onError: err => console.error(err),
+        updater: (store, data) => {
+            const field = store.get(storyID);
+            if (field) {
+                field.setValue(data.story, "story");
+            }
+        }
+    });
+}
+
+interface CompatProps {
+    relay: RelayPaginationPropCompat;
+}
+
+export class CompatComponent extends React.Component<CompatProps, {}> {
+    markNotificationAsRead(source: string, storyID: string) {
+        markNotificationAsReadCompat(this.props.relay.environment, source, storyID);
+    }
+
+    render() {
+        return (<div/>);
+    }
+}
+
+const CompatContainer = createFragmentContainerCompat(CompatComponent, {});
 
 ////////////////////////////
 //  RELAY-CLASSIC TESTS
@@ -398,6 +442,7 @@ const ArtworkContainer = Relay.createContainer(Artwork, {
         artwork: () => Relay.QL`
             fragment on Artwork {
                 title
+                ${ CompatContainer.getFragment('whatever') }
             }
         `,
     },

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -368,7 +368,7 @@ interface CompatProps {
     relay: RelayPaginationPropCompat;
 }
 
-export class CompatComponent extends React.Component<CompatProps, {}> {
+export class CompatComponent extends React.Component<CompatProps> {
     markNotificationAsRead(source: string, storyID: string) {
         markNotificationAsReadCompat(this.props.relay.environment, source, storyID);
     }


### PR DESCRIPTION
This is a quick turn on the just-merged relay-modern types: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/19533

We missed a couple edge cases in the `react-relay/compat` library having to do with situations where you're using the modern API in a classic environment. These changes should fix that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
