### PR TITLE
puppeteer: setCookie should be less strict

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -96,6 +96,25 @@ export interface Cookie {
   sameSite: "Strict" | "Lax";
 }
 
+export interface DeleteCookie {
+  name: string;
+  url?: string;
+  domain?: string;
+  path?: string;
+  secure?: boolean;
+}
+
+export interface SetCookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  expires?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "Strict" | "Lax";
+}
+
 export interface Viewport {
   width: number;
   height: number;
@@ -359,15 +378,7 @@ export interface Page extends FrameBase {
   close(): Promise<void>;
   content(): Promise<string>;
   cookies(...urls: string[]): Promise<Cookie[]>;
-  deleteCookie(
-    ...cookies: Array<{
-      name: string;
-      url?: string;
-      domain?: string;
-      path?: string;
-      secure?: boolean;
-    }>
-  ): Promise<void>;
+  deleteCookie(...cookies: DeleteCookie[]): Promise<void>;
   emulate(options: Partial<EmulateOptions>): Promise<void>;
   emulateMedia(mediaType: 'screen' | 'print' | null): Promise<void>;
   evaluateHandle(
@@ -398,7 +409,7 @@ export interface Page extends FrameBase {
   screenshot(options?: ScreenshotOptions): Promise<Buffer>;
   select(selector: string, ...values: string[]): Promise<void>;
   setContent(html: string): Promise<void>;
-  setCookie(...cookies: Cookie[]): Promise<void>;
+  setCookie(...cookies: SetCookie[]): Promise<void>;
   setExtraHTTPHeaders(headers: Headers): Promise<void>;
   setJavaScriptEnabled(enabled: boolean): Promise<void>;
   setRequestInterceptionEnabled(value: boolean): Promise<void>;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#pagesetcookiecookies
  - Note that only name and value are required
- [ ] ~Increase the version number in the header if appropriate.~

---

Commentary to maintainers: 

My gut reaction to fix the setCookie call was to create the `SetCookie` interface. After I implemented this and looked around a little more, I saw the deleteCookie call was instead using an anonymous type. I didn't see any other precedence in the file for using an anonymous type, so I refactored that one into the named `DeleteCookie` interface. IMO, named interfaces are easier to work with than anonymous ones, and now all of the cookie types are in the same part of the file.

If you'd like me to instead revert my refactoring and make `setCookie` use an anonymous type, I'd be happy to update this PR.