### PR TITLE
react-dropzone: export Dropzone by default as it is in the original package

### DIFF
--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -11,41 +11,37 @@
 
 import { CSSProperties, Component, DragEvent, InputHTMLAttributes } from "react";
 
-declare namespace Dropzone {
-    export interface ImageFile extends File {
-        preview?: string;
-    }
-
-    export type DropFileEventHandler = (acceptedOrRejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
-    export type DropFilesEventHandler = (accepted: ImageFile[], rejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
-
-    type PickedAttributes = "accept" | "className" | "multiple" | "name" | "onClick" | "onDragStart" | "onDragEnter" | "onDragOver" | "onDragLeave" | "style";
-
-    export interface DropzoneProps extends Pick<InputHTMLAttributes<HTMLDivElement>, PickedAttributes> {
-        disableClick?: boolean;
-        disabled?: boolean;
-        disablePreview?: boolean;
-        preventDropOnDocument?: boolean;
-        inputProps?: InputHTMLAttributes<HTMLInputElement>;
-        maxSize?: number;
-        minSize?: number;
-        activeClassName?: string;
-        acceptClassName?: string;
-        rejectClassName?: string;
-        disabledClassName?: string;
-        activeStyle?: CSSProperties;
-        acceptStyle?: CSSProperties;
-        rejectStyle?: CSSProperties;
-        disabledStyle?: CSSProperties;
-        onDrop?: DropFilesEventHandler;
-        onDropAccepted?: DropFileEventHandler;
-        onDropRejected?: DropFileEventHandler;
-        onFileDialogCancel?: () => void;
-    }
+export interface ImageFile extends File {
+    preview?: string;
 }
 
-declare class Dropzone extends Component<Dropzone.DropzoneProps> {
+export type DropFileEventHandler = (acceptedOrRejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
+export type DropFilesEventHandler = (accepted: ImageFile[], rejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
+
+type PickedAttributes = "accept" | "className" | "multiple" | "name" | "onClick" | "onDragStart" | "onDragEnter" | "onDragOver" | "onDragLeave" | "style";
+
+export interface DropzoneProps extends Pick<InputHTMLAttributes<HTMLDivElement>, PickedAttributes> {
+    disableClick?: boolean;
+    disabled?: boolean;
+    disablePreview?: boolean;
+    preventDropOnDocument?: boolean;
+    inputProps?: InputHTMLAttributes<HTMLInputElement>;
+    maxSize?: number;
+    minSize?: number;
+    activeClassName?: string;
+    acceptClassName?: string;
+    rejectClassName?: string;
+    disabledClassName?: string;
+    activeStyle?: CSSProperties;
+    acceptStyle?: CSSProperties;
+    rejectStyle?: CSSProperties;
+    disabledStyle?: CSSProperties;
+    onDrop?: DropFilesEventHandler;
+    onDropAccepted?: DropFileEventHandler;
+    onDropRejected?: DropFileEventHandler;
+    onFileDialogCancel?: () => void;
+}
+
+export default class Dropzone extends Component<DropzoneProps> {
     open(): void;
 }
-
-export = Dropzone;

--- a/types/react-dropzone/react-dropzone-tests.tsx
+++ b/types/react-dropzone/react-dropzone-tests.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { DragEvent, SyntheticEvent } from "react";
-import Dropzone = require("react-dropzone");
-import { ImageFile } from "react-dropzone";
+import Dropzone, { ImageFile } from "react-dropzone";
 
 class Test extends React.Component {
 
@@ -23,7 +22,7 @@ class Test extends React.Component {
     return (
       <div>
         <Dropzone
-          ref={(node) => { this.dz = node }}
+          ref={(node: Dropzone) => { this.dz = node }}
           onClick={this.handleDefault}
           onDrop={this.handleDropFiles}
           onDropAccepted={this.handleDropFile }


### PR DESCRIPTION
From [sources](https://github.com/react-dropzone/react-dropzone/blob/master/src/index.js#L417) `Dropzone` should be exported by default, not using `export = Dropzone`. It is also actual for the `4.1.3` version ([url](https://github.com/react-dropzone/react-dropzone/blob/1d270e5379576c1e62cb7ae6aba905f31a372c02/src/index.js#L417)). 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [current version](https://github.com/react-dropzone/react-dropzone/blob/master/src/index.js#L417), [version 4.1.3](https://github.com/react-dropzone/react-dropzone/blob/1d270e5379576c1e62cb7ae6aba905f31a372c02/src/index.js#L417)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
