### PR TITLE
[Codemirror] Text parameter should be an array in changeObj.update method

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -692,7 +692,7 @@ declare namespace CodeMirror {
 
     interface EditorChangeCancellable extends CodeMirror.EditorChange {
         /** may be used to modify the change. All three arguments to update are optional, and can be left off to leave the existing value for that field intact. */
-        update(from?: CodeMirror.Position, to?: CodeMirror.Position, text?: string): void;
+        update(from?: CodeMirror.Position, to?: CodeMirror.Position, text?: string[]): void;
 
         cancel(): void;
     }


### PR DESCRIPTION
Codemirror expects changeObj.text property to be an array.

https://codemirror.net/doc/manual.html#events

https://github.com/codemirror/CodeMirror/blob/8f35a1aa387c34677338d66086b15f0ed68f661a/src/model/changes.js#L35