### PR TITLE
nodemailer: bugfix: SMTPError is an interface and SMTPError.responseCode is a number

### DIFF
--- a/types/nodemailer/lib/smtp-connection.d.ts
+++ b/types/nodemailer/lib/smtp-connection.d.ts
@@ -70,13 +70,15 @@ declare namespace SMTPConnection {
         dsn?: DSNOptions;
     }
 
-    class SMTPError extends Error {
+    interface SMTPError extends NodeJS.ErrnoException {
         /** string code identifying the error, for example ‘EAUTH’ is returned when authentication */
-        code: string;
+        code?: string;
         /** the last response received from the server (if the error is caused by an error response from the server) */
-        response: string;
+        response?: string;
         /** the numeric response code of the response string (if available) */
-        responseCode: number;
+        responseCode?: number;
+        /** command which provoked an error */
+        command?: string;
     }
 
     interface SentMessageInfo {

--- a/types/nodemailer/lib/smtp-connection.d.ts
+++ b/types/nodemailer/lib/smtp-connection.d.ts
@@ -76,7 +76,7 @@ declare namespace SMTPConnection {
         /** the last response received from the server (if the error is caused by an error response from the server) */
         response: string;
         /** the numeric response code of the response string (if available) */
-        responseCode: string;
+        responseCode: number;
     }
 
     interface SentMessageInfo {

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -1035,7 +1035,12 @@ namespace smtp_connection_test {
         connection.login({ user: 'user', pass: 'pass' }, (err) => {
             if (err) throw err;
             connection.send({ from: 'a@example.com', to: 'b@example.net' }, 'message', (err, info) => {
-                if (err) throw err;
+                if (err) {
+                    const code: string = err.code;
+                    const response: string = err.response;
+                    const responseCode: number = err.responseCode;
+                    throw err;
+                }
                 connection.reset(() => {
                     if (err) throw err;
                     connection.quit();

--- a/types/nodemailer/nodemailer-tests.ts
+++ b/types/nodemailer/nodemailer-tests.ts
@@ -1036,9 +1036,10 @@ namespace smtp_connection_test {
             if (err) throw err;
             connection.send({ from: 'a@example.com', to: 'b@example.net' }, 'message', (err, info) => {
                 if (err) {
-                    const code: string = err.code;
-                    const response: string = err.response;
-                    const responseCode: number = err.responseCode;
+                    const code: string = err.code || '???';
+                    const response: string = err.response || '???';
+                    const responseCode: number = err.responseCode || 0;
+                    const command: string = err.command || '???';
                     throw err;
                 }
                 connection.reset(() => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodemailer/nodemailer/blob/11121b88c58259a0374d8b22ec6509c43d1656cb/lib/smtp-connection/index.js#L603
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
