### PR TITLE
Backport ts 2.6.1 fix to @types/react@15

### DIFF
--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -78,7 +78,7 @@ declare namespace React {
     type ComponentType<P = {}> = ComponentClass<P> | StatelessComponent<P>;
 
     type Key = string | number;
-    type Ref<T> = string | ((instance: T | null) => any);
+    type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"];
 
     // tslint:disable-next-line:interface-over-type-literal
     type ComponentState = {};
@@ -521,7 +521,7 @@ declare namespace React {
     // Event Handler Types
     // ----------------------------------------------------------------------
 
-    type EventHandler<E extends SyntheticEvent<any>> = (event: E) => void;
+    type EventHandler<E extends SyntheticEvent<any>> = { bivarianceHack(event: E): void }["bivarianceHack"];
 
     type ReactEventHandler<T> = EventHandler<SyntheticEvent<T>>;
 
@@ -3335,7 +3335,7 @@ declare namespace React {
     // React.PropTypes
     // ----------------------------------------------------------------------
 
-    type Validator<T> = (object: T, key: string, componentName: string, ...rest: any[]) => Error | null;
+    type Validator<T> = { bivarianceHack(object: T, key: string, componentName: string, ...rest: any[]): Error | null }["bivarianceHack"];
 
     interface Requireable<T> extends Validator<T> {
         isRequired: Validator<T>;


### PR DESCRIPTION
For those of us who want to upgrade to the latest version of TypeScript, but haven't gotten around to upgrade our app to react 16 yet.

The `bivarianceHack` seems like an ugly workaround, but that's how `@types/react@16` works atm.

`@types/react@15` is currently broken with ts 2.6.1 (without this fix).