### PR TITLE
Update knex to preserve type information

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Knex.js
 // Project: https://github.com/tgriesser/knex
-// Definitions by: Qubo <https://github.com/tkQubo>, Baronfel <https://github.com/baronfel>
+// Definitions by: Qubo <https://github.com/tkQubo>, Baronfel <https://github.com/baronfel>, Pablo Rodríguez <https://github.com/MeLlamoPablo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -8,7 +8,7 @@
 
 import events = require("events");
 import stream = require ("stream");
-import Promise = require("bluebird");
+import Bluebird = require("bluebird");
 
 type Callback = Function;
 type Client = Function;
@@ -22,9 +22,9 @@ interface Knex extends Knex.QueryInterface {
     __knex__: string;
 
     raw: Knex.RawBuilder;
-    transaction(transactionScope: (trx: Knex.Transaction) => any): Promise<any>;
+    transaction<T>(transactionScope: (trx: Knex.Transaction) => Promise<T> | Bluebird<T> | void): Bluebird<T>;
     destroy(callback: Function): void;
-    destroy(): Promise<void>;
+    destroy(): Bluebird<void>;
     batchInsert(tableName : TableName, data: any[], chunkSize : number) : Knex.QueryBuilder;
     schema: Knex.SchemaBuilder;
     queryBuilder(): Knex.QueryBuilder;
@@ -351,7 +351,7 @@ declare namespace Knex {
         and: QueryBuilder;
 
         //TODO: Promise?
-        columnInfo(column?: string): Promise<ColumnInfo>;
+        columnInfo(column?: string): Bluebird<ColumnInfo>;
 
         forUpdate(): QueryBuilder;
         forShare(): QueryBuilder;
@@ -372,18 +372,18 @@ declare namespace Knex {
     // Chainable interface
     //
 
-    interface ChainableInterface extends Promise<any> {
+    interface ChainableInterface extends Bluebird<any> {
         toQuery(): string;
         options(options: any): QueryBuilder;
-        stream(callback: (readable: stream.PassThrough) => any): Promise<any>;
+        stream(callback: (readable: stream.PassThrough) => any): Bluebird<any>;
         stream(options?: { [key: string]: any }): stream.PassThrough;
-        stream(options: { [key: string]: any }, callback: (readable: stream.PassThrough) => any): Promise<any>;
+        stream(options: { [key: string]: any }, callback: (readable: stream.PassThrough) => any): Bluebird<any>;
         pipe(writable: any): stream.PassThrough;
         exec(callback: Function): QueryBuilder;
     }
 
     interface Transaction extends Knex {
-        savepoint(transactionScope: (trx: Transaction) => any): Promise<any>;
+        savepoint(transactionScope: (trx: Transaction) => any): Bluebird<any>;
         commit(value?: any): QueryBuilder;
         rollback(error?: any): QueryBuilder;
     }
@@ -392,14 +392,14 @@ declare namespace Knex {
     // Schema builder
     //
 
-    interface SchemaBuilder extends Promise<any> {
+    interface SchemaBuilder extends Bluebird<any> {
         createTable(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
         createTableIfNotExists(tableName: string, callback: (tableBuilder: CreateTableBuilder) => any): SchemaBuilder;
-        renameTable(oldTableName: string, newTableName: string): Promise<void>;
+        renameTable(oldTableName: string, newTableName: string): Bluebird<void>;
         dropTable(tableName: string): SchemaBuilder;
-        hasTable(tableName: string): Promise<boolean>;
-        hasColumn(tableName: string, columnName: string): Promise<boolean>;
-        table(tableName: string, callback: (tableBuilder: AlterTableBuilder) => any): Promise<void>;
+        hasTable(tableName: string): Bluebird<boolean>;
+        hasColumn(tableName: string, columnName: string): Bluebird<boolean>;
+        table(tableName: string, callback: (tableBuilder: AlterTableBuilder) => any): Bluebird<void>;
         dropTableIfExists(tableName: string): SchemaBuilder;
         raw(statement: string): SchemaBuilder;
         withSchema(schemaName: string): SchemaBuilder;
@@ -666,11 +666,11 @@ declare namespace Knex {
     }
 
     interface Migrator {
-        make(name: string, config?: MigratorConfig): Promise<string>;
-        latest(config?: MigratorConfig): Promise<any>;
-        rollback(config?: MigratorConfig): Promise<any>;
-        status(config?: MigratorConfig): Promise<number>;
-        currentVersion(config?: MigratorConfig): Promise<string>;
+        make(name: string, config?: MigratorConfig): Bluebird<string>;
+        latest(config?: MigratorConfig): Bluebird<any>;
+        rollback(config?: MigratorConfig): Bluebird<any>;
+        status(config?: MigratorConfig): Bluebird<number>;
+        currentVersion(config?: MigratorConfig): Bluebird<string>;
     }
 
     interface FunctionHelper {

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -520,7 +520,6 @@ knex.transaction(function(trx) {
     })
     .then(trx.commit)
     .catch(trx.rollback);
-
 }).then(function() {
   console.log('Transaction complete.');
 }).catch(function(err) {
@@ -537,7 +536,17 @@ knex.transaction(function(trx) {
     .transacting(trx)
     .forShare()
     .select('*')
-});
+})
+
+const transactionReturnValue = knex.transaction(function(trx) {
+  return knex("table")
+    .insert({ foo: "bar" })
+    .returning(["id"])
+    .then(function(result) { return result[0].id as number })
+})
+
+// Tests that the transaction has kept the type of its return value by referencing a method of number
+transactionReturnValue.then(value => value.toExponential);
 
 knex('users').count('active');
 
@@ -616,7 +625,7 @@ knex.transaction(function(trx) {
 });
 
 // Using trx as a transaction object:
-knex.transaction(function(trx) {
+knex.transaction<{ length: number }>(function(trx) {
 
   trx.raw('');
 


### PR DESCRIPTION
Hello.

As it is now, `knex` loses type information when using the `transaction` method. Here's the desired result:

```typescript
const users = await knex.transaction(async (trx) => {
    const dbResponse = await trx("users")
        .insert({ name: "Foo" })
        .returning([ "id", "name" ]);
    return dbResponse.map(User.deserialize)
});

// users is Array<User>
```

With this code, we take the database return value outside of the transaction container (the callback passed to `transaction`) which can be beneficial, mainly to have cleaner code.

However, as it is now, `users` would be `any`, because `transaction` returns  `Promise<any>`.

Here are the justifications for all the changes made in this PR:

## Rename `Promise` to `Bluebird`

Previously, the `Promise` global type was being overridden by `Bluebird`. But with these changes we're going to need to use `Promise` too, so I've renamed all the invocations of `Promise` to `Bluebird`, so that the native Promise implementation can be referenced.

This makes sense to me: `Bluebird` is not `Promise`. `Bluebird` is `Bluebird`, so why would it take the name of `Promise`, thus preventing `Promise` to be referenced? I'll elaborate on why we need to reference it below.

## Adding a type parameter to `transaction` and return types to `transactionScope`

I've added a type parameter `T` to `transactionScope`. The developer can return three different types on `transactionScope`:

### `Bluebird<T>`

The result of knex queries are all bluebird, so this essentially enables most of the current code to work. An example of this would be:

```typescript
const users = await knex.transaction(trx => trx("users").select());
```

### `Promise<T>`

This enables compatibility with async funcions. If this wasn't in the return type, the "desired example" written above would be invalid because `Promise<T> is not assignable to Bluebird<T>`, which is perfectly valid otherwise.

### `void`

Finally, this enables existing code that returns nothing to work without any errors. In transactions where you only want to write data and don't care about return values, this is useful, because otherwise you'd have to return `Promise.resolve()` to work around `void` not being a valid return type.

That said, this change broke `knex-tests.ts`, but I believe that this is ok because the solution is simple.

First, let me explain why it broke: if you look at `knex-tests.ts:628`, a transaction that does some inserts is being defined. But the `transactionScope` function does not return anything (returns `void`). When `void` is returned, TypeScript can't infer a value for `T`, so the return type for `transaction` ends up being `Bluebird<{}>`. The defined function in the test attaches a `then` to the return value of `transaction`, and uses `inserts.length`. `length` does not exist on `{}`, therefore the test breaks. This worked before because the return value of  `transaction` was `Bluebird<any>`.

This code is correct because it's calling `trx.commit` and `trx.rollback` manually. [From the docs](http://knexjs.org/#Transactions):

> Notice that if a promise is not returned within the handler, it is up to you to ensure trx.commit, or trx.rollback are called, otherwise the transaction connection will hang.

So, this is valid code, but TypeScript can't infer `T` because it can't check where is `trx.commit` being called and with which parameters at compile time. The solution is manually passing the type parameter:

```typescript
knex.transaction<any>(function(trx) {
    // ...
});
```

That snippet will get the old behaviour back. And the upside is that a custom type definition can also be passed, like in `knex-tests.ts:628`.

Thanks for being able to put up with this wall of text :)

===================================

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
    - I'm having trouble compiling the project: I get "unknown compiler option strictFunctionTypes". I didn't change `tsconfig.json` though, so I figured it would be OK to send this PR. Please let me know if there's anything else I need to do. Here's the full log:
    ```sh
    $ pwd
    (...) DefinitelyTyped/types/knex
    
    $ ../../node_modules/.bin/tsc --version
    Version 2.6.0-dev.20170930
    
    $ ../../node_modules/.bin/tsc
    tsconfig.json(11,9): error TS5023: Unknown compiler option 'strictFunctionTypes'.
    ```

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://knexjs.org/#Transactions
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.