### PR TITLE
Better ramda's prop fn typing

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1456,8 +1456,8 @@ declare namespace R {
          * Returns a function that when supplied an object returns the indicated property of that object, if it exists.
          * Note: TS1.9 # replace any by dictionary
          */
-        prop<P extends string, T>(p: P, obj: Record<P, T>): T;
-        prop<P extends string>(p: P): <T>(obj: Record<P, T>) => T;
+        prop<K extends string, T extends {[P in K]: any}>(prop: K, obj: T): T[K];
+        prop<K extends string>(prop: K): <T extends {[P in K]: any}>(obj: T) => T[K];
 
         /**
          * Determines whether the given property of an object has a specific

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -1535,6 +1535,17 @@ class Rectangle {
 
 () => {
     const x: number = R.prop("x", {x: 100}); // => 100
+
+    const obj = {
+        x: 100,
+        y: 'CaSe',
+    };
+
+    R.prop("x", obj).toFixed();
+    R.prop("x")(obj).toFixed();
+
+    R.prop("y", obj).toLowerCase();
+    R.prop("y")(obj).toLowerCase();
 };
 
 () => {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Current typings for `prop` fn lose property type information. Now it passes types through correctly. 

One thing to note is that such prop must be defined on `obj` arg. If there's no prop with such name it will complain about it. Not sure how to treat it as `undefined` if it does not exist. Should it behave like that at all?