### PR TITLE
react-data-grid: update index.d.ts to make grouping example work

### DIFF
--- a/types/react-data-grid/index.d.ts
+++ b/types/react-data-grid/index.d.ts
@@ -161,6 +161,13 @@ declare namespace AdazzleReactDataGrid {
          * @default false
          */
         enableCellSelect?: boolean
+
+        /**
+         * Enables cells to be dragged and dropped 
+         * @default false
+         */
+        enableDragAndDrop?: boolean
+        
         /**
          * Called when a cell is selected.
          * @param coordinates The row and column indices of the selected cell.
@@ -198,6 +205,13 @@ declare namespace AdazzleReactDataGrid {
          * @param row object behind the row
          */
         onRowClick?: (rowIdx : number, row : object) => void
+
+        /**
+         * An event function called when a row is expanded with the toggle
+         * @param props OnRowExpandToggle object
+         */
+        onRowExpandToggle?: (props: OnRowExpandToggle ) => void
+        
         /**
          * Responsible for returning an Array of values that can be used for filtering
          * a column that is column.filterable and using a column.filterRenderer that 
@@ -417,6 +431,24 @@ declare namespace AdazzleReactDataGrid {
          * One of 'cellUpdate', 'cellDrag', 'columnFill', or 'copyPaste'.
          */
         action: 'cellUpdate' | 'cellDrag' | 'columnFill' | 'copyPaste'
+    }
+
+    /**
+     * Information about the row toggler
+     */
+    interface OnRowExpandToggle {
+        /**
+         * The name of the column group the row is in
+         */
+        columnGroupName: string
+        /**
+         * The name of the expanded row
+         */
+        name: string
+        /**
+         * If it should expand or not
+         */
+        shouldExpand: boolean
     }
 
     /**

--- a/types/react-data-grid/index.d.ts
+++ b/types/react-data-grid/index.d.ts
@@ -487,6 +487,7 @@ declare namespace AdazzleReactDataGrid {
         export import DragHandleDoubleClickEvent = AdazzleReactDataGrid.DragHandleDoubleClickEvent;
         export import CellCopyPasteEvent = AdazzleReactDataGrid.CellCopyPasteEvent;
         export import GridRowsUpdatedEvent = AdazzleReactDataGrid.GridRowsUpdatedEvent;
+        export import OnRowExpandToggle = AdazzleReactDataGrid.OnRowExpandToggle;
 
         // Actual classes exposed on module.exports
         /**

--- a/types/react-data-grid/react-data-grid-tests.tsx
+++ b/types/react-data-grid/react-data-grid-tests.tsx
@@ -249,6 +249,13 @@ class Example extends React.Component<any, any> {
         this.setState({rows: rows});
     }
 
+    onRowExpandToggle = ({ columnGroupName, name, shouldExpand }:ReactDataGrid.OnRowExpandToggle ) => {
+        let expandedRows = Object.assign({}, this.state.expandedRows);
+        expandedRows[columnGroupName] = Object.assign({}, expandedRows[columnGroupName]);
+        expandedRows[columnGroupName][name] = {isExpanded: shouldExpand};
+        this.setState({expandedRows: expandedRows});
+    }
+
     onRowClick(rowIdx:number, row: Object) {
         // Do nothing, just test that it accepts an event
     }
@@ -300,10 +307,12 @@ class Example extends React.Component<any, any> {
             <ReactDataGrid
                 ref='grid'
                 enableCellSelect={true}
+                enableDragAndDrop={true}
                 columns={this.getColumns()}
                 rowGetter={this.getRowAt}
                 rowsCount={this.getSize()}
                 onGridRowsUpdated={this.handleGridRowsUpdated}
+                onRowExpandToggle={this.onRowExpandToggle}
                 toolbar={<Toolbar onAddRow={this.handleAddRow}/>}
                 enableRowSelect={true}
                 rowHeight={50}


### PR DESCRIPTION
Types that are missing for this example to work with Typescript: http://adazzle.github.io/react-data-grid/examples.html#/grouping

