### PR TITLE
react-router-dom - Added missing location property to NavLinkProps

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -52,5 +52,6 @@ export interface NavLinkProps extends LinkProps {
     exact?: boolean;
     strict?: boolean;
     isActive?<P>(match: match<P>, location: H.Location): boolean;
+    location?: H.Location;
 }
 export class NavLink extends React.Component<NavLinkProps> {}

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React Router 4.0
+// Type definitions for React Router 4.2
 // Project: https://github.com/ReactTraining/react-router
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Huy Nguyen <https://github.com/huy-nguyen>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reacttraining.com/react-router/web/api/NavLink
- [x] Increase the version number in the header if appropriate.
NB. the CHANGELOG doesn't indicate which version this appeared in. I've bumped the version to 4.2 (current) as it is definitely post-4.0 (reported here: https://github.com/ReactTraining/react-router/issues/4910)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

