### PR TITLE
atom: fix several incorrect definitions.

### DIFF
--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -137,11 +137,11 @@ export interface AtomEnvironment {
 
     // Managing the Atom Window
     /** Open a new Atom window using the given options. */
-    open(params: {
+    open(params?: {
         pathsToOpen: ReadonlyArray<string>,
-        newWindow: boolean,
-        devMode: boolean,
-        safeMode: boolean,
+        newWindow?: boolean,
+        devMode?: boolean,
+        safeMode?: boolean,
     }): void;
 
     /** Close the current window. */
@@ -270,15 +270,18 @@ export interface CommandRegistry {
     }): CompositeDisposable;
 
     /** Find all registered commands matching a query. */
-    findCommands(params: { target: Node }): Array<{
+    findCommands(params: { target: string|Node }): Array<{
         name: string,
         displayName: string,
         description?: string,
         tags?: string[],
     }>;
 
-    /** Simulate the dispatch of a command on a DOM node. */
-    dispatch(target: Node, commandName: string): void;
+    /**
+     *  Simulate the dispatch of a command on a DOM node.
+     *  @return Whether or not there was a matching command for the target.
+     */
+    dispatch(target: Node, commandName: string): boolean;
 
     /** Invoke the given callback before dispatching a command event. */
     onWillDispatch(callback: (event: CommandEvent) => void): Disposable;
@@ -1092,10 +1095,10 @@ export class Point {
 export class Range {
     // Properties
     /** A Point representing the start of the Range. */
-    start: PointLike;
+    start: Point;
 
     /** A Point representing the end of the Range. */
-    end: PointLike;
+    end: Point;
 
     // Construction
     /** Convert any range-compatible object to a Range. */
@@ -1114,7 +1117,7 @@ export class Range {
     negate(): Range;
 
     // Serialization and Deserialization
-    /** Returns a plain javascript object representation of the range. */
+    /** Returns a plain javascript object representation of the Range. */
     serialize(): number[][];
 
     // Range Details
@@ -4710,7 +4713,7 @@ export class TextBuffer {
     destroyed: boolean;
 
     /** Create a new buffer backed by the given file path. */
-    static load(source: string, params?: BufferLoadOptions): Promise<TextBuffer>;
+    static load(filePath: string, params?: BufferLoadOptions): Promise<TextBuffer>;
 
     /**
      *  Create a new buffer backed by the given file path. For better performance,
@@ -4736,6 +4739,9 @@ export class TextBuffer {
          */
         shouldDestroyOnFileDelete?(): boolean
     });
+
+    /** Returns a plain javascript object representation of the TextBuffer. */
+    serialize(options?: { markerLayers?: boolean, history?: boolean }): object;
 
     /** Returns the unique identifier for this buffer. */
     getId(): string;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [AtomEnvironment::open](https://atom.io/docs/api/v1.22.0/AtomEnvironment#instance-open)
[CommandRegistry::findCommands](https://atom.io/docs/api/v1.22.0/CommandRegistry#instance-findCommands)
[CommandRegistry::dispatch](https://atom.io/docs/api/v1.22.0/CommandRegistry#instance-dispatch)
[Range::start](https://atom.io/docs/api/v1.22.0/Range#instance-start)
[Range::end](https://atom.io/docs/api/v1.22.0/Range#instance-end)
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This fixes several incorrect definitions that I've found while testing. Most are minor fixes, but Range.start and Range.end having the wrong types is somewhat significant.

TextBuffer::serialize is private, but not having it makes [TextBuffer.deserialize](https://atom.io/docs/api/v1.22.0/TextBuffer#deserialize) useless.