### PR TITLE
[redux-form] Export BaseFieldProps

### DIFF
--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -33,7 +33,7 @@ interface CommonFieldProps {
     onFocus: EventHandler<FocusEvent<any>>;
 }
 
-interface BaseFieldProps<P = {}> extends Partial<CommonFieldProps> {
+export interface BaseFieldProps<P = {}> extends Partial<CommonFieldProps> {
     name: string;
     component?: ComponentType<P> | "input" | "select" | "textarea",
     format?: Formatter | null;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -11,6 +11,7 @@ import {
     formValueSelector,
     Field,
     GenericField,
+    BaseFieldProps,
     WrappedFieldProps,
     Fields,
     GenericFields,
@@ -124,6 +125,11 @@ const MyField: StatelessComponent<MyFieldProps> = ({
     return null;
 };
 const FieldCustom = Field as new () => GenericField<MyFieldCustomProps>;
+
+type FieldProps = BaseFieldProps<MyFieldCustomProps> & MyFieldCustomProps;
+const FieldCustomComp: StatelessComponent<FieldProps> = props => (
+    <FieldCustom {...props} component={MyField} />
+)
 
 const MyFieldImm: StatelessComponent<MyFieldProps> = ({
     children,
@@ -259,6 +265,11 @@ const Test = reduxForm({
                             <FieldCustom
                                 name="field4"
                                 component={ MyField }
+                                foo="bar"
+                            />
+
+                            <FieldCustomComp
+                                name="field_4_comp"
                                 foo="bar"
                             />
 


### PR DESCRIPTION
This PR just exports BaseFieldProps to allow this style of using custom fields:

```jsx
<FieldCustomComp name="field_4_comp" foo="bar" />
```

instead (in addition) of this:
```jsx
<FieldCustom name="field4" component={ MyField } foo="bar" />
```
I prefer this style because it is more concise, and if you declare `FieldCustom` you are unlikely to use it with component other than `MyField` anyway, so why not to take one more step and declare `FieldCustomComp`.
 

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
