### PR TITLE
[cytoscape] Fixed missing return type at layout function

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -978,7 +978,7 @@ declare namespace cytoscape {
          * An analogue to run a layout on a subset of the graph exists as eles.layout().
          * http://js.cytoscape.org/#cy.layout
          */
-        layout(layout: LayoutOptions): void;
+        layout(layout: LayoutOptions): LayoutManipulation;
         /**
          * Get a new layout, which can be used to algorithmically
          * position the nodes in the graph.
@@ -991,7 +991,7 @@ declare namespace cytoscape {
          * Note that you must call layout.run() in order for it to affect the graph.
          * An analogue to make a layout on a subset of the graph exists as eles.makeLayout().
          */
-        makeLayout(options: LayoutOptions): void;
+        makeLayout(options: LayoutOptions): LayoutManipulation;
     }
 
     /**


### PR DESCRIPTION
The documentation correctly describes that a layout object should be returned by the methods layout(LayoutOptions) and makeLayout(LayoutOptions).
 It is essential that you are able to call layoutObject.run() after setting a new layout, because else the layout change will not be applied. So I changed the return type of these methods to the existing LayoutManipulation interface.
Can you please check the changes; @phreed , @wy193777 

