### PR TITLE
[orchestrator & gulp] Update 'Q' dependency

### DIFF
--- a/types/gulp/v3/tsconfig.json
+++ b/types/gulp/v3/tsconfig.json
@@ -15,9 +15,6 @@
         "paths": {
             "gulp": [
                 "gulp/v3"
-            ],
-            "q": [
-                "q/v0"
             ]
         },
         "types": [],

--- a/types/orchestrator/orchestrator-tests.ts
+++ b/types/orchestrator/orchestrator-tests.ts
@@ -4,7 +4,7 @@ import stream = require("stream");
 import Q = require('q');
 import Orchestrator = require('orchestrator');
 
-var orchestrator = new Orchestrator();
+const orchestrator = new Orchestrator();
 
 // API:
 
@@ -21,13 +21,13 @@ orchestrator.add('mytask', ['array', 'of', 'task', 'names'], function() {
     // Do stuff
 });
 orchestrator.add('thing2', function(callback){
-    var err: any = null;
+    const err: any = null;
     // do stuff
     callback(err);
 });
 
 orchestrator.add('thing3', function(){
-    var deferred = Q.defer<void>();
+    const deferred = Q.defer<void>();
 
     // do async stuff
     setTimeout(function() {
@@ -38,7 +38,7 @@ orchestrator.add('thing3', function(){
 });
 
 orchestrator.add('thing4', function(){
-    var stm = new stream.Stream();
+    const stm = new stream.Stream();
     // do stream stuff
     return stm;
 });
@@ -61,7 +61,7 @@ orchestrator.task('task3', ['task1', 'task2'], function() {
 // orchestrator.hasTask(name);
 //
 
-var hasThing1: boolean = orchestrator.hasTask('thing1');
+const hasThing1: boolean = orchestrator.hasTask('thing1');
 
 //
 // orchestrator.start(tasks...[, cb]);
@@ -70,7 +70,7 @@ var hasThing1: boolean = orchestrator.hasTask('thing1');
 orchestrator.start('thing1', 'thing2', 'thing3', 'thing4', function(err: any) {
     // all done
 }).start(['thing1', 'thing2'], ['thing3', 'thing4'], "thing5", function(err) {
-    var res: any = err;
+    const res: any = err;
 });
 
 //
@@ -90,14 +90,14 @@ orchestrator.reset();
 //
 
 orchestrator.on('task_start', function(e) {
-    var message: string = e.message;
-    var task: string = e.task;
-    var err: any = e.err;
+    const message: string = e.message;
+    const task: string = e.task;
+    const err: any = e.err;
 });
 orchestrator.on('task_stop', function(e) {
-    var message: string = e.message;
-    var task: string = e.task;
-    var duration: number = e.duration;
+    const message: string = e.message;
+    const task: string = e.task;
+    const duration: number = e.duration;
 });
 
 //
@@ -105,8 +105,8 @@ orchestrator.on('task_stop', function(e) {
 //
 
 orchestrator.onAll(function(e) {
-    var message: string = e.message;
-    var task: string = e.task;
-    var err: any = e.err;
-    var src: string = e.src;
+    const message: string = e.message;
+    const task: string = e.task;
+    const err: any = e.err;
+    const src: string = e.src;
 });

--- a/types/orchestrator/tsconfig.json
+++ b/types/orchestrator/tsconfig.json
@@ -5,20 +5,15 @@
             "es6",
             "dom"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": false,
-        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"
         ],
-        "paths": {
-            "q": [
-                "q/v0"
-            ]
-        },
         "types": [],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
Orchestrator has been using q@~1.0.0 since version 0.3.2 (current: 0.3.8) released back in Jan 2014 (see orchestrator commit referenced below).
It's been almost 4 years, I'm guessing most people are using orchestrator@^0.3.2 so most users want declarations for q@^1.0.0.

- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Run `node node_modules/types-publisher/bin/tester/testjs --run-from-definitely-typed`.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/robrich/orchestrator/commit/12c378cc2e1d44aad03b124a3f82e45b992b6df5#diff-b9cfc7f2cdf78a7f4b91a753d10865a2
