### PR TITLE
@types/chrome: Declare chrome.declarativeContent.onPageChanged, ShowPageAction, PageStateMatcher

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1426,8 +1426,7 @@ declare namespace chrome.declarativeContent {
         ports?: (number | number[])[];
     }
 
-    /** Matches the state of a web page by various criteria. */
-    interface PageStateMatcher {
+    class PageStateMatcherProperties {
         /** Optional. Filters URLs for various criteria. See event filtering. All criteria are case sensitive.  */
         pageUrl?: PageStateUrlDetails;
         /** Optional. Matches if all of the CSS selectors in the array match displayed elements in a frame with the same origin as the page's main frame. All selectors in this array must be compound selectors to speed up matching. Note that listing hundreds of CSS selectors or CSS selectors that match hundreds of times per page can still slow down web sites.  */
@@ -1439,6 +1438,19 @@ declare namespace chrome.declarativeContent {
          */
         isBookmarked?: boolean;
     }
+
+    /** Matches the state of a web page by various criteria. */
+    class PageStateMatcher {
+        constructor(options: PageStateMatcherProperties);
+    }
+
+    /** Declarative event action that shows the extension's page action while the corresponding conditions are met. */
+    class ShowPageAction {}
+
+    /** Provides the Declarative Event API consisting of addRules, removeRules, and getRules. */
+    interface PageChangedEvent extends chrome.events.Event<() => void> {}
+
+    var onPageChanged: PageChangedEvent;
 }
 
 ////////////////////
@@ -5126,7 +5138,7 @@ declare namespace chrome.runtime {
             actions?: {
                 type: string;
             }[];
-            conditions?: chrome.declarativeContent.PageStateMatcher[]
+            conditions?: chrome.declarativeContent.PageStateMatcherProperties[]
         }[];
         externally_connectable?: {
             ids?: string[];


### PR DESCRIPTION
Declare `chrome.declarativeContent.onPageChanged`, `chrome.declarativeContent.ShowPageAction`, `chrome.declarativeContent.PageStateMatcher`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://developer.chrome.com/extensions/declarativeContent#type-PageStateMatcher
https://developer.chrome.com/extensions/declarativeContent#type-ShowPageAction
https://developer.chrome.com/extensions/declarativeContent#event-onPageChanged
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
