### PR TITLE
[d3-dsv] Validate for strictNullChecks and JSDoc

### DIFF
--- a/types/d3-dsv/d3-dsv-tests.ts
+++ b/types/d3-dsv/d3-dsv-tests.ts
@@ -68,6 +68,25 @@ parseMappedArray = d3Dsv.csvParse(csvTestStringWithHeader, (rawRow, index, colum
     return pr;
 });
 
+parseMappedArray = d3Dsv.csvParse(csvTestStringWithHeader, (rawRow, index, columns) => {
+    const rr: d3Dsv.DSVRowString = rawRow;
+    const i: number = index;
+    const c: string[] = columns;
+    const pr: ParsedTestObject | null | undefined = +rr['Year'] > 1995
+        ? (
+            +rr['Year'] <= 2017
+                ? {
+                    year: new Date(+rr['Year'], 0, 1),
+                    make: rr['Make'],
+                    model: rr['Model'],
+                    length: +rr['Length']
+                }
+                : undefined
+        )
+        : null;
+    return pr;
+});
+
 columns = parseMappedArray.columns;
 
 date = parseMappedArray[0].year;
@@ -89,12 +108,18 @@ str = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = d3Dsv.csvParseRows(csvTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const pr: ParsedTestObject = {
-        year: new Date(+rr[0], 0, 1),
-        make: rr[1],
-        model: rr[2],
-        length: +rr[3]
-    };
+    const pr: ParsedTestObject | null | undefined = +rr[0] > 1995
+    ? (
+        +rr[0] <= 2017
+            ? {
+                year: new Date(+rr[0], 0, 1),
+                make: rr[1],
+                model: rr[2],
+                length: +rr[3]
+            }
+            : undefined
+    )
+    : null;
     return pr;
 });
 
@@ -138,12 +163,18 @@ parseMappedArray = d3Dsv.tsvParse(tsvTestStringWithHeader, (rawRow, index, colum
     const rr: d3Dsv.DSVRowString = rawRow;
     const i: number = index;
     const c: string[] = columns;
-    const pr: ParsedTestObject = {
-        year: new Date(+rr['Year'], 0, 1),
-        make: rr['Make'],
-        model: rr['Model'],
-        length: +rr['Length']
-    };
+    const pr: ParsedTestObject | null | undefined = +rr['Year'] > 1995
+        ? (
+            +rr['Year'] <= 2017
+                ? {
+                    year: new Date(+rr['Year'], 0, 1),
+                    make: rr['Make'],
+                    model: rr['Model'],
+                    length: +rr['Length']
+                }
+                : undefined
+        )
+        : null;
     return pr;
 });
 
@@ -168,12 +199,18 @@ str = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = d3Dsv.tsvParseRows(tsvTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const pr: ParsedTestObject = {
-        year: new Date(+rr[0], 0, 1),
-        make: rr[1],
-        model: rr[2],
-        length: +rr[3]
-    };
+    const pr: ParsedTestObject | null | undefined = +rr[0] > 1995
+    ? (
+        +rr[0] <= 2017
+            ? {
+                year: new Date(+rr[0], 0, 1),
+                make: rr[1],
+                model: rr[2],
+                length: +rr[3]
+            }
+            : undefined
+    )
+    : null;
     return pr;
 });
 
@@ -222,12 +259,18 @@ parseMappedArray = dsv.parse(pipedTestStringWithHeader, (rawRow, index, columns)
     const rr: d3Dsv.DSVRowString = rawRow;
     const i: number = index;
     const c: string[] = columns;
-    const pr: ParsedTestObject = {
-        year: new Date(+rr['Year'], 0, 1),
-        make: rr['Make'],
-        model: rr['Model'],
-        length: +rr['Length']
-    };
+    const pr: ParsedTestObject | null | undefined = +rr['Year'] > 1995
+        ? (
+            +rr['Year'] <= 2017
+                ? {
+                    year: new Date(+rr['Year'], 0, 1),
+                    make: rr['Make'],
+                    model: rr['Model'],
+                    length: +rr['Length']
+                }
+                : undefined
+        )
+        : null;
     return pr;
 });
 
@@ -252,12 +295,18 @@ str = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = dsv.parseRows(pipedTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const pr: ParsedTestObject = {
-        year: new Date(+rr[0], 0, 1),
-        make: rr[1],
-        model: rr[2],
-        length: +rr[3]
-    };
+    const pr: ParsedTestObject | null | undefined = +rr[0] > 1995
+    ? (
+        +rr[0] <= 2017
+            ? {
+                year: new Date(+rr[0], 0, 1),
+                make: rr[1],
+                model: rr[2],
+                length: +rr[3]
+            }
+            : undefined
+    )
+    : null;
     return pr;
 });
 

--- a/types/d3-dsv/d3-dsv-tests.ts
+++ b/types/d3-dsv/d3-dsv-tests.ts
@@ -21,7 +21,7 @@ const tsvTestStringWithHeader = 'Year\tMake\tModel\tLength\n1997\tFord\tE350\t2.
 const pipedTestStringWithHeader = 'Year|Make|Model|Length\n1997|Ford|E350|2.34\n2000|Mercury|Cougar|2.38';
 
 interface ParsedTestObject {
-    year: Date;
+    year: Date | null;
     make: string;
     model: string;
     length: number;
@@ -35,8 +35,9 @@ let parseRowsMappedArray: ParsedTestObject[];
 
 let columns: string[];
 let num: number;
-let date: Date;
+let dateNull: Date | null;
 let str: string;
+let strMaybe: string | undefined;
 
 // ------------------------------------------------------------------------------------------
 // Test CSV
@@ -50,7 +51,7 @@ parseArray = d3Dsv.csvParse(csvTestStringWithHeader);
 
 columns = parseArray.columns;
 
-str = parseArray[0]['Year'];
+strMaybe = parseArray[0]['Year'];
 // date = parseArray[0]['Year']; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
@@ -60,10 +61,10 @@ parseMappedArray = d3Dsv.csvParse(csvTestStringWithHeader, (rawRow, index, colum
     const i: number = index;
     const c: string[] = columns;
     const pr: ParsedTestObject = {
-        year: new Date(+rr['Year'], 0, 1),
-        make: rr['Make'],
-        model: rr['Model'],
-        length: +rr['Length']
+        year: rr['Year'] ? new Date(+rr['Year']!, 0, 1) : null,
+        make: rr['Make'] ? rr['Make']! : "Missing Value",
+        model: rr['Model'] ? rr['Model']! : "Missing Value",
+        length: ['Length'] ? +rr['Length']! : NaN
     };
     return pr;
 });
@@ -72,14 +73,15 @@ parseMappedArray = d3Dsv.csvParse(csvTestStringWithHeader, (rawRow, index, colum
     const rr: d3Dsv.DSVRowString = rawRow;
     const i: number = index;
     const c: string[] = columns;
-    const pr: ParsedTestObject | null | undefined = +rr['Year'] > 1995
+    const d: number | null = rr['Year'] ? +rr['Year']! : null;
+    const pr: ParsedTestObject | null | undefined = d !== null
         ? (
-            +rr['Year'] <= 2017
+            d > 1997
                 ? {
-                    year: new Date(+rr['Year'], 0, 1),
-                    make: rr['Make'],
-                    model: rr['Model'],
-                    length: +rr['Length']
+                    year: new Date(d, 0, 1),
+                    make: rr['Make'] ? rr['Make']! : "Missing Value",
+                    model: rr['Model'] ? rr['Model']! : "Missing Value",
+                    length: ['Length'] ? +rr['Length']! : NaN
                 }
                 : undefined
         )
@@ -89,9 +91,9 @@ parseMappedArray = d3Dsv.csvParse(csvTestStringWithHeader, (rawRow, index, colum
 
 columns = parseMappedArray.columns;
 
-date = parseMappedArray[0].year;
-str = parseMappedArray[0].make;
-str = parseMappedArray[0].model;
+dateNull = parseMappedArray[0].year;
+strMaybe = parseMappedArray[0].make;
+strMaybe = parseMappedArray[0].model;
 num = parseMappedArray[0].length;
 
 // csvParseRows(...) ============================================================================
@@ -100,7 +102,7 @@ num = parseMappedArray[0].length;
 
 parseRowsArray = d3Dsv.csvParseRows(csvTestString);
 
-str = parseRowsArray[0][0]; // 'Year' of first row
+strMaybe = parseRowsArray[0][0]; // 'Year' of first row
 // date = parseRowsArray[0][0]; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
@@ -108,24 +110,25 @@ str = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = d3Dsv.csvParseRows(csvTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const pr: ParsedTestObject | null | undefined = +rr[0] > 1995
-    ? (
-        +rr[0] <= 2017
-            ? {
-                year: new Date(+rr[0], 0, 1),
-                make: rr[1],
-                model: rr[2],
-                length: +rr[3]
-            }
-            : undefined
-    )
-    : null;
+    const d: number | null = rr[0] ? +rr[0]! : null;
+    const pr: ParsedTestObject | null | undefined = d !== null
+        ? (
+            d > 1997
+                ? {
+                    year: new Date(d, 0, 1),
+                    make: rr[1] ? rr[1]! : "Missing Value",
+                    model: rr[2] ? rr[2]! : "Missing Value",
+                    length: rr[3] ? +rr[3]! : NaN
+                }
+                : undefined
+        )
+        : null;
     return pr;
 });
 
-date = parseRowsMappedArray[0].year;
-str = parseRowsMappedArray[0].make;
-str = parseRowsMappedArray[0].model;
+dateNull = parseRowsMappedArray[0].year;
+strMaybe = parseRowsMappedArray[0].make;
+strMaybe = parseRowsMappedArray[0].model;
 num = parseRowsMappedArray[0].length;
 
 // csvFormat(...) ============================================================================
@@ -136,7 +139,7 @@ str = d3Dsv.csvFormat(parseRowsMappedArray, columns);
 // csvFormatRows(...) ========================================================================
 
 str = d3Dsv.csvFormatRows(parseRowsMappedArray.map((d, i) => [
-    d.year.getFullYear().toString(),
+    d.year ? d.year.getFullYear().toString() : '',
     d.make,
     d.model,
     d.length.toString()
@@ -154,7 +157,7 @@ parseArray = d3Dsv.tsvParse(tsvTestStringWithHeader);
 
 columns = parseArray.columns;
 
-str = parseArray[0]['Year'];
+strMaybe = parseArray[0]['Year'];
 // date = parseArray[0]['Year']; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
@@ -163,14 +166,15 @@ parseMappedArray = d3Dsv.tsvParse(tsvTestStringWithHeader, (rawRow, index, colum
     const rr: d3Dsv.DSVRowString = rawRow;
     const i: number = index;
     const c: string[] = columns;
-    const pr: ParsedTestObject | null | undefined = +rr['Year'] > 1995
+    const d: number | null = rr['Year'] ? +rr['Year']! : null;
+    const pr: ParsedTestObject | null | undefined = d !== null
         ? (
-            +rr['Year'] <= 2017
+            d > 1997
                 ? {
-                    year: new Date(+rr['Year'], 0, 1),
-                    make: rr['Make'],
-                    model: rr['Model'],
-                    length: +rr['Length']
+                    year: new Date(d, 0, 1),
+                    make: rr['Make'] ? rr['Make']! : "Missing Value",
+                    model: rr['Model'] ? rr['Model']! : "Missing Value",
+                    length: ['Length'] ? +rr['Length']! : NaN
                 }
                 : undefined
         )
@@ -180,9 +184,9 @@ parseMappedArray = d3Dsv.tsvParse(tsvTestStringWithHeader, (rawRow, index, colum
 
 columns = parseMappedArray.columns;
 
-date = parseMappedArray[0].year;
-str = parseMappedArray[0].make;
-str = parseMappedArray[0].model;
+dateNull = parseMappedArray[0].year;
+strMaybe = parseMappedArray[0].make;
+strMaybe = parseMappedArray[0].model;
 num = parseMappedArray[0].length;
 
 // tsvParseRows(...) ============================================================================
@@ -191,7 +195,7 @@ num = parseMappedArray[0].length;
 
 parseRowsArray = d3Dsv.tsvParseRows(tsvTestString);
 
-str = parseRowsArray[0][0]; // 'Year' of first row
+strMaybe = parseRowsArray[0][0]; // 'Year' of first row
 // date = parseRowsArray[0][0]; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
@@ -199,24 +203,25 @@ str = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = d3Dsv.tsvParseRows(tsvTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const pr: ParsedTestObject | null | undefined = +rr[0] > 1995
-    ? (
-        +rr[0] <= 2017
-            ? {
-                year: new Date(+rr[0], 0, 1),
-                make: rr[1],
-                model: rr[2],
-                length: +rr[3]
-            }
-            : undefined
-    )
-    : null;
+    const d: number | null = rr[0] ? +rr[0]! : null;
+    const pr: ParsedTestObject | null | undefined = d !== null
+        ? (
+            d > 1997
+                ? {
+                    year: new Date(d, 0, 1),
+                    make: rr[1] ? rr[1]! : "Missing Value",
+                    model: rr[2] ? rr[2]! : "Missing Value",
+                    length: rr[3] ? +rr[3]! : NaN
+                }
+                : undefined
+        )
+        : null;
     return pr;
 });
 
-date = parseRowsMappedArray[0].year;
-str = parseRowsMappedArray[0].make;
-str = parseRowsMappedArray[0].model;
+dateNull = parseRowsMappedArray[0].year;
+strMaybe = parseRowsMappedArray[0].make;
+strMaybe = parseRowsMappedArray[0].model;
 num = parseRowsMappedArray[0].length;
 
 // tsvFormat(...) ============================================================================
@@ -227,7 +232,7 @@ str = d3Dsv.tsvFormat(parseRowsMappedArray, columns);
 // tsvFormatRows(...) ========================================================================
 
 str = d3Dsv.tsvFormatRows(parseRowsMappedArray.map((d, i) => [
-    d.year.getFullYear().toString(),
+    d.year ? d.year.getFullYear().toString() : '',
     d.make,
     d.model,
     d.length.toString()
@@ -250,7 +255,7 @@ parseArray = dsv.parse(pipedTestStringWithHeader);
 
 columns = parseArray.columns;
 
-str = parseArray[0]['Year'];
+strMaybe = parseArray[0]['Year'];
 // date = parseArray[0]['Year']; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
@@ -259,14 +264,15 @@ parseMappedArray = dsv.parse(pipedTestStringWithHeader, (rawRow, index, columns)
     const rr: d3Dsv.DSVRowString = rawRow;
     const i: number = index;
     const c: string[] = columns;
-    const pr: ParsedTestObject | null | undefined = +rr['Year'] > 1995
+    const d: number | null = rr['Year'] ? +rr['Year']! : null;
+    const pr: ParsedTestObject | null | undefined = d !== null
         ? (
-            +rr['Year'] <= 2017
+            d > 1997
                 ? {
-                    year: new Date(+rr['Year'], 0, 1),
-                    make: rr['Make'],
-                    model: rr['Model'],
-                    length: +rr['Length']
+                    year: new Date(d, 0, 1),
+                    make: rr['Make'] ? rr['Make']! : "Missing Value",
+                    model: rr['Model'] ? rr['Model']! : "Missing Value",
+                    length: ['Length'] ? +rr['Length']! : NaN
                 }
                 : undefined
         )
@@ -276,9 +282,9 @@ parseMappedArray = dsv.parse(pipedTestStringWithHeader, (rawRow, index, columns)
 
 columns = parseMappedArray.columns;
 
-date = parseMappedArray[0].year;
-str = parseMappedArray[0].make;
-str = parseMappedArray[0].model;
+dateNull = parseMappedArray[0].year;
+strMaybe = parseMappedArray[0].make;
+strMaybe = parseMappedArray[0].model;
 num = parseMappedArray[0].length;
 
 // parseRows(...) ============================================================================
@@ -287,7 +293,7 @@ num = parseMappedArray[0].length;
 
 parseRowsArray = dsv.parseRows(pipedTestString);
 
-str = parseRowsArray[0][0]; // 'Year' of first row
+strMaybe = parseRowsArray[0][0]; // 'Year' of first row
 // date = parseRowsArray[0][0]; // fails, return value is string
 
 // with row mapper ---------------------------------------------------------------------------
@@ -295,24 +301,25 @@ str = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = dsv.parseRows(pipedTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const pr: ParsedTestObject | null | undefined = +rr[0] > 1995
-    ? (
-        +rr[0] <= 2017
-            ? {
-                year: new Date(+rr[0], 0, 1),
-                make: rr[1],
-                model: rr[2],
-                length: +rr[3]
-            }
-            : undefined
-    )
-    : null;
+    const d: number | null = rr[0] ? +rr[0]! : null;
+    const pr: ParsedTestObject | null | undefined = d !== null
+        ? (
+            d > 1997
+                ? {
+                    year: new Date(d, 0, 1),
+                    make: rr[1] ? rr[1]! : "Missing Value",
+                    model: rr[2] ? rr[2]! : "Missing Value",
+                    length: rr[3] ? +rr[3]! : NaN
+                }
+                : undefined
+        )
+        : null;
     return pr;
 });
 
-date = parseRowsMappedArray[0].year;
-str = parseRowsMappedArray[0].make;
-str = parseRowsMappedArray[0].model;
+dateNull = parseRowsMappedArray[0].year;
+strMaybe = parseRowsMappedArray[0].make;
+strMaybe = parseRowsMappedArray[0].model;
 num = parseRowsMappedArray[0].length;
 
 // format(...) ============================================================================
@@ -323,7 +330,7 @@ str = dsv.format(parseRowsMappedArray, columns);
 // formatRows(...) ========================================================================
 
 str = dsv.formatRows(parseRowsMappedArray.map((d, i) => [
-    d.year.getFullYear().toString(),
+    d.year ? d.year.getFullYear().toString() : '',
     d.make,
     d.model,
     d.length.toString()

--- a/types/d3-dsv/d3-dsv-tests.ts
+++ b/types/d3-dsv/d3-dsv-tests.ts
@@ -110,15 +110,15 @@ strMaybe = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = d3Dsv.csvParseRows(csvTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const d: number | null = rr[0] ? +rr[0]! : null;
+    const d: number | null = rr[0].length ? +rr[0] : null;
     const pr: ParsedTestObject | null | undefined = d !== null
         ? (
             d > 1997
                 ? {
                     year: new Date(d, 0, 1),
-                    make: rr[1] ? rr[1]! : "Missing Value",
-                    model: rr[2] ? rr[2]! : "Missing Value",
-                    length: rr[3] ? +rr[3]! : NaN
+                    make: rr[1].length ? rr[1] : "Missing Value",
+                    model: rr[2].length ? rr[2] : "Missing Value",
+                    length: rr[3].length ? +rr[3] : NaN
                 }
                 : undefined
         )
@@ -203,15 +203,15 @@ strMaybe = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = d3Dsv.tsvParseRows(tsvTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const d: number | null = rr[0] ? +rr[0]! : null;
+    const d: number | null = rr[0].length ? +rr[0] : null;
     const pr: ParsedTestObject | null | undefined = d !== null
         ? (
             d > 1997
                 ? {
                     year: new Date(d, 0, 1),
-                    make: rr[1] ? rr[1]! : "Missing Value",
-                    model: rr[2] ? rr[2]! : "Missing Value",
-                    length: rr[3] ? +rr[3]! : NaN
+                    make: rr[1].length ? rr[1] : "Missing Value",
+                    model: rr[2].length ? rr[2] : "Missing Value",
+                    length: rr[3].length ? +rr[3] : NaN
                 }
                 : undefined
         )
@@ -301,15 +301,15 @@ strMaybe = parseRowsArray[0][0]; // 'Year' of first row
 parseRowsMappedArray = dsv.parseRows(pipedTestString, (rawRow, index) => {
     const rr: string[] = rawRow;
     const i: number = index;
-    const d: number | null = rr[0] ? +rr[0]! : null;
+    const d: number | null = rr[0].length ? +rr[0] : null;
     const pr: ParsedTestObject | null | undefined = d !== null
         ? (
             d > 1997
                 ? {
                     year: new Date(d, 0, 1),
-                    make: rr[1] ? rr[1]! : "Missing Value",
-                    model: rr[2] ? rr[2]! : "Missing Value",
-                    length: rr[3] ? +rr[3]! : NaN
+                    make: rr[1].length ? rr[1] : "Missing Value",
+                    model: rr[2].length ? rr[2] : "Missing Value",
+                    length: rr[3].length ? +rr[3] : NaN
                 }
                 : undefined
         )

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -13,7 +13,7 @@
  * An object representing a DSV parsed row with values represented as strings.
  */
 export interface DSVRowString {
-    [key: string]: string;
+    [key: string]: string | undefined;
 }
 
 /**

--- a/types/d3-dsv/index.d.ts
+++ b/types/d3-dsv/index.d.ts
@@ -3,19 +3,35 @@
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// Last module patch version validated against: 1.0.30
+
 // ------------------------------------------------------------------------------------------
 // Shared Types and Interfaces
 // ------------------------------------------------------------------------------------------
 
+/**
+ * An object representing a DSV parsed row with values represented as strings.
+ */
 export interface DSVRowString {
     [key: string]: string;
 }
 
+/**
+ * An object representing a DSV parsed row with values represented as an arbitrary datatype, depending
+ * on the performed parsed row mapping.
+ */
 export interface DSVRowAny {
     [key: string]: any;
 }
 
+/**
+ * An array object representing all parsed rows. The array is enhanced with a property listing
+ * the names of the parsed columns.
+ */
 export interface DSVParsedArray<T> extends Array<T> {
+    /**
+     * List of column names.
+     */
     columns: string[];
 }
 
@@ -25,20 +41,108 @@ export interface DSVParsedArray<T> extends Array<T> {
 
 // csvParse(...) ============================================================================
 
+/**
+ * Parses the specified string, which must be in the comma-separated values format, returning an array of objects representing the parsed rows.
+ *
+ * Unlike csvParseRows, this method requires that the first line of the CSV content contains a comma-separated list of column names;
+ * these column names become the attributes on the returned objects.
+ *
+ * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
+ *
+ * Equivalent to dsvFormat(",").parse.
+ *
+ * @param csvString A string, which must be in the comma-separated values format.
+ */
 export function csvParse(csvString: string): DSVParsedArray<DSVRowString>;
-export function csvParse<ParsedRow extends DSVRowAny>(csvString: string, row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow): DSVParsedArray<ParsedRow>;
+/**
+ * Parses the specified string, which must be in the comma-separated values format, returning an array of objects representing the parsed rows.
+ *
+ * Unlike csvParseRows, this method requires that the first line of the CSV content contains a comma-separated list of column names;
+ * these column names become the attributes on the returned objects.
+ *
+ * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
+ *
+ * Equivalent to dsvFormat(",").parse.
+ *
+ * @param csvString A string, which must be in the comma-separated values format.
+ * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+ * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be ommitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function csvParse<ParsedRow extends DSVRowAny>(
+    csvString: string,
+    row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+): DSVParsedArray<ParsedRow>;
 
 // csvParseRows(...) ========================================================================
 
+/**
+ * Parses the specified string, which must be in the comma-separated values format, returning an array of arrays representing the parsed rows.
+ *
+ * Unlike csvParse, this method treats the header line as a standard row, and should be used whenever CSV content does not contain a header.
+ * Each row is represented as an array rather than an object. Rows may have variable length.
+ *
+ * If a row conversion function is not specified, field values are strings. For safety, there is no automatic conversion to numbers, dates, or other types.
+ * In some cases, JavaScript may coerce strings to numbers for you automatically (for example, using the + operator), but better is to specify a row conversion function.
+ *
+ * Equivalent to dsvFormat(",").parseRows.
+ *
+ * @param csvString A string, which must be in the comma-separated values format.
+ */
 export function csvParseRows(csvString: string): string[][];
-export function csvParseRows<ParsedRow extends DSVRowAny>(csvString: string, row: (rawRow: string[], index: number) => ParsedRow): ParsedRow[];
+/**
+ * Parses the specified string, which must be in the comma-separated values format, returning an array of arrays representing the parsed rows.
+ *
+ * Unlike csvParse, this method treats the header line as a standard row, and should be used whenever CSV content does not contain a header.
+ * Each row is represented as an array rather than an object. Rows may have variable length.
+ *
+ * Equivalent to dsvFormat(",").parseRows.
+ *
+ * @param csvString A string, which must be in the comma-separated values format.
+ * @param row A row conversion function which is invoked for each row, being passed an array representing the current row (d), the index (i)
+ * starting at zero for the first row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be ommitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function csvParseRows<ParsedRow extends DSVRowAny>(
+    csvString: string,
+    row: (rawRow: string[], index: number) => ParsedRow | undefined | null
+): ParsedRow[];
 
 // csvFormat(...) ============================================================================
 
+/**
+ * Formats the specified array of object rows as comma-separated values, returning a string.
+ * This operation is the inverse of csvParse. Each row will be separated by a newline (\n),
+ * and each column within each row will be separated by the comma-delimiter.
+ * Values that contain either the comma-delimiter, a double-quote (") or a newline will be escaped using double-quotes.
+ *
+ * If columns is not specified, the list of column names that forms the header row is determined by the union of all properties on all objects in rows;
+ * the order of columns is nondeterministic.
+ *
+ * Equivalent to dsvFormat(",").format.
+ *
+ * @param rows Array of object rows.
+ * @param columns An array of strings representing the column names.
+ */
 export function csvFormat(rows: DSVRowAny[], columns?: string[]): string;
 
 // csvFormatRows(...) ========================================================================
 
+/**
+ * Formats the specified array of array of string rows as comma-separated values, returning a string.
+ * This operation is the reverse of csvParseRows. Each row will be separated by a newline (\n),
+ * and each column within each row will be separated by the comma-delimiter.
+ * Values that contain either the comma-delimiter, a double-quote (") or a newline will be escaped using double-quotes.
+ *
+ * To convert an array of objects to an array of arrays while explicitly specifying the columns, use array.map.
+ * If you like, you can also array.concat this result with an array of column names to generate the first row.
+ *
+ * Equivalent to dsvFormat(",").formatRows.
+ *
+ * @param rows An array of array of string rows.
+ */
 export function csvFormatRows(rows: string[][]): string;
 
 // ------------------------------------------------------------------------------------------
@@ -47,33 +151,209 @@ export function csvFormatRows(rows: string[][]): string;
 
 // tsvParse(...) ============================================================================
 
+/**
+ * Parses the specified string, which must be in the tab-separated values format, returning an array of objects representing the parsed rows.
+ *
+ * Unlike tsvParseRows, this method requires that the first line of the TSV content contains a tab-separated list of column names;
+ * these column names become the attributes on the returned objects.
+ *
+ * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
+ *
+ * Equivalent to dsvFormat("\t").parse.
+ *
+ * @param tsvString A string, which must be in the tab-separated values format.
+ */
 export function tsvParse(tsvString: string): DSVParsedArray<DSVRowString>;
-export function tsvParse<MappedRow extends DSVRowAny>(tsvString: string, row: (rawRow: DSVRowString, index: number, columns: string[]) => MappedRow): DSVParsedArray<MappedRow>;
+/**
+ * Parses the specified string, which must be in the tab-separated values format, returning an array of objects representing the parsed rows.
+ *
+ * Unlike tsvParseRows, this method requires that the first line of the TSV content contains a tab-separated list of column names;
+ * these column names become the attributes on the returned objects.
+ *
+ * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
+ *
+ * Equivalent to dsvFormat("\t").parse.
+ *
+ * @param tsvString A string, which must be in the tab-separated values format.
+ * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+ * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be ommitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function tsvParse<MappedRow extends DSVRowAny>(
+    tsvString: string,
+    row: (rawRow: DSVRowString, index: number, columns: string[]) => MappedRow | undefined | null
+): DSVParsedArray<MappedRow>;
 
 // tsvParseRows(...) ========================================================================
 
+/**
+ * Parses the specified string, which must be in the tab-separated values format, returning an array of arrays representing the parsed rows.
+ *
+ * Unlike tsvParse, this method treats the header line as a standard row, and should be used whenever TSV content does not contain a header.
+ * Each row is represented as an array rather than an object. Rows may have variable length.
+ *
+ * If a row conversion function is not specified, field values are strings. For safety, there is no automatic conversion to numbers, dates, or other types.
+ * In some cases, JavaScript may coerce strings to numbers for you automatically (for example, using the + operator), but better is to specify a row conversion function.
+ *
+ * Equivalent to dsvFormat("\t").parseRows.
+ *
+ * @param tsvString A string, which must be in the tab-separated values format.
+ */
 export function tsvParseRows(tsvString: string): string[][];
-export function tsvParseRows<MappedRow extends DSVRowAny>(tsvString: string, row: (rawRow: string[], index: number) => MappedRow): MappedRow[];
+/**
+ * Parses the specified string, which must be in the tab-separated values format, returning an array of arrays representing the parsed rows.
+ *
+ * Unlike tsvParse, this method treats the header line as a standard row, and should be used whenever TSV content does not contain a header.
+ * Each row is represented as an array rather than an object. Rows may have variable length.
+ *
+ * Equivalent to dsvFormat("\t").parseRows.
+ *
+ * @param tsvString A string, which must be in the tab-separated values format.
+ * @param row A row conversion function which is invoked for each row, being passed an array representing the current row (d), the index (i)
+ * starting at zero for the first row, and the array of column names. If the returned value is null or undefined,
+ * the row is skipped and will be ommitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
+ * In effect, row is similar to applying a map and filter operator to the returned rows.
+ */
+export function tsvParseRows<MappedRow extends DSVRowAny>(
+    tsvString: string,
+    row: (rawRow: string[], index: number) => MappedRow | undefined | null
+): MappedRow[];
 
 // tsvFormat(...) ============================================================================
 
+/**
+ * Formats the specified array of object rows as tab-separated values, returning a string.
+ * This operation is the inverse of tsvParse. Each row will be separated by a newline (\n),
+ * and each column within each row will be separated by the tab-delimiter.
+ * Values that contain either the tab-delimiter, a double-quote (") or a newline will be escaped using double-quotes.
+ *
+ * If columns is not specified, the list of column names that forms the header row is determined by the union of all properties on all objects in rows;
+ * the order of columns is nondeterministic.
+ *
+ * Equivalent to dsvFormat("\t").format.
+ *
+ * @param rows Array of object rows.
+ * @param columns An array of strings representing the column names.
+ */
 export function tsvFormat(rows: DSVRowAny[], columns?: string[]): string;
 
 // tsvFormatRows(...) ========================================================================
 
+/**
+ * Formats the specified array of array of string rows as tab-separated values, returning a string.
+ * This operation is the reverse of tsvParseRows. Each row will be separated by a newline (\n),
+ * and each column within each row will be separated by the tab-delimiter.
+ * Values that contain either the tab-delimiter, a double-quote (") or a newline will be escaped using double-quotes.
+ *
+ * To convert an array of objects to an array of arrays while explicitly specifying the columns, use array.map.
+ * If you like, you can also array.concat this result with an array of column names to generate the first row.
+ *
+ * Equivalent to dsvFormat("\t").formatRows.
+ *
+ * @param rows An array of array of string rows.
+ */
 export function tsvFormatRows(rows: string[][]): string;
 
 // ------------------------------------------------------------------------------------------
 // DSV Generalized Parsers and Formatters
 // ------------------------------------------------------------------------------------------
 
+/**
+ * A DSV parser and formatter
+ */
 export interface DSV {
+    /**
+     * Parses the specified string, which must be in the delimiter-separated values format with the appropriate delimiter, returning an array of objects representing the parsed rows.
+     *
+     * Unlike dsv.parseRows, this method requires that the first line of the DSV content contains a delimiter-separated list of column names;
+     * these column names become the attributes on the returned objects.
+     *
+     * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
+     *
+     * @param dsvString A string, which must be in the delimiter-separated values format with the appropriate delimiter.
+     */
     parse(dsvString: string): DSVParsedArray<DSVRowString>;
-    parse<ParsedRow extends DSVRowAny>(dsvString: string, row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow): DSVParsedArray<ParsedRow>;
+    /**
+     * Parses the specified string, which must be in the delimiter-separated values format with the appropriate delimiter, returning an array of objects representing the parsed rows.
+     *
+     * Unlike dsv.parseRows, this method requires that the first line of the DSV content contains a delimiter-separated list of column names;
+     * these column names become the attributes on the returned objects.
+     *
+     * The returned array also exposes a columns property containing the column names in input order (in contrast to Object.keys, whose iteration order is arbitrary).
+     *
+     * @param dsvString A string, which must be in the delimiter-separated values format with the appropriate delimiter.
+     * @param row A row conversion function which is invoked for each row, being passed an object representing the current row (d),
+     * the index (i) starting at zero for the first non-header row, and the array of column names. If the returned value is null or undefined,
+     * the row is skipped and will be ommitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
+     * In effect, row is similar to applying a map and filter operator to the returned rows.
+     */
+    parse<ParsedRow extends DSVRowAny>(
+        dsvString: string,
+        row: (rawRow: DSVRowString, index: number, columns: string[]) => ParsedRow | undefined | null
+    ): DSVParsedArray<ParsedRow>;
+
+    /**
+     * Parses the specified string, which must be in the delimiter-separated values format with the appropriate delimiter, returning an array of arrays representing the parsed rows.
+     *
+     * Unlike dsv.parse, this method treats the header line as a standard row, and should be used whenever DSV content does not contain a header.
+     * Each row is represented as an array rather than an object. Rows may have variable length.
+     *
+     * If a row conversion function is not specified, field values are strings. For safety, there is no automatic conversion to numbers, dates, or other types.
+     * In some cases, JavaScript may coerce strings to numbers for you automatically (for example, using the + operator), but better is to specify a row conversion function.
+     *
+     * @param dsvString A string, which must be in the delimiter-separated values format with the appropriate delimiter.
+     */
     parseRows(dsvString: string): string[][];
-    parseRows<ParsedRow extends DSVRowAny>(dsvString: string, row: (rawRow: string[], index: number) => ParsedRow): ParsedRow[];
+    /**
+     * Parses the specified string, which must be in the delimiter-separated values format with the appropriate delimiter, returning an array of arrays representing the parsed rows.
+     *
+     * Unlike dsv.parse, this method treats the header line as a standard row, and should be used whenever DSV content does not contain a header.
+     * Each row is represented as an array rather than an object. Rows may have variable length.
+     *
+     * @param dsvString A string, which must be in the delimiter-separated values format with the appropriate delimiter.
+     * @param row A row conversion function which is invoked for each row, being passed an array representing the current row (d), the index (i)
+     * starting at zero for the first row, and the array of column names. If the returned value is null or undefined,
+     * the row is skipped and will be ommitted from the array returned by dsv.parse; otherwise, the returned value defines the corresponding row object.
+     * In effect, row is similar to applying a map and filter operator to the returned rows.
+     */
+    parseRows<ParsedRow extends DSVRowAny>(
+        dsvString: string,
+        row: (rawRow: string[], index: number) => ParsedRow | undefined | null
+    ): ParsedRow[];
+
+    /**
+     * Formats the specified array of object rows as delimiter-separated values, returning a string.
+     * This operation is the inverse of dsv.parse. Each row will be separated by a newline (\n),
+     * and each column within each row will be separated by the delimiter (such as a comma, ,).
+     * Values that contain either the delimiter, a double-quote (") or a newline will be escaped using double-quotes.
+     *
+     * If columns is not specified, the list of column names that forms the header row is determined by the union of all properties on all objects in rows;
+     * the order of columns is nondeterministic.
+     *
+     * @param rows Array of object rows.
+     * @param columns An array of strings representing the column names.
+     */
     format(rows: DSVRowAny[], columns?: string[]): string;
+
+    /**
+     * Formats the specified array of array of string rows as delimiter-separated values, returning a string.
+     * This operation is the reverse of dsv.parseRows. Each row will be separated by a newline (\n),
+     * and each column within each row will be separated by the delimiter (such as a comma, ,).
+     * Values that contain either the delimiter, a double-quote (") or a newline will be escaped using double-quotes.
+     *
+     * To convert an array of objects to an array of arrays while explicitly specifying the columns, use array.map.
+     * If you like, you can also array.concat this result with an array of column names to generate the first row.
+     *
+     * @param rows An array of array of string rows.
+     */
     formatRows(rows: string[][]): string;
 }
 
+/**
+ * Constructs a new DSV parser and formatter for the specified delimiter.
+ *
+ * @param delimiter A delimiter character. The delimiter must be a single character (i.e., a single 16-bit code unit);
+ * so, ASCII delimiters are fine, but emoji delimiters are not.
+ */
 export function dsvFormat(delimiter: string): DSV;

--- a/types/d3-dsv/tsconfig.json
+++ b/types/d3-dsv/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
This PR addresses the `strictNullChecks` validation of **d3-dsv** and adds complete JSDoc comments.

`strictNullChecks` are refined for:
* the return type of the row mapper/filter functions used in parsing
* the DSVRowString key/value object. This addresses the edge case, where the DSV content is not well-structured and some column-values are missing as a result.

Related to #11365.
Related to #11366.
Replaces #21092.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/d3/d3-dsv>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
