### PR TITLE
[redux-actions] Update definition to support nested reducer maps

### DIFF
--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -22,8 +22,10 @@ export interface ActionMeta<Payload, Meta> extends Action<Payload> {
     meta: Meta;
 }
 
+export type ReducerMapValue<State, Payload> = Reducer<State, Payload> | ReducerNextThrow<State, Payload> | ReducerMap<State, Payload>;
+
 export interface ReducerMap<State, Payload> {
-    [actionType: string]: Reducer<State, Payload> | ReducerNextThrow<State, Payload>;
+    [actionType: string]: ReducerMapValue<State, Payload>;
 }
 
 export interface ReducerMapMeta<State, Payload, Meta> {

--- a/types/redux-actions/redux-actions-tests.ts
+++ b/types/redux-actions/redux-actions-tests.ts
@@ -51,6 +51,15 @@ const actionsHandlerWithInitialState = ReduxActions.handleActions({
 
 state = actionsHandlerWithInitialState(0, { type: 'INCREMENT' });
 
+const actionsHandlerWithRecursiveReducerMap = ReduxActions.handleActions<number, number>({
+    ADJUST: {
+        UP: (state: number, action: ReduxActions.Action<number>) => state + action.payload,
+        DOWN: (state: number, action: ReduxActions.Action<number>) => state - action.payload,
+    }
+}, 0);
+
+state = actionsHandlerWithRecursiveReducerMap(0, { type: 'ADJUST/UP', payload: 1 });
+
 // ----------------------------------------------------------------------------------------------------
 
 interface TypedState {


### PR DESCRIPTION
Current definitions file didn't handle the nested reducer feature added in https://github.com/reduxactions/redux-actions/pull/218, so I've altered them to support it as well as added a test case.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reduxactions/redux-actions/pull/218
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
