### PR TITLE
[three] THREE.ShapeUtils functions expect to receive Vector(ish) arrays

### DIFF
--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -1,6 +1,20 @@
 // Type definitions for three.js 0.84
 // Project: http://mrdoob.github.com/three.js/
-// Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>, HouChunlei <https://github.com/omni360>, Ivo <https://github.com/ivoisbelongtous>, David Asmuth <https://github.com/piranha771>, Brandon Roberge, Qinsi ZHU <https://github.com/qszhusightp>, Toshiya Nakakura <https://github.com/nakakura>, Poul Kjeldager Sørensen <https://github.com/s093294>, Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>, Roelof Jooste <https://github.com/PsychoSTS>
+// Definitions by: Kon <http://phyzkit.net/>
+//                 Satoru Kimura <https://github.com/gyohk>
+//                 Florent Poujol <https://github.com/florentpoujol>
+//                 SereznoKot <https://github.com/SereznoKot>
+//                 HouChunlei <https://github.com/omni360>
+//                 Ivo <https://github.com/ivoisbelongtous>
+//                 David Asmuth <https://github.com/piranha771>
+//                 Brandon Roberge
+//                 Qinsi ZHU <https://github.com/qszhusightp>
+//                 Toshiya Nakakura <https://github.com/nakakura>
+//                 Poul Kjeldager Sørensen <https://github.com/s093294>
+//                 Stefan Profanter <https://github.com/Pro>
+//                 Edmund Fokschaner <https://github.com/efokschaner>
+//                 Roelof Jooste <https://github.com/PsychoSTS>
+//                 John Rees <https://github.com/johnrees>
 // Definitions: https://github.com//DefinitelyTyped
 
 export * from "./three-core";

--- a/types/three/test/extras/shapeutils.ts
+++ b/types/three/test/extras/shapeutils.ts
@@ -13,11 +13,16 @@ import {Vector2, Vector3, Vector4, ShapeUtils, Color} from "../../three-core"
     ShapeUtils.area(clockWisePointsAsXY); // $ExpectType number
     ShapeUtils.area(clockWisePointsAsVector2); // $ExpectType number
 
+    ShapeUtils.area(clockWisePoints2D); // $ExpectError
+
     // -------------------------------------------- isClockWise()
 
     // Always returns true or false. False if there is an error
 
     ShapeUtils.isClockWise(clockWisePointsAsXY); // $ExpectType boolean
+    ShapeUtils.isClockWise(clockWisePointsAsVector2); // $ExpectType boolean
+
+    ShapeUtils.area(clockWisePoints2D); // $ExpectError
 
     // -------------------------------------------- triangulate()
 
@@ -37,11 +42,12 @@ import {Vector2, Vector3, Vector4, ShapeUtils, Color} from "../../three-core"
     ShapeUtils.triangulate(clockWisePointsAsVector2, false); // $ExpectType Vector2[][]
     ShapeUtils.triangulate(clockWisePointsAsVector2); // $ExpectType Vector2[][]
 
-    // $ExpectError
-    ShapeUtils.triangulate([new Color('red'), new Color('yellow')]);
+    ShapeUtils.triangulate([new Color('red'), new Color('yellow')]); // $ExpectError
 
     // -------------------------------------------- triangulateShape()
 
+    ShapeUtils.triangulateShape(clockWisePointsAsVector2, []); // $ExpectType number[][]
     ShapeUtils.triangulateShape(clockWisePointsAsVector2, [clockWisePointsAsVector2]); // $ExpectType number[][]
 
+    ShapeUtils.triangulateShape(clockWisePointsAsVector2); // $ExpectError
 };

--- a/types/three/test/extras/shapeutils.ts
+++ b/types/three/test/extras/shapeutils.ts
@@ -44,7 +44,8 @@ ShapeUtils.triangulate([new Color('red'), new Color('yellow')]); // $ExpectError
 
 // -------------------------------------------- triangulateShape()
 
-ShapeUtils.triangulateShape(clockWisePointsAsVector2, []); // $ExpectType number[][]
-ShapeUtils.triangulateShape(clockWisePointsAsVector2, [clockWisePointsAsVector2]); // $ExpectType number[][]
+ShapeUtils.triangulateShape(clockWisePointsAsVector2, []); // $ExpectType [number, number, number][]
+
+ShapeUtils.triangulateShape(clockWisePointsAsVector2, [clockWisePointsAsVector2]); // $ExpectType [number, number, number][]
 
 ShapeUtils.triangulateShape(clockWisePointsAsVector2); // $ExpectError

--- a/types/three/test/extras/shapeutils.ts
+++ b/types/three/test/extras/shapeutils.ts
@@ -20,7 +20,7 @@ ShapeUtils.area(clockWisePoints2D); // $ExpectError
 ShapeUtils.isClockWise(clockWisePointsAsXY); // $ExpectType boolean
 ShapeUtils.isClockWise(clockWisePointsAsVector2); // $ExpectType boolean
 
-ShapeUtils.area(clockWisePoints2D); // $ExpectError
+ShapeUtils.isClockWise(clockWisePoints2D); // $ExpectError
 
 // -------------------------------------------- triangulate()
 

--- a/types/three/test/extras/shapeutils.ts
+++ b/types/three/test/extras/shapeutils.ts
@@ -1,0 +1,47 @@
+import {Vector2, Vector3, Vector4, ShapeUtils, Color} from "../../three-core"
+
+()=>{
+
+    const clockWisePoints2D = [[0,2],[2,2],[2,0],[0,0]]
+    const clockWisePointsAsXY = clockWisePoints2D.map( ([x,y]) => ({x,y}) )
+    const clockWisePointsAsVector2 = clockWisePoints2D.map( ([x,y]) => new Vector2(x,y))
+
+    // -------------------------------------------- area()
+
+    // The value can be positive or negative
+
+    ShapeUtils.area(clockWisePointsAsXY); // $ExpectType number
+    ShapeUtils.area(clockWisePointsAsVector2); // $ExpectType number
+
+    // -------------------------------------------- isClockWise()
+
+    // Always returns true or false. False if there is an error
+
+    ShapeUtils.isClockWise(clockWisePointsAsXY); // $ExpectType boolean
+
+    // -------------------------------------------- triangulate()
+
+    // Will either return tuples of indices ([number, number, number][]),
+    // or original points/objects/vectors, see PR comments for more:
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21192#issuecomment-341653093
+
+    ShapeUtils.triangulate(clockWisePoints2D, true); // $ExpectType number[][]
+    ShapeUtils.triangulate(clockWisePoints2D, false); // $ExpectType number[][][]
+    ShapeUtils.triangulate(clockWisePoints2D); // $ExpectType number[][][]
+
+    ShapeUtils.triangulate(clockWisePointsAsXY, true); // $ExpectType number[][]
+    ShapeUtils.triangulate(clockWisePointsAsXY, false); // $ExpectType { x: number; y: number; }[][]
+    ShapeUtils.triangulate(clockWisePointsAsXY); // $ExpectType { x: number; y: number; }[][]
+
+    ShapeUtils.triangulate(clockWisePointsAsVector2, true); // $ExpectType number[][]
+    ShapeUtils.triangulate(clockWisePointsAsVector2, false); // $ExpectType Vector2[][]
+    ShapeUtils.triangulate(clockWisePointsAsVector2); // $ExpectType Vector2[][]
+
+    // $ExpectError
+    ShapeUtils.triangulate([new Color('red'), new Color('yellow')]);
+
+    // -------------------------------------------- triangulateShape()
+
+    ShapeUtils.triangulateShape(clockWisePointsAsVector2, [clockWisePointsAsVector2]); // $ExpectType number[][]
+
+};

--- a/types/three/test/extras/shapeutils.ts
+++ b/types/three/test/extras/shapeutils.ts
@@ -28,15 +28,15 @@ ShapeUtils.isClockWise(clockWisePoints2D); // $ExpectError
 // or original points/objects/vectors, see PR comments for more:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21192#issuecomment-341653093
 
-ShapeUtils.triangulate(clockWisePoints2D, true); // $ExpectType number[][]
+ShapeUtils.triangulate(clockWisePoints2D, true); // $ExpectType [number, number, number][]
 ShapeUtils.triangulate(clockWisePoints2D, false); // $ExpectType number[][][]
 ShapeUtils.triangulate(clockWisePoints2D); // $ExpectType number[][][]
 
-ShapeUtils.triangulate(clockWisePointsAsXY, true); // $ExpectType number[][]
+ShapeUtils.triangulate(clockWisePointsAsXY, true); // $ExpectType [number, number, number][]
 ShapeUtils.triangulate(clockWisePointsAsXY, false); // $ExpectType { x: number; y: number; }[][]
 ShapeUtils.triangulate(clockWisePointsAsXY); // $ExpectType { x: number; y: number; }[][]
 
-ShapeUtils.triangulate(clockWisePointsAsVector2, true); // $ExpectType number[][]
+ShapeUtils.triangulate(clockWisePointsAsVector2, true); // $ExpectType [number, number, number][]
 ShapeUtils.triangulate(clockWisePointsAsVector2, false); // $ExpectType Vector2[][]
 ShapeUtils.triangulate(clockWisePointsAsVector2); // $ExpectType Vector2[][]
 

--- a/types/three/test/extras/shapeutils.ts
+++ b/types/three/test/extras/shapeutils.ts
@@ -6,7 +6,7 @@ const clockWisePointsAsVector2 = clockWisePoints2D.map( ([x,y]) => new Vector2(x
 
 // -------------------------------------------- area()
 
-// The value can be positive or negative
+// The returned value can be positive or negative
 
 ShapeUtils.area(clockWisePointsAsXY); // $ExpectType number
 ShapeUtils.area(clockWisePointsAsVector2); // $ExpectType number

--- a/types/three/test/extras/shapeutils.ts
+++ b/types/three/test/extras/shapeutils.ts
@@ -1,53 +1,50 @@
-import {Vector2, Vector3, Vector4, ShapeUtils, Color} from "../../three-core"
+import { Color, ShapeUtils, Vector2 } from "../../three-core"
 
-()=>{
+const clockWisePoints2D = [[0,2],[2,2],[2,0],[0,0]];
+const clockWisePointsAsXY = clockWisePoints2D.map( ([x,y]) => ({x,y}) );
+const clockWisePointsAsVector2 = clockWisePoints2D.map( ([x,y]) => new Vector2(x,y));
 
-    const clockWisePoints2D = [[0,2],[2,2],[2,0],[0,0]]
-    const clockWisePointsAsXY = clockWisePoints2D.map( ([x,y]) => ({x,y}) )
-    const clockWisePointsAsVector2 = clockWisePoints2D.map( ([x,y]) => new Vector2(x,y))
+// -------------------------------------------- area()
 
-    // -------------------------------------------- area()
+// The value can be positive or negative
 
-    // The value can be positive or negative
+ShapeUtils.area(clockWisePointsAsXY); // $ExpectType number
+ShapeUtils.area(clockWisePointsAsVector2); // $ExpectType number
 
-    ShapeUtils.area(clockWisePointsAsXY); // $ExpectType number
-    ShapeUtils.area(clockWisePointsAsVector2); // $ExpectType number
+ShapeUtils.area(clockWisePoints2D); // $ExpectError
 
-    ShapeUtils.area(clockWisePoints2D); // $ExpectError
+// -------------------------------------------- isClockWise()
 
-    // -------------------------------------------- isClockWise()
+// Always returns true or false. False if there is an error
 
-    // Always returns true or false. False if there is an error
+ShapeUtils.isClockWise(clockWisePointsAsXY); // $ExpectType boolean
+ShapeUtils.isClockWise(clockWisePointsAsVector2); // $ExpectType boolean
 
-    ShapeUtils.isClockWise(clockWisePointsAsXY); // $ExpectType boolean
-    ShapeUtils.isClockWise(clockWisePointsAsVector2); // $ExpectType boolean
+ShapeUtils.area(clockWisePoints2D); // $ExpectError
 
-    ShapeUtils.area(clockWisePoints2D); // $ExpectError
+// -------------------------------------------- triangulate()
 
-    // -------------------------------------------- triangulate()
+// Will either return tuples of indices ([number, number, number][]),
+// or original points/objects/vectors, see PR comments for more:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21192#issuecomment-341653093
 
-    // Will either return tuples of indices ([number, number, number][]),
-    // or original points/objects/vectors, see PR comments for more:
-    // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21192#issuecomment-341653093
+ShapeUtils.triangulate(clockWisePoints2D, true); // $ExpectType number[][]
+ShapeUtils.triangulate(clockWisePoints2D, false); // $ExpectType number[][][]
+ShapeUtils.triangulate(clockWisePoints2D); // $ExpectType number[][][]
 
-    ShapeUtils.triangulate(clockWisePoints2D, true); // $ExpectType number[][]
-    ShapeUtils.triangulate(clockWisePoints2D, false); // $ExpectType number[][][]
-    ShapeUtils.triangulate(clockWisePoints2D); // $ExpectType number[][][]
+ShapeUtils.triangulate(clockWisePointsAsXY, true); // $ExpectType number[][]
+ShapeUtils.triangulate(clockWisePointsAsXY, false); // $ExpectType { x: number; y: number; }[][]
+ShapeUtils.triangulate(clockWisePointsAsXY); // $ExpectType { x: number; y: number; }[][]
 
-    ShapeUtils.triangulate(clockWisePointsAsXY, true); // $ExpectType number[][]
-    ShapeUtils.triangulate(clockWisePointsAsXY, false); // $ExpectType { x: number; y: number; }[][]
-    ShapeUtils.triangulate(clockWisePointsAsXY); // $ExpectType { x: number; y: number; }[][]
+ShapeUtils.triangulate(clockWisePointsAsVector2, true); // $ExpectType number[][]
+ShapeUtils.triangulate(clockWisePointsAsVector2, false); // $ExpectType Vector2[][]
+ShapeUtils.triangulate(clockWisePointsAsVector2); // $ExpectType Vector2[][]
 
-    ShapeUtils.triangulate(clockWisePointsAsVector2, true); // $ExpectType number[][]
-    ShapeUtils.triangulate(clockWisePointsAsVector2, false); // $ExpectType Vector2[][]
-    ShapeUtils.triangulate(clockWisePointsAsVector2); // $ExpectType Vector2[][]
+ShapeUtils.triangulate([new Color('red'), new Color('yellow')]); // $ExpectError
 
-    ShapeUtils.triangulate([new Color('red'), new Color('yellow')]); // $ExpectError
+// -------------------------------------------- triangulateShape()
 
-    // -------------------------------------------- triangulateShape()
+ShapeUtils.triangulateShape(clockWisePointsAsVector2, []); // $ExpectType number[][]
+ShapeUtils.triangulateShape(clockWisePointsAsVector2, [clockWisePointsAsVector2]); // $ExpectType number[][]
 
-    ShapeUtils.triangulateShape(clockWisePointsAsVector2, []); // $ExpectType number[][]
-    ShapeUtils.triangulateShape(clockWisePointsAsVector2, [clockWisePointsAsVector2]); // $ExpectType number[][]
-
-    ShapeUtils.triangulateShape(clockWisePointsAsVector2); // $ExpectError
-};
+ShapeUtils.triangulateShape(clockWisePointsAsVector2); // $ExpectError

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -6123,10 +6123,10 @@ export namespace SceneUtils {
 }
 
 export namespace ShapeUtils {
-    export function area(contour: number[]): number;
-    export function triangulate(contour: number[], indices: boolean): number[];
-    export function triangulateShape(contour: number[], holes: any[]): number[];
-    export function isClockWise(pts: number[]): boolean;
+    export function area(contour: Vector[]): number;
+    export function triangulate(contour: Vector[], indices: boolean): [number, number, number][];
+    export function triangulateShape(contour: Vector[], holes: any[]): [number, number, number][];
+    export function isClockWise(pts: Vector[]): boolean;
 }
 
 // Extras / Audio /////////////////////////////////////////////////////////////////////

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -6123,10 +6123,14 @@ export namespace SceneUtils {
 }
 
 export namespace ShapeUtils {
-    export function area(contour: Vector[]): number;
-    export function triangulate(contour: Vector[], indices: boolean): [number, number, number][];
-    export function triangulateShape(contour: Vector[], holes: any[]): [number, number, number][];
-    export function isClockWise(pts: Vector[]): boolean;
+    export function area(contour: ArrayLike<{x: number, y: number}>): number;
+
+    export function isClockWise(pts: ArrayLike<{x: number, y: number}>): boolean;
+
+    export function triangulate<T extends ArrayLike<{x: number, y: number}> | number[][]>(contour: T, indices?: boolean): T[];
+    export function triangulate(contour: ArrayLike<{x: number, y: number}> | number[][], indices: true): number[][];
+
+    export function triangulateShape(contour: Vector2[], holes: Vector2[][]): number[][];
 }
 
 // Extras / Audio /////////////////////////////////////////////////////////////////////

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -6128,7 +6128,7 @@ export namespace ShapeUtils {
     export function isClockWise(pts: ArrayLike<{x: number, y: number}>): boolean;
 
     export function triangulate<T extends ArrayLike<{x: number, y: number}> | number[][]>(contour: T, indices?: boolean): T[];
-    export function triangulate(contour: ArrayLike<{x: number, y: number}> | number[][], indices: true): number[][];
+    export function triangulate(contour: ArrayLike<{x: number, y: number}> | number[][], indices: true): [number, number, number][];
 
     export function triangulateShape(contour: Vector2[], holes: Vector2[][]): number[][];
 }

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -54,6 +54,7 @@
         "test/examples/controls/vrcontrols.ts",
         "test/examples/ctm/ctmloader.ts",
         "test/examples/octree.ts",
-        "test/examples/loaders/webgl_loader_obj_mtl.ts"
+        "test/examples/loaders/webgl_loader_obj_mtl.ts",
+        "test/extras/shapeutils.ts"
     ]
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/46113381/three-js-shapeutils-types-first-argument-type-for-triangulateshape

- [ ] Increase the version number in the header if appropriate.
_is this considered a breaking change?_

- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

This is my first DefinitelyTyped PR so probably needs a bit of work.

I don't think `Vector[]` is the correct Type to use here, and despite the functions being designed for 2D calculations they all work with one of `Vector2[] | Vector3[] | Vector4[]`.