### PR TITLE
[lodash] Allow passing result type to _.get when using property path

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -13315,6 +13315,15 @@ declare namespace _ {
             path: PropertyPath,
             defaultValue?: any
         ): any;
+
+        /**
+         * @see _.get
+         */
+        get<TResult>(
+            object: any,
+            path: PropertyPath,
+            defaultValue?: any
+        ): TResult;
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -13362,10 +13371,18 @@ declare namespace _ {
         /**
          * @see _.get
          */
-        get<TResult>(
+        get(
             path: PropertyPath,
             defaultValue?: any
         ): any;
+
+        /**
+         * @see _.get
+         */
+        get<TResult>(
+            path: PropertyPath,
+            defaultValue?: any
+        ): TResult;
     }
 
     interface LoDashExplicitWrapper<TValue> {
@@ -13417,6 +13434,14 @@ declare namespace _ {
             path: PropertyPath,
             defaultValue?: any
         ): LoDashExplicitWrapper<any>;
+
+        /**
+         * @see _.get
+         */
+        get<TResult>(
+            path: PropertyPath,
+            defaultValue?: any
+        ): LoDashExplicitWrapper<TResult>;
     }
 
     //_.has

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -11382,6 +11382,21 @@ namespace TestGet {
         result = _({a: true}).get<boolean>('a', false);
         result = _({a: true}).get<boolean>(['a']);
         result = _({a: true}).get<boolean>(['a'], false);
+
+        result = _.get<boolean>({a: { b: true }}, 'a.b');
+        result = _.get<boolean>({a: { b: true }}, 'a.b', false);
+        result = _.get<boolean>({a: { b: true }}, ['a.b']);
+        result = _.get<boolean>({a: { b: true }}, ['a.b'], false);
+
+        result = _.get<boolean>({a: { b: true }}, 'a.b');
+        result = _.get<boolean>({a: { b: true }}, 'a.b', false);
+        result = _.get<boolean>({a: { b: true }}, ['a.b']);
+        result = _.get<boolean>({a: { b: true }}, ['a.b'], false);
+
+        result = _({a: { b: true }}).get<boolean>('a.b');
+        result = _({a: { b: true }}).get<boolean>('a.b', false);
+        result = _({a: { b: true }}).get<boolean>(['a.b']);
+        result = _({a: { b: true }}).get<boolean>(['a.b'], false);
     }
 
     {
@@ -11409,6 +11424,11 @@ namespace TestGet {
         result = _({a: true}).chain().get('a', false);
         result = _({a: true}).chain().get(['a']);
         result = _({a: true}).chain().get(['a'], false);
+
+        result = _({a: {b: true}}).chain().get<boolean>('a.b');
+        result = _({a: {b: true}}).chain().get<boolean>('a.b', false);
+        result = _({a: {b: true}}).chain().get<boolean>(['a.b']);
+        result = _({a: {b: true}}).chain().get<boolean>(['a.b'], false);
     }
 }
 


### PR DESCRIPTION
With changes introduced in #19356 it was no longer possible use generics to specify the return type for an object when using a property path string.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://lodash.com/docs/4.17.4#get
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.