### PR TITLE
[chai-jest-snapshot] Fixed incorrect casing for setFilename

### DIFF
--- a/types/chai-jest-snapshot/chai-jest-snapshot-tests.ts
+++ b/types/chai-jest-snapshot/chai-jest-snapshot-tests.ts
@@ -16,7 +16,7 @@ const mockContext: Mocha.IBeforeAndAfterContext = <any> {
     }
 };
 
-chaiJestSnapshot.setFileName("filename");
+chaiJestSnapshot.setFilename("filename");
 chaiJestSnapshot.setTestName("testname");
 chaiJestSnapshot.configureUsingMochaContext(mockContext);
 chaiJestSnapshot.resetSnapshotRegistry();

--- a/types/chai-jest-snapshot/index.d.ts
+++ b/types/chai-jest-snapshot/index.d.ts
@@ -21,7 +21,7 @@ interface ChaiJestSnapshot {
     (chai: any, utils: any): void;
 
     /** Set snapshot file name */
-    setFileName(filename: string): void;
+    setFilename(filename: string): void;
 
     /**
      * Set snapshot test name


### PR DESCRIPTION
Fixed incorrect casing for setFilename in chai-jest-snapshot

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/suchipi/chai-jest-snapshot/blob/master/src/index.js#L36>>
