### PR TITLE
[puppeteer] Fix return signatures that contain null

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -202,7 +202,7 @@ export interface BoundingBox {
 }
 
 export interface ElementHandle extends JSHandle {
-  boundingBox(): BoundingBox;
+  boundingBox(): BoundingBox | null;
   click(options?: ClickOptions): Promise<void>;
   focus(): Promise<void>;
   hover(): Promise<void>;
@@ -227,7 +227,7 @@ export interface ExecutionContext {
 }
 
 export interface JSHandle {
-  asElement(): ElementHandle;
+  asElement(): ElementHandle | null;
   dispose(): Promise<void>;
   executionContext(): ExecutionContext;
   getProperties(): Promise<Map<string, JSHandle>>;
@@ -305,7 +305,7 @@ export interface Response {
 }
 
 export interface FrameBase {
-  $(selector: string): Promise<ElementHandle>;
+  $(selector: string): Promise<ElementHandle | null>;
   $$(selector: string): Promise<ElementHandle[]>;
   $$eval(
     selector: string,
@@ -349,7 +349,7 @@ export interface Frame extends FrameBase {
   executionContext(): ExecutionContext;
   isDetached(): boolean;
   name(): string;
-  parentFrame(): Frame | undefined;
+  parentFrame(): Frame | null;
 }
 
 export interface EventObj {
@@ -396,9 +396,9 @@ export interface Page extends FrameBase {
   focus(selector: string): Promise<void>;
   frames(): Frame[];
   getMetrics(): Metrics;
-  goBack(options?: Partial<NavigationOptions>): Promise<Response>;
-  goForward(options?: Partial<NavigationOptions>): Promise<Response>;
-  goto(url: string, options?: Partial<NavigationOptions>): Promise<Response>;
+  goBack(options?: Partial<NavigationOptions>): Promise<Response | null>;
+  goForward(options?: Partial<NavigationOptions>): Promise<Response | null>;
+  goto(url: string, options?: Partial<NavigationOptions>): Promise<Response | null>;
   hover(selector: string): Promise<void>;
   keyboard: Keyboard;
   mainFrame(): Frame;

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -151,7 +151,7 @@ puppeteer.launch().then(async browser => {
   });
 
   const inputElement = await page.$("input[type=submit]");
-  await inputElement.click();
+  if (inputElement) await inputElement.click();
 });
 
 // Example with launch options
@@ -178,9 +178,9 @@ puppeteer.launch().then(async browser => {
     }
   });
   const page = await browser.newPage();
-  const button = await page.$("#myButton");
-  const div = await page.$("#myDiv");
-  const input = await page.$("#myInput");
+  const button = (await page.$("#myButton"))!;
+  const div = (await page.$("#myDiv"))!;
+  const input = (await page.$("#myInput"))!;
 
   await page.addStyleTag({
       url: "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
@@ -223,7 +223,7 @@ puppeteer.launch().then(async browser => {
   console.log(navResponse.ok, navResponse.status, navResponse.url, navResponse.headers);
 
   // evaluate example
-  const bodyHandle = await page.$('body');
+  const bodyHandle = (await page.$('body'))!;
   const html = await page.evaluate(body => body.innerHTML, bodyHandle);
   await bodyHandle.dispose();
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/GoogleChrome/puppeteer/issues/1358
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#pageselector
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#pagegobackoptions
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#pagegoforwardoptions
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#pagegotourl-options
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#frameselector
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#frameparentframe
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#jshandleaselement
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#elementhandleboundingbox
https://github.com/GoogleChrome/puppeteer/blob/v0.12.0/docs/api.md#requestresponse

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Both `frame.$(selector)` and `page.$(selector)` should return `Promise<ElementHandle | null>` which includes `null` as per the function descriptions.