### PR TITLE
Remove duplicated `as` in React. It's failing in nightly

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2782,7 +2782,6 @@ declare namespace React {
     }
 
     interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
-        as?: string;
         href?: string;
         hrefLang?: string;
         integrity?: string;


### PR DESCRIPTION
remove duplicated `as`

![image](https://user-images.githubusercontent.com/461084/31860790-06e1d796-b6ff-11e7-90e8-33368c9dd434.png)


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

