### PR TITLE
Added missing DocumentFragment to jsdom definition

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -11,6 +11,9 @@ import { MarkupData } from 'parse5';
 import * as tough from 'tough-cookie';
 import { Script } from 'vm';
 
+// Stub declaration when no "dom" lib is present
+interface DocumentFragument { }
+
 export class JSDOM {
     static fromURL(url: string, options?: FromUrlOptions): Promise<JSDOM>;
 

--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -12,7 +12,7 @@ import * as tough from 'tough-cookie';
 import { Script } from 'vm';
 
 // Stub declaration when no "dom" lib is present
-interface DocumentFragument { }
+export interface DocumentFragument { }
 
 export class JSDOM {
     static fromURL(url: string, options?: FromUrlOptions): Promise<JSDOM>;

--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -12,7 +12,7 @@ import * as tough from 'tough-cookie';
 import { Script } from 'vm';
 
 // Stub declaration when no "dom" lib is present
-export interface DocumentFragument { }
+export interface DocumentFragment { }
 
 export class JSDOM {
     static fromURL(url: string, options?: FromUrlOptions): Promise<JSDOM>;


### PR DESCRIPTION
`error TS2304: Cannot find name 'DocumentFragment'.` is thrown when compiling in tsc without the `"dom"` library.