### PR TITLE
[jasmine] Fix return type of `arrayContaining()` and add method for 2.8

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jasmine 2.6.0
+// Type definitions for Jasmine 2.8.0
 // Project: http://jasmine.github.io/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>, Theodore Brown <https://github.com/theodorejb>, David Pärsson <https://github.com/davidparsson>, Gabe Moothart <https://github.com/gmoothart>, Lukas Zech <https://github.com/lukas-zech-software>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -88,7 +88,7 @@ declare function expect<T>(actual: ArrayLike<T>): jasmine.ArrayLikeMatchers<T>;
  * Create an expectation for a spec.
  * @param actual Actual computed value to test expectations against.
  */
-declare function expect<T>(actual: T): jasmine.Matchers<T>;
+declare function expect<T>(actual?: T): jasmine.Matchers<T>;
 
 /**
  * Explicitly mark a spec as failed.
@@ -134,7 +134,8 @@ declare namespace jasmine {
 
     function anything(): Any;
 
-    function arrayContaining(sample: any[]): ArrayContaining;
+    function arrayContaining<T>(sample: ArrayLike<T>): ArrayContaining<T>;
+    function arrayWithExactContents<T>(sample: ArrayLike<T>): ArrayContaining<T>;
     function objectContaining<T>(sample: Partial<T>): ObjectContaining<T>;
     function createSpy(name: string, originalFn?: Function): Spy;
 
@@ -172,8 +173,8 @@ declare namespace jasmine {
         [n: number]: T;
     }
 
-    interface ArrayContaining {
-        new (sample: any[]): any;
+    interface ArrayContaining<T> {
+        new (sample: ArrayLike<T>): ArrayLike<T>;
 
         asymmetricMatch(other: any): boolean;
         jasmineToString(): string;
@@ -440,14 +441,16 @@ declare namespace jasmine {
         toThrow(expected?: any): boolean;
         toThrowError(message?: string | RegExp): boolean;
         toThrowError(expected?: new (...args: any[]) => Error, message?: string | RegExp): boolean;
+        nothing(): Any;
+
         not: Matchers<T>;
 
         Any: Any;
     }
 
     interface ArrayLikeMatchers<T> extends Matchers<ArrayLike<T>> {
-        toBe(expected: Expected<ArrayLike<T>>, expectationFailOutput?: any): boolean;
-        toEqual(expected: Expected<ArrayLike<T>>, expectationFailOutput?: any): boolean;
+        toBe(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
+        toEqual(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
         toContain(expected: Expected<T>, expectationFailOutput?: any): boolean;
         not: ArrayLikeMatchers<T>;
     }

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -769,6 +769,9 @@ describe("jasmine.arrayContaining", () => {
     it("matches arrays with some of the values", () => {
         expect(foo).toEqual(jasmine.arrayContaining([3, 1]));
         expect(foo).not.toEqual(jasmine.arrayContaining([6]));
+
+        expect(foo).toBe(jasmine.arrayContaining([3, 1]));
+        expect(foo).not.toBe(jasmine.arrayContaining([6]));
     });
 
     describe("when used with a spy", () => {
@@ -793,6 +796,9 @@ describe("jasmine.arrayWithExactContents", () => {
     it("matches arrays with exactly the same values", () => {
         expect(foo).toEqual(jasmine.arrayWithExactContents([1, 2, 3, 4]));
         expect(foo).not.toEqual(jasmine.arrayWithExactContents([6]));
+
+        expect(foo).toBe(jasmine.arrayWithExactContents([1, 2, 3, 4]));
+        expect(foo).not.toBe(jasmine.arrayWithExactContents([6]));
     });
 
     describe("when used with a spy", () => {

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -665,6 +665,12 @@ describe("Multiple spies, when created manually", () => {
     });
 });
 
+describe("jasmine.nothing", () => {
+    it("matches any value", () => {
+        expect().nothing();
+    });
+});
+
 describe("jasmine.any", () => {
     it("matches any value", () => {
         expect({}).toEqual(jasmine.any(Object));
@@ -754,7 +760,7 @@ describe("jasmine.objectContaining", () => {
 });
 
 describe("jasmine.arrayContaining", () => {
-    var foo: any;
+    var foo: Array<number>;
 
     beforeEach(() => {
         foo = [1, 2, 3, 4];
@@ -773,6 +779,30 @@ describe("jasmine.arrayContaining", () => {
 
             expect(callback).toHaveBeenCalledWith(jasmine.arrayContaining([4, 2, 3]));
             expect(callback).not.toHaveBeenCalledWith(jasmine.arrayContaining([5, 2]));
+        });
+    });
+});
+
+describe("jasmine.arrayWithExactContents", () => {
+    var foo: Array<number>;
+
+    beforeEach(() => {
+        foo = [1, 2, 3, 4];
+    });
+
+    it("matches arrays with exactly the same values", () => {
+        expect(foo).toEqual(jasmine.arrayWithExactContents([1, 2, 3, 4]));
+        expect(foo).not.toEqual(jasmine.arrayWithExactContents([6]));
+    });
+
+    describe("when used with a spy", () => {
+        it("is useful when comparing arguments", () => {
+            var callback = jasmine.createSpy('callback');
+
+            callback([1, 2, 3, 4]);
+
+            expect(callback).toHaveBeenCalledWith(jasmine.arrayWithExactContents([1, 2, 3, 4]));
+            expect(callback).not.toHaveBeenCalledWith(jasmine.arrayWithExactContents([5, 2]));
         });
     });
 });


### PR DESCRIPTION
Fix return type of `arrayContaining()`

New methods for jasmine 2.8

Add `arrayWithExactContents()`
Add `nothing()`

Fixes #21305

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jasmine/jasmine/releases/tag/v2.8.0
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
