### PR TITLE
Added stub Node interface to highlight.js

### DIFF
--- a/types/highlight.js/index.d.ts
+++ b/types/highlight.js/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Niklas Mollenhauer <https://github.com/nikeee>, Jeremy Hull <https://github.com/sourrust>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+interface Node { }
+
 declare namespace hljs
 {
 	export function highlight(


### PR DESCRIPTION
See https://github.com/TypeStrong/typedoc/issues/529.