### PR TITLE
add setDefaults to storybook__addon-info types to match implementation, fix propTables typing

### DIFF
--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @storybook/addon-info 3.2
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Mark Kornblum <https://github.com/mkornblum>
+//                 Mattias Wikstrom <https://github.com/fyrkant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -18,7 +19,7 @@ export interface Options {
   header?: boolean;
   inline?: boolean;
   source?: boolean;
-  propTables?: JSX.Element[];
+  propTables?: JSX.Element[] | false;
   propTablesExclude?: JSX.Element[];
   styles?: object;
   marksyConf?: object;
@@ -29,3 +30,5 @@ export interface Options {
 }
 
 export function withInfo(textOrOptions: string | Options): (storyFn: RenderFunction) => () => React.ReactElement<WrapStoryProps>;
+
+export function setDefaults(newDefaults: Options): Options;

--- a/types/storybook__addon-info/storybook__addon-info-tests.tsx
+++ b/types/storybook__addon-info/storybook__addon-info-tests.tsx
@@ -2,9 +2,14 @@
 
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withInfo } from '@storybook/addon-info';
+import { setDefaults, withInfo } from '@storybook/addon-info';
 
 const { Component } = React;
+
+setDefaults({
+    inline: false,
+    propTables: false
+});
 
 storiesOf('Component', module)
   .add('simple info',


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/storybooks/storybook/blob/master/addons/info/src/index.js
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.