### PR TITLE
[xml2js] Add processors to the main xml2js object

### DIFF
--- a/types/xml2js/index.d.ts
+++ b/types/xml2js/index.d.ts
@@ -4,10 +4,12 @@
 //                 Jason McNeil <https://github.com/jasonrm>
 //                 Christopher Currens <https://github.com/ccurrens>
 //                 Edward Hinkle <https://github.com/edwardhinkle>
+//                 Behind The Math <https://github.com/BehindTheMath>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
 import { EventEmitter } from 'events';
+import * as processors from './lib/processors';
 
 export function parseString(xml: convertableToString, callback: (err: any, result: any) => void): void;
 export function parseString(xml: convertableToString, options: OptionsV2, callback: (err: any, result: any) => void): void;
@@ -76,3 +78,5 @@ export interface OptionsV2 extends Options {
 export interface convertableToString {
     toString(): string;
 }
+
+export { processors };

--- a/types/xml2js/xml2js-tests.ts
+++ b/types/xml2js/xml2js-tests.ts
@@ -33,7 +33,7 @@ xml2js.parseString('<root>Hello xml2js!</root>', {
 }, (err: any, result: any) => { });
 
 xml2js.parseString('<root>Hello xml2js!</root>', {
-    attrNameProcessors: [processors.firstCharLowerCase],
+    attrNameProcessors: [processors.firstCharLowerCase, xml2js.processors.normalize],
     attrValueProcessors: [processors.normalize],
     tagNameProcessors: [processors.stripPrefix],
     valueProcessors: [processors.parseBooleans, processors.parseNumbers]


### PR DESCRIPTION
The processors are not only available by importing or requiring the file directly (`import * as processors from 'xml2js/lib/processors'`), they are also available on the main xml2js object (`xml2js.processors`).

---
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Leonidas-from-XIV/node-xml2js/blob/1ab44ea837eff59305bd11f0e1a1e542e7c3e79f/src/xml2js.coffee#L10
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.