### PR TITLE
Add all remaining ol.format.filter types to openlayers

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -4,6 +4,7 @@
 //                 Bin Wang <https://github.com/wb14123>
 //                 Junyoung Clare Jang <https://github.com/ailrun>
 //                 Alexandre Melard <https://github.com/mylen>
+//                 Chad Johnston <https://github.com/iamthechad>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Definitions partially generated using tsd-jsdoc (https://github.com/englercj/tsd-jsdoc)
 
@@ -2733,6 +2734,172 @@ declare module ol {
             function intersects(geometryName: string, geometry: ol.geom.Geometry, opt_srsName?: string): ol.format.filter.Intersects;
 
             /**
+             * Create a logical `<Or>` operator between two or more filter conditions.
+             *
+             * @param {...ol.format.filter.Filter} conditions Filter conditions.
+             * @returns {!ol.format.filter.Or} `<Or>` operator.
+             * @api
+             */
+            function or(...conditions: ol.format.filter.Filter[]): ol.format.filter.Or;
+
+            /**
+             * Create a logical `<And>` operator between two or more filter conditions.
+             *
+             * @param {...ol.format.filter.Filter} conditions Filter conditions.
+             * @returns {!ol.format.filter.And} `<And>` operator.
+             * @api
+             */
+            function and(...conditions: ol.format.filter.Filter[]): ol.format.filter.And;
+
+            /**
+             * Represents a logical `<Not>` operator for a filter condition.
+             *
+             * @param {!ol.format.filter.Filter} condition Filter condition.
+             * @returns {!ol.format.filter.Not} `<Not>` operator.
+             * @api
+             */
+            function not(condition: ol.format.filter.Filter): ol.format.filter.Not;
+
+            /**
+             * Create a `<BBOX>` operator to test whether a geometry-valued property
+             * intersects a fixed bounding box
+             *
+             * @param {!string} geometryName Geometry name to use.
+             * @param {!ol.Extent} extent Extent.
+             * @param {string=} opt_srsName SRS name. No srsName attribute will be
+             *    set on geometries when this is not provided.
+             * @returns {!ol.format.filter.Bbox} `<BBOX>` operator.
+             * @api
+             */
+            function bbox(geometryName: string, extent: ol.Extent, opt_srsName?: string): ol.format.filter.Bbox;
+
+            /**
+             * Create a `<Within>` operator to test whether a geometry-valued property
+             * is within a given geometry.
+             *
+             * @param {!string} geometryName Geometry name to use.
+             * @param {!ol.geom.Geometry} geometry Geometry.
+             * @param {string=} opt_srsName SRS name. No srsName attribute will be
+             *    set on geometries when this is not provided.
+             * @returns {!ol.format.filter.Within} `<Within>` operator.
+             * @api
+             */
+            function within(geometryName: string, geometry: ol.geom.Geometry, opt_srsName?: string): ol.format.filter.Within;
+
+            /**
+             * Creates a `<PropertyIsEqualTo>` comparison operator.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!(string|number)} expression The value to compare.
+             * @param {boolean=} opt_matchCase Case-sensitive?
+             * @returns {!ol.format.filter.EqualTo} `<PropertyIsEqualTo>` operator.
+             * @api
+             */
+            function equalTo(propertyName: string, expression: string|number, opt_matchCase?: boolean): ol.format.filter.EqualTo;
+
+            /**
+             * Creates a `<PropertyIsNotEqualTo>` comparison operator.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!(string|number)} expression The value to compare.
+             * @param {boolean=} opt_matchCase Case-sensitive?
+             * @returns {!ol.format.filter.NotEqualTo} `<PropertyIsNotEqualTo>` operator.
+             * @api
+             */
+            function notEqualTo(propertyName: string, expression: string|number, opt_matchCase?: boolean): ol.format.filter.NotEqualTo;
+
+            /**
+             * Creates a `<PropertyIsLessThan>` comparison operator.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} expression The value to compare.
+             * @returns {!ol.format.filter.LessThan} `<PropertyIsLessThan>` operator.
+             * @api
+             */
+            function lessThan(propertyName: string, expression: number): ol.format.filter.LessThan;
+
+            /**
+             * Creates a `<PropertyIsLessThanOrEqualTo>` comparison operator.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} expression The value to compare.
+             * @returns {!ol.format.filter.LessThanOrEqualTo} `<PropertyIsLessThanOrEqualTo>` operator.
+             * @api
+             */
+            function lessThanOrEqualTo(propertyName: string, expression: number): ol.format.filter.LessThanOrEqualTo;
+
+            /**
+             * Creates a `<PropertyIsGreaterThan>` comparison operator.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} expression The value to compare.
+             * @returns {!ol.format.filter.GreaterThan} `<PropertyIsGreaterThan>` operator.
+             * @api
+             */
+            function greaterThan(propertyName: string, expression: number): ol.format.filter.GreaterThan;
+
+            /**
+             * Creates a `<PropertyIsGreaterThanOrEqualTo>` comparison operator.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} expression The value to compare.
+             * @returns {!ol.format.filter.GreaterThanOrEqualTo} `<PropertyIsGreaterThanOrEqualTo>` operator.
+             * @api
+             */
+            function greaterThanOrEqualTo(propertyName: string, expression: number): ol.format.filter.GreaterThanOrEqualTo;
+
+            /**
+             * Creates a `<PropertyIsNull>` comparison operator to test whether a property value
+             * is null.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @returns {!ol.format.filter.IsNull} `<PropertyIsNull>` operator.
+             * @api
+             */
+            function isNull(propertyName: string): ol.format.filter.IsNull;
+
+            /**
+             * Creates a `<PropertyIsBetween>` comparison operator to test whether an expression
+             * value lies within a range given by a lower and upper bound (inclusive).
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} lowerBoundary The lower bound of the range.
+             * @param {!number} upperBoundary The upper bound of the range.
+             * @returns {!ol.format.filter.IsBetween} `<PropertyIsBetween>` operator.
+             * @api
+             */
+            function between(propertyName: string, lowerBoundary: number, upperBoundary: number): ol.format.filter.IsBetween;
+
+            /**
+             * Represents a `<PropertyIsLike>` comparison operator that matches a string property
+             * value against a text pattern.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!string} pattern Text pattern.
+             * @param {string=} opt_wildCard Pattern character which matches any sequence of
+             *    zero or more string characters. Default is '*'.
+             * @param {string=} opt_singleChar pattern character which matches any single
+             *    string character. Default is '.'.
+             * @param {string=} opt_escapeChar Escape character which can be used to escape
+             *    the pattern characters. Default is '!'.
+             * @param {boolean=} opt_matchCase Case-sensitive?
+             * @returns {!ol.format.filter.IsLike} `<PropertyIsLike>` operator.
+             * @api
+             */
+            function like(propertyName: string, pattern: string, opt_wildCard?: string, opt_singleChar?: string, opt_escapeChar?: string, opt_matchCase?: boolean): ol.format.filter.IsLike;
+
+            /**
+             * Create a `<During>` temporal operator.
+             *
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!string} begin The begin date in ISO-8601 format.
+             * @param {!string} end The end date in ISO-8601 format.
+             * @returns {!ol.format.filter.During} `<During>` operator.
+             * @api
+             */
+            function during(propertyName: string, begin: string, end: string): ol.format.filter.During;
+
+            /**
              * @classdesc
              * Abstract class; normally only used for creating subclasses and not instantiated in apps.
              * Base class for WFS GetFeature filters.
@@ -2822,6 +2989,467 @@ declare module ol {
                  * @api
                  */
                 constructor(geometryName: string, geometry: ol.geom.Geometry, opt_srsName?: string);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<Within>` operator to test whether a geometry-valued property
+             * is within a given geometry.
+             *
+             * @constructor
+             * @param {!string} geometryName Geometry name to use.
+             * @param {!ol.geom.Geometry} geometry Geometry.
+             * @param {string=} opt_srsName SRS name. No srsName attribute will be
+             *    set on geometries when this is not provided.
+             * @extends {ol.format.filter.Spatial}
+             * @api
+             */
+            class Within extends ol.format.filter.Spatial {
+                /**
+                 * @classdesc
+                 * Represents a `<Within>` operator to test whether a geometry-valued property
+                 * is within a given geometry.
+                 *
+                 * @constructor
+                 * @param {!string} geometryName Geometry name to use.
+                 * @param {!ol.geom.Geometry} geometry Geometry.
+                 * @param {string=} opt_srsName SRS name. No srsName attribute will be
+                 *    set on geometries when this is not provided.
+                 * @extends {ol.format.filter.Spatial}
+                 * @api
+                 */
+                constructor(geometryName: string, geometry: ol.geom.Geometry, opt_srsName?: string);
+            }
+
+            /**
+             * @classdesc
+             * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+             * Base class for WFS GetFeature n-ary logical filters.
+             */
+            class LogicalNary extends ol.format.filter.Filter {}
+
+            /**
+             * @classdesc
+             * Represents a logical <And> operator between two or more filter conditions.
+             *
+             * @constructor
+             * @param {!ol.format.filter.Filter} conditions Conditions
+             * @extends {ol.format.filter.LogicalNary}
+             * @api
+             */
+            class And extends ol.format.filter.LogicalNary {
+                /**
+                 * @classdesc
+                 * Represents a logical <And> operator between two or more filter conditions.
+                 *
+                 * @constructor
+                 * @param {!ol.format.filter.Filter} conditions Conditions
+                 * @extends {ol.format.filter.LogicalNary}
+                 * @api
+                 */
+                constructor(...conditions: ol.format.filter.Filter[]);
+            }
+
+            /**
+             * @classdesc
+             * Represents a logical <Or> operator between two or more filter conditions.
+             *
+             * @constructor
+             * @param {!ol.format.filter.Filter} conditions Conditions
+             * @extends {ol.format.filter.LogicalNary}
+             * @api
+             */
+            class Or extends ol.format.filter.LogicalNary {
+              /**
+               * @classdesc
+               * Represents a logical <Or> operator between two or more filter conditions.
+               *
+               * @constructor
+               * @param {!ol.format.filter.Filter} conditions Conditions
+               * @extends {ol.format.filter.LogicalNary}
+               * @api
+               */
+              constructor(...conditions: ol.format.filter.Filter[]);
+            }
+
+            /**
+             * @classdesc
+             * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+             * Base class for WFS GetFeature property comparison filters.
+             *
+             * deprecated: This class will no longer be exported starting from the next major version.
+             *
+             * @constructor
+             * @abstract
+             * @param {!string} tagName The XML tag name for this filter.
+             * @param {!string} propertyName Name of the context property to compare.
+             * @extends {ol.format.filter.Filter}
+             * @api
+             */
+            class Comparison extends ol.format.filter.Filter {
+                /**
+                 * @classdesc
+                 * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+                 * Base class for WFS GetFeature property comparison filters.
+                 *
+                 * deprecated: This class will no longer be exported starting from the next major version.
+                 *
+                 * @constructor
+                 * @abstract
+                 * @param {!string} tagName The XML tag name for this filter.
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @extends {ol.format.filter.Filter}
+                 * @api
+                 */
+                constructor(tagName: string, propertyName: string);
+            }
+
+            /**
+             * @classdesc
+             * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+             * Base class for WFS GetFeature property binary comparison filters.
+             *
+             * deprecated: This class will no longer be exported starting from the next major version.
+             *
+             * @constructor
+             * @abstract
+             * @param {!string} tagName The XML tag name for this filter.
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!(string|number)} expression The value to compare.
+             * @param {boolean=} opt_matchCase Case-sensitive?
+             * @extends {ol.format.filter.Comparison}
+             * @api
+             */
+            class ComparisonBinary extends ol.format.filter.Comparison {
+                /**
+                 * @classdesc
+                 * Abstract class; normally only used for creating subclasses and not instantiated in apps.
+                 * Base class for WFS GetFeature property binary comparison filters.
+                 *
+                 * deprecated: This class will no longer be exported starting from the next major version.
+                 *
+                 * @constructor
+                 * @abstract
+                 * @param {!string} tagName The XML tag name for this filter.
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!(string|number)} expression The value to compare.
+                 * @param {boolean=} opt_matchCase Case-sensitive?
+                 * @extends {ol.format.filter.Comparison}
+                 * @api
+                 */
+                constructor(tagName: string, propertyName: string, expression: string|number, opt_matchCase?: boolean);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsEqualTo>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!(string|number)} expression The value to compare.
+             * @param {boolean=} opt_matchCase Case-sensitive?
+             * @extends {ol.format.filter.ComparisonBinary}
+             * @api
+             */
+            class EqualTo extends ol.format.filter.ComparisonBinary {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsEqualTo>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!(string|number)} expression The value to compare.
+                 * @param {boolean=} opt_matchCase Case-sensitive?
+                 * @extends {ol.format.filter.ComparisonBinary}
+                 * @api
+                 */
+                constructor(propertyName: string, expression: string|number, opt_matchCase?: boolean);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsGreaterThan>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} expression The value to compare.
+             * @extends {ol.format.filter.ComparisonBinary}
+             * @api
+             */
+            class GreaterThan extends ol.format.filter.ComparisonBinary {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsGreaterThan>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!number} expression The value to compare.
+                 * @extends {ol.format.filter.ComparisonBinary}
+                 * @api
+                 */
+                constructor(propertyName: string, expression: number);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsGreaterThanOrEqualTo>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} expression The value to compare.
+             * @extends {ol.format.filter.ComparisonBinary}
+             * @api
+             */
+            class GreaterThanOrEqualTo extends ol.format.filter.ComparisonBinary {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsGreaterThanOrEqualTo>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!number} expression The value to compare.
+                 * @extends {ol.format.filter.ComparisonBinary}
+                 * @api
+                 */
+                constructor(propertyName: string, expression: number);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsLessThan>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} expression The value to compare.
+             * @extends {ol.format.filter.ComparisonBinary}
+             * @api
+             */
+            class LessThan extends ol.format.filter.ComparisonBinary {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsLessThan>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!number} expression The value to compare.
+                 * @extends {ol.format.filter.ComparisonBinary}
+                 * @api
+                 */
+                constructor(propertyName: string, expression: number);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsLessThanOrEqualTo>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} expression The value to compare.
+             * @extends {ol.format.filter.ComparisonBinary}
+             * @api
+             */
+            class LessThanOrEqualTo extends ol.format.filter.ComparisonBinary {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsLessThanOrEqualTo>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!number} expression The value to compare.
+                 * @extends {ol.format.filter.ComparisonBinary}
+                 * @api
+                 */
+                constructor(propertyName: string, expression: number);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsNotEqualTo>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!(string|number)} expression The value to compare.
+             * @param {boolean=} opt_matchCase Case-sensitive?
+             * @extends {ol.format.filter.ComparisonBinary}
+             * @api
+             */
+            class NotEqualTo extends ol.format.filter.ComparisonBinary {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsNotEqualTo>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!(string|number)} expression The value to compare.
+                 * @param {boolean=} opt_matchCase Case-sensitive?
+                 * @extends {ol.format.filter.ComparisonBinary}
+                 * @api
+                 */
+                constructor(propertyName: string, expression: string|number, opt_matchCase?: boolean);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<During>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!string} begin The begin date in ISO-8601 format.
+             * @param {!string} end The end date in ISO-8601 format.
+             * @extends {ol.format.filter.Comparison}
+             * @api
+             */
+            class During extends ol.format.filter.Comparison {
+                /**
+                 * @classdesc
+                 * Represents a `<During>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!string} begin The begin date in ISO-8601 format.
+                 * @param {!string} end The end date in ISO-8601 format.
+                 * @extends {ol.format.filter.Comparison}
+                 * @api
+                 */
+                constructor(propertyName: string, begin: string, end: string);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsBetween>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!number} lowerBoundary The lower bound of the range.
+             * @param {!number} upperBoundary The upper bound of the range.
+             * @extends {ol.format.filter.Comparison}
+             * @api
+             */
+            class IsBetween extends ol.format.filter.Comparison {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsBetween>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!number} lowerBoundary The lower bound of the range.
+                 * @param {!number} upperBoundary The upper bound of the range.
+                 * @extends {ol.format.filter.Comparison}
+                 * @api
+                 */
+                constructor(propertyName: string, lowerBoundary: number, upperBoundary: number);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsLike>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @param {!string} pattern Text pattern.
+             * @param {string=} opt_wildCard Pattern character which matches any sequence of
+             *    zero or more string characters. Default is '*'.
+             * @param {string=} opt_singleChar pattern character which matches any single
+             *    string character. Default is '.'.
+             * @param {string=} opt_escapeChar Escape character which can be used to escape
+             *    the pattern characters. Default is '!'.
+             * @param {boolean=} opt_matchCase Case-sensitive?
+             * @extends {ol.format.filter.Comparison}
+             * @api
+             */
+            class IsLike extends ol.format.filter.Comparison {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsLike>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @param {!string} pattern Text pattern.
+                 * @param {string=} opt_wildCard Pattern character which matches any sequence of
+                 *    zero or more string characters. Default is '*'.
+                 * @param {string=} opt_singleChar pattern character which matches any single
+                 *    string character. Default is '.'.
+                 * @param {string=} opt_escapeChar Escape character which can be used to escape
+                 *    the pattern characters. Default is '!'.
+                 * @param {boolean=} opt_matchCase Case-sensitive?
+                 * @extends {ol.format.filter.Comparison}
+                 * @api
+                 */
+                constructor(propertyName: string, pattern: string, opt_wildCard?: string, opt_singleChar?: string, opt_escapeChar?: string, opt_matchCase?: boolean);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<PropertyIsNull>` comparison operator.
+             *
+             * @constructor
+             * @param {!string} propertyName Name of the context property to compare.
+             * @extends {ol.format.filter.Comparison}
+             * @api
+             */
+            class IsNull extends ol.format.filter.Comparison {
+                /**
+                 * @classdesc
+                 * Represents a `<PropertyIsNull>` comparison operator.
+                 *
+                 * @constructor
+                 * @param {!string} propertyName Name of the context property to compare.
+                 * @extends {ol.format.filter.Comparison}
+                 * @api
+                 */
+                constructor(propertyName: string);
+            }
+
+            /**
+             * @classdesc
+             * Represents a logical `<Not>` operator for a filter condition.
+             *
+             * @constructor
+             * @param {!ol.format.filter.Filter} condition Filter condition.
+             * @extends {ol.format.filter.Filter}
+             * @api
+             */
+            class Not extends ol.format.filter.Filter {
+                /**
+                 * @classdesc
+                 * Represents a logical `<Not>` operator for a filter condition.
+                 *
+                 * @constructor
+                 * @param {!ol.format.filter.Filter} condition Filter condition.
+                 * @extends {ol.format.filter.Filter}
+                 * @api
+                 */
+                constructor(condition: ol.format.filter.Filter);
+            }
+
+            /**
+             * @classdesc
+             * Represents a `<BBOX>` operator to test whether a geometry-valued property
+             * intersects a fixed bounding box
+             *
+             * @constructor
+             * @param {!string} geometryName Geometry name to use.
+             * @param {!ol.Extent} extent Extent.
+             * @param {string=} opt_srsName SRS name. No srsName attribute will be
+             *    set on geometries when this is not provided.
+             * @extends {ol.format.filter.Filter}
+             * @api
+             */
+            class Bbox extends ol.format.filter.Filter {
+                /**
+                 * @classdesc
+                 * Represents a `<BBOX>` operator to test whether a geometry-valued property
+                 * intersects a fixed bounding box
+                 *
+                 * @constructor
+                 * @param {!string} geometryName Geometry name to use.
+                 * @param {!ol.Extent} extent Extent.
+                 * @param {string=} opt_srsName SRS name. No srsName attribute will be
+                 *    set on geometries when this is not provided.
+                 * @extends {ol.format.filter.Filter}
+                 * @api
+                 */
+                constructor(geometryName: string, extent: ol.Extent, opt_srsName?: string);
             }
         }
 
@@ -12632,7 +13260,7 @@ declare module olx {
             style?: (ol.style.Style | ol.style.Style[] | ol.StyleFunction);
             features?: ol.Collection<ol.Feature>;
             wrapX?: boolean;
-            source?: ol.source.Vector;            
+            source?: ol.source.Vector;
         }
 
 

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -700,6 +700,100 @@ jsonValue = geojsonFormat.writeGeometryObject(geometry);
 jsonValue = geojsonFormat.writeGeometryObject(geometry, writeOptions);
 
 //
+// ol.format.filter
+//
+
+let bboxFilter: ol.format.filter.Bbox;
+bboxFilter = new ol.format.filter.Bbox("geometry", extent);
+bboxFilter = new ol.format.filter.Bbox("geometry", extent, "srs");
+bboxFilter = ol.format.filter.bbox("geometry", extent);
+bboxFilter = ol.format.filter.bbox("geometry", extent, "srs");
+
+let equalToFilter: ol.format.filter.EqualTo;
+equalToFilter = new ol.format.filter.EqualTo("property", "abc");
+equalToFilter = new ol.format.filter.EqualTo("property", "abc", true);
+equalToFilter = new ol.format.filter.EqualTo("property", 123);
+equalToFilter = new ol.format.filter.EqualTo("property", 123, true);
+equalToFilter = ol.format.filter.equalTo("property", "abc");
+equalToFilter = ol.format.filter.equalTo("property", "abc", true);
+equalToFilter = ol.format.filter.equalTo("property", 123);
+equalToFilter = ol.format.filter.equalTo("property", 123, true);
+
+let greaterThanFilter: ol.format.filter.GreaterThan;
+greaterThanFilter = new ol.format.filter.GreaterThan("property", 123);
+greaterThanFilter = ol.format.filter.greaterThan("property", 123);
+
+let greaterThanEqualToFilter: ol.format.filter.GreaterThanOrEqualTo;
+greaterThanEqualToFilter = new ol.format.filter.GreaterThanOrEqualTo("property", 123);
+greaterThanEqualToFilter = ol.format.filter.greaterThanOrEqualTo("property", 123);
+
+let lessThanFilter: ol.format.filter.LessThan;
+lessThanFilter = new ol.format.filter.LessThan("property", 123);
+lessThanFilter = ol.format.filter.lessThan("property", 123);
+
+let lessThanEqualToFilter: ol.format.filter.LessThanOrEqualTo;
+lessThanEqualToFilter = new ol.format.filter.LessThanOrEqualTo("property", 123);
+lessThanEqualToFilter = ol.format.filter.lessThanOrEqualTo("property", 123);
+
+let notEqualToFilter: ol.format.filter.NotEqualTo;
+notEqualToFilter = new ol.format.filter.NotEqualTo("property", "abc");
+notEqualToFilter = new ol.format.filter.NotEqualTo("property", "abc", true);
+notEqualToFilter = new ol.format.filter.NotEqualTo("property", 123);
+notEqualToFilter = new ol.format.filter.NotEqualTo("property", 123, true);
+notEqualToFilter = ol.format.filter.notEqualTo("property", "abc");
+notEqualToFilter = ol.format.filter.notEqualTo("property", "abc", true);
+notEqualToFilter = ol.format.filter.notEqualTo("property", 123);
+notEqualToFilter = ol.format.filter.notEqualTo("property", 123, true);
+
+let duringFilter: ol.format.filter.During;
+duringFilter = new ol.format.filter.During("property", "2017-01-01T12:00Z", "2017-01-01T14:00Z");
+duringFilter = ol.format.filter.during("property", "2017-01-01T12:00Z", "2017-01-01T14:00Z");
+
+let isBetweenFilter: ol.format.filter.IsBetween;
+isBetweenFilter = new ol.format.filter.IsBetween("property", 1, 10);
+isBetweenFilter = ol.format.filter.between("property", 1, 10);
+
+let isLikeFilter: ol.format.filter.IsLike;
+isLikeFilter = new ol.format.filter.IsLike("property", "pattern");
+isLikeFilter = new ol.format.filter.IsLike("property", "pattern", "wildcard");
+isLikeFilter = new ol.format.filter.IsLike("property", "pattern", "wildcard", "s");
+isLikeFilter = new ol.format.filter.IsLike("property", "pattern", "wildcard", "s", "e");
+isLikeFilter = new ol.format.filter.IsLike("property", "pattern", "wildcard", "s", "e", true);
+isLikeFilter = ol.format.filter.like("property", "pattern");
+isLikeFilter = ol.format.filter.like("property", "pattern", "wildcard");
+isLikeFilter = ol.format.filter.like("property", "pattern", "wildcard", "s");
+isLikeFilter = ol.format.filter.like("property", "pattern", "wildcard", "s", "e");
+isLikeFilter = ol.format.filter.like("property", "pattern", "wildcard", "s", "e", true);
+
+let isNullFilter: ol.format.filter.IsNull;
+isNullFilter = new ol.format.filter.IsNull("property");
+isNullFilter = ol.format.filter.isNull("property");
+
+let andFilter: ol.format.filter.And;
+andFilter = new ol.format.filter.And(isNullFilter, duringFilter);
+andFilter = ol.format.filter.and(isNullFilter, duringFilter);
+
+let orFilter: ol.format.filter.Or;
+orFilter = new ol.format.filter.Or(isNullFilter, duringFilter);
+orFilter = ol.format.filter.or(isNullFilter, duringFilter);
+
+let notFilter: ol.format.filter.Not;
+notFilter = new ol.format.filter.Not(isBetweenFilter);
+notFilter = ol.format.filter.not(isBetweenFilter);
+
+let intersectsFilter: ol.format.filter.Intersects;
+intersectsFilter = new ol.format.filter.Intersects("geometry", geometry);
+intersectsFilter = new ol.format.filter.Intersects("geometry", geometry, "srs");
+intersectsFilter = ol.format.filter.intersects("geometry", geometry);
+intersectsFilter = ol.format.filter.intersects("geometry", geometry, "srs");
+
+let withinFilter: ol.format.filter.Within;
+withinFilter = new ol.format.filter.Within("geometry", geometry);
+withinFilter = new ol.format.filter.Within("geometry", geometry, "srs");
+withinFilter = ol.format.filter.within("geometry", geometry);
+withinFilter = ol.format.filter.within("geometry", geometry, "srs");
+
+//
 // ol.interactions
 //
 let modifyFeature: ol.interaction.Modify = new ol.interaction.Modify({


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://openlayers.org/en/latest/apidoc/ol.format.filter.Filter.html
- [-] Increase the version number in the header if appropriate.
- [-] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

(I tried adding a `tslint.json` file, but the number of existing issues found in the code and tests will probably require a separate PR to fix up.)