### PR TITLE
CKEDITOR: Fix typing for magicline_tabuList

### DIFF
--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -727,7 +727,7 @@ declare namespace CKEDITOR {
         magicline_holdDistance?: number;
         magicline_keystrokeNext?: number;
         magicline_keystrokePrevious?: number;
-        magicline_tabuList?: number;
+        magicline_tabuList?: string[];
         magicline_triggerOffset?: number;
         mathJaxLib?: string;
         menu_groups?: string;


### PR DESCRIPTION
Documentation for CKEDITOR.config _incorrectly_ lists **magicline_tabuList** as type **Number** (it looks like the type assigned in this file was based on the documentation). 

However, magicline source code expects **magicline_tabuList** to be a _string array_ [see source here](https://docs.ckeditor.com/ckeditor4/docs/source/plugin60.html#CKEDITOR-config-cfg-magicline_tabuList).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://docs.ckeditor.com/ckeditor4/docs/source/plugin60.html#CKEDITOR-config-cfg-magicline_tabuList)



