### PR TITLE
rollup-plugin-json: Create type definition

### DIFF
--- a/types/rollup-plugin-json/index.d.ts
+++ b/types/rollup-plugin-json/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for rollup-plugin-json 2.3
+// Project: https://github.com/rollup/rollup-plugin-json#readme
+// Definitions by: Andy Mockler <https://github.com/asmockler>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Plugin } from 'rollup';
+
+export interface Options {
+    include?: string | string[];
+    exclude?: string | string[];
+    preferConst?: boolean;
+    indent?: string;
+}
+
+export default function json(options?: Options): Plugin;

--- a/types/rollup-plugin-json/rollup-plugin-json-tests.ts
+++ b/types/rollup-plugin-json/rollup-plugin-json-tests.ts
@@ -1,0 +1,3 @@
+import json from 'rollup-plugin-json';
+
+json(); // $ExpectType Plugin

--- a/types/rollup-plugin-json/tsconfig.json
+++ b/types/rollup-plugin-json/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "rollup-plugin-json-tests.ts"
+    ]
+}

--- a/types/rollup-plugin-json/tslint.json
+++ b/types/rollup-plugin-json/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Library: https://github.com/rollup/rollup-plugin-json

This library converts JSON files to ES6 modules in rollup builds.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
