### PR TITLE
Fix react-list export

### DIFF
--- a/types/react-list/index.d.ts
+++ b/types/react-list/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-list 0.8
 // Project: https://github.com/orgsync/react-list
-// Definitions by: Yifei Yan <https://github.com/buptyyf>
+// Definitions by: Yifei Yan <https://github.com/buptyyf>, Tom Shen <https://github.com/tomshen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -8,22 +8,14 @@ import {
     Component,
     Props
 } from "react";
-export as namespace ReactList;
 
-/*~ If this module has methods, declare them as functions like so.
- */
-export function scrollTo(index: number): void;
-export function scrollAround(index: number): void;
-export function getVisibleRange(): number[];
+type ItemRenderer = (index: number, key: number | string) => JSX.Element;
+type ItemsRenderer = (items: JSX.Element[], ref: string) => JSX.Element;
+type ItemSizeEstimator = (index: number, cache: {}) => number;
+type ItemSizeGetter = (index: number) => number;
+type ScrollParentGetter = () => JSX.Element;
 
-/*~ You can declare types that are available via importing the module */
-export type ItemRenderer = (index: number, key: number | string) => JSX.Element;
-export type ItemsRenderer = (items: JSX.Element[], ref: string) => JSX.Element;
-export type ItemSizeEstimator = (index: number, cache: {}) => number;
-export type ItemSizeGetter = (index: number) => number;
-export type ScrollParentGetter = () => JSX.Element;
-
-export interface ReactListProps extends Props<ReactList> {
+interface ReactListProps extends Props<ReactList> {
     axis?: 'x' | 'y';
     initialIndex?: number;
     itemRenderer?: ItemRenderer;
@@ -40,4 +32,10 @@ export interface ReactListProps extends Props<ReactList> {
     useTranslate3d?: boolean;
 }
 
-export default class ReactList extends Component<ReactListProps> {}
+declare class ReactList extends Component<ReactListProps> {
+    scrollTo(index: number): void;
+    scrollAround(index: number): void;
+    getVisibleRange(): number[];
+}
+declare namespace ReactList { }
+export = ReactList;

--- a/types/react-list/react-list-tests.tsx
+++ b/types/react-list/react-list-tests.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-// import * as ReactDOM from "react-dom";
-import ReactList from "react-list";
+import * as ReactList from "react-list";
 
 const renderItem = (index: number, key: number) =>
     <div key={key} className={'item' + (index % 2 ? '' : ' even')}>


### PR DESCRIPTION
The issue with the existing typings is that the generated JS file does not use a default export, but a module.exports export.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/coderiety/react-list/blob/0.8.8/react-list.es6#L43
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
