### PR TITLE
Embrace the module-function nature of tress

### DIFF
--- a/types/tress/index.d.ts
+++ b/types/tress/index.d.ts
@@ -4,155 +4,157 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
-export type TressJobCallback = (this: TressJobData, ...args: any[]) => void;
-export type TressWorkerDoneCallback = (err: boolean | Error | null | undefined, ...args: any[]) => void;
+declare namespace tress {
+	export type TressJobCallback = (this: TressJobData, ...args: any[]) => void;
+	export type TressWorkerDoneCallback = (err: boolean | Error | null | undefined, ...args: any[]) => void;
 
-export interface TressJobData { [name: string]: {}; }
+	export interface TressJobData { [name: string]: {}; }
 
-export interface TressJob {
-	data: TressJobData;
-	callback: TressJobCallback;
-}
+	export interface TressJob {
+		data: TressJobData;
+		callback: TressJobCallback;
+	}
 
-export interface TressJobQueues {
-	failed: TressJobData[];
-	finished: TressJobData[];
-	waiting: TressJobData[];
-}
+	export interface TressJobQueues {
+		failed: TressJobData[];
+		finished: TressJobData[];
+		waiting: TressJobData[];
+	}
 
-export interface TressStatic {
-	// Properties
+	export interface TressStatic {
+		// Properties
 
-	/**
-	 * Array of jobs currently being processed (readonly)
-	 */
-	readonly active: TressJob[];
-	/**
-	 * A minimum threshold buffer in order to say that the queue is unsaturated
-	 */
-	buffer: number;
-	/**
-	 * This property for alter the concurrency/delay on-the-fly
-	 */
-	concurrency: number;
-	/**
-	 * Array of failed jobs
-	 * (the done callback was called from worker with error in first argument) (readonly)
-	 */
-	readonly failed: TressJob[];
-	/**
-	 * Array of correctly finished jobs
-	 * (the done callback was called from worker with null or undefined (or any other false equivalent) in first argument) (readonly)
-	 */
-	readonly finished: TressJob[];
-	/**
-	 *  A boolean for determining whether the queue is in a paused state.
-	 * (readonly - use pause() and resume() instead)
-	 */
-	readonly paused: boolean;
-	/**
-	 * false untill any items have been pushed and processed by the queue.
-	 * Then becomes true and never changes in queue lifecycle (readonly)
-	 */
-	readonly started: boolean;
-	/**
-	 * Array of queued jobs (readonly)
-	 */
-	readonly waiting: TressJob[];
+		/**
+		 * Array of jobs currently being processed (readonly)
+		 */
+		readonly active: TressJob[];
+		/**
+		 * A minimum threshold buffer in order to say that the queue is unsaturated
+		 */
+		buffer: number;
+		/**
+		 * This property for alter the concurrency/delay on-the-fly
+		 */
+		concurrency: number;
+		/**
+		 * Array of failed jobs
+		 * (the done callback was called from worker with error in first argument) (readonly)
+		 */
+		readonly failed: TressJob[];
+		/**
+		 * Array of correctly finished jobs
+		 * (the done callback was called from worker with null or undefined (or any other false equivalent) in first argument) (readonly)
+		 */
+		readonly finished: TressJob[];
+		/**
+		 *  A boolean for determining whether the queue is in a paused state.
+		 * (readonly - use pause() and resume() instead)
+		 */
+		readonly paused: boolean;
+		/**
+		 * false untill any items have been pushed and processed by the queue.
+		 * Then becomes true and never changes in queue lifecycle (readonly)
+		 */
+		readonly started: boolean;
+		/**
+		 * Array of queued jobs (readonly)
+		 */
+		readonly waiting: TressJob[];
 
-	// Methods
+		// Methods
 
-	/**
-	 * Returns false if there are items waiting or being processed,
-	 * or true if not
-	 */
-	idle(): boolean;
-	/**
-	 * Removes the drain callback and empties remaining jobs from the queue
-	 * forcing it to go idle
-	 */
-	kill(): void;
-	/**
-	 * Returns the number of items waiting to be processed
-	 */
-	length(): number;
-	/**
-	 * Loads new arrays from data object to waiting, failed, and finished arrays and sets active to empty array.
-	 * Rises an error if started is true
-	 */
-	load(data: TressJobQueues): void;
-	/**
-	 * Pauses the processing of jobs until resume() is called
-	 */
-	pause(): void;
-	/**
-	 * Adds a new job to the queue.
-	 * Instead of a single job, a jobs array can be submitted.
-	 * Note, that if you pass callback as second argument,
-	 * tress calls this callback once the worker has finished processing the job
-	 */
-	push(job: TressJobData | TressJobData[], done?: TressJobCallback): void;
-	/**
-	 * Resumes the processing of queued jobs when the queue is paused
-	 */
-	resume(): void;
-	/**
-	 * Returns the number of items currently being processed
-	 */
-	running(): number;
-	/**
-	 * Runs a callback with object, that contains arrays of waiting, failed, and finished jobs.
-	 * If there are any active jobs at the moment, they will be concatenated to waiting array
-	 */
-	save(callback: (data: TressJobQueues) => void): void;
-	/**
-	 * Returns the status of job ("waiting", "running", "finished", "pending" or "missing")
-	 */
-	status(job: TressJob): "active" | "failed" | "finished" | "missing" | "waiting";
-	/**
-	 * Adds a new job to the front of the queue.
-	 * Instead of a single job, a jobs array can be submitted.
-	 * Note, that if you pass callback as second argument,
-	 * tress calls this callback once the worker has finished processing the job
-	 */
-	unshift(job: TressJobData | TressJobData[], done?: TressJobCallback): void;
-	/**
-	 * Returns the array of items currently being processed
-	 */
-	workersList(): TressStatic["active"];
+		/**
+		 * Returns false if there are items waiting or being processed,
+		 * or true if not
+		 */
+		idle(): boolean;
+		/**
+		 * Removes the drain callback and empties remaining jobs from the queue
+		 * forcing it to go idle
+		 */
+		kill(): void;
+		/**
+		 * Returns the number of items waiting to be processed
+		 */
+		length(): number;
+		/**
+		 * Loads new arrays from data object to waiting, failed, and finished arrays and sets active to empty array.
+		 * Rises an error if started is true
+		 */
+		load(data: TressJobQueues): void;
+		/**
+		 * Pauses the processing of jobs until resume() is called
+		 */
+		pause(): void;
+		/**
+		 * Adds a new job to the queue.
+		 * Instead of a single job, a jobs array can be submitted.
+		 * Note, that if you pass callback as second argument,
+		 * tress calls this callback once the worker has finished processing the job
+		 */
+		push(job: TressJobData | TressJobData[], done?: TressJobCallback): void;
+		/**
+		 * Resumes the processing of queued jobs when the queue is paused
+		 */
+		resume(): void;
+		/**
+		 * Returns the number of items currently being processed
+		 */
+		running(): number;
+		/**
+		 * Runs a callback with object, that contains arrays of waiting, failed, and finished jobs.
+		 * If there are any active jobs at the moment, they will be concatenated to waiting array
+		 */
+		save(callback: (data: TressJobQueues) => void): void;
+		/**
+		 * Returns the status of job ("waiting", "running", "finished", "pending" or "missing")
+		 */
+		status(job: TressJob): "active" | "failed" | "finished" | "missing" | "waiting";
+		/**
+		 * Adds a new job to the front of the queue.
+		 * Instead of a single job, a jobs array can be submitted.
+		 * Note, that if you pass callback as second argument,
+		 * tress calls this callback once the worker has finished processing the job
+		 */
+		unshift(job: TressJobData | TressJobData[], done?: TressJobCallback): void;
+		/**
+		 * Returns the array of items currently being processed
+		 */
+		workersList(): TressStatic["active"];
 
-	// Callbacks
+		// Callbacks
 
-	/**
-	 * A callback that is called when the last item from the queue has returned from the worker
-	 */
-	drain(): void;
-	/**
-	 * A callback that is called when the last item from the queue is given to a worker
-	 */
-	empty(): void;
-	/**
-	 * A callback that is called when job failed (worker call done with error as first argument).
-	 * Note, that this callback is called after job has been moved from active to failed/finished and after job callback (from push/unshift) was called
-	 */
-	error(this: TressJobData, err: Error, job: TressJobData, ...args: any[]): void;
-	/**
-	 * A  callback that is called when job returned to queue (worker call done with boolean as first argument)
-	 */
-	retry(this: TressJobData, ...args: any[]): void;
-	/**
-	 * A callback that is called when the number of running workers hits the concurrency limit, and further jobs will be queued
-	 */
-	saturated(): void;
-	/**
-	 * A callback that is called when job correctly finished (worker call done with null or undefined as first argument).
-	 * Note, that this callback is called after job has been moved from active to failed/finished and after job callback (from push/unshift) was called
-	 */
-	success(this: TressJobData, ...args: any[]): void;
-	/**
-	 * A callback that is called when the number of running workers is less than the concurrency & buffer limits, and further jobs will not be queued
-	 */
-	unsaturated(): void;
+		/**
+		 * A callback that is called when the last item from the queue has returned from the worker
+		 */
+		drain(): void;
+		/**
+		 * A callback that is called when the last item from the queue is given to a worker
+		 */
+		empty(): void;
+		/**
+		 * A callback that is called when job failed (worker call done with error as first argument).
+		 * Note, that this callback is called after job has been moved from active to failed/finished and after job callback (from push/unshift) was called
+		 */
+		error(this: TressJobData, err: Error, job: TressJobData, ...args: any[]): void;
+		/**
+		 * A  callback that is called when job returned to queue (worker call done with boolean as first argument)
+		 */
+		retry(this: TressJobData, ...args: any[]): void;
+		/**
+		 * A callback that is called when the number of running workers hits the concurrency limit, and further jobs will be queued
+		 */
+		saturated(): void;
+		/**
+		 * A callback that is called when job correctly finished (worker call done with null or undefined as first argument).
+		 * Note, that this callback is called after job has been moved from active to failed/finished and after job callback (from push/unshift) was called
+		 */
+		success(this: TressJobData, ...args: any[]): void;
+		/**
+		 * A callback that is called when the number of running workers is less than the concurrency & buffer limits, and further jobs will not be queued
+		 */
+		unsaturated(): void;
+	}
 }
 
 /**
@@ -169,6 +171,8 @@ export interface TressStatic {
  * should be run in parallel. If omitted, the concurrency defaults to 1.
  * If negative - no parallel and delay between worker functions (concurrency -1,000 sets 1 second delay)
  */
-export function tress(
-	worker: (job: TressJobData, done: TressWorkerDoneCallback) => void,
-	concurrency?: number): TressStatic;
+declare function tress(
+	worker: (job: tress.TressJobData, done: tress.TressWorkerDoneCallback) => void,
+	concurrency?: number): tress.TressStatic;
+
+export = tress;

--- a/types/tress/tress-tests.ts
+++ b/types/tress/tress-tests.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import * as tress from "tress";
+import tress = require("tress");
 
 function someAsyncFunction(job: any, callback: (err: any, data?: any) => void): void {
 	const p = Promise.resolve(job)

--- a/types/tress/tress-tests.ts
+++ b/types/tress/tress-tests.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { tress } from "tress";
+import * as tress from "tress";
 
 function someAsyncFunction(job: any, callback: (err: any, data?: any) => void): void {
 	const p = Promise.resolve(job)

--- a/types/tress/tslint.json
+++ b/types/tress/tslint.json
@@ -1,6 +1,7 @@
 {
 	"extends": "dtslint/dt.json",
 	"rules": {
-		"space-before-function-paren": false
+		"space-before-function-paren": false,
+		"strict-export-declare-modifiers": false
 	}
 }


### PR DESCRIPTION
Fixed the definitions for tress to reflect the fact that the tress module exports a function.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/astur/tress/blob/master/index.js#L167
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.