### PR TITLE
Joi - Adds string base64 typings

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -8,6 +8,7 @@
 //                 Rytis Alekna <https://github.com/ralekna>
 //                 Pavel Ivanov <https://github.com/schfkt>
 //                 Youngrok Kim <https://github.com/rokoroku>
+//                 Dan Kraus <https://github.com/dankraus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -125,6 +126,13 @@ export interface UriOptions {
      * Can be an Array or String (strings are automatically escaped for use in a Regular Expression).
      */
     scheme?: string | RegExp | Array<string | RegExp>;
+}
+
+export interface Base64Options {
+    /**
+     * optional parameter defaulting to true which will require = padding if true or make padding optional if false
+     */
+    paddingRequired?: boolean;
 }
 
 export interface WhenOptions {
@@ -519,6 +527,12 @@ export interface StringSchema extends AnySchema {
      * @param form - The unicode normalization form to use. Valid values: NFC [default], NFD, NFKC, NFKD
      */
     normalize(form?: 'NFC' | 'NFD' | 'NFKC' | 'NFKD'): this;
+
+    /**
+     * Requires the string value to be a valid base64 string; does not check the decoded value.
+     * @param options - optional settings: The unicode normalization options to use. Valid values: NFC [default], NFD, NFKC, NFKD
+     */
+    base64(options?: Base64Options): this;
 
     /**
      * Requires the number to be a credit card number (Using Lunh Algorithm).

--- a/types/joi/joi-tests.ts
+++ b/types/joi/joi-tests.ts
@@ -2,50 +2,50 @@ import Joi = require('joi');
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var x: any = null;
-var value: any = null;
-var num: number = 0;
-var str: string = '';
-var bool: boolean = false;
-var exp: RegExp = null;
-var obj: object = null;
-var date: Date = null;
-var err: Error = null;
-var func: Function = null;
+let x: any = null;
+let value: any = null;
+let num: number = 0;
+let str: string = '';
+let bool: boolean = false;
+let exp: RegExp = null;
+let obj: object = null;
+let date: Date = null;
+let err: Error = null;
+let func: Function = null;
 
-var anyArr: any[] = [];
-var numArr: number[] = [];
-var strArr: string[] = [];
-var boolArr: boolean[] = [];
-var expArr: RegExp[] = [];
-var objArr: object[] = [];
-var errArr: Error[] = [];
-var funcArr: Function[] = [];
-
-// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
-
-var schema: Joi.Schema = null;
-var schemaLike: Joi.SchemaLike = null;
-
-var anySchema: Joi.AnySchema = null;
-var numSchema: Joi.NumberSchema = null;
-var strSchema: Joi.StringSchema = null;
-var arrSchema: Joi.ArraySchema = null;
-var boolSchema: Joi.BooleanSchema = null;
-var binSchema: Joi.BinarySchema = null;
-var dateSchema: Joi.DateSchema = null;
-var funcSchema: Joi.FunctionSchema = null;
-var objSchema: Joi.ObjectSchema = null;
-var altSchema: Joi.AlternativesSchema = null;
-
-var schemaArr: Joi.Schema[] = [];
-
-var ref: Joi.Reference = null;
-var description: Joi.Description = null;
+let anyArr: any[] = [];
+let numArr: number[] = [];
+let strArr: string[] = [];
+let boolArr: boolean[] = [];
+let expArr: RegExp[] = [];
+let objArr: object[] = [];
+let errArr: Error[] = [];
+let funcArr: Function[] = [];
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var validOpts: Joi.ValidationOptions = null;
+let schema: Joi.Schema = null;
+let schemaLike: Joi.SchemaLike = null;
+
+let anySchema: Joi.AnySchema = null;
+let numSchema: Joi.NumberSchema = null;
+let strSchema: Joi.StringSchema = null;
+let arrSchema: Joi.ArraySchema = null;
+let boolSchema: Joi.BooleanSchema = null;
+let binSchema: Joi.BinarySchema = null;
+let dateSchema: Joi.DateSchema = null;
+let funcSchema: Joi.FunctionSchema = null;
+let objSchema: Joi.ObjectSchema = null;
+let altSchema: Joi.AlternativesSchema = null;
+
+let schemaArr: Joi.Schema[] = [];
+
+let ref: Joi.Reference = null;
+let description: Joi.Description = null;
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+
+let validOpts: Joi.ValidationOptions = null;
 
 validOpts = { abortEarly: bool };
 validOpts = { convert: bool };
@@ -77,7 +77,7 @@ validOpts = {
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var renOpts: Joi.RenameOptions = null;
+let renOpts: Joi.RenameOptions = null;
 
 renOpts = { alias: bool };
 renOpts = { multiple: bool };
@@ -86,7 +86,7 @@ renOpts = { ignoreUndefined: bool };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var emailOpts: Joi.EmailOptions = null;
+let emailOpts: Joi.EmailOptions = null;
 
 emailOpts = { errorLevel: num };
 emailOpts = { errorLevel: bool };
@@ -96,7 +96,7 @@ emailOpts = { minDomainAtoms: num };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var ipOpts: Joi.IpOptions = null;
+let ipOpts: Joi.IpOptions = null;
 
 ipOpts = { version: str };
 ipOpts = { version: strArr };
@@ -104,7 +104,7 @@ ipOpts = { cidr: str };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var uriOpts: Joi.UriOptions = null;
+let uriOpts: Joi.UriOptions = null;
 
 uriOpts = { scheme: str };
 uriOpts = { scheme: exp };
@@ -113,13 +113,13 @@ uriOpts = { scheme: expArr };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var base64Opts: Joi.Base64Options = null;
+let base64Opts: Joi.Base64Options = null;
 
 base64Opts = { paddingRequired: bool };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var whenOpts: Joi.WhenOptions = null;
+let whenOpts: Joi.WhenOptions = null;
 
 whenOpts = { is: x };
 whenOpts = { is: schema, then: schema };
@@ -128,16 +128,16 @@ whenOpts = { is: schemaLike, then: schemaLike, otherwise: schemaLike };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var refOpts: Joi.ReferenceOptions = null;
+let refOpts: Joi.ReferenceOptions = null;
 
 refOpts = { separator: str };
 refOpts = { contextPrefix: str };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var validErr: Joi.ValidationError = null;
-var validErrItem: Joi.ValidationErrorItem;
-var validErrFunc: Joi.ValidationErrorFunction;
+let validErr: Joi.ValidationError = null;
+let validErrItem: Joi.ValidationErrorItem;
+let validErrFunc: Joi.ValidationErrorFunction;
 
 validErrItem = {
     message: str,
@@ -182,7 +182,7 @@ anySchema = objSchema;
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
-var schemaMap: Joi.SchemaMap = null;
+let schemaMap: Joi.SchemaMap = null;
 
 schemaMap = {
     a: numSchema,

--- a/types/joi/joi-tests.ts
+++ b/types/joi/joi-tests.ts
@@ -113,6 +113,12 @@ uriOpts = { scheme: expArr };
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
+var base64Opts: Joi.Base64Options = null;
+
+base64Opts = { paddingRequired: bool };
+
+// --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
+
 var whenOpts: Joi.WhenOptions = null;
 
 whenOpts = { is: x };
@@ -777,6 +783,8 @@ strSchema = strSchema.truncate();
 strSchema = strSchema.truncate(false);
 strSchema = strSchema.normalize();
 strSchema = strSchema.normalize('NFKC');
+strSchema = strSchema.base64();
+strSchema = strSchema.base64(base64Opts);
 
 namespace common {
     strSchema = strSchema.allow(x);

--- a/types/joi/joi-tests.ts
+++ b/types/joi/joi-tests.ts
@@ -1,4 +1,5 @@
 import Joi = require('joi');
+import { GuidVersions } from 'joi';
 
 // --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
 
@@ -771,7 +772,7 @@ strSchema = strSchema.ip(ipOpts);
 strSchema = strSchema.uri();
 strSchema = strSchema.uri(uriOpts);
 strSchema = strSchema.guid();
-strSchema = strSchema.guid({ version: ['uuidv1', 'uuidv2', 'uuidv3', 'uuidv4', 'uuidv5'] });
+strSchema = strSchema.guid({ version: ['uuidv1' as GuidVersions, 'uuidv2'  as GuidVersions, 'uuidv3' as GuidVersions, 'uuidv4' as GuidVersions, 'uuidv5'  as GuidVersions]});
 strSchema = strSchema.guid({ version: 'uuidv4' });
 strSchema = strSchema.hex();
 strSchema = strSchema.hostname();


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/joi/blob/v13.0.2/API.md#stringbase64options


I've run the linter but there is a prexisting TypeScript compilation unrelated to this PR in `joi-tests.ts` regarding GuidOptions.

```
ERROR: 768:28  expect  TypeScript@next compile error:
Argument of type '{ version: string[]; }' is not assignable to parameter of type 'GuidOptions'.
  Types of property 'version' are incompatible.
    Type 'string[]' is not assignable to type '"uuidv1" | "uuidv2" | "uuidv3" | "uuidv4" | "uuidv5" | GuidVersions[]'.
      Type 'string[]' is not assignable to type 'GuidVersions[]'.
        Type 'string' is not assignable to type 'GuidVersions'.
```

Removing that line (`strSchema = strSchema.guid({ version: ['uuidv1', 'uuidv2', 'uuidv3', 'uuidv4', 'uuidv5'] });`) will pass the tests.