### PR TITLE
React-Native: Add typings for ARTStatic Group + Shape fill

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -5,6 +5,7 @@
 //                 Kyle Roach <https://github.com/iRoachie>
 //                 Tim Wang <https://github.com/timwangdev>
 //                 Kamal Mahyuddin <https://github.com/kamal>
+//                 Nikolas LeBlanc <https://github.com/nikolasleblanc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -8193,7 +8194,8 @@ export interface ARTShapeProps {
     d: string,
     strokeWidth: number,
     strokeDash?: number[],
-    stroke: string
+    stroke: string,
+    fill: string
 }
 
 export interface ARTSurfaceProps {
@@ -8202,15 +8204,25 @@ export interface ARTSurfaceProps {
     height: number
 }
 
+export interface ARTGroupProps {
+    style: StyleProp<ViewStyle>,
+    x: number,
+    y: number
+}
+
 export interface ShapeStatic extends React.ComponentClass<ARTShapeProps> {
 }
 
 export interface SurfaceStatic extends React.ComponentClass<ARTSurfaceProps> {
 }
 
+export interface GroupStatic extends React.ComponentClass<ARTGroupProps> {
+}
+
 export interface ARTStatic {
     Shape: ShapeStatic,
-    Surface: SurfaceStatic
+    Surface: SurfaceStatic,
+    Group: GroupStatic
 }
 
 export interface KeyboardStatic extends NativeEventEmitter {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://medium.com/the-react-native-log/animated-charts-in-react-native-using-d3-and-art-21cd9ccf6c58>>