### PR TITLE
Correct gen-readlines function return type

### DIFF
--- a/types/gen-readlines/gen-readlines-tests.ts
+++ b/types/gen-readlines/gen-readlines-tests.ts
@@ -6,10 +6,10 @@ import readlines = require("gen-readlines");
 const fd = fs.openSync('./somefile.txt', 'r');
 const stats = fs.fstatSync(fd);
 
-let str: string;
+let buff: Buffer;
 
 for (const line of readlines(fd, stats.size)) {
-    str = line;
+    buff = line;
     console.log(line.toString());
 }
 
@@ -18,7 +18,7 @@ fs.closeSync(fd);
 fs.open('./test_data/hipster.txt', 'r', (err, fd) => {
     fs.fstat(fd, (err, stats) => {
         for (const line of readlines(fd, stats.size, 64 * 0x400, 0)) {
-            str = line;
+            buff = line;
             console.log(line.toString());
         }
     });

--- a/types/gen-readlines/index.d.ts
+++ b/types/gen-readlines/index.d.ts
@@ -13,6 +13,6 @@
  *
  * @returns The generator object, yeilding each line as a string
  */
-declare function readlines(fd: number, filesize: number, bufferSize?: number, position?: number): IterableIterator<string>;
+declare function readlines(fd: number, filesize: number, bufferSize?: number, position?: number): IterableIterator<Buffer>;
 
 export = readlines;


### PR DESCRIPTION
Update generator function to return Buffer instead of string [as per documentation](https://www.npmjs.com/package/gen-readlines#usage).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/gen-readlines#usage
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.