### PR TITLE
[thrift] Update thrift to use the more universal http.RequestOptions

### DIFF
--- a/types/thrift/index.d.ts
+++ b/types/thrift/index.d.ts
@@ -249,7 +249,7 @@ export interface ConnectOptions {
     retry_max_delay?: number;
     connect_timeout?: number;
     timeout?: number;
-    nodeOptions?: http.ClientRequestArgs;
+    nodeOptions?: http.RequestOptions;
 }
 
 export interface WSConnectOptions {

--- a/types/thrift/thrift-tests.ts
+++ b/types/thrift/thrift-tests.ts
@@ -1,3 +1,5 @@
+import * as http from 'http';
+
 import {
   createConnection,
   createServer,
@@ -41,9 +43,17 @@ const mockGeneratedService = {
 
 createServer<MockProcessor, MockServiceHandlers>(mockGeneratedService, mockServiceHandlers);
 
+const nodeOptions: http.RequestOptions = {
+    timeout: 10000,
+    headers: {
+        'Content-Type': 'application/octet-stream'
+    }
+};
+
 const clientConnection = createConnection('0.0.0.0', 1234, {
   transport: TBufferedTransport,
-  protocol: TBinaryProtocol
+  protocol: TBinaryProtocol,
+  nodeOptions
 });
 createClient<MockClient>(mockGeneratedService, clientConnection);
 


### PR DESCRIPTION
  * The RequestOptions interface is more universal across node versions than
    the ClientRequestArgs interface which is specific to Node v8.
  * Even in v8 RequestOptions is used in https module.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L849
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
