### PR TITLE
Dropzone: add  option dictFileSizeUnits

### DIFF
--- a/types/dropzone/dropzone-tests.ts
+++ b/types/dropzone/dropzone-tests.ts
@@ -56,6 +56,7 @@ const dropzoneWithOptions = new Dropzone(".test", {
 	dictRemoveFile: "",
 	dictRemoveFileConfirmation: "",
 	dictMaxFilesExceeded: "",
+	dictFileSizeUnits: { tb: "", gb: "", mb: "", kb: "", b: "" },
 
 	accept: (file: Dropzone.DropzoneFile, done: (error?: string | Error) => void) => {
 		if (file.accepted) {

--- a/types/dropzone/index.d.ts
+++ b/types/dropzone/index.d.ts
@@ -26,6 +26,14 @@ declare namespace Dropzone {
 		accepted: boolean;
 		xhr?: XMLHttpRequest;
 	}
+	
+	export interface DropzoneDictFileSizeUnits { 
+		tb?: string;
+		gb?: string;
+		mb?: string;
+		kb?: string;
+		b?: string;
+	}
 
 	export interface DropzoneOptions {
 		url?: string;
@@ -72,6 +80,7 @@ declare namespace Dropzone {
 		dictRemoveFile?: string;
 		dictRemoveFileConfirmation?: string;
 		dictMaxFilesExceeded?: string;
+		dictFileSizeUnits?: DropzoneDictFileSizeUnits;
 
 		accept?(file: DropzoneFile, done: (error?: string | Error) => void): void;
 		init?(): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.dropzonejs.com/#config-dictFileSizeUnits
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
