### PR TITLE
Fix snoowrap typedefs to refer to _Comment instead of Comment

### DIFF
--- a/types/snoowrap/index.d.ts
+++ b/types/snoowrap/index.d.ts
@@ -62,7 +62,7 @@ declare class Snoowrap {
   getFriends(): Promise<_RedditUser[]>;
   getGoldSubreddits(options?: ListingOptions): _Listing<_Subreddit>;
   getHot(subredditName?: string, options?: ListingOptions): _Listing<_Submission>;
-  getInbox(options?: { filter?: string }): _Listing<_PrivateMessage | Comment>;
+  getInbox(options?: { filter?: string }): _Listing<_PrivateMessage | _Comment>;
   getKarma(): Promise<Array<{ sr: _Subreddit; comment_karma: number; link_karma: number; }>>;
   getLivethread(threadId: string): _LiveThread;
   getMe(): _RedditUser;
@@ -73,7 +73,7 @@ declare class Snoowrap {
   getMyTrophies(): Promise<Snoowrap.Trophy[]>;
   getNew(subredditName?: string, options?: ListingOptions): _Listing<_Submission>;
   getNewCaptchaIdentifier(): Promise<string>;
-  getNewComments(subredditName?: string, options?: ListingOptions): _Listing<Comment>;
+  getNewComments(subredditName?: string, options?: ListingOptions): _Listing<_Comment>;
   getNewSubreddits(options?: ListingOptions): _Listing<_Subreddit>;
   getOauthScopeList(): Promise<{ [key: string]: { description: string; id: string; name: string } }>;
   getPopularSubreddit(options?: ListingOptions): _Listing<_Subreddit>;

--- a/types/snoowrap/snoowrap-tests.ts
+++ b/types/snoowrap/snoowrap-tests.ts
@@ -1,6 +1,7 @@
 import * as Snoowrap from 'snoowrap';
 import {
   Comment,
+  Listing,
   LiveThread,
   MultiReddit,
   PrivateMessage,
@@ -44,4 +45,8 @@ export function subreddit(name: string): Subreddit {
 
 export function wiki(subreddit: string, page: string): WikiPage {
   return r.getSubreddit(subreddit).getWikiPage(page);
+}
+
+export function getNewComments(subreddit: string): Listing<Comment> {
+  return r.getNewComments(subreddit);
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gist.github.com/xmonkee/669c49f6b97cf682c8bd8b6504aa9a85