### PR TITLE
Add types for `object-inspect@1.4`

### DIFF
--- a/types/object-inspect/index.d.ts
+++ b/types/object-inspect/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for object-inspect 1.4
+// Project: https://github.com/substack/object-inspect
+// Definitions by: Charles Samborski <https://github.com/demurgos>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace objectInspect {
+    /**
+     * Inspection options
+     */
+    interface Options {
+        /**
+         * Maximum depth of the inspection. Default: `5`.
+         */
+        depth?: number;
+    }
+}
+
+/**
+ * Return a string `s` with the string representation of `obj` up to a depth of `opts.depth`.
+ *
+ * @param obj Object to inspect
+ * @param opts Inspection options. Default: `{}`.
+ * @return String representation of `obj`
+ */
+declare function objectInspect(obj: any, opts?: objectInspect.Options): string;
+
+export = objectInspect;

--- a/types/object-inspect/object-inspect-tests.ts
+++ b/types/object-inspect/object-inspect-tests.ts
@@ -1,0 +1,10 @@
+import objectInspect = require('object-inspect');
+
+// $ExpectType string
+objectInspect({foo: "bar"});
+
+// $ExpectType string
+objectInspect({foo: "bar"}, {});
+
+// $ExpectType string
+objectInspect({foo: "bar"}, {depth: Infinity});

--- a/types/object-inspect/tsconfig.json
+++ b/types/object-inspect/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "object-inspect-tests.ts"
+    ]
+}

--- a/types/object-inspect/tslint.json
+++ b/types/object-inspect/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

This commit add type declarations for `object-inspect`.

Related:
- https://github.com/substack/object-inspect/pull/17
