### PR TITLE
Fix missing types for google_visualization

### DIFF
--- a/types/google.visualization/index.d.ts
+++ b/types/google.visualization/index.d.ts
@@ -456,8 +456,8 @@ declare namespace google {
             maxTextLines?: number;
             minTextSpacing?: number;
             showTextEvery?: number;
-            maxValue?: number;
-            minValue?: number;
+            maxValue?: number | Date | number[];
+            minValue?: number | Date | number[];
             viewWindowMode?: string;
             viewWindow?: ChartViewWindow;
         }
@@ -468,8 +468,8 @@ declare namespace google {
         }
 
         export interface ChartViewWindow {
-            max?: number;
-            min?: number;
+            max?: number | Date | number[];
+            min?: number | Date | number[];
         }
 
         export interface ChartTooltip {
@@ -645,6 +645,7 @@ declare namespace google {
             interpolateNulls?: boolean;
             legend?: ChartLegend | 'none';
             lineWidth?: number;
+            min?: number;
             orientation?: string;
             pointSize?: number;
             reverseCategories?: boolean;
@@ -1009,7 +1010,7 @@ declare namespace google {
         export interface TableOptions {
             allowHtml?: boolean;
             alternatingRowStyle?: boolean;
-            cssClassName?: CssClassNames;
+            cssClassNames?: CssClassNames;
             firstRowNumber?: number;
             height?: string;
             page?: string;


### PR DESCRIPTION
Fix LineChartOptions and TableOptions, improve type coverage of ViewWindow and ChartAxis

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/chart/interactive/docs/gallery/table shows cssClassName should be cssClassNames.
