### PR TITLE
supercluster: added initial,map,reduce to Options

### DIFF
--- a/types/supercluster/index.d.ts
+++ b/types/supercluster/index.d.ts
@@ -33,6 +33,27 @@ export interface Options {
      * Whether timing info should be logged.
      */
     log?: boolean;
+    /**
+     * a reduce function for calculating custom cluster properties
+     *
+     * @example
+     * function (accumulated, props) { accumulated.sum += props.sum; }
+     */
+    reduce?: (accumulated: any, props: any) => void;
+    /**
+     * initial properties of a cluster (before running the reducer)
+     *
+     * @example
+     * function () { return {sum: 0}; }
+     */
+    initial?: () => any;
+    /**
+     * properties to use for individual points when running the reducer
+     *
+     * @example
+     * function (props) { return {sum: props.my_value}; }
+     */
+    map?: (props: any) => any;
 }
 
 export class Supercluster {

--- a/types/supercluster/supercluster-tests.ts
+++ b/types/supercluster/supercluster-tests.ts
@@ -2,21 +2,36 @@ import supercluster, { Point } from 'supercluster';
 
 const point1: Point = {
     type: 'Feature',
-    properties: {},
+    properties: {my_value: 2},
     geometry: { type: 'Point', coordinates: [10, 20] }
 };
 const point2: Point = {
     type: 'Feature',
-    properties: {},
+    properties: {my_value: 3},
     geometry: { type: 'Point', coordinates: [20, 30] }
 };
 const points = [point1, point2];
+
+const initialFunction = () => {
+  return {sum: 0};
+};
+
+const mapFunction = (props: any) => {
+  return {sum: props.my_value};
+};
+
+const reduceFunction = (accumulated: any, props: any) => {
+  accumulated.sum += props.sum;
+};
 
 const index = supercluster({
     radius: 40,
     maxZoom: 16,
     extent: 256,
-    log: true
+    log: true,
+    initial: initialFunction,
+    map: mapFunction,
+    reduce: reduceFunction,
 });
 index.load(points);
 const clusters = index.getClusters([-180, -85, 180, 85], 2);


### PR DESCRIPTION
Talked with @DenisCarriere in #21211 

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes:
definition of initial,map,reduce in the Options for supercluster
https://www.npmjs.com/package/@types/supercluster

source code with usage of map,reduce,initial
https://github.com/mapbox/supercluster/blob/master/index.js

This is my first time opening an open pull request in a public repository. Let me know if there's anything I forgot to do. Thanks!
