### PR TITLE
Added support for ioredis arguments and reply transformer. e.g.

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -22,6 +22,7 @@ interface RedisStatic {
     (options: IORedis.RedisOptions): IORedis.Redis;
     (url: string): IORedis.Redis;
     Cluster: IORedis.Cluster;
+    Command: IORedis.Command;
 }
 
 declare var IORedis: RedisStatic;
@@ -37,6 +38,19 @@ declare module IORedis {
             lua?: string;
         }): any;
         sendCommand(): void;
+    }
+
+    interface ArgumentTransformer {
+        (args: Array<any>): Array<any>;
+    }
+
+    interface ReplyTransformer {
+        (result: any): any;
+    }
+
+    interface Command {
+        setArgumentTransformer(name: string, fn: ArgumentTransformer): void;
+        setReplyTransformer(name: string, fn: ReplyTransformer): void;
     }
 
     interface Redis extends NodeJS.EventEmitter, Commander {

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -54,3 +54,11 @@ redis.on('message', function(channel: any, message: any) {
 redis.on('messageBuffer', function(channel: any, message: any) {
     // Both `channel` and `message` are buffers.
 });
+
+Redis.Command.setArgumentTransformer('set', (args: Array<any>) => {
+    return args;
+});
+
+Redis.Command.setReplyTransformer('get', (result: any) => {
+    return result;
+});


### PR DESCRIPTION
```typescript
IORedis.Command.setArgumentTransformer('set', (args: Array<any>) => {
  return args;
});

IORedis.Command.setReplyTransformer('get', (result: any) => {
  return result;
});
```

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/search?utf8=%E2%9C%93&q=setArgumentTransformer&type=
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
