### PR TITLE
[react-scroll]: added missing property

### DIFF
--- a/types/react-scroll/modules/components/Link.d.ts
+++ b/types/react-scroll/modules/components/Link.d.ts
@@ -5,6 +5,7 @@ export interface ReactScrollLinkProps {
     containerId?: string;
     activeClass?: string;
     spy?: boolean;
+    hashSpy?: boolean;
     smooth?: boolean | string;
     offset?: number;
     delay?: number;


### PR DESCRIPTION
Link interface was lacking hashSpy property: https://github.com/fisshy/react-scroll#propsoptions