### PR TITLE
react-tabs: export props for every component

### DIFF
--- a/types/react-tabs/index.d.ts
+++ b/types/react-tabs/index.d.ts
@@ -6,59 +6,38 @@
 
 import * as React from 'react';
 
-export as namespace ReactTabs;
-
-declare namespace ReactTabs {
-
-    interface TabsProps {
-        className?: string | Array<string> | { [name: string]: boolean; };
-        defaultFocus?: boolean;
-        defaultIndex?: number;
-        disabledTabClassName?: string;
-        forceRenderTabPanel?: boolean;
-        onSelect?: (index: number, last: number, event: Event) => boolean | void;
-        selectedIndex?: number;
-        selectedTabClassName?: string;
-        selectedTabPanelClassName?: string;
-    }
-
-    interface Tabs extends React.ComponentClass<TabsProps> {}
-
-    interface TabListProps {
-        className?: string | Array<string> | { [name: string]: boolean; };
-    }
-
-    interface TabList extends React.ComponentClass<TabListProps> {}
-
-    interface TabProps {
-        className?: string | Array<string> | { [name: string]: boolean; };
-        disabled?: boolean;
-        disabledClassName?: string;
-        selectedClassName?: string;
-    }
-
-    interface Tab extends React.ComponentClass<TabProps> {}
-
-    interface TabPanelProps {
-        className?: string | Array<string> | { [name: string]: boolean; };
-        forceRender?: boolean;
-        selectedClassName?: string;
-    }
-
-    interface TabPanel extends React.ComponentClass<TabPanelProps> {}
+export interface TabsProps {
+    className?: string | Array<string> | { [name: string]: boolean; };
+    defaultFocus?: boolean;
+    defaultIndex?: number;
+    disabledTabClassName?: string;
+    forceRenderTabPanel?: boolean;
+    onSelect?: (index: number, last: number, event: Event) => boolean | void;
+    selectedIndex?: number;
+    selectedTabClassName?: string;
+    selectedTabPanelClassName?: string;
 }
 
-declare const Tabs: ReactTabs.Tabs;
-declare const TabList: ReactTabs.TabList;
-declare const Tab: ReactTabs.Tab;
-declare const TabPanel: ReactTabs.TabPanel;
+export interface TabListProps {
+    className?: string | Array<string> | { [name: string]: boolean; };
+}
 
-declare function resetIdCounter(): void;
+export interface TabProps {
+    className?: string | Array<string> | { [name: string]: boolean; };
+    disabled?: boolean;
+    disabledClassName?: string;
+    selectedClassName?: string;
+}
 
-export {
-    Tabs,
-    TabList,
-    Tab,
-    TabPanel,
-    resetIdCounter
-};
+export interface TabPanelProps {
+    className?: string | Array<string> | { [name: string]: boolean; };
+    forceRender?: boolean;
+    selectedClassName?: string;
+}
+
+export declare class Tabs extends React.Component<TabsProps> {}
+export declare class TabList extends React.Component<TabListProps> {}
+export declare class Tab extends React.Component<TabProps> {}
+export declare class TabPanel extends React.Component<TabPanelProps> {}
+
+export declare function resetIdCounter(): void;

--- a/types/react-tabs/react-tabs-tests.ts
+++ b/types/react-tabs/react-tabs-tests.ts
@@ -1,8 +1,22 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { Tabs, TabList, Tab, TabPanel, resetIdCounter } from "react-tabs";
+import {
+    Tabs,
+    TabsProps,
+    TabList,
+    TabListProps,
+    Tab,
+    TabProps,
+    TabPanel,
+    TabPanelProps,
+    resetIdCounter } from "react-tabs";
 
 resetIdCounter();
+
+interface TestTabProps extends TabProps {}
+interface TestTabListProps extends TabListProps {}
+interface TestTabPanelProps extends TabPanelProps {}
+interface TestTabsProps extends TabsProps {}
 
 class TestApp extends React.Component {
     onSelect = (index: number, last: number, event: Event) => {


### PR DESCRIPTION
Current typings version doesn't allow to use component props for extending or importing. This PR aims to fix this inconvenience. 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.