### PR TITLE
CKEDITOR: Added some missing properties in CKEDITOR.config

### DIFF
--- a/types/ckeditor/index.d.ts
+++ b/types/ckeditor/index.d.ts
@@ -602,13 +602,17 @@ declare namespace CKEDITOR {
         browserContextMenuOnCtrl?: boolean;
 
         clipboard_defaultContentType?: string; // html | text
+        clipboard_notificationDuration?: number;
         codeSnippet_codeClass?: string;
         codeSnippet_languages?: Object;
         coceSnippet_theme?: string;
         colorButton_backStyle?: config.styleObject;
         colorButton_colors?: string;
+        colorButton_colorsPerRow?: number;
+        colorButton_enableAutomatic?: boolean;
         colorButton_enableMore?: boolean;
         colorButton_foreStyle?: config.styleObject;
+        colorButton_normalizeBackground?: boolean;
         contentsCss?: string | string[];
         contentsLangDirection?: string;
         contentsLanguage?: string;


### PR DESCRIPTION
Added:
CKEDITOR.config.clipboard_notificationDuration
CKEDITOR.config.colorButton_colorsPerRow
CKEDITOR.config.colorButton_enableAutomatic
CKEDITOR.config.colorButton_normalizeBackground

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-clipboard_notificationDuration
https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-colorButton_colorsPerRow
https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-colorButton_enableAutomatic
https://docs.ckeditor.com/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-colorButton_normalizeBackground
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

