### PR TITLE
Fix duplicate definition of 'as' in react

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2790,7 +2790,6 @@ declare namespace React {
         rel?: string;
         sizes?: string;
         type?: string;
-        as?: string;
     }
 
     interface MapHTMLAttributes<T> extends HTMLAttributes<T> {


### PR DESCRIPTION
There was a conflict between #20628 and #20769 resulting in a duplicate property definition; this resolves it.