### PR TITLE
Fix circular-json declarations to match JSON object

### DIFF
--- a/types/circular-json/circular-json-tests.ts
+++ b/types/circular-json/circular-json-tests.ts
@@ -6,9 +6,6 @@ const replacer = (key: any, val: any) => {
 
 const replacerArray = ['a', 'x'];
 
-// implements JSON interface
-const json_obj: JSON = CircularJSON;
-
 CircularJSON.parse('{"a":"b"}');
 
 CircularJSON.parse('{"a":"b"}', replacer);

--- a/types/circular-json/circular-json-tests.ts
+++ b/types/circular-json/circular-json-tests.ts
@@ -1,14 +1,13 @@
-
 import CircularJSON = require('circular-json');
 
-var replacer = (key: any, val: any) => {
+const replacer = (key: any, val: any) => {
   return val;
-}
+};
 
-var replacerArray = ['a', 'x'];
+const replacerArray = ['a', 'x'];
 
 // implements JSON interface
-var json_obj: JSON = CircularJSON;
+const json_obj: JSON = CircularJSON;
 
 CircularJSON.parse('{"a":"b"}');
 

--- a/types/circular-json/index.d.ts
+++ b/types/circular-json/index.d.ts
@@ -1,12 +1,11 @@
-// Type definitions for circular-json v0.1.6
+// Type definitions for circular-json v0.1.31
 // Project: https://github.com/WebReflection/circular-json
 // Definitions by: Jonathan Pevarnek <https://github.com/jpevarnek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-
 interface ICircularJSON extends JSON {
     parse(text: string, reviver?: (key: any, value: any) => any): any;
-    stringify(value: any, replacer?: ((key: string, value: any) => any) | any[], space?: any, placeholder?: boolean): string;
+    stringify(value: any, replacer?: ((key: string, value: any) => any) | Array<number | string> | null, space?: any, placeholder?: boolean): string;
 }
 
 declare var CircularJSON: ICircularJSON;

--- a/types/circular-json/index.d.ts
+++ b/types/circular-json/index.d.ts
@@ -1,13 +1,7 @@
-// Type definitions for circular-json v0.1.31
+// Type definitions for circular-json 0.4
 // Project: https://github.com/WebReflection/circular-json
 // Definitions by: Jonathan Pevarnek <https://github.com/jpevarnek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface ICircularJSON extends JSON {
-    parse(text: string, reviver?: (key: any, value: any) => any): any;
-    stringify(value: any, replacer?: ((key: string, value: any) => any) | Array<number | string> | null, space?: any, placeholder?: boolean): string;
-}
-
-declare var CircularJSON: ICircularJSON;
-
-export = CircularJSON;
+export function parse(text: string, reviver?: (key: any, value: any) => any): any;
+export function stringify(value: any, replacer?: ((key: string, value: any) => any) | Array<number | string> | null, space?: any, placeholder?: boolean): string;

--- a/types/circular-json/tslint.json
+++ b/types/circular-json/tslint.json
@@ -1,7 +1,3 @@
 {
-	"extends": "dtslint/dt.json",
-	"rules": {
-		"dt-header": false,
-		"interface-name": false
-	}
+	"extends": "dtslint/dt.json"
 }

--- a/types/circular-json/tslint.json
+++ b/types/circular-json/tslint.json
@@ -1,0 +1,7 @@
+{
+	"extends": "dtslint/dt.json",
+	"rules": {
+		"dt-header": false,
+		"interface-name": false
+	}
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WebReflection/circular-json#api https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
