### PR TITLE
[react-redux][WIP] Allow for passing of the root redux state through to connect

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -143,6 +143,13 @@ export interface Connect {
         mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
         options: Options<TStateProps, TOwnProps, TMergedProps>
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
+        
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, TState = {}>(
+        mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, TState>,
+        mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
+        mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
+        options: Options<TStateProps, TOwnProps, TMergedProps>
+    ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 }
 
 /**
@@ -150,15 +157,15 @@ export interface Connect {
  */
 export declare const connect: Connect;
 
-interface MapStateToProps<TStateProps, TOwnProps> {
-    (state: any, ownProps: TOwnProps): TStateProps;
+interface MapStateToProps<TStateProps, TOwnProps, TState> {
+    (state: TState, ownProps: TOwnProps): TStateProps;
 }
 
-interface MapStateToPropsFactory<TStateProps, TOwnProps> {
-    (initialState: any, ownProps: TOwnProps): MapStateToProps<TStateProps, TOwnProps>;
+interface MapStateToPropsFactory<TStateProps, TOwnProps, TState> {
+    (initialState: Partial<TState>, ownProps: TOwnProps): MapStateToProps<TStateProps, TOwnProps, TState>;
 }
 
-type MapStateToPropsParam<TStateProps, TOwnProps> = MapStateToPropsFactory<TStateProps, TOwnProps> | MapStateToProps<TStateProps, TOwnProps> | null | undefined;
+type MapStateToPropsParam<TStateProps, TOwnProps, TState = any> = MapStateToPropsFactory<TStateProps, TOwnProps, TState> | MapStateToProps<TStateProps, TOwnProps, TState> | null | undefined;
 
 interface MapDispatchToPropsFunction<TDispatchProps, TOwnProps> {
     (dispatch: Dispatch<any>, ownProps: TOwnProps): TDispatchProps;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


---

@thasner @kenzierocks @clayne11 @tansongyang 

I'd like to be able to configure the state for `MapStateToProps` as part of connect, I can then wrap connect and pass my pre-bound real connect around my app.

Is there a reason it's not passed as a generic? Any issues with me adding it?