### PR TITLE
recharts: add missing animationDuration prop to Tooltip typings

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -657,6 +657,7 @@ export interface TooltipProps {
 	itemSorter?: RechartsFunction;
 	isAnimationActive?: boolean;
 	animationBegin?: number;
+	animationDuration?: number;
 	animationEasing?: AnimationEasingType;
 }
 export class Tooltip extends React.Component<TooltipProps, {}> {}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://recharts.org/#/en-US/api/Tooltip

The [Recharts documentation](http://recharts.org/#/en-US/api/Tooltip) confirms that `animationDuration` is a valid prop for a `Tooltip` component, but it's currently missing from the typings.  This PR adds it.

