### PR TITLE
Cytoscape Extended possible layout options with baselayout

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -178,7 +178,7 @@ declare namespace cytoscape {
          */
         layout?: NullLayoutOptions | RandomLayoutOptions | PresetLayoutOptions |
         GridLayoutOptions | CircleLayoutOptions | ConcentricLayoutOptions |
-        BreadthFirstLayoutOptions | CoseLayoutOptions;
+        BreadthFirstLayoutOptions | CoseLayoutOptions | BaseLayoutOptions;
 
         ///////////////////////////////////////
         // initial viewport state:
@@ -4144,7 +4144,7 @@ declare namespace cytoscape {
     type LayoutOptions =
         NullLayoutOptions | PresetLayoutOptions | GridLayoutOptions |
         CircleLayoutOptions | ConcentricLayoutOptions | BreadthFirstLayoutOptions |
-        CoseLayoutOptions;
+        CoseLayoutOptions | BaseLayoutOptions;
 
     type LayoutHandler = () => void;
 


### PR DESCRIPTION
Extended possible layout options with baselayout to support registraion of custom extensions. For more details see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21226 

I extended the definition file with the changes I described in the referenced github issue.
Authors: @phreed , @wy193777 if you could take a look at this please and let me know if this change is in your interest. 



