### PR TITLE
feat: export CSSProperties in types/react

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -814,7 +814,7 @@ declare namespace React {
 
     // This interface is not complete. Only properties accepting
     // unitless numbers are listed here (see CSSProperty.js in React)
-    interface CSSProperties {
+    export interface CSSProperties {
         /**
          * Aligns a flex container's lines within the flex container when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.
          */


### PR DESCRIPTION
with published CSSProperties
we could work with that type for styles instead of any
change file: types/react/index.d.ts