### PR TITLE
Fix angular-sanitize ILinky typing.

### DIFF
--- a/types/angular-sanitize/angular-sanitize-tests.ts
+++ b/types/angular-sanitize/angular-sanitize-tests.ts
@@ -4,5 +4,6 @@ declare var $sanitizeService: ng.sanitize.ISanitizeService;
 shouldBeString = $sanitizeService(shouldBeString);
 
 declare var $linky: ng.sanitize.filter.ILinky;
+shouldBeString = $linky(shouldBeString);
 shouldBeString = $linky(shouldBeString, "target");
 shouldBeString = $linky(shouldBeString, shouldBeString);

--- a/types/angular-sanitize/index.d.ts
+++ b/types/angular-sanitize/index.d.ts
@@ -36,7 +36,7 @@ declare module 'angular' {
              * see https://docs.angularjs.org/api/ngSanitize/filter/linky
              */
             interface ILinky {
-                (text: string, target: string, attributes?: { [attribute: string]: string } | ((url: string) => { [attribute: string]: string })): string;
+                (text: string, target?: string, attributes?: { [attribute: string]: string } | ((url: string) => { [attribute: string]: string })): string;
             }
         }
 


### PR DESCRIPTION
The second argument to the ILinky filter should be optional, per documentation.  See https://docs.angularjs.org/api/ngSanitize/filter/linky

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.angularjs.org/api/ngSanitize/filter/linky
