### PR TITLE
datadog-metrics

### DIFF
--- a/types/datadog-metrics/datadog-metrics-tests.ts
+++ b/types/datadog-metrics/datadog-metrics-tests.ts
@@ -1,9 +1,12 @@
 import metrics = require('datadog-metrics');
 metrics.init({ host: 'myhost', prefix: 'myapp.' });
 metrics.gauge('mygauge', 42);
+metrics.gauge("mykey", 11, ["a", "b", "c"], Date.now());
 metrics.increment('test.requests_served');
 metrics.increment('test.awesomeness_factor', 10);
-metrics.histogram('test.service_time', 0.248);
+metrics.increment('test.service_time', 0.248);
+metrics.histogram("mykey", 11, ["a", "b", "c"], Date.now());
+metrics.histogram("mykey", 11, ["a", "b", "c"], Date.now());
 metrics.flush();
 metrics.flush(() => {});
 metrics.flush(() => {}, err => {});
@@ -16,9 +19,12 @@ const metricsLogger = new metrics.BufferedMetricsLogger({
     defaultTags: ['env:staging', 'region:us-east-1']
 });
 metricsLogger.gauge('mygauge', 42);
+metricsLogger.gauge("mykey", 11, ["a", "b", "c"], Date.now());
 metricsLogger.increment('test.requests_served');
 metricsLogger.increment('test.awesomeness_factor', 10);
+metricsLogger.increment("mykey", 11, ["a", "b", "c"], Date.now());
 metricsLogger.histogram('test.service_time', 0.248);
+metricsLogger.histogram("mykey", 11, ["a", "b", "c"], Date.now());
 metricsLogger.flush();
 metricsLogger.flush(() => {});
 metricsLogger.flush(() => {}, err => {});

--- a/types/datadog-metrics/datadog-metrics-tests.ts
+++ b/types/datadog-metrics/datadog-metrics-tests.ts
@@ -1,12 +1,12 @@
 import metrics = require('datadog-metrics');
 metrics.init({ host: 'myhost', prefix: 'myapp.' });
 metrics.gauge('mygauge', 42);
-metrics.gauge("mykey", 11, ["a", "b", "c"], Date.now());
+metrics.gauge('mykey', 11, ['a', 'b', 'c'], Date.now());
 metrics.increment('test.requests_served');
 metrics.increment('test.awesomeness_factor', 10);
 metrics.increment('test.service_time', 0.248);
-metrics.histogram("mykey", 11, ["a", "b", "c"], Date.now());
-metrics.histogram("mykey", 11, ["a", "b", "c"], Date.now());
+metrics.histogram('mykey', 11, ['a', 'b', 'c'], Date.now());
+metrics.histogram('mykey', 11, ['a', 'b', 'c'], Date.now());
 metrics.flush();
 metrics.flush(() => {});
 metrics.flush(() => {}, err => {});
@@ -19,12 +19,12 @@ const metricsLogger = new metrics.BufferedMetricsLogger({
     defaultTags: ['env:staging', 'region:us-east-1']
 });
 metricsLogger.gauge('mygauge', 42);
-metricsLogger.gauge("mykey", 11, ["a", "b", "c"], Date.now());
+metricsLogger.gauge('mykey', 11, ['a', 'b', 'c'], Date.now());
 metricsLogger.increment('test.requests_served');
 metricsLogger.increment('test.awesomeness_factor', 10);
-metricsLogger.increment("mykey", 11, ["a", "b", "c"], Date.now());
+metricsLogger.increment('mykey', 11, ['a', 'b', 'c'], Date.now());
 metricsLogger.histogram('test.service_time', 0.248);
-metricsLogger.histogram("mykey", 11, ["a", "b", "c"], Date.now());
+metricsLogger.histogram('mykey', 11, ['a', 'b', 'c'], Date.now());
 metricsLogger.flush();
 metricsLogger.flush(() => {});
 metricsLogger.flush(() => {}, err => {});

--- a/types/datadog-metrics/index.d.ts
+++ b/types/datadog-metrics/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for datadog-metrics 0.4
+// Type definitions for datadog-metrics 0.6
 // Project: https://github.com/dbader/node-datadog-metrics
 // Definitions by: Jeffery Grajkowski <https://github.com/pushplay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -44,21 +44,21 @@ export class BufferedMetricsLogger {
      * the metric. This should be used for sum values such as total hard disk space,
      * process uptime, total number of active users, or number of rows in a database table.
      */
-    gauge(key: string, value: number, ...tags: string[]): void;
+    gauge(key: string, value: number, tags?: string[], timestamp?: number): void;
 
     /**
      * Increment the counter by the given value (or 1 by default). Optionally, specify a
      * list of tags to associate with the metric. This is useful for counting things such
      * as incrementing a counter each time a page is requested.
      */
-    increment(key: string, value?: number, ...tags: string[]): void;
+    increment(key: string, value?: number, tags?: string[], timestamp?: number): void;
 
     /**
      * Sample a histogram value. Histograms will produce metrics that describe the distribution
      * of the recorded values, namely the minimum, maximum, average, count and the 75th, 85th,
      * 95th and 99th percentiles. Optionally, specify a list of tags to associate with the metric.
      */
-    histogram(key: string, value: number, ...tags: string[]): void;
+    histogram(key: string, value: number, tags?: string[], timestamp?: number): void;
 
     /**
      * Calling flush sends any buffered metrics to DataDog. Unless you set flushIntervalSeconds
@@ -77,21 +77,21 @@ export function init(options: BufferedMetricsLoggerOptions): void;
  * the metric. This should be used for sum values such as total hard disk space,
  * process uptime, total number of active users, or number of rows in a database table.
  */
-export function gauge(key: string, value: number, ...tags: string[]): void;
+export function gauge(key: string, value: number, tags?: string[], timestamp?: number): void;
 
 /**
  * Increment the counter by the given value (or 1 by default). Optionally, specify a
  * list of tags to associate with the metric. This is useful for counting things such
  * as incrementing a counter each time a page is requested.
  */
-export function increment(key: string, value?: number, ...tags: string[]): void;
+export function increment(key: string, value?: number, tags?: string[], timestamp?: number): void;
 
 /**
  * Sample a histogram value. Histograms will produce metrics that describe the distribution
  * of the recorded values, namely the minimum, maximum, average, count and the 75th, 85th,
  * 95th and 99th percentiles. Optionally, specify a list of tags to associate with the metric.
  */
-export function histogram(key: string, value: number, ...tags: string[]): void;
+export function histogram(key: string, value: number, tags?: string[], timestamp?: number): void;
 
 /**
  * Calling flush sends any buffered metrics to DataDog. Unless you set flushIntervalSeconds


### PR DESCRIPTION
Fix how per-metric tags are passed in.  Support new timestamp param.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dbader/node-datadog-metrics/commit/3fa5fe948eec3b25207325d498a1023a8fb83334#diff-04c6e90faac2675aa89e2176d2eec7d8L133
- [x] Increase the version number in the header if appropriate.
