### PR TITLE
deepmerge does not exist on window

### DIFF
--- a/types/deepmerge/index.d.ts
+++ b/types/deepmerge/index.d.ts
@@ -18,3 +18,10 @@ declare namespace deepmerge {
 
     function all<T>(objects: Array<Partial<T>>, options?: Options): T;
 }
+
+declare global {
+    interface Window {
+        deepmerge<T>(x: Partial<T>, y: Partial<T>, options?: deepmerge.Options): T;
+        deepmerge<T1, T2>(x: T1, y: T2, options?: deepmerge.Options): T1 & T2;
+    }
+}


### PR DESCRIPTION
> [ts] Property 'deepmerge' does not exist on type 'Window'.

`deepmerge` is not found if it is being used within the browser

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
