### PR TITLE
[three]: Add color as valid type for light constructors

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -1917,9 +1917,9 @@ export class LightShadow {
 export class AmbientLight extends Light {
     /**
      * This creates a Ambientlight with a color.
-     * @param hex Numeric value of the RGB component of the color.
+     * @param color Numeric value of the RGB component of the color or a Color instance.
      */
-    constructor(hex?: number|string, intensity?: number);
+    constructor(color?: number|string|Color, intensity?: number);
 
     castShadow: boolean;
 }
@@ -1936,7 +1936,7 @@ export class AmbientLight extends Light {
  * @see <a href="https://github.com/mrdoob/three.js/blob/master/src/lights/DirectionalLight.js">src/lights/DirectionalLight.js</a>
  */
 export class DirectionalLight extends Light {
-    constructor(hex?: number|string, intensity?: number);
+    constructor(color?: number|string|Color, intensity?: number);
 
     /**
      * Target used for shadow camera orientation.
@@ -1957,7 +1957,7 @@ export class DirectionalLightShadow extends LightShadow {
 }
 
 export class HemisphereLight extends Light {
-    constructor(skyColorHex?: number|string, groundColorHex?: number|string, intensity?: number);
+    constructor(skyColor?: number|string|Color, groundColor?: number|string|Color, intensity?: number);
 
     groundColor: Color;
     intensity: number;
@@ -1972,7 +1972,7 @@ export class HemisphereLight extends Light {
  * scene.add( light );
  */
 export class PointLight extends Light {
-    constructor(hex?: number|string, intensity?: number, distance?: number, decay?: number);
+    constructor(color?: number|string|Color, intensity?: number, distance?: number, decay?: number);
 
     /*
         * Light's intensity.
@@ -1999,7 +1999,7 @@ export class PointLightShadow extends LightShadow {
  * A point light that can cast shadow in one direction.
  */
 export class SpotLight extends Light {
-    constructor(hex?: number|string, intensity?: number, distance?: number, angle?: number, exponent?: number, decay?: number);
+    constructor(color?: number|string|Color, intensity?: number, distance?: number, angle?: number, exponent?: number, decay?: number);
 
     /**
      * Spotlight focus points at target.position.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
 - Fixes #20772 
 - https://github.com/mrdoob/three.js/blob/dev/src/math/Color.js#L36-L37 
 - https://github.com/mrdoob/three.js/blob/dev/src/math/Color.js#L53-L55
- [ ] ~Increase the version number in the header if appropriate.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ (I don't have enough experience with the three package to feel comfortable with this.)

---

Patch Notes:
* I renamed the parameters to match the parameter names used in the source. Specifically, `hex` often became `color`.
* I did not add myself as an author in the index file because this is such a minor edit and I don't consider myself a maintainer.