### PR TITLE
fix(async): doWhilst, doUntil definitions and tests

### DIFF
--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -174,9 +174,9 @@ export function parallel<T, E>(tasks: Dictionary<AsyncFunction<T, E>>, callback?
 export function parallelLimit<T, E>(tasks: Array<AsyncFunction<T, E>>, limit: number, callback?: AsyncResultArrayCallback<T, E>): void;
 export function parallelLimit<T, E>(tasks: Dictionary<AsyncFunction<T, E>>, limit: number, callback?: AsyncResultObjectCallback<T, E>): void;
 export function whilst<E>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
-export function doWhilst<E>(fn: AsyncVoidFunction<E>, test: () => boolean, callback: ErrorCallback<E>): void;
+export function doWhilst<E>(fn: AsyncVoidFunction<E>, test: (result?: any) => boolean, callback: ErrorCallback<E>): void;
 export function until<E>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
-export function doUntil<E>(fn: AsyncVoidFunction<E>, test: () => boolean, callback: ErrorCallback<E>): void;
+export function doUntil<E>(fn: AsyncVoidFunction<E>, test: (result?: any) => boolean, callback: ErrorCallback<E>): void;
 export function during<E>(test: (testCallback : AsyncBooleanResultCallback<E>) => void, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
 export function doDuring<E>(fn: AsyncVoidFunction<E>, test: (testCallback: AsyncBooleanResultCallback<E>) => void, callback: ErrorCallback<E>): void;
 export function forever<E>(next: (next : ErrorCallback<E>) => void, errBack: ErrorCallback<E>) : void;

--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -174,9 +174,9 @@ export function parallel<T, E>(tasks: Dictionary<AsyncFunction<T, E>>, callback?
 export function parallelLimit<T, E>(tasks: Array<AsyncFunction<T, E>>, limit: number, callback?: AsyncResultArrayCallback<T, E>): void;
 export function parallelLimit<T, E>(tasks: Dictionary<AsyncFunction<T, E>>, limit: number, callback?: AsyncResultObjectCallback<T, E>): void;
 export function whilst<E>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
-export function doWhilst<E>(fn: AsyncVoidFunction<E>, test: (result?: any) => boolean, callback: ErrorCallback<E>): void;
+export function doWhilst<T, E>(fn: AsyncFunction<T, E>, test: (result?: any) => boolean, callback: ErrorCallback<E>): void;
 export function until<E>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
-export function doUntil<E>(fn: AsyncVoidFunction<E>, test: (result?: any) => boolean, callback: ErrorCallback<E>): void;
+export function doUntil<T, E>(fn: AsyncFunction<T, E>, test: (result?: any) => boolean, callback: ErrorCallback<E>): void;
 export function during<E>(test: (testCallback : AsyncBooleanResultCallback<E>) => void, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
 export function doDuring<E>(fn: AsyncVoidFunction<E>, test: (testCallback: AsyncBooleanResultCallback<E>) => void, callback: ErrorCallback<E>): void;
 export function forever<E>(next: (next : ErrorCallback<E>) => void, errBack: ErrorCallback<E>) : void;

--- a/types/async/index.d.ts
+++ b/types/async/index.d.ts
@@ -15,6 +15,7 @@ export interface AsyncResultArrayCallback<T, E> { (err?: E, results?: (T | undef
 export interface AsyncResultObjectCallback<T, E> { (err: E | undefined, results: Dictionary<T | undefined>): void; }
 
 export interface AsyncFunction<T, E> { (callback: (err?: E, result?: T) => void): void; }
+export interface AsyncFunctionEx<T, E> { (callback: (err?: E, ...results: T[]) => void): void; }
 export interface AsyncIterator<T, E> { (item: T, callback: ErrorCallback<E>): void; }
 export interface AsyncForEachOfIterator<T, E> { (item: T, key: number|string, callback: ErrorCallback<E>): void; }
 export interface AsyncResultIterator<T, R, E> { (item: T, callback: AsyncResultCallback<R, E>): void; }
@@ -174,9 +175,9 @@ export function parallel<T, E>(tasks: Dictionary<AsyncFunction<T, E>>, callback?
 export function parallelLimit<T, E>(tasks: Array<AsyncFunction<T, E>>, limit: number, callback?: AsyncResultArrayCallback<T, E>): void;
 export function parallelLimit<T, E>(tasks: Dictionary<AsyncFunction<T, E>>, limit: number, callback?: AsyncResultObjectCallback<T, E>): void;
 export function whilst<E>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
-export function doWhilst<T, E>(fn: AsyncFunction<T, E>, test: (result?: any) => boolean, callback: ErrorCallback<E>): void;
+export function doWhilst<T, E>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean, callback: ErrorCallback<E>): void;
 export function until<E>(test: () => boolean, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
-export function doUntil<T, E>(fn: AsyncFunction<T, E>, test: (result?: any) => boolean, callback: ErrorCallback<E>): void;
+export function doUntil<T, E>(fn: AsyncFunctionEx<T, E>, test: (...results: T[]) => boolean, callback: ErrorCallback<E>): void;
 export function during<E>(test: (testCallback : AsyncBooleanResultCallback<E>) => void, fn: AsyncVoidFunction<E>, callback: ErrorCallback<E>): void;
 export function doDuring<E>(fn: AsyncVoidFunction<E>, test: (testCallback: AsyncBooleanResultCallback<E>) => void, callback: ErrorCallback<E>): void;
 export function forever<E>(next: (next : ErrorCallback<E>) => void, errBack: ErrorCallback<E>) : void;

--- a/types/async/test/explicit.ts
+++ b/types/async/test/explicit.ts
@@ -47,13 +47,13 @@ interface NumberCallback { (err?: Error, result?: number): void; }
 interface AsyncNumberGetter { (callback: NumberCallback): void; }
 
 var taskDict: Lookup<AsyncNumberGetter> = {
-    one: function(callback){
-        setTimeout(function(){
+    one: function(callback) {
+        setTimeout(function() {
             callback(undefined, 1);
         }, 200);
     },
-    two: function(callback){
-        setTimeout(function(){
+    two: function(callback) {
+        setTimeout(function() {
             callback(undefined, 2);
         }, 100);
     }

--- a/types/async/test/index.ts
+++ b/types/async/test/index.ts
@@ -239,16 +239,16 @@ async.parallelLimit({
 
 
 function whileFn(callback: any) {
-    count++;
-    setTimeout(callback, 1000);
+    setTimeout(() => callback(null, ++count), 1000);
 }
 
 function whileTest() { return count < 5; }
+function doWhileTest(count: number) { return count < 5; }
 var count = 0;
 async.whilst(whileTest, whileFn, function (err) { });
 async.until(whileTest, whileFn, function (err) { });
-async.doWhilst(whileFn, whileTest, function (err) { });
-async.doUntil(whileFn, whileTest, function (err) { });
+async.doWhilst(whileFn, doWhileTest, function (err) { });
+async.doUntil(whileFn, doWhileTest, function (err) { });
 
 async.during(function (testCallback) { testCallback(new Error(), false); }, function (callback) { callback() }, function (error) { console.log(error) });
 async.doDuring(function (callback) { callback() }, function (testCallback) { testCallback(new Error(), false); }, function (error) { console.log(error) });


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/caolan/async/blob/master/CHANGELOG.md#breaking-changes
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Breaking changes in version 2.0.0 explain that the test function for `doWhilst` and `doUntil` may take a non-Error argument passed from the iteratee callback, and that only `while` and `until` pass no arguments.

Additionally, though not in this PR due to a failure to define the API implementation with Typescript, the [documentation for doDuring](https://caolan.github.io/async/docs.html#doDuring) says that test function for `doDuring` can take any number of non-Error values passed from the iteratee callback followed by the test function callback ie. `testFunction(...args, callback)`. Resulting in Typescript error: `A rest parameter must be last in a parameter list`.

## Relevant Section from Breaking Changes
> The test function for `whilst`, `until`, and `during` used to be passed non-error args from the iteratee function's callback, but this led to weirdness where the first call of the test function would be passed no args. We have made it so the test function is never passed extra arguments, and only the `doWhilst`, `doUntil`, and `doDuring` functions pass iteratee callback arguments to the test function ([#1217](https://github.com/caolan/async/issues/1217), [#1224](https://github.com/caolan/async/issues/1224))
