### PR TITLE
atom: support 1.22, fixes for AtomEnvironment, add useful methods.

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -825,8 +825,12 @@ function testDock() {
     subscription = dock.onDidChangeActivePane(pane => pane.activate());
     subscription = dock.observeActivePane(pane => pane.activate());
     subscription = dock.onDidAddPaneItem(event => event.index && event.item && event.pane);
-    subscription = dock.onWillDestroyPaneItem(event => event.index && event.item && event.pane);
-    subscription = dock.onDidDestroyPaneItem(event => event.index && event.item && event.pane);
+    subscription = dock.onWillDestroyPaneItem(event => {
+        event.index && event.item && event.pane;
+    });
+    subscription = dock.onDidDestroyPaneItem(event => {
+        event.index && event.item && event.pane;
+    });
 
     // Pane Items
     objs = dock.getPaneItems();
@@ -2987,8 +2991,9 @@ function testWorkspace() {
     subscription = atom.workspace.observeActivePane(pane => pane.activate());
     subscription = atom.workspace.onDidAddPaneItem(event => event.index && event.item &&
         event.pane);
-    subscription = atom.workspace.onWillDestroyPaneItem(event => event.index &&
-        event.item && event.pane);
+    subscription = atom.workspace.onWillDestroyPaneItem(event => {
+        event.index && event.item && event.pane;
+    });
     subscription = atom.workspace.onDidDestroyPaneItem(event => event.index &&
         event.item && event.pane);
     subscription = atom.workspace.onDidAddTextEditor(event => event.index && event.pane &&


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Atom v1.22 Release](https://github.com/atom/atom/releases/tag/v1.22.0)
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This adds support for Atom 1.22, which was a pretty small update. The `editor.maxScreenLineLength` config variable is 1.22 specific, with the only other changes being to documentation.

Fixes to AtomEnvironment from [atom-typings#10](https://github.com/GlenCFL/atom-typings/pull/10) are included, as well as additional methods requested in [atom-typings#8](https://github.com/GlenCFL/atom-typings/issues/8).
