### PR TITLE
Change escape-string-regexp export to const

### DIFF
--- a/types/escape-string-regexp/index.d.ts
+++ b/types/escape-string-regexp/index.d.ts
@@ -1,10 +1,11 @@
 // Type definitions for escape-string-regexp
 // Project: https://github.com/sindresorhus/escape-string-regexp
 // Definitions by: kruncher <https://github.com/kruncher>
+//                 faergeek <https://github.com/faergeek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
 
-declare function escapeStringRegexp(str: string): string;
+declare const escapeStringRegexp: (str: string) => string;
 
 export = escapeStringRegexp;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Right now I use `awesome-type-script-loader` for webpack and it complains like this:
```
TS2497: Module '"<...>/node_modules/@types/escape-string-regexp/index"' resolves to a non-module entity and cannot be imported using this construct.
```

I import it like this:
```
import * as escapeRegexp from 'escape-string-regexp'
```

If it's just me doing something wrong, would be nice to hear what exactly, Thanks 👍 