### PR TITLE
pg: Client constructor still accepts a string

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -93,7 +93,7 @@ export class Pool extends events.EventEmitter {
 }
 
 export class Client extends events.EventEmitter {
-    constructor(config: ClientConfig);
+    constructor(config: string | ClientConfig);
 
     connect(): Promise<void>;
     connect(callback: (err: Error) => void): void;


### PR DESCRIPTION
You should be able to construct a client with a string argument, for example:

```ts
new Client("postgres:///test:password@localhost:5432/test");
```

This was previously possible, but was removed with this commit:

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/3653eef83fb63e92c9751ea67670f0c43b9ef150#diff-4df252691d9600a100846d5bb742a99dL90

My guess is that the above commit was a result of a misunderstanding of this "pg" commit: https://github.com/brianc/node-postgres/pull/1363/commits/c2db98ece6dcc5d0fee87cd6f93547868a1a4e8a

However, the "pg" library does if fact continue to allow using a string, so please approve this pull request