### PR TITLE
[node] bump inspector types for V8 6.1

### DIFF
--- a/types/node/inspector.d.ts
+++ b/types/node/inspector.d.ts
@@ -690,6 +690,11 @@ declare module "inspector" {
              * Stack trace captured when the call was made.
              */
             stackTrace?: Runtime.StackTrace;
+            /**
+             * Console context descriptor for calls on non-default console context (not console.*): 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call on named context.
+             * @experimental
+             */
+            context?: string;
         }
 
         export interface InspectRequestedEventDataType {
@@ -1434,6 +1439,10 @@ declare module "inspector" {
              * Source ranges inside the function with coverage data.
              */
             ranges: Profiler.CoverageRange[];
+            /**
+             * Whether coverage data for this function has block granularity.
+             */
+            isBlockCoverage: boolean;
         }
 
         /**


### PR DESCRIPTION
A few new types for Node 8.7+; these are automatically generated by running `ts-node scripts/generate-inspector v8.8.0` in `types/node`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/commit/d82e1075dbc2cec2d6598ade10c1f43805f690fd#diff-1304fac45f0f71f192e121d23a8afe5c
