### PR TITLE
[node-zookeeper-client] fix exception path type

### DIFF
--- a/types/node-zookeeper-client/index.d.ts
+++ b/types/node-zookeeper-client/index.d.ts
@@ -171,8 +171,8 @@ export class Exception {
 
     code: number;
     name: string;
-    path: number;
-    constructor(code: number, name: string, path: number);
+    path?: string;
+    constructor(code: number, name: string, path?: string);
     toString(): string;
     getCode(): number;
     getName(): string;

--- a/types/node-zookeeper-client/node-zookeeper-client-tests.ts
+++ b/types/node-zookeeper-client/node-zookeeper-client-tests.ts
@@ -255,3 +255,8 @@ const client = zookeeper.createClient(
 {
     new zookeeper.Event(zookeeper.Event.NODE_CREATED, 'test', '/test');
 }
+
+{
+    new zookeeper.Exception(zookeeper.Exception.NO_NODE, 'test');
+    new zookeeper.Exception(zookeeper.Exception.NO_NODE, 'test', '/test');
+}


### PR DESCRIPTION
Exception constructor's path should be a string and optional
https://github.com/alexguan/node-zookeeper-client/blob/master/lib/Exception.js#L63

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.