### PR TITLE
[package-json] fix wrong return type

### DIFF
--- a/types/package-json/index.d.ts
+++ b/types/package-json/index.d.ts
@@ -9,6 +9,6 @@ interface PackageJsonOptions {
     allVersions?: boolean;
 }
 
-declare function packageJson(name: string, options?: PackageJsonOptions): {};
+declare function packageJson(name: string, options?: PackageJsonOptions): Promise<{}>;
 
 export = packageJson;

--- a/types/package-json/package-json-tests.ts
+++ b/types/package-json/package-json-tests.ts
@@ -1,7 +1,10 @@
 import packageJson = require('package-json');
 
-const pkg = packageJson('package-json', {
+let pkg: {};
+packageJson('package-json', {
     version: '1.2.3',
     fullMetadata: true,
     allVersions: true,
+}).then(x => {
+    pkg = x;
 });


### PR DESCRIPTION
I made a mistake in my original PR
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21578

The function should return a promise.
- https://www.npmjs.com/package/package-json
- https://github.com/sindresorhus/package-json/blob/master/index.js#L30

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
