### PR TITLE
react-native: Added missing SectionList.getItemLayout prop

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3744,6 +3744,18 @@ export interface SectionListProperties<ItemT> extends ScrollViewProperties {
     extraData?: any
 
     /**
+     * `getItemLayout` is an optional optimization that lets us skip measurement of dynamic
+     * content if you know the height of items a priori. getItemLayout is the most efficient,
+     * and is easy to use if you have fixed height items, for example:
+     * ```
+     * getItemLayout={(data, index) => (
+     *   {length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index}
+     * )}
+     * ```
+     */
+    getItemLayout?: (data: SectionListData<ItemT>[] | null, index: number) => {length: number, offset: number, index: number}
+
+    /**
      * How many items to render in the initial batch
      */
     initialNumToRender?: number


### PR DESCRIPTION
Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X] Test the change in your own code. (Compile and run.)
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: Unbdocumented, but referenced here: https://facebook.github.io/react-native/docs/sectionlist.html#scrolltolocation It's inherited from VirtualizedList
- [X ] Increase the version number in the header if appropriate.
- [X ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

