### PR TITLE
aws-iot-device-sdk-js: add missing types for device() constructor options

### DIFF
--- a/types/aws-iot-device-sdk/index.d.ts
+++ b/types/aws-iot-device-sdk/index.d.ts
@@ -32,19 +32,19 @@ export interface DeviceOptions extends mqtt.IClientOptions {
    * same as certPath, but can also accept a buffer containing client
    * certificate data
    */
-  clientCert?: string;
+  clientCert?: string | Buffer;
 
   /**
    * same as keyPath, but can also accept a buffer containing private key
    * data
    */
-  privateKey?: string;
+  privateKey?: string | Buffer;
 
   /**
    * same as caPath, but can also accept a buffer containing CA certificate
    * data
    */
-  caCert?: string;
+  caCert?: string | Buffer;
 
   /**
    * set to "true" to automatically re-subscribe to topics after


### PR DESCRIPTION
According to the docs, clientCert, privateKey and caCert can be Buffers: https://github.com/aws/aws-iot-device-sdk-js/blob/master/README.md#L226-L228

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/aws/aws-iot-device-sdk-js/blob/master/README.md#L226-L228
- [x] Increase the version number in the header if appropriate. (I don't think it's appropriate as the definition refers to version 2.1.0 which this PR is also targeting.)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
