### PR TITLE
fontfaceobserver: First argument in load should be a union of null and string

### DIFF
--- a/types/fontfaceobserver/index.d.ts
+++ b/types/fontfaceobserver/index.d.ts
@@ -25,7 +25,7 @@ declare class FontFaceObserver {
      * @param testString If your font doesn't contain latin characters you can pass a custom test string.
      * @param timeout The default timeout for giving up on font loading is 3 seconds. You can increase or decrease this by passing a number of milliseconds.
      */
-    load(testString?: string, timeout?: number): Promise<void>;
+    load(testString?: string | null, timeout?: number): Promise<void>;
 }
 
 declare module "fontfaceobserver" {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bramstein/fontfaceobserver#how-to-use

These changes allow for null to be explicitly passed to the fontfaceobserver's load method when using a timeout. In the current implementation this param is optional but not allowed to be the null object. Per the documentation it is acceptable for it to be the null object when passing a timeout for the second argument.