### PR TITLE
Update backbone/index.d.ts Backbone.sync to use a union

### DIFF
--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -460,8 +460,7 @@ declare namespace Backbone {
     }
 
     // SYNC
-    function sync(method: string, model: Model, options?: JQueryAjaxSettings): any;
-    function sync(method: string, collection: Collection<Model>, options?: JQueryAjaxSettings): any;
+    function sync(method: string, model: Model | Collection<Model>, options?: JQueryAjaxSettings): any;
     function ajax(options?: JQueryAjaxSettings): JQueryXHR;
     var emulateHTTP: boolean;
     var emulateJSON: boolean;


### PR DESCRIPTION
Updating file to use union to better follow the typescript Do's and Don'ts under the 'Use Union Types' section found in the link below.
https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html

This will help prevent issues where a line of code such as 'let proxiedSync = Backbone.sync;' will use the wrong sync function.
