### PR TITLE
rc-slider: Add definitions for props 'dotStyle' and 'activeDotStyle'

### DIFF
--- a/types/rc-slider/README.md
+++ b/types/rc-slider/README.md
@@ -5,7 +5,7 @@
 This package contains type definitions for rc-slider (https://github.com/react-component/slider).
 
 Additional Details
- * Last updated: Tue, 11 Oct 2017
+ * Last updated: Mon, 23 Oct 2017
  * Dependencies: react
  * Global values: none
 

--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for rc-slider 8.1
+// Type definitions for rc-slider 8.2
 // Project: https://github.com/react-component/slider
 // Definitions by: Marcinkus Mantas <https://github.com/mantasmarcinkus>, Alexander Mattoni <https://github.com/mattoni>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -103,6 +103,16 @@ export interface CommonApiProps {
      * The style used for the track base color.
      */
     railStyle?: React.CSSProperties;
+
+    /**
+     * The style used for the dots.
+     */
+    dotStyle?: React.CSSProperties;
+
+    /**
+     * The style used for the active dots.
+     */
+    activeDotStyle?: React.CSSProperties;
 }
 
 export interface SliderProps extends CommonApiProps {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-component/slider#common-api
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **-> Not applicable.**

