### PR TITLE
Three BufferGeometry setFromPoints and setFromObject method defintions

### DIFF
--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for three.js 0.84
 // Project: http://mrdoob.github.com/three.js/
-// Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>, HouChunlei <https://github.com/omni360>, Ivo <https://github.com/ivoisbelongtous>, David Asmuth <https://github.com/piranha771>, Brandon Roberge, Qinsi ZHU <https://github.com/qszhusightp>, Toshiya Nakakura <https://github.com/nakakura>, Poul Kjeldager Sørensen <https://github.com/s093294>, Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>
+// Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>, HouChunlei <https://github.com/omni360>, Ivo <https://github.com/ivoisbelongtous>, David Asmuth <https://github.com/piranha771>, Brandon Roberge, Qinsi ZHU <https://github.com/qszhusightp>, Toshiya Nakakura <https://github.com/nakakura>, Poul Kjeldager Sørensen <https://github.com/s093294>, Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>, Roelof Jooste <https://github.com/PsychoSTS>
 // Definitions: https://github.com//DefinitelyTyped
 
 export * from "./three-core";

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -862,7 +862,8 @@ export class BufferGeometry extends EventDispatcher {
 
     center(): Vector3;
 
-    setFromObject(object: Object3D): void;
+    setFromObject(object: Object3D): BufferGeometry;
+    setFromPoints(points: Vector3[]): BufferGeometry;
     updateFromObject(object: Object3D): void;
 
     fromGeometry(geometry: Geometry, settings?: any): BufferGeometry;


### PR DESCRIPTION
Added the **BufferGeometry.setFromPoints** method with the return type of **BufferGeometry**. Also added the return type of **BufferGeometry** to the existing **BufferGeometry.setFromObject** method.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

 **From line 13718 in three.js**
```javascript
setFromPoints: function ( points ) {

	var position = [];

	for ( var i = 0, l = points.length; i < l; i ++ ) {

		var point = points[ i ];
		position.push( point.x, point.y, point.z || 0 );

	}

	this.addAttribute( 'position', new Float32BufferAttribute( position, 3 ) );

	return this;

}
 ```
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

As can be seen in the source provided above, the method setFromPoints does exist and returns the instance of the BufferGeometry class. This is the same for the setFromObject method which had a type definition but had the wrong return type.
