### PR TITLE
[Jasmine] Add matchersUtil on jasmine object

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -128,6 +128,8 @@ declare namespace jasmine {
     type Expected<T> = T | ObjectContaining<T> | Any | Spy;
 
     var clock: () => Clock;
+    
+    var matchersUtil: MatchersUtil;
 
     function any(aclass: any): Any;
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -961,6 +961,16 @@ describe("Custom matcher: 'toBeGoofy'", () => {
             hyuk: 'this is fun'
         }).not.toBeGoofy();
     });
+    
+    it("has a proper message on failure", () => {
+        const actual = { hyuk: 'this is fun' };
+        
+        const matcher = customMatchers.toBeGoofy(jasmine.matchersUtil, []);
+        const result = matcher.compare(actual, null);
+        
+        expect(result.pass).toBe(false);
+        expect(result.message).toBe("Expected " + actual + " to be goofy, but it was not very goofy");
+    });
 });
 
 // test based on http://jasmine.github.io/2.5/custom_reporter.html


### PR DESCRIPTION
Bringing in line with https://github.com/jasmine/jasmine/blob/master/src/core/matchers/matchersUtil.js to do testing on custom matchers

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jasmine/jasmine/blob/master/src/core/matchers/matchersUtil.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.