### PR TITLE
[auth0-js] Add optional `connection` property to `Popup.authorize` options

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -355,6 +355,12 @@ export class Popup {
             domain: string,
             /** your Auth0 client identifier obtained when creating the client in the Auth0 Dashboard */
             clientId?: string,
+            /**
+             * identity provider whose login page will be displayed in the popup.
+             * If omitted the hosted login page is used.
+             * {@link https://auth0.com/docs/identityproviders}
+             */
+            connection?: string,
             /** url that the Auth0 will redirect after Auth with the Authorization Response */
             redirectUri: string,
             /**


### PR DESCRIPTION
PR #20852 changed the type of `Popup.authorize` options from `any` to an object literal, but omitted the optional `connection` property.

This PR adds `connection` as an optional string.

---
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.com/docs/libraries/auth0js/v8#webauth-popup-authorize-