### PR TITLE
emscripten: ccall and cwrap returnType type can also be null

### DIFF
--- a/types/emscripten/emscripten-tests.ts
+++ b/types/emscripten/emscripten-tests.ts
@@ -18,6 +18,7 @@ function ModuleTest(): void {
     Module.print = function(text) { alert('stdout: ' + text) };
 
     var int_sqrt = Module.cwrap('int_sqrt', 'number', ['number'])
+    int_sqrt = Module.cwrap('int_sqrt', null, ['number'])
     int_sqrt(12)
     int_sqrt(28)
 
@@ -27,6 +28,7 @@ function ModuleTest(): void {
     var x = Module.getValue(buf, 'i32') + 123;
     Module.HEAPU8.set(myTypedArray, buf);
     Module.ccall('my_function', 'number', ['number'], [buf]);
+    Module.ccall('my_function', null, ['number'], [buf]);
     Module._free(buf);
     Module.destroy({});
 }

--- a/types/emscripten/index.d.ts
+++ b/types/emscripten/index.d.ts
@@ -40,8 +40,8 @@ declare namespace Module {
 
     var Runtime: any;
 
-    function ccall(ident: string, returnType: string, argTypes: string[], args: any[]): any;
-    function cwrap(ident: string, returnType: string, argTypes: string[]): any;
+    function ccall(ident: string, returnType: string | null, argTypes: string[], args: any[]): any;
+    function cwrap(ident: string, returnType: string | null, argTypes: string[]): any;
 
     function setValue(ptr: number, value: any, type: string, noSafe?: boolean): void;
     function getValue(ptr: number, type: string, noSafe?: boolean): number;


### PR DESCRIPTION
See https://kripken.github.io/emscripten-site/docs/api_reference/preamble.js.html

> For a void function this can be null (note: the JavaScript null value, not a string containing the word “null”).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see commit message
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.