### PR TITLE
rollup: added typings for watch api

### DIFF
--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -164,3 +164,54 @@ export interface TransformContext {
 
 /** Returns a Promise that resolves with a bundle */
 export function rollup(options: Options): Promise<Bundle>
+
+export interface WatchOptions extends ConfigFileOptions {
+	watch?: {
+		/**
+		 * If set to true, will use chokidar for file watching (requires installation).
+		 * If set to object, the settings are passed on to chokidar
+		 */
+		chokidar?: boolean | { [key: string]: any };
+		/** Limit the file-watching to certain files, e.g. 'src/**' */
+		include?: string;
+		/** Prevent files from being watched, e.g. 'node_modules/**' */
+		exclude?: string;
+	}
+}
+
+export interface StartEvent {
+	code: 'START'
+}
+export interface EndEvent {
+	code: 'END'
+}
+export interface ErrorEvent {
+	code: 'ERROR'
+	error: Error
+}
+export interface FatalEvent {
+	code: 'FATAL'
+	error: Error
+}
+export interface BundleStartEvent {
+	code: 'BUNDLE_START'
+	input: string
+	output: string[]
+}
+export interface BundleEndEvent {
+	code: 'BUNDLE_END'
+	input: string
+	output: string[]
+	duration: number
+}
+export type WatchEvent = StartEvent | EndEvent | ErrorEvent | FatalEvent | BundleStartEvent | BundleEndEvent
+
+export class Watcher {
+	/** Listen to the events that are emitted by rollup during watching */
+	on(type: 'event', callback: (e: WatchEvent) => void): void
+	/** Stop watching for file changes */
+	close(): void
+}
+
+/** Starts rollup in watch mode. Returns a watcher instance for closing or listening to events */
+export function watch(options: WatchOptions): Watcher

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -1,4 +1,4 @@
-import { rollup, Bundle, Plugin, ConfigFileOptions } from 'rollup'
+import { rollup, watch, Bundle, Plugin, ConfigFileOptions } from 'rollup'
 
 declare const console: { log(...messages: any[]): void, warn(message: string): void }
 
@@ -69,6 +69,42 @@ async function main() {
         sourcemapFile: 'bundle.js.map',
         strict: true,
     })
+
+    const watcher = watch({
+        input: 'main.js',
+        output: {
+            file: 'bundle.js',
+            format: 'es'
+        },
+        watch: {
+            chokidar: true
+        }
+    })
+
+    watcher.on('event', e => {
+        switch (e.code) {
+            case 'START':
+                console.log(`We're rolling!`)
+                return
+            case 'END':
+                console.log(`We're all rolled up!`)
+                return
+            case 'ERROR':
+            case 'FATAL':
+                console.log(e.error.message)
+                return
+            case 'BUNDLE_START':
+                console.log(`Bundling: ${e.input}`)
+                return
+            case 'BUNDLE_END':
+                console.log(`Bundling: ${e.input}`)
+                return
+        }
+
+        assertNever(e)
+    })
+
+    watcher.close()
 }
 
 main()
@@ -93,4 +129,8 @@ export const multiConfig: ConfigFileOptions = {
             format: 'cjs',
         }
     ]
+}
+
+function assertNever(nope: never) {
+    throw new Error('Oh no!')
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://rollupjs.org/#rollup-watch
https://github.com/rollup/rollup/blob/e11a2fdf7e6f619cc66d28cfc1edc2f54aab4cce/src/watch/index.js
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.