### PR TITLE
React Router v2: `RouteComponentProps` non-optional `location` and `p…

### DIFF
--- a/types/react-router/v2/lib/Router.d.ts
+++ b/types/react-router/v2/lib/Router.d.ts
@@ -83,8 +83,8 @@ declare namespace Router {
 
     interface RouteComponentProps<P, R> {
         history?: History;
-        location?: Location;
-        params?: P;
+        location: Location;
+        params: P;
         route?: PlainRoute;
         routeParams?: R;
         routes?: PlainRoute[];


### PR DESCRIPTION
…arams`

I cannot find any documentation suggesting these will properties will ever be missing.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.