### PR TITLE
lodash use typescript Pick<> to improve _.pick typings

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -13908,10 +13908,30 @@ declare namespace _ {
          * _.pick(object, ['a', 'c']);
          * // => { 'a': 1, 'c': 3 }
          */
-        pick<T extends object>(
+        pick<T extends object, U extends keyof T>(
+            object: T | null | undefined,
+             ...props: U[]
+        ): Pick<T, U>;
+
+        pick<T extends object, U extends keyof T>(
+            object: T | null | undefined,
+            props: U[]
+        ): Pick<T, U>;
+
+        pick<T>(
+            object: T | null | undefined,
+            props: PropertyPath[]
+        ): PartialObject<T>;
+
+        pick<T>(
             object: T | null | undefined,
             ...props: PropertyPath[]
         ): PartialObject<T>;
+
+        pick<T extends object, U extends keyof T>(
+            object: T | null | undefined,
+            ...props: PropertyPath[]
+        ): Pick<T, U>;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -13910,28 +13910,13 @@ declare namespace _ {
          */
         pick<T extends object, U extends keyof T>(
             object: T | null | undefined,
-             ...props: U[]
-        ): Pick<T, U>;
-
-        pick<T extends object, U extends keyof T>(
-            object: T | null | undefined,
-            props: U[]
+             ...props: Array<Many<U>>
         ): Pick<T, U>;
 
         pick<T>(
             object: T | null | undefined,
-            props: PropertyPath[]
-        ): PartialObject<T>;
-
-        pick<T>(
-            object: T | null | undefined,
             ...props: PropertyPath[]
-        ): PartialObject<T>;
-
-        pick<T extends object, U extends keyof T>(
-            object: T | null | undefined,
-            ...props: PropertyPath[]
-        ): Pick<T, U>;
+        ): PartialDeep<T>;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -11184,6 +11184,12 @@ namespace TestPick {
     }
 
     {
+        let result: Pick<TResult, 'a' | 'b'>;
+        result = _.pick(obj, 'a', 'b');
+        result = _.pick(obj, ['a', 'b']);
+    }
+
+    {
         let result: _.LoDashImplicitWrapper<Partial<TResult>>;
 
         result = _(obj).pick<TResult>('a');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This provides the necessary overloads to provide correct and complete typings for `_.pick` by annotation or by type inference.

```
const o = {
  key1: [1, 2, 3],
  key2: "hello world"
}
let x = _.pick(o, ["key1"]);
x = _.pick(o, "key1");

// typeof x === {key1: number[]}

const key = "key1";
let y = _.pick(o, key);
y = _.pick(o, [key]);

// typeof y === {key1: number[]}

const keys: string[] = ["key1", "key2"];
let z = _.pick(o, keys);

/*
typeof z === Partial<{
  key1: number[],
  key2: string
}>
*/
```