### PR TITLE
Fix Algolia object spread typing

### DIFF
--- a/types/algoliasearch/index.d.ts
+++ b/types/algoliasearch/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for algoliasearch-client-js 3.24.5
+// Type definitions for algoliasearch-client-js 3.24.6
 // Project: https://github.com/algolia/algoliasearch-client-js
 // Definitions by: Baptiste Coquelle <https://github.com/cbaptiste>
 //                 Haroen Viaene <https://github.com/haroenv>
@@ -809,8 +809,8 @@ declare namespace algoliasearch {
     }: {
       facetName: string;
       facetQuery: string;
-      qp: AlgoliaQueryParameters;
-    }): Promise<any>;
+    } & AlgoliaQueryParameters
+    ): Promise<any>;
     /**
      * Search in an index
      * @param params query parameter
@@ -826,8 +826,7 @@ declare namespace algoliasearch {
       }: {
         facetName: string;
         facetQuery: string;
-        qp: AlgoliaQueryParameters;
-      },
+      } & AlgoliaQueryParameters,
       cb: (err: Error, res: any) => void
     ): void;
     /**


### PR DESCRIPTION
There's a bug in the spread/rest operator under `searchForFacetValues`. The previous typing indicates that `qp` is a key in the object which doesn't work if we're using `...qp`. I've changed it into an intersection type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/advanced-types.html#intersection-type
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
