### PR TITLE
[is-glob] Add typings for "is-glob" package

### DIFF
--- a/types/is-glob/index.d.ts
+++ b/types/is-glob/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for is-glob 4.0
+// Project: https://github.com/jonschlinkert/is-glob
+// Definitions by: mrmlnc <https://github.com/mrmlnc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function isGlob(pattern?: string | string[] | null, options?: isGlob.Options): boolean;
+
+declare namespace isGlob {
+    interface Options {
+        /**
+         * When `false` the behavior is less strict in determining if a pattern is a glob. Meaning that some patterns
+         * that would return false may return true. This is done so that matching libraries like micromatch
+         * have a chance at determining if the pattern is a glob or not.
+         */
+        strict?: boolean;
+    }
+}
+
+export = isGlob;

--- a/types/is-glob/is-glob-tests.ts
+++ b/types/is-glob/is-glob-tests.ts
@@ -1,0 +1,10 @@
+import * as isGlob from 'is-glob';
+
+// $ExpectType boolean
+isGlob();
+isGlob(null);
+isGlob('abc.js');
+isGlob(['abc.js']);
+
+isGlob('abc.js', {});
+isGlob('abc.js', { strict: false });

--- a/types/is-glob/tsconfig.json
+++ b/types/is-glob/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-glob-tests.ts"
+    ]
+}

--- a/types/is-glob/tslint.json
+++ b/types/is-glob/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
