### PR TITLE
[react-pointable] Allow Pointable element to be an SVG element

### DIFF
--- a/types/react-pointable/index.d.ts
+++ b/types/react-pointable/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-pointable 1.1
 // Project: https://github.com/MilllerTime/react-pointable
 // Definitions by: Stefan Fochler <https://github.com/istefo>
+//                 Dibyo Majumdar <https://github.com/mdibyo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -8,10 +9,10 @@ import * as React from 'react';
 
 export type TouchAction = 'auto' | 'none' | 'pan-x' | 'pan-y' | 'manipulation';
 
-export interface PointableProps extends React.HTMLAttributes<HTMLElement> {
-    tagName?: keyof HTMLElementTagNameMap;
+export interface PointableProps extends React.HTMLAttributes<Element>, React.SVGAttributes<Element> {
+    tagName?: keyof ElementTagNameMap;
     touchAction?: TouchAction;
-    elementRef?(el: HTMLElement): void;
+    elementRef?(el: HTMLElement|SVGElement): void;
     onPointerMove?(evt: PointerEvent): void;
     onPointerDown?(evt: PointerEvent): void;
     onPointerUp?(evt: PointerEvent): void;


### PR DESCRIPTION
Pointer events (and the `Pointable` component) work just fine with SVG elements. Reflect this in the types.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<no url>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
