### PR TITLE
Updated xrm definitions with getFormContext in execution context.

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -1404,6 +1404,7 @@ declare namespace Xrm {
              * @return The event arguments or null
              */
             getEventArgs(): SaveEventArguments | StageChangeEventArguments | StageSelectedEventArguments;
+
             /**
              * Gets a reference to the object for which event occurred.
              *

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -1398,11 +1398,12 @@ declare namespace Xrm {
             getDepth(): number;
 
             /**
-             * Get event args returns null for non-save operations
+             * Returns the event arguments for the event context
+             * Get event args returns null for read operations
              *
-             * @return null
+             * @return The event arguments or null
              */
-            getEventArgs(): null;
+            getEventArgs(): SaveEventArguments | StageChangeEventArguments | StageSelectedEventArguments;
             /**
              * Gets a reference to the object for which event occurred.
              *

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -1398,6 +1398,12 @@ declare namespace Xrm {
             getDepth(): number;
 
             /**
+             * Get event args returns null for non-save operations
+             *
+             * @return null
+             */
+            getEventArgs(): null;
+            /**
              * Gets a reference to the object for which event occurred.
              *
              * @return The event source.

--- a/types/xrm/v8/index.d.ts
+++ b/types/xrm/v8/index.d.ts
@@ -1090,6 +1090,13 @@ declare namespace Xrm {
             getDepth(): number;
 
             /**
+             * Get event args returns null for non-save operations
+             *
+             * @return null
+             */
+            getEventArgs(): null;
+
+            /**
              * Gets a reference to the object for which event occurred.
              *
              * @return  The event source.

--- a/types/xrm/v8/index.d.ts
+++ b/types/xrm/v8/index.d.ts
@@ -1090,11 +1090,12 @@ declare namespace Xrm {
             getDepth(): number;
 
             /**
-             * Get event args returns null for non-save operations
+             * Returns the event arguments for the event context
+             * Get event args returns null for read operations
              *
-             * @return null
+             * @return The event arguments or null
              */
-            getEventArgs(): null;
+            getEventArgs(): SaveEventArguments | StageChangeEventArguments | StageSelectedEventArguments;
 
             /**
              * Gets a reference to the object for which event occurred.

--- a/types/xrm/v8/index.d.ts
+++ b/types/xrm/v8/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Microsoft Dynamics xRM API 8.2
 // Project: http://www.microsoft.com/en-us/download/details.aspx?id=44567
-// Definitions by: David Berry <https://github.com/6ix4our>, Matt Ngan <https://github.com/mattngan>, Markus Mauch <https://github.com/markusmauch>, Daryl LaBar <https://github.com/daryllabar>, Tully H <https://github.com/clownwilleatme>
+// Definitions by: David Berry <https://github.com/6ix4our>, Matt Ngan <https://github.com/mattngan>, Markus Mauch <https://github.com/markusmauch>, Daryl LaBar <https://github.com/daryllabar>, Tully H <https://github.com/clownwilleatme>, Marius Agur <https://github.com/mariusagur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -1098,6 +1098,18 @@ declare namespace Xrm {
              * @param       key The key.
              *
              * @return  The shared variable.
+             *
+             * @remarks Used to pass values between handlers of an event.
+             */
+            getFormContext(): Page;
+
+            /**
+             * Gets the shared variable with the specified key.
+             *
+             * @param T Generic type parameter.
+             * @param key The key.
+             *
+             * @return The shared variable.
              *
              * @remarks Used to pass values between handlers of an event.
              */

--- a/types/xrm/v8/index.d.ts
+++ b/types/xrm/v8/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Microsoft Dynamics xRM API 8.2
 // Project: http://www.microsoft.com/en-us/download/details.aspx?id=44567
-// Definitions by: David Berry <https://github.com/6ix4our> 
+// Definitions by: David Berry <https://github.com/6ix4our>
 //                 Matt Ngan <https://github.com/mattngan>
 //                 Markus Mauch <https://github.com/markusmauch>
 //                 Daryl LaBar <https://github.com/daryllabar>

--- a/types/xrm/v8/index.d.ts
+++ b/types/xrm/v8/index.d.ts
@@ -1,6 +1,11 @@
 // Type definitions for Microsoft Dynamics xRM API 8.2
 // Project: http://www.microsoft.com/en-us/download/details.aspx?id=44567
-// Definitions by: David Berry <https://github.com/6ix4our>, Matt Ngan <https://github.com/mattngan>, Markus Mauch <https://github.com/markusmauch>, Daryl LaBar <https://github.com/daryllabar>, Tully H <https://github.com/clownwilleatme>, Marius Agur <https://github.com/mariusagur>
+// Definitions by: David Berry <https://github.com/6ix4our> 
+//                 Matt Ngan <https://github.com/mattngan>
+//                 Markus Mauch <https://github.com/markusmauch>
+//                 Daryl LaBar <https://github.com/daryllabar>
+//                 Tully H <https://github.com/clownwilleatme>
+//                 Marius Agur <https://github.com/mariusagur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 


### PR DESCRIPTION
Xrm.Page.EventContext has a function to retrieve the form context named getFormContext. This returns an Xrm.Page object.
This function has already been added in v9, but should be inside v8 as well.
See Microsoft documentation for details:
<https://msdn.microsoft.com/en-us/library/gg328130.aspx?f=255&MSPPError=-2147217396#BKMK_getFormContext>