### PR TITLE
[react-native] Reformat all files using prettier.

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -25,34 +25,23 @@
 /// <reference path="globals.d.ts" />
 
 export type MeasureOnSuccessCallback = (
-        x: number,
-        y: number,
-        width: number,
-        height: number,
-        pageX: number,
-        pageY: number
-    ) => void
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    pageX: number,
+    pageY: number
+) => void;
 
-export type MeasureInWindowOnSuccessCallback = (
-        x: number,
-        y: number,
-        width: number,
-        height: number
-    ) => void
+export type MeasureInWindowOnSuccessCallback = (x: number, y: number, width: number, height: number) => void;
 
-export type MeasureLayoutOnSuccessCallback = (
-        left: number,
-        top: number,
-        width: number,
-        height: number
-    ) => void
+export type MeasureLayoutOnSuccessCallback = (left: number, top: number, width: number, height: number) => void;
 
 /**
  * EventSubscription represents a subscription to a particular event. It can
  * remove its own subscription.
  */
 interface EventSubscription {
-
     eventType: string;
     key: number;
     subscriber: EventSubscriptionVendor;
@@ -61,12 +50,12 @@ interface EventSubscription {
      * @param subscriber the subscriber that controls
      *   this subscription.
      */
-    new(subscriber: EventSubscriptionVendor): EventSubscription
+    new (subscriber: EventSubscriptionVendor): EventSubscription;
 
     /**
      * Removes this subscription from the subscriber that controls it.
      */
-    remove(): void
+    remove(): void;
 }
 
 /**
@@ -74,14 +63,13 @@ interface EventSubscription {
  * subscribed to a particular event type.
  */
 interface EventSubscriptionVendor {
-
-    constructor(): EventSubscriptionVendor
+    constructor(): EventSubscriptionVendor;
 
     /**
      * Adds a subscription keyed by an event type.
      *
      */
-    addSubscription(eventType: string, subscription: EventSubscription): EventSubscription
+    addSubscription(eventType: string, subscription: EventSubscription): EventSubscription;
 
     /**
      * Removes a bulk set of the subscriptions.
@@ -89,14 +77,14 @@ interface EventSubscriptionVendor {
      * @param eventType - Optional name of the event type whose
      *   registered supscriptions to remove, if null remove all subscriptions.
      */
-    removeAllSubscriptions(eventType?: string): void
+    removeAllSubscriptions(eventType?: string): void;
 
     /**
      * Removes a specific subscription. Instead of calling this function, call
      * `subscription.remove()` directly.
      *
      */
-    removeSubscription(subscription: any): void
+    removeSubscription(subscription: any): void;
 
     /**
      * Returns the array of subscriptions that are currently registered for the
@@ -106,16 +94,16 @@ interface EventSubscriptionVendor {
      * from it when they are removed.
      *
      */
-    getSubscriptionsForType(eventType: string): EventSubscription[]
+    getSubscriptionsForType(eventType: string): EventSubscription[];
 }
 
 /**
  * EmitterSubscription represents a subscription with listener and context data.
  */
 interface EmitterSubscription extends EventSubscription {
-    emitter: EventEmitter
-    listener: () => any
-    context: any
+    emitter: EventEmitter;
+    listener: () => any;
+    context: any;
 
     /**
      * @param emitter - The event emitter that registered this
@@ -127,7 +115,12 @@ interface EmitterSubscription extends EventSubscription {
      * @param context - Optional context object to use when invoking the
      *   listener
      */
-    new(emitter: EventEmitter, subscriber: EventSubscriptionVendor, listener: () => any, context: any): EmitterSubscription
+    new (
+        emitter: EventEmitter,
+        subscriber: EventSubscriptionVendor,
+        listener: () => any,
+        context: any
+    ): EmitterSubscription;
 
     /**
      * Removes this subscription from the emitter that registered it.
@@ -135,7 +128,7 @@ interface EmitterSubscription extends EventSubscription {
      * but deliberately not calling `super.remove()` as the responsibility
      * for removing the subscription lies with the EventEmitter.
      */
-    remove(): void
+    remove(): void;
 }
 
 interface EventEmitterListener {
@@ -150,7 +143,7 @@ interface EventEmitterListener {
      * @param context - Optional context object to use when invoking the
      *   listener
      */
-    addListener(eventType: string, listener: (...args: any[]) => any, context?: any): EmitterSubscription
+    addListener(eventType: string, listener: (...args: any[]) => any, context?: any): EmitterSubscription;
 }
 
 interface EventEmitter extends EventEmitterListener {
@@ -159,7 +152,7 @@ interface EventEmitter extends EventEmitterListener {
      * @param subscriber - Optional subscriber instance
      *   to use. If omitted, a new subscriber will be created for the emitter.
      */
-    new(subscriber?: EventSubscriptionVendor): EventEmitter
+    new (subscriber?: EventSubscriptionVendor): EventEmitter;
 
     /**
      * Similar to addListener, except that the listener is removed after it is
@@ -171,7 +164,7 @@ interface EventEmitter extends EventEmitterListener {
      * @param context - Optional context object to use when invoking the
      *   listener
      */
-    once(eventType: string, listener: (...args: any[]) => any, context: any): EmitterSubscription
+    once(eventType: string, listener: (...args: any[]) => any, context: any): EmitterSubscription;
 
     /**
      * Removes all of the registered listeners, including those registered as
@@ -180,7 +173,7 @@ interface EventEmitter extends EventEmitterListener {
      * @param eventType - Optional name of the event whose registered
      *   listeners to remove
      */
-    removeAllListeners(eventType?: string): void
+    removeAllListeners(eventType?: string): void;
 
     /**
      * Provides an API that can be called during an eventing cycle to remove the
@@ -203,13 +196,13 @@ interface EventEmitter extends EventEmitterListener {
      *   emitter.emit('someEvent', 'abc'); // logs 'abc'
      *   emitter.emit('someEvent', 'def'); // does not log anything
      */
-    removeCurrentListener(): void
+    removeCurrentListener(): void;
 
     /**
      * Removes a specific subscription. Called by the `remove()` method of the
      * subscription itself to ensure any necessary cleanup is performed.
      */
-    removeSubscription(subscription: EmitterSubscription): void
+    removeSubscription(subscription: EmitterSubscription): void;
 
     /**
      * Returns an array of listeners that are currently registered for the given
@@ -217,7 +210,7 @@ interface EventEmitter extends EventEmitterListener {
      *
      * @param eventType - Name of the event to query
      */
-    listeners(eventType: string): EmitterSubscription[]
+    listeners(eventType: string): EmitterSubscription[];
 
     /**
      * Emits an event of the given type with the given data. All handlers of that
@@ -233,7 +226,7 @@ interface EventEmitter extends EventEmitterListener {
      *
      *   emitter.emit('someEvent', 'abc'); // logs 'abc'
      */
-    emit(eventType: string, ...params: any[]): void
+    emit(eventType: string, ...params: any[]): void;
 
     /**
      * Removes the given listener for event of specific type.
@@ -248,7 +241,7 @@ interface EventEmitter extends EventEmitterListener {
      *   }); // removes the listener if already registered
      *
      */
-    removeListener(eventType: string, listener: (...args: any[]) => any): void
+    removeListener(eventType: string, listener: (...args: any[]) => any): void;
 }
 
 /** NativeMethodsMixin provides methods to access the underlying native component directly.
@@ -307,7 +300,7 @@ export interface NativeMethodsMixinStatic {
      */
     measureLayout(
         relativeToNativeNode: number,
-    onSuccess: MeasureLayoutOnSuccessCallback,
+        onSuccess: MeasureLayoutOnSuccessCallback,
         onFail: () => void /* currently unused */
     ): void;
 
@@ -331,7 +324,7 @@ export interface NativeMethodsMixinStatic {
     blur(): void;
 
     refs: {
-        [key: string]: React.Component<any, any>
+        [key: string]: React.Component<any, any>;
     };
 }
 
@@ -339,8 +332,8 @@ export interface NativeMethodsMixinStatic {
 export function createElement<P>(
     type: React.ReactType,
     props?: P,
-    ...children: React.ReactNode[]): React.ReactElement<P>;
-
+    ...children: React.ReactNode[]
+): React.ReactElement<P>;
 
 export type Runnable = (appParameters: any) => void;
 
@@ -348,81 +341,79 @@ type NodeHandle = number;
 
 // Similar to React.SyntheticEvent except for nativeEvent
 interface NativeSyntheticEvent<T> {
-    bubbles: boolean
-    cancelable: boolean
-    currentTarget: NodeHandle
-    defaultPrevented: boolean
-    eventPhase: number
-    isTrusted: boolean
-    nativeEvent: T
-    preventDefault(): void
-    stopPropagation(): void
-    target: NodeHandle
-    timeStamp: number
-    type: string
+    bubbles: boolean;
+    cancelable: boolean;
+    currentTarget: NodeHandle;
+    defaultPrevented: boolean;
+    eventPhase: number;
+    isTrusted: boolean;
+    nativeEvent: T;
+    preventDefault(): void;
+    stopPropagation(): void;
+    target: NodeHandle;
+    timeStamp: number;
+    type: string;
 }
 
 export interface NativeTouchEvent {
     /**
      * Array of all touch events that have changed since the last event
      */
-    changedTouches: NativeTouchEvent[]
+    changedTouches: NativeTouchEvent[];
 
     /**
      * The ID of the touch
      */
-    identifier: string
+    identifier: string;
 
     /**
      * The X position of the touch, relative to the element
      */
-    locationX: number
+    locationX: number;
 
     /**
      * The Y position of the touch, relative to the element
      */
-    locationY: number
+    locationY: number;
 
     /**
      * The X position of the touch, relative to the screen
      */
-    pageX: number
+    pageX: number;
 
     /**
      * The Y position of the touch, relative to the screen
      */
-    pageY: number
+    pageY: number;
 
     /**
      * The node id of the element receiving the touch event
      */
-    target: string
+    target: string;
 
     /**
      * A time identifier for the touch, useful for velocity calculation
      */
-    timestamp: number
+    timestamp: number;
 
     /**
      * Array of all current touches on the screen
      */
-    touches: NativeTouchEvent[]
+    touches: NativeTouchEvent[];
 }
 
-export interface GestureResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {
-}
-
+export interface GestureResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {}
 
 export interface PointProperties {
-    x: number
-    y: number
+    x: number;
+    y: number;
 }
 
 export interface Insets {
-    top?: number
-    left?: number
-    bottom?: number
-    right?: number
+    top?: number;
+    left?: number;
+    bottom?: number;
+    right?: number;
 }
 
 /**
@@ -430,20 +421,20 @@ export interface Insets {
  * @see React.DOMAtributes
  */
 export interface Touchable {
-    onTouchStart?: (event: GestureResponderEvent) => void
-    onTouchMove?: (event: GestureResponderEvent) => void
-    onTouchEnd?: (event: GestureResponderEvent) => void
-    onTouchCancel?: (event: GestureResponderEvent) => void
-    onTouchEndCapture?: (event: GestureResponderEvent) => void
+    onTouchStart?: (event: GestureResponderEvent) => void;
+    onTouchMove?: (event: GestureResponderEvent) => void;
+    onTouchEnd?: (event: GestureResponderEvent) => void;
+    onTouchCancel?: (event: GestureResponderEvent) => void;
+    onTouchEndCapture?: (event: GestureResponderEvent) => void;
 }
 
-export type ComponentProvider = () => React.ComponentType<any>
+export type ComponentProvider = () => React.ComponentType<any>;
 
 export type AppConfig = {
     appKey: string;
-    component?: ComponentProvider
+    component?: ComponentProvider;
     run?: Runnable;
-}
+};
 
 // https://github.com/facebook/react-native/blob/master/Libraries/AppRegistry/AppRegistry.js
 /**
@@ -464,7 +455,7 @@ export type AppConfig = {
 export namespace AppRegistry {
     function registerConfig(config: AppConfig[]): void;
 
-    function registerComponent( appKey: string, getComponentFunc: ComponentProvider ): string;
+    function registerComponent(appKey: string, getComponentFunc: ComponentProvider): string;
 
     function registerRunnable(appKey: string, func: Runnable): string;
 
@@ -476,32 +467,32 @@ export namespace AppRegistry {
 }
 
 export interface LayoutAnimationTypes {
-    spring: string
-    linear: string
-    easeInEaseOut: string
-    easeIn: string
-    easeOut: string
+    spring: string;
+    linear: string;
+    easeInEaseOut: string;
+    easeIn: string;
+    easeOut: string;
 }
 
 export interface LayoutAnimationProperties {
-    opacity: string
-    scaleXY: string
+    opacity: string;
+    scaleXY: string;
 }
 
 export interface LayoutAnimationAnim {
-    duration?: number
-    delay?: number
-    springDamping?: number
-    initialVelocity?: number
-    type?: string //LayoutAnimationTypes
-    property?: string //LayoutAnimationProperties
+    duration?: number;
+    delay?: number;
+    springDamping?: number;
+    initialVelocity?: number;
+    type?: string; //LayoutAnimationTypes
+    property?: string; //LayoutAnimationProperties
 }
 
 export interface LayoutAnimationConfig {
-    duration: number
-    create?: LayoutAnimationAnim
-    update?: LayoutAnimationAnim
-    delete?: LayoutAnimationAnim
+    duration: number;
+    create?: LayoutAnimationAnim;
+    update?: LayoutAnimationAnim;
+    delete?: LayoutAnimationAnim;
 }
 
 /** Automatically animates views to their new positions when the next layout happens.
@@ -515,20 +506,20 @@ export interface LayoutAnimationStatic {
      * `update`, config for animating views that have been updated (see Anim type)
      * @param onAnimationDidEnd Called when the animation finished. Only supported on iOS.
      */
-    configureNext: ( config: LayoutAnimationConfig, onAnimationDidEnd?: () => void ) => void
+    configureNext: (config: LayoutAnimationConfig, onAnimationDidEnd?: () => void) => void;
     /** Helper for creating a config for configureNext. */
-    create: (duration: number, type?: string, creationProp?: string) => LayoutAnimationConfig
-    Types: LayoutAnimationTypes
-    Properties: LayoutAnimationProperties
-    configChecker: (shapeTypes: {[key: string]: any}) => any
+    create: (duration: number, type?: string, creationProp?: string) => LayoutAnimationConfig;
+    Types: LayoutAnimationTypes;
+    Properties: LayoutAnimationProperties;
+    configChecker: (shapeTypes: { [key: string]: any }) => any;
     Presets: {
-        easeInEaseOut: LayoutAnimationConfig
-        linear: LayoutAnimationConfig
-        spring: LayoutAnimationConfig
-    }
-    easeInEaseOut: (onAnimationDidEnd?: () => void) => void
-    linear: (onAnimationDidEnd?: () => void) => void
-    spring: (onAnimationDidEnd?: () => void) => void
+        easeInEaseOut: LayoutAnimationConfig;
+        linear: LayoutAnimationConfig;
+        spring: LayoutAnimationConfig;
+    };
+    easeInEaseOut: (onAnimationDidEnd?: () => void) => void;
+    linear: (onAnimationDidEnd?: () => void) => void;
+    spring: (onAnimationDidEnd?: () => void) => void;
 }
 
 type FlexAlignType = "flex-start" | "flex-end" | "center" | "stretch" | "baseline";
@@ -539,54 +530,54 @@ type FlexAlignType = "flex-start" | "flex-end" | "center" | "stretch" | "baselin
  * @see LayoutPropTypes.js
  */
 export interface FlexStyle {
-    alignContent?: "flex-start" | "flex-end" | "center" | "stretch" | "space-between" | "space-around"
-    alignItems?: FlexAlignType
-    alignSelf?: "auto" | FlexAlignType
-    aspectRatio?: number
-    borderBottomWidth?: number
-    borderLeftWidth?: number
-    borderRightWidth?: number
-    borderTopWidth?: number
-    borderWidth?: number
-    bottom?: number | string
-    flex?: number
-    flexBasis?: number | string
-    flexDirection?: "row" | "column" | "row-reverse" | "column-reverse"
-    flexGrow?: number
-    flexShrink?: number
-    flexWrap?: "wrap" | "nowrap"
-    height?: number | string
-    justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around"
-    left?: number | string
-    margin?: number | string
-    marginBottom?: number | string
-    marginHorizontal?: number | string
-    marginLeft?: number | string
-    marginRight?: number | string
-    marginTop?: number | string
-    marginVertical?: number | string
-    maxHeight?: number | string
-    maxWidth?: number | string
-    minHeight?: number | string
-    minWidth?: number | string
-    overflow?: "visible" | "hidden" | "scroll"
-    padding?: number | string
-    paddingBottom?: number | string
-    paddingHorizontal?: number | string
-    paddingLeft?: number | string
-    paddingRight?: number | string
-    paddingTop?: number | string
-    paddingVertical?: number | string
-    position?: "absolute" | "relative"
-    right?: number | string
-    top?: number | string
-    width?: number | string
-    zIndex?: number
+    alignContent?: "flex-start" | "flex-end" | "center" | "stretch" | "space-between" | "space-around";
+    alignItems?: FlexAlignType;
+    alignSelf?: "auto" | FlexAlignType;
+    aspectRatio?: number;
+    borderBottomWidth?: number;
+    borderLeftWidth?: number;
+    borderRightWidth?: number;
+    borderTopWidth?: number;
+    borderWidth?: number;
+    bottom?: number | string;
+    flex?: number;
+    flexBasis?: number | string;
+    flexDirection?: "row" | "column" | "row-reverse" | "column-reverse";
+    flexGrow?: number;
+    flexShrink?: number;
+    flexWrap?: "wrap" | "nowrap";
+    height?: number | string;
+    justifyContent?: "flex-start" | "flex-end" | "center" | "space-between" | "space-around";
+    left?: number | string;
+    margin?: number | string;
+    marginBottom?: number | string;
+    marginHorizontal?: number | string;
+    marginLeft?: number | string;
+    marginRight?: number | string;
+    marginTop?: number | string;
+    marginVertical?: number | string;
+    maxHeight?: number | string;
+    maxWidth?: number | string;
+    minHeight?: number | string;
+    minWidth?: number | string;
+    overflow?: "visible" | "hidden" | "scroll";
+    padding?: number | string;
+    paddingBottom?: number | string;
+    paddingHorizontal?: number | string;
+    paddingLeft?: number | string;
+    paddingRight?: number | string;
+    paddingTop?: number | string;
+    paddingVertical?: number | string;
+    position?: "absolute" | "relative";
+    right?: number | string;
+    top?: number | string;
+    width?: number | string;
+    zIndex?: number;
 
     /**
      * @platform ios
      */
-    direction?: 'inherit' | 'ltr' | 'rtl'
+    direction?: "inherit" | "ltr" | "rtl";
 }
 
 /**
@@ -597,51 +588,51 @@ export interface ShadowPropTypesIOSStatic {
      * Sets the drop shadow color
      * @platform ios
      */
-    shadowColor: string
+    shadowColor: string;
 
     /**
      * Sets the drop shadow offset
      * @platform ios
      */
-    shadowOffset: { width: number, height: number }
+    shadowOffset: { width: number; height: number };
 
     /**
      * Sets the drop shadow opacity (multiplied by the color's alpha component)
      * @platform ios
      */
-    shadowOpacity: number
+    shadowOpacity: number;
 
     /**
      * Sets the drop shadow blur radius
      * @platform ios
      */
-    shadowRadius: number
+    shadowRadius: number;
 }
 
 type GeoConfiguration = {
     skipPermissionRequests: boolean;
-}
+};
 
 type GeoOptions = {
-    timeout?: number,
-    maximumAge?: number,
-    enableHighAccuracy?: boolean,
-    distanceFilter?: number,
-    useSignificantChanges?: boolean,
-}
+    timeout?: number;
+    maximumAge?: number;
+    enableHighAccuracy?: boolean;
+    distanceFilter?: number;
+    useSignificantChanges?: boolean;
+};
 
 type GeolocationReturnType = {
     coords: {
-        latitude: number
-        longitude: number
-        altitude: number | null
-        accuracy: number
-        altitudeAccuracy: number | null
-        heading: number | null
-        speed: number | null
-    }
-    timestamp: number
-}
+        latitude: number;
+        longitude: number;
+        altitude: number | null;
+        accuracy: number;
+        altitudeAccuracy: number | null;
+        heading: number | null;
+        speed: number | null;
+    };
+    timestamp: number;
+};
 
 type GeolocationError = {
     code: number;
@@ -649,7 +640,7 @@ type GeolocationError = {
     PERMISSION_DENIED: number;
     POSITION_UNAVAILABLE: number;
     TIMEOUT: number;
-}
+};
 
 interface PerpectiveTransform {
     perspective: number;
@@ -701,31 +692,29 @@ interface SkewYTransform {
 
 export interface TransformsStyle {
     transform?: (
-        PerpectiveTransform |
-        RotateTransform |
-        RotateXTransform |
-        RotateYTransform |
-        RotateZTransform |
-        ScaleTransform |
-        ScaleXTransform |
-        ScaleYTransform |
-        TranslateXTransform |
-        TranslateYTransform |
-        SkewXTransform |
-        SkewYTransform
-    )[]
-    transformMatrix?: Array<number>
-    rotation?: number
-    scaleX?: number
-    scaleY?: number
-    translateX?: number
-    translateY?: number
+        | PerpectiveTransform
+        | RotateTransform
+        | RotateXTransform
+        | RotateYTransform
+        | RotateZTransform
+        | ScaleTransform
+        | ScaleXTransform
+        | ScaleYTransform
+        | TranslateXTransform
+        | TranslateYTransform
+        | SkewXTransform
+        | SkewYTransform)[];
+    transformMatrix?: Array<number>;
+    rotation?: number;
+    scaleX?: number;
+    scaleY?: number;
+    translateX?: number;
+    translateY?: number;
 }
 
-
 export interface StyleSheetProperties {
-    hairlineWidth: number
-    flatten<T extends string>(style: T): T
+    hairlineWidth: number;
+    flatten<T extends string>(style: T): T;
 }
 
 export interface LayoutRectangle {
@@ -738,48 +727,48 @@ export interface LayoutRectangle {
 // @see TextProperties.onLayout
 export interface LayoutChangeEvent {
     nativeEvent: {
-        layout: LayoutRectangle
-    }
+        layout: LayoutRectangle;
+    };
 }
 
 export interface TextStyleIOS extends ViewStyle {
-    letterSpacing?: number
-    textDecorationColor?: string
-    textDecorationStyle?: "solid" | "double" | "dotted" | "dashed"
-    writingDirection?: "auto" | "ltr" | "rtl"
+    letterSpacing?: number;
+    textDecorationColor?: string;
+    textDecorationStyle?: "solid" | "double" | "dotted" | "dashed";
+    writingDirection?: "auto" | "ltr" | "rtl";
 }
 
 export interface TextStyleAndroid extends ViewStyle {
-    textAlignVertical?: "auto" | "top" | "bottom" | "center"
-    includeFontPadding?: boolean
+    textAlignVertical?: "auto" | "top" | "bottom" | "center";
+    includeFontPadding?: boolean;
 }
 
 // @see https://facebook.github.io/react-native/docs/text.html#style
 export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle {
-    color?: string
-    fontFamily?: string
-    fontSize?: number
-    fontStyle?: "normal" | "italic"
+    color?: string;
+    fontFamily?: string;
+    fontSize?: number;
+    fontStyle?: "normal" | "italic";
     /**
      * Specifies font weight. The values 'normal' and 'bold' are supported
      * for most fonts. Not all fonts have a variant for each of the numeric
      * values, in that case the closest one is chosen.
      */
-    fontWeight?: "normal" | "bold" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900"
-    letterSpacing?: number
-    lineHeight?: number
+    fontWeight?: "normal" | "bold" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900";
+    letterSpacing?: number;
+    lineHeight?: number;
     /**
      * Specifies text alignment.
      * The value 'justify' is only supported on iOS.
      */
-    textAlign?: "auto" | "left" | "right" | "center"
-    textDecorationLine?: "none" | "underline" | "line-through" | "underline line-through"
-    textDecorationStyle?: "solid" | "double" | "dotted" | "dashed"
-    textDecorationColor?: string
-    textShadowColor?: string
-    textShadowOffset?: { width: number, height: number }
-    textShadowRadius?: number
-    testID?: string
+    textAlign?: "auto" | "left" | "right" | "center";
+    textDecorationLine?: "none" | "underline" | "line-through" | "underline line-through";
+    textDecorationStyle?: "solid" | "double" | "dotted" | "dashed";
+    textDecorationColor?: string;
+    textShadowColor?: string;
+    textShadowOffset?: { width: number; height: number };
+    textShadowRadius?: number;
+    testID?: string;
 }
 
 export interface TextPropertiesIOS {
@@ -787,46 +776,45 @@ export interface TextPropertiesIOS {
      * Specifies whether fonts should scale to respect Text Size accessibility setting on iOS. The
      * default is `true`.
      */
-    allowFontScaling?: boolean
+    allowFontScaling?: boolean;
 
     /**
      * Specifies whether font should be scaled down automatically to fit given style constraints.
      */
-    adjustsFontSizeToFit?: boolean
+    adjustsFontSizeToFit?: boolean;
 
     /**
      * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
      */
-    minimumFontScale?: number
+    minimumFontScale?: number;
 
     /**
      * When `true`, no visual change is made when text is pressed down. By
      * default, a gray oval highlights the text on press down.
      */
-    suppressHighlighting?: boolean
+    suppressHighlighting?: boolean;
 }
 
 export interface TextPropertiesAndroid {
     /**
      * Lets the user select text, to use the native copy and paste functionality.
      */
-    selectable?: boolean
+    selectable?: boolean;
 
     /**
      * The highlight color of the text.
      */
-    selectionColor?: string
+    selectionColor?: string;
 
     /**
      * Set text break strategy on Android API Level 23+
      * default is `highQuality`.
      */
-    textBreakStrategy?: "simple" | "highQuality" | "balanced"
+    textBreakStrategy?: "simple" | "highQuality" | "balanced";
 }
 
 // https://facebook.github.io/react-native/docs/text.html#props
 export interface TextProperties extends TextPropertiesIOS, TextPropertiesAndroid {
-
     /**
      * When set to `true`, indicates that the view is an accessibility element. The default value
      * for a `Text` element is `true`.
@@ -835,7 +823,7 @@ export interface TextProperties extends TextPropertiesIOS, TextPropertiesAndroid
      * [Accessibility guide](/react-native/docs/accessibility.html#accessible-ios-android)
      * for more information.
      */
-    accessible?: boolean
+    accessible?: boolean;
 
     /**
      * This can be one of the following values:
@@ -854,13 +842,13 @@ export interface TextProperties extends TextPropertiesIOS, TextPropertiesAndroid
      *
      * > `clip` is working only for iOS
      */
-    ellipsizeMode?: 'head' | 'middle' | 'tail' | 'clip'
+    ellipsizeMode?: "head" | "middle" | "tail" | "clip";
 
     /**
      * Line Break mode. Works only with numberOfLines.
      * clip is working only for iOS
      */
-    lineBreakMode?: 'head' | 'middle' | 'tail' | 'clip'
+    lineBreakMode?: "head" | "middle" | "tail" | "clip";
 
     /**
      * Used to truncate the text with an ellipsis after computing the text
@@ -869,46 +857,44 @@ export interface TextProperties extends TextPropertiesIOS, TextPropertiesAndroid
      *
      * This prop is commonly used with `ellipsizeMode`.
      */
-    numberOfLines?: number
+    numberOfLines?: number;
 
     /**
      * Invoked on mount and layout changes with
      *
      * {nativeEvent: { layout: {x, y, width, height}}}.
      */
-    onLayout?: (event: LayoutChangeEvent) => void
+    onLayout?: (event: LayoutChangeEvent) => void;
 
     /**
      * This function is called on press.
      * Text intrinsically supports press handling with a default highlight state (which can be disabled with suppressHighlighting).
      */
-    onPress?: (event: GestureResponderEvent) => void
+    onPress?: (event: GestureResponderEvent) => void;
 
     /**
      * This function is called on long press.
      * e.g., `onLongPress={this.increaseSize}>``
      */
-    onLongPress?: (event: GestureResponderEvent) => void
+    onLongPress?: (event: GestureResponderEvent) => void;
 
     /**
      * @see https://facebook.github.io/react-native/docs/text.html#style
      */
-    style?: StyleProp<TextStyle>
+    style?: StyleProp<TextStyle>;
 
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testID?: string
+    testID?: string;
 }
 
 /**
  * A React component for displaying text which supports nesting, styling, and touch handling.
  */
-export interface TextStatic extends NativeMethodsMixin, React.ClassicComponentClass<TextProperties> {
+export interface TextStatic extends NativeMethodsMixin, React.ClassicComponentClass<TextProperties> {}
 
-}
-
-type DataDetectorTypes = 'phoneNumber' | 'link' | 'address' | 'calendarEvent' | 'none' | 'all';
+type DataDetectorTypes = "phoneNumber" | "link" | "address" | "calendarEvent" | "none" | "all";
 
 /**
  * DocumentSelectionState is responsible for maintaining selection information
@@ -920,52 +906,50 @@ type DataDetectorTypes = 'phoneNumber' | 'link' | 'address' | 'calendarEvent' | 
  * components re-render.
  */
 export interface DocumentSelectionState extends EventEmitter {
-    new(anchor: number, focus: number): DocumentSelectionState
+    new (anchor: number, focus: number): DocumentSelectionState;
 
     /**
      * Apply an update to the state. If either offset value has changed,
      * set the values and emit the `change` event. Otherwise no-op.
      *
      */
-    update(anchor: number, focus: number): void
+    update(anchor: number, focus: number): void;
 
     /**
      * Given a max text length, constrain our selection offsets to ensure
      * that the selection remains strictly within the text range.
      *
      */
-    constrainLength(maxLength: number): void
+    constrainLength(maxLength: number): void;
 
-    focus(): void
-    blur(): void
-    hasFocus(): boolean
-    isCollapsed(): boolean
-    isBackward(): boolean
+    focus(): void;
+    blur(): void;
+    hasFocus(): boolean;
+    isCollapsed(): boolean;
+    isBackward(): boolean;
 
-    getAnchorOffset(): number
-    getFocusOffset(): number
-    getStartOffset(): number
-    getEndOffset(): number
-    overlaps(start: number, end: number): boolean
+    getAnchorOffset(): number;
+    getFocusOffset(): number;
+    getStartOffset(): number;
+    getEndOffset(): number;
+    overlaps(start: number, end: number): boolean;
 }
-
 
 /**
  * IOS Specific properties for TextInput
  * @see https://facebook.github.io/react-native/docs/textinput.html#props
  */
 export interface TextInputIOSProperties {
-
     /**
      * enum('never', 'while-editing', 'unless-editing', 'always')
      * When the clear button should appear on the right side of the text view
      */
-    clearButtonMode?: 'never' | 'while-editing' | 'unless-editing' | 'always'
+    clearButtonMode?: "never" | "while-editing" | "unless-editing" | "always";
 
     /**
      * If true, clears the text field automatically when editing begins
      */
-    clearTextOnFocus?: boolean
+    clearTextOnFocus?: boolean;
 
     /**
      * Determines the types of data converted to clickable URLs in the text input.
@@ -983,35 +967,35 @@ export interface TextInputIOSProperties {
      * - `'none'`
      * - `'all'`
      */
-    dataDetectorTypes?: DataDetectorTypes | DataDetectorTypes[]
+    dataDetectorTypes?: DataDetectorTypes | DataDetectorTypes[];
 
     /**
      * If true, the keyboard disables the return key when there is no text and automatically enables it when there is text.
      * The default value is false.
      */
-    enablesReturnKeyAutomatically?: boolean
+    enablesReturnKeyAutomatically?: boolean;
 
     /**
      * Determines the color of the keyboard.
      */
-    keyboardAppearance?: 'default' | 'light' | 'dark'
+    keyboardAppearance?: "default" | "light" | "dark";
 
     /**
      * Callback that is called when a key is pressed.
      * Pressed key value is passed as an argument to the callback handler.
      * Fires before onChange callbacks.
      */
-    onKeyPress?: (key: string) => void
+    onKeyPress?: (key: string) => void;
 
     /**
      * See DocumentSelectionState.js, some state that is responsible for maintaining selection information for a document
      */
-    selectionState?: DocumentSelectionState
+    selectionState?: DocumentSelectionState;
 
     /**
      * If false, disables spell-check style (i.e. red underlines). The default value is inherited from autoCorrect
      */
-    spellCheck?: boolean
+    spellCheck?: boolean;
 }
 
 /**
@@ -1019,61 +1003,67 @@ export interface TextInputIOSProperties {
  * @see https://facebook.github.io/react-native/docs/textinput.html#props
  */
 export interface TextInputAndroidProperties {
-
     /**
      * When false, if there is a small amount of space available around a text input (e.g. landscape orientation on a phone),
      *   the OS may choose to have the user edit the text inside of a full screen text input mode.
      * When true, this feature is disabled and users will always edit the text directly inside of the text input.
      * Defaults to false.
      */
-    disableFullscreenUI?: boolean
+    disableFullscreenUI?: boolean;
 
     /**
      * If defined, the provided image resource will be rendered on the left.
      */
-    inlineImageLeft?: string
+    inlineImageLeft?: string;
 
     /**
      * Padding between the inline image, if any, and the text input itself.
      */
-    inlineImagePadding?: number
+    inlineImagePadding?: number;
 
     /**
      * Sets the number of lines for a TextInput.
      * Use it with multiline set to true to be able to fill the lines.
      */
-    numberOfLines?: number
+    numberOfLines?: number;
 
     /**
      * Sets the return key to the label. Use it instead of `returnKeyType`.
      * @platform android
      */
-    returnKeyLabel?: string
+    returnKeyLabel?: string;
 
     /**
      * Set text break strategy on Android API Level 23+, possible values are simple, highQuality, balanced
      * The default value is simple.
      */
-    textBreakStrategy?: "simple" | "highQuality" | "balanced"
+    textBreakStrategy?: "simple" | "highQuality" | "balanced";
 
     /**
      * The color of the textInput underline.
      */
-    underlineColorAndroid?: string
+    underlineColorAndroid?: string;
 }
 
-export type KeyboardType = "default" | "email-address" | "numeric" | "phone-pad"
-export type KeyboardTypeIOS = "ascii-capable" | "numbers-and-punctuation" | "url" | "number-pad" | "name-phone-pad" | "decimal-pad" | "twitter" | "web-search"
+export type KeyboardType = "default" | "email-address" | "numeric" | "phone-pad";
+export type KeyboardTypeIOS =
+    | "ascii-capable"
+    | "numbers-and-punctuation"
+    | "url"
+    | "number-pad"
+    | "name-phone-pad"
+    | "decimal-pad"
+    | "twitter"
+    | "web-search";
 
-export type ReturnKeyType = "done" | "go" | "next" | "search" | "send"
-export type ReturnKeyTypeAndroid = "none" | "previous"
-export type ReturnKeyTypeIOS = "default" | "google" | "join" | "route" | "yahoo" | "emergency-call"
+export type ReturnKeyType = "done" | "go" | "next" | "search" | "send";
+export type ReturnKeyTypeAndroid = "none" | "previous";
+export type ReturnKeyTypeIOS = "default" | "google" | "join" | "route" | "yahoo" | "emergency-call";
 
 /**
  * @see https://facebook.github.io/react-native/docs/textinput.html#props
  */
 export interface TextInputProperties extends ViewProperties, TextInputIOSProperties, TextInputAndroidProperties {
-
     /**
      * Can tell TextInput to automatically capitalize certain characters.
      *      characters: all characters,
@@ -1083,71 +1073,80 @@ export interface TextInputProperties extends ViewProperties, TextInputIOSPropert
      *
      * https://facebook.github.io/react-native/docs/textinput.html#autocapitalize
      */
-    autoCapitalize?: "none" | "sentences" | "words" | "characters"
+    autoCapitalize?: "none" | "sentences" | "words" | "characters";
 
     /**
      * If false, disables auto-correct.
      * The default value is true.
      */
-    autoCorrect?: boolean
+    autoCorrect?: boolean;
 
     /**
      * If true, focuses the input on componentDidMount.
      * The default value is false.
      */
-    autoFocus?: boolean
+    autoFocus?: boolean;
 
     /**
      * If true, the text field will blur when submitted.
      * The default value is true.
      */
-    blurOnSubmit?: boolean
+    blurOnSubmit?: boolean;
 
     /**
      * Provides an initial value that will change when the user starts typing.
      * Useful for simple use-cases where you don't want to deal with listening to events
      * and updating the value prop to keep the controlled state in sync.
      */
-    defaultValue?: string
+    defaultValue?: string;
 
     /**
      * If false, text is not editable. The default value is true.
      */
-    editable?: boolean
+    editable?: boolean;
 
     /**
      * enum("default", 'numeric', 'email-address', "ascii-capable", 'numbers-and-punctuation', 'url', 'number-pad', 'phone-pad', 'name-phone-pad', 'decimal-pad', 'twitter', 'web-search')
      * Determines which keyboard to open, e.g.numeric.
      * The following values work across platforms: - default - numeric - email-address - phone-pad
      */
-    keyboardType?: KeyboardType | KeyboardTypeIOS
+    keyboardType?: KeyboardType | KeyboardTypeIOS;
 
     /**
      * Limits the maximum number of characters that can be entered.
      * Use this instead of implementing the logic in JS to avoid flicker.
      */
-    maxLength?: number
+    maxLength?: number;
 
     /**
      * If true, the text input can be multiple lines. The default value is false.
      */
-    multiline?: boolean
+    multiline?: boolean;
 
     /**
      * Callback that is called when the text input is blurred
      */
-    onBlur?: () => void
+    onBlur?: () => void;
 
     /**
      * Callback that is called when the text input's text changes.
      */
-    onChange?: (event: { nativeEvent: { text: string, contentSize: { width: number, height: number }, target: number, eventCount: number } }) => void
+    onChange?: (
+        event: {
+            nativeEvent: {
+                text: string;
+                contentSize: { width: number; height: number };
+                target: number;
+                eventCount: number;
+            };
+        }
+    ) => void;
 
     /**
      * Callback that is called when the text input's text changes.
      * Changed text is passed as an argument to the callback handler.
      */
-    onChangeText?: (text: string) => void
+    onChangeText?: (text: string) => void;
 
     /**
      * Callback that is called when the text input's content size changes.
@@ -1156,75 +1155,75 @@ export interface TextInputProperties extends ViewProperties, TextInputIOSPropert
      *
      * Only called for multiline text inputs.
      */
-    onContentSizeChange?: ( event: {nativeEvent: {contentSize: { width: number, height: number}}} ) => void
+    onContentSizeChange?: (event: { nativeEvent: { contentSize: { width: number; height: number } } }) => void;
 
     /**
      * Callback that is called when text input ends.
      */
-    onEndEditing?: (event: { nativeEvent: { text: string } }) => void
+    onEndEditing?: (event: { nativeEvent: { text: string } }) => void;
 
     /**
      * Callback that is called when the text input is focused
      */
-    onFocus?: () => void
+    onFocus?: () => void;
 
     /**
      * Callback that is called when the text input selection is changed.
      */
-    onSelectionChange?: (event: { nativeEvent: { selection: { start: number, end: number }, target: number } }) => void
+    onSelectionChange?: (event: { nativeEvent: { selection: { start: number; end: number }; target: number } }) => void;
 
     /**
      * Callback that is called when the text input's submit button is pressed.
      */
-    onSubmitEditing?: (event: { nativeEvent: { text: string } }) => void
+    onSubmitEditing?: (event: { nativeEvent: { text: string } }) => void;
 
     /**
      * The string that will be rendered before text input has been entered
      */
-    placeholder?: string
+    placeholder?: string;
 
     /**
      * The text color of the placeholder string
      */
-    placeholderTextColor?: string
+    placeholderTextColor?: string;
 
     /**
      * enum('default', 'go', 'google', 'join', 'next', 'route', 'search', 'send', 'yahoo', 'done', 'emergency-call')
      * Determines how the return key should look.
      */
-    returnKeyType?: ReturnKeyType | ReturnKeyTypeAndroid | ReturnKeyTypeIOS
+    returnKeyType?: ReturnKeyType | ReturnKeyTypeAndroid | ReturnKeyTypeIOS;
 
     /**
      * If true, the text input obscures the text entered so that sensitive text like passwords stay secure.
      * The default value is false.
      */
-    secureTextEntry?: boolean
+    secureTextEntry?: boolean;
 
     /**
      * If true, all text will automatically be selected on focus
      */
-    selectTextOnFocus?: boolean
+    selectTextOnFocus?: boolean;
 
     /**
      * The start and end of the text input's selection. Set start and end to
      * the same value to position the cursor.
      */
-    selection?: { start: number, end?: number }
+    selection?: { start: number; end?: number };
 
     /**
      * The highlight (and cursor on ios) color of the text input
      */
-    selectionColor?: string
+    selectionColor?: string;
 
     /**
      * Styles
      */
-    style?: StyleProp<TextStyle>
+    style?: StyleProp<TextStyle>;
 
     /**
      * Used to locate this view in end-to-end tests
      */
-    testID?: string
+    testID?: string;
 
     /**
      * The value to show for the text input. TextInput is a controlled component,
@@ -1233,7 +1232,7 @@ export interface TextInputProperties extends ViewProperties, TextInputIOSPropert
      * In addition to simply setting the same value, either set editable={false},
      * or set/update maxLength to prevent unwanted edits without flicker.
      */
-    value?: string
+    value?: string;
 }
 
 /**
@@ -1246,64 +1245,63 @@ interface TextInputState {
      * Returns the ID of the currently focused text field, if one exists
      * If no text field is focused it returns null
      */
-    currentlyFocusedField(): number
+    currentlyFocusedField(): number;
 
     /**
      * @param TextInputID id of the text field to focus
      * Focuses the specified text field
      * noop if the text field was already focused
      */
-    focusTextInput(textFieldID?: number): void
+    focusTextInput(textFieldID?: number): void;
 
     /**
      * @param textFieldID id of the text field to focus
      * Unfocuses the specified text field
      * noop if it wasn't focused
      */
-    blurTextInput(textFieldID?: number): void
+    blurTextInput(textFieldID?: number): void;
 }
 
 /**
  * @see https://facebook.github.io/react-native/docs/textinput.html#methods
  */
 export interface TextInputStatic extends NativeMethodsMixin, TimerMixin, React.ComponentClass<TextInputProperties> {
-    State: TextInputState
+    State: TextInputState;
 
     /**
      * Returns if the input is currently focused.
      */
-    isFocused: () => boolean
+    isFocused: () => boolean;
 
     /**
      * Removes all text from the input.
      */
-    clear: () => void
+    clear: () => void;
 }
 
 export type ToolbarAndroidAction = {
     /**
      *  title: required, the title of this action
      */
-    title: string
+    title: string;
 
     /**
      * icon: the icon for this action, e.g. require('./some_icon.png')
      */
-    icon?: ImageURISource
+    icon?: ImageURISource;
 
     /**
      * show: when to show this action as an icon or hide it in the overflow menu: always, ifRoom or never
      */
-    show?: "always" | "ifRoom" | "never"
+    show?: "always" | "ifRoom" | "never";
 
     /**
      * showWithText: boolean, whether to show text alongside the icon or not
      */
-    showWithText?: boolean
-}
+    showWithText?: boolean;
+};
 
 export interface ToolbarAndroidProperties extends ViewProperties {
-
     /**
      * Sets possible actions on the toolbar as part of the action menu. These are displayed as icons
      * or text on the right side of the widget. If they don't fit they are placed in an 'overflow'
@@ -1317,7 +1315,7 @@ export interface ToolbarAndroidProperties extends ViewProperties {
      * `ifRoom` or `never`
      * * `showWithText`: boolean, whether to show text alongside the icon or not
      */
-    actions?: ToolbarAndroidAction[]
+    actions?: ToolbarAndroidAction[];
 
     /**
      * Sets the content inset for the toolbar ending edge.
@@ -1326,7 +1324,7 @@ export interface ToolbarAndroidProperties extends ViewProperties {
      * margin for these components and can be used to effectively align
      * Toolbar content along well-known gridlines.
      */
-    contentInsetEnd?: number
+    contentInsetEnd?: number;
 
     /**
      * Sets the content inset for the toolbar starting edge.
@@ -1335,34 +1333,34 @@ export interface ToolbarAndroidProperties extends ViewProperties {
      * minimum margin for these components and can be used to effectively
      * align Toolbar content along well-known gridlines.
      */
-    contentInsetStart?: number
+    contentInsetStart?: number;
 
     /**
      * Sets the toolbar logo.
      */
-    logo?: ImageURISource
+    logo?: ImageURISource;
 
     /**
      * Sets the navigation icon.
      */
-    navIcon?: ImageURISource
+    navIcon?: ImageURISource;
 
     /**
      * Callback that is called when an action is selected. The only
      * argument that is passed to the callback is the position of the
      * action in the actions array.
      */
-    onActionSelected?: (position: number) => void
+    onActionSelected?: (position: number) => void;
 
     /**
      * Callback called when the icon is selected.
      */
-    onIconClicked?: () => void
+    onIconClicked?: () => void;
 
     /**
      * Sets the overflow icon.
      */
-    overflowIcon?: ImageURISource
+    overflowIcon?: ImageURISource;
 
     /**
      * Used to set the toolbar direction to RTL.
@@ -1372,32 +1370,32 @@ export interface ToolbarAndroidProperties extends ViewProperties {
      * setLayoutDirection(LayoutDirection.RTL) in your MainActivity
      * onCreate method.
      */
-    rtl?: boolean
+    rtl?: boolean;
 
     /**
      * Sets the toolbar subtitle.
      */
-    subtitle?: string
+    subtitle?: string;
 
     /**
      * Sets the toolbar subtitle color.
      */
-    subtitleColor?: string
+    subtitleColor?: string;
 
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testID?: string
+    testID?: string;
 
     /**
      * Sets the toolbar title.
      */
-    title?: string
+    title?: string;
 
     /**
      * Sets the toolbar title color.
      */
-    titleColor?: string
+    titleColor?: string;
 }
 
 /**
@@ -1416,10 +1414,7 @@ export interface ToolbarAndroidProperties extends ViewProperties {
  *
  * [0]: https://developer.android.com/reference/android/support/v7/widget/Toolbar.html
  */
-export interface ToolbarAndroidStatic extends NativeMethodsMixin, React.ComponentClass<ToolbarAndroidProperties> {
-
-}
-
+export interface ToolbarAndroidStatic extends NativeMethodsMixin, React.ComponentClass<ToolbarAndroidProperties> {}
 
 /**
  * Gesture recognition on mobile devices is much more complicated than web.
@@ -1447,7 +1442,6 @@ export interface ToolbarAndroidStatic extends NativeMethodsMixin, React.Componen
  * Use TouchableHighlight anywhere where you would use a button or link on web.
  */
 export interface GestureResponderHandlers {
-
     /**
      * A view can become the touch responder by implementing the correct negotiation methods.
      * There are two methods to ask the view if it wants to become responder:
@@ -1456,29 +1450,29 @@ export interface GestureResponderHandlers {
     /**
      * Does this view want to become responder on the start of a touch?
      */
-    onStartShouldSetResponder?: (event: GestureResponderEvent) => boolean
+    onStartShouldSetResponder?: (event: GestureResponderEvent) => boolean;
 
     /**
      * Called for every touch move on the View when it is not the responder: does this view want to "claim" touch responsiveness?
      */
-    onMoveShouldSetResponder?: (event: GestureResponderEvent) => boolean
+    onMoveShouldSetResponder?: (event: GestureResponderEvent) => boolean;
 
     /**
      * If the View returns true and attempts to become the responder, one of the following will happen:
      */
 
-    onResponderEnd?: ( event: GestureResponderEvent ) => void
+    onResponderEnd?: (event: GestureResponderEvent) => void;
 
     /**
      * The View is now responding for touch events.
      * This is the time to highlight and show the user what is happening
      */
-    onResponderGrant?: (event: GestureResponderEvent) => void
+    onResponderGrant?: (event: GestureResponderEvent) => void;
 
     /**
      * Something else is the responder right now and will not release it
      */
-    onResponderReject?: (event: GestureResponderEvent) => void
+    onResponderReject?: (event: GestureResponderEvent) => void;
 
     /**
      * If the view is responding, the following handlers can be called:
@@ -1487,27 +1481,27 @@ export interface GestureResponderHandlers {
     /**
      * The user is moving their finger
      */
-    onResponderMove?: (event: GestureResponderEvent) => void
+    onResponderMove?: (event: GestureResponderEvent) => void;
 
     /**
      * Fired at the end of the touch, ie "touchUp"
      */
-    onResponderRelease?: (event: GestureResponderEvent) => void
+    onResponderRelease?: (event: GestureResponderEvent) => void;
 
-    onResponderStart?: ( event: GestureResponderEvent ) => void
+    onResponderStart?: (event: GestureResponderEvent) => void;
 
     /**
      *  Something else wants to become responder.
      *  Should this view release the responder? Returning true allows release
      */
-    onResponderTerminationRequest?: (event: GestureResponderEvent) => boolean
+    onResponderTerminationRequest?: (event: GestureResponderEvent) => boolean;
 
     /**
      * The responder has been taken from the View.
      * Might be taken by other views after a call to onResponderTerminationRequest,
      * or might be taken by the OS without asking (happens with control center/ notification center on iOS)
      */
-    onResponderTerminate?: (event: GestureResponderEvent) => void
+    onResponderTerminate?: (event: GestureResponderEvent) => void;
 
     /**
      * onStartShouldSetResponder and onMoveShouldSetResponder are called with a bubbling pattern,
@@ -1522,7 +1516,7 @@ export interface GestureResponderHandlers {
      * So if a parent View wants to prevent the child from becoming responder on a touch start,
      * it should have a onStartShouldSetResponderCapture handler which returns true.
      */
-    onStartShouldSetResponderCapture?: (event: GestureResponderEvent) => boolean
+    onStartShouldSetResponderCapture?: (event: GestureResponderEvent) => boolean;
 
     /**
      * onStartShouldSetResponder and onMoveShouldSetResponder are called with a bubbling pattern,
@@ -1538,12 +1532,11 @@ export interface GestureResponderHandlers {
      * it should have a onStartShouldSetResponderCapture handler which returns true.
      */
     onMoveShouldSetResponderCapture?: () => void;
-
 }
 
 // @see https://facebook.github.io/react-native/docs/view.html#style
 export interface ViewStyle extends FlexStyle, TransformsStyle {
-    backfaceVisibility?: "visible" | "hidden"
+    backfaceVisibility?: "visible" | "hidden";
     backgroundColor?: string;
     borderBottomColor?: string;
     borderBottomLeftRadius?: number;
@@ -1554,25 +1547,23 @@ export interface ViewStyle extends FlexStyle, TransformsStyle {
     borderRadius?: number;
     borderRightColor?: string;
     borderRightWidth?: number;
-    borderStyle?: "solid" | "dotted" | "dashed"
+    borderStyle?: "solid" | "dotted" | "dashed";
     borderTopColor?: string;
     borderTopLeftRadius?: number;
     borderTopRightRadius?: number;
     borderTopWidth?: number;
     display?: "none" | "flex";
     opacity?: number;
-    overflow?: "visible" | "hidden"
+    overflow?: "visible" | "hidden";
     shadowColor?: string;
-    shadowOffset?: { width: number, height: number };
+    shadowOffset?: { width: number; height: number };
     shadowOpacity?: number;
     shadowRadius?: number;
     elevation?: number;
     testID?: string;
 }
 
-
 export interface ViewPropertiesIOS {
-
     /**
      * Provides additional traits to screen reader.
      * By default no traits are provided unless specified otherwise in element
@@ -1589,32 +1580,29 @@ export interface ViewPropertiesIOS {
      * Rasterization incurs an off-screen drawing pass and the bitmap consumes memory.
      * Test and measure when using this property.
      */
-    shouldRasterizeIOS?: boolean
+    shouldRasterizeIOS?: boolean;
 }
 
 export interface ViewPropertiesAndroid {
-
     /**
      * Indicates to accessibility services to treat UI component like a native one.
      * Works for Android only.
      */
-    accessibilityComponentType?: 'none' | 'button' | 'radiobutton_checked' | 'radiobutton_unchecked'
-
+    accessibilityComponentType?: "none" | "button" | "radiobutton_checked" | "radiobutton_unchecked";
 
     /**
      * Indicates to accessibility services whether the user should be notified when this view changes.
      * Works for Android API >= 19 only.
      * See http://developer.android.com/reference/android/view/View.html#attr_android:accessibilityLiveRegion for references.
      */
-    accessibilityLiveRegion?: 'none' | 'polite' | 'assertive'
+    accessibilityLiveRegion?: "none" | "polite" | "assertive";
 
     /**
      * Views that are only used to layout their children or otherwise don't draw anything
      * may be automatically removed from the native hierarchy as an optimization.
      * Set this property to false to disable this optimization and ensure that this View exists in the native view hierarchy.
      */
-    collapsable?: boolean
-
+    collapsable?: boolean;
 
     /**
      * Controls how view is important for accessibility which is if it fires accessibility events
@@ -1627,8 +1615,7 @@ export interface ViewPropertiesAndroid {
      *      'no' - The view is not important for accessibility.
      *      'no-hide-descendants' - The view is not important for accessibility, nor are any of its descendant views.
      */
-    importantForAccessibility?: 'auto' | 'yes' | 'no' | 'no-hide-descendants'
-
+    importantForAccessibility?: "auto" | "yes" | "no" | "no-hide-descendants";
 
     /**
      * Whether this view needs to rendered offscreen and composited with an alpha in order to preserve 100% correct colors and blending behavior.
@@ -1644,8 +1631,7 @@ export interface ViewPropertiesAndroid {
      * If that property is enabled, this View will be rendered off-screen once,
      * saved in a hardware texture, and then composited onto the screen with an alpha each frame without having to switch rendering targets on the GPU.
      */
-    needsOffscreenAlphaCompositing?: boolean
-
+    needsOffscreenAlphaCompositing?: boolean;
 
     /**
      * Whether this view should render itself (and all of its children) into a single hardware texture on the GPU.
@@ -1655,20 +1641,18 @@ export interface ViewPropertiesAndroid {
      * re-used and re-composited with different parameters. The downside is that this can use up limited video memory, so this prop should be set back to false at the end of the interaction/animation.
      */
     renderToHardwareTextureAndroid?: boolean;
-
 }
 
-type Falsy = undefined | null | false
+type Falsy = undefined | null | false;
 interface RecursiveArray<T> extends Array<T | RecursiveArray<T>> {}
 /** Keep a brand of 'T' so that calls to `StyleSheet.flatten` can take `RegisteredStyle<T>` and return `T`. */
 type RegisteredStyle<T> = number & { __registeredStyleBrand: T };
-export type StyleProp<T> = T | RegisteredStyle<T> | RecursiveArray<T | RegisteredStyle<T> | Falsy> | Falsy
+export type StyleProp<T> = T | RegisteredStyle<T> | RecursiveArray<T | RegisteredStyle<T> | Falsy> | Falsy;
 
 /**
  * @see https://facebook.github.io/react-native/docs/view.html#props
  */
 export interface ViewProperties extends ViewPropertiesAndroid, ViewPropertiesIOS, GestureResponderHandlers, Touchable {
-
     /**
      * Overrides the text that's read by the screen reader when the user interacts with the element. By default, the
      * label is constructed by traversing all the children and accumulating all the Text nodes separated by space.
@@ -1682,16 +1666,16 @@ export interface ViewProperties extends ViewPropertiesAndroid, ViewPropertiesIOS
     accessible?: boolean;
 
     /**
-    * This defines how far a touch event can start away from the view.
-    * Typical interface guidelines recommend touch targets that are at least
-    * 30 - 40 points/density-independent pixels. If a Touchable view has
-    * a height of 20 the touchable height can be extended to 40 with
-    * hitSlop={{top: 10, bottom: 10, left: 0, right: 0}}
-    * NOTE The touch area never extends past the parent view bounds and
-    * the Z-index of sibling views always takes precedence if a touch
-    * hits two overlapping views.
-    */
-    hitSlop?: Insets
+     * This defines how far a touch event can start away from the view.
+     * Typical interface guidelines recommend touch targets that are at least
+     * 30 - 40 points/density-independent pixels. If a Touchable view has
+     * a height of 20 the touchable height can be extended to 40 with
+     * hitSlop={{top: 10, bottom: 10, left: 0, right: 0}}
+     * NOTE The touch area never extends past the parent view bounds and
+     * the Z-index of sibling views always takes precedence if a touch
+     * hits two overlapping views.
+     */
+    hitSlop?: Insets;
 
     /**
      * When `accessible` is true, the system will try to invoke this function when the user performs accessibility tap gesture.
@@ -1733,7 +1717,7 @@ export interface ViewProperties extends ViewPropertiesAndroid, ViewPropertiesIOS
      * But since pointerEvents does not affect layout/appearance, and we are already deviating from the spec by adding additional modes,
      * we opt to not include pointerEvents on style. On some platforms, we would need to implement it as a className anyways. Using style or not is an implementation detail of the platform.
      */
-    pointerEvents?: "box-none" | "none" | "box-only" | "auto"
+    pointerEvents?: "box-none" | "none" | "box-only" | "auto";
 
     /**
      *
@@ -1741,9 +1725,9 @@ export interface ViewProperties extends ViewPropertiesAndroid, ViewPropertiesIOS
      * most of which are offscreen. For this property to be effective, it must be applied to a view that contains many subviews that extend outside its bound.
      * The subviews must also have overflow: hidden, as should the containing view (or one of its superviews).
      */
-    removeClippedSubviews?: boolean
+    removeClippedSubviews?: boolean;
 
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 
     /**
      * Used to locate this view in end-to-end tests.
@@ -1759,43 +1743,37 @@ export interface ViewProperties extends ViewPropertiesAndroid, ViewPropertiesIOS
  */
 export interface ViewStatic extends NativeMethodsMixin, React.ClassicComponentClass<ViewProperties> {
     AccessibilityTraits: [
-        'none',
-        'button',
-        'link',
-        'header',
-        'search',
-        'image',
-        'selected',
-        'plays',
-        'key',
-        'text',
-        'summary',
-        'disabled',
-        'frequentUpdates',
-        'startsMedia',
-        'adjustable',
-        'allowsDirectInteraction',
-        'pageTurn'
-    ]
+        "none",
+        "button",
+        "link",
+        "header",
+        "search",
+        "image",
+        "selected",
+        "plays",
+        "key",
+        "text",
+        "summary",
+        "disabled",
+        "frequentUpdates",
+        "startsMedia",
+        "adjustable",
+        "allowsDirectInteraction",
+        "pageTurn"
+    ];
 
-    AccessibilityComponentType: [
-        'none',
-        'button',
-        'radiobutton_checked',
-        'radiobutton_unchecked'
-    ],
+    AccessibilityComponentType: ["none", "button", "radiobutton_checked", "radiobutton_unchecked"];
 
     /**
      * Is 3D Touch / Force Touch available (i.e. will touch events include `force`)
      * @platform ios
      */
-    forceTouchAvailable: boolean,
+    forceTouchAvailable: boolean;
 }
 
 /**
  * @see https://facebook.github.io/react-native/docs/viewpagerandroid.html#props
  */
-
 
 export interface ViewPagerAndroidOnPageScrollEventData {
     position: number;
@@ -1846,20 +1824,20 @@ export interface ViewPagerAndroidProperties extends ViewProperties {
      * - settling, meaning that there was an interaction with the page scroller, and the
      *   page scroller is now finishing it's closing or opening animation
      */
-    onPageScrollStateChanged?: (state: "Idle" | "Dragging" | "Settling") => void
+    onPageScrollStateChanged?: (state: "Idle" | "Dragging" | "Settling") => void;
 
     /**
      * Determines whether the keyboard gets dismissed in response to a drag.
      *   - 'none' (the default), drags do not dismiss the keyboard.
      *   - 'on-drag', the keyboard is dismissed when a drag begins.
      */
-    keyboardDismissMode?: "none" | "on-drag"
+    keyboardDismissMode?: "none" | "on-drag";
 
     /**
      * Blank space to show between pages. This is only visible while scrolling, pages are still
      * edge-to-edge.
      */
-    pageMargin?: number
+    pageMargin?: number;
 }
 
 export interface ViewPagerAndroidStatic extends NativeMethodsMixin, React.ComponentClass<ViewPagerAndroidProperties> {
@@ -1867,95 +1845,91 @@ export interface ViewPagerAndroidStatic extends NativeMethodsMixin, React.Compon
      * A helper function to scroll to a specific page in the ViewPager.
      * The transition between pages will be animated.
      */
-    setPage(selectedPage: number): void
+    setPage(selectedPage: number): void;
 
     /**
      * A helper function to scroll to a specific page in the ViewPager.
      * The transition between pages will *not* be animated.
      */
-    setPageWithoutAnimation(selectedPage: number): void
+    setPageWithoutAnimation(selectedPage: number): void;
 }
 
 /**
  * It is a component to solve the common problem of views that need to move out of the way of the virtual keyboard.
  * It can automatically adjust either its position or bottom padding based on the position of the keyboard.
  */
-export interface KeyboardAvoidingViewStatic extends TimerMixin, React.ClassicComponentClass<KeyboardAvoidingViewProps> {
-
-}
+export interface KeyboardAvoidingViewStatic
+    extends TimerMixin,
+        React.ClassicComponentClass<KeyboardAvoidingViewProps> {}
 
 export interface KeyboardAvoidingViewProps extends ViewProperties {
-
-    behavior?: 'height' | 'position' | 'padding'
+    behavior?: "height" | "position" | "padding";
 
     /**
      * The style of the content container(View) when behavior is 'position'.
      */
-    contentContainerStyle?: StyleProp<ViewStyle>
+    contentContainerStyle?: StyleProp<ViewStyle>;
 
     /**
      * This is the distance between the top of the user screen and the react native view,
      * may be non-zero in some use cases.
      */
-    keyboardVerticalOffset?: number
+    keyboardVerticalOffset?: number;
 }
 
 /**
  * //FIXME: No documentation extracted from code comment on WebView.ios.js
  */
 export interface NavState {
-
-    url?: string
-    title?: string
-    loading?: boolean
-    canGoBack?: boolean
+    url?: string;
+    title?: string;
+    loading?: boolean;
+    canGoBack?: boolean;
     canGoForward?: boolean;
 
-    [key: string]: any
+    [key: string]: any;
 }
 
 /**
  * Passed data from WebView via window.postMessage.
  */
 export interface WebViewMessageEventData {
-/**
- * The data sent from a WebView; can only be a string.
- */
-data: string
+    /**
+     * The data sent from a WebView; can only be a string.
+     */
+    data: string;
 }
 
 export interface WebViewPropertiesAndroid {
-
     /**
      * Used for android only, JS is enabled by default for WebView on iOS
      */
-    javaScriptEnabled?: boolean
+    javaScriptEnabled?: boolean;
 
     /**
      * Used on Android only, controls whether DOM Storage is enabled
      * or not android
      */
-    domStorageEnabled?: boolean,
+    domStorageEnabled?: boolean;
 
     /**
      * Sets the user-agent for the WebView.
      */
-    userAgent?: string
+    userAgent?: string;
 }
 
 export interface WebViewIOSLoadRequestEvent {
-    target: number
-    canGoBack: boolean
-    lockIdentifier: number
-    loading: boolean
-    title: string
-    canGoForward: boolean
-    navigationType: 'other' | 'click'
-    url: string
+    target: number;
+    canGoBack: boolean;
+    lockIdentifier: number;
+    loading: boolean;
+    title: string;
+    canGoForward: boolean;
+    navigationType: "other" | "click";
+    url: string;
 }
 
 export interface WebViewPropertiesIOS {
-
     /**
      * Determines whether HTML5 videos play inline or use the native
      * full-screen controller. default value false
@@ -1964,14 +1938,14 @@ export interface WebViewPropertiesIOS {
      * in the HTML document must also include the webkit-playsinline
      * attribute."
      */
-    allowsInlineMediaPlayback?: boolean
+    allowsInlineMediaPlayback?: boolean;
 
     /**
      * Boolean value that determines whether the web view bounces
      * when it reaches the edge of the content. The default value is `true`.
      * @platform ios
      */
-    bounces?: boolean
+    bounces?: boolean;
 
     /**
      * Determines the types of data converted to clickable URLs in
@@ -1988,7 +1962,7 @@ export interface WebViewPropertiesIOS {
      * - `'none'`
      * - `'all'`
      */
-    dataDetectorTypes?: DataDetectorTypes | DataDetectorTypes[]
+    dataDetectorTypes?: DataDetectorTypes | DataDetectorTypes[];
 
     /**
      * A floating-point number that determines how quickly the scroll
@@ -1998,24 +1972,23 @@ export interface WebViewPropertiesIOS {
      * and UIScrollViewDecelerationRateFast respectively.
      * - normal: 0.998 - fast: 0.99 (the default for iOS WebView)
      */
-    decelerationRate?: "normal" | "fast" | number
+    decelerationRate?: "normal" | "fast" | number;
 
     /**
      * Allows custom handling of any webview requests by a JS handler.
      * Return true or false from this method to continue loading the
      * request.
      */
-    onShouldStartLoadWithRequest?: (event: WebViewIOSLoadRequestEvent) => boolean
+    onShouldStartLoadWithRequest?: (event: WebViewIOSLoadRequestEvent) => boolean;
 
     /**
      * Boolean value that determines whether scrolling is enabled in the
      * `WebView`. The default value is `true`.
      */
-    scrollEnabled?: boolean
+    scrollEnabled?: boolean;
 }
 
 export interface WebViewUriSource {
-
     /*
         * The URI to load in the WebView. Can be a local or remote file.
         */
@@ -2043,7 +2016,6 @@ export interface WebViewUriSource {
 }
 
 export interface WebViewHtmlSource {
-
     /*
         * A static HTML page to display in the WebView.
         */
@@ -2059,179 +2031,174 @@ export interface WebViewHtmlSource {
  * @see https://facebook.github.io/react-native/docs/webview.html#props
  */
 export interface WebViewProperties extends ViewProperties, WebViewPropertiesAndroid, WebViewPropertiesIOS {
-
     /**
      * Controls whether to adjust the content inset for web views that are
      * placed behind a navigation bar, tab bar, or toolbar. The default value
      * is `true`.
      */
-    automaticallyAdjustContentInsets?: boolean
+    automaticallyAdjustContentInsets?: boolean;
 
     /**
      * The amount by which the web view content is inset from the edges of
      * the scroll view. Defaults to {top: 0, left: 0, bottom: 0, right: 0}.
      */
-    contentInset?: Insets
+    contentInset?: Insets;
 
     /**
      * @deprecated
      */
-    html?: string
+    html?: string;
 
     /**
      * Set this to provide JavaScript that will be injected into the web page
      * when the view loads.
      */
-    injectedJavaScript?: string
+    injectedJavaScript?: string;
 
     /**
      * Invoked when load fails
      */
-    onError?: (event: NavState) => void
+    onError?: (event: NavState) => void;
 
     /**
      * Invoked when load finish
      */
-    onLoad?: (event: NavState) => void
+    onLoad?: (event: NavState) => void;
 
     /**
      * Invoked when load either succeeds or fails
      */
-    onLoadEnd?: (event: NavState) => void
+    onLoadEnd?: (event: NavState) => void;
 
     /**
      * Invoked on load start
      */
-    onLoadStart?: (event: NavState) => void
+    onLoadStart?: (event: NavState) => void;
 
     /**
      * Invoked when window.postMessage is called from WebView.
      */
-    onMessage?: ( event: NativeSyntheticEvent<WebViewMessageEventData> ) => void
+    onMessage?: (event: NativeSyntheticEvent<WebViewMessageEventData>) => void;
 
     /**
      * Function that is invoked when the `WebView` loading starts or ends.
      */
-    onNavigationStateChange?: ( event: NavState ) => void
+    onNavigationStateChange?: (event: NavState) => void;
 
     /**
      * Function that returns a view to show if there's an error.
      */
-    renderError?: () => React.ReactElement<ViewProperties>
+    renderError?: () => React.ReactElement<ViewProperties>;
 
     /**
      * Function that returns a loading indicator.
      */
-    renderLoading?: () => React.ReactElement<ViewProperties>
+    renderLoading?: () => React.ReactElement<ViewProperties>;
 
     /**
      * Boolean value that forces the `WebView` to show the loading view
      * on the first load.
      */
-    startInLoadingState?: boolean
+    startInLoadingState?: boolean;
 
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 
     // Deprecated: Use the `source` prop instead.
-    url?: string
+    url?: string;
 
-    source?: WebViewUriSource | WebViewHtmlSource | number
+    source?: WebViewUriSource | WebViewHtmlSource | number;
 
     /**
      * Determines whether HTML5 audio & videos require the user to tap
      * before they can start playing. The default value is false.
      */
-    mediaPlaybackRequiresUserAction?: boolean
+    mediaPlaybackRequiresUserAction?: boolean;
 
     /**
      * sets whether the webpage scales to fit the view and the user can change the scale
      */
-    scalesPageToFit?: boolean
+    scalesPageToFit?: boolean;
 }
 
-
 export interface WebViewStatic extends React.ClassicComponentClass<WebViewProperties> {
-
     /**
      * Go back one page in the webview's history.
      */
-    goBack: () => void
+    goBack: () => void;
 
     /**
      * Go forward one page in the webview's history.
      */
-    goForward: () => void
+    goForward: () => void;
 
-/**
- * Post a message to the WebView in the form of a string.
- */
-postMessage: (message: string) => void
+    /**
+     * Post a message to the WebView in the form of a string.
+     */
+    postMessage: (message: string) => void;
 
     /**
      * Reloads the current page.
      */
-    reload: () => void
+    reload: () => void;
 
     /**
      * Stop loading the current page.
      */
-    stopLoading(): void
+    stopLoading(): void;
 
     /**
-         * Returns the native webview node.
+     * Returns the native webview node.
      */
-    getWebViewHandle: () => any
+    getWebViewHandle: () => any;
 }
-
 
 /**
  * @see https://facebook.github.io/react-native/docs/segmentedcontrolios.html
  * @see SegmentedControlIOS.ios.js
  */
 export interface NativeSegmentedControlIOSChangeEvent {
-    value: string
-    selectedSegmentIndex: number
-    target: number
+    value: string;
+    selectedSegmentIndex: number;
+    target: number;
 }
 
 export interface SegmentedControlIOSProperties extends ViewProperties {
-
     /**
      * If false the user won't be able to interact with the control. Default value is true.
      */
-    enabled?: boolean
+    enabled?: boolean;
 
     /**
      * If true, then selecting a segment won't persist visually.
      * The onValueChange callback will still work as expected.
      */
-    momentary?: boolean
+    momentary?: boolean;
 
     /**
      * Callback that is called when the user taps a segment;
      * passes the event as an argument
      */
-    onChange?: (event: NativeSyntheticEvent<NativeSegmentedControlIOSChangeEvent>) => void
+    onChange?: (event: NativeSyntheticEvent<NativeSegmentedControlIOSChangeEvent>) => void;
 
     /**
      * Callback that is called when the user taps a segment; passes the segment's value as an argument
      */
-    onValueChange?: (value: string) => void
+    onValueChange?: (value: string) => void;
 
     /**
      * The index in props.values of the segment to be (pre)selected.
      */
-    selectedIndex?: number
+    selectedIndex?: number;
 
     /**
      * Accent color of the control.
      */
-    tintColor?: string
+    tintColor?: string;
 
     /**
      * The labels for the control's segment buttons, in order.
      */
-    values?: string[]
+    values?: string[];
 }
 
 /**
@@ -2240,9 +2207,7 @@ export interface SegmentedControlIOSProperties extends ViewProperties {
  * Moreover, and most importantly, Safe Area's paddings feflect physical limitation of the screen,
  * such as rounded corners or camera notches (aka sensor housing area on iPhone X).
  */
-export interface SafeAreaViewStatic extends NativeMethodsMixin, React.ClassicComponentClass<ViewProperties> {
-
-}
+export interface SafeAreaViewStatic extends NativeMethodsMixin, React.ClassicComponentClass<ViewProperties> {}
 
 /**
  * Use `SegmentedControlIOS` to render a UISegmentedControl iOS.
@@ -2264,28 +2229,27 @@ export interface SafeAreaViewStatic extends NativeMethodsMixin, React.ClassicCom
  * />
  * ````
  */
-export interface SegmentedControlIOSStatic extends NativeMethodsMixin, React.ClassicComponentClass<SegmentedControlIOSProperties> {
-
-}
-
+export interface SegmentedControlIOSStatic
+    extends NativeMethodsMixin,
+        React.ClassicComponentClass<SegmentedControlIOSProperties> {}
 
 export interface NavigatorIOSProperties {
     /**
      * The default background color of the navigation bar.
      */
-    barTintColor?: string
+    barTintColor?: string;
 
     /**
      * NavigatorIOS uses "route" objects to identify child views, their props, and navigation bar configuration.
      * "push" and all the other navigation operations expect routes to be like this
      */
-    initialRoute: Route
+    initialRoute: Route;
 
     /**
      * The default wrapper style for components in the navigator.
      * A common use case is to set the backgroundColor for every page
      */
-    itemWrapperStyle?: StyleProp<ViewStyle>
+    itemWrapperStyle?: StyleProp<ViewStyle>;
 
     /**
      * Boolean value that indicates whether the interactive pop gesture is
@@ -2298,37 +2262,37 @@ export interface NavigatorIOSProperties {
      * `interactivePopGestureEnabled` prop, you can never restore the default
      * behavior.
      */
-    interactivePopGestureEnabled?: boolean
+    interactivePopGestureEnabled?: boolean;
 
     /**
      * A Boolean value that indicates whether the navigation bar is hidden
      */
-    navigationBarHidden?: boolean
+    navigationBarHidden?: boolean;
 
     /**
      * A Boolean value that indicates whether to hide the 1px hairline shadow
      */
-    shadowHidden?: boolean
+    shadowHidden?: boolean;
 
     /**
      * The color used for buttons in the navigation bar
      */
-    tintColor?: string
+    tintColor?: string;
 
     /**
      * The text color of the navigation bar title
      */
-    titleTextColor?: string
+    titleTextColor?: string;
 
     /**
      * A Boolean value that indicates whether the navigation bar is translucent
      */
-    translucent?: boolean
+    translucent?: boolean;
 
     /**
      * NOT IN THE DOC BUT IN THE EXAMPLES
      */
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 }
 
 /**
@@ -2343,72 +2307,69 @@ export interface NavigationIOS {
     /**
      * Navigate forward to a new route
      */
-    push: (route: Route) => void
+    push: (route: Route) => void;
 
     /**
      * Go back one page
      */
-    pop: () => void
+    pop: () => void;
 
     /**
      * Go back N pages at once. When N=1, behavior matches pop()
      */
-    popN: (n: number) => void
+    popN: (n: number) => void;
 
     /**
      * Replace the route for the current page and immediately load the view for the new route
      */
-    replace: (route: Route) => void
+    replace: (route: Route) => void;
 
     /**
      * Replace the route/view for the previous page
      */
-    replacePrevious: (route: Route) => void
+    replacePrevious: (route: Route) => void;
 
     /**
      * Replaces the previous route/view and transitions back to it
      */
-    replacePreviousAndPop: (route: Route) => void
+    replacePreviousAndPop: (route: Route) => void;
 
     /**
      * Replaces the top item and popToTop
      */
-    resetTo: (route: Route) => void
+    resetTo: (route: Route) => void;
 
     /**
      * Go back to the item for a particular route object
      */
-    popToRoute(route: Route): void
+    popToRoute(route: Route): void;
 
     /**
      * Go back to the top item
      */
-    popToTop(): void
+    popToTop(): void;
 }
 
-export interface NavigatorIOSStatic extends NavigationIOS, React.ComponentClass<NavigatorIOSProperties> {
-}
-
+export interface NavigatorIOSStatic extends NavigationIOS, React.ComponentClass<NavigatorIOSProperties> {}
 
 /**
  * @see https://facebook.github.io/react-native/docs/activityindicator.html#props
  */
 export interface ActivityIndicatorProperties extends ViewProperties {
-
     /**
      * Whether to show the indicator (true, the default) or hide it (false).
      */
-    animating?: boolean
+    animating?: boolean;
 
     /**
      * The foreground color of the spinner (default is gray).
      */
-    color?: string
+    color?: string;
 
     /**
      * Whether the indicator should hide when not animating (true by default).
      */
-    hidesWhenStopped?: boolean
+    hidesWhenStopped?: boolean;
 
     /**
      * Size of the indicator.
@@ -2416,39 +2377,38 @@ export interface ActivityIndicatorProperties extends ViewProperties {
      *
      * enum('small', 'large')
      */
-    size?: number | 'small' | 'large'
+    size?: number | "small" | "large";
 
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 }
 
-export interface ActivityIndicatorStatic extends NativeMethodsMixin, React.ClassicComponentClass<ActivityIndicatorProperties> {
-}
-
+export interface ActivityIndicatorStatic
+    extends NativeMethodsMixin,
+        React.ClassicComponentClass<ActivityIndicatorProperties> {}
 
 /**
  * @see https://facebook.github.io/react-native/docs/activityindicatorios.html#props
  */
 export interface ActivityIndicatorIOSProperties extends ViewProperties {
-
     /**
      * Whether to show the indicator (true, the default) or hide it (false).
      */
-    animating?: boolean
+    animating?: boolean;
 
     /**
      * The foreground color of the spinner (default is gray).
      */
-    color?: string
+    color?: string;
 
     /**
      * Whether the indicator should hide when not animating (true by default).
      */
-    hidesWhenStopped?: boolean
+    hidesWhenStopped?: boolean;
 
     /**
      * Invoked on mount and layout changes with
      */
-    onLayout?: (event: { nativeEvent: { layout: { x: number, y: number, width: number, height: number } } }) => void
+    onLayout?: (event: { nativeEvent: { layout: { x: number; y: number; width: number; height: number } } }) => void;
 
     /**
      * Size of the indicator.
@@ -2456,76 +2416,69 @@ export interface ActivityIndicatorIOSProperties extends ViewProperties {
      *
      * enum('small', 'large')
      */
-    size?: 'small' | 'large'
+    size?: "small" | "large";
 
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 }
 
 /**
  * @Deprecated since version 0.28.0
  */
-export interface ActivityIndicatorIOSStatic extends React.ComponentClass<ActivityIndicatorIOSProperties> {
-}
-
+export interface ActivityIndicatorIOSStatic extends React.ComponentClass<ActivityIndicatorIOSProperties> {}
 
 export interface DatePickerIOSProperties extends ViewProperties {
-
     /**
      * The currently selected date.
      */
-    date: Date
-
-
-    /**
-     * Maximum date.
-     * Restricts the range of possible date/time values.
-     */
-    maximumDate?: Date
+    date: Date;
 
     /**
      * Maximum date.
      * Restricts the range of possible date/time values.
      */
-    minimumDate?: Date
+    maximumDate?: Date;
+
+    /**
+     * Maximum date.
+     * Restricts the range of possible date/time values.
+     */
+    minimumDate?: Date;
 
     /**
      *  enum(1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30)
      *  The interval at which minutes can be selected.
      */
-    minuteInterval?: number
+    minuteInterval?: number;
 
     /**
      *  enum('date', 'time', 'datetime')
      *  The date picker mode.
      */
-    mode?: "date" | "time" | "datetime"
+    mode?: "date" | "time" | "datetime";
 
     /**
      * Date change handler.
      * This is called when the user changes the date or time in the UI.
      * The first and only argument is a Date object representing the new date and time.
      */
-    onDateChange: ( newDate: Date ) => void
+    onDateChange: (newDate: Date) => void;
 
     /**
      * Timezone offset in minutes.
      * By default, the date picker will use the device's timezone. With this parameter, it is possible to force a certain timezone offset.
      * For instance, to show times in Pacific Standard Time, pass -7 * 60.
      */
-    timeZoneOffsetInMinutes?: number
+    timeZoneOffsetInMinutes?: number;
 }
 
-export interface DatePickerIOSStatic extends NativeMethodsMixin, React.ComponentClass<DatePickerIOSProperties> {
-}
+export interface DatePickerIOSStatic extends NativeMethodsMixin, React.ComponentClass<DatePickerIOSProperties> {}
 
-export interface DrawerSlideEvent extends NativeSyntheticEvent<NativeTouchEvent> {
-}
+export interface DrawerSlideEvent extends NativeSyntheticEvent<NativeTouchEvent> {}
 
 /**
  * @see DrawerLayoutAndroid.android.js
  */
 export interface DrawerLayoutAndroidProperties extends ViewProperties {
-
     /**
      * Specifies the background color of the drawer. The default value
      * is white. If you want to set the opacity of the drawer, use rgba.
@@ -2570,22 +2523,22 @@ export interface DrawerLayoutAndroidProperties extends ViewProperties {
      * - 'none' (the default), drags do not dismiss the keyboard.
      * - 'on-drag', the keyboard is dismissed when a drag begins.
      */
-    keyboardDismissMode?: "none" | "on-drag"
+    keyboardDismissMode?: "none" | "on-drag";
 
     /**
      * Function called whenever the navigation view has been closed.
      */
-    onDrawerClose?: () => void
+    onDrawerClose?: () => void;
 
     /**
      * Function called whenever the navigation view has been opened.
      */
-    onDrawerOpen?: () => void
+    onDrawerOpen?: () => void;
 
     /**
      * Function called whenever there is an interaction with the navigation view.
      */
-    onDrawerSlide?: (event: DrawerSlideEvent) => void
+    onDrawerSlide?: (event: DrawerSlideEvent) => void;
 
     /**
      * Function called when the drawer state has changed.
@@ -2598,89 +2551,86 @@ export interface DrawerLayoutAndroidProperties extends ViewProperties {
      *   navigation view, and the navigation view is now finishing
      *   it's closing or opening animation
      */
-    onDrawerStateChanged?: (event: "Idle" | "Dragging" | "Settling") => void
+    onDrawerStateChanged?: (event: "Idle" | "Dragging" | "Settling") => void;
 
     /**
      * The navigation view that will be rendered to the side of the
      * screen and can be pulled in.
      */
-    renderNavigationView: () => JSX.Element
+    renderNavigationView: () => JSX.Element;
 
     /**
      * Make the drawer take the entire screen and draw the background of
      * the status bar to allow it to open over the status bar. It will
      * only have an effect on API 21+.
      */
-    statusBarBackgroundColor?: string
+    statusBarBackgroundColor?: string;
 }
 
 interface DrawerPosition {
-    Left: number
-    Right: number
+    Left: number;
+    Right: number;
 }
 
-export interface DrawerLayoutAndroidStatic extends NativeMethodsMixin, React.ClassicComponentClass<DrawerLayoutAndroidProperties> {
-
+export interface DrawerLayoutAndroidStatic
+    extends NativeMethodsMixin,
+        React.ClassicComponentClass<DrawerLayoutAndroidProperties> {
     /**
      * drawer's positions.
      */
-    positions: DrawerPosition
+    positions: DrawerPosition;
 
     /**
      * Opens the drawer.
      */
-    openDrawer(): void
+    openDrawer(): void;
 
     /**
      * Closes the drawer.
      */
-    closeDrawer(): void
+    closeDrawer(): void;
 }
 
 /**
  * @see PickerIOS.ios.js
  */
 export interface PickerIOSItemProperties {
-    value?: string | number
-    label?: string
+    value?: string | number;
+    label?: string;
 }
 
 /**
  * @see PickerIOS.ios.js
  */
-export interface PickerIOSItemStatic extends React.ComponentClass<PickerIOSItemProperties> {
-}
+export interface PickerIOSItemStatic extends React.ComponentClass<PickerIOSItemProperties> {}
 
 /**
  * @see Picker.js
  */
 export interface PickerItemProperties {
-    testID?: string
-    color?: string
-    label: string
-    value?: any
+    testID?: string;
+    color?: string;
+    label: string;
+    value?: any;
 }
 
-export interface PickerItem extends React.ComponentClass<PickerItemProperties> {
-}
+export interface PickerItem extends React.ComponentClass<PickerItemProperties> {}
 
 export interface PickerPropertiesIOS extends ViewProperties {
-
     /**
      * Style to apply to each of the item labels.
      * @platform ios
      */
-    itemStyle?: StyleProp<ViewStyle>,
+    itemStyle?: StyleProp<ViewStyle>;
 }
 
 export interface PickerPropertiesAndroid extends ViewProperties {
-
     /**
      * If set to false, the picker will be disabled, i.e. the user will not be able to make a
      * selection.
      * @platform android
      */
-    enabled?: boolean
+    enabled?: boolean;
 
     /**
      * On Android, specifies how to display the selection items when the user taps on the picker:
@@ -2690,13 +2640,13 @@ export interface PickerPropertiesAndroid extends ViewProperties {
      *
      * @platform android
      */
-    mode?: "dialog" | "dropdown"
+    mode?: "dialog" | "dropdown";
 
     /**
      * Prompt string for this picker, used on Android in dialog mode as the title of the dialog.
      * @platform android
      */
-    prompt?: string
+    prompt?: string;
 }
 
 /**
@@ -2704,27 +2654,26 @@ export interface PickerPropertiesAndroid extends ViewProperties {
  * @see Picker.js
  */
 export interface PickerProperties extends PickerPropertiesIOS, PickerPropertiesAndroid {
-
     /**
      * Callback for when an item is selected. This is called with the
      * following parameters:
      * - itemValue: the value prop of the item that was selected
      * - itemPosition: the index of the selected item in this picker
      */
-    onValueChange?: (itemValue: any, itemPosition: number) => void
+    onValueChange?: (itemValue: any, itemPosition: number) => void;
 
     /**
      * Value matching value of one of the items.
      * Can be a string or an integer.
      */
-    selectedValue?: any
+    selectedValue?: any;
 
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testId?: string
+    testId?: string;
 }
 
 /**
@@ -2732,17 +2681,16 @@ export interface PickerProperties extends PickerPropertiesIOS, PickerPropertiesA
  * @see Picker.js
  */
 export interface PickerStatic extends React.ComponentClass<PickerProperties> {
-
     /**
      * On Android, display the options in a dialog.
      */
-    MODE_DIALOG: string
+    MODE_DIALOG: string;
     /**
      * On Android, display the options in a dropdown (this is the default).
      */
-    MODE_DROPDOWN: string
+    MODE_DROPDOWN: string;
 
-    Item: PickerItem
+    Item: PickerItem;
 }
 
 /**
@@ -2750,10 +2698,9 @@ export interface PickerStatic extends React.ComponentClass<PickerProperties> {
  * @see PickerIOS.ios.js
  */
 export interface PickerIOSProperties extends ViewProperties {
-
-    itemStyle?: StyleProp<TextStyle>
-    onValueChange?: ( value: string | number ) => void
-    selectedValue?: string | number
+    itemStyle?: StyleProp<TextStyle>;
+    onValueChange?: (value: string | number) => void;
+    selectedValue?: string | number;
 }
 
 /**
@@ -2761,8 +2708,7 @@ export interface PickerIOSProperties extends ViewProperties {
  * @see PickerIOS.ios.js
  */
 export interface PickerIOSStatic extends NativeMethodsMixin, React.ClassicComponentClass<PickerIOSProperties> {
-
-    Item: PickerIOSItemStatic
+    Item: PickerIOSItemStatic;
 }
 
 /**
@@ -2770,7 +2716,6 @@ export interface PickerIOSStatic extends NativeMethodsMixin, React.ClassicCompon
  * @see ProgressBarAndroid.android.js
  */
 export interface ProgressBarAndroidProperties extends ViewProperties {
-
     /**
      * Style of the ProgressBar. One of:
          Horizontal
@@ -2781,133 +2726,131 @@ export interface ProgressBarAndroidProperties extends ViewProperties {
          SmallInverse
          LargeInverse
      */
-    styleAttr?: "Horizontal" | "Normal" | "Small" | "Large" | "Inverse" | "SmallInverse" | "LargeInverse"
+    styleAttr?: "Horizontal" | "Normal" | "Small" | "Large" | "Inverse" | "SmallInverse" | "LargeInverse";
 
     /**
      * If the progress bar will show indeterminate progress.
      * Note that this can only be false if styleAttr is Horizontal.
      */
-    indeterminate?: boolean
+    indeterminate?: boolean;
 
     /**
      * The progress value (between 0 and 1).
      */
-    progress?: number
+    progress?: number;
 
     /**
      * Color of the progress bar.
      */
-    color?: string
+    color?: string;
 
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testID?: string
+    testID?: string;
 }
 /**
  * React component that wraps the Android-only `ProgressBar`. This component is used to indicate
  * that the app is loading or there is some activity in the app.
-*/
-export interface ProgressBarAndroidStatic extends NativeMethodsMixin, React.ClassicComponentClass<ProgressBarAndroidProperties> {
-}
+ */
+export interface ProgressBarAndroidStatic
+    extends NativeMethodsMixin,
+        React.ClassicComponentClass<ProgressBarAndroidProperties> {}
 
 /**
  * @see https://facebook.github.io/react-native/docs/progressviewios.html
  * @see ProgressViewIOS.ios.js
  */
 export interface ProgressViewIOSProperties extends ViewProperties {
-
     /**
      * The progress bar style.
      */
-    progressViewStyle?: "default" | "bar"
+    progressViewStyle?: "default" | "bar";
 
     /**
      * The progress value (between 0 and 1).
      */
-    progress?: number
+    progress?: number;
 
     /**
      * The tint color of the progress bar itself.
      */
-    progressTintColor?: string
+    progressTintColor?: string;
 
     /**
      * The tint color of the progress bar track.
      */
-    trackTintColor?: string
+    trackTintColor?: string;
 
     /**
      * A stretchable image to display as the progress bar.
      */
-    progressImage?: ImageURISource | ImageURISource[]
+    progressImage?: ImageURISource | ImageURISource[];
 
     /**
      * A stretchable image to display behind the progress bar.
      */
-    trackImage?: ImageURISource | ImageURISource[]
+    trackImage?: ImageURISource | ImageURISource[];
 }
-export interface ProgressViewIOSStatic extends NativeMethodsMixin, React.ClassicComponentClass<ProgressViewIOSProperties> {
-}
+export interface ProgressViewIOSStatic
+    extends NativeMethodsMixin,
+        React.ClassicComponentClass<ProgressViewIOSProperties> {}
 
 export interface RefreshControlPropertiesIOS extends ViewProperties {
-
     /**
      * The color of the refresh indicator.
      */
-    tintColor?: string
+    tintColor?: string;
 
     /**
      * The title displayed under the refresh indicator.
      */
-    title?: string
+    title?: string;
 
     /**
      * Title color.
      */
-    titleColor?: string
+    titleColor?: string;
 }
 
 export interface RefreshControlPropertiesAndroid extends ViewProperties {
-
     /**
      * The colors (at least one) that will be used to draw the refresh indicator.
      */
-    colors?: string[]
+    colors?: string[];
 
     /**
      * Whether the pull to refresh functionality is enabled.
      */
-    enabled?: boolean
+    enabled?: boolean;
 
     /**
      * The background color of the refresh indicator.
      */
-    progressBackgroundColor?: string
+    progressBackgroundColor?: string;
 
     /**
      * Size of the refresh indicator, see RefreshControl.SIZE.
      */
-    size?: number
+    size?: number;
 
     /**
      * Progress view top offset
      * @platform android
      */
-    progressViewOffset?: number
+    progressViewOffset?: number;
 }
 
 export interface RefreshControlProperties extends RefreshControlPropertiesIOS, RefreshControlPropertiesAndroid {
-
     /**
      * Called when the view starts refreshing.
      */
-    onRefresh?: () => void
+    onRefresh?: () => void;
 
     /**
      * Whether the view should be indicating an active refresh.
      */
-    refreshing: boolean
+    refreshing: boolean;
 }
 
 /**
@@ -2918,12 +2861,13 @@ export interface RefreshControlProperties extends RefreshControlPropertiesIOS, R
  * __Note:__ `refreshing` is a controlled prop, this is why it needs to be set to true
  * in the `onRefresh` function otherwise the refresh indicator will stop immediately.
  */
-export interface RefreshControlStatic extends NativeMethodsMixin, React.ClassicComponentClass<RefreshControlProperties> {
-    SIZE: Object // Undocumented
+export interface RefreshControlStatic
+    extends NativeMethodsMixin,
+        React.ClassicComponentClass<RefreshControlProperties> {
+    SIZE: Object; // Undocumented
 }
 
-export interface RecyclerViewBackedScrollViewProperties extends ScrollViewProperties {
-}
+export interface RecyclerViewBackedScrollViewProperties extends ScrollViewProperties {}
 
 /**
  * Wrapper around android native recycler view.
@@ -2939,8 +2883,9 @@ export interface RecyclerViewBackedScrollViewProperties extends ScrollViewProper
  * use it pass this component as `renderScrollComponent` to the list view. For
  * now only horizontal scrolling is supported.
  */
-export interface RecyclerViewBackedScrollViewStatic extends ScrollResponderMixin, React.ClassicComponentClass<RecyclerViewBackedScrollViewProperties> {
-
+export interface RecyclerViewBackedScrollViewStatic
+    extends ScrollResponderMixin,
+        React.ClassicComponentClass<RecyclerViewBackedScrollViewProperties> {
     /**
      * A helper function to scroll to a specific point  in the scrollview.
      * This is currently used to help focus on child textviews, but can also
@@ -2952,11 +2897,7 @@ export interface RecyclerViewBackedScrollViewStatic extends ScrollResponderMixin
      * the function also accepts separate arguments as as alternative to the options object.
      * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
      */
-    scrollTo(
-        y?: number | { x?: number, y?: number, animated?: boolean },
-        x?: number,
-        animated?: boolean
-    ): void;
+    scrollTo(y?: number | { x?: number; y?: number; animated?: boolean }, x?: number, animated?: boolean): void;
 
     /**
      * Returns a reference to the underlying scroll responder, which supports
@@ -2971,90 +2912,88 @@ export interface SliderPropertiesAndroid extends ViewProperties {
     /**
      * Color of the foreground switch grip.
      */
-    thumbTintColor?: string,
+    thumbTintColor?: string;
 }
 
 export interface SliderPropertiesIOS extends ViewProperties {
-
     /**
      * Assigns a maximum track image. Only static images are supported.
      * The leftmost pixel of the image will be stretched to fill the track.
      */
-    maximumTrackImage?: ImageURISource
+    maximumTrackImage?: ImageURISource;
 
     /**
      * Assigns a minimum track image. Only static images are supported.
      * The rightmost pixel of the image will be stretched to fill the track.
      */
-    minimumTrackImage?: ImageURISource
+    minimumTrackImage?: ImageURISource;
 
     /**
      * Sets an image for the thumb. Only static images are supported.
      */
-    thumbImage?: ImageURISource
+    thumbImage?: ImageURISource;
 
     /**
      * Assigns a single image for the track. Only static images
      * are supported. The center pixel of the image will be stretched
      * to fill the track.
      */
-    trackImage?: ImageURISource
+    trackImage?: ImageURISource;
 }
 
 export interface SliderProperties extends SliderPropertiesIOS, SliderPropertiesAndroid {
-
     /**
      * If true the user won't be able to move the slider.
      * Default value is false.
      */
-    disabled?: boolean
+    disabled?: boolean;
 
     /**
      * The color used for the track to the right of the button.
      * Overrides the default blue gradient image.
      */
-    maximumTrackTintColor?: string
+    maximumTrackTintColor?: string;
 
     /**
      * Initial maximum value of the slider. Default value is 1.
      */
-    maximumValue?: number
+    maximumValue?: number;
 
     /**
      * The color used for the track to the left of the button.
      * Overrides the default blue gradient image.
      */
-    minimumTrackTintColor?: string
+    minimumTrackTintColor?: string;
 
     /**
      * Initial minimum value of the slider. Default value is 0.
      */
-    minimumValue?: number
+    minimumValue?: number;
 
     /**
      * Callback called when the user finishes changing the value (e.g. when the slider is released).
      */
-    onSlidingComplete?: (value: number) => void
+    onSlidingComplete?: (value: number) => void;
 
     /**
      * Callback continuously called while the user is dragging the slider.
      */
-    onValueChange?: (value: number) => void
+    onValueChange?: (value: number) => void;
 
     /**
      * Step value of the slider. The value should be between 0 and (maximumValue - minimumValue). Default value is 0.
      */
-    step?: number
+    step?: number;
 
     /**
      * Used to style and layout the Slider. See StyleSheet.js and ViewStylePropTypes.js for more info.
      */
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 
     /**
      * Used to locate this view in UI automation tests.
      */
-    testID?: string
+    testID?: string;
 
     /**
      * Initial value of the slider. The value should be between minimumValue
@@ -3063,50 +3002,47 @@ export interface SliderProperties extends SliderPropertiesIOS, SliderPropertiesA
      * This is not a controlled component, you don't need to update
      * the value during dragging.
      */
-    value?: number
+    value?: number;
 }
 
 /**
  * A component used to select a single value from a range of values.
  */
-export interface SliderStatic extends NativeMethodsMixin, React.ClassicComponentClass<SliderProperties> {
-
-}
+export interface SliderStatic extends NativeMethodsMixin, React.ClassicComponentClass<SliderProperties> {}
 
 /**
  * https://facebook.github.io/react-native/docs/switchios.html#props
  */
 export interface SwitchIOSProperties extends ViewProperties {
-
     /**
      * If true the user won't be able to toggle the switch. Default value is false.
      */
-    disabled?: boolean
+    disabled?: boolean;
 
     /**
      * Background color when the switch is turned on.
      */
-    onTintColor?: string
+    onTintColor?: string;
 
     /**
      * Callback that is called when the user toggles the switch.
      */
-    onValueChange?: (value: boolean) => void
+    onValueChange?: (value: boolean) => void;
 
     /**
      * Background color for the switch round button.
      */
-    thumbTintColor?: string
+    thumbTintColor?: string;
 
     /**
      * Background color when the switch is turned off.
      */
-    tintColor?: string
+    tintColor?: string;
 
     /**
      * The value of the switch, if true the switch will be turned on. Default value is false.
      */
-    value?: boolean
+    value?: boolean;
 }
 
 /**
@@ -3118,11 +3054,9 @@ export interface SwitchIOSProperties extends ViewProperties {
  *
  * @see https://facebook.github.io/react-native/docs/switchios.html
  */
-export interface SwitchIOSStatic extends React.ComponentClass<SwitchIOSProperties> {
+export interface SwitchIOSStatic extends React.ComponentClass<SwitchIOSProperties> {}
 
-}
-
-export type ImageResizeMode =  "contain" | "cover" | "stretch" | "center" | "repeat"
+export type ImageResizeMode = "contain" | "cover" | "stretch" | "center" | "repeat";
 
 /**
  * @see ImageResizeMode.js
@@ -3132,37 +3066,37 @@ export interface ImageResizeModeStatic {
      * contain - The image will be resized such that it will be completely
      * visible, contained within the frame of the View.
      */
-    contain: ImageResizeMode
+    contain: ImageResizeMode;
     /**
      * cover - The image will be resized such that the entire area of the view
      * is covered by the image, potentially clipping parts of the image.
      */
-    cover: ImageResizeMode
+    cover: ImageResizeMode;
     /**
      * stretch - The image will be stretched to fill the entire frame of the
      * view without clipping.  This may change the aspect ratio of the image,
      * distoring it.  Only supported on iOS.
      */
-    stretch: ImageResizeMode
+    stretch: ImageResizeMode;
     /**
      * center - The image will be scaled down such that it is completely visible,
      * if bigger than the area of the view.
      * The image will not be scaled up.
      */
-    center: ImageResizeMode,
+    center: ImageResizeMode;
 
     /**
      * repeat - The image will be repeated to cover the frame of the View. The
      * image will keep it's size and aspect ratio.
      */
-    repeat: ImageResizeMode,
+    repeat: ImageResizeMode;
 }
 
 export interface ShadowStyleIOS {
-    shadowColor?: string
-    shadowOffset?: {width: number, height: number}
-    shadowOpacity?: number
-    shadowRadius?: number
+    shadowColor?: string;
+    shadowOffset?: { width: number; height: number };
+    shadowOpacity?: number;
+    shadowRadius?: number;
 }
 
 /**
@@ -3170,20 +3104,20 @@ export interface ShadowStyleIOS {
  * @see https://facebook.github.io/react-native/docs/image.html#style
  */
 export interface ImageStyle extends FlexStyle, TransformsStyle, ShadowStyleIOS {
-    resizeMode?: ImageResizeMode
-    backfaceVisibility?: "visible" | "hidden"
-    borderBottomLeftRadius?: number
-    borderBottomRightRadius?: number
-    backgroundColor?: string
-    borderColor?: string
-    borderWidth?: number
-    borderRadius?: number
-    borderTopLeftRadius?: number
-    borderTopRightRadius?: number
-    overflow?: "visible" | "hidden"
-    overlayColor?: string
-    tintColor?: string
-    opacity?: number
+    resizeMode?: ImageResizeMode;
+    backfaceVisibility?: "visible" | "hidden";
+    borderBottomLeftRadius?: number;
+    borderBottomRightRadius?: number;
+    backgroundColor?: string;
+    borderColor?: string;
+    borderWidth?: number;
+    borderRadius?: number;
+    borderTopLeftRadius?: number;
+    borderTopRightRadius?: number;
+    overflow?: "visible" | "hidden";
+    overlayColor?: string;
+    tintColor?: string;
+    opacity?: number;
 }
 
 /*
@@ -3196,22 +3130,22 @@ export interface ImageURISource {
      * resource (which should be wrapped in the `require('./path/to/image.png')`
      * function).
      */
-    uri?: string,
+    uri?: string;
     /**
      * `bundle` is the iOS asset bundle which the image is included in. This
      * will default to [NSBundle mainBundle] if not set.
      * @platform ios
      */
-    bundle?: string,
+    bundle?: string;
     /**
      * `method` is the HTTP Method to use. Defaults to GET if not specified.
      */
-    method?: string,
+    method?: string;
     /**
      * `headers` is an object representing the HTTP headers to send along with the
      * request for a remote image.
      */
-    headers?: {[key: string]: string},
+    headers?: { [key: string]: string };
     /**
      * `cache` determines how the requests handles potentially cached
      * responses.
@@ -3232,24 +3166,24 @@ export interface ImageURISource {
      *
      * @platform ios
      */
-    cache?: 'default' | 'reload' | 'force-cache' | 'only-if-cached',
+    cache?: "default" | "reload" | "force-cache" | "only-if-cached";
     /**
      * `body` is the HTTP body to send with the request. This must be a valid
      * UTF-8 string, and will be sent exactly as specified, with no
      * additional encoding (e.g. URL-escaping or base64) applied.
      */
-    body?: string,
+    body?: string;
     /**
      * `width` and `height` can be specified if known at build time, in which case
      * these will be used to set the default `<Image/>` component dimensions.
      */
-    width?: number,
-    height?: number,
+    width?: number;
+    height?: number;
     /**
      * `scale` is used to indicate the scale factor of the image. Defaults to 1.0 if
      * unspecified, meaning that one image pixel equates to one display point / DIP.
      */
-    scale?: number,
+    scale?: number;
 }
 
 export type ImageRequireSource = number;
@@ -3266,10 +3200,10 @@ export interface ImagePropertiesIOS {
     accessible?: boolean;
 
     /**
-    * blurRadius: the blur radius of the blur filter added to the image
-    * @platform ios
-    */
-    blurRadius?: number,
+     * blurRadius: the blur radius of the blur filter added to the image
+     * @platform ios
+     */
+    blurRadius?: number;
 
     /**
      * When the image is resized, the corners of the size specified by capInsets will stay a fixed size,
@@ -3277,17 +3211,17 @@ export interface ImagePropertiesIOS {
      * This is useful for creating resizable rounded buttons, shadows, and other resizable assets.
      * More info on Apple documentation
      */
-    capInsets?: Insets
+    capInsets?: Insets;
 
     /**
      * A static image to display while downloading the final image off the network.
      */
-    defaultSource?: ImageURISource | number
+    defaultSource?: ImageURISource | number;
 
     /**
      * Invoked on download progress with {nativeEvent: {loaded, total}}
      */
-    onProgress?: (event: { nativeEvent: { loaded: number, total: number }}) => void
+    onProgress?: (event: { nativeEvent: { loaded: number; total: number } }) => void;
 
     /**
      * Invoked when a partial load of the image is complete. The definition of
@@ -3295,7 +3229,7 @@ export interface ImagePropertiesIOS {
      * for progressive JPEG loads.
      * @platform ios
      */
-    onPartialLoad?: () => void,
+    onPartialLoad?: () => void;
 }
 
 interface ImagePropertiesAndroid {
@@ -3312,7 +3246,7 @@ interface ImagePropertiesAndroid {
      * and produces higher quality images. This should be used if the image is smaller than the view.
      * It should also be used if the image is slightly bigger than the view.
      */
-    resizeMethod?: 'auto' | 'resize' | 'scale'
+    resizeMethod?: "auto" | "resize" | "scale";
 
     /**
      * Duration of fade in animation.
@@ -3336,24 +3270,24 @@ export interface ImageProperties extends ImagePropertiesIOS, ImagePropertiesAndr
     /**
      * Invoked on load error with {nativeEvent: {error}}
      */
-    onError?: (error: { nativeEvent: any }) => void
+    onError?: (error: { nativeEvent: any }) => void;
 
     /**
      * Invoked when load completes successfully
      */
-    onLoad?: () => void
+    onLoad?: () => void;
 
     /**
      * Invoked when load either succeeds or fails
      */
-    onLoadEnd?: () => void
+    onLoadEnd?: () => void;
 
     /**
      * Invoked on load start
      */
-    onLoadStart?: () => void
+    onLoadStart?: () => void;
 
-    progressiveRenderingEnabled?: boolean
+    progressiveRenderingEnabled?: boolean;
 
     /**
      * Determines how to resize the image when the frame doesn't match the raw
@@ -3377,7 +3311,7 @@ export interface ImageProperties extends ImagePropertiesIOS, ImagePropertiesAndr
      * if bigger than the area of the view.
      * The image will not be scaled up.
      */
-    resizeMode?: 'cover' | 'contain' | 'stretch' | 'repeat' | 'center'
+    resizeMode?: "cover" | "contain" | "stretch" | "repeat" | "center";
 
     /**
      * The mechanism that should be used to resize the image when the image's dimensions
@@ -3398,7 +3332,7 @@ export interface ImageProperties extends ImagePropertiesIOS, ImagePropertiesAndr
      *
      * @platform android
      */
-    resizeMethod?: 'auto' | 'resize' | 'scale'
+    resizeMethod?: "auto" | "resize" | "scale";
 
     /**
      * `uri` is a string representing the resource identifier for the image, which
@@ -3408,7 +3342,7 @@ export interface ImageProperties extends ImagePropertiesIOS, ImagePropertiesAndr
      * their width and height. The native side will then choose the best `uri` to display
      * based on the measured size of the image container.
      */
-    source: ImageURISource | ImageURISource[] | ImageRequireSource
+    source: ImageURISource | ImageURISource[] | ImageRequireSource;
 
     /**
      * similarly to `source`, this property represents the resource used to render
@@ -3427,32 +3361,27 @@ export interface ImageProperties extends ImagePropertiesIOS, ImagePropertiesAndr
      * A unique identifier for this element to be used in UI Automation testing scripts.
      */
     testID?: string;
-
 }
 
 export interface ImageStatic extends NativeMethodsMixin, React.ComponentClass<ImageProperties> {
-    resizeMode: ImageResizeMode
-    getSize(uri: string, success: (width: number, height: number) => void, failure: (error: any) => void): any
-    prefetch(url: string): any
-    abortPrefetch?(requestId: number): void
-    queryCache?(urls: string[]): Promise<Map<string, 'memory' | 'disk'>>
+    resizeMode: ImageResizeMode;
+    getSize(uri: string, success: (width: number, height: number) => void, failure: (error: any) => void): any;
+    prefetch(url: string): any;
+    abortPrefetch?(requestId: number): void;
+    queryCache?(urls: string[]): Promise<Map<string, "memory" | "disk">>;
 }
 
 export interface ImageBackgroundProperties extends ImageProperties {
-    style?: StyleProp<ViewStyle>
-    imageStyle?: StyleProp<ImageStyle>
+    style?: StyleProp<ViewStyle>;
+    imageStyle?: StyleProp<ImageStyle>;
 }
 
 export interface ImageBackgroundStatic extends NativeMethodsMixin, React.ComponentClass<ImageBackgroundProperties> {
-    resizeMode: ImageResizeMode
-    getSize(
-      uri: string,
-      success: (width: number, height: number) => void,
-      failure: (error: any) => void
-    ): any
-    prefetch(url: string): any
-    abortPrefetch?(requestId: number): void
-    queryCache?(urls: string[]): Promise<Map<string, 'memory' | 'disk'>>
+    resizeMode: ImageResizeMode;
+    getSize(uri: string, success: (width: number, height: number) => void, failure: (error: any) => void): any;
+    prefetch(url: string): any;
+    abortPrefetch?(requestId: number): void;
+    queryCache?(urls: string[]): Promise<Map<string, "memory" | "disk">>;
 }
 
 export interface ViewToken {
@@ -3497,46 +3426,44 @@ export interface ViewabilityConfig {
  */
 
 interface ListRenderItemInfo<ItemT> {
+    item: ItemT;
 
-    item: ItemT
-
-    index: number
+    index: number;
 
     separators: {
-        highlight: () => void,
-        unhighlight: () => void,
-        updateProps: (select: 'leading' | 'trailing', newProps: any) => void,
-    },
+        highlight: () => void;
+        unhighlight: () => void;
+        updateProps: (select: "leading" | "trailing", newProps: any) => void;
+    };
 }
 
-type ListRenderItem<ItemT> = (info: ListRenderItemInfo<ItemT>) => React.ReactElement<any> | null
+type ListRenderItem<ItemT> = (info: ListRenderItemInfo<ItemT>) => React.ReactElement<any> | null;
 
 export interface FlatListProperties<ItemT> extends VirtualizedListProperties<ItemT> {
-
     /**
      * Rendered in between each item, but not at the top or bottom
      */
-    ItemSeparatorComponent?: React.ComponentType<any> | (() => React.ReactElement<any>) | null
+    ItemSeparatorComponent?: React.ComponentType<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
+    ListEmptyComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
+    ListFooterComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
+    ListHeaderComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Optional custom style for multi-item rows generated when numColumns > 1
      */
-    columnWrapperStyle?: StyleProp<ViewStyle>
+    columnWrapperStyle?: StyleProp<ViewStyle>;
 
     /**
      * When false tapping outside of the focused text input when the keyboard
@@ -3544,7 +3471,7 @@ export interface FlatListProperties<ItemT> extends VirtualizedListProperties<Ite
      * taps and the keyboard will not dismiss automatically. The default value
      * is false.
      */
-    keyboardShouldPersistTaps?: boolean | 'always' | 'never' | 'handled'
+    keyboardShouldPersistTaps?: boolean | "always" | "never" | "handled";
 
     /**
      * For simplicity, data is just a plain array. If you want to use something else,
@@ -3557,7 +3484,7 @@ export interface FlatListProperties<ItemT> extends VirtualizedListProperties<Ite
      * If any of your `renderItem`, Header, Footer, etc. functions depend on anything outside of the `data` prop,
      * stick it here and treat it immutably.
      */
-    extraData?: any
+    extraData?: any;
 
     /**
      * `getItemLayout` is an optional optimization that lets us skip measurement of dynamic
@@ -3571,42 +3498,42 @@ export interface FlatListProperties<ItemT> extends VirtualizedListProperties<Ite
      * Remember to include separator length (height or width) in your offset calculation if you specify
      * `ItemSeparatorComponent`.
      */
-    getItemLayout?: (data: Array<ItemT> | null, index: number) => {length: number, offset: number, index: number}
+    getItemLayout?: (data: Array<ItemT> | null, index: number) => { length: number; offset: number; index: number };
 
     /**
      * If true, renders items next to each other horizontally instead of stacked vertically.
      */
-    horizontal?: boolean
+    horizontal?: boolean;
 
     /**
      * How many items to render in the initial batch
      */
-    initialNumToRender?: number
+    initialNumToRender?: number;
 
     /**
      * Instead of starting at the top with the first item, start at initialScrollIndex
      */
-    initialScrollIndex?: number
+    initialScrollIndex?: number;
 
     /**
      * Used to extract a unique key for a given item at the specified index. Key is used for caching
      * and as the react key to track item re-ordering. The default extractor checks `item.key`, then
      * falls back to using the index, like React does.
      */
-    keyExtractor?: (item: ItemT, index: number) => string
+    keyExtractor?: (item: ItemT, index: number) => string;
 
-    legacyImplementation?: boolean
+    legacyImplementation?: boolean;
 
     /**
      * Multiple columns can only be rendered with `horizontal={false}` and will zig-zag like a `flexWrap` layout.
      * Items should all be the same height - masonry layouts are not supported.
      */
-    numColumns?: number
+    numColumns?: number;
 
     /**
      * Called once when the scroll position gets within onEndReachedThreshold of the rendered content.
      */
-    onEndReached?: ((info: {distanceFromEnd: number}) => void) | null
+    onEndReached?: ((info: { distanceFromEnd: number }) => void) | null;
 
     /**
      * How far from the end (in units of visible length of the list) the bottom edge of the
@@ -3614,23 +3541,23 @@ export interface FlatListProperties<ItemT> extends VirtualizedListProperties<Ite
      * Thus a value of 0.5 will trigger `onEndReached` when the end of the content is
      * within half the visible length of the list.
      */
-    onEndReachedThreshold?: number | null
+    onEndReachedThreshold?: number | null;
 
     /**
      * If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality.
      * Make sure to also set the refreshing prop correctly.
      */
-    onRefresh?: (() => void) | null
+    onRefresh?: (() => void) | null;
 
     /**
      * Called when the viewability of rows changes, as defined by the `viewablePercentThreshold` prop.
      */
-    onViewableItemsChanged?: ((info: {viewableItems: Array<ViewToken>, changed: Array<ViewToken>}) => void) | null
+    onViewableItemsChanged?: ((info: { viewableItems: Array<ViewToken>; changed: Array<ViewToken> }) => void) | null;
 
     /**
      * Set this true while waiting for new data from a refresh.
      */
-    refreshing?: boolean | null
+    refreshing?: boolean | null;
 
     /**
      * Takes an item from data and renders it into the list. Typical usage:
@@ -3645,78 +3572,76 @@ export interface FlatListProperties<ItemT> extends VirtualizedListProperties<Ite
      * ```
      * Provides additional metadata like `index` if you need it.
      */
-    renderItem: ListRenderItem<ItemT>
+    renderItem: ListRenderItem<ItemT>;
 
     /**
      * See `ViewabilityHelper` for flow type and further documentation.
      */
-    viewabilityConfig?: any
+    viewabilityConfig?: any;
 
     /**
      * Note: may have bugs (missing content) in some circumstances - use at your own risk.
      *
      * This may improve scroll performance for large lists.
      */
-    removeClippedSubviews?: boolean
+    removeClippedSubviews?: boolean;
 }
 
 export interface FlatListStatic<ItemT> extends React.ComponentClass<FlatListProperties<ItemT>> {
-
     /**
      * Exports some data, e.g. for perf investigations or analytics.
      */
     getMetrics: () => {
-        contentLength: number,
-        totalRows: number,
-        renderedRows: number,
-        visibleRows: number,
-    }
+        contentLength: number;
+        totalRows: number;
+        renderedRows: number;
+        visibleRows: number;
+    };
 
     /**
      * Scrolls to the end of the content. May be janky without `getItemLayout` prop.
      */
-    scrollToEnd: (params?: {animated?: boolean}) => void
+    scrollToEnd: (params?: { animated?: boolean }) => void;
 
     /**
      * Scrolls to the item at a the specified index such that it is positioned in the viewable area
      * such that `viewPosition` 0 places it at the top, 1 at the bottom, and 0.5 centered in the middle.
      * May be janky without `getItemLayout` prop.
      */
-    scrollToIndex: (params: {animated?: boolean, index: number, viewPosition?: number}) => void
+    scrollToIndex: (params: { animated?: boolean; index: number; viewPosition?: number }) => void;
 
     /**
      * Requires linear scan through data - use `scrollToIndex` instead if possible.
      * May be janky without `getItemLayout` prop.
      */
-    scrollToItem: (params: {animated?: boolean, index: number, viewPosition?: number}) => void
+    scrollToItem: (params: { animated?: boolean; index: number; viewPosition?: number }) => void;
 
     /**
      * Scroll to a specific content pixel offset, like a normal `ScrollView`.
      */
-    scrollToOffset: (params: {animated?: boolean, offset: number}) => void
+    scrollToOffset: (params: { animated?: boolean; offset: number }) => void;
 
     /**
      * Tells the list an interaction has occured, which should trigger viewability calculations,
      * e.g. if waitForInteractions is true and the user has not scrolled. This is typically called
      * by taps on items or by navigation actions.
      */
-    recordInteraction: () => void
+    recordInteraction: () => void;
 }
 
 /**
  * @see https://facebook.github.io/react-native/docs/sectionlist.html
  */
 export interface SectionBase<ItemT> {
+    data: ItemT[];
 
-    data: ItemT[]
+    key?: string;
 
-    key?: string
+    renderItem?: ListRenderItem<ItemT>;
 
-    renderItem?: ListRenderItem<ItemT>
+    ItemSeparatorComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null;
 
-    ItemSeparatorComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null
-
-    keyExtractor?: (item: ItemT, index: number) => string
+    keyExtractor?: (item: ItemT, index: number) => string;
 }
 
 export interface SectionListData<ItemT> extends SectionBase<ItemT> {
@@ -3724,38 +3649,37 @@ export interface SectionListData<ItemT> extends SectionBase<ItemT> {
 }
 
 export interface SectionListProperties<ItemT> extends ScrollViewProperties {
-
     /**
      * Rendered in between adjacent Items within each section.
      */
-    ItemSeparatorComponent?: React.ComponentType<any> | null
+    ItemSeparatorComponent?: React.ComponentType<any> | null;
 
     /**
      * Rendered when the list is empty.
      */
-    ListEmptyComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
+    ListEmptyComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Rendered at the very end of the list.
      */
-    ListFooterComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null
+    ListFooterComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Rendered at the very beginning of the list.
      */
-    ListHeaderComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null
+    ListHeaderComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Rendered in between each section.
      */
-    SectionSeparatorComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null
+    SectionSeparatorComponent?: React.ComponentClass<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * A marker property for telling the list to re-render (since it implements PureComponent).
      * If any of your `renderItem`, Header, Footer, etc. functions depend on anything outside of the `data` prop,
      * stick it here and treat it immutably.
      */
-    extraData?: any
+    extraData?: any;
 
     /**
      * `getItemLayout` is an optional optimization that lets us skip measurement of dynamic
@@ -3767,147 +3691,150 @@ export interface SectionListProperties<ItemT> extends ScrollViewProperties {
      * )}
      * ```
      */
-    getItemLayout?: (data: SectionListData<ItemT>[] | null, index: number) => {length: number, offset: number, index: number}
+    getItemLayout?: (
+        data: SectionListData<ItemT>[] | null,
+        index: number
+    ) => { length: number; offset: number; index: number };
 
     /**
      * How many items to render in the initial batch
      */
-    initialNumToRender?: number
+    initialNumToRender?: number;
 
     /**
      * Used to extract a unique key for a given item at the specified index. Key is used for caching
      * and as the react key to track item re-ordering. The default extractor checks `item.key`, then
      * falls back to using the index, like React does.
      */
-    keyExtractor?: (item: ItemT, index: number) => string
+    keyExtractor?: (item: ItemT, index: number) => string;
 
     /**
      * If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality.
      * Make sure to also set the refreshing prop correctly.
      */
-    onRefresh?: (() => void) | null
+    onRefresh?: (() => void) | null;
 
     /**
      * Set this true while waiting for new data from a refresh.
      */
-    refreshing?: boolean | null
+    refreshing?: boolean | null;
 
     /**
      * Default renderer for every item in every section. Can be over-ridden on a per-section basis.
      */
-    renderItem?: ListRenderItem<ItemT>
+    renderItem?: ListRenderItem<ItemT>;
 
     /**
      * Rendered at the top of each section. Sticky headers are not yet supported.
      */
-    renderSectionHeader?: (info: {section: SectionListData<ItemT>}) => React.ReactElement<any> | null
+    renderSectionHeader?: (info: { section: SectionListData<ItemT> }) => React.ReactElement<any> | null;
 
     /**
      * Rendered at the bottom of each section.
      */
-    renderSectionFooter?: (info: {section: SectionListData<ItemT>}) => React.ReactElement<any> | null
+    renderSectionFooter?: (info: { section: SectionListData<ItemT> }) => React.ReactElement<any> | null;
 
     /**
      * An array of objects with data for each section.
      */
-    sections: SectionListData<ItemT>[]
+    sections: SectionListData<ItemT>[];
 
     /**
      * Render a custom scroll component, e.g. with a differently styled `RefreshControl`.
      */
-    renderScrollComponent?: (props: ScrollViewProperties) => React.ReactElement<ScrollViewProperties>
+    renderScrollComponent?: (props: ScrollViewProperties) => React.ReactElement<ScrollViewProperties>;
 
     /**
      * Note: may have bugs (missing content) in some circumstances - use at your own risk.
      *
      * This may improve scroll performance for large lists.
-    */
-    removeClippedSubviews?: boolean
+     */
+    removeClippedSubviews?: boolean;
 
     /**
      * Makes section headers stick to the top of the screen until the next one pushes it off.
      * Only enabled by default on iOS because that is the platform standard there.
      */
-    stickySectionHeadersEnabled?: boolean
+    stickySectionHeadersEnabled?: boolean;
 }
 
-export interface SectionListStatic<SectionT> extends React.ComponentClass<SectionListProperties<SectionT>> {
-
-}
+export interface SectionListStatic<SectionT> extends React.ComponentClass<SectionListProperties<SectionT>> {}
 
 /**
  * @see https://facebook.github.io/react-native/docs/virtualizedlist.html#props
  */
 export interface VirtualizedListProperties<ItemT> extends ScrollViewProperties {
-
     /**
      * Rendered when the list is empty. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListEmptyComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
+    ListEmptyComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Rendered at the bottom of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListFooterComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
+    ListFooterComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * Rendered at the top of all the items. Can be a React Component Class, a render function, or
      * a rendered element.
      */
-    ListHeaderComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null
+    ListHeaderComponent?: React.ComponentClass<any> | React.ReactElement<any> | (() => React.ReactElement<any>) | null;
 
     /**
      * The default accessor functions assume this is an Array<{key: string}> but you can override
      * getItem, getItemCount, and keyExtractor to handle any type of index-based data.
      */
-    data?: any
+    data?: any;
 
     /**
      * `debug` will turn on extra logging and visual overlays to aid with debugging both usage and
      * implementation, but with a significant perf hit.
      */
-    debug?: boolean
+    debug?: boolean;
 
     /**
      * DEPRECATED: Virtualization provides significant performance and memory optimizations, but fully
      * unmounts react instances that are outside of the render window. You should only need to disable
      * this for debugging purposes.
      */
-    disableVirtualization?: boolean
+    disableVirtualization?: boolean;
 
     /**
      * A marker property for telling the list to re-render (since it implements `PureComponent`). If
      * any of your `renderItem`, Header, Footer, etc. functions depend on anything outside of the
      * `data` prop, stick it here and treat it immutably.
      */
-    extraData?: any
+    extraData?: any;
 
     /**
      * A generic accessor for extracting an item from any sort of data blob.
      */
-    getItem?: (data: any, index: number) => ItemT
+    getItem?: (data: any, index: number) => ItemT;
 
     /**
      * Determines how many items are in the data blob.
      */
-    getItemCount?: (data: any) => number
+    getItemCount?: (data: any) => number;
 
-    getItemLayout?: (data: any, index: number) => {
-        length: number,
-        offset: number,
+    getItemLayout?: (
+        data: any,
         index: number
-    }
+    ) => {
+        length: number;
+        offset: number;
+        index: number;
+    };
 
-    horizontal?: boolean
+    horizontal?: boolean;
 
     /**
      * How many items to render in the initial batch. This should be enough to fill the screen but not
      * much more. Note these items will never be unmounted as part of the windowed rendering in order
      * to improve perceived performance of scroll-to-top actions.
      */
-    initialNumToRender?: number
+    initialNumToRender?: number;
 
     /**
      * Instead of starting at the top with the first item, start at `initialScrollIndex`. This
@@ -3915,25 +3842,25 @@ export interface VirtualizedListProperties<ItemT> extends ScrollViewProperties {
      * always rendered and immediately renders the items starting at this initial index. Requires
      * `getItemLayout` to be implemented.
      */
-    initialScrollIndex?: number
+    initialScrollIndex?: number;
 
     /**
      * Reverses the direction of scroll. Uses scale transforms of -1.
      */
-    inverted?: boolean
+    inverted?: boolean;
 
-    keyExtractor?: (item: ItemT, index: number) => string
+    keyExtractor?: (item: ItemT, index: number) => string;
 
     /**
      * The maximum number of items to render in each incremental render batch. The more rendered at
      * once, the better the fill rate, but responsiveness my suffer because rendering content may
      * interfere with responding to button taps or other interactions.
      */
-    maxToRenderPerBatch?: number
+    maxToRenderPerBatch?: number;
 
-    onEndReached?: ((info: {distanceFromEnd: number}) => void) | null
+    onEndReached?: ((info: { distanceFromEnd: number }) => void) | null;
 
-    onEndReachedThreshold?: number | null
+    onEndReachedThreshold?: number | null;
 
     onLayout?: (event: LayoutChangeEvent) => void;
 
@@ -3941,46 +3868,46 @@ export interface VirtualizedListProperties<ItemT> extends ScrollViewProperties {
      * If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make
      * sure to also set the `refreshing` prop correctly.
      */
-    onRefresh?: (() => void) | null
+    onRefresh?: (() => void) | null;
 
     /**
      * Called when the viewability of rows changes, as defined by the
      * `viewabilityConfig` prop.
      */
-    onViewableItemsChanged?: ((info: {viewableItems: Array<ViewToken>, changed: Array<ViewToken>}) => void) | null
+    onViewableItemsChanged?: ((info: { viewableItems: Array<ViewToken>; changed: Array<ViewToken> }) => void) | null;
 
     /**
      * Set this when offset is needed for the loading indicator to show correctly.
      * @platform android
      */
-    progressViewOffset?: number
+    progressViewOffset?: number;
 
     /**
      * Set this true while waiting for new data from a refresh.
      */
-    refreshing?: boolean | null
+    refreshing?: boolean | null;
 
     /**
      * Note: may have bugs (missing content) in some circumstances - use at your own risk.
      *
      * This may improve scroll performance for large lists.
      */
-    removeClippedSubviews?: boolean
+    removeClippedSubviews?: boolean;
 
-    renderItem: ListRenderItem<ItemT>
+    renderItem: ListRenderItem<ItemT>;
 
     /**
      * Render a custom scroll component, e.g. with a differently styled `RefreshControl`.
      */
-    renderScrollComponent?: (props: ScrollViewProperties) => React.ReactElement<ScrollViewProperties>
+    renderScrollComponent?: (props: ScrollViewProperties) => React.ReactElement<ScrollViewProperties>;
 
     /**
      * Amount of time between low-pri item render batches, e.g. for rendering items quite a ways off
      * screen. Similar fill rate/responsiveness tradeoff as `maxToRenderPerBatch`.
      */
-    updateCellsBatchingPeriod?: number
+    updateCellsBatchingPeriod?: number;
 
-    viewabilityConfig?: ViewabilityConfig
+    viewabilityConfig?: ViewabilityConfig;
 
     /**
      * Determines the maximum number of items rendered outside of the visible area, in units of
@@ -3989,18 +3916,17 @@ export interface VirtualizedListProperties<ItemT> extends ScrollViewProperties {
      * this number will reduce memory consumption and may improve performance, but will increase the
      * chance that fast scrolling may reveal momentary blank areas of unrendered content.
      */
-    windowSize?: number
+    windowSize?: number;
 }
 
 /**
  * @see https://facebook.github.io/react-native/docs/listview.html#props
  */
 export interface ListViewProperties extends ScrollViewProperties {
-
     /**
      * An instance of [ListView.DataSource](docs/listviewdatasource.html) to use
      */
-    dataSource: ListViewDataSource
+    dataSource: ListViewDataSource;
 
     /**
      * Flag indicating whether empty section headers should be rendered.
@@ -4009,14 +3935,14 @@ export interface ListViewProperties extends ScrollViewProperties {
      * desired to be rendered their indices should be excluded from
      * sectionID object.
      */
-    enableEmptySections?: boolean
+    enableEmptySections?: boolean;
 
     /**
      * How many rows to render on initial component mount.  Use this to make
      * it so that the first screen worth of data apears at one time instead of
      * over the course of multiple frames.
      */
-    initialListSize?: number
+    initialListSize?: number;
 
     /**
      * (visibleRows, changedRows) => void
@@ -4027,31 +3953,34 @@ export interface ListViewProperties extends ScrollViewProperties {
      * that have changed their visibility, with true indicating visible, and
      * false indicating the view has moved out of view.
      */
-    onChangeVisibleRows?: (visibleRows: Array<{ [sectionId: string]: { [rowID: string]: boolean } }>, changedRows: Array<{ [sectionId: string]: { [rowID: string]: boolean } }>) => void
+    onChangeVisibleRows?: (
+        visibleRows: Array<{ [sectionId: string]: { [rowID: string]: boolean } }>,
+        changedRows: Array<{ [sectionId: string]: { [rowID: string]: boolean } }>
+    ) => void;
 
     /**
      * Called when all rows have been rendered and the list has been scrolled
      * to within onEndReachedThreshold of the bottom.  The native scroll
      * event is provided.
      */
-    onEndReached?: () => void
+    onEndReached?: () => void;
 
     /**
      * Threshold in pixels for onEndReached.
      */
-    onEndReachedThreshold?: number
+    onEndReachedThreshold?: number;
 
     /**
      * Number of rows to render per event loop.
      */
-    pageSize?: number
+    pageSize?: number;
 
     /**
      * A performance optimization for improving scroll perf of
      * large lists, used in conjunction with overflow: 'hidden' on the row
      * containers.  Use at your own risk.
      */
-    removeClippedSubviews?: boolean
+    removeClippedSubviews?: boolean;
 
     /**
      * () => renderable
@@ -4061,7 +3990,7 @@ export interface ListViewProperties extends ScrollViewProperties {
      * in StaticContainer or other mechanism as appropriate.  Footer is always
      * at the bottom of the list, and header at the top, on every render pass.
      */
-    renderFooter?: () => React.ReactElement<any>
+    renderFooter?: () => React.ReactElement<any>;
 
     /**
      * () => renderable
@@ -4071,7 +4000,7 @@ export interface ListViewProperties extends ScrollViewProperties {
      * in StaticContainer or other mechanism as appropriate.  Footer is always
      * at the bottom of the list, and header at the top, on every render pass.
      */
-    renderHeader?: () => React.ReactElement<any>
+    renderHeader?: () => React.ReactElement<any>;
 
     /**
      * (rowData, sectionID, rowID) => renderable
@@ -4080,14 +4009,18 @@ export interface ListViewProperties extends ScrollViewProperties {
      * is exactly what was put into the data source, but it's also possible to
      * provide custom extractors.
      */
-    renderRow: ( rowData: any, sectionID: string | number, rowID: string | number, highlightRow?: boolean ) => React.ReactElement<any>
-
+    renderRow: (
+        rowData: any,
+        sectionID: string | number,
+        rowID: string | number,
+        highlightRow?: boolean
+    ) => React.ReactElement<any>;
 
     /**
      * A function that returns the scrollable component in which the list rows are rendered.
      * Defaults to returning a ScrollView with the given props.
      */
-    renderScrollComponent?: (props: ScrollViewProperties) => React.ReactElement<ScrollViewProperties>
+    renderScrollComponent?: (props: ScrollViewProperties) => React.ReactElement<ScrollViewProperties>;
 
     /**
      * (sectionData, sectionID) => renderable
@@ -4098,8 +4031,7 @@ export interface ListViewProperties extends ScrollViewProperties {
      * stick to the top until it is pushed off the screen by the next section
      * header.
      */
-    renderSectionHeader?: (sectionData: any, sectionId: string | number) => React.ReactElement<any>
-
+    renderSectionHeader?: (sectionData: any, sectionId: string | number) => React.ReactElement<any>;
 
     /**
      * (sectionID, rowID, adjacentRowHighlighted) => renderable
@@ -4107,13 +4039,17 @@ export interface ListViewProperties extends ScrollViewProperties {
      * but not the last row if there is a section header below.
      * Take a sectionID and rowID of the row above and whether its adjacent row is highlighted.
      */
-    renderSeparator?: (sectionID: string | number, rowID: string | number, adjacentRowHighlighted?: boolean) => React.ReactElement<any>
+    renderSeparator?: (
+        sectionID: string | number,
+        rowID: string | number,
+        adjacentRowHighlighted?: boolean
+    ) => React.ReactElement<any>;
 
     /**
      * How early to start rendering rows before they come on screen, in
      * pixels.
      */
-    scrollRenderAheadDistance?: number
+    scrollRenderAheadDistance?: number;
 
     /**
      * An array of child indices determining which children get docked to the
@@ -4123,7 +4059,7 @@ export interface ListViewProperties extends ScrollViewProperties {
      * with `horizontal={true}`.
      * @platform ios
      */
-    stickyHeaderIndices?: number[]
+    stickyHeaderIndices?: number[];
 
     /**
      * Makes the sections headers sticky. The sticky behavior means that it will scroll with the
@@ -4132,19 +4068,18 @@ export interface ListViewProperties extends ScrollViewProperties {
      * property is not supported in conjunction with `horizontal={true}`. Only enabled by default
      * on iOS because of typical platform standards.
      */
-    stickySectionHeadersEnabled?: boolean
+    stickySectionHeadersEnabled?: boolean;
 }
 
-
 interface TimerMixin {
-    setTimeout: typeof setTimeout,
-    clearTimeout: typeof clearTimeout,
-    setInterval: typeof setInterval,
-    clearInterval: typeof clearInterval,
-    setImmediate: typeof setImmediate,
-    clearImmediate: typeof clearImmediate,
-    requestAnimationFrame: typeof requestAnimationFrame,
-    cancelAnimationFrame: typeof cancelAnimationFrame,
+    setTimeout: typeof setTimeout;
+    clearTimeout: typeof clearTimeout;
+    setInterval: typeof setInterval;
+    clearInterval: typeof clearInterval;
+    setImmediate: typeof setImmediate;
+    clearImmediate: typeof clearImmediate;
+    requestAnimationFrame: typeof requestAnimationFrame;
+    cancelAnimationFrame: typeof cancelAnimationFrame;
 }
 
 export interface ListViewStatic extends ScrollResponderMixin, TimerMixin, React.ComponentClass<ListViewProperties> {
@@ -4154,88 +4089,86 @@ export interface ListViewStatic extends ScrollResponderMixin, TimerMixin, React.
      * Exports some data, e.g. for perf investigations or analytics.
      */
     getMetrics: () => {
-        contentLength: number,
-        totalRows: number,
-        renderedRows: number,
-        visibleRows: number,
-    }
+        contentLength: number;
+        totalRows: number;
+        renderedRows: number;
+        visibleRows: number;
+    };
 
     /**
      * Provides a handle to the underlying scroll responder.
      */
-    getScrollResponder: () => any,
+    getScrollResponder: () => any;
 
     /**
      * Scrolls to a given x, y offset, either immediately or with a smooth animation.
      *
      * See `ScrollView#scrollTo`.
      */
-    scrollTo: ( y?: number | { x?: number, y?: number, animated?: boolean } , x?: number, animated?: boolean ) => void,
+    scrollTo: (y?: number | { x?: number; y?: number; animated?: boolean }, x?: number, animated?: boolean) => void;
 }
 
-
 export interface MapViewAnnotation {
-    latitude: number
-    longitude: number
-    animateDrop?: boolean
-    draggable?: boolean
-    onDragStateChange?: () => any,
-    onFocus?: () => any,
-    onBlur?: () => any,
-    title?: string
-    subtitle?: string
-    leftCalloutView?: React.ReactElement<any>
-    rightCalloutView?: React.ReactElement<any>
-    detailCalloutView?: React.ReactElement<any>
-    tintColor?: string
-    image?: ImageURISource
-    view?: React.ReactElement<any>
-    hasLeftCallout?: boolean
-    hasRightCallout?: boolean
-    onLeftCalloutPress?: () => void
-    onRightCalloutPress?: () => void
-    id?: string
+    latitude: number;
+    longitude: number;
+    animateDrop?: boolean;
+    draggable?: boolean;
+    onDragStateChange?: () => any;
+    onFocus?: () => any;
+    onBlur?: () => any;
+    title?: string;
+    subtitle?: string;
+    leftCalloutView?: React.ReactElement<any>;
+    rightCalloutView?: React.ReactElement<any>;
+    detailCalloutView?: React.ReactElement<any>;
+    tintColor?: string;
+    image?: ImageURISource;
+    view?: React.ReactElement<any>;
+    hasLeftCallout?: boolean;
+    hasRightCallout?: boolean;
+    onLeftCalloutPress?: () => void;
+    onRightCalloutPress?: () => void;
+    id?: string;
 }
 
 export interface MapViewRegion {
-    latitude: number
-    longitude: number
-    latitudeDelta?: number
-    longitudeDelta?: number
+    latitude: number;
+    longitude: number;
+    latitudeDelta?: number;
+    longitudeDelta?: number;
 }
 
 export interface MapViewOverlay {
-    coordinates: ({ latitude: number, longitude: number })[]
-    lineWidth?: number
-    strokeColor?: string
-    fillColor?: string
-    id?: string
+    coordinates: ({ latitude: number; longitude: number })[];
+    lineWidth?: number;
+    strokeColor?: string;
+    fillColor?: string;
+    id?: string;
 }
 
 export interface MapViewProperties extends ViewProperties {
-
     /**
      * If false points of interest won't be displayed on the map.
      * Default value is true.
      */
-    showsPointsOfInterest?: boolean
+    showsPointsOfInterest?: boolean;
 
     /**
      * Map annotations with title/subtitle.
      */
-    annotations?: MapViewAnnotation[]
+    annotations?: MapViewAnnotation[];
 
     /**
      * If true the map will follow the user's location whenever it changes.
      * Note that this has no effect unless showsUserLocation is enabled.
      * Default value is true.
      */
-    followUserLocation?: boolean
+    followUserLocation?: boolean;
 
     /**
      * Insets for the map's legal label, originally at bottom left of the map. See EdgeInsetsPropType.js for more information.
      */
-    legalLabelInsets?: Insets
+    legalLabelInsets?: Insets;
 
     /**
      * The map type to be displayed.
@@ -4245,43 +4178,43 @@ export interface MapViewProperties extends ViewProperties {
      *
      * enum('standard', 'satellite', 'hybrid')
      */
-    mapType?: 'standard' |'satellite' |'hybrid'
+    mapType?: "standard" | "satellite" | "hybrid";
 
     /**
      * Maximum size of area that can be displayed.
      */
-    maxDelta?: number
+    maxDelta?: number;
 
     /**
      * Minimum size of area that can be displayed.
      */
-    minDelta?: number
+    minDelta?: number;
 
     /**
      * Map overlays
      */
-    overlays?: MapViewOverlay[]
+    overlays?: MapViewOverlay[];
 
     /**
      * If false compass won't be displayed on the map.
      * Default value is true.
      */
-    showsCompass?: boolean
+    showsCompass?: boolean;
 
     /**
      * Callback that is called once, when the user taps an annotation.
      */
-    onAnnotationPress?: () => void
+    onAnnotationPress?: () => void;
 
     /**
      * Callback that is called continuously when the user is dragging the map.
      */
-    onRegionChange?: (region: MapViewRegion) => void
+    onRegionChange?: (region: MapViewRegion) => void;
 
     /**
      * Callback that is called once, when the user is done moving the map.
      */
-    onRegionChangeComplete?: (region: MapViewRegion) => void
+    onRegionChangeComplete?: (region: MapViewRegion) => void;
 
     /**
      * When this property is set to true and a valid camera is associated with the map,
@@ -4290,13 +4223,13 @@ export interface MapViewProperties extends ViewProperties {
      * When this property is set to false, the camera’s pitch angle is ignored and
      * the map is always displayed as if the user is looking straight down onto it.
      */
-    pitchEnabled?: boolean
+    pitchEnabled?: boolean;
 
     /**
      * The region to be displayed by the map.
      * The region is defined by the center coordinates and the span of coordinates to display.
      */
-    region?: MapViewRegion
+    region?: MapViewRegion;
 
     /**
      * When this property is set to true and a valid camera is associated with the map,
@@ -4305,13 +4238,13 @@ export interface MapViewProperties extends ViewProperties {
      * When this property is set to false, the camera’s heading angle is ignored and the map is always oriented
      * so that true north is situated at the top of the map view
      */
-    rotateEnabled?: boolean
+    rotateEnabled?: boolean;
 
     /**
      * If false the user won't be able to change the map region being displayed.
      * Default value is true.
      */
-    scrollEnabled?: boolean
+    scrollEnabled?: boolean;
 
     /**
      * If true the app will ask for the user's location and focus on it.
@@ -4320,19 +4253,19 @@ export interface MapViewProperties extends ViewProperties {
      * NOTE: You need to add NSLocationWhenInUseUsageDescription key in Info.plist to enable geolocation,
      * otherwise it is going to fail silently!
      */
-    showsUserLocation?: boolean
+    showsUserLocation?: boolean;
 
     /**
      * Used to style and layout the MapView.
      * See StyleSheet.js and ViewStylePropTypes.js for more info.
      */
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 
     /**
      * If false the user won't be able to pinch/zoom the map.
      * Default value is true.
      */
-    zoomEnabled?: boolean
+    zoomEnabled?: boolean;
 }
 
 /**
@@ -4340,27 +4273,25 @@ export interface MapViewProperties extends ViewProperties {
  */
 export interface MapViewStatic extends NativeMethodsMixin, React.ComponentClass<MapViewProperties> {
     PinColors: {
-        RED: string,
-        GREEN: string,
-        PURPLE: string
-    }
+        RED: string;
+        GREEN: string;
+        PURPLE: string;
+    };
 }
 
 interface MaskedViewProperties extends ViewProperties {
-    maskElement: React.ReactElement<any>,
+    maskElement: React.ReactElement<any>;
 }
 
 /**
  * @see https://facebook.github.io/react-native/docs/maskedviewios.html
  */
-export interface MaskedViewStatic extends NativeMethodsMixin, React.ComponentClass<MaskedViewProperties> {
-}
+export interface MaskedViewStatic extends NativeMethodsMixin, React.ComponentClass<MaskedViewProperties> {}
 
 export interface ModalProperties {
-
     // Only `animated` is documented. The JS code says `animated` is
     // deprecated and `animationType` is preferred.
-    animated?: boolean
+    animated?: boolean;
     /**
      * The `animationType` prop controls how the modal animates.
      *
@@ -4368,54 +4299,56 @@ export interface ModalProperties {
      * - `fade` fades into view
      * - `none` appears without an animation
      */
-    animationType?: "none" | "slide" | "fade"
+    animationType?: "none" | "slide" | "fade";
     /**
      * The `transparent` prop determines whether your modal will fill the entire view.
      * Setting this to `true` will render the modal over a transparent background.
      */
-    transparent?: boolean
+    transparent?: boolean;
     /**
      * The `visible` prop determines whether your modal is visible.
      */
-    visible?: boolean
+    visible?: boolean;
     /**
      * The `onRequestClose` prop allows passing a function that will be called once the modal has been dismissed.
      * _On the Android platform, this is a required function._
      */
-    onRequestClose?: () => void
+    onRequestClose?: () => void;
     /**
      * The `onShow` prop allows passing a function that will be called once the modal has been shown.
      */
-    onShow?: (event: NativeSyntheticEvent<any>) => void
+    onShow?: (event: NativeSyntheticEvent<any>) => void;
     /**
      * The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations.
      * On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field.
      * @platform ios
      */
-    supportedOrientations?: ('portrait' | 'portrait-upside-down' | 'landscape' | 'landscape-left' | 'landscape-right')[]
+    supportedOrientations?: (
+        | "portrait"
+        | "portrait-upside-down"
+        | "landscape"
+        | "landscape-left"
+        | "landscape-right")[];
     /**
      * The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed.
      * The orientation provided is only 'portrait' or 'landscape'. This callback is also called on initial render, regardless of the current orientation.
      * @platform ios
      */
-    onOrientationChange?: () => void
+    onOrientationChange?: () => void;
 }
 
-export interface ModalStatic extends React.ComponentClass<ModalProperties> {
-
-}
+export interface ModalStatic extends React.ComponentClass<ModalProperties> {}
 
 /**
  * @see https://github.com/facebook/react-native/blob/0.34-stable\Libraries\Components\Touchable\Touchable.js
  */
 interface TouchableMixin {
-
     /**
      * Invoked when the item should be highlighted. Mixers should implement this
      * to visually distinguish the `VisualRect` so that the user knows that
      * releasing a touch will result in a "selection" (analog to click).
      */
-    touchableHandleActivePressIn(e: GestureResponderEvent): void
+    touchableHandleActivePressIn(e: GestureResponderEvent): void;
 
     /**
      * Invoked when the item is "active" (in that it is still eligible to become
@@ -4426,14 +4359,14 @@ interface TouchableMixin {
      * event will not fire on an `touchEnd/mouseUp` event, only move events while
      * the user is depressing the mouse/touch.
      */
-    touchableHandleActivePressOut(e: GestureResponderEvent): void
+    touchableHandleActivePressOut(e: GestureResponderEvent): void;
 
     /**
      * Invoked when the item is "selected" - meaning the interaction ended by
      * letting up while the item was either in the state
      * `RESPONDER_ACTIVE_PRESS_IN` or `RESPONDER_INACTIVE_PRESS_IN`.
      */
-    touchableHandlePress(e: GestureResponderEvent): void
+    touchableHandlePress(e: GestureResponderEvent): void;
 
     /**
      * Invoked when the item is long pressed - meaning the interaction ended by
@@ -4445,68 +4378,66 @@ interface TouchableMixin {
      * to return false. As a result, `touchableHandlePress` will be called when
      * lifting up, even if `touchableHandleLongPress` has also been called.
      */
-    touchableHandleLongPress(e: GestureResponderEvent): void
+    touchableHandleLongPress(e: GestureResponderEvent): void;
 
     /**
      * Returns the amount to extend the `HitRect` into the `PressRect`. Positive
      * numbers mean the size expands outwards.
      */
-    touchableGetPressRectOffset(): Insets
+    touchableGetPressRectOffset(): Insets;
 
     /**
      * Returns the number of millis to wait before triggering a highlight.
      */
-    touchableGetHighlightDelayMS(): number
+    touchableGetHighlightDelayMS(): number;
 
     // These methods are undocumented but still being used by TouchableMixin internals
-    touchableGetLongPressDelayMS(): number
-    touchableGetPressOutDelayMS(): number
-    touchableGetHitSlop(): Insets
+    touchableGetLongPressDelayMS(): number;
+    touchableGetPressOutDelayMS(): number;
+    touchableGetHitSlop(): Insets;
 }
 
 export interface TouchableWithoutFeedbackAndroidProperties {
-
     /**
      * Indicates to accessibility services to treat UI component like a native one.
      * Works for Android only.
      */
-    accessibilityComponentType?: 'none' | 'button' | 'radiobutton_checked' | 'radiobutton_unchecked'
+    accessibilityComponentType?: "none" | "button" | "radiobutton_checked" | "radiobutton_unchecked";
 }
 
 type ViewAccessibilityTraits =
-    'none' |
-    'button' |
-    'link' |
-    'header' |
-    'search' |
-    'image' |
-    'selected' |
-    'plays' |
-    'key' |
-    'text' |
-    'summary' |
-    'disabled' |
-    'frequentUpdates' |
-    'startsMedia' |
-    'adjustable' |
-    'allowsDirectInteraction' |
-    'pageTurn'
+    | "none"
+    | "button"
+    | "link"
+    | "header"
+    | "search"
+    | "image"
+    | "selected"
+    | "plays"
+    | "key"
+    | "text"
+    | "summary"
+    | "disabled"
+    | "frequentUpdates"
+    | "startsMedia"
+    | "adjustable"
+    | "allowsDirectInteraction"
+    | "pageTurn";
 
 export interface TouchableWithoutFeedbackIOSProperties {
-
     /**
      * Provides additional traits to screen reader.
      * By default no traits are provided unless specified otherwise in element
      */
-    accessibilityTraits?: ViewAccessibilityTraits | ViewAccessibilityTraits[]
-
+    accessibilityTraits?: ViewAccessibilityTraits | ViewAccessibilityTraits[];
 }
 
 /**
  * @see https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#props
  */
-export interface TouchableWithoutFeedbackProperties extends TouchableWithoutFeedbackAndroidProperties, TouchableWithoutFeedbackIOSProperties {
-
+export interface TouchableWithoutFeedbackProperties
+    extends TouchableWithoutFeedbackAndroidProperties,
+        TouchableWithoutFeedbackIOSProperties {
     /**
      * Overrides the text that's read by the screen reader when the user interacts with the element. By default, the
      * label is constructed by traversing all the children and accumulating all the Text nodes separated by space.
@@ -4537,7 +4468,7 @@ export interface TouchableWithoutFeedbackProperties extends TouchableWithoutFeed
     /**
      * If true, disable all interactions for this component.
      */
-    disabled?: boolean
+    disabled?: boolean;
 
     /**
      * This defines how far your touch can start away from the button.
@@ -4546,13 +4477,13 @@ export interface TouchableWithoutFeedbackProperties extends TouchableWithoutFeed
      * the Z-index of sibling views always takes precedence if a touch hits
      * two overlapping views.
      */
-    hitSlop?: Insets
+    hitSlop?: Insets;
 
     /**
      * Invoked on mount and layout changes with
      * {nativeEvent: {layout: {x, y, width, height}}}
      */
-    onLayout?: (event: LayoutChangeEvent) => void
+    onLayout?: (event: LayoutChangeEvent) => void;
 
     onLongPress?: (event: GestureResponderEvent) => void;
 
@@ -4569,7 +4500,7 @@ export interface TouchableWithoutFeedbackProperties extends TouchableWithoutFeed
     /**
      * //FIXME: not in doc but available in examples
      */
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 
     /**
      * When the scroll view is disabled, this defines how far your
@@ -4579,18 +4510,15 @@ export interface TouchableWithoutFeedbackProperties extends TouchableWithoutFeed
      * while the scroll view is disabled. Ensure you pass in a constant
      * to reduce memory allocations.
      */
-    pressRetentionOffset?: Insets
+    pressRetentionOffset?: Insets;
 
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testID?: string
+    testID?: string;
 }
 
-
-export interface TouchableWithoutFeedbackProps extends TouchableWithoutFeedbackProperties {
-
-}
+export interface TouchableWithoutFeedbackProps extends TouchableWithoutFeedbackProperties {}
 
 /**
  * Do not use unless you have a very good reason.
@@ -4599,40 +4527,40 @@ export interface TouchableWithoutFeedbackProps extends TouchableWithoutFeedbackP
  *
  * @see https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html
  */
-export interface TouchableWithoutFeedbackStatic extends TimerMixin, TouchableMixin, React.ClassicComponentClass<TouchableWithoutFeedbackProps> {
-
-}
+export interface TouchableWithoutFeedbackStatic
+    extends TimerMixin,
+        TouchableMixin,
+        React.ClassicComponentClass<TouchableWithoutFeedbackProps> {}
 
 /**
  * @see https://facebook.github.io/react-native/docs/touchablehighlight.html#props
  */
 export interface TouchableHighlightProperties extends TouchableWithoutFeedbackProperties {
-
     /**
      * Determines what the opacity of the wrapped view should be when touch is active.
      */
-    activeOpacity?: number
+    activeOpacity?: number;
 
     /**
      *
      * Called immediately after the underlay is hidden
      */
-    onHideUnderlay?: () => void
+    onHideUnderlay?: () => void;
 
     /**
      * Called immediately after the underlay is shown
      */
-    onShowUnderlay?: () => void
+    onShowUnderlay?: () => void;
 
     /**
      * @see https://facebook.github.io/react-native/docs/view.html#style
      */
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 
     /**
      * The color of the underlay that will show through when the touch is active.
      */
-    underlayColor?: string
+    underlayColor?: string;
 }
 
 /**
@@ -4648,9 +4576,11 @@ export interface TouchableHighlightProperties extends TouchableWithoutFeedbackPr
  *
  * @see https://facebook.github.io/react-native/docs/touchablehighlight.html
  */
-export interface TouchableHighlightStatic extends NativeMethodsMixin, TimerMixin, TouchableMixin, React.ClassicComponentClass<TouchableHighlightProperties> {
-}
-
+export interface TouchableHighlightStatic
+    extends NativeMethodsMixin,
+        TimerMixin,
+        TouchableMixin,
+        React.ClassicComponentClass<TouchableHighlightProperties> {}
 
 /**
  * @see https://facebook.github.io/react-native/docs/touchableopacity.html#props
@@ -4660,7 +4590,7 @@ export interface TouchableOpacityProperties extends TouchableWithoutFeedbackProp
      * Determines what the opacity of the wrapped view should be when touch is active.
      * Defaults to 0.2
      */
-    activeOpacity?: number
+    activeOpacity?: number;
 }
 
 /**
@@ -4671,29 +4601,33 @@ export interface TouchableOpacityProperties extends TouchableWithoutFeedbackProp
  *
  * @see https://facebook.github.io/react-native/docs/touchableopacity.html
  */
-export interface TouchableOpacityStatic extends TimerMixin, TouchableMixin, NativeMethodsMixin, React.ClassicComponentClass<TouchableOpacityProperties> {
+export interface TouchableOpacityStatic
+    extends TimerMixin,
+        TouchableMixin,
+        NativeMethodsMixin,
+        React.ClassicComponentClass<TouchableOpacityProperties> {
     /**
      * Animate the touchable to a new opacity.
      */
-    setOpacityTo: (value: number) => void
+    setOpacityTo: (value: number) => void;
 }
 
 interface BaseBackgroundPropType {
-    type: string
+    type: string;
 }
 
 interface RippleBackgroundPropType extends BaseBackgroundPropType {
-    type: 'RippleAndroid'
-    color?: number,
-    borderless?: boolean
+    type: "RippleAndroid";
+    color?: number;
+    borderless?: boolean;
 }
 
 interface ThemeAttributeBackgroundPropType extends BaseBackgroundPropType {
-    type: 'ThemeAttrAndroid'
-    attribute: string
+    type: "ThemeAttrAndroid";
+    attribute: string;
 }
 
-type BackgroundPropType = RippleBackgroundPropType | ThemeAttributeBackgroundPropType
+type BackgroundPropType = RippleBackgroundPropType | ThemeAttributeBackgroundPropType;
 
 /**
  * @see https://facebook.github.io/react-native/docs/touchableopacity.html#props
@@ -4713,8 +4647,8 @@ export interface TouchableNativeFeedbackProperties extends TouchableWithoutFeedb
      *         outside of the view bounds (see native actionbar buttons as an example of that behavior). This background
      *         type is available on Android API level 21+
      */
-    background?: BackgroundPropType
-    useForeground?: boolean
+    background?: BackgroundPropType;
+    useForeground?: boolean;
 }
 
 /**
@@ -4727,20 +4661,21 @@ export interface TouchableNativeFeedbackProperties extends TouchableWithoutFeedb
  *
  * @see https://facebook.github.io/react-native/docs/touchablenativefeedback.html#content
  */
-export interface TouchableNativeFeedbackStatic extends TouchableMixin, React.ClassicComponentClass<TouchableNativeFeedbackProperties> {
-
+export interface TouchableNativeFeedbackStatic
+    extends TouchableMixin,
+        React.ClassicComponentClass<TouchableNativeFeedbackProperties> {
     /**
      * Creates an object that represents android theme's default background for
      * selectable elements (?android:attr/selectableItemBackground).
      */
-    SelectableBackground(): ThemeAttributeBackgroundPropType
+    SelectableBackground(): ThemeAttributeBackgroundPropType;
 
     /**
      * Creates an object that represent android theme's default background for borderless
      * selectable elements (?android:attr/selectableItemBackgroundBorderless).
      * Available on android API level 21+.
      */
-    SelectableBackgroundBorderless(): ThemeAttributeBackgroundPropType
+    SelectableBackgroundBorderless(): ThemeAttributeBackgroundPropType;
 
     /**
      * Creates an object that represents ripple drawable with specified color (as a
@@ -4752,36 +4687,36 @@ export interface TouchableNativeFeedbackStatic extends TouchableMixin, React.Cla
      * @param color The ripple color
      * @param borderless If the ripple can render outside it's bounds
      */
-    Ripple( color: string, borderless?: boolean ): RippleBackgroundPropType
+    Ripple(color: string, borderless?: boolean): RippleBackgroundPropType;
 }
 
 export interface Route {
-    component?: React.ComponentType<any>
-    id?: string
-    title?: string
+    component?: React.ComponentType<any>;
+    id?: string;
+    title?: string;
     passProps?: Object;
 
     //anything else
-    [key: string]: any
+    [key: string]: any;
 
     //Commonly found properties
-    backButtonTitle?: string
-    content?: string
+    backButtonTitle?: string;
+    content?: string;
     message?: string;
-    index?: number
-    onRightButtonPress?: () => void
-    rightButtonTitle?: string
-    wrapperStyle?: any
+    index?: number;
+    onRightButtonPress?: () => void;
+    rightButtonTitle?: string;
+    wrapperStyle?: any;
 }
 
 interface InteractionMixin {
-    createInteractionHandle(): number
-    clearInteractionHandle(clearHandle: number): void
+    createInteractionHandle(): number;
+    clearInteractionHandle(clearHandle: number): void;
     /**
      * Schedule work for after all interactions have completed.
      *
      */
-    runAfterInteractions(callback: () => any): void
+    runAfterInteractions(callback: () => any): void;
 }
 
 interface SubscribableMixin {
@@ -4798,21 +4733,17 @@ interface SubscribableMixin {
      * @param listener Function to invoke when event occurs.
      * @param context Object to use as listener context.
      */
-    addListenerOn( eventEmitter: any, eventType: string, listener: () => any, context: any ): void
+    addListenerOn(eventEmitter: any, eventType: string, listener: () => any, context: any): void;
 }
 
 // @see https://github.com/facebook/react-native/blob/0.34-stable\Libraries\StyleSheet\StyleSheetTypes.js
 export namespace StyleSheet {
-    type NamedStyles<T> = {
-        [P in keyof T]: ViewStyle | TextStyle | ImageStyle;
-    }
+    type NamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageStyle };
 
     /**
      * Creates a StyleSheet style reference from the given object.
      */
-    export function create<T extends NamedStyles<T>>( styles: T ): {
-        [P in keyof T]: RegisteredStyle<T[P]>;
-    };
+    export function create<T extends NamedStyles<T>>(styles: T): { [P in keyof T]: RegisteredStyle<T[P]> };
 
     /**
      * Flattens an array of style objects, into one aggregated style object.
@@ -4853,10 +4784,10 @@ export namespace StyleSheet {
      * their respective objects, merged as one and then returned. This also explains
      * the alternative use.
      */
-    export function flatten<T>(style?: RegisteredStyle<T>): T
-    export function flatten(style?: StyleProp<ViewStyle>): ViewStyle
-    export function flatten(style?: StyleProp<TextStyle>): TextStyle
-    export function flatten(style?: StyleProp<ImageStyle>): ImageStyle
+    export function flatten<T>(style?: RegisteredStyle<T>): T;
+    export function flatten(style?: StyleProp<ViewStyle>): ViewStyle;
+    export function flatten(style?: StyleProp<TextStyle>): TextStyle;
+    export function flatten(style?: StyleProp<ImageStyle>): ImageStyle;
 
     /**
      * This is defined as the width of a thin line on the platform. It can be
@@ -4875,14 +4806,14 @@ export namespace StyleSheet {
      * constant size, because on different platforms and screen densities its
      * value may be calculated differently.
      */
-    export var hairlineWidth: number
+    export var hairlineWidth: number;
 
     interface AbsoluteFillStyle {
-        position: "absolute"
-        left: 0
-        right: 0
-        top: 0
-        bottom: 0
+        position: "absolute";
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
     }
 
     /**
@@ -4897,59 +4828,53 @@ export namespace StyleSheet {
      *     },
      *   });
      */
-    export var absoluteFillObject: AbsoluteFillStyle
+    export var absoluteFillObject: AbsoluteFillStyle;
 
     /**
      * A very common pattern is to create overlays with position absolute and zero positioning,
      * so `absoluteFill` can be used for convenience and to reduce duplication of these repeated
      * styles.
      */
-    export var absoluteFill: RegisteredStyle<AbsoluteFillStyle>
+    export var absoluteFill: RegisteredStyle<AbsoluteFillStyle>;
 }
 
 export interface RelayProfiler {
-    attachProfileHandler(
-        name: string,
-        handler: (name: string, state?: any) => () => void
-    ): void,
+    attachProfileHandler(name: string, handler: (name: string, state?: any) => () => void): void;
 
-    attachAggregateHandler(
-        name: string,
-        handler: (name: string, callback: () => void) => void
-    ): void,
+    attachAggregateHandler(name: string, handler: (name: string, callback: () => void) => void): void;
 }
 
 export interface SystraceStatic {
-    setEnabled(enabled: boolean): void
+    setEnabled(enabled: boolean): void;
 
     /**
      * beginEvent/endEvent for starting and then ending a profile within the same call stack frame
      **/
-    beginEvent(profileName?: any, args?: any): void
-    endEvent(): void
+    beginEvent(profileName?: any, args?: any): void;
+    endEvent(): void;
 
     /**
      * beginAsyncEvent/endAsyncEvent for starting and then ending a profile where the end can either
      * occur on another thread or out of the current stack frame, eg await
      * the returned cookie variable should be used as input into the endAsyncEvent call to end the profile
      **/
-    beginAsyncEvent(profileName?: any): any
-    endAsyncEvent(profileName?: any, cookie?: any): void
+    beginAsyncEvent(profileName?: any): any;
+    endAsyncEvent(profileName?: any, cookie?: any): void;
 
     /**
      * counterEvent registers the value to the profileName on the systrace timeline
      **/
-    counterEvent(profileName?: any, value?: any): void
+    counterEvent(profileName?: any, value?: any): void;
 
     /**
      * Relay profiles use await calls, so likely occur out of current stack frame
      * therefore async variant of profiling is used
      **/
-    attachToRelayProfiler(relayProfiler: RelayProfiler): void
+    attachToRelayProfiler(relayProfiler: RelayProfiler): void;
 
     /* This is not called by default due to perf overhead but it's useful
         if you want to find traces which spend too much time in JSON. */
-    swizzleJSON(): void
+    swizzleJSON(): void;
 
     /**
      * Measures multiple methods of a class. For example, you can do:
@@ -4957,7 +4882,7 @@ export interface SystraceStatic {
      *
      * @param methodNames Map from method names to method display names.
      */
-    measureMethods(object: any, objectName: string, methodNames: Array<string>): void
+    measureMethods(object: any, objectName: string, methodNames: Array<string>): void;
 
     /**
      * Returns an profiled version of the input function. For example, you can:
@@ -4965,17 +4890,17 @@ export interface SystraceStatic {
      *
      * @return replacement function
      */
-    measure<T extends Function>(objName: string, fnName: string, func: T): T
+    measure<T extends Function>(objName: string, fnName: string, func: T): T;
 }
 
 /**
  * //FIXME: Could not find docs. Inferred from examples and jscode : ListViewDataSource.js
  */
 export interface DataSourceAssetCallback {
-    rowHasChanged?: (r1: any, r2: any) => boolean
-    sectionHeaderHasChanged?: (h1: any, h2: any) => boolean
-    getRowData?: (dataBlob: any, sectionID: number | string, rowID: number | string) => any
-    getSectionHeaderData?: (dataBlob: any, sectionID: number | string) => any
+    rowHasChanged?: (r1: any, r2: any) => boolean;
+    sectionHeaderHasChanged?: (h1: any, h2: any) => boolean;
+    getRowData?: (dataBlob: any, sectionID: number | string, rowID: number | string) => any;
+    getSectionHeaderData?: (dataBlob: any, sectionID: number | string) => any;
 }
 
 /**
@@ -5035,7 +4960,10 @@ export interface ListViewDataSource {
      * handle merging of old and new data separately and then pass that into
      * this function as the `dataBlob`.
      */
-    cloneWithRows(dataBlob: Array<any> | { [key: string]: any }, rowIdentities?: Array<string | number>): ListViewDataSource
+    cloneWithRows(
+        dataBlob: Array<any> | { [key: string]: any },
+        rowIdentities?: Array<string | number>
+    ): ListViewDataSource;
 
     /**
      * This performs the same function as the `cloneWithRows` function but here
@@ -5048,97 +4976,99 @@ export interface ListViewDataSource {
      *
      * Note: this returns a new object!
      */
-    cloneWithRowsAndSections(dataBlob: Array<any> | { [key: string]: any }, sectionIdentities?: Array<string | number>, rowIdentities?: Array<Array<string | number>>): ListViewDataSource
+    cloneWithRowsAndSections(
+        dataBlob: Array<any> | { [key: string]: any },
+        sectionIdentities?: Array<string | number>,
+        rowIdentities?: Array<Array<string | number>>
+    ): ListViewDataSource;
 
-    getRowCount(): number
-    getRowAndSectionCount(): number
+    getRowCount(): number;
+    getRowAndSectionCount(): number;
 
     /**
      * Returns if the row is dirtied and needs to be rerendered
      */
-    rowShouldUpdate(sectionIndex: number, rowIndex: number): boolean
+    rowShouldUpdate(sectionIndex: number, rowIndex: number): boolean;
 
     /**
      * Gets the data required to render the row.
      */
-    getRowData(sectionIndex: number, rowIndex: number): any
+    getRowData(sectionIndex: number, rowIndex: number): any;
 
     /**
      * Gets the rowID at index provided if the dataSource arrays were flattened,
      * or null of out of range indexes.
      */
-    getRowIDForFlatIndex(index: number): string
+    getRowIDForFlatIndex(index: number): string;
 
     /**
      * Gets the sectionID at index provided if the dataSource arrays were flattened,
      * or null for out of range indexes.
      */
-    getSectionIDForFlatIndex(index: number): string
+    getSectionIDForFlatIndex(index: number): string;
 
     /**
      * Returns an array containing the number of rows in each section
      */
-    getSectionLengths(): Array<number>
+    getSectionLengths(): Array<number>;
 
     /**
      * Returns if the section header is dirtied and needs to be rerendered
      */
-    sectionHeaderShouldUpdate(sectionIndex: number): boolean
+    sectionHeaderShouldUpdate(sectionIndex: number): boolean;
 
     /**
      * Gets the data required to render the section header
      */
-    getSectionHeaderData(sectionIndex: number): any
+    getSectionHeaderData(sectionIndex: number): any;
 }
-
 
 /**
  * @see https://facebook.github.io/react-native/docs/tabbarios-item.html#props
  */
 export interface TabBarItemProperties extends ViewProperties {
-
     /**
      * Little red bubble that sits at the top right of the icon.
      */
-    badge?: string | number
+    badge?: string | number;
 
     /**
      * Background color for the badge. Available since iOS 10.
      */
-    badgeColor?: string
+    badgeColor?: string;
 
     /**
      * A custom icon for the tab. It is ignored when a system icon is defined.
      */
-    icon?: ImageURISource
+    icon?: ImageURISource;
 
     /**
      * Callback when this tab is being selected,
      * you should change the state of your component to set selected={true}.
      */
-    onPress?: () => void
+    onPress?: () => void;
 
     /**
      * If set to true it renders the image as original,
      * it defaults to being displayed as a template
      */
-    renderAsOriginal?: boolean
+    renderAsOriginal?: boolean;
 
     /**
      * It specifies whether the children are visible or not. If you see a blank content, you probably forgot to add a selected one.
      */
-    selected?: boolean
+    selected?: boolean;
 
     /**
      * A custom icon when the tab is selected.
      * It is ignored when a system icon is defined. If left empty, the icon will be tinted in blue.
      */
-    selectedIcon?: ImageURISource
+    selectedIcon?: ImageURISource;
 
     /**
      * React style object.
      */
-    style?: StyleProp<ViewStyle>
+    style?: StyleProp<ViewStyle>;
 
     /**
      * Items comes with a few predefined system icons.
@@ -5146,26 +5076,36 @@ export interface TabBarItemProperties extends ViewProperties {
      *
      *  enum('bookmarks', 'contacts', 'downloads', 'favorites', 'featured', 'history', 'more', 'most-recent', 'most-viewed', 'recents', 'search', 'top-rated')
      */
-    systemIcon?: "bookmarks" | "contacts" | "downloads" | "favorites" | "featured" | "history" | "more" | "most-recent" | "most-viewed" | "recents" | "search" | "top-rated"
+    systemIcon?:
+        | "bookmarks"
+        | "contacts"
+        | "downloads"
+        | "favorites"
+        | "featured"
+        | "history"
+        | "more"
+        | "most-recent"
+        | "most-viewed"
+        | "recents"
+        | "search"
+        | "top-rated";
 
     /**
      * Text that appears under the icon. It is ignored when a system icon is defined.
      */
-    title?: string
+    title?: string;
 }
 
-export interface TabBarItemStatic extends React.ComponentClass<TabBarItemProperties> {
-}
+export interface TabBarItemStatic extends React.ComponentClass<TabBarItemProperties> {}
 
 /**
  * @see https://facebook.github.io/react-native/docs/tabbarios.html#props
  */
 export interface TabBarIOSProperties extends ViewProperties {
-
     /**
      * Background color of the tab bar
      */
-    barTintColor?: string
+    barTintColor?: string;
 
     /**
      * Specifies tab bar item positioning. Available values are:
@@ -5176,36 +5116,34 @@ export interface TabBarIOSProperties extends ViewProperties {
      * this value defaults to `fill`, in a horizontally regular one (e.g. iPad)
      * it defaults to center.
      */
-    itemPositioning?: 'fill' | 'center' | 'auto'
+    itemPositioning?: "fill" | "center" | "auto";
 
     /**
      * Color of the currently selected tab icon
      */
-    tintColor?: string
+    tintColor?: string;
 
     /**
      * A Boolean value that indicates whether the tab bar is translucent
      */
-    translucent?: boolean
+    translucent?: boolean;
 
     /**
      * Color of text on unselected tabs
      */
-    unselectedTintColor?: string
+    unselectedTintColor?: string;
 
     /**
      * Color of unselected tab icons. Available since iOS 10.
      */
-    unselectedItemTintColor?: string
+    unselectedItemTintColor?: string;
 }
 
 export interface TabBarIOSStatic extends React.ComponentClass<TabBarIOSProperties> {
     Item: TabBarItemStatic;
 }
 
-
 export interface PixelRatioStatic {
-
     /*
         Returns the device pixel density. Some examples:
             PixelRatio.get() === 1
@@ -5236,13 +5174,13 @@ export interface PixelRatioStatic {
         preference set in Settings > Display > Font size,
         on iOS it will always return the default pixel ratio.
         */
-    getFontScale(): number
+    getFontScale(): number;
 
     /**
      * Converts a layout size (dp) to pixel size (px).
      * Guaranteed to return an integer number.
      */
-    getPixelSizeForLayoutSize(layoutSize: number): number
+    getPixelSizeForLayoutSize(layoutSize: number): number;
 
     /**
      * Rounds a layout size (dp) to the nearest layout size that
@@ -5251,32 +5189,32 @@ export interface PixelRatioStatic {
      * PixelRatio.roundToNearestPixel(8.4) = 8.33,
      * which corresponds to exactly (8.33 * 3) = 25 pixels.
      */
-    roundToNearestPixel(layoutSize: number): number
+    roundToNearestPixel(layoutSize: number): number;
 
     /**
      * No-op for iOS, but used on the web. Should not be documented. [sic]
      */
-    startDetecting(): void
+    startDetecting(): void;
 }
 
 /**
  * @see https://facebook.github.io/react-native/docs/platform-specific-code.html#content
  */
-export type PlatformOSType = 'ios' | 'android' | 'macos' | 'windows' | 'web'
+export type PlatformOSType = "ios" | "android" | "macos" | "windows" | "web";
 
 interface PlatformStatic {
-    OS: PlatformOSType
-    Version: number
+    OS: PlatformOSType;
+    Version: number;
 
     /**
      * @see https://facebook.github.io/react-native/docs/platform-specific-code.html#content
      */
-    select<T>( specifics: { [platform in PlatformOSType]?: T; } ): T;
+    select<T>(specifics: { [platform in PlatformOSType]?: T }): T;
 }
 
 interface PlatformIOSStatic extends PlatformStatic {
-    isPad: boolean
-    isTVOS: boolean
+    isPad: boolean;
+    isTVOS: boolean;
 }
 
 /**
@@ -5284,9 +5222,9 @@ interface PlatformIOSStatic extends PlatformStatic {
  * adding all event listeners directly to RCTDeviceEventEmitter.
  */
 interface DeviceEventEmitterStatic extends EventEmitter {
-    sharedSubscriber: EventSubscriptionVendor
-    new(): DeviceEventEmitterStatic;
-    addListener( type: string, listener: ( data: any ) => void, context?: any ): EmitterSubscription;
+    sharedSubscriber: EventSubscriptionVendor;
+    new (): DeviceEventEmitterStatic;
+    addListener(type: string, listener: (data: any) => void, context?: any): EmitterSubscription;
 }
 
 // Used by Dimensions below
@@ -5334,7 +5272,7 @@ export interface Dimensions {
      * This should only be called from native code by sending the didUpdateDimensions event.
      * @param dims Simple string-keyed object of dimensions to set
      */
-    set( dims: {[key: string]: any} ): void;
+    set(dims: { [key: string]: any }): void;
 
     /**
      * Add an event listener for dimension changes
@@ -5354,89 +5292,87 @@ export interface Dimensions {
 }
 
 export type SimpleTask = {
-    name: string
-    gen: () => void
-}
+    name: string;
+    gen: () => void;
+};
 export type PromiseTask = {
-    name: string
-    gen: () => Promise<any>
-}
+    name: string;
+    gen: () => Promise<any>;
+};
 
-export type Handle = number
+export type Handle = number;
 
 export interface InteractionManagerStatic extends EventEmitterListener {
     Events: {
-        interactionStart: string
-        interactionComplete: string
-    }
+        interactionStart: string;
+        interactionComplete: string;
+    };
 
     /**
      * Schedule a function to run after all interactions have completed.
      * Returns a cancellable
      */
-    runAfterInteractions(task?: (() => any) | SimpleTask | PromiseTask): {
-        then: (onfulfilled?: () => any, onrejected?: () => any) => Promise<any>,
-        done: (...args: any[]) => any,
-        cancel: () => void,
-    }
+    runAfterInteractions(
+        task?: (() => any) | SimpleTask | PromiseTask
+    ): {
+        then: (onfulfilled?: () => any, onrejected?: () => any) => Promise<any>;
+        done: (...args: any[]) => any;
+        cancel: () => void;
+    };
 
     /**
      * Notify manager that an interaction has started.
      */
-    createInteractionHandle(): Handle
+    createInteractionHandle(): Handle;
 
     /**
      * Notify manager that an interaction has completed.
      */
-    clearInteractionHandle(handle: Handle): void
+    clearInteractionHandle(handle: Handle): void;
 
     /**
      * A positive number will use setTimeout to schedule any tasks after
      * the eventLoopRunningTime hits the deadline value, otherwise all
      * tasks will be executed in one setImmediate batch (default).
      */
-    setDeadline(deadline: number): void
+    setDeadline(deadline: number): void;
 }
-
 
 export interface ScrollViewStyle extends FlexStyle, TransformsStyle {
-
-    backfaceVisibility?: "visible" | "hidden"
-    backgroundColor?: string
-    borderColor?: string
-    borderTopColor?: string
-    borderRightColor?: string
-    borderBottomColor?: string
-    borderLeftColor?: string
-    borderRadius?: number
-    borderTopLeftRadius?: number
-    borderTopRightRadius?: number
-    borderBottomLeftRadius?: number
-    borderBottomRightRadius?: number
-    borderStyle?: "solid" | "dotted" | "dashed"
-    borderWidth?: number
-    borderTopWidth?: number
-    borderRightWidth?: number
-    borderBottomWidth?: number
-    borderLeftWidth?: number
-    opacity?: number
-    overflow?: "visible" | "hidden"
-    shadowColor?: string
-    shadowOffset?: { width: number; height: number }
-    shadowOpacity?: number
-    shadowRadius?: number
-    elevation?: number
+    backfaceVisibility?: "visible" | "hidden";
+    backgroundColor?: string;
+    borderColor?: string;
+    borderTopColor?: string;
+    borderRightColor?: string;
+    borderBottomColor?: string;
+    borderLeftColor?: string;
+    borderRadius?: number;
+    borderTopLeftRadius?: number;
+    borderTopRightRadius?: number;
+    borderBottomLeftRadius?: number;
+    borderBottomRightRadius?: number;
+    borderStyle?: "solid" | "dotted" | "dashed";
+    borderWidth?: number;
+    borderTopWidth?: number;
+    borderRightWidth?: number;
+    borderBottomWidth?: number;
+    borderLeftWidth?: number;
+    opacity?: number;
+    overflow?: "visible" | "hidden";
+    shadowColor?: string;
+    shadowOffset?: { width: number; height: number };
+    shadowOpacity?: number;
+    shadowRadius?: number;
+    elevation?: number;
 }
 
-export interface ScrollResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {
-}
-
+export interface ScrollResponderEvent extends NativeSyntheticEvent<NativeTouchEvent> {}
 
 interface ScrollResponderMixin extends SubscribableMixin {
     /**
      * Invoke this from an `onScroll` event.
      */
-    scrollResponderHandleScrollShouldSetResponder(): boolean
+    scrollResponderHandleScrollShouldSetResponder(): boolean;
 
     /**
      * Merely touch starting is not sufficient for a scroll view to become the
@@ -5463,7 +5399,7 @@ interface ScrollResponderMixin extends SubscribableMixin {
      *   true.
      *
      */
-    scrollResponderHandleStartShouldSetResponder(): boolean
+    scrollResponderHandleStartShouldSetResponder(): boolean;
 
     /**
      * There are times when the scroll view wants to become the responder
@@ -5476,7 +5412,7 @@ interface ScrollResponderMixin extends SubscribableMixin {
      *
      * Invoke this from an `onStartShouldSetResponderCapture` event.
      */
-    scrollResponderHandleStartShouldSetResponderCapture(e: ScrollResponderEvent): boolean
+    scrollResponderHandleStartShouldSetResponderCapture(e: ScrollResponderEvent): boolean;
 
     /**
      * Invoke this from an `onResponderReject` event.
@@ -5488,7 +5424,7 @@ interface ScrollResponderMixin extends SubscribableMixin {
      * altogether. To improve this, find a way to disable the `UIScrollView` after
      * a touch has already started.
      */
-    scrollResponderHandleResponderReject(): any
+    scrollResponderHandleResponderReject(): any;
 
     /**
      * We will allow the scroll view to give up its lock iff it acquired the lock
@@ -5505,26 +5441,26 @@ interface ScrollResponderMixin extends SubscribableMixin {
      *   navigation of a swipe gesture higher in the view hierarchy, should be
      *   rejected.
      */
-    scrollResponderHandleTerminationRequest(): boolean
+    scrollResponderHandleTerminationRequest(): boolean;
 
     /**
      * Invoke this from an `onTouchEnd` event.
      *
      * @param e Event.
      */
-    scrollResponderHandleTouchEnd(e: ScrollResponderEvent): void
+    scrollResponderHandleTouchEnd(e: ScrollResponderEvent): void;
 
     /**
      * Invoke this from an `onResponderRelease` event.
      */
-    scrollResponderHandleResponderRelease(e: ScrollResponderEvent): void
+    scrollResponderHandleResponderRelease(e: ScrollResponderEvent): void;
 
-    scrollResponderHandleScroll(e: ScrollResponderEvent): void
+    scrollResponderHandleScroll(e: ScrollResponderEvent): void;
 
     /**
      * Invoke this from an `onResponderGrant` event.
      */
-    scrollResponderHandleResponderGrant(e: ScrollResponderEvent): void
+    scrollResponderHandleResponderGrant(e: ScrollResponderEvent): void;
 
     /**
      * Unfortunately, `onScrollBeginDrag` also fires when *stopping* the scroll
@@ -5533,22 +5469,22 @@ interface ScrollResponderMixin extends SubscribableMixin {
      *
      * Invoke this from an `onScrollBeginDrag` event.
      */
-    scrollResponderHandleScrollBeginDrag(e: ScrollResponderEvent): void
+    scrollResponderHandleScrollBeginDrag(e: ScrollResponderEvent): void;
 
     /**
      * Invoke this from an `onScrollEndDrag` event.
      */
-    scrollResponderHandleScrollEndDrag(e: ScrollResponderEvent): void
+    scrollResponderHandleScrollEndDrag(e: ScrollResponderEvent): void;
 
     /**
      * Invoke this from an `onMomentumScrollBegin` event.
      */
-    scrollResponderHandleMomentumScrollBegin(e: ScrollResponderEvent): void
+    scrollResponderHandleMomentumScrollBegin(e: ScrollResponderEvent): void;
 
     /**
      * Invoke this from an `onMomentumScrollEnd` event.
      */
-    scrollResponderHandleMomentumScrollEnd(e: ScrollResponderEvent): void
+    scrollResponderHandleMomentumScrollEnd(e: ScrollResponderEvent): void;
 
     /**
      * Invoke this from an `onTouchStart` event.
@@ -5561,7 +5497,7 @@ interface ScrollResponderMixin extends SubscribableMixin {
      *
      * @param e Touch Start event.
      */
-    scrollResponderHandleTouchStart(e: ScrollResponderEvent): void
+    scrollResponderHandleTouchStart(e: ScrollResponderEvent): void;
 
     /**
      * Invoke this from an `onTouchMove` event.
@@ -5574,21 +5510,21 @@ interface ScrollResponderMixin extends SubscribableMixin {
      *
      * @param e Touch Start event.
      */
-    scrollResponderHandleTouchMove(e: ScrollResponderEvent): void
+    scrollResponderHandleTouchMove(e: ScrollResponderEvent): void;
 
     /**
      * A helper function for this class that lets us quickly determine if the
      * view is currently animating. This is particularly useful to know when
      * a touch has just started or ended.
      */
-    scrollResponderIsAnimating(): boolean
+    scrollResponderIsAnimating(): boolean;
 
     /**
      * Returns the node that represents native view that can be scrolled.
      * Components can pass what node to use by defining a `getScrollableNode`
      * function otherwise `this` is used.
      */
-    scrollResponderGetScrollableNode(): any
+    scrollResponderGetScrollableNode(): any;
 
     /**
      * A helper function to scroll to a specific point  in the scrollview.
@@ -5601,7 +5537,11 @@ interface ScrollResponderMixin extends SubscribableMixin {
      * the function also accepts separate arguments as as alternative to the options object.
      * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
      */
-    scrollResponderScrollTo( x?: number | { x?: number, y?: number, animated?: boolean }, y?: number, animated?: boolean ): void,
+    scrollResponderScrollTo(
+        x?: number | { x?: number; y?: number; animated?: boolean },
+        y?: number,
+        animated?: boolean
+    ): void;
 
     /**
      * A helper function to zoom to a specific rect in the scrollview. The argument has the shape
@@ -5610,9 +5550,9 @@ interface ScrollResponderMixin extends SubscribableMixin {
      * @platform ios
      */
     scrollResponderZoomTo(
-        rect: { x: number, y: number, width: number, height: number, animated?: boolean },
+        rect: { x: number; y: number; width: number; height: number; animated?: boolean },
         animated?: boolean // deprecated, put this inside the rect argument instead
-    ): void
+    ): void;
 
     /**
      * This method should be used as the callback to onFocus in a TextInputs'
@@ -5624,7 +5564,11 @@ interface ScrollResponderMixin extends SubscribableMixin {
      * @param preventNegativeScrolling Whether to allow pulling the content
      *        down to make it meet the keyboard's top. Default is false.
      */
-    scrollResponderScrollNativeHandleToKeyboard(nodeHandle: any, additionalOffset?: number, preventNegativeScrollOffset?: boolean): void
+    scrollResponderScrollNativeHandleToKeyboard(
+        nodeHandle: any,
+        additionalOffset?: number,
+        preventNegativeScrollOffset?: boolean
+    ): void;
 
     /**
      * The calculations performed here assume the scroll view takes up the entire
@@ -5636,9 +5580,9 @@ interface ScrollResponderMixin extends SubscribableMixin {
      * @param width Width of the text input.
      * @param height Height of the text input.
      */
-    scrollResponderInputMeasureAndScrollToKeyboard(left: number, top: number, width: number, height: number): void
+    scrollResponderInputMeasureAndScrollToKeyboard(left: number, top: number, width: number, height: number): void;
 
-    scrollResponderTextInputFocusError(e: ScrollResponderEvent): void
+    scrollResponderTextInputFocusError(e: ScrollResponderEvent): void;
 
     /**
      * `componentWillMount` is the closest thing to a  standard "constructor" for
@@ -5646,7 +5590,7 @@ interface ScrollResponderMixin extends SubscribableMixin {
      *
      * The `keyboardWillShow` is called before input focus.
      */
-    componentWillMount(): void
+    componentWillMount(): void;
 
     /**
      * Warning, this may be called several times for a single keyboard opening.
@@ -5676,35 +5620,34 @@ interface ScrollResponderMixin extends SubscribableMixin {
      * relevant to you. (For example, only if you receive these callbacks after
      * you had explicitly focused a node etc).
      */
-    scrollResponderKeyboardWillShow(e: ScrollResponderEvent): void
+    scrollResponderKeyboardWillShow(e: ScrollResponderEvent): void;
 
-    scrollResponderKeyboardWillHide(e: ScrollResponderEvent): void
+    scrollResponderKeyboardWillHide(e: ScrollResponderEvent): void;
 
-    scrollResponderKeyboardDidShow(e: ScrollResponderEvent): void
+    scrollResponderKeyboardDidShow(e: ScrollResponderEvent): void;
 
-    scrollResponderKeyboardDidHide(e: ScrollResponderEvent): void
+    scrollResponderKeyboardDidHide(e: ScrollResponderEvent): void;
 }
 
 export interface ScrollViewPropertiesIOS {
-
     /**
      * When true the scroll view bounces horizontally when it reaches the end
      * even if the content is smaller than the scroll view itself. The default
      * value is true when `horizontal={true}` and false otherwise.
      */
-    alwaysBounceHorizontal?: boolean
+    alwaysBounceHorizontal?: boolean;
     /**
      * When true the scroll view bounces vertically when it reaches the end
      * even if the content is smaller than the scroll view itself. The default
      * value is false when `horizontal={true}` and true otherwise.
      */
-    alwaysBounceVertical?: boolean
+    alwaysBounceVertical?: boolean;
 
     /**
      * Controls whether iOS should automatically adjust the content inset for scroll views that are placed behind a navigation bar or tab bar/ toolbar.
      * The default value is true.
      */
-    automaticallyAdjustContentInsets?: boolean // true
+    automaticallyAdjustContentInsets?: boolean; // true
 
     /**
      * When true the scroll view bounces when it reaches the end of the
@@ -5712,19 +5655,19 @@ export interface ScrollViewPropertiesIOS {
      * the scroll direction. When false it disables all bouncing even if
      * the `alwaysBounce*` props are true. The default value is true.
      */
-    bounces?: boolean
+    bounces?: boolean;
     /**
      * When true gestures can drive zoom past min/max and the zoom will animate
      * to the min/max value at gesture end otherwise the zoom will not exceed
      * the limits.
      */
-    bouncesZoom?: boolean
+    bouncesZoom?: boolean;
 
     /**
      * When false once tracking starts won't try to drag if the touch moves.
      * The default value is true.
      */
-    canCancelContentTouches?: boolean
+    canCancelContentTouches?: boolean;
 
     /**
      * When true the scroll view automatically centers the content when the
@@ -5732,19 +5675,19 @@ export interface ScrollViewPropertiesIOS {
      * larger than the scroll view this property has no effect. The default
      * value is false.
      */
-    centerContent?: boolean
+    centerContent?: boolean;
 
     /**
      * The amount by which the scroll view content is inset from the edges of the scroll view.
      * Defaults to {0, 0, 0, 0}.
      */
-    contentInset?: Insets // zeros
+    contentInset?: Insets; // zeros
 
     /**
      * Used to manually set the starting scroll offset.
      * The default value is {x: 0, y: 0}
      */
-    contentOffset?: PointProperties // zeros
+    contentOffset?: PointProperties; // zeros
 
     /**
      * A floating-point number that determines how quickly the scroll view
@@ -5752,13 +5695,13 @@ export interface ScrollViewPropertiesIOS {
      *   - Normal: 0.998 (the default)
      *   - Fast: 0.9
      */
-    decelerationRate?: "fast" | "normal" | number
+    decelerationRate?: "fast" | "normal" | number;
 
     /**
      * When true the ScrollView will try to lock to only vertical or horizontal
      * scrolling while dragging.  The default value is false.
      */
-    directionalLockEnabled?: boolean
+    directionalLockEnabled?: boolean;
 
     /**
      * The style of the scroll indicators.
@@ -5768,28 +5711,28 @@ export interface ScrollViewPropertiesIOS {
      * - white, scroll indicator is white. This style is good against
      *   a black content background.
      */
-    indicatorStyle?: "default" | "black" | "white"
+    indicatorStyle?: "default" | "black" | "white";
 
     /**
      * The maximum allowed zoom scale. The default value is 1.0.
      */
-    maximumZoomScale?: number
+    maximumZoomScale?: number;
 
     /**
      * The minimum allowed zoom scale. The default value is 1.0.
      */
-    minimumZoomScale?: number
+    minimumZoomScale?: number;
 
     /**
      * Called when a scrolling animation ends.
      */
-    onScrollAnimationEnd?: () => void
+    onScrollAnimationEnd?: () => void;
 
     /**
      * When true, ScrollView allows use of pinch gestures to zoom in and out.
      * The default value is true.
      */
-    pinchGestureEnabled?: boolean
+    pinchGestureEnabled?: boolean;
 
     /**
      * This controls how often the scroll event will be fired while scrolling (in events per seconds).
@@ -5797,20 +5740,20 @@ export interface ScrollViewPropertiesIOS {
      * but can lead to scroll performance problems due to the volume of information being send over the bridge.
      * The default value is zero, which means the scroll event will be sent only once each time the view is scrolled.
      */
-    scrollEventThrottle?: number // null
+    scrollEventThrottle?: number; // null
 
     /**
      * The amount by which the scroll view indicators are inset from the edges of the scroll view.
      * This should normally be set to the same value as the contentInset.
      * Defaults to {0, 0, 0, 0}.
      */
-    scrollIndicatorInsets?: Insets //zeroes
+    scrollIndicatorInsets?: Insets; //zeroes
 
     /**
      * When true the scroll view scrolls to top when the status bar is tapped.
      * The default value is true.
      */
-    scrollsToTop?: boolean
+    scrollsToTop?: boolean;
 
     /**
      * When snapToInterval is set, snapToAlignment will define the relationship of the the snapping to the scroll view.
@@ -5818,14 +5761,14 @@ export interface ScrollViewPropertiesIOS {
      *      - center will align the snap in the center
      *      - end will align the snap at the right (horizontal) or bottom (vertical)
      */
-    snapToAlignment?: "start" | "center" | "end"
+    snapToAlignment?: "start" | "center" | "end";
 
     /**
      * When set, causes the scroll view to stop at multiples of the value of snapToInterval.
      * This can be used for paginating through children that have lengths smaller than the scroll view.
      * Used in combination with snapToAlignment.
      */
-    snapToInterval?: number
+    snapToInterval?: number;
 
     /**
      * An array of child indices determining which children get docked to the
@@ -5834,16 +5777,15 @@ export interface ScrollViewPropertiesIOS {
      * top of the scroll view. This property is not supported in conjunction
      * with `horizontal={true}`.
      */
-    stickyHeaderIndices?: number[]
+    stickyHeaderIndices?: number[];
 
     /**
      * The current scale of the scroll view content. The default value is 1.0.
      */
-    zoomScale?: number
+    zoomScale?: number;
 }
 
 export interface ScrollViewPropertiesAndroid {
-
     /**
      * Sometimes a scrollview takes up more space than its content fills.
      * When this is the case, this prop will fill the rest of the
@@ -5851,7 +5793,7 @@ export interface ScrollViewPropertiesAndroid {
      * unnecessary overdraw. This is an advanced optimization that is not
      * needed in the general case.
      */
-    endFillColor?: string
+    endFillColor?: string;
 
     /**
      * Tag used to log scroll performance on this scroll view. Will force
@@ -5860,7 +5802,7 @@ export interface ScrollViewPropertiesAndroid {
      * FpsListener for it to be useful.
      * @platform android
      */
-    scrollPerfTag?: string
+    scrollPerfTag?: string;
 
     /**
      * Used to override default value of overScroll mode.
@@ -5870,11 +5812,14 @@ export interface ScrollViewPropertiesAndroid {
         *   - 'always' - Always allow a user to over-scroll this view.
         *   - 'never' - Never allow a user to over-scroll this view.
         */
-    overScrollMode?: 'auto' | 'always' | 'never'
+    overScrollMode?: "auto" | "always" | "never";
 }
 
-export interface ScrollViewProperties extends ViewProperties, ScrollViewPropertiesIOS, ScrollViewPropertiesAndroid, Touchable {
-
+export interface ScrollViewProperties
+    extends ViewProperties,
+        ScrollViewPropertiesIOS,
+        ScrollViewPropertiesAndroid,
+        Touchable {
     /**
      * These styles will be applied to the scroll view content container which
      * wraps all of the child views. Example:
@@ -5890,13 +5835,13 @@ export interface ScrollViewProperties extends ViewProperties, ScrollViewProperti
      *     }
      *   });
      */
-    contentContainerStyle?: StyleProp<ViewStyle>
+    contentContainerStyle?: StyleProp<ViewStyle>;
 
     /**
      * When true the scroll view's children are arranged horizontally in a row
      * instead of vertically in a column. The default value is false.
      */
-    horizontal?: boolean
+    horizontal?: boolean;
 
     /**
      * Determines whether the keyboard gets dismissed in response to a drag.
@@ -5906,7 +5851,7 @@ export interface ScrollViewProperties extends ViewProperties, ScrollViewProperti
      *     and moves in synchrony with the touch; dragging upwards cancels the
      *     dismissal.
      */
-    keyboardDismissMode?: 'none' | 'interactive' | 'on-drag'
+    keyboardDismissMode?: "none" | "interactive" | "on-drag";
 
     /**
      * When false tapping outside of the focused text input when the keyboard
@@ -5914,7 +5859,7 @@ export interface ScrollViewProperties extends ViewProperties, ScrollViewProperti
      * taps and the keyboard will not dismiss automatically. The default value
      * is false.
      */
-    keyboardShouldPersistTaps?: boolean | 'always' | 'never' | 'handled'
+    keyboardShouldPersistTaps?: boolean | "always" | "never" | "handled";
 
     /**
      * Called when scrollable content view of the ScrollView changes.
@@ -5922,45 +5867,45 @@ export interface ScrollViewProperties extends ViewProperties, ScrollViewProperti
      * It's implemented using onLayout handler attached to the content container which this ScrollView renders.
      *
      */
-    onContentSizeChange?: (w: number, h: number) => void
+    onContentSizeChange?: (w: number, h: number) => void;
 
     /**
      * Fires at most once per frame during scrolling.
      * The frequency of the events can be contolled using the scrollEventThrottle prop.
      */
-    onScroll?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
+    onScroll?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void;
 
     /**
      * Fires if a user initiates a scroll gesture.
      */
-    onScrollBeginDrag?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
+    onScrollBeginDrag?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void;
 
     /**
      * Fires when a user has finished scrolling.
      */
-    onScrollEndDrag?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
+    onScrollEndDrag?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void;
 
     /**
      * Fires when scroll view has finished moving
      */
-    onMomentumScrollEnd?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
+    onMomentumScrollEnd?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void;
 
     /**
      * Fires when scroll view has begun moving
      */
-    onMomentumScrollBegin?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void
+    onMomentumScrollBegin?: (event?: NativeSyntheticEvent<NativeScrollEvent>) => void;
 
     /**
      * When true the scroll view stops on multiples of the scroll view's size
      * when scrolling. This can be used for horizontal pagination. The default
      * value is false.
      */
-    pagingEnabled?: boolean
+    pagingEnabled?: boolean;
 
     /**
      * When false, the content does not scroll. The default value is true
      */
-    scrollEnabled?: boolean // true
+    scrollEnabled?: boolean; // true
 
     /**
      * Experimental: When true offscreen child views (whose `overflow` value is
@@ -5968,35 +5913,33 @@ export interface ScrollViewProperties extends ViewProperties, ScrollViewProperti
      * This canimprove scrolling performance on long lists. The default value is
      * false.
      */
-    removeClippedSubviews?: boolean
+    removeClippedSubviews?: boolean;
 
     /**
      * When true, shows a horizontal scroll indicator.
      */
-    showsHorizontalScrollIndicator?: boolean
+    showsHorizontalScrollIndicator?: boolean;
 
     /**
      * When true, shows a vertical scroll indicator.
      */
-    showsVerticalScrollIndicator?: boolean
+    showsVerticalScrollIndicator?: boolean;
 
     /**
      * Style
      */
-    style?: StyleProp<ScrollViewStyle>
+    style?: StyleProp<ScrollViewStyle>;
 
     /**
      * A RefreshControl component, used to provide pull-to-refresh
      * functionality for the ScrollView.
      */
-    refreshControl?: React.ReactElement<RefreshControlProperties>
+    refreshControl?: React.ReactElement<RefreshControlProperties>;
 }
 
-export interface ScrollViewProps extends ScrollViewProperties {
-}
+export interface ScrollViewProps extends ScrollViewProperties {}
 
 interface ScrollViewStatic extends ScrollResponderMixin, React.ComponentClass<ScrollViewProps> {
-
     /**
      * Scrolls to a given x, y offset, either immediately or with a smooth animation.
      * Syntax:
@@ -6007,11 +5950,7 @@ interface ScrollViewStatic extends ScrollResponderMixin, React.ComponentClass<Sc
      * the function also accepts separate arguments as as alternative to the options object.
      * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
      */
-    scrollTo(
-        y?: number | { x?: number, y?: number, animated?: boolean },
-        x?: number,
-        animated?: boolean
-    ): void;
+    scrollTo(y?: number | { x?: number; y?: number; animated?: boolean }, x?: number, animated?: boolean): void;
 
     /**
      * A helper function that scrolls to the end of the scrollview;
@@ -6021,7 +5960,7 @@ interface ScrollViewStatic extends ScrollResponderMixin, React.ComponentClass<Sc
      * The options object has an animated prop, that enables the scrolling animation or not.
      * The animated prop defaults to true
      */
-    scrollToEnd(options?: {animated: boolean}): void;
+    scrollToEnd(options?: { animated: boolean }): void;
 
     /**
      * Returns a reference to the underlying scroll responder, which supports
@@ -6037,9 +5976,8 @@ interface ScrollViewStatic extends ScrollResponderMixin, React.ComponentClass<Sc
     getInnerViewNode(): any;
 
     // Deprecated, do not use.
-    scrollWithoutAnimationTo?: (y: number, x: number) => void
+    scrollWithoutAnimationTo?: (y: number, x: number) => void;
 }
-
 
 export interface NativeScrollRectangle {
     left: number;
@@ -6073,12 +6011,11 @@ export interface NativeScrollEvent {
 }
 
 export interface SnapshotViewIOSProperties extends ViewProperties {
-
     // A callback when the Snapshot view is ready to be compared
-    onSnapshotReady(): any,
+    onSnapshotReady(): any;
 
     // A name to identify the individual instance to the SnapshotView
-    testIdentifier: string,
+    testIdentifier: string;
 }
 
 export interface SnapshotViewIOSStatic extends NativeMethodsMixin, React.ComponentClass<SnapshotViewIOSProperties> {}
@@ -6095,37 +6032,43 @@ export interface SnapshotViewIOSStatic extends NativeMethodsMixin, React.Compone
  * ListViewDataSource is not subclassed.
  */
 export interface SwipeableListViewDataSource {
-    cloneWithRowsAndSections(dataBlob: any,
-                                sectionIdentities?: Array<string>,
-                                rowIdentities?: Array<Array<string>>): SwipeableListViewDataSource
-    getDataSource(): ListViewDataSource
-    getOpenRowID(): string
-    getFirstRowID(): string
-    setOpenRowID(rowID: string): SwipeableListViewDataSource
+    cloneWithRowsAndSections(
+        dataBlob: any,
+        sectionIdentities?: Array<string>,
+        rowIdentities?: Array<Array<string>>
+    ): SwipeableListViewDataSource;
+    getDataSource(): ListViewDataSource;
+    getOpenRowID(): string;
+    getFirstRowID(): string;
+    setOpenRowID(rowID: string): SwipeableListViewDataSource;
 }
 
 export interface SwipeableListViewProps {
-
     /**
      * To alert the user that swiping is possible, the first row can bounce
      * on component mount.
      */
-    bounceFirstRowOnMount: boolean
+    bounceFirstRowOnMount: boolean;
 
     /**
      * Use `SwipeableListView.getNewDataSource()` to get a data source to use,
      * then use it just like you would a normal ListView data source
      */
-    dataSource: SwipeableListViewDataSource
+    dataSource: SwipeableListViewDataSource;
 
     // Maximum distance to open to after a swipe
-    maxSwipeDistance: number
+    maxSwipeDistance: number;
 
     // Callback method to render the swipeable view
-    renderRow: (rowData: any, sectionID: string | number, rowID: string | number, highlightRow?: boolean) => React.ReactElement<any>
+    renderRow: (
+        rowData: any,
+        sectionID: string | number,
+        rowID: string | number,
+        highlightRow?: boolean
+    ) => React.ReactElement<any>;
 
     // Callback method to render the view that will be unveiled on swipe
-    renderQuickActions(rowData: any, sectionID: string | number, rowID: string | number): React.ReactElement<any>
+    renderQuickActions(rowData: any, sectionID: string | number, rowID: string | number): React.ReactElement<any>;
 }
 
 /**
@@ -6147,9 +6090,8 @@ export interface SwipeableListViewProps {
  * - More to come
  */
 export interface SwipeableListViewStatic extends React.ComponentClass<SwipeableListViewProps> {
-    getNewDataSource(): SwipeableListViewDataSource
+    getNewDataSource(): SwipeableListViewDataSource;
 }
-
 
 //////////////////////////////////////////////////////////////////////////
 //
@@ -6161,21 +6103,21 @@ export interface SwipeableListViewStatic extends React.ComponentClass<SwipeableL
  * @see: http://facebook.github.io/react-native/docs/actionsheetios.html#content
  */
 export interface ActionSheetIOSOptions {
-    title?: string
-    options: string[]
-    cancelButtonIndex?: number
-    destructiveButtonIndex?: number
-    message?: string
+    title?: string;
+    options: string[];
+    cancelButtonIndex?: number;
+    destructiveButtonIndex?: number;
+    message?: string;
 }
 
 export interface ShareActionSheetIOSOptions {
-    message?: string
-    url?: string
-    subject?: string
+    message?: string;
+    url?: string;
+    subject?: string;
     /** The activities to exclude from the ActionSheet.
      * For example: ['com.apple.UIKit.activity.PostToTwitter']
      */
-    excludedActivityTypes?: string[]
+    excludedActivityTypes?: string[];
 }
 
 /**
@@ -6191,7 +6133,7 @@ export interface ActionSheetIOSStatic {
      * - `title` (string) - a title to show above the action sheet
      * - `message` (string) - a message to show below the title
      */
-    showActionSheetWithOptions: (options: ActionSheetIOSOptions, callback: (buttonIndex: number) => void) => void
+    showActionSheetWithOptions: (options: ActionSheetIOSOptions, callback: (buttonIndex: number) => void) => void;
 
     /**
      * Display the iOS share sheet. The `options` object should contain
@@ -6207,22 +6149,28 @@ export interface ActionSheetIOSStatic {
      * uri, the file it points to will be loaded and shared directly.
      * In this way, you can share images, videos, PDF files, etc.
      */
-    showShareActionSheetWithOptions: (options: ShareActionSheetIOSOptions, failureCallback: (error: Error) => void, successCallback: (success: boolean, method: string) => void) => void
+    showShareActionSheetWithOptions: (
+        options: ShareActionSheetIOSOptions,
+        failureCallback: (error: Error) => void,
+        successCallback: (success: boolean, method: string) => void
+    ) => void;
 }
 
-export type ShareContent = {
-    title?: string
-    message: string
-} | {
-    title?: string
-    url: string
-}
+export type ShareContent =
+    | {
+          title?: string;
+          message: string;
+      }
+    | {
+          title?: string;
+          url: string;
+      };
 
 export type ShareOptions = {
-    dialogTitle?: string
-    excludedActivityTypes?: Array<string>
-    tintColor?: string
-}
+    dialogTitle?: string;
+    excludedActivityTypes?: Array<string>;
+    tintColor?: string;
+};
 
 export interface ShareStatic {
     /**
@@ -6257,12 +6205,12 @@ export interface ShareStatic {
      * - `dialogTitle`
      *
      */
-    share(content: ShareContent, options?: ShareOptions): Promise<Object>
-    sharedAction: string
-    dismissedAction: string
+    share(content: ShareContent, options?: ShareOptions): Promise<Object>;
+    sharedAction: string;
+    dismissedAction: string;
 }
 
-type AccessibilityChangeEventName = 'change' | 'announcementFinished';
+type AccessibilityChangeEventName = "change" | "announcementFinished";
 
 /**
  * @see https://facebook.github.io/react-native/docs/accessibilityinfo.html
@@ -6311,9 +6259,9 @@ export interface AccessibilityInfoStatic {
  * @see https://facebook.github.io/react-native/docs/alert.html#content
  */
 export interface AlertButton {
-    text?: string
-    onPress?: () => void
-    style?: "default" | "cancel" | "destructive"
+    text?: string;
+    onPress?: () => void;
+    style?: "default" | "cancel" | "destructive";
 }
 
 interface AlertOptions {
@@ -6362,31 +6310,31 @@ interface AlertOptions {
  * ```
  */
 export interface AlertStatic {
-    alert: (title: string, message?: string, buttons?: AlertButton[], options?: AlertOptions, type?: string) => void
+    alert: (title: string, message?: string, buttons?: AlertButton[], options?: AlertOptions, type?: string) => void;
 }
 
 /**
  * Wrapper around the Android native module.
  */
 export interface AlertAndroidStatic {
-    alert: (title: string, message?: string, buttons?: AlertButton[], options?: AlertOptions) => void
+    alert: (title: string, message?: string, buttons?: AlertButton[], options?: AlertOptions) => void;
 }
 
 /**
  * //FIXME: No documentation - inferred from RCTAdSupport.m
  */
 export interface AdSupportIOSStatic {
-    getAdvertisingId: (onSuccess: (deviceId: string) => void, onFailure: (err: Error) => void) => void
-    getAdvertisingTrackingEnabled: (onSuccess: (hasTracking: boolean) => void, onFailure: (err: Error) => void) => void
+    getAdvertisingId: (onSuccess: (deviceId: string) => void, onFailure: (err: Error) => void) => void;
+    getAdvertisingTrackingEnabled: (onSuccess: (hasTracking: boolean) => void, onFailure: (err: Error) => void) => void;
 }
 
 interface AlertIOSButton {
-    text: string
-    onPress?: (message?: string) => void
-    style?: "default" | "cancel" | "destructive"
+    text: string;
+    onPress?: (message?: string) => void;
+    style?: "default" | "cancel" | "destructive";
 }
 
-export type AlertType = "default" | "plain-text" | "secure-text" | "login-password"
+export type AlertType = "default" | "plain-text" | "secure-text" | "login-password";
 
 /**
  * @description
@@ -6399,7 +6347,6 @@ export type AlertType = "default" | "plain-text" | "secure-text" | "login-passwo
  * @see https://facebook.github.io/react-native/docs/alertios.html#content
  */
 export interface AlertIOSStatic {
-
     /**
      * Create and display a popup alert.
      * @param title The dialog's title.
@@ -6414,7 +6361,12 @@ export interface AlertIOSStatic {
      *    should be one of 'default', 'cancel' or 'destructive'.
      * @param type Deprecated, do not use.
      */
-    alert: ( title: string, message?: string, callbackOrButtons?: (() => void) | Array<AlertIOSButton>, type?: AlertType ) => void
+    alert: (
+        title: string,
+        message?: string,
+        callbackOrButtons?: (() => void) | Array<AlertIOSButton>,
+        type?: AlertType
+    ) => void;
 
     /**
      * Create and display a prompt to enter some text.
@@ -6433,7 +6385,13 @@ export interface AlertIOSStatic {
      *    'secure-text' or 'login-password'.
      * @param defaultValue The default text in text input.
      */
-    prompt: ( title: string, message?: string, callbackOrButtons?: ((value: string) => void) | Array<AlertIOSButton>, type?: AlertType, defaultValue?: string ) => void
+    prompt: (
+        title: string,
+        message?: string,
+        callbackOrButtons?: ((value: string) => void) | Array<AlertIOSButton>,
+        type?: AlertType,
+        defaultValue?: string
+    ) => void;
 }
 
 /**
@@ -6452,23 +6410,22 @@ export interface AlertIOSStatic {
  *
  * @see https://facebook.github.io/react-native/docs/appstateios.html#content
  */
-export type AppStateEvent = "change" | "memoryWarning"
-export type AppStateStatus = "active" | "background" | "inactive"
+export type AppStateEvent = "change" | "memoryWarning";
+export type AppStateStatus = "active" | "background" | "inactive";
 
 export interface AppStateStatic {
-
-    currentState: string
+    currentState: string;
 
     /**
      * Add a handler to AppState changes by listening to the change event
      * type and providing the handler
      */
-    addEventListener(type: AppStateEvent, listener: (state: AppStateStatus) => void): void
+    addEventListener(type: AppStateEvent, listener: (state: AppStateStatus) => void): void;
 
     /**
      * Remove a handler by passing the change event type and the handler
      */
-    removeEventListener(type: AppStateEvent, listener: (state: AppStateStatus) => void): void
+    removeEventListener(type: AppStateEvent, listener: (state: AppStateStatus) => void): void;
 }
 
 /**
@@ -6487,52 +6444,54 @@ export interface AppStateStatic {
  * @see https://facebook.github.io/react-native/docs/asyncstorage.html#content
  */
 export interface AsyncStorageStatic {
-
     /**
      * Fetches key and passes the result to callback, along with an Error if there is any.
      */
-    getItem(key: string, callback?: (error?: Error, result?: string) => void): Promise<string>
+    getItem(key: string, callback?: (error?: Error, result?: string) => void): Promise<string>;
 
     /**
      * Sets value for key and calls callback on completion, along with an Error if there is any
      */
-    setItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>
+    setItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
 
-    removeItem(key: string, callback?: (error?: Error) => void): Promise<void>
+    removeItem(key: string, callback?: (error?: Error) => void): Promise<void>;
 
     /**
      * Merges existing value with input value, assuming they are stringified json. Returns a Promise object.
      * Not supported by all native implementation
      */
-    mergeItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>
+    mergeItem(key: string, value: string, callback?: (error?: Error) => void): Promise<void>;
 
     /**
      * Erases all AsyncStorage for all clients, libraries, etc. You probably don't want to call this.
      * Use removeItem or multiRemove to clear only your own keys instead.
      */
-    clear(callback?: (error?: Error) => void): Promise<void>
+    clear(callback?: (error?: Error) => void): Promise<void>;
 
     /**
      * Gets all keys known to the app, for all callers, libraries, etc
      */
-    getAllKeys(callback?: (error?: Error, keys?: string[]) => void): Promise<string[]>
+    getAllKeys(callback?: (error?: Error, keys?: string[]) => void): Promise<string[]>;
 
     /**
      * multiGet invokes callback with an array of key-value pair arrays that matches the input format of multiSet
      */
-    multiGet(keys: string[], callback?: (errors?: Error[], result?: [string, string][]) => void): Promise<[string, string][]>
+    multiGet(
+        keys: string[],
+        callback?: (errors?: Error[], result?: [string, string][]) => void
+    ): Promise<[string, string][]>;
 
     /**
      * multiSet and multiMerge take arrays of key-value array pairs that match the output of multiGet,
      *
      * multiSet([['k1', 'val1'], ['k2', 'val2']], cb);
      */
-    multiSet(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>
+    multiSet(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
 
     /**
      * Delete all the keys in the keys array.
      */
-    multiRemove(keys: string[], callback?: (errors?: Error[]) => void): Promise<void>
+    multiRemove(keys: string[], callback?: (errors?: Error[]) => void): Promise<void>;
 
     /**
      * Merges existing values with input values, assuming they are stringified json.
@@ -6540,10 +6499,10 @@ export interface AsyncStorageStatic {
      *
      * Not supported by all native implementations.
      */
-    multiMerge(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>
+    multiMerge(keyValuePairs: string[][], callback?: (errors?: Error[]) => void): Promise<void>;
 }
 
-export type BackPressEventName = "hardwareBackPress"
+export type BackPressEventName = "hardwareBackPress";
 
 /**
  * Detect hardware back button presses, and programmatically invoke the
@@ -6577,8 +6536,7 @@ export interface ButtonProperties {
     disabled?: boolean;
 }
 
-export interface ButtonStatic extends React.ComponentClass<ButtonProperties> {
-}
+export interface ButtonStatic extends React.ComponentClass<ButtonProperties> {}
 
 export type CameraRollGroupType = "Album" | "All" | "Event" | "Faces" | "Library" | "PhotoStream" | "SavedPhotos";
 export type CameraRollAssetType = "All" | "Videos" | "Photos";
@@ -6586,9 +6544,9 @@ export type CameraRollAssetType = "All" | "Videos" | "Photos";
 export interface CameraRollFetchParams {
     first: number;
     after?: string;
-    groupTypes?: CameraRollGroupType
-    groupName?: string
-    assetType?: CameraRollAssetType
+    groupTypes?: CameraRollGroupType;
+    groupName?: string;
+    assetType?: CameraRollAssetType;
 }
 
 export interface CameraRollNodeInfo {
@@ -6611,41 +6569,41 @@ export interface CameraRollAssetInfo {
 }
 
 export interface GetPhotosParamType {
-    first: number
-    after?: string
-    groupTypes?: CameraRollGroupType
-    groupName?: string
-    assetType?: CameraRollAssetType
-    mimeTypes?: string[]
+    first: number;
+    after?: string;
+    groupTypes?: CameraRollGroupType;
+    groupName?: string;
+    assetType?: CameraRollAssetType;
+    mimeTypes?: string[];
 }
 
 export interface GetPhotosReturnType {
     edges: {
         node: {
-            type: string
-            group_name: string
+            type: string;
+            group_name: string;
             image: {
-                uri: string
-                height: number
-                width: number
-                isStored?: boolean
-            }
-            timestamp: number
+                uri: string;
+                height: number;
+                width: number;
+                isStored?: boolean;
+            };
+            timestamp: number;
             location: {
-            latitude: number
-            longitude: number
-            altitude: number
-            heading: number
-            speed: number
-            }
-        }
-    }[]
+                latitude: number;
+                longitude: number;
+                altitude: number;
+                heading: number;
+                speed: number;
+            };
+        };
+    }[];
 
     page_info: {
-        has_next_page: boolean
-        start_cursor?: string
-        end_cursor?: string
-    }
+        has_next_page: boolean;
+        start_cursor?: string;
+        end_cursor?: string;
+    };
 }
 
 /**
@@ -6654,9 +6612,8 @@ export interface GetPhotosReturnType {
  * You can refer to (Linking)[https://facebook.github.io/react-native/docs/linking-libraries-ios.html] for help.
  */
 export interface CameraRollStatic {
-
-    GroupTypesOptions: CameraRollGroupType[] //'Album','All','Event','Faces','Library','PhotoStream','SavedPhotos'
-    AssetTypeOptions: CameraRollAssetType[] // "All", "Videos", "Photos"
+    GroupTypesOptions: CameraRollGroupType[]; //'Album','All','Event','Faces','Library','PhotoStream','SavedPhotos'
+    AssetTypeOptions: CameraRollAssetType[]; // "All", "Videos", "Photos"
 
     /**
      * Saves the image to the camera roll / gallery.
@@ -6669,7 +6626,7 @@ export interface CameraRollStatic {
      *
      * @deprecated use saveToCameraRoll instead
      */
-    saveImageWithTag(tag: string): Promise<string>
+    saveImageWithTag(tag: string): Promise<string>;
 
     /**
      * Saves the photo or video to the camera roll / gallery.
@@ -6685,7 +6642,7 @@ export interface CameraRollStatic {
      *
      * Returns a Promise which will resolve with the new URI.
      */
-    saveToCameraRoll(tag: string, type?: 'photo' | 'video'): Promise<string>
+    saveToCameraRoll(tag: string, type?: "photo" | "video"): Promise<string>;
 
     /**
      * Saves the photo or video to the camera roll / gallery.
@@ -6701,7 +6658,7 @@ export interface CameraRollStatic {
      *
      * Returns a Promise which will resolve with the new URI.
      */
-    saveToCameraRoll(tag: string, type?: 'photo' | 'video'): Promise<string>
+    saveToCameraRoll(tag: string, type?: "photo" | "video"): Promise<string>;
 
     /**
      * Invokes callback with photo identifier objects from the local camera roll of the device matching shape defined by getPhotosReturnChecker.
@@ -6718,18 +6675,18 @@ export interface ClipboardStatic {
 }
 
 export interface DatePickerAndroidOpenOption {
-    date?: Date | number
-    minDate?: Date | number
-    maxDate?: Date | number
-    mode?: 'calendar' | 'spinner' | 'default'
+    date?: Date | number;
+    minDate?: Date | number;
+    maxDate?: Date | number;
+    mode?: "calendar" | "spinner" | "default";
 }
 
 // Deduced from DatePickerAndroid.android.js
 export interface DatePickerAndroidOpenReturn {
-    action: string // "dateSetAction" | "dismissedAction"
-    year?: number
-    month?: number
-    day?: number
+    action: string; // "dateSetAction" | "dismissedAction"
+    year?: number;
+    month?: number;
+    day?: number;
 }
 
 export interface DatePickerAndroidStatic {
@@ -6748,17 +6705,17 @@ export interface DatePickerAndroidStatic {
 
         Note the native date picker dialog has some UI glitches on Android 4 and lower when using the minDate and maxDate options.
         */
-    open(options?: DatePickerAndroidOpenOption): Promise<DatePickerAndroidOpenReturn>
+    open(options?: DatePickerAndroidOpenOption): Promise<DatePickerAndroidOpenReturn>;
 
     /**
      * A date has been selected.
      */
-    dateSetAction: string
+    dateSetAction: string;
 
     /**
      * The dialog has been dismissed.
      */
-    dismissedAction: string
+    dismissedAction: string;
 }
 
 export interface IntentAndroidStatic {
@@ -6775,7 +6732,7 @@ export interface IntentAndroidStatic {
 
         @deprecated
         */
-    openURL(url: string): void
+    openURL(url: string): void;
 
     /**
      * Determine whether or not an installed app can handle a given URL.
@@ -6788,7 +6745,7 @@ export interface IntentAndroidStatic {
 
         @deprecated
         */
-    canOpenURL(url: string, callback: (supported: boolean) => void): void
+    canOpenURL(url: string, callback: (supported: boolean) => void): void;
 
     /**
      * If the app launch was triggered by an app link with {@code Intent.ACTION_VIEW}, it will give the link url, otherwise it will give null
@@ -6797,7 +6754,7 @@ export interface IntentAndroidStatic {
 
         @deprecated
         */
-    getInitialURL(callback: (url: string) => void): void
+    getInitialURL(callback: (url: string) => void): void;
 }
 
 export interface LinkingStatic extends NativeEventEmitter {
@@ -6805,12 +6762,12 @@ export interface LinkingStatic extends NativeEventEmitter {
      * Add a handler to Linking changes by listening to the `url` event type
      * and providing the handler
      */
-    addEventListener(type: string, handler: (event: { url: string }) => void): void
+    addEventListener(type: string, handler: (event: { url: string }) => void): void;
 
     /**
      * Remove a handler by passing the `url` event type and the handler
      */
-    removeEventListener(type: string, handler: (event: { url: string }) => void): void
+    removeEventListener(type: string, handler: (event: { url: string }) => void): void;
 
     /**
      * Try to open the given url with any of the installed apps.
@@ -6818,7 +6775,7 @@ export interface LinkingStatic extends NativeEventEmitter {
      * NOTE: This method will fail if the system doesn't know how to open the specified URL. If you're passing in a non-http(s) URL, it's best to check {@code canOpenURL} first.
      * NOTE: For web URLs, the protocol ("http://", "https://") must be set accordingly!
      */
-    openURL(url: string): Promise<any>
+    openURL(url: string): Promise<any>;
 
     /**
      * Determine whether or not an installed app can handle a given URL.
@@ -6826,13 +6783,13 @@ export interface LinkingStatic extends NativeEventEmitter {
      * NOTE: As of iOS 9, your app needs to provide the LSApplicationQueriesSchemes key inside Info.plist.
      * @param URL the URL to open
      */
-    canOpenURL(url: string): Promise<boolean>
+    canOpenURL(url: string): Promise<boolean>;
 
     /**
      * If the app launch was triggered by an app link with, it will give the link url, otherwise it will give null
      * NOTE: To support deep linking on Android, refer http://developer.android.com/training/app-indexing/deep-linking.html#handling-intents
      */
-    getInitialURL(): Promise<string>
+    getInitialURL(): Promise<string>;
 }
 
 export interface LinkingIOSStatic {
@@ -6840,26 +6797,26 @@ export interface LinkingIOSStatic {
      * Add a handler to LinkingIOS changes by listening to the url event type and providing the handler
      @deprecated
      */
-    addEventListener(type: string, handler: (event: { url: string }) => void): void
+    addEventListener(type: string, handler: (event: { url: string }) => void): void;
 
     /**
      * Remove a handler by passing the url event type and the handler
      @deprecated
      */
-    removeEventListener(type: string, handler: (event: { url: string }) => void): void
+    removeEventListener(type: string, handler: (event: { url: string }) => void): void;
 
     /**
      * Try to open the given url with any of the installed apps.
      @deprecated
      */
-    openURL(url: string): void
+    openURL(url: string): void;
 
     /**
      * Determine whether or not an installed app can handle a given URL. The callback function will be called with bool supported as the only argument
      NOTE: As of iOS 9, your app needs to provide the LSApplicationQueriesSchemes key inside Info.plist.
      @deprecated
      */
-    canOpenURL(url: string, callback: (supported: boolean) => void): void
+    canOpenURL(url: string, callback: (supported: boolean) => void): void;
 
     /**
      * If the app launch was triggered by an app link, it will pop the link url, otherwise it will return null
@@ -6868,33 +6825,51 @@ export interface LinkingIOSStatic {
     popInitialURL(): string;
 }
 
-
 /**
  * NetInfo exposes info about online/offline status
  * @see https://facebook.github.io/react-native/docs/netinfo.html#content
  */
 
 // @Deprecated ConnectionType
-export type ConnectionType = "none" | "wifi" | "cell" | "unknown" |
-    "NONE" | "MOBILE" | "WIFI" | "MOBILE_MMS" | "MOBILE_SUPL" | "MOBILE_DUN" |
-    "MOBILE_HIPRI" | "WIMAX" | "BLUETOOTH" | "DUMMY" | "ETHERNET" | "MOBILE_FOTA" |
-    "MOBILE_IMS" | "MOBILE_CBS" | "WIFI_P2P" | "MOBILE_IA" | "MOBILE_EMERGENCY" |
-    "PROXY" | "VPN" | "UNKNOWN"
+export type ConnectionType =
+    | "none"
+    | "wifi"
+    | "cell"
+    | "unknown"
+    | "NONE"
+    | "MOBILE"
+    | "WIFI"
+    | "MOBILE_MMS"
+    | "MOBILE_SUPL"
+    | "MOBILE_DUN"
+    | "MOBILE_HIPRI"
+    | "WIMAX"
+    | "BLUETOOTH"
+    | "DUMMY"
+    | "ETHERNET"
+    | "MOBILE_FOTA"
+    | "MOBILE_IMS"
+    | "MOBILE_CBS"
+    | "WIFI_P2P"
+    | "MOBILE_IA"
+    | "MOBILE_EMERGENCY"
+    | "PROXY"
+    | "VPN"
+    | "UNKNOWN";
 
-export type EffectiveConnectionType = "2g" | "3g" | "4g" | "unknown"
+export type EffectiveConnectionType = "2g" | "3g" | "4g" | "unknown";
 
 export interface ConnectionInfo {
-    type: ConnectionType
-    effectiveType: EffectiveConnectionType
+    type: ConnectionType;
+    effectiveType: EffectiveConnectionType;
 }
 
 export interface NetInfoStatic {
-
     /**
      * This function is deprecated. Use `getConnectionInfo` instead. Returns a promise that
      * resolves with one of the deprecated connectivity types listed above.
      */
-    fetch: () => Promise<ConnectionType>
+    fetch: () => Promise<ConnectionType>;
 
     /**
      * Adds an event handler. Supported events:
@@ -6907,19 +6882,19 @@ export interface NetInfoStatic {
      *   the network status changes. The argument to the event handler is one of the deprecated
      *   connectivity types listed above.
      */
-    addEventListener: (eventName: string, listener: (result: ConnectionInfo | ConnectionType) => void) => void
+    addEventListener: (eventName: string, listener: (result: ConnectionInfo | ConnectionType) => void) => void;
 
     /**
      * Removes the listener for network status changes.
      */
-    removeEventListener: (eventName: string, listener: (result: ConnectionInfo | ConnectionType) => void) => void
+    removeEventListener: (eventName: string, listener: (result: ConnectionInfo | ConnectionType) => void) => void;
 
     /**
      * Returns a promise that resolves to an object with `type` and `effectiveType` keys
      * whose values are a `ConnectionType` and an `EffectiveConnectionType`, (described above),
      * respectively.
      */
-    getConnectionInfo: () => Promise<ConnectionInfo>
+    getConnectionInfo: () => Promise<ConnectionInfo>;
 
     /**
      * An object with the same methods as above but the listener receives a
@@ -6928,19 +6903,18 @@ export interface NetInfoStatic {
      * connectivity.
      */
     isConnected: {
-
-        fetch: () => Promise<boolean>
-
-        /**
-         * eventName is expected to be `change`(deprecated) or `connectionChange`
-         */
-        addEventListener: (eventName: string, listener: (result: boolean) => void) => void
+        fetch: () => Promise<boolean>;
 
         /**
          * eventName is expected to be `change`(deprecated) or `connectionChange`
          */
-        removeEventListener: (eventName: string, listener: (result: boolean) => void) => void
-    }
+        addEventListener: (eventName: string, listener: (result: boolean) => void) => void;
+
+        /**
+         * eventName is expected to be `change`(deprecated) or `connectionChange`
+         */
+        removeEventListener: (eventName: string, listener: (result: boolean) => void) => void;
+    };
 
     /**
      * Detect if the current active connection is
@@ -6948,90 +6922,86 @@ export interface NetInfoStatic {
      * sensitive to heavy data usage on that connection due to monetary
      * costs, data limitations or battery/performance issues.
      */
-    isConnectionExpensive: Promise<boolean>
+    isConnectionExpensive: Promise<boolean>;
 }
 
-
 export interface PanResponderGestureState {
-
     /**
      *  ID of the gestureState- persisted as long as there at least one touch on
      */
-    stateID: number
+    stateID: number;
 
     /**
      *  the latest screen coordinates of the recently-moved touch
      */
-    moveX: number
+    moveX: number;
 
     /**
      *  the latest screen coordinates of the recently-moved touch
      */
-    moveY: number
+    moveY: number;
 
     /**
      * the screen coordinates of the responder grant
      */
-    x0: number
+    x0: number;
 
     /**
      * the screen coordinates of the responder grant
      */
-    y0: number
+    y0: number;
 
     /**
      * accumulated distance of the gesture since the touch started
      */
-    dx: number
+    dx: number;
 
     /**
      * accumulated distance of the gesture since the touch started
      */
-    dy: number
+    dy: number;
 
     /**
      * current velocity of the gesture
      */
-    vx: number
+    vx: number;
 
     /**
      * current velocity of the gesture
      */
-    vy: number
+    vy: number;
 
     /**
      * Number of touches currently on screen
      */
-    numberActiveTouches: number
-
+    numberActiveTouches: number;
 
     // All `gestureState` accounts for timeStamps up until:
-    _accountsForMovesUpTo: number
+    _accountsForMovesUpTo: number;
 }
-
 
 /**
  * @see documentation of GestureResponderHandlers
  */
 export interface PanResponderCallbacks {
-    onMoveShouldSetPanResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean
-    onStartShouldSetPanResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean
-    onPanResponderGrant?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
-    onPanResponderMove?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
-    onPanResponderRelease?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
-    onPanResponderTerminate?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
+    onMoveShouldSetPanResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean;
+    onStartShouldSetPanResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean;
+    onPanResponderGrant?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void;
+    onPanResponderMove?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void;
+    onPanResponderRelease?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void;
+    onPanResponderTerminate?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void;
 
-    onMoveShouldSetPanResponderCapture?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean
-    onStartShouldSetPanResponderCapture?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean
-    onPanResponderReject?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
-    onPanResponderStart?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
-    onPanResponderEnd?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void
-    onPanResponderTerminationRequest?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean
-    onShouldBlockNativeResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean
+    onMoveShouldSetPanResponderCapture?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean;
+    onStartShouldSetPanResponderCapture?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean;
+    onPanResponderReject?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void;
+    onPanResponderStart?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void;
+    onPanResponderEnd?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => void;
+    onPanResponderTerminationRequest?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean;
+    onShouldBlockNativeResponder?: (e: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean;
 }
 
 export interface PanResponderInstance {
-    panHandlers: GestureResponderHandlers
+    panHandlers: GestureResponderHandlers;
 }
 
 /**
@@ -7075,65 +7045,65 @@ export interface PanResponderStatic {
      *  accordingly. (numberActiveTouches) may not be totally accurate unless you
      *  are the responder.
      */
-    create(config: PanResponderCallbacks): PanResponderInstance
+    create(config: PanResponderCallbacks): PanResponderInstance;
 }
 
 export interface Rationale {
-    title: string
-    message: string
+    title: string;
+    message: string;
 }
 
 export type Permission =
-    "android.permission.READ_CALENDAR" |
-    "android.permission.WRITE_CALENDAR" |
-    "android.permission.CAMERA" |
-    "android.permission.READ_CONTACTS" |
-    "android.permission.WRITE_CONTACTS" |
-    "android.permission.GET_ACCOUNTS" |
-    "android.permission.ACCESS_FINE_LOCATION" |
-    "android.permission.ACCESS_COARSE_LOCATION" |
-    "android.permission.RECORD_AUDIO" |
-    "android.permission.READ_PHONE_STATE" |
-    "android.permission.CALL_PHONE" |
-    "android.permission.READ_CALL_LOG" |
-    "android.permission.WRITE_CALL_LOG" |
-    "com.android.voicemail.permission.ADD_VOICEMAIL" |
-    "android.permission.USE_SIP" |
-    "android.permission.PROCESS_OUTGOING_CALLS" |
-    "android.permission.BODY_SENSORS" |
-    "android.permission.SEND_SMS" |
-    "android.permission.RECEIVE_SMS" |
-    "android.permission.READ_SMS" |
-    "android.permission.RECEIVE_WAP_PUSH" |
-    "android.permission.RECEIVE_MMS" |
-    "android.permission.READ_EXTERNAL_STORAGE" |
-    "android.permission.WRITE_EXTERNAL_STORAGE"
+    | "android.permission.READ_CALENDAR"
+    | "android.permission.WRITE_CALENDAR"
+    | "android.permission.CAMERA"
+    | "android.permission.READ_CONTACTS"
+    | "android.permission.WRITE_CONTACTS"
+    | "android.permission.GET_ACCOUNTS"
+    | "android.permission.ACCESS_FINE_LOCATION"
+    | "android.permission.ACCESS_COARSE_LOCATION"
+    | "android.permission.RECORD_AUDIO"
+    | "android.permission.READ_PHONE_STATE"
+    | "android.permission.CALL_PHONE"
+    | "android.permission.READ_CALL_LOG"
+    | "android.permission.WRITE_CALL_LOG"
+    | "com.android.voicemail.permission.ADD_VOICEMAIL"
+    | "android.permission.USE_SIP"
+    | "android.permission.PROCESS_OUTGOING_CALLS"
+    | "android.permission.BODY_SENSORS"
+    | "android.permission.SEND_SMS"
+    | "android.permission.RECEIVE_SMS"
+    | "android.permission.READ_SMS"
+    | "android.permission.RECEIVE_WAP_PUSH"
+    | "android.permission.RECEIVE_MMS"
+    | "android.permission.READ_EXTERNAL_STORAGE"
+    | "android.permission.WRITE_EXTERNAL_STORAGE";
 
-export type PermissionStatus = "granted" | "denied" | "never_ask_again"
+export type PermissionStatus = "granted" | "denied" | "never_ask_again";
 
 export interface PermissionsAndroidStatic {
     /**
      * A list of permission results that are returned
      */
-    RESULTS: {[key: string]: PermissionStatus}
+    RESULTS: { [key: string]: PermissionStatus };
     /**
      * A list of specified "dangerous" permissions that require prompting the user
      */
-    PERMISSIONS: {[key: string]: Permission}
-    new(): PermissionsAndroidStatic
+    PERMISSIONS: { [key: string]: Permission };
+    new (): PermissionsAndroidStatic;
     /**
      * Deprecated
      */
-    checkPermission(permission: Permission): Promise<boolean>
+    checkPermission(permission: Permission): Promise<boolean>;
     /**
      * Returns a promise resolving to a boolean value as to whether the specified
      * permissions has been granted
      */
-    check(permission: Permission): Promise<boolean>
+    check(permission: Permission): Promise<boolean>;
     /**
      * Deprecated
      */
-    requestPermission(permission: Permission, rationale?: Rationale): Promise<boolean>
+    requestPermission(permission: Permission, rationale?: Rationale): Promise<boolean>;
     /**
      * Prompts the user to enable a permission and returns a promise resolving to a
      * string value indicating whether the user allowed or denied the request
@@ -7144,72 +7114,68 @@ export interface PermissionsAndroidStatic {
      * (https://developer.android.com/training/permissions/requesting.html#explain)
      * and then shows the system permission dialog
      */
-    request(permission: Permission, rationale?: Rationale): Promise<string>
+    request(permission: Permission, rationale?: Rationale): Promise<string>;
     /**
      * Prompts the user to enable multiple permissions in the same dialog and
      * returns an object with the permissions as keys and strings as values
      * indicating whether the user allowed or denied the request
      */
-    requestMultiple(permissions: Array<string>): Promise<{[permission: string]: PermissionStatus}>
+    requestMultiple(permissions: Array<string>): Promise<{ [permission: string]: PermissionStatus }>;
 }
 
 export interface PushNotificationPermissions {
-    alert?: boolean
-    badge?: boolean
-    sound?: boolean
+    alert?: boolean;
+    badge?: boolean;
+    sound?: boolean;
 }
 
 export interface PushNotification {
-
-
     /**
      * An alias for `getAlert` to get the notification's main message string
      */
-    getMessage(): string | Object
+    getMessage(): string | Object;
 
     /**
      * Gets the sound string from the `aps` object
      */
-    getSound(): string
+    getSound(): string;
 
     /**
      * Gets the notification's main message from the `aps` object
      */
-    getAlert(): string | Object
+    getAlert(): string | Object;
 
     /**
      * Gets the badge count number from the `aps` object
      */
-    getBadgeCount(): number
+    getBadgeCount(): number;
 
     /**
      * Gets the data object on the notif
      */
-    getData(): Object
-
+    getData(): Object;
 }
-
 
 type PresentLocalNotificationDetails = {
-    alertBody: string
-    alertAction: string
-    soundName?: string
-    category?: string
-    userInfo?: Object
-    applicationIconBadgeNumber?: number
-}
+    alertBody: string;
+    alertAction: string;
+    soundName?: string;
+    category?: string;
+    userInfo?: Object;
+    applicationIconBadgeNumber?: number;
+};
 
 type ScheduleLocalNotificationDetails = {
-    fireDate: Date
-    alertBody: string
-    alertAction: string
-    soundName?: string
-    category?: string
-    userInfo?: Object
-    applicationIconBadgeNumber?: number
-}
+    fireDate: Date;
+    alertBody: string;
+    alertAction: string;
+    soundName?: string;
+    category?: string;
+    userInfo?: Object;
+    applicationIconBadgeNumber?: number;
+};
 
-export type PushNotificationEventName = "notification" | "localNotification" | "register" | "registrationError"
+export type PushNotificationEventName = "notification" | "localNotification" | "register" | "registrationError";
 
 /**
  * Handle push notifications for your app, including permission handling and icon badge number.
@@ -7218,7 +7184,6 @@ export type PushNotificationEventName = "notification" | "localNotification" | "
  * //FIXME: BGR: The documentation seems completely off compared to the actual js implementation. I could never get the example to run
  */
 export interface PushNotificationIOSStatic {
-
     /**
      * Schedules the localNotification for immediate presentation.
      * details is an object containing:
@@ -7229,7 +7194,7 @@ export interface PushNotificationIOSStatic {
      * userInfo : An optional object containing additional notification data.
      * applicationIconBadgeNumber (optional) : The number to display as the app's icon badge. The default value of this property is 0, which means that no badge is displayed.
      */
-    presentLocalNotification(details: PresentLocalNotificationDetails): void
+    presentLocalNotification(details: PresentLocalNotificationDetails): void;
 
     /**
      * Schedules the localNotification for future presentation.
@@ -7242,33 +7207,33 @@ export interface PushNotificationIOSStatic {
      * userInfo : An optional object containing additional notification data.
      * applicationIconBadgeNumber (optional) : The number to display as the app's icon badge. Setting the number to 0 removes the icon badge.
      */
-    scheduleLocalNotification(details: ScheduleLocalNotificationDetails): void
+    scheduleLocalNotification(details: ScheduleLocalNotificationDetails): void;
 
     /**
      * Cancels all scheduled localNotifications
      */
-    cancelAllLocalNotifications(): void
+    cancelAllLocalNotifications(): void;
 
     /**
      * Cancel local notifications.
      * Optionally restricts the set of canceled notifications to those notifications whose userInfo fields match the corresponding fields in the userInfo argument.
      */
-    cancelLocalNotifications(userInfo: Object): void
+    cancelLocalNotifications(userInfo: Object): void;
 
     /**
      * Sets the badge number for the app icon on the home screen
      */
-    setApplicationIconBadgeNumber(number: number): void
+    setApplicationIconBadgeNumber(number: number): void;
 
     /**
      * Gets the current badge number for the app icon on the home screen
      */
-    getApplicationIconBadgeNumber(callback: (badge: number) => void): void
+    getApplicationIconBadgeNumber(callback: (badge: number) => void): void;
 
     /**
      * Gets the local notifications that are currently scheduled.
      */
-    getScheduledLocalNotifications(callback: (notifications: ScheduleLocalNotificationDetails[]) => void): void
+    getScheduledLocalNotifications(callback: (notifications: ScheduleLocalNotificationDetails[]) => void): void;
 
     /**
      * Attaches a listener to remote notifications while the app is running in the
@@ -7278,25 +7243,25 @@ export interface PushNotificationIOSStatic {
      *
      * The type MUST be 'notification'
      */
-    addEventListener(type: PushNotificationEventName, handler: (notification: PushNotification) => void): void
+    addEventListener(type: PushNotificationEventName, handler: (notification: PushNotification) => void): void;
 
     /**
      * Removes the event listener. Do this in `componentWillUnmount` to prevent
      * memory leaks
      */
-    removeEventListener(type: PushNotificationEventName, handler: (notification: PushNotification) => void): void
+    removeEventListener(type: PushNotificationEventName, handler: (notification: PushNotification) => void): void;
 
     /**
      * Requests all notification permissions from iOS, prompting the user's
      * dialog box.
      */
-    requestPermissions(permissions?: PushNotificationPermissions[]): void
+    requestPermissions(permissions?: PushNotificationPermissions[]): void;
 
     /**
      * Requests all notification permissions from iOS, prompting the user's
      * dialog box.
      */
-    requestPermissions(permissions?: PushNotificationPermissions): Promise<PushNotificationPermissions>
+    requestPermissions(permissions?: PushNotificationPermissions): Promise<PushNotificationPermissions>;
 
     /**
      * Unregister for all remote notifications received via Apple Push
@@ -7308,7 +7273,7 @@ export interface PushNotificationIOSStatic {
      * Settings app. Apps unregistered through this method can always
      * re-register.
      */
-    abandonPermissions(): void
+    abandonPermissions(): void;
 
     /**
      * See what push permissions are currently enabled. `callback` will be
@@ -7318,82 +7283,77 @@ export interface PushNotificationIOSStatic {
      *  - `badge` :boolean
      *  - `sound` :boolean
      */
-    checkPermissions(callback: (permissions: PushNotificationPermissions) => void): void
+    checkPermissions(callback: (permissions: PushNotificationPermissions) => void): void;
 
     /**
      * This method returns a promise that resolves to either the notification
      * object if the app was launched by a push notification, or `null` otherwise.
      */
-    getInitialNotification(): Promise<PushNotification>
+    getInitialNotification(): Promise<PushNotification>;
 }
 
 export interface SettingsStatic {
-    get(key: string): any
-    set(settings: Object): void
-    watchKeys(keys: string | Array<string>, callback: (() => void)): number
-    clearWatch(watchId: number): void
+    get(key: string): any;
+    set(settings: Object): void;
+    watchKeys(keys: string | Array<string>, callback: (() => void)): number;
+    clearWatch(watchId: number): void;
 }
 
+export type StatusBarStyle = "default" | "light-content" | "dark-content";
 
-
-export type StatusBarStyle = "default" | "light-content" | "dark-content"
-
-
-export type StatusBarAnimation = "none" | "fade" | "slide"
+export type StatusBarAnimation = "none" | "fade" | "slide";
 
 export interface StatusBarPropertiesIOS {
     /**
      * Sets the color of the status bar text.
      */
-    barStyle?: StatusBarStyle
+    barStyle?: StatusBarStyle;
 
     /**
      * If the network activity indicator should be visible.
      */
-    networkActivityIndicatorVisible?: boolean
+    networkActivityIndicatorVisible?: boolean;
 
     /**
      * The transition effect when showing and hiding the status bar using
      * the hidden prop. Defaults to 'fade'.
      */
-    showHideTransition?: "fade" | "slide"
+    showHideTransition?: "fade" | "slide";
 }
 
 export interface StatusBarPropertiesAndroid {
     /**
      * The background color of the status bar.
      */
-    backgroundColor?: string
+    backgroundColor?: string;
 
     /**
      * If the status bar is translucent. When translucent is set to true,
      * the app will draw under the status bar. This is useful when using a
      * semi transparent status bar color.
      */
-    translucent?: boolean
+    translucent?: boolean;
 }
 
 export interface StatusBarProperties extends StatusBarPropertiesIOS, StatusBarPropertiesAndroid {
-
     /**
      * If the transition between status bar property changes should be
      * animated. Supported for backgroundColor, barStyle and hidden.
      */
-    animated?: boolean
+    animated?: boolean;
 
     /**
      * If the status bar is hidden.
      */
-    hidden?: boolean
+    hidden?: boolean;
 }
 
 export interface StatusBarStatic extends React.ComponentClass<StatusBarProperties> {
-
     /**
      * The current height of the status bar on the device.
      * @platform android
      */
-    currentHeight?: number
+    currentHeight?: number;
 
     /**
      * Show or hide the status bar
@@ -7401,47 +7361,46 @@ export interface StatusBarStatic extends React.ComponentClass<StatusBarPropertie
      * @param animation Optional animation when
      *    changing the status bar hidden property.
      */
-    setHidden: (hidden: boolean, animation?: StatusBarAnimation) => void
+    setHidden: (hidden: boolean, animation?: StatusBarAnimation) => void;
 
     /**
      * Set the status bar style
      * @param style Status bar style to set
      * @param animated Animate the style change.
      */
-    setBarStyle: (style: StatusBarStyle, animated?: boolean) => void
+    setBarStyle: (style: StatusBarStyle, animated?: boolean) => void;
 
     /**
      * Control the visibility of the network activity indicator
      * @param visible Show the indicator.
      */
-    setNetworkActivityIndicatorVisible: (visible: boolean) => void
+    setNetworkActivityIndicatorVisible: (visible: boolean) => void;
 
     /**
      * Set the background color for the status bar
      * @param color Background color.
      * @param animated Animate the style change.
      */
-    setBackgroundColor: (color: string, animated?: boolean) => void
+    setBackgroundColor: (color: string, animated?: boolean) => void;
 
     /**
      * Control the translucency of the status bar
      * @param translucent Set as translucent.
      */
-    setTranslucent: (translucent: boolean) => void
+    setTranslucent: (translucent: boolean) => void;
 }
 
 /**
  * StatusBarIOS is deprecated.
  * Use `StatusBar` for mutating the status bar.
  */
-export interface StatusBarIOSStatic extends NativeEventEmitter {
-}
+export interface StatusBarIOSStatic extends NativeEventEmitter {}
 
 type TimePickerAndroidOpenOptions = {
-    hour?: number
-    minute?: number
-    is24Hour?: boolean
-}
+    hour?: number;
+    minute?: number;
+    is24Hour?: boolean;
+};
 
 /**
  * Opens the standard Android time picker dialog.
@@ -7464,7 +7423,6 @@ type TimePickerAndroidOpenOptions = {
  * ```
  */
 export interface TimePickerAndroidStatic {
-
     /**
      * Opens the standard Android time picker dialog.
      *
@@ -7480,17 +7438,17 @@ export interface TimePickerAndroidStatic {
      * still be resolved with action being `TimePickerAndroid.dismissedAction` and all the other keys
      * being undefined. **Always** check whether the `action` before reading the values.
      */
-    open(options: TimePickerAndroidOpenOptions): Promise<{ action: string, hour: number, minute: number }>
+    open(options: TimePickerAndroidOpenOptions): Promise<{ action: string; hour: number; minute: number }>;
 
     /**
      * A time has been selected.
      */
-    timeSetAction: string
+    timeSetAction: string;
 
     /**
      * The dialog has been dismissed.
      */
-    dismissedAction: string
+    dismissedAction: string;
 }
 
 /**
@@ -7509,20 +7467,16 @@ export interface ToastAndroidStatic {
      * int duration: The duration of the toast.
      * May be ToastAndroid.SHORT or ToastAndroid.LONG
      */
-    show(message: string, duration: number): void
+    show(message: string, duration: number): void;
     /** `gravity` may be ToastAndroid.TOP, ToastAndroid.BOTTOM, ToastAndroid.CENTER */
-    showWithGravity(
-        message: string,
-        duration: number,
-        gravity: number
-    ): void
+    showWithGravity(message: string, duration: number, gravity: number): void;
     // Toast duration constants
-    SHORT: number
-    LONG: number
+    SHORT: number;
+    LONG: number;
     // Toast gravity constants
-    TOP: number
-    BOTTOM: number
-    CENTER: number
+    TOP: number;
+    BOTTOM: number;
+    CENTER: number;
 }
 
 export interface UIManagerStatic {
@@ -7544,14 +7498,14 @@ export interface UIManagerStatic {
      * @platform ios
      */
     takeSnapshot: (
-        view ?: 'window' | React.ReactElement<any> | number,
-        options ?: {
-            width ?: number,
-            height ?: number,
-            format ?: 'png' | 'jpeg',
-            quality ?: number,
+        view?: "window" | React.ReactElement<any> | number,
+        options?: {
+            width?: number;
+            height?: number;
+            format?: "png" | "jpeg";
+            quality?: number;
         }
-    ) => Promise<string>
+    ) => Promise<string>;
 
     /**
      * Determines the location on screen, width, and height of the given view and
@@ -7600,7 +7554,7 @@ export interface UIManagerStatic {
     measureLayout(
         node: number,
         relativeToNativeNode: number,
-        onFail: () => void, /* currently unused */
+        onFail: () => void /* currently unused */,
         onSuccess: MeasureLayoutOnSuccessCallback
     ): void;
 
@@ -7618,47 +7572,45 @@ export interface UIManagerStatic {
 }
 
 export interface SwitchPropertiesIOS extends ViewProperties {
-
     /**
      * Background color when the switch is turned on.
      */
-    onTintColor?: string
+    onTintColor?: string;
 
     /**
      * Color of the foreground switch grip.
      */
-    thumbTintColor?: string
+    thumbTintColor?: string;
 
     /**
      * Background color when the switch is turned off.
      */
-    tintColor?: string
+    tintColor?: string;
 }
 
 export interface SwitchProperties extends SwitchPropertiesIOS {
-
     /**
      * If true the user won't be able to toggle the switch.
      * Default value is false.
      */
-    disabled?: boolean
+    disabled?: boolean;
 
     /**
      * Invoked with the new value when the value changes.
      */
-    onValueChange?: (value: boolean) => void
+    onValueChange?: (value: boolean) => void;
 
     /**
      * Used to locate this view in end-to-end tests.
      */
-    testID?: string
+    testID?: string;
 
     /**
      * The value of the switch. If true the switch will be turned on.
      * Default value is false.
      */
-    value?: boolean
-    style?: StyleProp<ViewStyle>
+    value?: boolean;
+    style?: StyleProp<ViewStyle>;
 }
 
 /**
@@ -7669,9 +7621,7 @@ export interface SwitchProperties extends SwitchPropertiesIOS {
  * If the `value` prop is not updated, the component will continue to render
  * the supplied `value` prop instead of the expected result of any user actions.
  */
-export interface SwitchStatic extends NativeMethodsMixin, React.ClassicComponentClass<SwitchProperties> {
-
-}
+export interface SwitchStatic extends NativeMethodsMixin, React.ClassicComponentClass<SwitchProperties> {}
 
 /**
  * NOTE: `VibrationIOS` is being deprecated. Use `Vibration` instead.
@@ -7690,7 +7640,7 @@ export interface VibrationIOSStatic {
     /**
      * @deprecated
      */
-    vibrate(): void
+    vibrate(): void;
 }
 
 /**
@@ -7717,12 +7667,12 @@ export interface VibrationIOSStatic {
  * V(fixed) --wait(1s)--> V(fixed) --wait(2s)--> V(fixed) --wait(3s)--> V(fixed)
  */
 export interface VibrationStatic {
-    vibrate(pattern: number | number[], repeat: boolean): void
+    vibrate(pattern: number | number[], repeat: boolean): void;
 
     /**
      * Stop vibration
      */
-    cancel(): void
+    cancel(): void;
 }
 
 /**
@@ -7745,10 +7695,7 @@ export interface EasingStatic {
     elastic(bounciness: number): EasingFunction;
     back(s: number): EasingFunction;
     bounce: EasingFunction;
-    bezier(x1: number,
-        y1: number,
-        x2: number,
-        y2: number): EasingFunction;
+    bezier(x1: number, y1: number, x2: number, y2: number): EasingFunction;
     in(easing: EasingFunction): EasingFunction;
     out(easing: EasingFunction): EasingFunction;
     inOut(easing: EasingFunction): EasingFunction;
@@ -7773,11 +7720,11 @@ export namespace Animated {
         interpolate(config: InterpolationConfigType): AnimatedInterpolation;
     }
 
-    type ExtrapolateType = 'extend' | 'identity' | 'clamp';
+    type ExtrapolateType = "extend" | "identity" | "clamp";
 
     type InterpolationConfigType = {
         inputRange: number[];
-        outputRange: (number[] | string[]);
+        outputRange: number[] | string[];
         easing?: ((input: number) => number);
         extrapolate?: ExtrapolateType;
         extrapolateLeft?: ExtrapolateType;
@@ -7795,10 +7742,10 @@ export namespace Animated {
     export class Value extends AnimatedWithChildren {
         constructor(value: number);
 
-    /**
-     * Directly set the value.  This will stop any animations running on the value
-     * and update all the bound properties.
-     */
+        /**
+         * Directly set the value.  This will stop any animations running on the value
+         * and update all the bound properties.
+         */
         setValue(value: number): void;
 
         /**
@@ -7866,7 +7813,7 @@ export namespace Animated {
 
         extractOffset(): void;
 
-        stopAnimation(callback?: (value: {x: number, y: number}) => void): void;
+        stopAnimation(callback?: (value: { x: number; y: number }) => void): void;
 
         addListener(callback: ValueXYListenerCallback): string;
 
@@ -7891,7 +7838,6 @@ export namespace Animated {
          *```
          */
         getTranslateTransform(): { [key: string]: AnimatedValue }[];
-
     }
 
     type EndResult = { finished: boolean };
@@ -7911,13 +7857,10 @@ export namespace Animated {
      * Animates a value from an initial velocity to zero based on a decay
      * coefficient.
      */
-    export function decay(
-        value: AnimatedValue | AnimatedValueXY,
-        config: DecayAnimationConfig
-    ): CompositeAnimation;
+    export function decay(value: AnimatedValue | AnimatedValueXY, config: DecayAnimationConfig): CompositeAnimation;
 
     interface DecayAnimationConfig extends AnimationConfig {
-        velocity: number | { x: number, y: number };
+        velocity: number | { x: number; y: number };
         deceleration?: number;
     }
 
@@ -7925,24 +7868,21 @@ export namespace Animated {
      * Animates a value along a timed easing curve.  The `Easing` module has tons
      * of pre-defined curves, or you can use your own function.
      */
-    export var timing: (
-        value: AnimatedValue | AnimatedValueXY,
-        config: TimingAnimationConfig
-    ) => CompositeAnimation;
+    export var timing: (value: AnimatedValue | AnimatedValueXY, config: TimingAnimationConfig) => CompositeAnimation;
 
     interface TimingAnimationConfig extends AnimationConfig {
-        toValue: number | AnimatedValue | { x: number, y: number } | AnimatedValueXY;
+        toValue: number | AnimatedValue | { x: number; y: number } | AnimatedValueXY;
         easing?: (value: number) => number;
         duration?: number;
         delay?: number;
     }
 
     interface SpringAnimationConfig extends AnimationConfig {
-        toValue: number | AnimatedValue | { x: number, y: number } | AnimatedValueXY;
+        toValue: number | AnimatedValue | { x: number; y: number } | AnimatedValueXY;
         overshootClamping?: boolean;
         restDisplacementThreshold?: number;
         restSpeedThreshold?: number;
-        velocity?: number | { x: number, y: number };
+        velocity?: number | { x: number; y: number };
         bounciness?: number;
         speed?: number;
         tension?: number;
@@ -7957,45 +7897,33 @@ export namespace Animated {
      * Creates a new Animated value composed from two Animated values added
      * together.
      */
-    export function add(
-        a: Animated,
-        b: Animated
-    ): AnimatedAddition;
+    export function add(a: Animated, b: Animated): AnimatedAddition;
 
-    class AnimatedAddition extends AnimatedInterpolation { }
+    class AnimatedAddition extends AnimatedInterpolation {}
 
     /**
      * Creates a new Animated value composed by dividing the first Animated
      * value by the second Animated value.
      */
-    export function divide(
-        a: Animated,
-        b: Animated
-    ): AnimatedDivision;
+    export function divide(a: Animated, b: Animated): AnimatedDivision;
 
-    class AnimatedDivision extends AnimatedInterpolation { }
+    class AnimatedDivision extends AnimatedInterpolation {}
 
     /**
      * Creates a new Animated value composed from two Animated values multiplied
      * together.
      */
-    export function multiply(
-        a: Animated,
-        b: Animated
-    ): AnimatedMultiplication;
+    export function multiply(a: Animated, b: Animated): AnimatedMultiplication;
 
-    class AnimatedMultiplication extends AnimatedInterpolation { }
+    class AnimatedMultiplication extends AnimatedInterpolation {}
 
     /**
      * Creates a new Animated value that is the (non-negative) modulo of the
      * provided Animated value
      */
-    export function modulo(
-        a: Animated,
-        modulus: number
-    ): AnimatedModulo;
+    export function modulo(a: Animated, modulus: number): AnimatedModulo;
 
-    class AnimatedModulo extends AnimatedInterpolation { }
+    class AnimatedModulo extends AnimatedInterpolation {}
 
     /**
      * Create a new Animated value that is limited between 2 values. It uses the
@@ -8020,19 +7948,14 @@ export namespace Animated {
      * before starting the next.  If the current running animation is stopped, no
      * following animations will be started.
      */
-    export function sequence(
-        animations: Array<CompositeAnimation>
-    ): CompositeAnimation;
+    export function sequence(animations: Array<CompositeAnimation>): CompositeAnimation;
 
     /**
      * Array of animations may run in parallel (overlap), but are started in
      * sequence with successive delays.  Nice for doing trailing effects.
      */
 
-    export function stagger(
-        time: number,
-        animations: Array<CompositeAnimation>
-    ): CompositeAnimation
+    export function stagger(time: number, animations: Array<CompositeAnimation>): CompositeAnimation;
 
     /**
      * Loops a given animation continuously, so that each time it reaches the end,
@@ -8041,33 +7964,24 @@ export namespace Animated {
      * the UI thread if the child animation is set to 'useNativeDriver'.
      */
 
-    export function loop(
-        animation: CompositeAnimation,
-        config?: LoopAnimationConfig,
-    ): CompositeAnimation
+    export function loop(animation: CompositeAnimation, config?: LoopAnimationConfig): CompositeAnimation;
 
     /**
      * Spring animation based on Rebound and Origami.  Tracks velocity state to
      * create fluid motions as the `toValue` updates, and can be chained together.
      */
-    export function spring(
-        value: AnimatedValue | AnimatedValueXY,
-        config: SpringAnimationConfig
-    ): CompositeAnimation;
+    export function spring(value: AnimatedValue | AnimatedValueXY, config: SpringAnimationConfig): CompositeAnimation;
 
     type ParallelConfig = {
         stopTogether?: boolean; // If one is stopped, stop all.  default: true
-    }
+    };
 
     /**
      * Starts an array of animations all at the same time.  By default, if one
      * of the animations is stopped, they will all be stopped.  You can override
      * this with the `stopTogether` flag.
      */
-    export function parallel(
-        animations: Array<CompositeAnimation>,
-        config?: ParallelConfig
-    ): CompositeAnimation;
+    export function parallel(animations: Array<CompositeAnimation>, config?: ParallelConfig): CompositeAnimation;
 
     type Mapping = { [key: string]: Mapping } | AnimatedValue;
     interface EventConfig {
@@ -8091,10 +8005,7 @@ export namespace Animated {
      *  ]),
      *```
      */
-    export function event(
-        argMapping: Array<Mapping | null>,
-        config?: EventConfig
-    ): (...args: any[]) => void;
+    export function event(argMapping: Array<Mapping | null>, config?: EventConfig): (...args: any[]) => void;
 
     /**
      * Make any React component Animatable.  Used to create `Animated.View`, etc.
@@ -8113,9 +8024,9 @@ export namespace Animated {
 
 // tslint:disable-next-line:interface-name
 export interface I18nManagerStatic {
-    isRTL: boolean
-    allowRTL: (allowRTL: boolean) => {}
-    forceRTL: (forceRTL: boolean) => {}
+    isRTL: boolean;
+    allowRTL: (allowRTL: boolean) => {};
+    forceRTL: (forceRTL: boolean) => {};
 }
 
 export interface GeolocationStatic {
@@ -8125,17 +8036,25 @@ export interface GeolocationStatic {
      * On Android, this can return almost immediately if the location is cached or
      * request an update, which might take a while.
      */
-    getCurrentPosition(geo_success: (position: GeolocationReturnType) => void, geo_error?: (error: GeolocationError) => void, geo_options?: GeoOptions): void
+    getCurrentPosition(
+        geo_success: (position: GeolocationReturnType) => void,
+        geo_error?: (error: GeolocationError) => void,
+        geo_options?: GeoOptions
+    ): void;
 
     /**
      * Invokes the success callback whenever the location changes.  Supported
      * options: timeout (ms), maximumAge (ms), enableHighAccuracy (bool), distanceFilter(m)
      */
-    watchPosition(success: (position: GeolocationReturnType) => void, error?: (error: GeolocationError) => void, options?: GeoOptions): number
+    watchPosition(
+        success: (position: GeolocationReturnType) => void,
+        error?: (error: GeolocationError) => void,
+        options?: GeoOptions
+    ): number;
 
-    clearWatch(watchID: number): void
+    clearWatch(watchID: number): void;
 
-    stopObserving(): void
+    stopObserving(): void;
 
     requestAuthorization(): void;
 
@@ -8144,24 +8063,32 @@ export interface GeolocationStatic {
 
 export interface OpenCameraDialogOptions {
     /** Defaults to false */
-    videoMode?: boolean
+    videoMode?: boolean;
 }
 
 export interface OpenSelectDialogOptions {
     /** Defaults to true */
-    showImages?: boolean
+    showImages?: boolean;
     /** Defaults to false */
-    showVideos?: boolean
+    showVideos?: boolean;
 }
 
 /** [imageURL|tempImageTag, height, width] */
-export type ImagePickerResult = [string, number, number]
+export type ImagePickerResult = [string, number, number];
 
 export interface ImagePickerIOSStatic {
-    canRecordVideos(callback: (value: boolean) => void): void
-    canUseCamera(callback: (value: boolean) => void): void
-    openCameraDialog(config: OpenCameraDialogOptions, successCallback: (args: ImagePickerResult) => void, cancelCallback: (args: any[]) => void): void
-    openSelectDialog(config: OpenSelectDialogOptions, successCallback: (args: ImagePickerResult) => void, cancelCallback: (args: any[]) => void): void
+    canRecordVideos(callback: (value: boolean) => void): void;
+    canUseCamera(callback: (value: boolean) => void): void;
+    openCameraDialog(
+        config: OpenCameraDialogOptions,
+        successCallback: (args: ImagePickerResult) => void,
+        cancelCallback: (args: any[]) => void
+    ): void;
+    openSelectDialog(
+        config: OpenSelectDialogOptions,
+        successCallback: (args: ImagePickerResult) => void,
+        cancelCallback: (args: any[]) => void
+    ): void;
 }
 
 export interface ImageStoreStatic {
@@ -8169,7 +8096,7 @@ export interface ImageStoreStatic {
      * Check if the ImageStore contains image data for the specified URI.
      * @platform ios
      */
-    hasImageForTag(uri: string, callback: (hasImage: boolean) => void): void
+    hasImageForTag(uri: string, callback: (hasImage: boolean) => void): void;
 
     /**
      * Delete an image from the ImageStore. Images are stored in memory and
@@ -8179,7 +8106,7 @@ export interface ImageStoreStatic {
      * will simply fail silently.
      * @platform ios
      */
-    removeImageForTag(uri: string): void
+    removeImageForTag(uri: string): void;
 
     /**
      * Stores a base64-encoded image in the ImageStore, and returns a URI that
@@ -8192,11 +8119,7 @@ export interface ImageStoreStatic {
      * than necessary.
      * @platform ios
      */
-    addImageFromBase64(
-        base64ImageData: string,
-        success: (uri: string) => void,
-        failure: (error: any) => void
-    ): void
+    addImageFromBase64(base64ImageData: string, success: (uri: string) => void, failure: (error: any) => void): void;
 
     /**
      * Retrieves the base64-encoded data for an image in the ImageStore. If the
@@ -8209,11 +8132,7 @@ export interface ImageStoreStatic {
      * the URI to an `<Image/>` component; there is no need to retrieve the
      * base64 data.
      */
-    getBase64ForTag(
-        uri: string,
-        success: (base64ImageData: string) => void,
-        failure: (error: any) => void
-    ): void
+    getBase64ForTag(uri: string, success: (base64ImageData: string) => void, failure: (error: any) => void): void;
 }
 
 //
@@ -8235,7 +8154,7 @@ export interface NativeEventSubscription {
  * @see https://github.com/facebook/react-native/blob/0.34-stable\Libraries\EventEmitter\RCTNativeAppEventEmitter.js
  * @see https://facebook.github.io/react-native/docs/native-modules-ios.html#sending-events-to-javascript
  */
-type RCTNativeAppEventEmitter = DeviceEventEmitterStatic
+type RCTNativeAppEventEmitter = DeviceEventEmitterStatic;
 
 interface ImageCropData {
     /**
@@ -8245,7 +8164,7 @@ interface ImageCropData {
     offset: {
         x: number;
         y: number;
-    }
+    };
 
     /**
      * The size (dimensions) of the cropped image, specified in the original
@@ -8254,18 +8173,18 @@ interface ImageCropData {
     size: {
         width: number;
         height: number;
-    }
+    };
 
     /**
      * (Optional) size to scale the cropped image to.
      */
-    displaySize?: { width: number, height: number }
+    displaySize?: { width: number; height: number };
 
     /**
      * (Optional) the resizing mode to use when scaling the image. If the
      * `displaySize` param is not specified, this has no effect.
      */
-    resizeMode?: 'contain' | 'cover' | 'stretch'
+    resizeMode?: "contain" | "cover" | "stretch";
 }
 
 interface ImageEditorStatic {
@@ -8279,35 +8198,38 @@ interface ImageEditorStatic {
      * callback will point to the image in the store. Remember to delete the
      * cropped image from the ImageStore when you are done with it.
      */
-    cropImage( uri: string, cropData: ImageCropData, success: (uri: string) => void, failure: (error: Object) => void ): void
+    cropImage(
+        uri: string,
+        cropData: ImageCropData,
+        success: (uri: string) => void,
+        failure: (error: Object) => void
+    ): void;
 }
 
 export interface ARTShapeProps {
-    d: string,
-    strokeWidth: number,
-    strokeDash?: number[],
-    stroke: string
+    d: string;
+    strokeWidth: number;
+    strokeDash?: number[];
+    stroke: string;
 }
 
 export interface ARTSurfaceProps {
-    style: StyleProp<ViewStyle>,
-    width: number,
-    height: number
+    style: StyleProp<ViewStyle>;
+    width: number;
+    height: number;
 }
 
-export interface ShapeStatic extends React.ComponentClass<ARTShapeProps> {
-}
+export interface ShapeStatic extends React.ComponentClass<ARTShapeProps> {}
 
-export interface SurfaceStatic extends React.ComponentClass<ARTSurfaceProps> {
-}
+export interface SurfaceStatic extends React.ComponentClass<ARTSurfaceProps> {}
 
 export interface ARTStatic {
-    Shape: ShapeStatic,
-    Surface: SurfaceStatic
+    Shape: ShapeStatic;
+    Surface: SurfaceStatic;
 }
 
 export interface KeyboardStatic extends NativeEventEmitter {
-    dismiss: () => void
+    dismiss: () => void;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -8318,255 +8240,254 @@ export interface KeyboardStatic extends NativeEventEmitter {
 
 // TODO: The following components need to be added
 // - [ ] ART
-export var ART: ARTStatic
-export type ART = ARTStatic
+export var ART: ARTStatic;
+export type ART = ARTStatic;
 
-export var ActivityIndicator: ActivityIndicatorStatic
-export type ActivityIndicator = ActivityIndicatorStatic
+export var ActivityIndicator: ActivityIndicatorStatic;
+export type ActivityIndicator = ActivityIndicatorStatic;
 
-export var ActivityIndicatorIOS: ActivityIndicatorIOSStatic
-export type ActivityIndicatorIOS = ActivityIndicatorIOSStatic
+export var ActivityIndicatorIOS: ActivityIndicatorIOSStatic;
+export type ActivityIndicatorIOS = ActivityIndicatorIOSStatic;
 
-export var DatePickerIOS: DatePickerIOSStatic
-export type DatePickerIOS = DatePickerIOSStatic
+export var DatePickerIOS: DatePickerIOSStatic;
+export type DatePickerIOS = DatePickerIOSStatic;
 
-export var DrawerLayoutAndroid: DrawerLayoutAndroidStatic
-export type DrawerLayoutAndroid = DrawerLayoutAndroidStatic
+export var DrawerLayoutAndroid: DrawerLayoutAndroidStatic;
+export type DrawerLayoutAndroid = DrawerLayoutAndroidStatic;
 
-export var Image: ImageStatic
-export type Image = ImageStatic
+export var Image: ImageStatic;
+export type Image = ImageStatic;
 
-export var ImageBackground: ImageBackgroundStatic
-export type ImageBackground = ImageBackgroundStatic
+export var ImageBackground: ImageBackgroundStatic;
+export type ImageBackground = ImageBackgroundStatic;
 
-export var ImagePickerIOS: ImagePickerIOSStatic
-export type ImagePickerIOS = ImagePickerIOSStatic
+export var ImagePickerIOS: ImagePickerIOSStatic;
+export type ImagePickerIOS = ImagePickerIOSStatic;
 
-export var FlatList: FlatListStatic<any>
-export type FlatList<ItemT> = FlatListStatic<ItemT>
+export var FlatList: FlatListStatic<any>;
+export type FlatList<ItemT> = FlatListStatic<ItemT>;
 
-export var LayoutAnimation: LayoutAnimationStatic
-export type LayoutAnimation = LayoutAnimationStatic
+export var LayoutAnimation: LayoutAnimationStatic;
+export type LayoutAnimation = LayoutAnimationStatic;
 
-export var ListView: ListViewStatic
-export type ListView = ListViewStatic
+export var ListView: ListViewStatic;
+export type ListView = ListViewStatic;
 
-export var MapView: MapViewStatic
-export type MapView = MapViewStatic
+export var MapView: MapViewStatic;
+export type MapView = MapViewStatic;
 
-export var MaskedView: MaskedViewStatic
-export type MaskedView = MaskedViewStatic
+export var MaskedView: MaskedViewStatic;
+export type MaskedView = MaskedViewStatic;
 
-export var Modal: ModalStatic
-export type Modal = ModalStatic
+export var Modal: ModalStatic;
+export type Modal = ModalStatic;
 
-export var NavigatorIOS: NavigatorIOSStatic
-export type NavigatorIOS = NavigatorIOSStatic
+export var NavigatorIOS: NavigatorIOSStatic;
+export type NavigatorIOS = NavigatorIOSStatic;
 
-export var Picker: PickerStatic
-export type Picker = PickerStatic
+export var Picker: PickerStatic;
+export type Picker = PickerStatic;
 
-export var PickerIOS: PickerIOSStatic
-export type PickerIOS = PickerIOSStatic
+export var PickerIOS: PickerIOSStatic;
+export type PickerIOS = PickerIOSStatic;
 
-export var ProgressBarAndroid: ProgressBarAndroidStatic
-export type ProgressBarAndroid = ProgressBarAndroidStatic
+export var ProgressBarAndroid: ProgressBarAndroidStatic;
+export type ProgressBarAndroid = ProgressBarAndroidStatic;
 
-export var ProgressViewIOS: ProgressViewIOSStatic
-export type ProgressViewIOS = ProgressViewIOSStatic
+export var ProgressViewIOS: ProgressViewIOSStatic;
+export type ProgressViewIOS = ProgressViewIOSStatic;
 
-export var RefreshControl: RefreshControlStatic
-export type RefreshControl = RefreshControlStatic
+export var RefreshControl: RefreshControlStatic;
+export type RefreshControl = RefreshControlStatic;
 
-export var RecyclerViewBackedScrollView: RecyclerViewBackedScrollViewStatic
-export type RecyclerViewBackedScrollView = RecyclerViewBackedScrollViewStatic
+export var RecyclerViewBackedScrollView: RecyclerViewBackedScrollViewStatic;
+export type RecyclerViewBackedScrollView = RecyclerViewBackedScrollViewStatic;
 
-export var SafeAreaView: SafeAreaViewStatic
-export type SafeAreaView = SafeAreaViewStatic
+export var SafeAreaView: SafeAreaViewStatic;
+export type SafeAreaView = SafeAreaViewStatic;
 
-export var SegmentedControlIOS: SegmentedControlIOSStatic
-export type SegmentedControlIOS = SegmentedControlIOSStatic
+export var SegmentedControlIOS: SegmentedControlIOSStatic;
+export type SegmentedControlIOS = SegmentedControlIOSStatic;
 
-export var Slider: SliderStatic
-export type Slider = SliderStatic
+export var Slider: SliderStatic;
+export type Slider = SliderStatic;
 
-export var SliderIOS: SliderStatic
-export type SliderIOS = SliderStatic
+export var SliderIOS: SliderStatic;
+export type SliderIOS = SliderStatic;
 
-export var StatusBar: StatusBarStatic
-export type StatusBar = StatusBarStatic
+export var StatusBar: StatusBarStatic;
+export type StatusBar = StatusBarStatic;
 
-export var ScrollView: ScrollViewStatic
-export type ScrollView = ScrollViewStatic
+export var ScrollView: ScrollViewStatic;
+export type ScrollView = ScrollViewStatic;
 
-export var SectionList: SectionListStatic<any>
-export type SectionList<ItemT> = SectionListStatic<ItemT>
+export var SectionList: SectionListStatic<any>;
+export type SectionList<ItemT> = SectionListStatic<ItemT>;
 
-export var SnapshotViewIOS: SnapshotViewIOSStatic
-export type SnapshotViewIOS = SnapshotViewIOSStatic
+export var SnapshotViewIOS: SnapshotViewIOSStatic;
+export type SnapshotViewIOS = SnapshotViewIOSStatic;
 
-export var Systrace: SystraceStatic
-export type Systrace = SystraceStatic
+export var Systrace: SystraceStatic;
+export type Systrace = SystraceStatic;
 
-export var SwipeableListView: SwipeableListViewStatic
-export type SwipeableListView = SwipeableListViewStatic
+export var SwipeableListView: SwipeableListViewStatic;
+export type SwipeableListView = SwipeableListViewStatic;
 
-export var Switch: SwitchStatic
-export type Switch = SwitchStatic
+export var Switch: SwitchStatic;
+export type Switch = SwitchStatic;
 
-export var SwitchIOS: SwitchIOSStatic
-export type SwitchIOS = SwitchIOSStatic
+export var SwitchIOS: SwitchIOSStatic;
+export type SwitchIOS = SwitchIOSStatic;
 
-export var TabBarIOS: TabBarIOSStatic
-export type TabBarIOS = TabBarIOSStatic
+export var TabBarIOS: TabBarIOSStatic;
+export type TabBarIOS = TabBarIOSStatic;
 
-export var Text: TextStatic
-export type Text = TextStatic
+export var Text: TextStatic;
+export type Text = TextStatic;
 
-export var TextInput: TextInputStatic
-export type TextInput = TextInputStatic
+export var TextInput: TextInputStatic;
+export type TextInput = TextInputStatic;
 
-export var ToolbarAndroid: ToolbarAndroidStatic
-export type ToolbarAndroid = ToolbarAndroidStatic
+export var ToolbarAndroid: ToolbarAndroidStatic;
+export type ToolbarAndroid = ToolbarAndroidStatic;
 
-export var TouchableHighlight: TouchableHighlightStatic
-export type TouchableHighlight = TouchableHighlightStatic
+export var TouchableHighlight: TouchableHighlightStatic;
+export type TouchableHighlight = TouchableHighlightStatic;
 
-export var TouchableNativeFeedback: TouchableNativeFeedbackStatic
-export type TouchableNativeFeedback = TouchableNativeFeedbackStatic
+export var TouchableNativeFeedback: TouchableNativeFeedbackStatic;
+export type TouchableNativeFeedback = TouchableNativeFeedbackStatic;
 
-export var TouchableOpacity: TouchableOpacityStatic
-export type TouchableOpacity = TouchableOpacityStatic
+export var TouchableOpacity: TouchableOpacityStatic;
+export type TouchableOpacity = TouchableOpacityStatic;
 
-export var TouchableWithoutFeedback: TouchableWithoutFeedbackStatic
-export type TouchableWithoutFeedback = TouchableWithoutFeedbackStatic
+export var TouchableWithoutFeedback: TouchableWithoutFeedbackStatic;
+export type TouchableWithoutFeedback = TouchableWithoutFeedbackStatic;
 
-export var View: ViewStatic
-export type View = ViewStatic
+export var View: ViewStatic;
+export type View = ViewStatic;
 
-export var ViewPagerAndroid: ViewPagerAndroidStatic
-export type ViewPagerAndroid = ViewPagerAndroidStatic
+export var ViewPagerAndroid: ViewPagerAndroidStatic;
+export type ViewPagerAndroid = ViewPagerAndroidStatic;
 
-export var WebView: WebViewStatic
-export type WebView = WebViewStatic
-
+export var WebView: WebViewStatic;
+export type WebView = WebViewStatic;
 
 //////////// APIS //////////////
-export var ActionSheetIOS: ActionSheetIOSStatic
-export type ActionSheetIOS = ActionSheetIOSStatic
+export var ActionSheetIOS: ActionSheetIOSStatic;
+export type ActionSheetIOS = ActionSheetIOSStatic;
 
-export var Share: ShareStatic
-export type Share = ShareStatic
+export var Share: ShareStatic;
+export type Share = ShareStatic;
 
-export var AdSupportIOS: AdSupportIOSStatic
-export type AdSupportIOS = AdSupportIOSStatic
+export var AdSupportIOS: AdSupportIOSStatic;
+export type AdSupportIOS = AdSupportIOSStatic;
 
-export var AccessibilityInfo: AccessibilityInfoStatic
-export type AccessibilityInfo = AccessibilityInfoStatic
+export var AccessibilityInfo: AccessibilityInfoStatic;
+export type AccessibilityInfo = AccessibilityInfoStatic;
 
-export var Alert: AlertStatic
-export type Alert = AlertStatic
+export var Alert: AlertStatic;
+export type Alert = AlertStatic;
 
-export var AlertAndroid: AlertAndroidStatic
-export type AlertAndroid = AlertAndroidStatic
+export var AlertAndroid: AlertAndroidStatic;
+export type AlertAndroid = AlertAndroidStatic;
 
-export var AlertIOS: AlertIOSStatic
-export type AlertIOS = AlertIOSStatic
+export var AlertIOS: AlertIOSStatic;
+export type AlertIOS = AlertIOSStatic;
 
 export var AppState: AppStateStatic;
 export type AppState = AppStateStatic;
 
-export var AppStateIOS: AppStateStatic
-export type AppStateIOS = AppStateStatic
+export var AppStateIOS: AppStateStatic;
+export type AppStateIOS = AppStateStatic;
 
-export var AsyncStorage: AsyncStorageStatic
-export type AsyncStorage = AsyncStorageStatic
+export var AsyncStorage: AsyncStorageStatic;
+export type AsyncStorage = AsyncStorageStatic;
 
-export var BackAndroid: BackAndroidStatic
-export type BackAndroid = BackAndroidStatic
+export var BackAndroid: BackAndroidStatic;
+export type BackAndroid = BackAndroidStatic;
 
-export var BackHandler: BackHandlerStatic
-export type BackHandler = BackHandlerStatic
+export var BackHandler: BackHandlerStatic;
+export type BackHandler = BackHandlerStatic;
 
-export var Button: ButtonStatic
-export type Button = ButtonStatic
+export var Button: ButtonStatic;
+export type Button = ButtonStatic;
 
-export var CameraRoll: CameraRollStatic
-export type CameraRoll = CameraRollStatic
+export var CameraRoll: CameraRollStatic;
+export type CameraRoll = CameraRollStatic;
 
-export var Clipboard: ClipboardStatic
-export type Clipboard = ClipboardStatic
+export var Clipboard: ClipboardStatic;
+export type Clipboard = ClipboardStatic;
 
-export var DatePickerAndroid: DatePickerAndroidStatic
-export type DatePickerAndroid = DatePickerAndroidStatic
+export var DatePickerAndroid: DatePickerAndroidStatic;
+export type DatePickerAndroid = DatePickerAndroidStatic;
 
-export var Geolocation: GeolocationStatic
-export type Geolocation = GeolocationStatic
+export var Geolocation: GeolocationStatic;
+export type Geolocation = GeolocationStatic;
 
 /** http://facebook.github.io/react-native/blog/2016/08/19/right-to-left-support-for-react-native-apps.html */
-export var I18nManager: I18nManagerStatic
-export type I18nManager = I18nManagerStatic
+export var I18nManager: I18nManagerStatic;
+export type I18nManager = I18nManagerStatic;
 
-export var ImageEditor: ImageEditorStatic
-export type ImageEditor = ImageEditorStatic
+export var ImageEditor: ImageEditorStatic;
+export type ImageEditor = ImageEditorStatic;
 
-export var ImageStore: ImageStoreStatic
-export type ImageStore = ImageStoreStatic
+export var ImageStore: ImageStoreStatic;
+export type ImageStore = ImageStoreStatic;
 
-export var InteractionManager: InteractionManagerStatic
+export var InteractionManager: InteractionManagerStatic;
 
-export var IntentAndroid: IntentAndroidStatic
-export type IntentAndroid = IntentAndroidStatic
+export var IntentAndroid: IntentAndroidStatic;
+export type IntentAndroid = IntentAndroidStatic;
 
-export var Keyboard: KeyboardStatic
+export var Keyboard: KeyboardStatic;
 
-export var KeyboardAvoidingView: KeyboardAvoidingViewStatic
-export type KeyboardAvoidingView = KeyboardAvoidingViewStatic
+export var KeyboardAvoidingView: KeyboardAvoidingViewStatic;
+export type KeyboardAvoidingView = KeyboardAvoidingViewStatic;
 
-export var Linking: LinkingStatic
-export type Linking = LinkingStatic
+export var Linking: LinkingStatic;
+export type Linking = LinkingStatic;
 
-export var LinkingIOS: LinkingIOSStatic
-export type LinkingIOS = LinkingIOSStatic
+export var LinkingIOS: LinkingIOSStatic;
+export type LinkingIOS = LinkingIOSStatic;
 
-export var NativeMethodsMixin: NativeMethodsMixinStatic
-export type NativeMethodsMixin = NativeMethodsMixinStatic
+export var NativeMethodsMixin: NativeMethodsMixinStatic;
+export type NativeMethodsMixin = NativeMethodsMixinStatic;
 
-export var NativeComponent: NativeMethodsMixinStatic
-export type NativeComponent = NativeMethodsMixinStatic
+export var NativeComponent: NativeMethodsMixinStatic;
+export type NativeComponent = NativeMethodsMixinStatic;
 
-export var NetInfo: NetInfoStatic
-export type NetInfo = NetInfoStatic
+export var NetInfo: NetInfoStatic;
+export type NetInfo = NetInfoStatic;
 
-export var PanResponder: PanResponderStatic
-export type PanResponder = PanResponderStatic
+export var PanResponder: PanResponderStatic;
+export type PanResponder = PanResponderStatic;
 
-export var PermissionsAndroid: PermissionsAndroidStatic
-export type PermissionsAndroid = PermissionsAndroidStatic
+export var PermissionsAndroid: PermissionsAndroidStatic;
+export type PermissionsAndroid = PermissionsAndroidStatic;
 
-export var PushNotificationIOS: PushNotificationIOSStatic
-export type PushNotificationIOS = PushNotificationIOSStatic
+export var PushNotificationIOS: PushNotificationIOSStatic;
+export type PushNotificationIOS = PushNotificationIOSStatic;
 
-export var Settings: SettingsStatic
-export type Settings = SettingsStatic
+export var Settings: SettingsStatic;
+export type Settings = SettingsStatic;
 
-export var StatusBarIOS: StatusBarIOSStatic
-export type StatusBarIOS = StatusBarIOSStatic
+export var StatusBarIOS: StatusBarIOSStatic;
+export type StatusBarIOS = StatusBarIOSStatic;
 
-export var TimePickerAndroid: TimePickerAndroidStatic
-export type TimePickerAndroid = TimePickerAndroidStatic
+export var TimePickerAndroid: TimePickerAndroidStatic;
+export type TimePickerAndroid = TimePickerAndroidStatic;
 
-export var ToastAndroid: ToastAndroidStatic
-export type ToastAndroid = ToastAndroidStatic
+export var ToastAndroid: ToastAndroidStatic;
+export type ToastAndroid = ToastAndroidStatic;
 
-export var UIManager: UIManagerStatic
-export type UIManager = UIManagerStatic
+export var UIManager: UIManagerStatic;
+export type UIManager = UIManagerStatic;
 
-export var VibrationIOS: VibrationIOSStatic
-export type VibrationIOS = VibrationIOSStatic
+export var VibrationIOS: VibrationIOSStatic;
+export type VibrationIOS = VibrationIOSStatic;
 
-export var Vibration: VibrationStatic
-export type Vibration = VibrationStatic
+export var Vibration: VibrationStatic;
+export type Vibration = VibrationStatic;
 
 export var Dimensions: Dimensions;
 export var ShadowPropTypesIOS: ShadowPropTypesIOSStatic;
@@ -8576,18 +8497,18 @@ export var Easing: EasingStatic;
 
 //////////// Plugins //////////////
 
-export var DeviceEventEmitter: DeviceEventEmitterStatic
+export var DeviceEventEmitter: DeviceEventEmitterStatic;
 /**
  * Abstract base class for implementing event-emitting modules. This implements
  * a subset of the standard EventEmitter node module API.
  */
 export interface NativeEventEmitter extends EventEmitter {}
-export var NativeEventEmitter: NativeEventEmitter
+export var NativeEventEmitter: NativeEventEmitter;
 /**
  * Deprecated - subclass NativeEventEmitter to create granular event modules instead of
  * adding all event listeners directly to RCTNativeAppEventEmitter.
  */
-export var NativeAppEventEmitter: RCTNativeAppEventEmitter
+export var NativeAppEventEmitter: RCTNativeAppEventEmitter;
 
 /**
  * Interface for NativeModules which allows to augment NativeModules with type informations.
@@ -8604,15 +8525,15 @@ interface NativeModulesStatic {
  * Use:
  * <code>const MyModule = NativeModules.ModuleName</code>
  */
-export var NativeModules: NativeModulesStatic
-export var Platform: PlatformStatic
-export var PlatformIOS: PlatformIOSStatic
-export var PixelRatio: PixelRatioStatic
+export var NativeModules: NativeModulesStatic;
+export var Platform: PlatformStatic;
+export var PlatformIOS: PlatformIOSStatic;
+export var PixelRatio: PixelRatioStatic;
 
 export interface ComponentInterface<P> {
     name?: string;
     displayName?: string;
-    propTypes: P
+    propTypes: P;
 }
 
 /**
@@ -8633,10 +8554,12 @@ export interface ComponentInterface<P> {
 export function requireNativeComponent<P>(
     viewName: string,
     componentInterface?: ComponentInterface<P>,
-    extraConfig?: {nativeOnly?: any}
+    extraConfig?: { nativeOnly?: any }
 ): React.ComponentClass<P>;
 
-export function findNodeHandle(componentOrHandle: null | number | React.Component<any, any> | React.ComponentClass<any>): null | number;
+export function findNodeHandle(
+    componentOrHandle: null | number | React.Component<any, any> | React.ComponentClass<any>
+): null | number;
 
 export function processColor(color: any): number;
 
@@ -8659,25 +8582,23 @@ export interface ErrorUtils {
 // Add-Ons
 //
 export namespace addons {
-
     //FIXME: Documentation ?
     export interface TestModuleStatic {
-
-        verifySnapshot: (done: (indicator?: any) => void) => void
-        markTestPassed: (indicator: any) => void
-        markTestCompleted: () => void
+        verifySnapshot: (done: (indicator?: any) => void) => void;
+        markTestPassed: (indicator: any) => void;
+        markTestCompleted: () => void;
     }
 
-    export var TestModule: TestModuleStatic
-    export type TestModule = TestModuleStatic
+    export var TestModule: TestModuleStatic;
+    export type TestModule = TestModuleStatic;
 }
 
 //
 // Prop Types
 //
-export var ColorPropType: React.Requireable<any>
-export var EdgeInsetsPropType: React.Requireable<any>
-export var PointPropType: React.Requireable<any>
+export var ColorPropType: React.Requireable<any>;
+export var EdgeInsetsPropType: React.Requireable<any>;
+export var PointPropType: React.Requireable<any>;
 
 declare global {
     function require(name: string): any;
@@ -8687,18 +8608,18 @@ declare global {
      * @see https://facebook.github.io/react-native/docs/javascript-environment.html#polyfills
      */
     interface Console {
-        error(message?: any, ...optionalParams: any[]): void
-        info(message?: any, ...optionalParams: any[]): void
-        log(message?: any, ...optionalParams: any[]): void
-        warn(message?: any, ...optionalParams: any[]): void
-        trace(message?: any, ...optionalParams: any[]): void
-        debug(message?: any, ...optionalParams: any[]): void
+        error(message?: any, ...optionalParams: any[]): void;
+        info(message?: any, ...optionalParams: any[]): void;
+        log(message?: any, ...optionalParams: any[]): void;
+        warn(message?: any, ...optionalParams: any[]): void;
+        trace(message?: any, ...optionalParams: any[]): void;
+        debug(message?: any, ...optionalParams: any[]): void;
         table(...data: any[]): void;
         disableYellowBox: boolean;
         ignoredYellowBox: string[];
     }
 
-    var console: Console
+    var console: Console;
 
     /**
      * Navigator object for accessing location API
@@ -8729,5 +8650,5 @@ declare global {
      * Typical usage:
      * <code> if (__DEV__) console.log('Running in dev mode')</code>
      */
-    var __DEV__: boolean
+    var __DEV__: boolean;
 }

--- a/types/react-native/test/animated.tsx
+++ b/types/react-native/test/animated.tsx
@@ -1,94 +1,80 @@
-import * as React from 'react-native'
+import * as React from "react-native";
 
-import {
-  Animated,
-  View,
-} from 'react-native';
+import { Animated, View } from "react-native";
 
 function TestAnimatedAPI() {
-  // Value
-  const v1 = new Animated.Value(0);
-  const v2 = new Animated.Value(0);
+    // Value
+    const v1 = new Animated.Value(0);
+    const v2 = new Animated.Value(0);
 
-  v1.setValue(0.1);
+    v1.setValue(0.1);
 
-  v1.addListener(e => {
-    const n: number = e.value;
-  });
+    v1.addListener(e => {
+        const n: number = e.value;
+    });
 
-  const v200 = v1.interpolate({
-    inputRange: [0, 1],
-    outputRange: [0, 200],
-  });
+    const v200 = v1.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 200],
+    });
 
-  // ValueXY
-  const position = new Animated.ValueXY({ x: 0, y: 0 });
+    // ValueXY
+    const position = new Animated.ValueXY({ x: 0, y: 0 });
 
-  // Animation functions
-  const spring1 = Animated.spring(v1, {
-    toValue: 0.5,
-    tension: 10,
-  });
+    // Animation functions
+    const spring1 = Animated.spring(v1, {
+        toValue: 0.5,
+        tension: 10,
+    });
 
-  const springXY =  Animated.spring(position, {
-    toValue: {
-      x: 1,
-      y: 2,
-    }
-  });
+    const springXY = Animated.spring(position, {
+        toValue: {
+            x: 1,
+            y: 2,
+        },
+    });
 
-  spring1.start();
-  spring1.stop();
+    spring1.start();
+    spring1.stop();
 
-  Animated.parallel([
-    Animated.spring(v1, { toValue: 1 }),
-    Animated.spring(v2, { toValue: 1 }),
-  ], {
-    stopTogether: true,
-  });
+    Animated.parallel([Animated.spring(v1, { toValue: 1 }), Animated.spring(v2, { toValue: 1 })], {
+        stopTogether: true,
+    });
 
-  Animated.decay(v1, {
-    velocity: 2,
-  });
+    Animated.decay(v1, {
+        velocity: 2,
+    });
 
-  Animated.timing(v1, {
-    toValue: 1,
-    duration: 100,
-    delay: 100,
-    easing: v => v,
-  });
+    Animated.timing(v1, {
+        toValue: 1,
+        duration: 100,
+        delay: 100,
+        easing: v => v,
+    });
 
-  Animated.add(v1, v2);
-  Animated.divide(v1, v2);
-  Animated.multiply(v1, v2);
-  Animated.modulo(v1, 2);
+    Animated.add(v1, v2);
+    Animated.divide(v1, v2);
+    Animated.multiply(v1, v2);
+    Animated.modulo(v1, 2);
 
-  Animated.delay(100);
+    Animated.delay(100);
 
-  Animated.sequence([
-    spring1,
-    springXY,
-  ]);
+    Animated.sequence([spring1, springXY]);
 
-  Animated.stagger(100, [
-    spring1,
-    springXY,
-  ]);
+    Animated.stagger(100, [spring1, springXY]);
 
-  return (
-    <View>
-      <Animated.View
-        style={[
-          position.getLayout(),
-          {
-            opacity: v1,
-          }]}>
-      </Animated.View>
+    return (
+        <View>
+            <Animated.View
+                style={[
+                    position.getLayout(),
+                    {
+                        opacity: v1,
+                    },
+                ]}
+            />
 
-      <Animated.Image
-        style={position.getTranslateTransform()}
-        >
-      </Animated.Image>
-    </View>
-  );
+            <Animated.Image style={position.getTranslateTransform()} />
+        </View>
+    );
 }

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -11,7 +11,7 @@ The content of index.io.js could be something like
 For a list of complete Typescript examples: check https://github.com/bgrieder/RNTSExplorer
 */
 
-import * as React from 'react'
+import * as React from "react";
 import {
     Alert,
     AppState,
@@ -43,15 +43,15 @@ import {
     TabBarIOS,
     NativeModules,
     MaskedView,
-} from 'react-native';
+} from "react-native";
 
-declare module 'react-native' {
+declare module "react-native" {
     interface NativeTypedModule {
         someFunction(): void;
         someProperty: string;
     }
     interface NativeModulesStatic {
-        NativeTypedModule: NativeTypedModule
+        NativeTypedModule: NativeTypedModule;
     }
 }
 
@@ -61,16 +61,10 @@ NativeModules.NativeTypedModule.someFunction();
 NativeModules.NativeTypedModule.someProperty = "";
 
 function testDimensions() {
-  const {
-    width,
-    height,
-    scale,
-    fontScale,
-  } = Dimensions.get(1 === 1 ? "window" : "screen");
+    const { width, height, scale, fontScale } = Dimensions.get(1 === 1 ? "window" : "screen");
 }
 
-BackAndroid.addEventListener("hardwareBackPress", () => {
-});
+BackAndroid.addEventListener("hardwareBackPress", () => {});
 
 interface LocalStyles {
     container: ViewStyle;
@@ -78,80 +72,69 @@ interface LocalStyles {
     instructions: TextStyle;
 }
 
-const styles = StyleSheet.create<LocalStyles>(
-    {
-        container:    {
-            flex:            1,
-            justifyContent:  'center',
-            alignItems:      'center',
-            backgroundColor: '#F5FCFF',
-        },
-        welcome:   {
-            fontSize:  20,
-            textAlign: 'center',
-            margin:    10,
-        },
-        instructions: {
-            textAlign:    'center',
-            color:        '#333333',
-            marginBottom: 5,
-        },
-    }
-)
+const styles = StyleSheet.create<LocalStyles>({
+    container: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "#F5FCFF",
+    },
+    welcome: {
+        fontSize: 20,
+        textAlign: "center",
+        margin: 10,
+    },
+    instructions: {
+        textAlign: "center",
+        color: "#333333",
+        marginBottom: 5,
+    },
+});
 
 //alternative declaration of styles (inline typings)
-const stylesAlt = StyleSheet.create(
-    {
-        container: {
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-            backgroundColor: '#F5FCFF',
-        },
-        welcome: {
-            fontSize: 20,
-            textAlign: 'center',
-            margin: 10,
-        },
-        instructions: {
-            textAlign: 'center',
-            color: '#333333',
-            marginBottom: 5,
-        }
-    }
-);
+const stylesAlt = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "#F5FCFF",
+    },
+    welcome: {
+        fontSize: 20,
+        textAlign: "center",
+        margin: 10,
+    },
+    instructions: {
+        textAlign: "center",
+        color: "#333333",
+        marginBottom: 5,
+    },
+});
 
-const welcomeFontSize = StyleSheet.flatten(styles.welcome).fontSize
+const welcomeFontSize = StyleSheet.flatten(styles.welcome).fontSize;
 
 class CustomView extends React.Component {
-
     render() {
-        return (
-            <Text style={[StyleSheet.absoluteFill, {...StyleSheet.absoluteFillObject}]}>Custom View</Text>
-        );
+        return <Text style={[StyleSheet.absoluteFill, { ...StyleSheet.absoluteFillObject }]}>Custom View</Text>;
     }
-
 }
 
 class Welcome extends React.Component {
     refs: {
-        [key: string]: any
-        rootView: View
-        customView: CustomView
-    }
+        [key: string]: any;
+        rootView: View;
+        customView: CustomView;
+    };
 
     testNativeMethods() {
         // this.setNativeProps({});
 
         const { rootView } = this.refs;
 
-        rootView.measure((x: number, y: number, width: number, height: number) => {
-        });
-
+        rootView.measure((x: number, y: number, width: number, height: number) => {});
     }
 
     testFindNodeHandle() {
-
         const { rootView, customView } = this.refs;
 
         const nativeComponentHandle = findNodeHandle(rootView);
@@ -159,25 +142,20 @@ class Welcome extends React.Component {
         const customComponentHandle = findNodeHandle(customView);
 
         const fromHandle = findNodeHandle(customComponentHandle);
-
     }
 
     render() {
         return (
             <View ref="rootView" style={[[styles.container], undefined, null, false]}>
-                <Text style={styles.welcome}>
-                    Welcome to React Native
-                </Text>
+                <Text style={styles.welcome}>Welcome to React Native</Text>
+                <Text style={styles.instructions}>To get started, edit index.ios.js</Text>
                 <Text style={styles.instructions}>
-                    To get started, edit index.ios.js
-                </Text>
-                <Text style={styles.instructions}>
-                    Press Cmd+R to reload,{'\n'}
+                    Press Cmd+R to reload,{"\n"}
                     Cmd+D or shake for dev menu
                 </Text>
                 <CustomView ref="customView" />
             </View>
-        )
+        );
     }
 }
 
@@ -186,17 +164,17 @@ export default Welcome;
 // App State
 
 function appStateListener(state: string) {
-    console.log('New state: ' + state);
+    console.log("New state: " + state);
 }
 
 function appStateTest() {
-    console.log('Current state: ' + AppState.currentState);
-    AppState.addEventListener('change', appStateListener);
+    console.log("Current state: " + AppState.currentState);
+    AppState.addEventListener("change", appStateListener);
 }
 
 function appStateIOSTest() {
-    console.log('Current state: ' + AppStateIOS.currentState);
-    AppStateIOS.addEventListener('change', appStateListener);
+    console.log("Current state: " + AppStateIOS.currentState);
+    AppStateIOS.addEventListener("change", appStateListener);
 }
 
 // ViewPagerAndroid
@@ -204,27 +182,28 @@ function appStateIOSTest() {
 export class ViewPagerAndroidTest {
     render() {
         return (
-            <ViewPagerAndroid style={{height: 56}}
+            <ViewPagerAndroid
+                style={{ height: 56 }}
                 initialPage={0}
-                keyboardDismissMode={'on-drag'}
-                onPageScroll={(e) => {
+                keyboardDismissMode={"on-drag"}
+                onPageScroll={e => {
                     console.log(`position: ${e.nativeEvent.position}`);
                     console.log(`offset: ${e.nativeEvent.offset}`);
                 }}
-                onPageSelected={(e) => {
-                    console.log(`position: ${e.nativeEvent.position}`)
+                onPageSelected={e => {
+                    console.log(`position: ${e.nativeEvent.position}`);
                 }}
-                />
+            />
         );
     }
 }
 
-const profiledJSONParse = Systrace.measure('JSON', 'parse', JSON.parse)
-profiledJSONParse('[]')
+const profiledJSONParse = Systrace.measure("JSON", "parse", JSON.parse);
+profiledJSONParse("[]");
 
 InteractionManager.runAfterInteractions(() => {
     // ...
-}).then(() => 'done')
+}).then(() => "done");
 
 export class FlatListTest extends React.Component<FlatListProperties<number>, {}> {
     _renderItem = (rowData: any) => {
@@ -233,9 +212,9 @@ export class FlatListTest extends React.Component<FlatListProperties<number>, {}
                 <Text> {rowData.item} </Text>
             </View>
         );
-      }
+    };
 
-    _renderSeparator= () => <View style={{height: 1, width: '100%', backgroundColor: 'gray'}} />
+    _renderSeparator = () => <View style={{ height: 1, width: "100%", backgroundColor: "gray" }} />;
 
     render() {
         return (
@@ -250,20 +229,35 @@ export class FlatListTest extends React.Component<FlatListProperties<number>, {}
 
 export class SectionListTest extends React.Component<SectionListProperties<string>, {}> {
     render() {
-        const sections = [{
-            title: 'Section 1',
-            data: ['A', 'B', 'C', 'D', 'E'],
-        }, {
-            title: 'Section 2',
-            data: ['A2', 'B2', 'C2', 'D2', 'E2'],
-            renderItem: (info: { item: string }) => <View><Text>{info.item}</Text></View>
-        }];
+        const sections = [
+            {
+                title: "Section 1",
+                data: ["A", "B", "C", "D", "E"],
+            },
+            {
+                title: "Section 2",
+                data: ["A2", "B2", "C2", "D2", "E2"],
+                renderItem: (info: { item: string }) => (
+                    <View>
+                        <Text>{info.item}</Text>
+                    </View>
+                ),
+            },
+        ];
 
         return (
             <SectionList
                 sections={sections}
-                renderSectionHeader={({section}) => <View><Text>{section.title}</Text></View>}
-                renderItem={(info: { item: string }) => <View><Text>{info.item}</Text></View>}
+                renderSectionHeader={({ section }) => (
+                    <View>
+                        <Text>{section.title}</Text>
+                    </View>
+                )}
+                renderItem={(info: { item: string }) => (
+                    <View>
+                        <Text>{info.item}</Text>
+                    </View>
+                )}
             />
         );
     }
@@ -271,42 +265,38 @@ export class SectionListTest extends React.Component<SectionListProperties<strin
 
 export class CapsLockComponent extends React.Component<TextProperties> {
     render() {
-        const content = (this.props.children || "") as string
-        return (
-            <Text {...this.props} >
-                {content.toUpperCase()}
-            </Text>
-        )
+        const content = (this.props.children || "") as string;
+        return <Text {...this.props}>{content.toUpperCase()}</Text>;
     }
 }
 
-class ScrollerListComponentTest extends React.Component<{}, { dataSource: ListViewDataSource}> {
+class ScrollerListComponentTest extends React.Component<{}, { dataSource: ListViewDataSource }> {
     render() {
         const scrollViewStyle1 = StyleSheet.create({
             scrollView: {
-                backgroundColor: 'red',
+                backgroundColor: "red",
             },
         });
         const scrollViewStyle2 = {
-            flex: 1
+            flex: 1,
         };
         return (
-            <ListView dataSource={this.state.dataSource}
-                renderScrollComponent={(props) => {
+            <ListView
+                dataSource={this.state.dataSource}
+                renderScrollComponent={props => {
                     if (props.scrollEnabled) {
-                        throw new Error("Expected scroll to be enabled.")
+                        throw new Error("Expected scroll to be enabled.");
                     }
 
-                    return <ScrollView {...props} style={[scrollViewStyle1.scrollView, scrollViewStyle2]}/>
+                    return <ScrollView {...props} style={[scrollViewStyle1.scrollView, scrollViewStyle2]} />;
                 }}
                 renderRow={({ type, data }, _, row) => {
-                    return <Text>Filler</Text>
-                }
-            } />
-        )
+                    return <Text>Filler</Text>;
+                }}
+            />
+        );
     }
 }
-
 
 class TabBarTest extends React.Component {
     render() {
@@ -315,20 +305,21 @@ class TabBarTest extends React.Component {
                 barTintColor="darkslateblue"
                 itemPositioning="center"
                 tintColor="white"
-                translucent={ true }
+                translucent={true}
                 unselectedTintColor="black"
-                unselectedItemTintColor="red">
+                unselectedItemTintColor="red"
+            >
                 <TabBarIOS.Item
-                    badge={ 0 }
+                    badge={0}
                     badgeColor="red"
-                    icon={{uri: undefined}}
-                    selected={ true }
+                    icon={{ uri: undefined }}
+                    selected={true}
                     onPress={() => {}}
-                    renderAsOriginal={ true }
-                    selectedIcon={ undefined }
+                    renderAsOriginal={true}
+                    selectedIcon={undefined}
                     systemIcon="history"
-                    title="Item 1">
-                </TabBarIOS.Item>
+                    title="Item 1"
+                />
             </TabBarIOS>
         );
     }
@@ -337,38 +328,32 @@ class TabBarTest extends React.Component {
 class AlertTest extends React.Component {
     showAlert() {
         Alert.alert(
-            'Title',
-            'Message',
+            "Title",
+            "Message",
             [
-                { text: 'First button', onPress: () => {} },
-                { text: 'Second button', onPress: () => {} },
-                { text: 'Third button', onPress: () => {} }
+                { text: "First button", onPress: () => {} },
+                { text: "Second button", onPress: () => {} },
+                { text: "Third button", onPress: () => {} },
             ],
             {
                 cancelable: false,
-                onDismiss: () => {}
+                onDismiss: () => {},
             }
-        )
+        );
     }
 
     render() {
-        return (
-            <Button title='Press me' onPress={this.showAlert}/>
-        );
+        return <Button title="Press me" onPress={this.showAlert} />;
     }
 }
 
 class MaskedViewTest extends React.Component {
     render() {
         return (
-            <MaskedView
-                maskElement={
-                    <View />
-                }
-            >
+            <MaskedView maskElement={<View />}>
                 <View />
             </MaskedView>
-        )
+        );
     }
 }
 
@@ -378,11 +363,11 @@ const dataSourceAssetCallback1: DataSourceAssetCallback = {
     sectionHeaderHasChanged: (h1, h2) => true,
     getRowData: (dataBlob, sectionID, rowID) => (sectionID as number) + (rowID as number),
     getSectionHeaderData: (dataBlob, sectionID) => sectionID as string,
-}
+};
 
-const dataSourceAssetCallback2: DataSourceAssetCallback = {}
+const dataSourceAssetCallback2: DataSourceAssetCallback = {};
 
 // DeviceEventEmitterStatic
 const deviceEventEmitterStatic: DeviceEventEmitterStatic = null;
-deviceEventEmitterStatic.addListener('keyboardWillShow', (data) => true);
-deviceEventEmitterStatic.addListener('keyboardWillShow', (data) => true, {});
+deviceEventEmitterStatic.addListener("keyboardWillShow", data => true);
+deviceEventEmitterStatic.addListener("keyboardWillShow", data => true, {});

--- a/types/react-native/test/init-example.tsx
+++ b/types/react-native/test/init-example.tsx
@@ -1,45 +1,36 @@
-import * as React from 'react';
-import {
-  AppRegistry,
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
+import * as React from "react";
+import { AppRegistry, StyleSheet, Text, View } from "react-native";
 
 export default class AwesomeProject extends React.Component {
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.ios.js
-        </Text>
-        <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu
-        </Text>
-      </View>
-    );
-  }
+    render() {
+        return (
+            <View style={styles.container}>
+                <Text style={styles.welcome}>Welcome to React Native!</Text>
+                <Text style={styles.instructions}>To get started, edit index.ios.js</Text>
+                <Text style={styles.instructions}>
+                    Press Cmd+R to reload,{"\n"}
+                    Cmd+D or shake for dev menu
+                </Text>
+            </View>
+        );
+    }
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
+    container: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "#F5FCFF",
+    },
+    welcome: {
+        fontSize: 20,
+        textAlign: "center",
+        margin: 10,
+    },
+    instructions: {
+        textAlign: "center",
+        color: "#333333",
+        marginBottom: 5,
+    },
 });


### PR DESCRIPTION
I’ve already been using [prettier](https://github.com/prettier/prettier) with the Relay typings and think it makes sense to start using it for the RN typings too. This is the command I used and which we can periodically run to get all the style consistent again.

    prettier --parser typescript --tab-width 4 --semi --trailing-comma es5 \
             --write --print-width 120 \
             types/react-native{,/test}/*.ts*

@iRoachie @huhuanming @timwangdev @kamal Opinions? 👍 👎 