### PR TITLE
fix(gulp-util): add chalk as a dependency

### DIFF
--- a/types/gulp-util/package.json
+++ b/types/gulp-util/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "chalk": "^2.2.0"
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chalk/chalk/commit/f653b061d6fbdb1c7224f7d80476391202c47877
---
As of [`chalk@2.2.0`](https://github.com/chalk/chalk/releases/tag/v2.2.0) the project is providing its own type definitions. `gulp-util` depends on these definitions, so the package needs to be updated to reflect that dependency.

There's a related PR to remove the `chalk` type definitions (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20789) from this repo. There I asked what's the right process to indicate said dependency, so this PR is simply fulfilling the advice given by @andy-ms on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20789#issuecomment-339042005.