### PR TITLE
Add types for react-alert

### DIFF
--- a/types/react-alert/index.d.ts
+++ b/types/react-alert/index.d.ts
@@ -73,7 +73,7 @@ export interface AlertShowOptions {
     type?: string;
 }
 
-export class AlertContainer extends React.Component<AlertContainerProps> {
+export default class AlertContainer extends React.Component<AlertContainerProps> {
     /**
      * Show a success alert.
      * @returns The id of the created alert.

--- a/types/react-alert/index.d.ts
+++ b/types/react-alert/index.d.ts
@@ -1,0 +1,110 @@
+// Type definitions for react-alert 2.4
+// Project: https://github.com/schiehll/react-alert
+// Definitions by: Steve Syrell <https://github.com/ssyrell>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as React from "react";
+
+export interface AlertContainerProps {
+    /**
+     * The offset of the alert from the page border, can be any number.
+     *
+     * Default: 14.
+     */
+    offset: number;
+
+    /**
+     * The position of the alert. Can be [bottom left, bottom right, top left, top right].
+     *
+     * Default: 'bottom left'
+     */
+    position: string;
+
+    /**
+     * The color theme of the alert. Can be [dark, light].
+     *
+     * Default: 'dark'
+     */
+    theme: string;
+
+    /**
+     * The time in milliseconds the alert is displayed. After this
+     * time ellapses, the alert will close itself. Use 0 to prevent self-closure
+     * (applies to all alerts).
+     *
+     * Default: 5000
+     */
+    time: number;
+
+    /**
+     * The transition animation. Can be [scale, fade].
+     *
+     * Default: 'scale'
+     */
+    transition: string;
+}
+
+export interface AlertShowOptions {
+    /**
+     * The time in milliseconds the alert is displayed. After this
+     * time ellapses, the alert will close itself. Use 0 to prevent self-closure.
+     */
+    time?: number;
+
+    /**
+     * The icon to show in the alert.
+     *
+     * Default: the icon which matches the type of alert to be shown.
+     */
+    icon?: React.ReactNode;
+
+    /**
+     * A callback function that will be called when the alert is closed.
+     */
+    onClose?: () => void;
+
+    /**
+     * The type of alert to show. This will only be used when calling show().
+     * Can be [info, success, error].
+     *
+     * Default: 'info'
+     */
+    type?: string;
+}
+
+export class AlertContainer extends React.Component<AlertContainerProps> {
+    /**
+     * Show a success alert.
+     * @returns The id of the created alert.
+     */
+    success(message: string, options?: AlertShowOptions): string;
+
+    /**
+     * Show an error alert.
+     * @returns The id of the created alert.
+     */
+    error(message: string, options?: AlertShowOptions): string;
+
+    /**
+     * Show an info alert.
+     * @returns The id of the created alert.
+     */
+    info(message: string, options?: AlertShowOptions): string;
+
+    /**
+     * Show an alert.
+     * @returns The id of the created alert.
+     */
+    show(message: string, options?: AlertShowOptions): string;
+
+    /**
+     * Remove all alerts from the page.
+     */
+    removeAll(): void;
+
+    /**
+     * Removes the alert with the specified id from the page.
+     */
+    remove(id: string): void;
+}

--- a/types/react-alert/react-alert-tests.tsx
+++ b/types/react-alert/react-alert-tests.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { AlertContainer, AlertContainerProps, AlertShowOptions } from "react-alert";
+
+export class ReactAlertTest extends React.Component {
+    private _alert: AlertContainer;
+    render() {
+        const props: AlertContainerProps = {
+            offset: 14,
+            position: "bottom left",
+            theme: "dark",
+            time: 5000,
+            transition: "scale"
+        };
+
+        return (
+            <div>
+                <AlertContainer ref={a => this._alert = a as AlertContainer} {...props} />
+            </div>
+        );
+    }
+
+    private _testMethods(): void {
+        const options: AlertShowOptions = {
+            time: 5000,
+            type: "info",
+            onClose: this._onAlertClosed,
+            icon: <img src="path/to/some/image/32x32.png" />
+        };
+
+        let alertId: string;
+        alertId = this._alert.show("show without options");
+        alertId = this._alert.show("show with options", options);
+
+        alertId = this._alert.error("error without options");
+        alertId = this._alert.error("error with options", options);
+
+        alertId = this._alert.info("info without options");
+        alertId = this._alert.info("info with options", options);
+
+        alertId = this._alert.success("success without options");
+        alertId = this._alert.success("success with options", options);
+
+        this._alert.remove(alertId);
+        this._alert.removeAll();
+    }
+
+    private _onAlertClosed(): void { }
+}

--- a/types/react-alert/react-alert-tests.tsx
+++ b/types/react-alert/react-alert-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { AlertContainer, AlertContainerProps, AlertShowOptions } from "react-alert";
+import AlertContainer, { AlertContainerProps, AlertShowOptions } from "react-alert";
 
 export class ReactAlertTest extends React.Component {
     private _alert: AlertContainer;

--- a/types/react-alert/tsconfig.json
+++ b/types/react-alert/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-alert-tests.tsx"
+    ]
+}

--- a/types/react-alert/tslint.json
+++ b/types/react-alert/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This commit adds types for [react-alert](https://github.com/schiehll/react-alert)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.