### PR TITLE
Change debounce export type

### DIFF
--- a/types/debounce/index.d.ts
+++ b/types/debounce/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for debounce 1.0
 // Project: https://github.com/component/debounce
 // Definitions by: Denis Sokolov <https://github.com/denis-sokolov>
+//                 faergeek <https://github.com/faergeek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function debounce<A extends Function>(f: A, interval?: number, immediate?: boolean): A & { clear(): void; };
+declare const debounce: <A extends Function>(f: A, interval?: number, immediate?: boolean) => A & { clear(): void; };
 export = debounce;

--- a/types/debounce/tslint.json
+++ b/types/debounce/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "dtslint/dt.json",
   "rules": {
-    "ban-types": false
+    "ban-types": false,
+    "prefer-declare-function": false
   }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

TL;DR: This is similar to #21062

Right now I use `awesome-type-script-loader` for webpack and it complains like this:
```
TS2497: Module '"<...>/node_modules/@types/debounce/index"' resolves to a non-module entity and cannot be imported using this construct.
```

I import it like this:
```
import * as debounce from 'debounce'
```