### PR TITLE
[html-webpack-plugin] Added 'manual' to the 'chunksSortMode' configuration

### DIFF
--- a/types/html-webpack-plugin/html-webpack-plugin-tests.ts
+++ b/types/html-webpack-plugin/html-webpack-plugin-tests.ts
@@ -19,6 +19,9 @@ const optionsArray: HtmlWebpackPlugin.Options[] = [
 	{
 		arbitrary: 'data',
 	},
+	{
+		chunksSortMode: 'manual',
+	}
 ];
 
 const plugins: HtmlWebpackPlugin[] = optionsArray.map(options => new HtmlWebpackPlugin(options));

--- a/types/html-webpack-plugin/index.d.ts
+++ b/types/html-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for html-webpack-plugin 2.28
+// Type definitions for html-webpack-plugin 2.30
 // Project: https://github.com/ampedandwired/html-webpack-plugin
 // Definitions by: Simon Hartcher <https://github.com/deevus>, Benjamin Lim <https://github.com/bumbleblym>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -37,7 +37,7 @@ declare namespace HtmlWebpackPlugin {
 		 * Allows to control how chunks should be sorted before they are included to the html.
 		 * Allowed values: `'none' | 'auto' | 'dependency' | {function}` - default: `'auto'`
 		 */
-		chunksSortMode?: 'none' | 'auto' | 'dependency' | ChunkComparator;
+		chunksSortMode?: 'none' | 'auto' | 'dependency' | 'manual' | ChunkComparator;
 		/** Allows you to add only some chunks (e.g. only the unit-test chunk) */
 		chunks?: string[];
 		/** Allows you to skip some chunks (e.g. don't add the unit-test chunk) */


### PR DESCRIPTION
Added in 2.30.0
https://github.com/jantimon/html-webpack-plugin/blob/672f34bc98ff4130dba94551866d0e57086a7915/CHANGELOG.md#v2300

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jantimon/html-webpack-plugin/commit/6f15d185dae742d5324076b33717ce49c93b759d
- [X] Increase the version number in the header if appropriate.
