### PR TITLE
ckeditor: Added support for separators in CKEditor toolbarGroups configuration

### DIFF
--- a/types/ckeditor/ckeditor-tests.ts
+++ b/types/ckeditor/ckeditor-tests.ts
@@ -52,6 +52,23 @@ function test_config() {
             [ 'list', 'indent', 'blocks', 'align', 'bidi' ],
         ],
     };
+    var config3: CKEDITOR.config = {
+        toolbarGroups: [
+            { name: 'clipboard', groups: [ 'clipboard', 'undo' ] },
+		    { name: 'editing', groups: [ 'find', 'selection', 'spellchecker', 'editing' ] },
+		    { name: 'links', groups: [ 'links' ] },
+		    { name: 'insert', groups: [ 'insert' ] },
+		    { name: 'tools', groups: [ 'tools' ] },
+		    { name: 'document', groups: [ 'mode' ] },
+		    { name: 'about', groups: [ 'about' ] },
+		    '/',
+		    { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },
+		    { name: 'paragraph', groups: [ 'list', 'indent', 'blocks', 'align', 'paragraph' ] },
+		    '/',
+		    { name: 'styles', groups: [ 'styles' ] },
+		    { name: 'colors', groups: [ 'colors' ] },
+        ],
+    }
 }
 
 function test_dom_comment() {

--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for CKEditor
 // Project: http://ckeditor.com/
 // Definitions by: Ondrej Sevcik <https://github.com/ondrejsevcik>
+//                 Thomas Wittwer <https://github.com/wittwert>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // WORK-IN-PROGRESS: Any contribution support welcomed.
@@ -814,7 +815,7 @@ declare namespace CKEDITOR {
         toolbar?: string | (string | string[])[];
         toolbarCanCollapse?: boolean;
         toolbarGroupCycling?: boolean;
-        toolbarGroups?: toolbarGroups[];
+        toolbarGroups?: (toolbarGroups | string)[];
         toolbarLocation?: string;
         toolbarStartupExpanded?: boolean;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_toolbar>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
