### PR TITLE
[react-router] Fix for --strictFunctionTypes

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -65,7 +65,7 @@ export interface RouteComponentProps<P> {
 
 export interface RouteProps {
   location?: H.Location;
-  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<{}>
+  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -65,7 +65,7 @@ export interface RouteComponentProps<P> {
 
 export interface RouteProps {
   location?: H.Location;
-  component?: React.ComponentType<RouteComponentProps<any> | {}>;
+  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<{}>
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;


### PR DESCRIPTION
It seems it's not possible for a SFC to conform to React.ComponentType<RouteComponentProps<any> | {}> with both strictFunctionTypes and strictNullChecks (they have to either be `Partial<RouteComponentProps<any>>` or `{}`).

The whole point of the `| {}` is to allow for components that have defaulted `Props` / don't use any `Props` anyway, so adding it as another listed type should work.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
