### PR TITLE
Passportjs - add passReqToCallback to AuthenticateOptions

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -41,8 +41,8 @@ declare module 'passport' {
             successRedirect?: string;
             successReturnToOrRedirect?: string;
             pauseStream?: boolean;
-				    userProperty?: string;
-			      passReqToCallback?: boolean;
+            userProperty?: string;
+            passReqToCallback?: boolean;
         }
 
         interface Passport {

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -41,8 +41,8 @@ declare module 'passport' {
             successRedirect?: string;
             successReturnToOrRedirect?: string;
             pauseStream?: boolean;
-						userProperty?: string;
-						passReqToCallback?: boolean;
+				    userProperty?: string;
+			      passReqToCallback?: boolean;
         }
 
         interface Passport {

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for Passport 0.3
+// Type definitions for Passport 0.4
 // Project: http://passportjs.org
-// Definitions by: Horiuchi_H <https://github.com/horiuchi>, Eric Naeseth <https://github.com/enaeseth>
+// Definitions by: Horiuchi_H <https://github.com/horiuchi>, Eric Naeseth <https://github.com/enaeseth>, Igor Belagorudsky <https://github.com/theigor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -41,7 +41,8 @@ declare module 'passport' {
             successRedirect?: string;
             successReturnToOrRedirect?: string;
             pauseStream?: boolean;
-            userProperty?: string;
+						userProperty?: string;
+						passReqToCallback?: boolean;
         }
 
         interface Passport {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: This is used in many strategies - https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L49, https://github.com/jaredhanson/passport-http-bearer/blob/master/lib/strategy.js#L71, etc
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.