### PR TITLE
Rollup: Sync typings for latest version

### DIFF
--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -133,7 +133,7 @@ export interface Plugin {
 	 */
 	resolveId?(importee: string, importer: string): string | null | undefined | false | 0 | ''
 	/** A module transformer function */
-	transform?(source: string, id: string): string | { code: string, map: SourceMap }
+	transform?(this: TransformContext, source: string, id: string): string | { code: string, map: SourceMap }
 	/** A bundle transformer function */
 	transformBundle?(source: string, options: { format: Format }): string | { code: string, map: SourceMap }
 	/** Function hook called when bundle.generate() is being executed. */
@@ -148,6 +148,14 @@ export interface Plugin {
 	banner?: string | (() => string)
 	/** Apppend to the bundle. */
 	footer?: string | (() => string)
+}
+
+// See https://github.com/rollup/rollup/wiki/Plugins#warnings-and-errors
+export interface TransformContext {
+	/** Emit warnings to Rollup which will be logged during bundling */
+	warn(message: string | { message: string }, pos?: number | { line: number, column: number }): void;
+	/** Emit an error, which will abort the bundling process */
+	error(message: string | { message: string }, pos?: number | { line: number, column: number }): void;
 }
 
 /** Returns a Promise that resolves with a bundle */

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for rollup 0.41
+// Type definitions for rollup 0.51
 // Project: https://github.com/rollup/rollup
 // Definitions by: Philipp A. <https://github.com/flying-sheep>, Christian Svensson <https://github.com/csvn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -118,6 +118,10 @@ export interface Options {
 	legacy?: boolean
 }
 
+export interface ConfigFileOptions extends Options {
+	output: WriteOptions | WriteOptions[]
+}
+
 // https://github.com/rollup/rollup/wiki/Plugins#creating-plugins
 export interface Plugin {
 	/** The name of the plugin, for use in error messages and warnings */

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -86,7 +86,7 @@ export interface Bundle {
 
 export interface Options {
 	/** The bundle's entry point (e.g. your `main.js` or `app.js` or `index.js`) */
-	entry: string | string[]
+	input: string
 	/** A previous bundle. Use it to speed up subsequent bundles :) */
 	cache?: Bundle
 	/**

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -84,7 +84,7 @@ export interface WriteOptions extends BundleOptions {
 
 export interface Bundle {
 	/** Generate bundled code as an object */
-	generate(options: GenerateOptions): { code: string, map: SourceMap }
+	generate(options: GenerateOptions): Promise<{ code: string, map: SourceMap | null }>
 	/** writes the file (and accompanying sourcemap file, if appropriate) to the file system. */
 	write(options: WriteOptions): Promise<void>
 }

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -29,9 +29,14 @@ export interface BundleOptions {
 	/** An ID to use for AMD/UMD bundles. */
 	moduleId?: string
 	/** The name to use for the module for UMD/IIFE bundles (required for bundles with exports). */
-	moduleName?: string
+	name?: string
 	/** Mapping of IDs → global variable names. Used for UMD/IIFE bundles. */
 	globals?: { [id: string]: string }
+	/**
+	 * Function that takes an ID and returns a path, or Object of id: path pairs.
+	 * Where supplied, these paths will be used in the generated bundle instead of the module ID, allowing you to (for example) load dependencies from a CDN.
+	 */
+	paths?: ((id: string) => string) | { [id: string]: string }
 	/**
 	 * The indent string to use, for formats that require code to be indented (AMD, IIFE, UMD).
 	 * Can also be false (no indent), or true (the default – auto-indent)
@@ -55,26 +60,26 @@ export interface BundleOptions {
 	 * Whether to include the 'use strict' pragma at the top of generated non-ES6 bundles.
 	 * Strictly-speaking (geddit?), ES6 modules are always in strict mode, so you shouldn't disable this without good reason.
 	 */
-	useStrict?: boolean
+	strict?: boolean
 }
 
 export interface GenerateOptions extends BundleOptions {
 	/** Whether to generate a sourcemap. If true, the return value from `bundle.generate(...)` will include a map property */
-	sourceMap?: boolean
+	sourcemap?: boolean
 	/**
 	 * The location of the generated bundle. If this is an absolute path, all the sources paths in the sourcemap will be relative to it.
-	 * The map.file property is the basename of sourceMapFile, as the location of the sourcemap is assumed to be adjacent to the bundle.
+	 * The map.file property is the basename of sourcemapFile, as the location of the sourcemap is assumed to be adjacent to the bundle.
 	 */
-	sourceMapFile?: string
+	sourcemapFile?: string
 }
 
 export interface WriteOptions extends BundleOptions {
-	/** The file to write to. If `options.sourceMap === true`, two files will be created – `dest` and `dest + '.map`. */
-	dest: string
-	/** If `true`, a separate sourcemap file will be created. If `'inline'`, the sourcemap will be appended to the resulting dest file as a data URI. */
-	sourceMap?: boolean | 'inline'
-	/** This option is unnecessary, as it defaults to the value of dest. */
-	sourceMapFile?: string
+	/** The file to write to. If `options.sourcemap === true`, two files will be created – `file` and `file + '.map`. */
+	file: string
+	/** If `true`, a separate sourcemap file will be created. If `'inline'`, the sourcemap will be appended to the resulting file as a data URI. */
+	sourcemap?: boolean | 'inline'
+	/** This option is unnecessary, as it defaults to the value of file. */
+	sourcemapFile?: string
 }
 
 export interface Bundle {
@@ -94,11 +99,6 @@ export interface Options {
 	 * The IDs should be either the name of an external dependency or a resolved ID (like an absolute path to a file)
 	 */
 	external?: ((id: string) => boolean) | string[]
-	/**
-	 * Function that takes an ID and returns a path, or Object of id: path pairs.
-	 * Where supplied, these paths will be used in the generated bundle instead of the module ID, allowing you to (for example) load dependencies from a CDN.
-	 */
-	paths?: ((id: string) => string) | { [id: string]: string }
 	/** Function that will intercept warning messages. If not supplied, warnings will be deduplicated and printed to the console. */
 	onwarn?(warning: Warning): void
 	/** Array of plugin objects or a single plugin object */

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -23,7 +23,7 @@ export interface Warning {
 
 export interface BundleOptions {
 	/** The format of the generated bundle. */
-	format?: Format
+	format: Format
 	/** What export mode to use. Defaults to auto, which guesses your intentions based on what the `entry` module exports. */
 	exports?: 'auto' | 'default' | 'named' | 'none'
 	/** An ID to use for AMD/UMD bundles. */

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for rollup 0.41
 // Project: https://github.com/rollup/rollup
-// Definitions by: Philipp A. <https://github.com/flying-sheep>
+// Definitions by: Philipp A. <https://github.com/flying-sheep>, Christian Svensson <https://github.com/csvn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { RawSourceMap } from 'source-map'
@@ -157,9 +157,9 @@ export interface Plugin {
 // See https://github.com/rollup/rollup/wiki/Plugins#warnings-and-errors
 export interface TransformContext {
 	/** Emit warnings to Rollup which will be logged during bundling */
-	warn(message: string | { message: string }, pos?: number | { line: number, column: number }): void;
+	warn(message: string | { message: string }, pos?: number | { line: number, column: number }): void
 	/** Emit an error, which will abort the bundling process */
-	error(message: string | { message: string }, pos?: number | { line: number, column: number }): void;
+	error(message: string | { message: string }, pos?: number | { line: number, column: number }): void
 }
 
 /** Returns a Promise that resolves with a bundle */

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -1,5 +1,7 @@
 import { rollup, Bundle, Plugin } from 'rollup'
 
+let console: any
+
 let cache: Bundle | undefined
 let plugin: Plugin
 
@@ -8,6 +10,16 @@ async function main() {
         input: 'main.js',
         external: ['external-module'],
         plugins: [plugin],
+        onwarn: ({ code, frame, loc, message }) => {
+            if (loc) {
+                const { file, line, column } = loc
+                console.log(`[${code}] - ${file}(${line},${column}): ${message}`)
+            } else {
+                console.log(`[${code}] - ${message}`)
+            }
+
+            if (frame) console.warn(frame)
+        },
         cache,
     })
 
@@ -20,13 +32,16 @@ async function main() {
     const result = bundle.generate({
         format: 'cjs',
         indent: false,
+        sourcemap: true,
     })
 
     cache = bundle
 
     await bundle.write({
         format: 'cjs',
-        dest: 'bundle.js',
+        file: 'bundle.js',
+        name: 'myLib',
+        interop: false,
         globals: {
             jquery: '$',
             lodash: '_',
@@ -36,6 +51,9 @@ async function main() {
         intro: 'var ENV = "production";',
         outro: 'var VERSION = "1.0.0";',
         indent: '  ',
+        sourcemap: 'inline',
+        sourcemapFile: 'bundle.js.map',
+        strict: true,
     })
 }
 

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -29,11 +29,13 @@ async function main() {
         plugins: plugin
     })
 
-    const result = bundle.generate({
+    const { code, map } = await bundle.generate({
         format: 'cjs',
         indent: false,
         sourcemap: true,
     })
+
+    console.log(code, map)
 
     cache = bundle
 

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -1,15 +1,25 @@
-import { rollup, Bundle } from 'rollup'
+import { rollup, Bundle, Plugin } from 'rollup'
 
 let cache: Bundle | undefined
+let plugin: Plugin
 
 async function main() {
     const bundle = await rollup({
         input: 'main.js',
+        external: ['external-module'],
+        plugins: [plugin],
         cache,
+    })
+
+    const bundle2 = await rollup({
+        input: 'main.js',
+        external: id => /^rxjs/.test(id),
+        plugins: plugin
     })
 
     const result = bundle.generate({
         format: 'cjs',
+        indent: false,
     })
 
     cache = bundle
@@ -17,6 +27,15 @@ async function main() {
     await bundle.write({
         format: 'cjs',
         dest: 'bundle.js',
+        globals: {
+            jquery: '$',
+            lodash: '_',
+        },
+        banner: '/* Banner */',
+        footer: '/* Footer */',
+        intro: 'var ENV = "production";',
+        outro: 'var VERSION = "1.0.0";',
+        indent: '  ',
     })
 }
 

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -1,4 +1,4 @@
-import { rollup, Bundle, Plugin } from 'rollup'
+import { rollup, Bundle, Plugin, ConfigFileOptions } from 'rollup'
 
 let console: any
 
@@ -72,3 +72,26 @@ async function main() {
 }
 
 main()
+
+
+export const defaultConfig: ConfigFileOptions = {
+    input: 'main.js',
+    output: {
+        file: 'bundle.js',
+        format: 'iife',
+    }
+}
+
+export const multiConfig: ConfigFileOptions = {
+    input: 'main.js',
+    output: [
+        {
+            file: 'bundle.esm.js',
+            format: 'es',
+        },
+        {
+            file: 'bundle.cjs.js',
+            format: 'cjs',
+        }
+    ]
+}

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -3,7 +3,19 @@ import { rollup, Bundle, Plugin } from 'rollup'
 let console: any
 
 let cache: Bundle | undefined
-let plugin: Plugin
+let plugin: Plugin = {
+    name: 'test-plugin',
+    transform(source, id) {
+        if (id === 'rxjs') {
+            this.error(new Error(`Don't import this directly`))
+        }
+        let indexOfQuote = source.indexOf('"')
+        if (indexOfQuote >= 0) {
+            this.warn(`Prefer ' over " for strings`, indexOfQuote)
+        }
+        return source
+    }
+}
 
 async function main() {
     const bundle = await rollup({

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -4,7 +4,7 @@ let cache: Bundle | undefined
 
 async function main() {
     const bundle = await rollup({
-        entry: 'main.js',
+        input: 'main.js',
         cache,
     })
 

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -1,15 +1,15 @@
 import { rollup, Bundle, Plugin, ConfigFileOptions } from 'rollup'
 
-let console: any
+declare const console: { log(...messages: any[]): void, warn(message: string): void }
 
 let cache: Bundle | undefined
-let plugin: Plugin = {
+const plugin: Plugin = {
     name: 'test-plugin',
     transform(source, id) {
         if (id === 'rxjs') {
             this.error(new Error(`Don't import this directly`))
         }
-        let indexOfQuote = source.indexOf('"')
+        const indexOfQuote = source.indexOf('"')
         if (indexOfQuote >= 0) {
             this.warn(`Prefer ' over " for strings`, indexOfQuote)
         }
@@ -72,7 +72,6 @@ async function main() {
 }
 
 main()
-
 
 export const defaultConfig: ConfigFileOptions = {
     input: 'main.js',


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [rollup API](https://rollupjs.org/#rollup-rollup) (see `inputOptions` and `outputOptions`)
[`path` moved to output](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0482)
[renamed properties](https://github.com/rollup/rollup/blob/6fc2088bfaf6b47b7225223398d1335f167a0aea/src/rollup/index.js#L82-L88)
[`generate` returns promise](https://github.com/rollup/rollup/blob/master/src/rollup/index.js#L157-L188)
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
