### PR TITLE
Add missing property and constructor

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -407,6 +407,12 @@ declare namespace PDF {
      * in browsers which support the fullscreen API.
      */
     disableFullscreen: boolean;
+      
+    /**
+     * Disable the text layer of PDF when used PDF.js renders a canvas instead of div elements
+     *
+     */
+    disableTextLayer: boolean;
 
     /**
      * Enables CSS only zooming.
@@ -475,5 +481,11 @@ declare namespace PDF {
         : PDFPromise<PDFDocumentProxy>;
 
     PDFViewer(params: PDFViewerParams): void;
+    /**
+    * yet another viewer, this will render only one page at the time, reducing rendering time
+    * very important for mobile development
+    * @params {PDFViewerParams}
+    */
+    PDFSinglePageViewer(params: PDFViewerParams): void;
   }
 }


### PR DESCRIPTION
This attemp to add:
- Property **disableTextLayer**
- Constructor function for **PDFSinglePageViewer**

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mozilla/pdf.js/blob/master/examples/components/singlepageviewer.js>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.