### PR TITLE
@types/sequelize add missing useCLS function def

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -17,6 +17,7 @@
 
 import * as _ from "lodash";
 import * as Promise from "bluebird";
+import * as cls from "continuation-local-storage"
 
 declare namespace sequelize {
 
@@ -5739,6 +5740,7 @@ declare namespace sequelize {
          * Provide access to continuation-local-storage (http://docs.sequelizejs.com/en/latest/api/sequelize/#transactionoptions-promise)
          */
         cls: any;
+        useCLS(namespace:cls.Namespace): Sequelize;
 
     }
 


### PR DESCRIPTION
The definition for types/sequelize does not have [useCLS](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#static-method-useCLS) function. For setting CLS only way is to use `Sequelize.cls = namespace` but this gives a warning:

> sequelize deprecated Sequelize.cls should not be set directly. Use Sequelize.useCLS(). node_modules/sequelize/lib/sequelize.js:1031:11

This PR adds a the missing useCLS function.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
