### PR TITLE
socket.io-client: Replace 'extraHeaders' with 'transportOptions' in connectOpts

### DIFF
--- a/types/socket.io-client/index.d.ts
+++ b/types/socket.io-client/index.d.ts
@@ -617,9 +617,9 @@ declare namespace SocketIOClient {
 		onlyBinaryUpgrades?: boolean;
 
 		/**
-		 * Header options for Node.js client
+		 * Transport options for Node.js client (headers etc)
 		 */
-		extraHeaders?: Object;
+		transportOptions?: Object;
 
 		/**
 		 * (SSL) Certificate, Private key and CA certificates to use for SSL.


### PR DESCRIPTION
Without this change, you can't set custom headers for the socket client.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/socketio/socket.io-client/blob/master/docs/API.md#with-extraheaders
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
