### PR TITLE
[iframe-resizer] Fix IFrameMessageData message type

### DIFF
--- a/types/iframe-resizer/index.d.ts
+++ b/types/iframe-resizer/index.d.ts
@@ -260,7 +260,7 @@ export interface IFrameResizedData {
 // tslint:disable-next-line:interface-name
 export interface IFrameMessageData {
   iframe: IFrameComponent;
-  message: string;
+  message: any;
 }
 
 // tslint:disable-next-line:interface-name


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/davidjbradshaw/iframe-resizer#sendmessagemessagetargetorigin
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The message in IFrameMessageData can be any data that can be serialised, not just a string. The related sendMessage already allows any kind of data sendMessage(message: any, targetOrigin?: string): void;