### PR TITLE
aws-lambda: Add support for custom REQUEST authorisers

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -5,7 +5,8 @@ var num: number = 5;
 var error: Error = new Error();
 var b: boolean = true;
 var apiGwEvt: AWSLambda.APIGatewayEvent;
-var customAuthorizerEvt: AWSLambda.CustomAuthorizerEvent;
+var customTokenAuthorizerEvt: AWSLambda.CustomTokenAuthorizerEvent;
+var customRequestAuthorizerEvt: AWSLambda.CustomRequestAuthorizerEvent;
 var clientCtx: AWSLambda.ClientContext;
 var clientContextEnv: AWSLambda.ClientContextEnv;
 var clientContextClient: AWSLambda.ClientContextClient;
@@ -95,10 +96,30 @@ str = apiGwEvt.requestContext.resourceId;
 str = apiGwEvt.requestContext.resourcePath;
 str = apiGwEvt.resource;
 
-/* API Gateway CustomAuthorizer Event */
-str = customAuthorizerEvt.type;
-str = customAuthorizerEvt.authorizationToken;
-str = customAuthorizerEvt.methodArn;
+/* API Gateway CustomTokenAuthorizer Event */
+str = customTokenAuthorizerEvt.type;
+str = customTokenAuthorizerEvt.authorizationToken;
+str = customTokenAuthorizerEvt.methodArn;
+
+/* API Gateway CustomRequestAuthorizer Event */
+str = customRequestAuthorizerEvt.type;
+str = customRequestAuthorizerEvt.methodArn;
+str = customRequestAuthorizerEvt.resource;
+str = customRequestAuthorizerEvt.path;
+str = customRequestAuthorizerEvt.httpMethod;
+str = customRequestAuthorizerEvt.headers.Authorization;
+str = customRequestAuthorizerEvt.queryStringParameters.test;
+str = customRequestAuthorizerEvt.pathParameters.proxy;
+str = customRequestAuthorizerEvt.stageVariables.environment;
+str = customRequestAuthorizerEvt.requestContext.path;
+str = customRequestAuthorizerEvt.requestContext.accountId;
+str = customRequestAuthorizerEvt.requestContext.resourceId;
+str = customRequestAuthorizerEvt.requestContext.stage;
+str = customRequestAuthorizerEvt.requestContext.requestId;
+str = customRequestAuthorizerEvt.requestContext.identity.test;
+str = customRequestAuthorizerEvt.requestContext.resourcePath;
+str = customRequestAuthorizerEvt.requestContext.httpMethod;
+str = customRequestAuthorizerEvt.requestContext.apiId;
 
 /* SNS Event */
 snsEvtRecs = snsEvt.Records;

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -116,7 +116,7 @@ str = customRequestAuthorizerEvt.requestContext.accountId;
 str = customRequestAuthorizerEvt.requestContext.resourceId;
 str = customRequestAuthorizerEvt.requestContext.stage;
 str = customRequestAuthorizerEvt.requestContext.requestId;
-str = customRequestAuthorizerEvt.requestContext.identity.test;
+str = customRequestAuthorizerEvt.requestContext.identity.caller;
 str = customRequestAuthorizerEvt.requestContext.resourcePath;
 str = customRequestAuthorizerEvt.requestContext.httpMethod;
 str = customRequestAuthorizerEvt.requestContext.apiId;
@@ -320,6 +320,7 @@ function proxyCallback(cb: AWSLambda.ProxyCallback) {
 function customAuthorizerCallback(cb: AWSLambda.CustomAuthorizerCallback) {
     cb();
     cb(null);
+    cb("Unauthorized");
     cb(error);
     cb(null, authResponse);
 }

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -48,11 +48,36 @@ interface APIGatewayEvent {
 }
 
 // API Gateway CustomAuthorizer "event"
-interface CustomAuthorizerEvent {
-    type: string;
+interface CustomTokenAuthorizerEvent {
+    type: "TOKEN";
     authorizationToken: string;
     methodArn: string;
 }
+
+interface CustomRequestAuthorizerEvent {
+    type: "REQUEST";
+    methodArn: string;
+    resource: string;
+    path: string;
+    httpMethod: string;
+    headers: { [ header: string]: string | undefined };
+    queryStringParameters: { [parameter: string]: string | undefined };
+    pathParameters: { [parameter: string]: string | undefined };
+    stageVariables: { [parameter: string]: string | undefined };
+    requestContext: {
+        path: string;
+        accountId: string;
+        resourceId: string;
+        stage: string;
+        requestId: string;
+        identity: { [parameter: string]: string | null | undefined };
+        resourcePath: string;
+        httpMethod: string;
+        apiId: string;
+    };
+}
+
+type CustomAuthorizerEvent = CustomTokenAuthorizerEvent | CustomRequestAuthorizerEvent
 
 // SNS "event"
 interface SNSMessageAttribute {

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -39,6 +39,7 @@ interface APIGatewayEvent {
             userAgent: string | null;
             userArn: string | null;
         },
+        path: string | null;
         stage: string;
         requestId: string;
         resourceId: string;
@@ -54,27 +55,9 @@ interface CustomTokenAuthorizerEvent {
     methodArn: string;
 }
 
-interface CustomRequestAuthorizerEvent {
+interface CustomRequestAuthorizerEvent extends APIGatewayEvent {
     type: "REQUEST";
     methodArn: string;
-    resource: string;
-    path: string;
-    httpMethod: string;
-    headers: { [ header: string]: string | undefined };
-    queryStringParameters: { [parameter: string]: string | undefined };
-    pathParameters: { [parameter: string]: string | undefined };
-    stageVariables: { [parameter: string]: string | undefined };
-    requestContext: {
-        path: string;
-        accountId: string;
-        resourceId: string;
-        stage: string;
-        requestId: string;
-        identity: { [parameter: string]: string | null | undefined };
-        resourcePath: string;
-        httpMethod: string;
-        apiId: string;
-    };
 }
 
 type CustomAuthorizerEvent = CustomTokenAuthorizerEvent | CustomRequestAuthorizerEvent
@@ -382,6 +365,6 @@ export type CustomAuthorizerHandler = (event: CustomAuthorizerEvent, context: Co
  */
 export type Callback = (error?: Error | null, result?: object) => void;
 export type ProxyCallback = (error?: Error | null, result?: ProxyResult) => void;
-export type CustomAuthorizerCallback = (error?: Error | null, result?: AuthResponse) => void;
+export type CustomAuthorizerCallback = (error?: "Unauthorized" | Error | null, result?: AuthResponse) => void;
 
 export as namespace AWSLambda;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-input (see the subsection about `REQUEST` authorizers)
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
