### PR TITLE
[mongoose] Fix types for SchemaDefinition

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -473,7 +473,7 @@ declare module "mongoose" {
     /** defaults to 1 */
     parallel?: number;
   }
-  
+
   /*
    * section querycursor.js
    * http://mongoosejs.com/docs/api.html#querycursor-js
@@ -764,7 +764,7 @@ declare module "mongoose" {
    * Intellisense for Schema definitions
    */
   interface SchemaDefinition {
-    [path: string]: SchemaTypeOpts<any>;
+    [path: string]: SchemaTypeOpts<any> | Schema | SchemaType;
   }
 
   /*
@@ -2680,7 +2680,7 @@ declare module "mongoose" {
     passRawResult?: boolean;
     /** overwrites the schema's strict mode option for this update */
     strict?: boolean;
-    /** 
+    /**
      * if true, run all setters defined on the associated model's schema for all fields
      * defined in the query and the update.
      */

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -368,8 +368,8 @@ new mongoose.Schema({d: {type: Date, min: [
 new mongoose.Schema({
   integerOnly: {
     type: Number,
-    get: v => Math.round(v),
-    set: v => Math.round(v)
+    get: (v: number) => Math.round(v),
+    set: (v: number) => Math.round(v)
   }
 });
 new mongoose.Schema({ name: { type: String, validate: [


### PR DESCRIPTION
A property of a SchemaDefinition can either be a SchemaTypeOpts<any, a Schema or a SchemaType.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Definition changes:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - http://mongoosejs.com/docs/guide.html
  - http://mongoosejs.com/docs/schematypes.html
  - http://mongoosejs.com/docs/subdocs.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I have encountered the missing type union for the schema definition, when upgrading to the newest version of type script.
