### PR TITLE
HAPI: Changed type of options property in PluginRegistrationObject interface

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2661,7 +2661,7 @@ export interface PluginRegistrationObject<OptionsPassedToPlugin> extends PluginR
     /** the plugin registration function. */
     register: PluginFunction<OptionsPassedToPlugin>;
     /** optional options passed to the registration function when called. */
-    options?: OptionsPassedToPlugin;
+    options?: any;
 }
 
 /**


### PR DESCRIPTION
change to: types/hapi/index.d.ts
It is not possible to use HAPI "attache" plug-in with OptionsPassedToPlugin type of options property. 
Seems similar changes were done in other places of this file but not in mentioned file part.
After this change the configuration below is possible.

server.register([
    {
        register: attache,
        options: {
            service: {
                name: 'some custom service name'
            }
        }
    },

link to attache plugin: 
https://www.npmjs.com/package/attache
https://github.com/kanongil/attache
