### PR TITLE
A-Frame register custom geometry fix

### DIFF
--- a/types/aframe/aframe-tests.ts
+++ b/types/aframe/aframe-tests.ts
@@ -1,5 +1,4 @@
 // Global
-
 const threeCamera = new AFRAME.THREE.Camera();
 AFRAME.TWEEN.Easing;
 
@@ -42,9 +41,18 @@ entity.addEventListener('child-detached', (event) => {
 const Component = AFRAME.registerComponent('test', {});
 
 // Scene
-
 const scene = document.querySelector('a-scene');
 scene.hasLoaded;
 
 // System
 const system = scene.systems['systemName'];
+
+// Register Custom Geometry
+AFRAME.registerGeometry('a-test-geometry', {
+	schema: {
+		groupIndex: { default: 0 }
+	},
+	init(data) {
+		this.geometry = new THREE.Geometry();
+	}
+});

--- a/types/aframe/index.d.ts
+++ b/types/aframe/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for AFRAME 0.5
+// Type definitions for AFRAME 0.7
 // Project: https://aframe.io/
 // Definitions by: Paul Shannon <https://github.com/devpaul>
+//                 Roberto Ritger <https://github.com/bertoritger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -40,7 +41,7 @@ declare namespace AFrame {
 		primitives: { [ key: string ]: Entity };
 		registerComponent(name: string, component: ComponentDefinition): ComponentConstructor;
 		registerElement(name: string, element: ANode): void;
-		registerGeometry(name: string, geometery: THREE.Geometry): Geometry;
+		registerGeometry(name: string, geometry: GeometryDefinition): Geometry;
 		registerPrimitive(name: string, primitive: PrimitiveDefinition): void;
 		registerShader(name: string, shader: any): void;
 		registerSystem(name: string, definition: SystemDefinition): void;
@@ -101,7 +102,7 @@ declare namespace AFrame {
 		name: string;
 		schema: Schema;
 
-		init(): void;
+		init(data?: any): void;
 		pause(): void;
 		play(): void;
 		remove(): void;
@@ -124,7 +125,7 @@ declare namespace AFrame {
 		multiple?: boolean;
 		schema?: Schema;
 
-		init?(): void;
+		init?(data?: any): void;
 		pause?(): void;
 		play?(): void;
 		remove?(): void;
@@ -220,6 +221,10 @@ declare namespace AFrame {
 		schema: Schema;
 		update(data: object): void;
 		[ key: string ]: any;
+	}
+
+	interface GeometryDefinition extends ComponentDefinition {
+		geometry?: THREE.Geometry;
 	}
 
 	interface GeometryDescriptor {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://aframe.io/docs/0.7.0/components/geometry.html#register-a-custom-geometry
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Problem
"Geometry" was misspelled and RegisterGeometry was expecting a ComponentDefinition, not a THREE.Geometry, so registering a custom geometry would throw a type error.

## Solution
Added a GeometryDefinion that extends ComponentDefinition which takes an optional geometry component of type THREE.Geometry.