### PR TITLE
Include the option to add customized buttons to the toolbar

### DIFF
--- a/types/medium-editor/index.d.ts
+++ b/types/medium-editor/index.d.ts
@@ -1,26 +1,22 @@
-// Type definitions for medium-editor v5.0.0
+// Type definitions for medium-editor 5.0
 // Project: https://yabwe.github.io/medium-editor/
 // Definitions by: keika299 <https://github.com/keika299>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace MediumEditor {
-
-    export interface MediumEditor {
-
+    export class MediumEditor {
         // Initialization Functions
-        new (elements: elementType, options?: CoreOptions): MediumEditor;
+        constructor(elements: elementType, options?: CoreOptions);
         destroy(): void;
         setup(): void;
         addElements(elements: elementType): void;
         removeElements(elements: elementType): void;
 
         // Event Functions
-        on(targets: HTMLElement | NodeList, event: string, listener: (event: Event) => void, useCapture: boolean): MediumEditor;
         on(targets: HTMLElement | NodeList, event: string, listener: EventListenerOrEventListenerObject, useCapture: boolean): MediumEditor;
-        off(targets: HTMLElement | NodeList, event: string, listener: Function, useCapture: boolean): MediumEditor;
         off(targets: HTMLElement | NodeList, event: string, listener: EventListenerOrEventListenerObject, useCapture: boolean): MediumEditor;
         subscribe(name: string, listener: (data: any, editable: HTMLElement) => void): MediumEditor;
-        unsubscribe(name: string, listener: Function): MediumEditor;
+        unsubscribe(name: string, listener: (data: any, editable: HTMLElement) => void): MediumEditor;
         trigger(name: string, data: any, editable: HTMLElement): MediumEditor;
 
         // Selection Functions
@@ -39,14 +35,13 @@ declare namespace MediumEditor {
         // Editor Action Functions
         cleanPaste(text: string): void;
         createLink(opts: CreateLinkOptions): void;
-        execAction(action: string, opts?: string): boolean;
-        execAction(action: string, opts?: CreateLinkOptions): boolean;
-        pasteHTML(html: string, options?:PasteHTMLOptions): void;
+        execAction(action: string, opts?: string | CreateLinkOptions): boolean;
+        pasteHTML(html: string, options?: PasteHTMLOptions): void;
         queryCommandState(action: string): boolean;
 
         // Helper Functions
         checkContentChanged(editable?: HTMLElement): void;
-        delay(fn: Function): void;
+        delay(fn: () => any): void;
         getContent(index?: number): string;
         getExtensionByName(name: string): any;
         resetContent(element: HTMLElement): void;
@@ -62,8 +57,8 @@ declare namespace MediumEditor {
             minor: number;
             revision: number;
             preRelease: string;
-            toString: Function;
-        }
+            toString(): string;
+        };
     }
 
     export interface CoreOptions {
@@ -131,11 +126,11 @@ declare namespace MediumEditor {
     export interface PasteOptions {
         forcePlainText?: boolean;
         cleanPastedHTML?: boolean;
-        preCleanReplacements?: any[],
-        cleanReplacements?: any[],
+        preCleanReplacements?: any[];
+        cleanReplacements?: any[];
         cleanAttrs?: string[];
         cleanTags?: string[];
-        unwrapTags?: string[],
+        unwrapTags?: string[];
     }
 
     export interface KeyboardCommandsOptions {
@@ -156,7 +151,7 @@ declare namespace MediumEditor {
         buttonClass?: string;
     }
 
-    export interface PasteHTMLOptions{
+    export interface PasteHTMLOptions {
         cleanAttrs?: string[];
         cleanTags?: string[];
         unwrapTags?: string[];
@@ -177,11 +172,12 @@ declare namespace MediumEditor {
 
     export type Button = string | ButtonOptions;
     export type elementType = string | HTMLElement | HTMLElement[] | NodeList | NodeListOf<Element> | HTMLCollection;
-    export type selectionObject = {start: number, end: number};
+    export interface selectionObject {
+        start: number;
+        end: number;
+    }
 }
 
-declare var MediumEditor: MediumEditor.MediumEditor;
-
 declare module "medium-editor" {
-    export = MediumEditor;
+    export = MediumEditor.MediumEditor;
 }

--- a/types/medium-editor/index.d.ts
+++ b/types/medium-editor/index.d.ts
@@ -94,7 +94,7 @@ declare namespace MediumEditor {
     export interface ToolbarOptions {
         align?: string;
         allowMultiParagraphSelection?: boolean;
-        buttons?: string[];
+        buttons?: Button[];
         diffLeft?: number;
         diffTop?: number;
         firstButtonClass?: string;
@@ -162,6 +162,20 @@ declare namespace MediumEditor {
         unwrapTags?: string[];
     }
 
+    export interface ButtonOptions {
+        name?: string;
+        action?: string;
+        aria?: string;
+        tagNames?: string[];
+        style?: { prop: string, value: string };
+        useQueryState?: boolean;
+        contentDefault?: string;
+        contentFA?: string;
+        classList?: string[];
+        attrs?: { [key: string]: string };
+    }
+
+    export type Button = string | ButtonOptions;
     export type elementType = string | HTMLElement | HTMLElement[] | NodeList | NodeListOf<Element> | HTMLCollection;
     export type selectionObject = {start: number, end: number};
 }

--- a/types/medium-editor/index.d.ts
+++ b/types/medium-editor/index.d.ts
@@ -4,9 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare namespace MediumEditor {
-    export class MediumEditor {
+    export interface MediumEditor {
         // Initialization Functions
-        constructor(elements: elementType, options?: CoreOptions);
+        new(elements: elementType, options?: CoreOptions): MediumEditor;
         destroy(): void;
         setup(): void;
         addElements(elements: elementType): void;
@@ -178,6 +178,8 @@ declare namespace MediumEditor {
     }
 }
 
+declare var MediumEditor: MediumEditor.MediumEditor;
+
 declare module "medium-editor" {
-    export = MediumEditor.MediumEditor;
+    export = MediumEditor;
 }

--- a/types/medium-editor/medium-editor-tests.ts
+++ b/types/medium-editor/medium-editor-tests.ts
@@ -14,7 +14,7 @@ var editor = new MediumEditor('.editable', {
     delay: 1000,
     targetBlank: true,
     toolbar: {
-        buttons: ['bold', 'italic', 'quote'],
+        buttons: ['bold', 'italic', 'quote', { name: 'underline', classList: ['icon-strike'] }],
         diffLeft: 25,
         diffTop: 10,
     },

--- a/types/medium-editor/medium-editor-tests.ts
+++ b/types/medium-editor/medium-editor-tests.ts
@@ -1,16 +1,18 @@
+import MediumEditor = require('medium-editor');
+
 /**
  * Test document usage
  */
 
 // Init Example
-var editor = new MediumEditor('.editable');
+const editor1 = new MediumEditor('.editable');
 
-var elements = document.querySelectorAll('.editable');
-var editor = new MediumEditor(elements);
+const elements = document.querySelectorAll('.editable');
+const editor2 = new MediumEditor(elements);
 
-var editor = new MediumEditor(elements,{});
+const editor3 = new MediumEditor(elements, {});
 
-var editor = new MediumEditor('.editable', {
+const editor4 = new MediumEditor('.editable', {
     delay: 1000,
     targetBlank: true,
     toolbar: {
@@ -37,8 +39,7 @@ var editor = new MediumEditor('.editable', {
     }
 });
 
-
 // API Example
 
-var editor = new MediumEditor('.editable');
-editor.subscribe('editableInput', function (event, editable) {});
+const editor = new MediumEditor('.editable');
+editor.subscribe('editableInput', (event: any, editable: HTMLElement) => {});

--- a/types/medium-editor/tslint.json
+++ b/types/medium-editor/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/medium-editor/tslint.json
+++ b/types/medium-editor/tslint.json
@@ -1,3 +1,0 @@
-{
-    "extends": "dtslint/dt.json"
-}


### PR DESCRIPTION
Add the option to add customized buttons to the toolbar.

It is not documented, but there are multiple references in bug reports as the way to create a customized button:

https://github.com/yabwe/medium-editor/issues/890

It is explicitly described in the `spec/button.spec.js` in the repository:

https://github.com/yabwe/medium-editor/blob/9b511b2ae12f6481f6645b83d9878039e5ca8d0a/spec/buttons.spec.js

I tried to change the current code to fix all the lint errors, but I do not know how to make the linter happy and keep current code working:
