### PR TITLE
fixing merge() function not accepting with BufferGeometry-typed argument

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -1355,7 +1355,7 @@ export class Geometry extends EventDispatcher {
      */
     computeBoundingSphere(): void;
 
-    merge(geometry: Geometry, matrix?: Matrix, materialIndexOffset?: number): void;
+    merge(geometry: Geometry | BufferGeometry, matrix?: Matrix, materialIndexOffset?: number): void;
 
     mergeMesh(mesh: Mesh): void;
 


### PR DESCRIPTION
Example of the error I was getting before applying this fix:

> TS2345: Argument of type 'Geometry | BufferGeometry' is not assignable to parameter of type 'Geometry'

How to reproduce:

```
import { ObjectLoader } from 'three';

let objectInJson = <get the JSON object>;
let loader = new THREE.ObjectLoader();
let object = loader.parse( objectInJson  );
let geometry = new Geometry();
object.traverse( function(child) {
    if(child instanceof Mesh) {
        geometry.merge( child.geometry );
    }
});
```