### PR TITLE
updated writeFile and outputFile in fs-extra

### DIFF
--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -37,7 +37,7 @@ export function mkdirp(dir: string): Promise<void>;
 export function mkdirp(dir: string, callback: (err: Error | null) => void): void;
 export function mkdirsSync(dir: string): void;
 export function mkdirpSync(dir: string): void;
-                                                                                
+
 export function outputFile(file: string, data: any, options?: WriteFileOptions | string): Promise<void>;
 export function outputFile(file: string, data: any, callback: (err: Error | null) => void): void;
 export function outputFile(file: string, data: any, options: WriteFileOptions | string, callback: (err: Error | null) => void): void;
@@ -280,7 +280,7 @@ export interface ReadOptions {
     encoding?: string;
     flag?: string;
 }
-                                                                                
+
 export interface WriteFileOptions {
     encoding?: string;
     flag?: string;

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -37,10 +37,11 @@ export function mkdirp(dir: string): Promise<void>;
 export function mkdirp(dir: string, callback: (err: Error | null) => void): void;
 export function mkdirsSync(dir: string): void;
 export function mkdirpSync(dir: string): void;
-
-export function outputFile(file: string, data: any): Promise<void>;
+                                                                                
+export function outputFile(file: string, data: any, options?: WriteFileOptions | string): Promise<void>;
 export function outputFile(file: string, data: any, callback: (err: Error | null) => void): void;
-export function outputFileSync(file: string, data: any): void;
+export function outputFile(file: string, data: any, options: WriteFileOptions | string, callback: (err: Error | null) => void): void;
+export function outputFileSync(file: string, data: any, options?: WriteFileOptions | string): void;
 
 export function readJson(file: string, options?: ReadOptions): Promise<any>;
 export function readJson(file: string, callback: (err: Error | null, jsonObject: any) => void): void;
@@ -234,8 +235,8 @@ export function write(fd: number, buffer: Buffer, offset: number, length: number
 export function write(fd: number, data: any, offset: number, encoding?: string): Promise<WriteResult>;
 
 export function writeFile(file: string | Buffer | number, data: any, callback: (err: NodeJS.ErrnoException | null) => void): void;
-export function writeFile(file: string | Buffer | number, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): Promise<void>;
-export function writeFile(file: string | Buffer | number, data: any, options: { encoding?: string; mode?: number; flag?: string; }, callback: (err: NodeJS.ErrnoException | null) => void): void;
+export function writeFile(file: string | Buffer | number, data: any, options?: WriteFileOptions | string): Promise<void>;
+export function writeFile(file: string | Buffer | number, data: any, options: WriteFileOptions | string, callback: (err: NodeJS.ErrnoException | null) => void): void;
 
 /**
  * Asynchronous mkdtemp - Creates a unique temporary directory. Generates six random characters to be appended behind a required prefix to create a unique temporary directory.
@@ -279,14 +280,17 @@ export interface ReadOptions {
     encoding?: string;
     flag?: string;
 }
-
-export interface WriteOptions {
-    fs?: object;
-    replacer?: any;
-    spaces?: number;
+                                                                                
+export interface WriteFileOptions {
     encoding?: string;
     flag?: string;
     mode?: number;
+}
+
+export interface WriteOptions extends WriteFileOptions {
+    fs?: object;
+    replacer?: any;
+    spaces?: number;
 }
 
 export interface ReadResult {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see below
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

https://github.com/jprichardson/node-fs-extra/blob/master/docs/outputFile.md

- `outputFile` missed to set `options` while returning a `Promise`.
- `writeFile` missed the possibility for `options` to be a `string`.
- Introduced `WriteFileOptions` for easier `options` handling in `outputFile` and `writeFile`.
