### PR TITLE
[@types/jsdom] - Fix #21235: add global types to DOMWindow interface

### DIFF
--- a/types/jsdom/index.d.ts
+++ b/types/jsdom/index.d.ts
@@ -103,7 +103,153 @@ export type ConstructorOptions = Options & {
     contentType?: string;
 };
 
-export interface DOMWindow extends Window { eval(script: string): void; }
+export interface DOMWindow extends Window {
+    eval(script: string): void;
+
+    /* node_modules/jsdom/living/index.js */
+    DOMException: typeof DOMException;
+    Attr: typeof Attr;
+    Node: typeof Node;
+    Element: typeof Element;
+    DocumentFragment: typeof DocumentFragment;
+    Document: typeof Document;
+    HTMLDocument: typeof HTMLDocument;
+    XMLDocument: typeof XMLDocument;
+    CharacterData: typeof CharacterData;
+    Text: typeof Text;
+    CDATASection: typeof CDATASection;
+    ProcessingInstruction: typeof ProcessingInstruction;
+    Comment: typeof Comment;
+    DocumentType: typeof DocumentType;
+    DOMImplementation: typeof DOMImplementation;
+    NodeList: typeof NodeList;
+    HTMLCollection: typeof HTMLCollection;
+    HTMLOptionsCollection: typeof HTMLOptionsCollection;
+    DOMStringMap: typeof DOMStringMap;
+    DOMTokenList: typeof DOMTokenList;
+    Event: typeof Event;
+    CustomEvent: typeof CustomEvent;
+    MessageEvent: typeof MessageEvent;
+    ErrorEvent: typeof ErrorEvent;
+    HashChangeEvent: typeof HashChangeEvent;
+    FocusEvent: typeof FocusEvent;
+    PopStateEvent: typeof PopStateEvent;
+    UIEvent: typeof UIEvent;
+    MouseEvent: typeof MouseEvent;
+    KeyboardEvent: typeof KeyboardEvent;
+    TouchEvent: typeof TouchEvent;
+    ProgressEvent: typeof ProgressEvent;
+    CompositionEvent: typeof CompositionEvent;
+    WheelEvent: typeof WheelEvent;
+    EventTarget: typeof EventTarget;
+    Location: typeof Location;
+    History: typeof History;
+    Blob: typeof Blob;
+    File: typeof File;
+    FileList: typeof FileList;
+    DOMParser: typeof DOMParser;
+    FormData: typeof FormData;
+    XMLHttpRequestEventTarget: XMLHttpRequestEventTarget;
+    XMLHttpRequestUpload: typeof XMLHttpRequestUpload;
+    NodeIterator: typeof NodeIterator;
+    TreeWalker: typeof TreeWalker;
+    NamedNodeMap: typeof NamedNodeMap;
+    URL: typeof URL;
+    URLSearchParams: typeof URLSearchParams;
+
+    /* node_modules/jsdom/living/register-elements.js */
+    HTMLElement: typeof HTMLElement;
+    HTMLAnchorElement: typeof HTMLAnchorElement;
+    HTMLAppletElement: typeof HTMLAppletElement;
+    HTMLAreaElement: typeof HTMLAreaElement;
+    HTMLAudioElement: typeof HTMLAudioElement;
+    HTMLBaseElement: typeof HTMLBaseElement;
+    HTMLBodyElement: typeof HTMLBodyElement;
+    HTMLBRElement: typeof HTMLBRElement;
+    HTMLButtonElement: typeof HTMLButtonElement;
+    HTMLCanvasElement: typeof HTMLCanvasElement;
+    HTMLDataElement: typeof HTMLDataElement;
+    HTMLDataListElement: typeof HTMLDataListElement;
+    // HTMLDetailsElement: typeof HTMLDetailsElement;
+    // HTMLDialogElement: typeof HTMLDialogElement;
+    HTMLDirectoryElement: typeof HTMLDirectoryElement;
+    HTMLDivElement: typeof HTMLDivElement;
+    HTMLDListElement: typeof HTMLDListElement;
+    HTMLEmbedElement: typeof HTMLEmbedElement;
+    HTMLFieldSetElement: typeof HTMLFieldSetElement;
+    HTMLFontElement: typeof HTMLFontElement;
+    HTMLFormElement: typeof HTMLFormElement;
+    HTMLFrameElement: typeof HTMLFrameElement;
+    HTMLFrameSetElement: typeof HTMLFrameSetElement;
+    HTMLHeadingElement: typeof HTMLHeadingElement;
+    HTMLHeadElement: typeof HTMLHeadElement;
+    HTMLHRElement: typeof HTMLHRElement;
+    HTMLHtmlElement: typeof HTMLHtmlElement;
+    HTMLIFrameElement: typeof HTMLIFrameElement;
+    HTMLImageElement: typeof HTMLImageElement;
+    HTMLInputElement: typeof HTMLInputElement;
+    HTMLLabelElement: typeof HTMLLabelElement;
+    HTMLLegendElement: typeof HTMLLegendElement;
+    HTMLLIElement: typeof HTMLLIElement;
+    HTMLLinkElement: typeof HTMLLinkElement;
+    HTMLMapElement: typeof HTMLMapElement;
+    HTMLMarqueeElement: typeof HTMLMarqueeElement;
+    HTMLMediaElement: typeof HTMLMediaElement;
+    HTMLMenuElement: typeof HTMLMenuElement;
+    HTMLMetaElement: typeof HTMLMetaElement;
+    HTMLMeterElement: typeof HTMLMeterElement;
+    HTMLModElement: typeof HTMLModElement;
+    HTMLObjectElement: typeof HTMLObjectElement;
+    HTMLOListElement: typeof HTMLOListElement;
+    HTMLOptGroupElement: typeof HTMLOptGroupElement;
+    HTMLOptionElement: typeof HTMLOptionElement;
+    HTMLOutputElement: typeof HTMLOutputElement;
+    HTMLParagraphElement: typeof HTMLParagraphElement;
+    HTMLParamElement: typeof HTMLParamElement;
+    HTMLPictureElement: typeof HTMLPictureElement;
+    HTMLPreElement: typeof HTMLPreElement;
+    HTMLProgressElement: typeof HTMLProgressElement;
+    HTMLQuoteElement: typeof HTMLQuoteElement;
+    HTMLScriptElement: typeof HTMLScriptElement;
+    HTMLSelectElement: typeof HTMLSelectElement;
+    HTMLSourceElement: typeof HTMLSourceElement;
+    HTMLSpanElement: typeof HTMLSpanElement;
+    HTMLStyleElement: typeof HTMLStyleElement;
+    HTMLTableCaptionElement: typeof HTMLTableCaptionElement;
+    HTMLTableCellElement: typeof HTMLTableCellElement;
+    HTMLTableColElement: typeof HTMLTableColElement;
+    HTMLTableElement: typeof HTMLTableElement;
+    HTMLTimeElement: typeof HTMLTimeElement;
+    HTMLTitleElement: typeof HTMLTitleElement;
+    HTMLTableRowElement: typeof HTMLTableRowElement;
+    HTMLTableSectionElement: typeof HTMLTableSectionElement;
+    HTMLTemplateElement: typeof HTMLTemplateElement;
+    HTMLTextAreaElement: typeof HTMLTextAreaElement;
+    HTMLTrackElement: typeof HTMLTrackElement;
+    HTMLUListElement: typeof HTMLUListElement;
+    HTMLUnknownElement: typeof HTMLUnknownElement;
+    HTMLVideoElement: typeof HTMLVideoElement;
+
+    /* node_modules/jsdom/level2/style.js */
+    StyleSheet: typeof StyleSheet;
+    MediaList: typeof MediaList;
+    CSSStyleSheet: typeof CSSStyleSheet;
+    CSSRule: typeof CSSRule;
+    CSSStyleRule: typeof CSSStyleRule;
+    CSSMediaRule: typeof CSSMediaRule;
+    CSSImportRule: typeof CSSImportRule;
+    CSSStyleDeclaration: typeof CSSStyleDeclaration;
+    StyleSheetList: typeof StyleSheetList;
+
+    /* node_modules/jsdom/level3/xpath.js */
+    // XPathException: typeof XPathException;
+    XPathExpression: typeof XPathExpression;
+    XPathResult: typeof XPathResult;
+    XPathEvaluator: typeof XPathEvaluator;
+
+    /* node_modules/jsdom/living/node-filter.js */
+    NodeFilter: typeof NodeFilter;
+}
 
 export type BinaryData = ArrayBuffer | DataView | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
 


### PR DESCRIPTION
TypeScript team is figuring out how to expose these types on their `Window` interface, which `DOMWindow` extends (discussion [here](https://github.com/Microsoft/TypeScript/issues/19816)). In the meantime, this workaround will ensure that jsdom code compiles.

Some types are not defined even globally by TypeScript. These have been commented out in the `DOMWindow` interface, but are still valid properties in jsdom. If someone tries to use these properties, their code will still not compile.

This should be an exhaustive list of all properties on the DOM window object implemented by jsdom.

------------------

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [jsdom/lib/jsdom/living/index.js](https://github.com/tmpvar/jsdom/blob/master/lib/jsdom/living/index.js) (other files included in changes as comments)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
