### PR TITLE
activeIndex and activeShape parameters of Pie component are optional

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -345,8 +345,8 @@ export interface PieProps extends Partial<CSSStyleDeclaration> {
 	label?: boolean | any | React.ReactElement<any> | RechartsFunction;
 	labelLine?: boolean | any | React.ReactElement<any> | RechartsFunction;
 	data: any[];
-	activeIndex: any[];
-	activeShape: any | React.ReactElement<any> | RechartsFunction;
+	activeIndex?: number | number[];
+	activeShape?: any | React.ReactElement<any> | RechartsFunction;
 	isAnimationActive?: boolean;
 	animationBegin?: number;
 	animationEasing?: AnimationEasingType | RechartsFunction;


### PR DESCRIPTION
Pie's `activeIndex` and `activeShape` are optional parameters. Also, `activeIndex` can contains numbers and array of numbers, not an array of any. Correct typings defined in PropTypes (`/src/polar/Pie.js`).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://recharts.org/#/en-US/api/Pie