### PR TITLE
atom: Make ErrorNotification extend Notification

### DIFF
--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -206,7 +206,7 @@ declare global {
                 gutterName?: string;
             }
 
-            interface ErrorNotification extends NotificationOptions {
+            interface ErrorNotification extends Notification {
                 stack?: string;
             }
 


### PR DESCRIPTION
It was extending the non existent NotificationOptions, causing only the `stack` attribute to be available.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://atom.io/docs/api/v1.21.2/NotificationManager#instance-addError
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.