### PR TITLE
[@types/google-cloud__datastore] return type of runQuery should be a promise

### DIFF
--- a/types/google-cloud__datastore/index.d.ts
+++ b/types/google-cloud__datastore/index.d.ts
@@ -223,7 +223,7 @@ declare module '@google-cloud/datastore/request' {
 
         runQuery(query: Query, options: QueryOptions, callback: QueryCallback): void;
         runQuery(query: Query, callback: QueryCallback): void;
-        runQuery(query: Query, options?: QueryOptions): QueryResult;
+        runQuery(query: Query, options?: QueryOptions): Promise<QueryResult>;
 
         runQueryStream(query: Query, options?: QueryOptions): NodeJS.ReadableStream;
 


### PR DESCRIPTION
Fix for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20724

