### PR TITLE
Change typing of ItemSeparatorComponent to React.ComponentType for SectionListProperties

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3728,7 +3728,7 @@ export interface SectionListProperties<ItemT> extends ScrollViewProperties {
     /**
      * Rendered in between adjacent Items within each section.
      */
-    ItemSeparatorComponent?: React.ComponentType<any> | (() => React.ReactElement<any>) | null
+    ItemSeparatorComponent?: React.ComponentType<any> | null
 
     /**
      * Rendered when the list is empty.

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3728,7 +3728,7 @@ export interface SectionListProperties<ItemT> extends ScrollViewProperties {
     /**
      * Rendered in between adjacent Items within each section.
      */
-    ItemSeparatorComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null
+    ItemSeparatorComponent?: React.ComponentType<any> | (() => React.ReactElement<any>) | null
 
     /**
      * Rendered when the list is empty.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

Typing have already been fixed for the FlatListProperties (see links below) so this PR is to fix the SectionListProperties
 * https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18924
 * https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18823

