### PR TITLE
fix(msgpack-lite): fix msgpack-lite option parameters

### DIFF
--- a/types/msgpack-lite/index.d.ts
+++ b/types/msgpack-lite/index.d.ts
@@ -125,7 +125,7 @@ export interface CodecOptions {
    * @see https://github.com/kawanet/msgpack-lite#compatibility-mode
    * @default false
    */
-  raw?: boolean;
+  useraw?: boolean;
   /**
    * It decodes msgpack's int64/uint64 formats with int64-buffer object.
    * int64-buffer is a cutom integer type with 64 bits of precision instead
@@ -140,8 +140,14 @@ export interface CodecOptions {
   binarraybuffer?: boolean;
   /**
    * It returns Uint8Array object when encoding, instead of Buffer object.
+   * @default false
    */
   uint8array?: boolean;
+  /**
+   * It uses the global JavaScript Map type, if available, to unpack MessagePack map elements.
+   * @default false
+   */
+  usemap?: boolean;
 }
 
 export interface EncoderOptions {

--- a/types/msgpack-lite/msgpack-lite-tests.ts
+++ b/types/msgpack-lite/msgpack-lite-tests.ts
@@ -9,6 +9,18 @@ function encodingAndDecoding() {
   const data = msgpack.decode(buffer); // => {"foo": "bar"}
 }
 
+function customCodec() {
+  msgpack.createCodec({
+    preset: true,
+    safe: true,
+    useraw: true,
+    int64: true,
+    binarraybuffer: true,
+    uint8array: true,
+    usemap: true
+  });
+}
+
 // https://github.com/kawanet/msgpack-lite#writing-to-messagepack-stream
 function writingToStream() {
   const fs = require("fs");


### PR DESCRIPTION
The current msgpack-lite `CodecOptions` are broken:
- the raw option is actually `useraw` and not `raw`
- the `usemap` option was missing

This fixes it.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kawanet/msgpack-lite#custom-codec-options
- [x] ~Increase the version number in the header if appropriate.~
- [x] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~