### PR TITLE
React.Components template arguments fixed for react-router and react-router-dom

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -31,20 +31,20 @@ export interface BrowserRouterProps {
     forceRefresh?: boolean;
     keyLength?: number;
 }
-export class BrowserRouter extends React.Component<BrowserRouterProps> {}
+export class BrowserRouter extends React.Component<BrowserRouterProps, any> {}
 
 export interface HashRouterProps {
     basename?: string;
     getUserConfirmation?(): void;
     hashType?: 'slash' | 'noslash' | 'hashbang';
 }
-export class HashRouter extends React.Component<HashRouterProps> {}
+export class HashRouter extends React.Component<HashRouterProps, any> {}
 
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to: H.LocationDescriptor;
     replace?: boolean;
 }
-export class Link extends React.Component<LinkProps> {}
+export class Link extends React.Component<LinkProps, any> {}
 
 export interface NavLinkProps extends LinkProps {
     activeClassName?: string;
@@ -54,4 +54,4 @@ export interface NavLinkProps extends LinkProps {
     isActive?<P>(match: match<P>, location: H.Location): boolean;
     location?: H.Location;
 }
-export class NavLink extends React.Component<NavLinkProps> {}
+export class NavLink extends React.Component<NavLinkProps, any> {}

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -38,13 +38,13 @@ export interface MemoryRouterProps {
   keyLength?: number;
 }
 
-export class MemoryRouter extends React.Component<MemoryRouterProps> { }
+export class MemoryRouter extends React.Component<MemoryRouterProps, any> { }
 
 export interface PromptProps {
   message: string | ((location: H.Location) => void);
   when?: boolean;
 }
-export class Prompt extends React.Component<PromptProps> { }
+export class Prompt extends React.Component<PromptProps, any> { }
 
 export interface RedirectProps {
   to: H.LocationDescriptor;
@@ -54,7 +54,7 @@ export interface RedirectProps {
   exact?: boolean;
   strict?: boolean;
 }
-export class Redirect extends React.Component<RedirectProps> { }
+export class Redirect extends React.Component<RedirectProps, any> { }
 
 export interface RouteComponentProps<P> {
   match: match<P>;
@@ -65,19 +65,19 @@ export interface RouteComponentProps<P> {
 
 export interface RouteProps {
   location?: H.Location;
-  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType;
+  component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
   render?: ((props: RouteComponentProps<any>) => React.ReactNode);
   children?: ((props: RouteComponentProps<any>) => React.ReactNode) | React.ReactNode;
   path?: string;
   exact?: boolean;
   strict?: boolean;
 }
-export class Route<T extends RouteProps = RouteProps> extends React.Component<T> { }
+export class Route<T extends RouteProps = RouteProps> extends React.Component<T, any> { }
 
 export interface RouterProps {
   history: any;
 }
-export class Router extends React.Component<RouterProps> { }
+export class Router extends React.Component<RouterProps, any> { }
 
 export interface StaticRouterProps {
   basename?: string;
@@ -85,12 +85,12 @@ export interface StaticRouterProps {
   context?: object;
 }
 
-export class StaticRouter extends React.Component<StaticRouterProps> { }
+export class StaticRouter extends React.Component<StaticRouterProps, any> { }
 export interface SwitchProps {
   children?: React.ReactNode;
   location?: H.Location;
 }
-export class Switch extends React.Component<SwitchProps> { }
+export class Switch extends React.Component<SwitchProps, any> { }
 
 export interface match<P> {
   params: P;


### PR DESCRIPTION
The Typescript requires to explicitly specify both props and state types for `React.Component` class. This was not the case in `react-router` and `react-router-dom` typings. 

Result of this problem was error (example): 

> TS2604: JSX element type 'Switch' does not have any construct or call signatures.

This commit fixes that by adding `any` type for the state types.