### PR TITLE
sip.js: fix typing of SIP.NameAddrHeader

### DIFF
--- a/types/sip.js/index.d.ts
+++ b/types/sip.js/index.d.ts
@@ -336,10 +336,10 @@ export interface IncomingMessage extends Request {
 
 /* Header */
 export class NameAddrHeader {
-    uri: string | URI;
+    uri: URI;
     displayName: string;
 
-    constructor(uri: string | sipjs.URI, displayName: string, parameters: Array<{ key: string, value: string }>);
+    constructor(uri: sipjs.URI, displayName: string, parameters: Array<{ key: string, value: string }>);
     static parse(name_addr_header: string): sipjs.NameAddrHeader;
 
     setParam(key: string, value?: string): void;


### PR DESCRIPTION
According to sip.js source code, the "uri" parameter and member are never a string, they are always SIP.URI instances.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/onsip/SIP.js/blob/master/src/NameAddrHeader.js#L22
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.