### PR TITLE
[benchmark] Fixed return types of on(), off().

### DIFF
--- a/types/benchmark/benchmark-tests.ts
+++ b/types/benchmark/benchmark-tests.ts
@@ -229,6 +229,27 @@ suite.add({
   'onComplete': onComplete
 });
 
+// unregister a listener for an event type
+suite.off('cycle', listener) as Benchmark.Suite;
+
+// unregister a listener for multiple event types
+suite.off('start cycle', listener) as Benchmark.Suite;
+
+// unregister all listeners for an event type
+suite.off('cycle') as Benchmark.Suite;
+
+// unregister all listeners for multiple event types
+suite.off('start cycle complete') as Benchmark.Suite;
+
+// unregister all listeners for all event types
+suite.off() as Benchmark.Suite;
+
+// register a listener for an event type
+suite.on('cycle', listener) as Benchmark.Suite;
+
+// register a listener for multiple event types
+suite.on('start cycle', listener) as Benchmark.Suite;
+
 // basic usage
 suite.run();
 

--- a/types/benchmark/index.d.ts
+++ b/types/benchmark/index.d.ts
@@ -170,10 +170,10 @@ declare namespace Benchmark {
         join(separator?: string): string;
         listeners(type: string): Function[];
         map(callback: Function): any[];
-        off(type?: string, callback?: Function): Benchmark;
-        off(types: string[]): Benchmark;
-        on(type?: string, callback?: Function): Benchmark;
-        on(types: string[]): Benchmark;
+        off(type?: string, callback?: Function): Suite;
+        off(types: string[]): Suite;
+        on(type?: string, callback?: Function): Suite;
+        on(types: string[]): Suite;
         pluck(property: string): any[];
         pop(): Function;
         push(benchmark: Benchmark): number;


### PR DESCRIPTION
The methods on, off returns this, Benchmark or Benchmark.Suite respectively.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
  ...but we had better adopt `this` rather than its class name all around.
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L1289 and https://github.com/bestiejs/benchmark.js/blob/master/benchmark.js#L1317
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
