### PR TITLE
Fix WeakSet interface

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -10,7 +10,7 @@
 //                 Georgii Dolzhykov <https://github.com/thorn0>,
 //                 Jack Moore <https://github.com/jtmthf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.7
 
 /**
 ### 4.0.0 Changelog (https://github.com/lodash/lodash/wiki/Changelog)
@@ -17091,6 +17091,6 @@ declare namespace _ {
 declare global {
     interface Set<T> { }
     interface Map<K, V> { }
-    interface WeakSet<T> { }
+    interface WeakSet<T extends object> { }
     interface WeakMap<K extends object, V> { }
 }


### PR DESCRIPTION
A plan to fix the WeakSet interface. Should be merged when releasing TypeScript 2.7 to fix https://github.com/Microsoft/TypeScript/issues/14840.

related: https://github.com/Microsoft/definitelytyped-header-parser/pull/10, https://github.com/Microsoft/TypeScript/pull/19756

@andy-ms 