### PR TITLE
[promise-retry] Add types for the promise-retry module.

### DIFF
--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -13,7 +13,7 @@ import { WrapOptions } from "../retry";
  * @param attempt The number of the attempt.
  * @returns A Promise for anything (eg. a HTTP response).
  */
-export declare type RetryableFn = ((retry: (error: any) => never, attempt: number) => Promise<any>);
+declare type RetryableFn = ((retry: (error: any) => never, attempt: number) => Promise<any>);
 /**
  * Wrap all functions of the object with retry. The params can be entered in either order, just like in the original library.
  *
@@ -21,4 +21,5 @@ export declare type RetryableFn = ((retry: (error: any) => never, attempt: numbe
  * @param options The options for how long/often to retry the function for.
  * @returns The Promise resolved by the input retryableFn, or rejected (if not retried) from its catch block.
  */
-export declare function promiseRetry(retryableFn: RetryableFn | WrapOptions, options?: WrapOptions | RetryableFn): Promise<any>;
+declare function promiseRetry(retryableFn: RetryableFn | WrapOptions, options?: WrapOptions | RetryableFn): Promise<any>;
+export = promiseRetry;

--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for promise-retry 1.1.1
+// Type definitions for promise-retry 1.1
 // Project: https://github.com/IndigoUnited/node-promise-retry
-// Definitions by: Jamie Birch <https://www.github.com/shirakaba/>
+// Definitions by: Jamie Birch <https://github.com/shirakaba>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { WrapOptions } from "retry";
@@ -13,11 +13,11 @@ import { WrapOptions } from "retry";
  * @param attempt The number of the attempt.
  * @returns A Promise for anything (eg. a HTTP response).
  */
-declare type RetryableFn = ((retry: (error: any) => never, attempt: number) => Promise<any>);
+type RetryableFn = ((retry: (error: any) => never, attempt: number) => Promise<any>);
 /**
  * Wrap all functions of the object with retry. The params can be entered in either order, just like in the original library.
  *
- * @param retryableFn The function to retry. Should include its own 
+ * @param retryableFn The function to retry.
  * @param options The options for how long/often to retry the function for.
  * @returns The Promise resolved by the input retryableFn, or rejected (if not retried) from its catch block.
  */

--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jamie Birch <https://www.github.com/shirakaba/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { WrapOptions } from "../retry";
+import { WrapOptions } from "retry";
 /**
  * A function that is retryable, by having implicitly-bound params for both an error handler and an attempt number.
  *

--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -21,5 +21,6 @@ type RetryableFn = ((retry: (error: any) => never, attempt: number) => Promise<a
  * @param options The options for how long/often to retry the function for.
  * @returns The Promise resolved by the input retryableFn, or rejected (if not retried) from its catch block.
  */
-declare function promiseRetry(retryableFn: RetryableFn | WrapOptions, options?: WrapOptions | RetryableFn): Promise<any>;
+declare function promiseRetry(retryableFn: RetryableFn, options?: WrapOptions): Promise<any>;
+declare function promiseRetry(options: WrapOptions, retryableFn: RetryableFn): Promise<any>;
 export = promiseRetry;

--- a/types/promise-retry/index.d.ts
+++ b/types/promise-retry/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for promise-retry 1.1.1
+// Project: https://github.com/IndigoUnited/node-promise-retry
+// Definitions by: Jamie Birch <https://www.github.com/shirakaba/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { WrapOptions } from "../retry";
+/**
+ * A function that is retryable, by having implicitly-bound params for both an error handler and an attempt number.
+ *
+ * @param retry The retry callback upon any rejection. Essentially throws the error on in the form of a { retried: err }
+ * wrapper, and tags it with a 'code' field of value "EPROMISERETRY" so that it is recognised as needing retrying. Call
+ * this from the catch() block when you want to retry a rejected attempt.
+ * @param attempt The number of the attempt.
+ * @returns A Promise for anything (eg. a HTTP response).
+ */
+export declare type RetryableFn = ((retry: (error: any) => never, attempt: number) => Promise<any>);
+/**
+ * Wrap all functions of the object with retry. The params can be entered in either order, just like in the original library.
+ *
+ * @param retryableFn The function to retry. Should include its own 
+ * @param options The options for how long/often to retry the function for.
+ * @returns The Promise resolved by the input retryableFn, or rejected (if not retried) from its catch block.
+ */
+export declare function promiseRetry(retryableFn: RetryableFn | WrapOptions, options?: WrapOptions | RetryableFn): Promise<any>;

--- a/types/promise-retry/promise-retry-tests.ts
+++ b/types/promise-retry/promise-retry-tests.ts
@@ -9,30 +9,28 @@ interface Assertion {
     not: Assertion;
     to: Assertion;
 }
-interface Equal {
-    (value: any, message?: string): Assertion;
-}
+type Equal = (value: any, message?: string) => Assertion;
 type Operator = string; // "==" | "===" | ">" | ">=" | "<" | "<=" | "!=" | "!==";
-declare interface ExpectStatic {
+interface ExpectStatic {
     (target: any, message?: string): Assertion;
     fail(actual?: any, expected?: any, message?: string, operator?: Operator): void;
 }
 declare const expect: ExpectStatic;
 
 // Adapted from Mocha
-interface IContextDefinition {
+interface ContextDefinition {
     (desc: string, f: () => void): void;
     timeout(ms: number): void;
 }
-declare const describe: IContextDefinition;
-interface IRunnable {
+declare const describe: ContextDefinition;
+interface Runnable {
     timeout(n: number): this;
 }
-interface ITestDefinition {
-    (desc: string, f: (done?: (error?: Error)=>void) => void): IRunnable;
+interface TestDefinition {
+    (desc: string, f: (done?: (error?: Error) => void) => void): Runnable;
     timeout(ms: number): void;
 }
-declare const it: ITestDefinition;
+declare const it: TestDefinition;
 
 // Adapted from lib.d.ts
 interface Console {
@@ -40,15 +38,14 @@ interface Console {
     error(message?: any, ...optionalParams: any[]): void;
     log(message?: any, ...optionalParams: any[]): void;
 }
-declare var Console: {
+declare let Console: {
     prototype: Console;
     new(): Console;
 };
-declare var console: Console;
+declare let console: Console;
 
-
-describe("Promise-retry tests", function(){
-    it('should allow params to be input either way round', function(){
+describe("Promise-retry tests", () => {
+    it('should allow params to be input either way round', () => {
         let count = 0;
 
         promiseRetry(
@@ -93,218 +90,4 @@ describe("Promise-retry tests", function(){
         .then((value: any) => console.log("Finished with value ", value))
         .catch((err: any) => console.error(err.message || err));
     });
-
-    it('should call fn again if retry was called', function(done){
-        let count = 0;
-
-        promiseRetry((retryCb, attemptNumber) => {
-            count += 1;
-
-            return sleep(10)
-            .then(() => {
-                console.log("Count in then(): " + count);
-                if (count > 1) return Promise.resolve('final');
-                else return Promise.reject(new Error('arbitrary excuse to retry'));
-            })
-            .catch((err: any) => {
-                console.log("Count in catch(): " + count);
-                if (count > 1) return Promise.resolve('final');
-                else return retryCb(err);
-            });
-        }, {factor: 1})
-        .then((value: string) => {
-            // console.log("got into here");
-            expect(value).to.equal('final');
-            expect(count).to.equal(2);
-            // if(value !== 'final') return Promise.reject(new Error('value != final'));
-            // if(count !== 2) return Promise.reject(new Error('count != 2'));
-            return Promise.resolve();
-        })
-        .then(() => done!())
-        .catch((err: any) => done!(err));
-    });
-
-    it('should call fn with the attempt number', function(done){
-        var count = 0;
-
-        promiseRetry((retryCb, attemptNumber) => {
-            count += 1;
-            expect(count).to.equal(attemptNumber);
-
-            return sleep(10)
-            .then(() => {
-                // console.log("Count in then(): " + count);
-                if (count > 2) return Promise.resolve('final');
-                else return Promise.reject(new Error('arbitrary excuse to retry'));
-            })
-            .catch((err: any) => {
-                // console.log("Count in catch(): " + count);
-                if (count > 2) return Promise.resolve('final');
-                else return retryCb(err);
-            });
-        }, {forever: true, factor: 1, minTimeout: 0, maxTimeout: 30, randomize: false})
-        .then((value: string) => {
-            // console.log("got into here");
-            expect(value).to.equal('final');
-            expect(count).to.equal(3);
-            // if(value !== 'final') return Promise.reject(new Error('value != final'));
-            // if(count !== 2) return Promise.reject(new Error('count != 2'));
-            return Promise.resolve();
-        })
-        .then(() => done!())
-        .catch((err: any) => done!(err));
-    });
-
-    it('should not retry on fulfillment if retry was not called', function(done){
-        let count = 0;
-
-        promiseRetry((retryCb, attemptNumber) => {
-            count += 1;
-
-            return sleep(10)
-            .then(() => Promise.resolve('final'));
-        }, {factor: 1})
-        .then((value: string) => {
-            expect(value).to.equal('final');
-            expect(count).to.equal(1);
-            return Promise.resolve();
-        })
-        .then(() => done!())
-        .catch((err: any) => done!(err));
-    });
-
-    it('should not retry on rejection if retry was not called', function(){
-        var count = 0;
-
-        return promiseRetry(function(){
-            count += 1;
-
-            return sleep(10)
-            .then(function(){
-                throw new Error('foo');
-            });
-        })
-        .then(function(){
-            throw new Error('should not succeed');
-        }, function (err) {
-            expect(err.message).to.equal('foo');
-            expect(count).to.equal(1);
-        });
-    });
-
-    it('should not retry on rejection if nr of retries is 0', function(){
-        var count = 0;
-
-        return promiseRetry(function(retryCb, attemptNumber) {
-            count += 1;
-
-            return sleep(10)
-            .then(function(){
-                throw new Error('foo');
-            })
-            .catch(retryCb);
-        }, {retries: 0})
-        .then(function(){
-            throw new Error('should not succeed');
-        }, function (err) {
-            expect(err.message).to.equal('foo');
-            expect(count).to.equal(1);
-        });
-    });
-
-    it('should reject the promise if the retries were exceeded', function(){
-        var count = 0;
-
-        return promiseRetry(function(retryCb, attemptNumber) {
-            count += 1;
-
-            return sleep(10)
-            .then(function(){
-                throw new Error('foo');
-            })
-            .catch(retryCb);
-        }, {retries: 2, factor: 1})
-        .then(function(){
-            throw new Error('should not succeed');
-        }, function (err) {
-            expect(err.message).to.equal('foo');
-            expect(count).to.equal(3);
-        });
-    }).timeout(3500);
-
-    it('should pass options to the underlying retry module', function(){
-        var count = 0;
-
-        return promiseRetry(function(retryCb, attemptNumber) {
-            return sleep(10)
-            .then(function(){
-                if (count < 2) {
-                    count += 1;
-                    retryCb(new Error('foo'));
-                }
-
-                return 'final';
-            });
-        }, {retries: 1, factor: 1})
-        .then(function(){
-            throw new Error('should not succeed');
-        }, function (err) {
-            expect(err.message).to.equal('foo');
-        });
-    });
-
-    it('should convert direct rejections into promises', function(){
-        promiseRetry(function(retryCb, attemptNumber) {
-            throw new Error('foo');
-        }, {retries: 1, factor: 1})
-        .then(function(){
-            throw new Error('should not succeed');
-        }, function (err) {
-            expect(err.message).to.equal('foo');
-        });
-    });
-
-    it('should work with several retries in the same chain', function(){
-        var count = 0;
-
-        return promiseRetry(function(retryCb, attemptNumber) {
-            count += 1;
-
-            return sleep(10)
-            .then(function(){
-                retryCb(new Error('foo'));
-            })
-            .catch(function (err: any) {
-                retryCb(err);
-            });
-        }, {retries: 1, factor: 1})
-        .then(function(){
-            throw new Error('should not succeed');
-        }, function (err) {
-            expect(err.message).to.equal('foo');
-            expect(count).to.equal(2);
-        });
-    });
-
-    it('should allow options to be passed first', function(){
-        var count = 0;
-
-        return promiseRetry({factor: 1}, function(retryCb, attemptNumber) {
-            count += 1;
-
-            return sleep(10)
-            .then(function(){
-                if (count <= 2) {
-                    retryCb(new Error('foo'));
-                }
-
-                return 'final';
-            });
-        }).then(function (value) {
-            expect(value).to.equal('final');
-            expect(count).to.equal(3);
-        }, function(){
-            throw new Error('should not fail');
-        });
-    }).timeout(3500);
 });

--- a/types/promise-retry/promise-retry-tests.ts
+++ b/types/promise-retry/promise-retry-tests.ts
@@ -35,6 +35,18 @@ interface ITestDefinition {
 }
 declare const it: ITestDefinition;
 
+// Adapted from lib.d.ts
+interface Console {
+    assert(test?: boolean, message?: string, ...optionalParams: any[]): void;
+    error(message?: any, ...optionalParams: any[]): void;
+    log(message?: any, ...optionalParams: any[]): void;
+}
+declare var Console: {
+    prototype: Console;
+    new(): Console;
+};
+declare var console: Console;
+
 
 describe("Promise-retry tests", function(){
     it('should allow params to be input either way round', function(){
@@ -46,32 +58,41 @@ describe("Promise-retry tests", function(){
 
                 return Promise.resolve()
                 .then(() => {
+                    console.log("Count in then()", count);
                     if (count > 1) return Promise.resolve('final');
                     else return Promise.reject(new Error('arbitrary excuse to retry'));
                 })
                 .catch((err: any) => {
+                    console.log("Count in catch()", count);
                     if (count > 1) return Promise.resolve('final');
                     else return retryCb(err);
                 });
             },
             {forever: true, factor: 1, minTimeout: 0, maxTimeout: 30, randomize: false}
-        );
+        )
+        .then((value: any) => console.log("Finished with value ", value))
+        .catch((err: any) => console.error(err.message || err));
 
         promiseRetry(
             {forever: true, factor: 1, minTimeout: 0, maxTimeout: 30, randomize: false},
             (retryCb, attemptNumber) => {
-            count += 1;
+                count += 1;
 
-            return Promise.resolve()
-            .then(() => {
-                if (count > 1) return Promise.resolve('final');
-                else return Promise.reject(new Error('arbitrary excuse to retry'));
-            })
-            .catch((err: any) => {
-                if (count > 1) return Promise.resolve('final');
-                else return retryCb(err);
-            });
-        });
+                return Promise.resolve()
+                .then(() => {
+                    console.log("Count in then()", count);
+                    if (count > 1) return Promise.resolve('final');
+                    else return Promise.reject(new Error('arbitrary excuse to retry'));
+                })
+                .catch((err: any) => {
+                    console.log("Count in catch()", count);
+                    if (count > 1) return Promise.resolve('final');
+                    else return retryCb(err);
+                });
+            }
+        )
+        .then((value: any) => console.log("Finished with value ", value))
+        .catch((err: any) => console.error(err.message || err));
     });
 
     it('should call fn again if retry was called', function(done){
@@ -82,12 +103,12 @@ describe("Promise-retry tests", function(){
 
             return sleep(10)
             .then(() => {
-                // console.log("Count in then(): " + count);
+                console.log("Count in then(): " + count);
                 if (count > 1) return Promise.resolve('final');
                 else return Promise.reject(new Error('arbitrary excuse to retry'));
             })
             .catch((err: any) => {
-                // console.log("Count in catch(): " + count);
+                console.log("Count in catch(): " + count);
                 if (count > 1) return Promise.resolve('final');
                 else return retryCb(err);
             });

--- a/types/promise-retry/promise-retry-tests.ts
+++ b/types/promise-retry/promise-retry-tests.ts
@@ -1,8 +1,5 @@
 import { WrapOptions } from "../retry";
-// import * as chai from "chai";
-// const expect = chai.expect;
-// import promiseRetry = require('promise-retry');
-import * as pr from "promise-retry";
+import pr = require('promise-retry');
 const promiseRetry = pr.promiseRetry;
 
 // From sleep

--- a/types/promise-retry/promise-retry-tests.ts
+++ b/types/promise-retry/promise-retry-tests.ts
@@ -1,6 +1,5 @@
 import { WrapOptions } from "../retry";
-import pr = require('promise-retry');
-const promiseRetry = pr.promiseRetry;
+import promiseRetry = require('promise-retry');
 
 // From sleep
 declare function sleep(milliseconds: number): Promise<void>;

--- a/types/promise-retry/promise-retry-tests.ts
+++ b/types/promise-retry/promise-retry-tests.ts
@@ -1,4 +1,3 @@
-import { WrapOptions } from "../retry";
 import promiseRetry = require('promise-retry');
 
 // From sleep

--- a/types/promise-retry/promise-retry-tests.ts
+++ b/types/promise-retry/promise-retry-tests.ts
@@ -1,0 +1,294 @@
+import { WrapOptions } from "../retry";
+// import * as chai from "chai";
+// const expect = chai.expect;
+// import promiseRetry = require('promise-retry');
+import * as pr from "promise-retry";
+const promiseRetry = pr.promiseRetry;
+
+// From sleep
+declare function sleep(milliseconds: number): Promise<void>;
+
+// Adapted from Chai
+interface Assertion {
+    equal: Equal;
+    not: Assertion;
+    to: Assertion;
+}
+interface Equal {
+    (value: any, message?: string): Assertion;
+}
+type Operator = string; // "==" | "===" | ">" | ">=" | "<" | "<=" | "!=" | "!==";
+declare interface ExpectStatic {
+    (target: any, message?: string): Assertion;
+    fail(actual?: any, expected?: any, message?: string, operator?: Operator): void;
+}
+declare const expect: ExpectStatic;
+
+// Adapted from Mocha
+interface IContextDefinition {
+    (desc: string, f: () => void): void;
+    timeout(ms: number): void;
+}
+declare const describe: IContextDefinition;
+interface IRunnable {
+    timeout(n: number): this;
+}
+interface ITestDefinition {
+    (desc: string, f: (done?: (error?: Error)=>void) => void): IRunnable;
+    timeout(ms: number): void;
+}
+declare const it: ITestDefinition;
+
+
+describe("Promise-retry tests", function(){
+    it('should allow params to be input either way round', function(){
+        let count = 0;
+
+        promiseRetry(
+            (retryCb, attemptNumber) => {
+                count += 1;
+
+                return Promise.resolve()
+                .then(() => {
+                    if (count > 1) return Promise.resolve('final');
+                    else return Promise.reject(new Error('arbitrary excuse to retry'));
+                })
+                .catch((err: any) => {
+                    if (count > 1) return Promise.resolve('final');
+                    else return retryCb(err);
+                });
+            },
+            {forever: true, factor: 1, minTimeout: 0, maxTimeout: 30, randomize: false}
+        );
+
+        promiseRetry(
+            {forever: true, factor: 1, minTimeout: 0, maxTimeout: 30, randomize: false},
+            (retryCb, attemptNumber) => {
+            count += 1;
+
+            return Promise.resolve()
+            .then(() => {
+                if (count > 1) return Promise.resolve('final');
+                else return Promise.reject(new Error('arbitrary excuse to retry'));
+            })
+            .catch((err: any) => {
+                if (count > 1) return Promise.resolve('final');
+                else return retryCb(err);
+            });
+        });
+    });
+
+    it('should call fn again if retry was called', function(done){
+        let count = 0;
+
+        promiseRetry((retryCb, attemptNumber) => {
+            count += 1;
+
+            return sleep(10)
+            .then(() => {
+                // console.log("Count in then(): " + count);
+                if (count > 1) return Promise.resolve('final');
+                else return Promise.reject(new Error('arbitrary excuse to retry'));
+            })
+            .catch((err: any) => {
+                // console.log("Count in catch(): " + count);
+                if (count > 1) return Promise.resolve('final');
+                else return retryCb(err);
+            });
+        }, {factor: 1})
+        .then((value: string) => {
+            // console.log("got into here");
+            expect(value).to.equal('final');
+            expect(count).to.equal(2);
+            // if(value !== 'final') return Promise.reject(new Error('value != final'));
+            // if(count !== 2) return Promise.reject(new Error('count != 2'));
+            return Promise.resolve();
+        })
+        .then(() => done!())
+        .catch((err: any) => done!(err));
+    });
+
+    it('should call fn with the attempt number', function(done){
+        var count = 0;
+
+        promiseRetry((retryCb, attemptNumber) => {
+            count += 1;
+            expect(count).to.equal(attemptNumber);
+
+            return sleep(10)
+            .then(() => {
+                // console.log("Count in then(): " + count);
+                if (count > 2) return Promise.resolve('final');
+                else return Promise.reject(new Error('arbitrary excuse to retry'));
+            })
+            .catch((err: any) => {
+                // console.log("Count in catch(): " + count);
+                if (count > 2) return Promise.resolve('final');
+                else return retryCb(err);
+            });
+        }, {forever: true, factor: 1, minTimeout: 0, maxTimeout: 30, randomize: false})
+        .then((value: string) => {
+            // console.log("got into here");
+            expect(value).to.equal('final');
+            expect(count).to.equal(3);
+            // if(value !== 'final') return Promise.reject(new Error('value != final'));
+            // if(count !== 2) return Promise.reject(new Error('count != 2'));
+            return Promise.resolve();
+        })
+        .then(() => done!())
+        .catch((err: any) => done!(err));
+    });
+
+    it('should not retry on fulfillment if retry was not called', function(done){
+        let count = 0;
+
+        promiseRetry((retryCb, attemptNumber) => {
+            count += 1;
+
+            return sleep(10)
+            .then(() => Promise.resolve('final'));
+        }, {factor: 1})
+        .then((value: string) => {
+            expect(value).to.equal('final');
+            expect(count).to.equal(1);
+            return Promise.resolve();
+        })
+        .then(() => done!())
+        .catch((err: any) => done!(err));
+    });
+
+    it('should not retry on rejection if retry was not called', function(){
+        var count = 0;
+
+        return promiseRetry(function(){
+            count += 1;
+
+            return sleep(10)
+            .then(function(){
+                throw new Error('foo');
+            });
+        })
+        .then(function(){
+            throw new Error('should not succeed');
+        }, function (err) {
+            expect(err.message).to.equal('foo');
+            expect(count).to.equal(1);
+        });
+    });
+
+    it('should not retry on rejection if nr of retries is 0', function(){
+        var count = 0;
+
+        return promiseRetry(function(retryCb, attemptNumber) {
+            count += 1;
+
+            return sleep(10)
+            .then(function(){
+                throw new Error('foo');
+            })
+            .catch(retryCb);
+        }, {retries: 0})
+        .then(function(){
+            throw new Error('should not succeed');
+        }, function (err) {
+            expect(err.message).to.equal('foo');
+            expect(count).to.equal(1);
+        });
+    });
+
+    it('should reject the promise if the retries were exceeded', function(){
+        var count = 0;
+
+        return promiseRetry(function(retryCb, attemptNumber) {
+            count += 1;
+
+            return sleep(10)
+            .then(function(){
+                throw new Error('foo');
+            })
+            .catch(retryCb);
+        }, {retries: 2, factor: 1})
+        .then(function(){
+            throw new Error('should not succeed');
+        }, function (err) {
+            expect(err.message).to.equal('foo');
+            expect(count).to.equal(3);
+        });
+    }).timeout(3500);
+
+    it('should pass options to the underlying retry module', function(){
+        var count = 0;
+
+        return promiseRetry(function(retryCb, attemptNumber) {
+            return sleep(10)
+            .then(function(){
+                if (count < 2) {
+                    count += 1;
+                    retryCb(new Error('foo'));
+                }
+
+                return 'final';
+            });
+        }, {retries: 1, factor: 1})
+        .then(function(){
+            throw new Error('should not succeed');
+        }, function (err) {
+            expect(err.message).to.equal('foo');
+        });
+    });
+
+    it('should convert direct rejections into promises', function(){
+        promiseRetry(function(retryCb, attemptNumber) {
+            throw new Error('foo');
+        }, {retries: 1, factor: 1})
+        .then(function(){
+            throw new Error('should not succeed');
+        }, function (err) {
+            expect(err.message).to.equal('foo');
+        });
+    });
+
+    it('should work with several retries in the same chain', function(){
+        var count = 0;
+
+        return promiseRetry(function(retryCb, attemptNumber) {
+            count += 1;
+
+            return sleep(10)
+            .then(function(){
+                retryCb(new Error('foo'));
+            })
+            .catch(function (err: any) {
+                retryCb(err);
+            });
+        }, {retries: 1, factor: 1})
+        .then(function(){
+            throw new Error('should not succeed');
+        }, function (err) {
+            expect(err.message).to.equal('foo');
+            expect(count).to.equal(2);
+        });
+    });
+
+    it('should allow options to be passed first', function(){
+        var count = 0;
+
+        return promiseRetry({factor: 1}, function(retryCb, attemptNumber) {
+            count += 1;
+
+            return sleep(10)
+            .then(function(){
+                if (count <= 2) {
+                    retryCb(new Error('foo'));
+                }
+
+                return 'final';
+            });
+        }).then(function (value) {
+            expect(value).to.equal('final');
+            expect(count).to.equal(3);
+        }, function(){
+            throw new Error('should not fail');
+        });
+    }).timeout(3500);
+});

--- a/types/promise-retry/tsconfig.json
+++ b/types/promise-retry/tsconfig.json
@@ -6,6 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/promise-retry/tsconfig.json
+++ b/types/promise-retry/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "promise-retry-tests.ts"
+    ]
+}

--- a/types/promise-retry/tslint.json
+++ b/types/promise-retry/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Independent typings for IndigoUnited's promise-retry package: https://github.com/IndigoUnited/node-promise-retry

- [ √ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ √ ] Test the change in your own code. (Compile and run.)
- [ √ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ √ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ √ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [√] The package does not provide its own types, and you can not add them.
- [√] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [√] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [√] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.