### PR TITLE
Jest matchers can accept many arguments

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -8,6 +8,7 @@
 //                 Allan Lukwago <https://github.com/epicallan>
 //                 Ika <https://github.com/ikatyang>
 //                 Waseem Dahman <https://github.com/wsmd>
+//                 Jamie Mason <https://github.com/JamieMason>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -240,7 +241,7 @@ declare namespace jest {
     }
 
     interface ExpectExtendMap {
-        [key: string]: (this: MatcherUtils, received: any, actual: any) => { message(): string, pass: boolean };
+        [key: string]: (this: MatcherUtils, received: any, ...actual: any[]) => { message(): string, pass: boolean };
     }
 
     interface SnapshotSerializerOptions {

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -259,6 +259,12 @@ describe('Extending extend', () => {
                     () => `expected ${received} ${pass ? 'not ' : ''} to be ${actual}`;
                 return { message, pass };
             },
+            toBeVariadicMatcher(received: any, floor: number, ceiling: number) {
+                const pass = received >= floor && received <= ceiling;
+                const message =
+                    () => `expected ${received} ${pass ? 'not ' : ''} to be within range ${floor}-${ceiling}`;
+                return { message, pass };
+            },
             toBeTest(received: any, actual: any) {
                 this.utils.ensureNoExpected(received);
                 this.utils.ensureActualIsNumber(received);


### PR DESCRIPTION
This PR removes the restriction on the number of arguments Jest's custom matchers can accept, which does not exist in Jest itself.

Jest allows you to define the following custom matcher for example which accepts 2 arguments:

```js
expect.extend({
  toBeWithinRange(received, floor, ceiling) {
    // implementation...
  }
});
```

The Jest typings currently state that a Jest matcher can only accept one argument.

A URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/jest/docs/en/expect.html#expectextendmatchers.

Thanks.