### PR TITLE
fix(gulp-util): reference to chalk types should reflect `default` export

### DIFF
--- a/types/gulp-util/index.d.ts
+++ b/types/gulp-util/index.d.ts
@@ -8,7 +8,7 @@
 /// <reference types="vinyl" />
 
 import vinyl = require('vinyl');
-import chalk = require('chalk');
+import chalk from 'chalk';
 import through2 = require('through2');
 
 export { vinyl as File };


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chalk/chalk/blob/master/types/index.d.ts#L97 and https://github.com/chalk/chalk/blob/master/index.js#L228
---
The type definitions needed from `chalk` are now a `default` export. See https://github.com/chalk/chalk/blob/master/types/index.d.ts#L97 and https://github.com/chalk/chalk/blob/master/index.js#L228. For more background on the change from the author see https://github.com/chalk/chalk/issues/215#issuecomment-337459457. Also worth noting, the definitions provided for `chalk` from this repo are going to be removed; see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20789.

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21004.