### PR TITLE
node: add documented highWaterMark option to fs.createReadStream

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -14,6 +14,7 @@
 //                 Kelvin Jin <https://github.com/kjin>
 //                 Alvis HT Tang <https://github.com/alvis>
 //                 Oliver Joseph Ash <https://github.com/OliverJAsh>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /************************************************
@@ -4350,6 +4351,7 @@ declare module "fs" {
         autoClose?: boolean;
         start?: number;
         end?: number;
+        highWaterMark?: number;
     }): ReadStream;
 
     /**

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for Node.js 4.2
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>, DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions by: Microsoft TypeScript <http://typescriptlang.org>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /************************************************
@@ -1847,6 +1849,7 @@ declare module "fs" {
         fd?: number;
         mode?: number;
         autoClose?: boolean;
+        highWaterMark?: number;
     }): ReadStream;
     export function createWriteStream(path: string, options?: {
         flags?: string;

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for Node.js v6.x
 // Project: http://nodejs.org/
-// Definitions by: Microsoft TypeScript <http://typescriptlang.org>, DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>, Wilco Bakker <https://github.com/WilcoBakker>, Thomas Bouldin <https://github.com/inlined>
+// Definitions by: Microsoft TypeScript <http://typescriptlang.org>
+//                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
+//                 Wilco Bakker <https://github.com/WilcoBakker>
+//                 Thomas Bouldin <https://github.com/inlined>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /************************************************
@@ -2746,6 +2750,7 @@ declare module "fs" {
         autoClose?: boolean;
         start?: number;
         end?: number;
+        highWaterMark?: number;
     }): ReadStream;
     export function createWriteStream(path: string | Buffer, options?: {
         flags?: string;

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -5,6 +5,7 @@
 //                 Parambir Singh <https://github.com/parambirs>
 //                 Christian Vaagland Tellnes <https://github.com/tellnes>
 //                 Wilco Bakker <https://github.com/WilcoBakker>
+//                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /************************************************
@@ -2879,6 +2880,7 @@ declare module "fs" {
         autoClose?: boolean;
         start?: number;
         end?: number;
+        highWaterMark?: number;
     }): ReadStream;
     export function createWriteStream(path: string | Buffer, options?: {
         flags?: string;


### PR DESCRIPTION
Added the `highWaterMark` option for all node versions that document that option.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
[](url)
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - 8.x [source](https://github.com/nodejs/node/blob/v8.x/lib/fs.js#L1935) and [documentation](https://nodejs.org/dist/latest-v8.x/docs/api/fs.html#fs_fs_createreadstream_path_options)
  - 7.x [source](https://github.com/nodejs/node/blob/v7.x/lib/fs.js#L1824) and [documentation](https://nodejs.org/dist/latest-v8.x/docs/api/fs.html#fs_fs_createreadstream_path_options)
  - 6.x [source](https://github.com/nodejs/node/blob/v6.x/lib/fs.js#L1912) and [documentation](https://nodejs.org/dist/latest-v8.x/docs/api/fs.html#fs_fs_createreadstream_path_options)
  - 4.x [source](https://github.com/nodejs/node/blob/v4.x/lib/fs.js#L1627) and [documentation](https://nodejs.org/dist/latest-v8.x/docs/api/fs.html#fs_fs_createreadstream_path_options)
  - 0.12.0 [source](https://github.com/nodejs/node/blob/v0.12.0/lib/fs.js#L1570) but [not documented](https://nodejs.org/dist/v0.12.0/docs/api/fs.html#fs_fs_createreadstream_path_options) so I'm thinking we should not add it.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
