### PR TITLE
execa: export all the interfaces and types

### DIFF
--- a/types/execa/index.d.ts
+++ b/types/execa/index.d.ts
@@ -4,7 +4,7 @@
 //                 BendingBender <https://github.com/BendingBender>
 //                 Borek Bernard <https://github.com/borekb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.5
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/execa/index.d.ts
+++ b/types/execa/index.d.ts
@@ -1,63 +1,65 @@
-// Type definitions for execa 0.7
+// Type definitions for execa 0.8
 // Project: https://github.com/sindresorhus/execa#readme
 // Definitions by: Douglas Duteil <https://github.com/douglasduteil>
 //                 BendingBender <https://github.com/BendingBender>
+//                 Borek Bernard <https://github.com/borekb>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.5
 
 /// <reference types="node" />
 
 import { ChildProcess, ExecOptions, SpawnOptions, SpawnSyncOptions } from "child_process";
 import { Stream } from 'stream';
 
-type StdIOOption = 'pipe' | 'ipc' | 'ignore' | number | Stream | undefined | null;
-
-interface ExecaOptions {
-    input: string | Buffer | Stream;
-    preferLocal: boolean;
-    stripEof: boolean;
-    extendEnv: boolean;
-    argv0: string;
-    localDir: string;
-    reject: boolean;
-    cleanup: boolean;
-    stdin: StdIOOption;
-    stdout: StdIOOption;
-    stderr: StdIOOption;
-}
-
-type Options = SpawnOptions & ExecaOptions & ExecOptions;
-type SyncOptions = SpawnSyncOptions & ExecaOptions & ExecOptions;
-
-interface ExecaReturns {
-    cmd: string;
-    code: number;
-    failed: boolean;
-    killed: boolean;
-    signal: string | null;
-    stderr: string;
-    stdout: string;
-    timedOut: boolean;
-}
-
-type ExecaError = Error & ExecaReturns;
-
-interface ExecaChildPromise {
-    catch<TResult = never>(onrejected?: ((reason: ExecaError) => TResult | PromiseLike<TResult>) | null): Promise<ExecaReturns | TResult>;
-}
-type ExecaChildProcess = ChildProcess & ExecaChildPromise & Promise<ExecaReturns>;
-
-declare function execa(file: string, options?: Partial<Options>): ExecaChildProcess;
-declare function execa(file: string, args?: string[], options?: Partial<Options>): ExecaChildProcess;
+declare function execa(file: string, options?: Partial<execa.Options>): execa.ExecaChildProcess;
+declare function execa(file: string, args?: string[], options?: Partial<execa.Options>): execa.ExecaChildProcess;
 declare namespace execa {
-    function stdout(file: string, options?: Partial<Options>): Promise<string>;
-    function stdout(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
-    function stderr(file: string, options?: Partial<Options>): Promise<string>;
-    function stderr(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
-    function shell(command: string, options?: Partial<Options>): ExecaChildProcess;
-    function sync(file: string, options?: Partial<SyncOptions>): ExecaReturns;
-    function sync(file: string, args?: string[], options?: Partial<SyncOptions>): ExecaReturns;
-    function shellSync(command: string, options?: Partial<Options>): ExecaReturns;
+
+    export type StdIOOption = 'pipe' | 'ipc' | 'ignore' | number | Stream | undefined | null;
+
+    export interface ExecaOptions {
+        input: string | Buffer | Stream;
+        preferLocal: boolean;
+        stripEof: boolean;
+        extendEnv: boolean;
+        argv0: string;
+        localDir: string;
+        reject: boolean;
+        cleanup: boolean;
+        stdin: StdIOOption;
+        stdout: StdIOOption;
+        stderr: StdIOOption;
+    }
+
+    export type Options = SpawnOptions & ExecaOptions & ExecOptions;
+    export type SyncOptions = SpawnSyncOptions & ExecaOptions & ExecOptions;
+
+    export interface ExecaReturns {
+        cmd: string;
+        code: number;
+        failed: boolean;
+        killed: boolean;
+        signal: string | null;
+        stderr: string;
+        stdout: string;
+        timedOut: boolean;
+    }
+
+    export type ExecaError = Error & ExecaReturns;
+
+    export interface ExecaChildPromise {
+        catch<TResult = never>(onrejected?: ((reason: ExecaError) => TResult | PromiseLike<TResult>) | null): Promise<ExecaReturns | TResult>;
+    }
+    export type ExecaChildProcess = ChildProcess & ExecaChildPromise & Promise<ExecaReturns>;
+
+    export function stdout(file: string, options?: Partial<Options>): Promise<string>;
+    export function stdout(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
+    export function stderr(file: string, options?: Partial<Options>): Promise<string>;
+    export function stderr(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
+    export function shell(command: string, options?: Partial<Options>): ExecaChildProcess;
+    export function sync(file: string, options?: Partial<SyncOptions>): ExecaReturns;
+    export function sync(file: string, args?: string[], options?: Partial<SyncOptions>): ExecaReturns;
+    export function shellSync(command: string, options?: Partial<Options>): ExecaReturns;
 }
 
 export = execa;

--- a/types/execa/index.d.ts
+++ b/types/execa/index.d.ts
@@ -14,10 +14,9 @@ import { Stream } from 'stream';
 declare function execa(file: string, options?: Partial<execa.Options>): execa.ExecaChildProcess;
 declare function execa(file: string, args?: string[], options?: Partial<execa.Options>): execa.ExecaChildProcess;
 declare namespace execa {
+    type StdIOOption = 'pipe' | 'ipc' | 'ignore' | number | Stream | undefined | null;
 
-    export type StdIOOption = 'pipe' | 'ipc' | 'ignore' | number | Stream | undefined | null;
-
-    export interface ExecaOptions {
+    interface ExecaOptions {
         input: string | Buffer | Stream;
         preferLocal: boolean;
         stripEof: boolean;
@@ -31,10 +30,10 @@ declare namespace execa {
         stderr: StdIOOption;
     }
 
-    export type Options = SpawnOptions & ExecaOptions & ExecOptions;
-    export type SyncOptions = SpawnSyncOptions & ExecaOptions & ExecOptions;
+    type Options = SpawnOptions & ExecaOptions & ExecOptions;
+    type SyncOptions = SpawnSyncOptions & ExecaOptions & ExecOptions;
 
-    export interface ExecaReturns {
+    interface ExecaReturns {
         cmd: string;
         code: number;
         failed: boolean;
@@ -45,21 +44,21 @@ declare namespace execa {
         timedOut: boolean;
     }
 
-    export type ExecaError = Error & ExecaReturns;
+    type ExecaError = Error & ExecaReturns;
 
-    export interface ExecaChildPromise {
+    interface ExecaChildPromise {
         catch<TResult = never>(onrejected?: ((reason: ExecaError) => TResult | PromiseLike<TResult>) | null): Promise<ExecaReturns | TResult>;
     }
-    export type ExecaChildProcess = ChildProcess & ExecaChildPromise & Promise<ExecaReturns>;
+    type ExecaChildProcess = ChildProcess & ExecaChildPromise & Promise<ExecaReturns>;
 
-    export function stdout(file: string, options?: Partial<Options>): Promise<string>;
-    export function stdout(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
-    export function stderr(file: string, options?: Partial<Options>): Promise<string>;
-    export function stderr(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
-    export function shell(command: string, options?: Partial<Options>): ExecaChildProcess;
-    export function sync(file: string, options?: Partial<SyncOptions>): ExecaReturns;
-    export function sync(file: string, args?: string[], options?: Partial<SyncOptions>): ExecaReturns;
-    export function shellSync(command: string, options?: Partial<Options>): ExecaReturns;
+    function stdout(file: string, options?: Partial<Options>): Promise<string>;
+    function stdout(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
+    function stderr(file: string, options?: Partial<Options>): Promise<string>;
+    function stderr(file: string, args?: string[], options?: Partial<Options>): Promise<string>;
+    function shell(command: string, options?: Partial<Options>): ExecaChildProcess;
+    function sync(file: string, options?: Partial<SyncOptions>): ExecaReturns;
+    function sync(file: string, args?: string[], options?: Partial<SyncOptions>): ExecaReturns;
+    function shellSync(command: string, options?: Partial<Options>): ExecaReturns;
 }
 
 export = execa;


### PR DESCRIPTION
This does not change the API for the main `execa` functions, just exports the related interfaces like `ExecaOptions` and `ExecaChildProcess` so that any custom code may reference them.

I've bumped version number to the latest v0.8.0 to be up to date.