### PR TITLE
Add typings for leo/args 3.0.7

### DIFF
--- a/types/args/args-tests.ts
+++ b/types/args/args-tests.ts
@@ -1,0 +1,67 @@
+import * as args from "args";
+
+args
+    .option("opt1", "desc")
+    .option("opt2", "desc", false, (value: any): any => value)
+    .options([
+        {
+            name: 'opt3',
+            description: 'desc',
+            defaultValue: 1,
+            init: (value: any) => { },
+        },
+        {
+            name: 'opt4',
+            description: 'desc',
+        },
+    ])
+    .command("cm1", "desc")
+    .command("cm2", "desc", (value: any): void => { }, ['a'])
+    .example("ex1", "desc")
+    .examples([
+        {
+            usage: "ex2",
+            description: "desc",
+        },
+    ]);
+
+args.parse(['~/bin/node', '~/dir', 'arg', '--param'], {
+    help: true,
+    name: "name",
+    version: true,
+    usageFilter: (a: any): any => a,
+    value: "value",
+    mri: {
+        args: ['a'],
+        alias: {
+            a: "b",
+            c: ['d'],
+        },
+        boolean: ['wat'],
+        default: {
+            foo: 'bar',
+        },
+        string: ['zulu'],
+        unknown: (param: string): boolean => true,
+    },
+    minimist: {
+        string: ['string'],
+        boolean: ['string'],
+        alias: {
+            bar: 'foo',
+            foo: ['bar1', 'bar2'],
+        },
+        default: {
+            foo: 'bar',
+        },
+        stopEarly: true,
+        "--": false,
+        unknown: (param: string): boolean => true,
+    },
+    mainColor: "yellow",
+    subColor: "dim"
+});
+
+args.showHelp();
+
+const x: string = args.sub[0];

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -1,0 +1,87 @@
+declare var args: Args.API;
+export = args;
+
+declare namespace Args {
+    export interface IMriUnknownFunction {
+        (param: string): boolean
+    }
+
+    export interface IMinimistUnknownFunction {
+        (param: string): boolean
+    }
+
+    export interface IMriArguments {
+        args?: string[];
+        alias?: {
+            [key: string]: string | string[]
+        };
+        boolean?: string | string[];
+        default?: {
+            [key: string]: any
+        };
+        string?: string | string[];
+        unknown?: IMriUnknownFunction;
+    }
+
+    export interface IMinimistArguments {
+        string?: string | string[];
+        boolean?: boolean | string | string[];
+        alias?: {
+            [key: string]: string | string[]
+        };
+        default?: {
+            [key: string]: any
+        };
+        stopEarly?: boolean;
+        "--"?: boolean;
+        unknown?: IMinimistUnknownFunction;
+    }
+
+    export interface IOptionInitFunction {
+        (value: any): any;
+    }
+
+    export interface ICommandInitFunction {
+        (name: string, sub: {}[], options: {}[]): void;
+    }
+
+    export interface IUsageFilterFunction {
+        (output: any): any;
+    }
+
+    export interface IConfiguration {
+        help?: boolean;
+        name?: string;
+        version?: boolean;
+        usageFilter?: IUsageFilterFunction;
+        value?: string;
+        mri: IMriArguments;
+        minimist?: IMinimistArguments;
+        mainColor: string | string[];
+        subColor: string | string[];
+    }
+
+    export interface IOption {
+        name: string;
+        description: string;
+        init?: IOptionInitFunction;
+        defaultValue?: any;
+    }
+
+    export interface IExample {
+        usage: string;
+        description: string;
+    }
+
+    export interface API {
+        sub: string[];
+
+        option(name: string | [string, string], description: string, defaultValue?: any, init?: IOptionInitFunction): API;
+        options(list: IOption[]): API;
+        command(name: string, description: string, init?: ICommandInitFunction, aliases?: string[]): API;
+        example(usage: string, description: string): API;
+        examples(list: IExample[]): API;
+        parse(argv: string[], options?: IConfiguration): { [key: string]: any };
+        showHelp(): void;
+    }
+}

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -2,20 +2,20 @@
 // Project: https://github.com/leo/args#readme
 // Definitions by: Slessi <https://github.com/Slessi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
-export = args;
+declare const c: args;
+export = c;
 
-declare namespace args {
-    let sub: string[];
+interface args {
+    sub: string[];
 
-    function option(name: string | [string, string], description: string, defaultValue?: any, init?: OptionInitFunction): typeof args;
-    function options(list: Option[]): typeof args;
-    function command(name: string, description: string, init?: CommandInitFunction, aliases?: string[]): typeof args;
-    function example(usage: string, description: string): typeof args;
-    function examples(list: Example[]): typeof args;
-    function parse(argv: string[], options?: ConfigurationOptions): { [key: string]: any };
-    function showHelp(): void;
+    option(name: string | [string, string], description: string, defaultValue?: any, init?: OptionInitFunction): args;
+    options(list: Option[]): args;
+    command(name: string, description: string, init?: CommandInitFunction, aliases?: string[]): args;
+    example(usage: string, description: string): args;
+    examples(list: Example[]): args;
+    parse(argv: string[], options?: ConfigurationOptions): { [key: string]: any };
+    showHelp(): void;
 }
 
 type MriUnknownFunction = (param: string) => boolean;

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -1,87 +1,77 @@
-declare var args: Args.API;
+// Type definitions for args 3.0
+// Project: https://github.com/leo/args#readme
+// Definitions by: Slessi <https://github.com/Slessi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
 export = args;
 
-declare namespace Args {
-    export interface IMriUnknownFunction {
-        (param: string): boolean
-    }
+declare namespace args {
+    let sub: string[];
 
-    export interface IMinimistUnknownFunction {
-        (param: string): boolean
-    }
+    function option(name: string | [string, string], description: string, defaultValue?: any, init?: OptionInitFunction): typeof args;
+    function options(list: Option[]): typeof args;
+    function command(name: string, description: string, init?: CommandInitFunction, aliases?: string[]): typeof args;
+    function example(usage: string, description: string): typeof args;
+    function examples(list: Example[]): typeof args;
+    function parse(argv: string[], options?: ConfigurationOptions): { [key: string]: any };
+    function showHelp(): void;
+}
 
-    export interface IMriArguments {
-        args?: string[];
-        alias?: {
-            [key: string]: string | string[]
-        };
-        boolean?: string | string[];
-        default?: {
-            [key: string]: any
-        };
-        string?: string | string[];
-        unknown?: IMriUnknownFunction;
-    }
+type MriUnknownFunction = (param: string) => boolean;
+type MinimistUnknownFunction = (param: string) => boolean;
 
-    export interface IMinimistArguments {
-        string?: string | string[];
-        boolean?: boolean | string | string[];
-        alias?: {
-            [key: string]: string | string[]
-        };
-        default?: {
-            [key: string]: any
-        };
-        stopEarly?: boolean;
-        "--"?: boolean;
-        unknown?: IMinimistUnknownFunction;
-    }
+type OptionInitFunction = (value: any) => any;
+type CommandInitFunction = (name: string, sub: string[], options: ConfigurationOptions) => void;
+type UsageFilterFunction = (output: any) => any;
 
-    export interface IOptionInitFunction {
-        (value: any): any;
-    }
+interface MriOptions {
+    args?: string[];
+    alias?: {
+        [key: string]: string | string[]
+    };
+    boolean?: string | string[];
+    default?: {
+        [key: string]: any
+    };
+    string?: string | string[];
+    unknown?: MriUnknownFunction;
+}
 
-    export interface ICommandInitFunction {
-        (name: string, sub: {}[], options: {}[]): void;
-    }
+interface MinimistOptions {
+    string?: string | string[];
+    boolean?: boolean | string | string[];
+    alias?: {
+        [key: string]: string | string[]
+    };
+    default?: {
+        [key: string]: any
+    };
+    stopEarly?: boolean;
+    "--"?: boolean;
+    unknown?: MinimistUnknownFunction;
+}
 
-    export interface IUsageFilterFunction {
-        (output: any): any;
-    }
+interface ConfigurationOptions {
+    help?: boolean;
+    name?: string;
+    version?: boolean;
+    usageFilter?: UsageFilterFunction;
+    value?: string;
+    mri: MriOptions;
+    minimist?: MinimistOptions;
+    mainColor: string | string[];
+    subColor: string | string[];
+}
 
-    export interface IConfiguration {
-        help?: boolean;
-        name?: string;
-        version?: boolean;
-        usageFilter?: IUsageFilterFunction;
-        value?: string;
-        mri: IMriArguments;
-        minimist?: IMinimistArguments;
-        mainColor: string | string[];
-        subColor: string | string[];
-    }
+interface Option {
+    name: string;
+    description: string;
+    init?: OptionInitFunction;
+    defaultValue?: any;
+}
 
-    export interface IOption {
-        name: string;
-        description: string;
-        init?: IOptionInitFunction;
-        defaultValue?: any;
-    }
-
-    export interface IExample {
-        usage: string;
-        description: string;
-    }
-
-    export interface API {
-        sub: string[];
-
-        option(name: string | [string, string], description: string, defaultValue?: any, init?: IOptionInitFunction): API;
-        options(list: IOption[]): API;
-        command(name: string, description: string, init?: ICommandInitFunction, aliases?: string[]): API;
-        example(usage: string, description: string): API;
-        examples(list: IExample[]): API;
-        parse(argv: string[], options?: IConfiguration): { [key: string]: any };
-        showHelp(): void;
-    }
+interface Example {
+    usage: string;
+    description: string;
 }

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -11,19 +11,14 @@ interface args {
 
     option(name: string | [string, string], description: string, defaultValue?: any, init?: OptionInitFunction): args;
     options(list: Option[]): args;
-    command(name: string, description: string, init?: CommandInitFunction, aliases?: string[]): args;
+    command(name: string, description: string, init?: (name: string, sub: string[], options: ConfigurationOptions) => void, aliases?: string[]): args;
     example(usage: string, description: string): args;
     examples(list: Example[]): args;
     parse(argv: string[], options?: ConfigurationOptions): { [key: string]: any };
     showHelp(): void;
 }
 
-type MriUnknownFunction = (param: string) => boolean;
-type MinimistUnknownFunction = (param: string) => boolean;
-
 type OptionInitFunction = (value: any) => any;
-type CommandInitFunction = (name: string, sub: string[], options: ConfigurationOptions) => void;
-type UsageFilterFunction = (output: any) => any;
 
 interface MriOptions {
     args?: string[];
@@ -35,7 +30,7 @@ interface MriOptions {
         [key: string]: any
     };
     string?: string | string[];
-    unknown?: MriUnknownFunction;
+    unknown?: (param: string) => boolean;
 }
 
 interface MinimistOptions {
@@ -49,14 +44,14 @@ interface MinimistOptions {
     };
     stopEarly?: boolean;
     "--"?: boolean;
-    unknown?: MinimistUnknownFunction;
+    unknown?: (param: string) => boolean;
 }
 
 interface ConfigurationOptions {
     help?: boolean;
     name?: string;
     version?: boolean;
-    usageFilter?: UsageFilterFunction;
+    usageFilter?: (output: any) => any;
     value?: string;
     mri: MriOptions;
     minimist?: MinimistOptions;
@@ -65,7 +60,7 @@ interface ConfigurationOptions {
 }
 
 interface Option {
-    name: [string, string];
+    name: string | [string, string];
     description: string;
     init?: OptionInitFunction;
     defaultValue?: any;

--- a/types/args/index.d.ts
+++ b/types/args/index.d.ts
@@ -65,7 +65,7 @@ interface ConfigurationOptions {
 }
 
 interface Option {
-    name: string;
+    name: [string, string];
     description: string;
     init?: OptionInitFunction;
     defaultValue?: any;

--- a/types/args/tsconfig.json
+++ b/types/args/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/args/tsconfig.json
+++ b/types/args/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "args-tests.ts"
+    ]
+}

--- a/types/args/tslint.json
+++ b/types/args/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
# Note

> Edit: This was fixed thanks to help from comments :)

Following guidelines and running `npm run lint args` as requested and this gives me the following error ...

```
ERROR: 7:1  export-just-namespace  Instead of `export =`-ing a namespace, use the body of the namespace as the module body. See: https://github.com/Microsoft/dtslint/blob/master/docs/export-just-namespace.md
```

... which I understand but as some of the functions return `this` I needed to add `: typeof args` as return type for some functions.

I don't know how to reflect that if I do [as suggested](https://github.com/Microsoft/dtslint/blob/master/docs/export-just-namespace.md) and extract the items from `namespace args`. Any pointers please?

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
