### PR TITLE
Add types for react-numeric-input

### DIFF
--- a/types/react-numeric-input/index.d.ts
+++ b/types/react-numeric-input/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for react-numeric-input 2.2
+// Project: https://github.com/vlad-ignatov/react-numeric-input#readme
+// Definitions by: Heather Booker <https://github.com/heatherbooker>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as React from 'react';
+
+export = NumericInput;
+
+declare namespace NumericInput {
+    interface NumericInputProps extends React.Props<NumericInput> {
+        addLabelText?: string;
+        className?: string;
+        defaultValue?: number | string;
+        disabled?: boolean;
+        format?: ((s: string) => string);
+        max?: number | ((v: number) => number);
+        maxLength?: number;
+        min?: number | ((v: number) => number);
+        mobile?: boolean | 'auto' | ((this: NumericInput) => any); // TODO: fix `any`
+        noValidate?: boolean| string;
+        onBlur?: React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
+        onChange?: ((v: number, s: string, i: JSX.Element) => void);
+        onFocus?: React.FocusEventHandler<HTMLDivElement | HTMLInputElement>;
+        onInput?: ((...args: any[]) => void);
+        onInvalid?: ((err: string, v: number, s: string) => void);
+        onKeyDown?: React.KeyboardEventHandler<HTMLDivElement | HTMLInputElement>;
+        onSelect?: ((...args: any[]) => void);
+        onValid?: ((v: number, s: string) => void);
+        parse?: ((s: string) => number | string);
+        pattern?: string;
+        precision?: number | ((this: NumericInput) => void);
+        readOnly?: boolean;
+        required?: boolean;
+        size?: number | string;
+        snap?: boolean;
+        step?: number | object; // TODO: should be `number | <some function>`
+        strict?: boolean;
+        style?: { [key: string]: { [key: string]: string } } | boolean;
+        type?: string;
+        value?: number | string;
+    }
+}
+
+declare class NumericInput extends React.Component<NumericInput.NumericInputProps> {}

--- a/types/react-numeric-input/react-numeric-input-tests.tsx
+++ b/types/react-numeric-input/react-numeric-input-tests.tsx
@@ -1,0 +1,8 @@
+import { Component } from 'react';
+import * as NumericInput from 'react-numeric-input';
+
+export class NumericInputTest extends Component {
+  render() {
+    return(<NumericInput />);
+  }
+}

--- a/types/react-numeric-input/tsconfig.json
+++ b/types/react-numeric-input/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "jsx": "preserve",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-numeric-input-tests.tsx"
+    ]
+}

--- a/types/react-numeric-input/tslint.json
+++ b/types/react-numeric-input/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This adds types for [react-numeric-input](https://github.com/vlad-ignatov/react-numeric-input). (This is my first go at adding types to a project so apologies for anything that's not quite right.)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them. (Maybe - last update to that repo was 3mths)
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`. (dts-gen does not include strictFunctionTypes, and compiler complains it is an unexpected option.)

