### PR TITLE
Support arrays in fields generated by formidable

### DIFF
--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -11,6 +11,9 @@ http.createServer((req, res) => {
     form.parse(req, (err, fields, files) => {
       res.writeHead(200, {'content-type': 'text/plain'});
       res.write('received upload:\n\n');
+
+      let array = fields.list as Array<string>;
+
       res.end(util.inspect({fields: fields, files: files}));
     });
 

--- a/types/formidable/formidable-tests.ts
+++ b/types/formidable/formidable-tests.ts
@@ -12,7 +12,7 @@ http.createServer((req, res) => {
       res.writeHead(200, {'content-type': 'text/plain'});
       res.write('received upload:\n\n');
 
-      let array = fields.list as Array<string>;
+      let array = fields['an-array'] as Array<string>;
 
       res.end(util.inspect({fields: fields, files: files}));
     });

--- a/types/formidable/index.d.ts
+++ b/types/formidable/index.d.ts
@@ -29,7 +29,7 @@ export declare class IncomingForm extends events.EventEmitter {
 }
 
 export interface Fields {
-    [key: string]: string;
+    [key: string]: string|Array<string>;
 }
 
 export interface Files {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Formidable uses a querystring parser [here](https://github.com/felixge/node-formidable/blob/master/lib/querystring_parser.js#L19) which can generate array data types.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.