### PR TITLE
[Chart.js] Fixes tooltip callbacks, set return and data type

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -115,17 +115,17 @@ declare namespace Chart {
     }
 
     interface ChartTooltipCallback {
-        beforeTitle?(item?: ChartTooltipItem[], data?: any): void;
-        title?(item?: ChartTooltipItem[], data?: any): void;
-        afterTitle?(item?: ChartTooltipItem[], data?: any): void;
-        beforeBody?(item?: ChartTooltipItem[], data?: any): void;
-        beforeLabel?(tooltipItem?: ChartTooltipItem, data?: any): void;
-        label?(tooltipItem?: ChartTooltipItem, data?: any): void;
-        afterLabel?(tooltipItem?: ChartTooltipItem, data?: any): void;
-        afterBody?(item?: ChartTooltipItem[], data?: any): void;
-        beforeFooter?(item?: ChartTooltipItem[], data?: any): void;
-        footer?(item?: ChartTooltipItem[], data?: any): void;
-        afterFooter?(item?: ChartTooltipItem[], data?: any): void;
+        beforeTitle?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
+        title?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
+        afterTitle?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
+        beforeBody?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
+        beforeLabel?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
+        label?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
+        afterLabel?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
+        afterBody?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
+        beforeFooter?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
+        footer?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
+        afterFooter?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
     }
 
     interface ChartAnimationParameter {

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Chart.js 2.6
+// Type definitions for Chart.js 2.7
 // Project: https://github.com/nnnick/Chart.js
 // Definitions by: Alberto Nuti <https://github.com/anuti>
 //                 Fabien Lavocat <https://github.com/FabienLavocat>
@@ -114,6 +114,11 @@ declare namespace Chart {
         index?: number;
     }
 
+    interface ChartTooltipLabelColor {
+        borderColor: ChartColor;
+        backgroundColor: ChartColor;
+    }
+
     interface ChartTooltipCallback {
         beforeTitle?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
         title?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
@@ -121,6 +126,8 @@ declare namespace Chart {
         beforeBody?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
         beforeLabel?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
         label?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
+        labelColor?(tooltipItem?: ChartTooltipItem, chart?: Chart): ChartTooltipLabelColor;
+        labelTextColor?(tooltipItem?: ChartTooltipItem, chart?: Chart): string;
         afterLabel?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
         afterBody?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
         beforeFooter?(item?: ChartTooltipItem[], data?: ChartData): string | string[];

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -120,19 +120,19 @@ declare namespace Chart {
     }
 
     interface ChartTooltipCallback {
-        beforeTitle?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
-        title?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
-        afterTitle?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
-        beforeBody?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
-        beforeLabel?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
-        label?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
-        labelColor?(tooltipItem?: ChartTooltipItem, chart?: Chart): ChartTooltipLabelColor;
-        labelTextColor?(tooltipItem?: ChartTooltipItem, chart?: Chart): string;
-        afterLabel?(tooltipItem?: ChartTooltipItem, data?: ChartData): string | string[];
-        afterBody?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
-        beforeFooter?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
-        footer?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
-        afterFooter?(item?: ChartTooltipItem[], data?: ChartData): string | string[];
+        beforeTitle?(item: ChartTooltipItem[], data: ChartData): string | string[];
+        title?(item: ChartTooltipItem[], data: ChartData): string | string[];
+        afterTitle?(item: ChartTooltipItem[], data: ChartData): string | string[];
+        beforeBody?(item: ChartTooltipItem[], data: ChartData): string | string[];
+        beforeLabel?(tooltipItem: ChartTooltipItem, data: ChartData): string | string[];
+        label?(tooltipItem: ChartTooltipItem, data: ChartData): string | string[];
+        labelColor?(tooltipItem: ChartTooltipItem, chart: Chart): ChartTooltipLabelColor;
+        labelTextColor?(tooltipItem: ChartTooltipItem, chart: Chart): string;
+        afterLabel?(tooltipItem: ChartTooltipItem, data: ChartData): string | string[];
+        afterBody?(item: ChartTooltipItem[], data: ChartData): string | string[];
+        beforeFooter?(item: ChartTooltipItem[], data: ChartData): string | string[];
+        footer?(item: ChartTooltipItem[], data: ChartData): string | string[];
+        afterFooter?(item: ChartTooltipItem[], data: ChartData): string | string[];
     }
 
     interface ChartAnimationParameter {


### PR DESCRIPTION
> All functions are called with the same arguments: a tooltip item and
> the data object passed to the chart. All functions must return either
> a string or an array of strings

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://www.chartjs.org/docs/latest/configuration/tooltip.html#tooltip-callbacks>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
