### PR TITLE
Fixed camelCasing for webpack-manifest-plugin fileName

### DIFF
--- a/types/webpack-manifest-plugin/index.d.ts
+++ b/types/webpack-manifest-plugin/index.d.ts
@@ -34,7 +34,7 @@ declare namespace WebpackManifestPlugin {
          * The manifest filename in your output directory.
          * Default: manifest.json
          */
-        filename?: string;
+        fileName?: string;
 
         /**
          * A path prefix for all file references. Useful for including your output path in the manifest.

--- a/types/webpack-manifest-plugin/webpack-manifest-plugin-tests.ts
+++ b/types/webpack-manifest-plugin/webpack-manifest-plugin-tests.ts
@@ -3,7 +3,7 @@ import path = require('path');
 import WebpackManifestPlugin = require('webpack-manifest-plugin');
 
 const options: WebpackManifestPlugin.Options = {
-    filename: 'manifest.json',
+    fileName: 'manifest.json',
     basePath: '/src/',
     seed: {
         name: 'Hello world',
@@ -28,7 +28,7 @@ const c: Configuration = {
     plugins: [
         new WebpackManifestPlugin(),
         new WebpackManifestPlugin({
-            filename: 'my-manifest.json',
+            fileName: 'my-manifest.json',
             basePath: '/app/',
             seed: {
                 name: 'My Manifest',


### PR DESCRIPTION
It's listed as fileName in the docs. I think this was just a typo.

https://www.npmjs.com/package/webpack-manifest-plugin
