### PR TITLE
Adds type definitions for raspi, raspi-board, and raspi-peripheral

### DIFF
--- a/types/raspi-board/index.d.ts
+++ b/types/raspi-board/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for raspi-board 5.0
+// Project: https://github.com/nebrius/raspi-board
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export const VERSION_1_MODEL_A = "rpi1_a";
+export const VERSION_1_MODEL_B_REV_1 = "rpi1_b1";
+export const VERSION_1_MODEL_B_REV_2 = "rpi1_b2";
+export const VERSION_1_MODEL_B_PLUS = "rpi1_bplus";
+export const VERSION_1_MODEL_A_PLUS = "rpi1_aplus";
+export const VERSION_1_MODEL_ZERO = "rpi1_zero";
+export const VERSION_1_MODEL_ZERO_W = "rpi1_zerow";
+export const VERSION_2_MODEL_B = "rpi2_b";
+export const VERSION_3_MODEL_B = "rpi3_b";
+export const VERSION_UNKNOWN = "unknown";
+export interface PinInfo {
+    pins: string[];
+    peripherals: string[];
+    gpio: number;
+}
+export function getBoardRevision(): string;
+export function getPins(): {
+    [wiringpi: number]: PinInfo;
+};
+export function getPinNumber(alias: string | number): number | null;
+export function getGpioNumber(alias: string | number): number | null;

--- a/types/raspi-board/raspi-board-tests.ts
+++ b/types/raspi-board/raspi-board-tests.ts
@@ -1,0 +1,6 @@
+import { getBoardRevision, getPins, getPinNumber, getGpioNumber } from 'raspi-board';
+
+getBoardRevision();
+getPins();
+getPinNumber('GPIO18');
+getGpioNumber('GPIO18');

--- a/types/raspi-board/tsconfig.json
+++ b/types/raspi-board/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-board-tests.ts"
+    ]
+}

--- a/types/raspi-board/tslint.json
+++ b/types/raspi-board/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/raspi-peripheral/index.d.ts
+++ b/types/raspi-peripheral/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for raspi-peripheral 2.0
+// Project: https://github.com/nebrius/raspi-peripheral
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+import { EventEmitter } from 'events';
+export class Peripheral extends EventEmitter {
+    private _alive;
+    readonly alive: boolean;
+    private _pins;
+    readonly pins: number[];
+    constructor(pins: string | number | Array<string | number>);
+    destroy(): void;
+    validateAlive(): void;
+}

--- a/types/raspi-peripheral/raspi-peripheral-tests.ts
+++ b/types/raspi-peripheral/raspi-peripheral-tests.ts
@@ -1,0 +1,5 @@
+import { Peripheral } from 'raspi-peripheral';
+
+const myPeripheral = new Peripheral('GPIO2');
+myPeripheral.alive;
+myPeripheral.pins.filter((pin) => true);

--- a/types/raspi-peripheral/tsconfig.json
+++ b/types/raspi-peripheral/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-peripheral-tests.ts"
+    ]
+}

--- a/types/raspi-peripheral/tslint.json
+++ b/types/raspi-peripheral/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/raspi/index.d.ts
+++ b/types/raspi/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for raspi 5.0
+// Project: https://github.com/nebrius/raspi
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export function init(cb: () => void): void;

--- a/types/raspi/raspi-tests.ts
+++ b/types/raspi/raspi-tests.ts
@@ -1,0 +1,3 @@
+import { init } from 'raspi';
+
+init(() => {});

--- a/types/raspi/tsconfig.json
+++ b/types/raspi/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-tests.ts"
+    ]
+}

--- a/types/raspi/tslint.json
+++ b/types/raspi/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

**Justification for not checking the first option above**: I am the author of [raspi](https://github.com/nebrius/raspi), [raspi-board](https://github.com/nebrius/raspi-board), and [raspi-peripheral](https://github.com/nebrius/raspi-peripheral). Normally the DefinitelyTyped way would be to add these definitions as types in my package. Indeed I [already do this](https://github.com/nebrius/raspi/blob/master/package.json#L6), but I have a reason for publishing these in DefinitelyTyped separately.

This set of modules allows access to hardware peripherals on a Raspberry Pi, as part of [raspi-io](https://github.com/nebrius/raspi-io), an [IO Plugin](https://github.com/rwaldron/io-plugins) for the [Johnny-Five Node.js robotics framework](johnny-five.io). Because of the hard dependence of running on a Raspberry Pi, these modules _are not installable_ on anything other than a Raspberry Pi.

However, development of these modules is not done on a Raspberry Pi itself, because that way lies madness (I tried). This means that the code is developed on a laptop running macOS or Windows, but deployed on a Raspberry Pi running Linux.

On the laptop, I run `npm install --only=dev --force` to install all of my build tools (tsc, tslint, `@types` definitions, etc), and on device I run `npm install --only-prod`. These modules are not dev dependencies, and so they are not installed on my laptop at build time, meaning `tsc` _cannot_ access the types included with these three modules, because they are not on disk.

My current approach is to manually copy the type definition files into `node_modules` manually. While this works, it's cludgy, error-prone, and makes it difficult to onboard other developers. Getting this in DefinitelyTyped would make the workflow for these modules effectively the same as any other module and smooth out my workflow considerably.

If this works out here, I will soon be publishing types for the rest of the modules listed in https://github.com/nebrius/raspi-io/blob/master/CONTRIBUTING.md#raspi-io-and-raspijs-modular-architecture. I picked the three most foundational to figure out the correct process before publishing the rest.

Thanks for taking a look!