### PR TITLE
Use `string[]` for path in koa-router

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -140,7 +140,7 @@ declare class Router {
      * "down" the middleware stack.
      */
     use(...middleware: Array<Router.IMiddleware>): Router;
-    use(path: string | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
+    use(path: string | string[] | RegExp, ...middleware: Array<Router.IMiddleware>): Router;
 
     /**
      * HTTP get method


### PR DESCRIPTION
According to the source code of koa-router, path can be array of strings

Example:

`router.use(['/users', '/admin'], userAuth());`

- [x]  URL to documentation or source code which provides context for the suggested changes: https://github.com/alexmingoia/koa-router
