### PR TITLE
add missing function signature to @types/tape

### DIFF
--- a/types/tape/index.d.ts
+++ b/types/tape/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for tape v4.2.29
+// Type definitions for tape v4.2.30
 // Project: https://github.com/substack/tape
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 //                 Haoqun Jiang <https://github.com/sodatea>
 //                 Dennis Schwartz <https://github.com/DennisSchwartz>
+//                 Michael Henretty <https://github.com/mikehenrty>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -73,6 +74,7 @@ declare namespace tape {
          * Additional tests queued up after t will not be run until all subtests finish.
          */
         test(name: string, cb: tape.TestCase): void;
+        test(name: string, opts: TestOptions, cb: tape.TestCase): void;
 
         /**
          * Declare that n assertions should be run. end() will be called automatically after the nth assertion.

--- a/types/tape/tape-tests.ts
+++ b/types/tape/tape-tests.ts
@@ -156,5 +156,9 @@ tape(name, (test: tape.Test) => {
 		t = st;
 	});
 
+	test.test(name, opts, (st) => {
+		t = st;
+	});
+
 	test.comment(msg);
 });


### PR DESCRIPTION
There is simply a missing definition for a function signature in the tape package. I updated the tests to reflect this.

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x] Test the change in your own code. (Compile and run.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/substack/tape#ttestname-opts-cb
- [ x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

