### PR TITLE
React-Router v2 Link: extend LinkHTMLAttributes instead of HTMLAttributes

### DIFF
--- a/types/react-router/v2/lib/Link.d.ts
+++ b/types/react-router/v2/lib/Link.d.ts
@@ -7,7 +7,7 @@ type Link = Link.Link;
 export default Link;
 
 declare namespace Link {
-    interface LinkProps extends React.HTMLAttributes<Link> {
+    interface LinkProps extends React.LinkHTMLAttributes<Link> {
         activeStyle?: React.CSSProperties;
         activeClassName?: string;
         onlyActiveOnIndex?: boolean;


### PR DESCRIPTION
After upgrading my project's @types/react to `15.6`, I started getting errors where the `rel` property is not found. Extending `LinkHTMLAttributes` is more specific and fixes this problem.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
