### PR TITLE
Update webpack-hot-middleware to use `webpack.ICompiler` instead of `compiler.Compiler`

### DIFF
--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -1,15 +1,15 @@
 // Type definitions for webpack-hot-middleware 2.16
 // Project: https://github.com/glenjamin/webpack-hot-middleware#readme
-// Definitions by: Benjamin Lim <https://github.com/bumbleblym>
+// Definitions by: Benjamin Lim <https://github.com/bumbleblym>, Ron Martinez <https://github.com/icylace>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { NextHandleFunction } from 'connect';
-import { compiler } from 'webpack';
+import * as webpack from 'webpack';
 
 export = WebpackHotMiddleware;
 
 declare function WebpackHotMiddleware(
-	compiler: compiler.Compiler,
+	compiler: webpack.ICompiler,
 	options?: WebpackHotMiddleware.Options
 ): NextHandleFunction & WebpackHotMiddleware.EventStream;
 


### PR DESCRIPTION
This PR updates the definitions for webpack-hot-middleware so it uses `webpack.ICompiler` instead of `compiler.Compiler`.  This will bring it into alignment with the definitions for webpack-dev-middleware which already uses `webpack.ICompiler`.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5d6c651a1a9f991cbc1f5a3f3097dcf9b64b68ec/types/webpack-dev-middleware/index.d.ts#L12
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
