### PR TITLE
googlemaps: make a type definition consistent with docstring for strictNullChecks

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for Google Maps JavaScript API 3.29
+// Type definitions for Google Maps JavaScript API 3.30
 // Project: https://developers.google.com/maps/
-// Definitions by: Folia A/S <http://www.folia.dk>, Chris Wrench <https://github.com/cgwrench>, Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>,  Grant Hutchins <https://github.com/nertzy>, Denis Atyasov <https://github.com/xaolas>, Michael McMullin <https://github.com/mrmcnerd>, Martin Costello <https://github.com/martincostello>
+// Definitions by: Folia A/S <http://www.folia.dk>, Chris Wrench <https://github.com/cgwrench>, Kiarash Ghiaseddin <https://github.com/Silver-Connection/DefinitelyTyped>,  Grant Hutchins <https://github.com/nertzy>, Denis Atyasov <https://github.com/xaolas>, Michael McMullin <https://github.com/mrmcnerd>, Martin Costello <https://github.com/martincostello>, Sven Kreiss <https://github.com/svenkreiss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2697,7 +2697,7 @@ declare namespace google.maps {
              * Accepted values are 'marker', 'polygon', 'polyline', 'rectangle', 'circle', or null. A drawing mode
              * of null means that the user can interact with the map as normal, and clicks do not draw anything.
              */
-            drawingMode?: OverlayType;
+            drawingMode?: OverlayType | null;
             /**
              * The Map to which the DrawingManager is attached, which is the Map on which the overlays created
              * will be placed.


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: docstring is right above the changed line
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
