### PR TITLE
fix rendering types for React 16

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -286,7 +286,7 @@ declare namespace React {
         // tslint:enable:unified-signatures
 
         forceUpdate(callBack?: () => any): void;
-        render(): JSX.Element | JSX.Element[] | ReactPortal | string | number | null | false;
+        render(): ReactNode;
 
         // React.Props<T> is now deprecated, which means that the `children`
         // property is not available on `P` by default, even though you can
@@ -421,7 +421,7 @@ declare namespace React {
     }
 
     interface ComponentSpec<P, S> extends Mixin<P, S> {
-        render(): ReactElement<any> | Array<ReactElement<any>> | string | number | null;
+        render(): ReactNode;
 
         [propertyName: string]: any;
     }
@@ -3519,7 +3519,7 @@ declare global {
         // tslint:disable:no-empty-interface
         interface Element extends React.ReactElement<any> { }
         interface ElementClass extends React.Component<any> {
-            render(): Element | Element[] | React.ReactPortal | string | number | null | false;
+            render(): React.ReactNode;
         }
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -698,3 +698,11 @@ declare var x: React.DOMElement<{
         transition: string;
     };
 }, Element>;
+
+// React 16 should be able to render its children directly
+class RenderChildren extends React.Component {
+    render() {
+        const { children } = this.props;
+        return children !== undefined ? children : null;
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20097
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Apart from imposing artificial limitations that React does need, the current types are quite a pain as none of the named types line up with the result of rendering a component which creates the need to either cast, type with `any` or type with a really long and messy union.