### PR TITLE
Add type definition for react-widgets-moment.

### DIFF
--- a/types/react-widgets-moment/index.d.ts
+++ b/types/react-widgets-moment/index.d.ts
@@ -1,0 +1,6 @@
+// Type definitions for react-widgets-moment 4.0
+// Project: https://github.com/jquense/react-widgets#readme
+// Definitions by: Janeene Beeforth <https://github.com/dawnmist>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export default function momentLocalizer(): void;

--- a/types/react-widgets-moment/react-widgets-moment-tests.ts
+++ b/types/react-widgets-moment/react-widgets-moment-tests.ts
@@ -1,0 +1,6 @@
+import * as moment from 'moment';
+import momentLocalizer from 'react-widgets-moment';
+
+// Usage example from http://jquense.github.io/react-widgets/localization/
+moment.locale('en');
+momentLocalizer();

--- a/types/react-widgets-moment/tsconfig.json
+++ b/types/react-widgets-moment/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-widgets-moment-tests.ts"
+    ]
+}

--- a/types/react-widgets-moment/tslint.json
+++ b/types/react-widgets-moment/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is used to set up locale data for the Calendar/Date Picker widgets in react-widgets.
Documentation: http://jquense.github.io/react-widgets/localization/

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
