### PR TITLE
jasmine: fix `expect()` typing so it works with `strictNullChecks` and nullable argument

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -93,7 +93,7 @@ declare function expect<T>(actual: T): jasmine.Matchers<T>;
 /**
  * Create an expectation for a spec.
  */
-declare function expect(): jasmine.Matchers<undefined>;
+declare function expect(): jasmine.NothingMatcher;
 
 /**
  * Explicitly mark a spec as failed.
@@ -446,7 +446,6 @@ declare namespace jasmine {
         toThrow(expected?: any): boolean;
         toThrowError(message?: string | RegExp): boolean;
         toThrowError(expected?: new (...args: any[]) => Error, message?: string | RegExp): boolean;
-        nothing(): Any;
 
         not: Matchers<T>;
 
@@ -458,6 +457,10 @@ declare namespace jasmine {
         toEqual(expected: Expected<ArrayLike<T>> | ArrayContaining<T>, expectationFailOutput?: any): boolean;
         toContain(expected: Expected<T>, expectationFailOutput?: any): boolean;
         not: ArrayLikeMatchers<T>;
+    }
+
+    interface NothingMatcher {
+        nothing(): void;
     }
 
     interface Reporter {

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -88,7 +88,7 @@ declare function expect<T>(actual: ArrayLike<T>): jasmine.ArrayLikeMatchers<T>;
  * Create an expectation for a spec.
  * @param actual Actual computed value to test expectations against.
  */
-declare function expect<T>(actual?: T): jasmine.Matchers<T>;
+declare function expect<T>(actual: T): jasmine.Matchers<T>;
 
 /**
  * Explicitly mark a spec as failed.

--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -91,6 +91,11 @@ declare function expect<T>(actual: ArrayLike<T>): jasmine.ArrayLikeMatchers<T>;
 declare function expect<T>(actual: T): jasmine.Matchers<T>;
 
 /**
+ * Create an expectation for a spec.
+ */
+declare function expect(): jasmine.Matchers<undefined>;
+
+/**
  * Explicitly mark a spec as failed.
  * @param e
  */

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -672,7 +672,7 @@ describe("Multiple spies, when created manually", () => {
 
 describe("jasmine.nothing", () => {
     it("matches any value", () => {
-        expect("s").nothing();
+        expect().nothing();
     });
 });
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -672,7 +672,7 @@ describe("Multiple spies, when created manually", () => {
 
 describe("jasmine.nothing", () => {
     it("matches any value", () => {
-        expect().nothing();
+        expect("s").nothing();
     });
 });
 

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -33,7 +33,7 @@ describe("Included matchers:", () => {
         var b = a;
 
         expect(a).toBe(b);
-        expect(a).not.toBe(null);
+        expect(a).not.toBe(24);
     });
 
     describe("The 'toEqual' matcher", () => {
@@ -83,7 +83,7 @@ describe("Included matchers:", () => {
     });
 
     it("The 'toBeNull' matcher compares against null", () => {
-        var a: string = null;
+        var a: string | null = null;
         var foo = "foo";
 
         expect(null).toBeNull();
@@ -92,14 +92,14 @@ describe("Included matchers:", () => {
     });
 
     it("The 'toBeTruthy' matcher is for boolean casting testing", () => {
-        var a: string, foo = "foo";
+        var a: string | undefined, foo = "foo";
 
         expect(foo).toBeTruthy();
         expect(a).not.toBeTruthy();
     });
 
     it("The 'toBeFalsy' matcher is for boolean casting testing", () => {
-        var a: string, foo = "foo";
+        var a: string | undefined, foo = "foo";
 
         expect(a).toBeFalsy();
         expect(foo).not.toBeFalsy();
@@ -1026,19 +1026,19 @@ var myReporter: jasmine.CustomReporter = {
     specDone: (result: jasmine.CustomReporterResult) => {
         console.log("Spec: " + result.description + " was " + result.status);
         //tslint:disable-next-line:prefer-for-of
-        for (var i = 0; i < result.failedExpectations.length; i++) {
+        for (var i = 0; result.failedExpectations && i < result.failedExpectations.length; i++) {
             console.log("Failure: " + result.failedExpectations[i].message);
             console.log("Actual: " + result.failedExpectations[i].actual);
             console.log("Expected: " + result.failedExpectations[i].expected);
             console.log(result.failedExpectations[i].stack);
         }
-        console.log(result.passedExpectations.length);
+        console.log(result.passedExpectations && result.passedExpectations.length);
     },
 
     suiteDone: (result: jasmine.CustomReporterResult) => {
         console.log('Suite: ' + result.description + ' was ' + result.status);
         //tslint:disable-next-line:prefer-for-of
-        for (var i = 0; i < result.failedExpectations.length; i++) {
+        for (var i = 0; result.failedExpectations && i < result.failedExpectations.length; i++) {
             console.log('AfterAll ' + result.failedExpectations[i].message);
             console.log(result.failedExpectations[i].stack);
         }

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -54,6 +54,11 @@ describe("Included matchers:", () => {
             };
             expect(foo).toEqual(bar);
         });
+
+        it("should work for optional values", () => {
+            var opt: string | undefined = "s";
+            expect(opt as (string | undefined)).toEqual(undefined);
+        });
     });
 
     it("The 'toMatch' matcher is for regular expressions", () => {

--- a/types/jasmine/tsconfig.json
+++ b/types/jasmine/tsconfig.json
@@ -11,7 +11,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": false,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": false,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
During #21305 `expect<T>(actual: T)` signature was changed to mark `actual` as optional parameter. This breaks the type inference in cases where passed value is nullable: e.g. when `actual` value is of type `string | undefined`, typescript infers `T` as `string`, and hence `toEqual(undefined)` is not allowed with enabled `strictNullChecks`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
- [ ] ~Increase the version number in the header if appropriate.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~

/cc @lukas-zech-software 
