### PR TITLE
Added two missing properties in OptionDefinition

### DIFF
--- a/types/command-line-args/index.d.ts
+++ b/types/command-line-args/index.d.ts
@@ -30,70 +30,44 @@ declare module commandLineArgs {
   export interface OptionDefinition {
     /**
      * The only required definition property is name, the value of each option will be either a Boolean or string.
-     *
-     * @type {string}
-     * @memberof OptionDefinition
      */
     name: string,
     /**
      * The type value is a setter function (you receive the output from this),
      * enabling you to be specific about the type and value received.
-     *
-     * @memberof OptionDefinition
      */
     type?: (arg: string) => any,
     /**
      * getopt-style short option names. Can be any single character (unicode included) except a digit or hypen.
-     *
-     * @type {string}
-     * @memberof OptionDefinition
      */
     alias?: string,
     /**
      * Set this flag if the option takes a list of values. You will receive an array of values, each passed
      * through the type function (if specified).
-     *
-     * @type {boolean}
-     * @memberof OptionDefinition
      */
     multiple?: boolean,
     /**
      * Any unclaimed command-line args will be set on this option. This flag is typically set on
      * the most commonly-used option to make for more concise usage
      * (i.e. $ myapp *.js instead of $ myapp --files *.js).
-     *
-     * @type {boolean}
-     * @memberof OptionDefinition
      */
     defaultOption?: boolean,
     /**
      * An initial value for the option.
-     *
-     * @type {*}
-     * @memberof OptionDefinition
      */
     defaultValue?: any,
     /**
      * When your app has a large amount of options it makes sense to organise them in groups.
      * There are two automatic groups: _all (contains all options) and _none (contains options
      * without a group specified in their definition).
-     *
-     * @type {(string | string[])}
-     * @memberof OptionDefinition
      */
     group?: string | string[],
     /**
      * Describes the option.
-     *
-     * @type {string}
-     * @memberof OptionDefinition
      */
     description?: string,
     /**
      * A label for the type, e.g. <ms>.
-     *
-     * @type {string}
-     * @memberof OptionDefinition
      */
     typeLabel?: string;
   }
@@ -101,16 +75,10 @@ declare module commandLineArgs {
   export interface Options {
     /**
      * An array of strings, which if passed will be parsed instead  of `process.argv`.
-     *
-     * @type {string[]}
-     * @memberof Options
      */
     argv?: string[];
     /**
      * If `true`, an array of unknown arguments is returned in the `_unknown` property of the output.
-     *
-     * @type {boolean}
-     * @memberof Options
      */
     partial?: boolean;
   }

--- a/types/command-line-args/index.d.ts
+++ b/types/command-line-args/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for command-line-args 4.0.6
+// Type definitions for command-line-args 4.0.7
 // Project: https://github.com/75lb/command-line-args
 // Definitions by: CzBuCHi <https://github.com/CzBuCHi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -25,50 +25,95 @@
  */
 declare function commandLineArgs(optionDefinitions: commandLineArgs.OptionDefinition[], options?: commandLineArgs.Options): any;
 
-declare module commandLineArgs { 
+declare module commandLineArgs {
 
-    export interface OptionDefinition {
-        /**
-         * The only required definition property is name, the value of each option will be either a Boolean or string.
-         */
-        name: string,
-        /**
-         * The type value is a setter function (you receive the output from this), enabling you to be specific about the type and value received.
-         */
-        type?: (arg: string) => any,
-        /**
-         * getopt-style short option names. Can be any single character (unicode included) except a digit or hypen.
-         */
-        alias?: string,
-        /**
-         * Set this flag if the option takes a list of values. You will receive an array of values, each passed through the type function (if specified).
-         */
-        multiple?: boolean,
-        /**
-         * Any unclaimed command-line args will be set on this option. This flag is typically set on the most commonly-used option to make for more concise usage (i.e. $ myapp *.js instead of $ myapp --files *.js).
-         */
-        defaultOption?: boolean,
-        /**
-         * An initial value for the option.
-         */
-        defaultValue?: any,
-        /**
-         * When your app has a large amount of options it makes sense to organise them in groups.
-         * There are two automatic groups: _all (contains all options) and _none (contains options without a group specified in their definition).
-         */
-        group?: string | string[],
-    }
+  export interface OptionDefinition {
+    /**
+     * The only required definition property is name, the value of each option will be either a Boolean or string.
+     *
+     * @type {string}
+     * @memberof OptionDefinition
+     */
+    name: string,
+    /**
+     * The type value is a setter function (you receive the output from this),
+     * enabling you to be specific about the type and value received.
+     *
+     * @memberof OptionDefinition
+     */
+    type?: (arg: string) => any,
+    /**
+     * getopt-style short option names. Can be any single character (unicode included) except a digit or hypen.
+     *
+     * @type {string}
+     * @memberof OptionDefinition
+     */
+    alias?: string,
+    /**
+     * Set this flag if the option takes a list of values. You will receive an array of values, each passed
+     * through the type function (if specified).
+     *
+     * @type {boolean}
+     * @memberof OptionDefinition
+     */
+    multiple?: boolean,
+    /**
+     * Any unclaimed command-line args will be set on this option. This flag is typically set on
+     * the most commonly-used option to make for more concise usage
+     * (i.e. $ myapp *.js instead of $ myapp --files *.js).
+     *
+     * @type {boolean}
+     * @memberof OptionDefinition
+     */
+    defaultOption?: boolean,
+    /**
+     * An initial value for the option.
+     *
+     * @type {*}
+     * @memberof OptionDefinition
+     */
+    defaultValue?: any,
+    /**
+     * When your app has a large amount of options it makes sense to organise them in groups.
+     * There are two automatic groups: _all (contains all options) and _none (contains options
+     * without a group specified in their definition).
+     *
+     * @type {(string | string[])}
+     * @memberof OptionDefinition
+     */
+    group?: string | string[],
+    /**
+     * Describes the option.
+     *
+     * @type {string}
+     * @memberof OptionDefinition
+     */
+    description?: string,
+    /**
+     * A label for the type, e.g. <ms>.
+     *
+     * @type {string}
+     * @memberof OptionDefinition
+     */
+    typeLabel?: string;
+  }
 
-    export interface Options {
-        /**
-         * An array of strings, which if passed will be parsed instead  of `process.argv`.
-         */
-        argv?: string[];
-        /**
-         * If `true`, an array of unknown arguments is returned in the `_unknown` property of the output.
-         */
-        partial?: boolean;
-    }
+  export interface Options {
+    /**
+     * An array of strings, which if passed will be parsed instead  of `process.argv`.
+     *
+     * @type {string[]}
+     * @memberof Options
+     */
+    argv?: string[];
+    /**
+     * If `true`, an array of unknown arguments is returned in the `_unknown` property of the output.
+     *
+     * @type {boolean}
+     * @memberof Options
+     */
+    partial?: boolean;
+  }
 }
 
 export = commandLineArgs;


### PR DESCRIPTION
Missing options: description and typeLabel.
Also changed documentation style (using 'Document-this') and changed version from 4.0.6 to 4.0.7.

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
