### PR TITLE
Add `fancy-log` types

### DIFF
--- a/types/fancy-log/fancy-log-tests.ts
+++ b/types/fancy-log/fancy-log-tests.ts
@@ -1,0 +1,26 @@
+import log = require('./');
+
+log();
+log(1);
+log('foo');
+log('foo', 'bar');
+
+log.dir();
+log.dir(1);
+log.dir('foo');
+log.dir('foo', 'bar');
+
+log.error();
+log.error(1);
+log.error('foo');
+log.error('foo', 'bar');
+
+log.info();
+log.info(1);
+log.info('foo');
+log.info('foo', 'bar');
+
+log.warn();
+log.warn(1);
+log.warn('foo');
+log.warn('foo', 'bar');

--- a/types/fancy-log/fancy-log-tests.ts
+++ b/types/fancy-log/fancy-log-tests.ts
@@ -1,4 +1,4 @@
-import log = require('./');
+import log = require('fancy-log');
 
 log();
 log(1);

--- a/types/fancy-log/index.d.ts
+++ b/types/fancy-log/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for fancy-log 1.3
+// Project: https://github.com/js-cli/fancy-log
+// Definitions by: Pine Mizune <https://github.com/pine>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace FancyLog {
+    interface Logger {
+        (...args: any[]): Logger;
+        dir(...args: any[]): Logger;
+        error(...args: any[]): Logger;
+        info(...args: any[]): Logger;
+        warn(...args: any[]): Logger;
+    }
+}
+
+declare var logger: FancyLog.Logger;
+export = logger;

--- a/types/fancy-log/tsconfig.json
+++ b/types/fancy-log/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fancy-log-tests.ts"
+    ]
+}

--- a/types/fancy-log/tslint.json
+++ b/types/fancy-log/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Hello. I've added `fancy-log` types. Thanks.
https://github.com/js-cli/fancy-log

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
