### PR TITLE
Bookshelf transaction incompatible with async/await due to forced Bluebird return type. 

### DIFF
--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -17,7 +17,7 @@ interface Bookshelf extends Bookshelf.Events<any> {
 	Collection: typeof Bookshelf.Collection;
 
 	plugin(name: string | string[] | Function, options?: any): Bookshelf;
-	transaction<T>(callback: (transaction: knex.Transaction) => BlueBird<T>): BlueBird<T>;
+	transaction<T>(callback: (transaction: knex.Transaction) => PromiseLike<T>): BlueBird<T>;
 }
 
 declare function Bookshelf(knex: knex): Bookshelf;

--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for bookshelfjs v0.9.3
+// Type definitions for bookshelfjs v0.9.4
 // Project: http://bookshelfjs.org/
 // Definitions by: Andrew Schurman <https://github.com/arcticwaters>, Vesa Poikajärvi <https://github.com/vesse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
The existing code forces the user function in the transaction to return a bluebird promise, which is incompatiable with es6 promises and async/await.

Thus if the user application is written in es6 promises with async/await, and have to return a bluebird promise in order to use bookshelf transactions, it becomes a burden to translate.
The bookshelf.transaction is an alias for knex.transaction(http://bookshelfjs.org/#Bookshelf-instance-transaction), and the knex.transaction uses any as a return type instead of promise.

I updated the return type of the user supplied function to PromiseLike, which both es6 and bluebird promises implement.

Tested with both bluebird and es6 promises.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/knex/index.d.ts
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.