### PR TITLE
[swagger-tools] Fixing type of req.swagger field

### DIFF
--- a/types/swagger-tools/index.d.ts
+++ b/types/swagger-tools/index.d.ts
@@ -8,32 +8,42 @@ import { NextHandleFunction } from 'connect';
 import { IncomingMessage, ServerResponse } from 'http';
 
 export interface SwaggerParameterSchema {
+    allowMultiple?: boolean;
+    description?: string;
+    format?: string;
+    in?: string;
+    maximum?: string;
+    minimum?: string;
     name: string;
-    in: string;
+    paramType?: string;
+    required?: boolean;
+    type: string;
 }
 
-export interface SwaggerRequestParameter {
-    path: string;
+export interface SwaggerRequestParameter<T> {
+    path: string[];
     schema: SwaggerParameterSchema;
     originalValue: any;
-    value: any;
+    value: T;
 }
 
 export interface SwaggerRequestParameters {
-    [paramName: string]: SwaggerRequestParameter;
+    [paramName: string]: SwaggerRequestParameter<any>;
 }
 
 export interface Swagger12Request extends IncomingMessage {
     swagger: {
-        api: string;
+        api: any;
         apiDeclaration: any;
         apiIndex: number;
-        authorizations?: any[];
-        operation?: string;
-        operationPath?: string;
+        authorizations?: any;
+        operation?: any;
+        operationPath?: string[];
         params: SwaggerRequestParameters;
         resourceIndex: number;
         resourceListing: any;
+        swaggerVersion: string;
+        useStubs?: boolean;
     };
 }
 
@@ -50,20 +60,40 @@ export interface SwaggerRouter12Options {
 }
 
 export interface OperationParameter {
-    path: string;
+    path: string[];
     schema: SwaggerParameterSchema;
+}
+
+export interface Swagger20Security {
+    [name: string]: any;
+}
+
+export interface Swagger20Response {
+    description?: string;
+    schema?: any;
+}
+
+export interface Swagger20Operation {
+    operationId?: string;
+    parameters?: SwaggerParameterSchema[];
+    responses: { [code: string]: Swagger20Response };
+    security?: Swagger20Security[];
+    summary?: string;
+    tags?: string[];
 }
 
 export interface Swagger20Request extends IncomingMessage {
     swagger: {
         apiPath: string;
-        operation?: string;
-        operationPath?: string;
+        operation?: Swagger20Operation;
+        operationPath?: string[];
         operationParameters?: OperationParameter[];
-        path: string;
+        path: any;
         params: SwaggerRequestParameters;
         security: any[];
         swaggerObject: any;
+        swaggerVersion: string;
+        useStubs?: boolean;
     };
 }
 

--- a/types/swagger-tools/swagger-tools-tests.ts
+++ b/types/swagger-tools/swagger-tools-tests.ts
@@ -37,17 +37,102 @@ swaggerTools.initializeMiddleware(swaggerDoc20, middleware => {
     // Test passing in the handlers directly
     app.use(middleware.swaggerRouter({
         controllers: {
-            foo_bar: (req, res, next) => {
-                console.log(req.swagger.apiPath);
-                console.log(req.swagger.operation);
-                console.log(req.swagger.operationParameters);
-                console.log(req.swagger.operationPath);
-                console.log(req.swagger.path);
-                console.log(req.swagger.security);
-                console.log(req.swagger.swaggerObject);
+            // These tests are based on tests here:
+            // https://github.com/apigee-127/swagger-tools/blob/0cea535b122265c6d01546e199e2e8fda4c0f5da/test/2.0/test-middleware-swagger-metadata.js#L102-L138
 
-                console.log(req.swagger.params.location.value);
-                console.log(req.swagger.params.unit.value);
+            foo_bar: (req, res, next) => {
+                req.swagger.swaggerVersion = '2.0';
+                req.swagger.apiPath = '/pets/{id}';
+                req.swagger.operation = {
+                    security: [
+                        {
+                            oauth2: ["read"]
+                        }
+                    ],
+                    tags: [ "Pet Operations" ],
+                    operationId: "getPetById",
+                    summary: "Finds the pet by id",
+                    responses: {
+                        200: {
+                            description: "Pet response",
+                            schema: {
+                                $ref: "#/definitions/Pet"
+                            }
+                        },
+                        default: {
+                            description: "Unexpected error",
+                            schema: {
+                                $ref: "#/definitions/Error"
+                            }
+                        }
+                    },
+                    parameters: [
+                        {
+                            in: 'query',
+                            name: 'mock',
+                            description: 'Mock mode',
+                            required: false,
+                            type: 'boolean'
+                        }
+                    ]
+                };
+
+                req.swagger.operationParameters = [
+                    {
+                        path: ['paths', '/pets/{id}', 'get', 'parameters', '0'],
+                        schema: {
+                            in: 'query',
+                            name: 'mock',
+                            description: 'Mock mode',
+                            required: false,
+                            type: 'boolean'
+                        },
+                    },
+                    {
+                        path: ['paths', '/pets/{id}', 'parameters', '0'],
+                        schema: {
+                            name: "id",
+                            in: "path",
+                            description: "ID of pet",
+                            required: true,
+                            type: "integer",
+                            format: "int64"
+                        }
+                    }
+                ];
+                req.swagger.operationPath = ['paths', '/pets/{id}', 'get'];
+                req.swagger.security = [
+                    {
+                        oauth2: [ 'read' ]
+                    }
+                ];
+                req.swagger.params = {
+                    id: {
+                        path: ['paths', '/pets/{id}', 'parameters', '0'],
+                        schema: {
+                            name: "id",
+                            in: "path",
+                            description: "ID of pet",
+                            required: true,
+                            type: "integer",
+                            format: "int64"
+                        },
+                        originalValue: '1',
+                        value: 1
+                    },
+                    mock: {
+                        path: ['paths', '/pets/{id}', 'get', 'parameters', '0'],
+                        schema: {
+                            in: 'query',
+                            name: 'mock',
+                            description: 'Mock mode',
+                            required: false,
+                            type: 'boolean'
+                        },
+                        originalValue: 'false',
+                        value: false
+                    }
+                };
 
                 res.setHeader('Content-Type', 'application/json');
                 res.end([ 'foo', 0 ]);
@@ -90,17 +175,139 @@ swaggerTools.initializeMiddleware(apiDoc12, apiDeclarations, middleware => {
     // Test passing in the handlers directly
     app.use(middleware.swaggerRouter({
         controllers: {
-            foo_bar: (req, res, next) => {
-                console.log(req.swagger.api);
-                console.log(req.swagger.apiDeclaration);
-                console.log(req.swagger.apiIndex);
-                console.log(req.swagger.operation);
-                console.log(req.swagger.operationPath);
-                console.log(req.swagger.resourceIndex);
-                console.log(req.swagger.resourceListing);
+            // These tests are based on tests here:
+            // https://github.com/apigee-127/swagger-tools/blob/0cea535b122265c6d01546e199e2e8fda4c0f5da/test/1.2/test-middleware-swagger-metadata.js#L72-L89
 
-                console.log(req.swagger.params.location.value);
-                console.log(req.swagger.params.unit.value);
+            foo_bar: (req, res, next) => {
+                req.swagger.swaggerVersion = '1.2';
+                req.swagger.api = {
+                    operations: [
+                        {
+                            authorizations: {},
+                            method: "GET",
+                            nickname: "getPetById",
+                            notes: "Returns a pet based on ID",
+                            parameters: [
+                                {
+                                    allowMultiple: false,
+                                    description: "ID of pet that needs to be fetched",
+                                    format: "int64",
+                                    maximum: "100000.0",
+                                    minimum: "1.0",
+                                    name: "petId",
+                                    paramType: "path",
+                                    required: true,
+                                    type: "integer"
+                                }
+                            ],
+                            responseMessages: [
+                                {
+                                    code: 400,
+                                    message: "Invalid ID supplied"
+                                },
+                                {
+                                    code: 404,
+                                    message: "Pet not found"
+                                }
+                            ],
+                            summary: "Find pet by ID",
+                            type: "Pet"
+                        },
+                        {
+                            authorizations: {
+                                oauth2: [
+                                    {
+                                        description: "modify pets in your account",
+                                        scope: "write:pets"
+                                    }
+                                ]
+                            },
+                            method: "DELETE",
+                            nickname: "deletePet",
+                            notes: "",
+                            parameters: [
+                                {
+                                    allowMultiple: false,
+                                    description: "Pet id to delete",
+                                    name: "petId",
+                                    paramType: "path",
+                                    required: true,
+                                    type: "string"
+                                }
+                            ],
+                            responseMessages: [
+                                {
+                                    code: 400,
+                                    message: "Invalid pet value"
+                                }
+                            ],
+                            summary: "Deletes a pet",
+                            type: "void"
+                        },
+                    ],
+                    path: "/pet/{petId}"
+                };
+
+                req.swagger.apiDeclaration = {};
+                req.swagger.apiIndex = 0;
+                req.swagger.authorizations = {
+                    oauth2: [
+                        {
+                            description: "modify pets in your account",
+                            scope: "write:pets"
+                        }
+                    ]
+                };
+                req.swagger.operation = {
+                    authorizations: {},
+                    method: "GET",
+                    nickname: "getPetById",
+                    notes: "Returns a pet based on ID",
+                    parameters: [
+                        {
+                            allowMultiple: false,
+                            description: "ID of pet that needs to be fetched",
+                            format: "int64",
+                            maximum: "100000.0",
+                            minimum: "1.0",
+                            name: "petId",
+                            paramType: "path",
+                            required: true,
+                            type: "integer"
+                        }
+                    ],
+                    responseMessages: [
+                        {
+                            code: 400,
+                            message: "Invalid ID supplied"
+                        },
+                        {
+                            code: 404,
+                            message: "Pet not found"
+                        }
+                    ],
+                    summary: "Find pet by ID",
+                    type: "Pet"
+                };
+                req.swagger.operationPath = ['apis', '0', 'operations', '0'];
+                req.swagger.params = {
+                    petId: {
+                        path: ['apis', '0', 'operations', '0', 'parameters', '0'],
+                        schema: {
+                            allowMultiple: false,
+                            description: "ID of pet that needs to be fetched",
+                            format: "int64",
+                            maximum: "100000.0",
+                            minimum: "1.0",
+                            name: "petId",
+                            paramType: "path",
+                            required: true,
+                            type: "integer"
+                        },
+                        originalValue: '1',
+                        value: 1
+                    }
+                };
 
                 res.setHeader('Content-Type', 'application/json');
                 res.end([ 'foo', 0 ]);


### PR DESCRIPTION
I managed to find some tests in the `swagger-tools` codebase for this
field, so I was able to verify the typing. I found a number of
mistakes I had made. I've also changed a few fields to `any` where I
had no good structure to give them.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: In the code comments
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.