### PR TITLE
Export BaseFieldProps interface

### DIFF
--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -33,7 +33,7 @@ interface CommonFieldProps {
     onFocus: EventHandler<FocusEvent<any>>;
 }
 
-interface BaseFieldProps<P = {}> extends Partial<CommonFieldProps> {
+export interface BaseFieldProps<P = {}> extends Partial<CommonFieldProps> {
     name: string;
     component?: ComponentType<P> | "input" | "select" | "textarea",
     format?: Formatter | null;


### PR DESCRIPTION
Export `BaseFieldProps` to extend `Field` props, example code:

```
import * as React from 'react'

import {
  Form
} from 'antd'
import {
  WrappedFieldProps,
  Field,
  BaseFieldProps
} from 'redux-form'

interface SharedProps {
  label?: any
  required?: boolean
}

interface ComponentProps extends WrappedFieldProps, SharedProps { }

interface FieldProps extends BaseFieldProps, SharedProps { }

const Component: React.ComponentType<ComponentProps> = ({
  input,
  label,
  required
}: ComponentProps) =>
  <Form.Item
    label={label}
    required={required}
    colon={false}
  >
    <span className="ant-form-text">{input.value}</span>
  </Form.Item>

export default (props: FieldProps) => <Field {...props} component={Component} />
```