### PR TITLE
[node-zookeeper-client] fix zookeeper client exception constructor type

### DIFF
--- a/types/node-zookeeper-client/index.d.ts
+++ b/types/node-zookeeper-client/index.d.ts
@@ -172,7 +172,13 @@ export class Exception {
     code: number;
     name: string;
     path?: string;
-    constructor(code: number, name: string, path?: string);
+
+    // tslint:disable-next-line ban-types
+    constructor(code: number, name: string, path: string, ctor: Function);
+
+    // tslint:disable-next-line ban-types
+    constructor(code: number, name: string, ctor: Function);
+
     toString(): string;
     getCode(): number;
     getName(): string;

--- a/types/node-zookeeper-client/node-zookeeper-client-tests.ts
+++ b/types/node-zookeeper-client/node-zookeeper-client-tests.ts
@@ -257,6 +257,6 @@ const client = zookeeper.createClient(
 }
 
 {
-    new zookeeper.Exception(zookeeper.Exception.NO_NODE, 'test');
-    new zookeeper.Exception(zookeeper.Exception.NO_NODE, 'test', '/test');
+    new zookeeper.Exception(zookeeper.Exception.NO_NODE, 'test', zookeeper.Exception);
+    new zookeeper.Exception(zookeeper.Exception.NO_NODE, 'test', '/test', zookeeper.Exception);
 }


### PR DESCRIPTION
Zookeeper client exception constructor expects last argument to be a function. I've disabled the "ban-types" tslint rule for those two lines as `Function` type represents the argument the best.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/alexguan/node-zookeeper-client/blob/b462db540b13412f6261d202012ed9d4d4cbeb84/lib/Exception.js#L64
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
