### PR TITLE
react-native-elements: iconRight in ButtonProps should be of type ButtonIcon

### DIFF
--- a/types/react-native-elements/index.d.ts
+++ b/types/react-native-elements/index.d.ts
@@ -255,11 +255,9 @@ export interface ButtonProps extends TouchableWithoutFeedbackProps {
     fontWeight?: string;
 
     /**
-     * Moves icon to right of title
-     *
-     * @default false
+     * Icon configuration
      */
-    iconRight?: boolean;
+    iconRight?: ButtonIcon;
 
     /**
      * onPress method

--- a/types/react-native-elements/index.d.ts
+++ b/types/react-native-elements/index.d.ts
@@ -255,7 +255,7 @@ export interface ButtonProps extends TouchableWithoutFeedbackProps {
     fontWeight?: string;
 
     /**
-     * Icon configuration
+     * Icon configuration for icon on right side of title
      */
     iconRight?: ButtonIcon;
 

--- a/types/react-native-elements/react-native-elements-tests.tsx
+++ b/types/react-native-elements/react-native-elements-tests.tsx
@@ -222,8 +222,7 @@ class ButtonTest extends React.Component<any, any> {
 
                 <Button
                     large
-                    iconRight
-                    icon={{ name: 'code' }}
+                    iconRight = {{ name: 'code' }}
                     title="LARGE WITH RIGHT ICON"
                     onPress={() => this.handleButtonPress()}
                 />


### PR DESCRIPTION
If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://react-native-training.github.io/react-native-elements/API/buttons/ - see 'iconRight or rightIcon' under 'Button props'. The expected type is an icon.

- [X] Increase the version number in the header if appropriate. **N/A**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **N/A**
