### PR TITLE
Return type of `onStartShouldSetPanRespnder` should be boolean

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6966,7 +6966,7 @@ export interface PanResponderGestureState {
  */
 export interface PanResponderCallbacks {
     onMoveShouldSetPanResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean
-    onStartShouldSetPanResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
+    onStartShouldSetPanResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean
     onPanResponderGrant?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
     onPanResponderMove?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
     onPanResponderRelease?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void


### PR DESCRIPTION
The callback `onStartShouldSetPanRespnder` returns a boolean that indicates whether the responder wants to become active.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/panresponder.html#basic-usage
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.