### PR TITLE
change "export =" to "export default" index.d.ts

### DIFF
--- a/types/pouchdb/index.d.ts
+++ b/types/pouchdb/index.d.ts
@@ -24,5 +24,5 @@
 
 declare module 'pouchdb' {
     const plugin: PouchDB.Static;
-    export = plugin;
+    export default plugin;
 }


### PR DESCRIPTION
Fixes the error:
Module ''pouchdb'' has no default export.
In typescript 2.4.2 / angular 5.0.0