### PR TITLE
fix: enzyme -> allow contains fns to accept arrays (react 16)

### DIFF
--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -54,22 +54,22 @@ export interface CommonWrapper<P = {}, S = {}> {
     /**
      * Returns whether or not the current wrapper has a node anywhere in it's render tree that looks like the one passed in.
      */
-    contains(node: ReactElement<any> | string): boolean;
+    contains(node: ReactElement<any> | Array<ReactElement<any>> | string): boolean;
 
     /**
      * Returns whether or not a given react element exists in the shallow render tree.
      */
-    containsMatchingElement(node: ReactElement<any>): boolean;
+    containsMatchingElement(node: ReactElement<any> | Array<ReactElement<any>>): boolean;
 
     /**
      * Returns whether or not all the given react elements exists in the shallow render tree
      */
-    containsAllMatchingElements(nodes: Array<ReactElement<any>>): boolean;
+    containsAllMatchingElements(nodes: Array<ReactElement<any>> | Array<Array<ReactElement<any>>>): boolean;
 
     /**
      * Returns whether or not one of the given react elements exists in the shallow render tree.
      */
-    containsAnyMatchingElements(nodes: Array<ReactElement<any>>): boolean;
+    containsAnyMatchingElements(nodes: Array<ReactElement<any>> | Array<Array<ReactElement<any>>>): boolean;
 
     /**
      * Returns whether or not the current render tree is equal to the given node, based on the expected value.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://medium.com/reactnative/arrays-in-react-16-and-the-necessity-of-keys-c62e7adb4206

The contains functions are great but when using them with React 16 they currently don't allow arrays of Nodes to be passed in (or arrays of arrays of Nodes in the case of containsAll / containsAny). This is imporant since in React 16 you may be wanting to check against an array of Nodes (since React will sometimes return an Element[]).



