### PR TITLE
[bash-glob] Add typings for "bash-glob" package

### DIFF
--- a/types/bash-glob/bash-glob-tests.ts
+++ b/types/bash-glob/bash-glob-tests.ts
@@ -1,0 +1,21 @@
+import bashGlob = require('bash-glob');
+
+bashGlob('pattern', (err, files) => {});
+bashGlob(['pattern'], (err, files) => {});
+bashGlob(['pattern'], {}, (err, files) => {});
+bashGlob(['pattern'], { cwd: 'cwd' }, (err, files) => { });
+
+bashGlob.on('match', (match, cwd) => {});
+bashGlob.on('files', (files, cwd) => {});
+bashGlob.on('end', (files) => {});
+
+bashGlob.each('pattern', (err, files) => {});
+bashGlob.each(['pattern'], (err, files) => {});
+bashGlob.each(['pattern'], {}, (err, files) => {});
+bashGlob.each(['pattern'], { cwd: 'cwd' }, (err, files) => {});
+
+// $ExpectType string[]
+bashGlob.sync('pattern');
+bashGlob.sync(['pattern']);
+bashGlob.sync(['pattern'], {});
+bashGlob.sync(['pattern'], { cwd: 'cwd' });

--- a/types/bash-glob/index.d.ts
+++ b/types/bash-glob/index.d.ts
@@ -1,0 +1,36 @@
+// Type definitions for bash-glob 2.0
+// Project: https://github.com/micromatch/bash-glob
+// Definitions by: mrmlnc <https://github.com/mrmlnc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+type Patterns = string | string[];
+type Callback = (err: Error, files: string[]) => void;
+
+declare function bashGlob(pattern: Patterns, callback: Callback): void;
+declare function bashGlob(pattern: Patterns, options: bashGlob.Options, callback: Callback): void;
+
+declare namespace bashGlob {
+    interface Options {
+        cwd?: string;
+        dot?: boolean;
+        dotglob?: boolean;
+        extglob?: boolean;
+        failglob?: boolean;
+        globstar?: boolean;
+        nocase?: boolean;
+        nocaseglob?: boolean;
+        nullglob?: boolean;
+    }
+
+    function on(event: 'match' | 'files', callback: (files: string, cwd: string) => void): void;
+    function on(event: 'end', callback: (files: string) => void): void;
+
+    function each(patterns: Patterns, callback: Callback): void;
+    function each(patterns: Patterns, options: Options, callback: Callback): void;
+
+    function promise(patterns: Patterns, options?: Options): Promise<string[]>;
+
+    function sync(patterns: Patterns, options?: Options): string[];
+}
+
+export = bashGlob;

--- a/types/bash-glob/tsconfig.json
+++ b/types/bash-glob/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "bash-glob-tests.ts"
+    ]
+}

--- a/types/bash-glob/tslint.json
+++ b/types/bash-glob/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
