### PR TITLE
Revert "lodash use typescript Pick<> to improve _.pick typings"

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -13908,15 +13908,10 @@ declare namespace _ {
          * _.pick(object, ['a', 'c']);
          * // => { 'a': 1, 'c': 3 }
          */
-        pick<T extends object, U extends keyof T>(
-            object: T | null | undefined,
-             ...props: Array<Many<U>>
-        ): Pick<T, U>;
-
-        pick<T>(
+        pick<T extends object>(
             object: T | null | undefined,
             ...props: PropertyPath[]
-        ): PartialDeep<T>;
+        ): PartialObject<T>;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -11188,12 +11188,6 @@ namespace TestPick {
     }
 
     {
-        let result: Pick<TResult, 'a' | 'b'>;
-        result = _.pick(obj, 'a', 'b');
-        result = _.pick(obj, ['a', 'b']);
-    }
-
-    {
         let result: _.LoDashImplicitWrapper<Partial<TResult>>;
 
         result = _(obj).pick<TResult>('a');


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#21127

The new typings are incompatible with function maps, like this:

```ts
import { pick } from 'lodash';

interface IGreeter {
    [species: string]: (name: string) => string;
}

const greet = pick<IGreeter>(
    { human: (name: string) => `hello ${name}` },
    ['human']
);

console.log(greet.human('connor'));
```

Errors with:

```
error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'PartialDeep<(name: string) => string>' has no compatible call signatures.
```
