### PR TITLE
material-ui: fix Chip missing `containerElement` prop

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -947,6 +947,7 @@ declare namespace __MaterialUI {
     export interface ChipProps {
         backgroundColor?: string;
         className?: string;
+        containerElement?: React.ReactNode | string;
         labelColor?: string;
         labelStyle?: React.CSSProperties;
         onRequestDelete?: React.TouchEventHandler<Chip>;

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -3030,6 +3030,8 @@ const ChipExampleSimple = () => (
     <Chip labelColor={blue500}>Blue Label Color</Chip>
     <Chip><Avatar size={32} color={blue300} backgroundColor={indigo900}>UI</Avatar> Avatar</Chip>
     <Chip style={styles.chip}>Styled</Chip>
+    <Chip containerElement="span">String Container</Chip>
+    <Chip containerElement={() => {}}>ReactNode Container</Chip>
   </div>
 );
 


### PR DESCRIPTION
Add `containerElement` prop on `Chip`.

See: http://www.material-ui.com/v0.18.7/#/components/chip

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://www.material-ui.com/v0.18.7/#/components/chip>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
