### PR TITLE
cson parser returns `any` rather than `Object`

### DIFF
--- a/types/cson/cson-tests.ts
+++ b/types/cson/cson-tests.ts
@@ -13,7 +13,7 @@ console.log('cson.createJSONString => %s', data);
 data = cson.createCSONString({hello: 'world'});
 console.log('cson.createCSONString => %s', data);
 
-var obj: Object = cson.parse(data);
+var obj = cson.parse(data);
 console.log('cson.parse => %s', JSON.stringify(obj));
 
 obj = cson.parseCSONString(data);

--- a/types/cson/index.d.ts
+++ b/types/cson/index.d.ts
@@ -5,27 +5,27 @@
 
 
 // Create Strings
-export declare function stringify(data: Object, opts?: Object, indent?: any): string;
-export declare function createCSONString(data: Object, opts?: Object, next?: any): string;
-export declare function createJSONString(data: Object, opts?: Object, next?: any): string;
-export declare function createString(data: Object, opts?: Object, next?: any): string;
+export declare function stringify(data: any, opts?: Object, indent?: any): string;
+export declare function createCSONString(data: any, opts?: Object, next?: any): string;
+export declare function createJSONString(data: any, opts?: Object, next?: any): string;
+export declare function createString(data: any, opts?: Object, next?: any): string;
 
 // Parse Strings
-export declare function parse(data: string, opts?: Object, next?: any): Object;
-export declare function parseCSONString(data: string, opts?: Object, next?: any): Object;
-export declare function parseJSONString(data: string, opts?: Object, next?: any): Object;
-export declare function parseCSString(data: string, opts?: Object, next?: any): Object;
-export declare function parseJSString(data: string, opts?: Object, next?: any): Object;
-export declare function parseString(data: string, opts?: Object, next?: any): Object;
+export declare function parse(data: string, opts?: Object, next?: any): any;
+export declare function parseCSONString(data: string, opts?: Object, next?: any): any;
+export declare function parseJSONString(data: string, opts?: Object, next?: any): any;
+export declare function parseCSString(data: string, opts?: Object, next?: any): any;
+export declare function parseJSString(data: string, opts?: Object, next?: any): any;
+export declare function parseString(data: string, opts?: Object, next?: any): any;
 
 // Parse Files
-export declare function load(filePath: string, opts?: Object, next?: any): Object;
-export declare function parseCSONFile(filePath: string, opts?: Object, next?: any): Object;
-export declare function parseJSONFile(filePath: string, opts?: Object, next?: any): Object;
-export declare function parseCSFile(filePath: string, opts?: Object, next?: any): Object;
-export declare function parseJSFile(filePath: string, opts?: Object, next?: any): Object;
+export declare function load(filePath: string, opts?: Object, next?: any): any;
+export declare function parseCSONFile(filePath: string, opts?: Object, next?: any): any;
+export declare function parseJSONFile(filePath: string, opts?: Object, next?: any): any;
+export declare function parseCSFile(filePath: string, opts?: Object, next?: any): any;
+export declare function parseJSFile(filePath: string, opts?: Object, next?: any): any;
 
 // Require Files
-export declare function requireCSFile(filePath: string, opts?: Object, next?: any): Object;
-export declare function requireJSFile(filePath: string, opts?: Object, next?: any): Object;
-export declare function requireFile(filePath: string, opts?: Object, next?: any): Object;
+export declare function requireCSFile(filePath: string, opts?: Object, next?: any): any;
+export declare function requireJSFile(filePath: string, opts?: Object, next?: any): any;
+export declare function requireFile(filePath: string, opts?: Object, next?: any): any;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

CSON parsers returns non-Object too:

```js
const result = require('cson').parse('"foo"')
assert(! result instanceof Object)
```

so basically it should return and accept `any` rather than `Object`.
