### PR TITLE
[Redux-first-router] redirect and setKind do not require meta / payload properties to be set inside the action property / actionToPath has an optional querySerializer param

### DIFF
--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -194,7 +194,7 @@ export type Payload = object;
 
 export type ScrollUpdater = (performedByUser: boolean) => void;
 
-export const NOT_FOUND: string;
+export const NOT_FOUND: '@@redux-first-router/NOT_FOUND';
 
 export function actionToPath(action: ReceivedAction, routesMap: RoutesMap, querySerializer?: QuerySerializer): string;
 

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/faceyspacey/redux-first-router#readme
 // Definitions by: Valbrand <https://github.com/Valbrand>
 //                 viggyfresh <https://github.com/viggyfresh>
+//                 janb87 <https://github.com/janb87>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -113,8 +114,8 @@ export interface Meta {
 
 export interface Action {
     type: string;
-    payload: Payload;
-    meta: Meta;
+    payload?: Payload;
+    meta?: Meta;
     query?: object;
     navKey?: Nullable<string>;
 }
@@ -195,7 +196,7 @@ export type ScrollUpdater = (performedByUser: boolean) => void;
 
 export const NOT_FOUND: string;
 
-export function actionToPath(action: ReceivedAction, routesMap: RoutesMap): string;
+export function actionToPath(action: ReceivedAction, routesMap: RoutesMap, querySerializer?: QuerySerializer): string;
 
 export function back(): void;
 

--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -1,4 +1,13 @@
-import { connectRoutes, LocationState, RoutesMap } from 'redux-first-router';
+import {
+    connectRoutes,
+    LocationState,
+    RoutesMap,
+    actionToPath,
+    ReceivedAction,
+    redirect,
+    Action as ReduxFirstRouterAction,
+    QuerySerializer
+} from 'redux-first-router';
 import {
   createStore,
   applyMiddleware,
@@ -39,6 +48,23 @@ const composedMiddleware = applyMiddleware(middleware, dumbMiddleware);
 const storeEnhancer = compose<StoreCreator, StoreCreator, StoreCreator>(enhancer, composedMiddleware);
 
 const store = createStore(reducer, storeEnhancer);
+
+const receivedAction: ReceivedAction = {
+    type: 'HOME',
+    payload: {}
+};
+actionToPath(receivedAction, routesMap);
+
+const querySerializer: QuerySerializer = {
+    stringify: (params) => '',
+    parse: (queryString) => ({})
+};
+actionToPath(receivedAction, routesMap, querySerializer);
+
+const action: ReduxFirstRouterAction = {
+    type: 'HOME'
+};
+redirect(action);
 
 // $ExpectType Store<LocationState>
 store;

--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -53,18 +53,18 @@ const receivedAction: ReceivedAction = {
     type: 'HOME',
     payload: {}
 };
-actionToPath(receivedAction, routesMap);
+actionToPath(receivedAction, routesMap); // $ExpectType string
 
 const querySerializer: QuerySerializer = {
     stringify: (params) => '',
     parse: (queryString) => ({})
 };
-actionToPath(receivedAction, routesMap, querySerializer);
+actionToPath(receivedAction, routesMap, querySerializer); // $ExpectType string
 
 const action: ReduxFirstRouterAction = {
     type: 'HOME'
 };
-redirect(action);
+redirect(action); // $ExpectType Action
 
 // $ExpectType Store<LocationState>
 store;


### PR DESCRIPTION
…ad properties to be set inside the action property / actionToPath has an optional querySerializer param

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Documentation:

**Redirect does not require payload or meta**
https://github.com/faceyspacey/redux-first-router/blob/master/docs/server-rendering.md#redirects--not_found-example (See code snippet)
https://github.com/faceyspacey/redux-first-router/blob/master/src/action-creators/redirect.js (overwrites payload on action from param, no usage of meta)
https://github.com/faceyspacey/redux-first-router/blob/master/src/pure-utils/setKind.js (no usage of payload, checks if meta is defined)

**ActionToPath has optional serializer property**
https://github.com/faceyspacey/redux-first-router/blob/master/src/pure-utils/actionToPath.js#L12

**NOT_FOUND const**
https://github.com/faceyspacey/redux-first-router/blob/f736d27e56da3a476d3010183b33958d58ab7ea6/src/index.js#L21
I'm using NOT_FOUND in context of a string literal type (to prevent actions to be called with a type which don't exist inside my routes) Therefore it should also point to a specific string value.

