### PR TITLE
json-schema : add types for JSON Schema v6

### DIFF
--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -471,3 +471,5 @@ export interface JSONSchema6 {
    */
   examples?: JSONSchema6Type[];
 }
+
+export { JSONSchema6 as JSONSchema };

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -10,24 +10,24 @@
  * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1
  */
 export type JSONSchema4TypeName = 'string' | 'number' | 'integer' | 'boolean'
-                                | 'object' | 'array' | 'null' | 'any';
+                                | 'object' | 'array' | 'null' | 'any'
 
 /**
  * @see https://tools.ietf.org/html/draft-zyp-json-schema-04#section-3.5
  */
-export type JSONSchema4Type = any[] | boolean | number | null | object | string;
+export type JSONSchema4Type = any[] | boolean | number | null | object | string
 
 /**
  * JSON Schema V4
  * @see https://tools.ietf.org/html/draft-zyp-json-schema-04
  */
 export interface JSONSchema4 {
-  id?: string;
-  $ref?: string;
+  id?: string
+  $ref?: string
   $schema?: 'http://json-schema.org/schema#' | 'http://json-schema.org/hyper-schema#'
           | 'http://json-schema.org/draft-04/schema#' | 'http://json-schema.org/draft-04/hyper-schema#'
           | 'http://json-schema.org/draft-03/schema#' | 'http://json-schema.org/draft-03/hyper-schema#'
-          | string;
+          | string
 
   /**
    * This attribute is a string that provides a short description of the
@@ -35,7 +35,7 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.21
    */
-  title?: string;
+  title?: string
 
   /**
    * This attribute is a string that provides a full description of the of
@@ -43,17 +43,17 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.22
    */
-  description?: string;
+  description?: string
 
-  default?: JSONSchema4Type;
-  multipleOf?: number;
-  maximum?: number;
-  exclusiveMaximum?: boolean;
-  minimum?: number;
-  exclusiveMinimum?: boolean;
-  maxLength?: number;
-  minLength?: number;
-  pattern?: string;
+  default?: JSONSchema4Type
+  multipleOf?: number
+  maximum?: number
+  exclusiveMaximum?: boolean
+  minimum?: number
+  exclusiveMinimum?: boolean
+  maxLength?: number
+  minLength?: number
+  pattern?: string
 
   /**
    * May only be defined when "items" is defined, and is a tuple of JSONSchemas.
@@ -65,7 +65,7 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.6
    */
-  additionalItems?: boolean | JSONSchema4;
+  additionalItems?: boolean | JSONSchema4
 
   /**
    * This attribute defines the allowed items in an instance array, and
@@ -86,13 +86,13 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.5
    */
-  items?: JSONSchema4 | JSONSchema4[];
+  items?: JSONSchema4 | JSONSchema4[]
 
-  maxItems?: number;
-  minItems?: number;
-  uniqueItems?: boolean;
-  maxProperties?: number;
-  minProperties?: number;
+  maxItems?: number
+  minItems?: number
+  uniqueItems?: boolean
+  maxProperties?: number
+  minProperties?: number
 
   /**
    * This attribute indicates if the instance must have a value, and not
@@ -101,7 +101,7 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.7
    */
-  required?: false | string[];
+  required?: false | string[]
 
   /**
    * This attribute defines a schema for all properties that are not
@@ -113,11 +113,11 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.4
    */
-  additionalProperties?: boolean | JSONSchema4;
+  additionalProperties?: boolean | JSONSchema4
 
   definitions?: {
-    [k: string]: JSONSchema4;
-  };
+    [k: string]: JSONSchema4
+  }
 
   /**
    * This attribute is an object with property definitions that define the
@@ -133,8 +133,8 @@ export interface JSONSchema4 {
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.2
    */
   properties?: {
-    [k: string]: JSONSchema4;
-  };
+    [k: string]: JSONSchema4
+  }
 
   /**
    * This attribute is an object that defines the schema for a set of
@@ -148,11 +148,11 @@ export interface JSONSchema4 {
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.3
    */
   patternProperties?: {
-    [k: string]: JSONSchema4;
-  };
+    [k: string]: JSONSchema4
+  }
   dependencies?: {
-    [k: string]: JSONSchema4 | string[];
-  };
+    [k: string]: JSONSchema4 | string[]
+  }
 
   /**
    * This provides an enumeration of all possible values that are valid
@@ -163,17 +163,17 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.19
    */
-  enum?: JSONSchema4Type[];
+  enum?: JSONSchema4Type[]
 
   /**
    * A single type, or a union of simple types
    */
-  type?: JSONSchema4TypeName | JSONSchema4TypeName[];
+  type?: JSONSchema4TypeName | JSONSchema4TypeName[]
 
-  allOf?: JSONSchema4[];
-  anyOf?: JSONSchema4[];
-  oneOf?: JSONSchema4[];
-  not?: JSONSchema4;
+  allOf?: JSONSchema4[]
+  anyOf?: JSONSchema4[]
+  oneOf?: JSONSchema4[]
+  not?: JSONSchema4
 
   /**
    * The value of this property MUST be another schema which will provide
@@ -191,71 +191,71 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.26
    */
-  extends?: string | string[];
+  extends?: string | string[]
 
   /**
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-04#section-5.6
    */
-  [k: string]: any;
+  [k: string]: any
 }
 
 /* JSON Schema 6 */
 
-export type JSONSchema6TypeName = 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array' | 'null' | 'any';
+export type JSONSchema6TypeName = 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array' | 'null' | 'any'
 
-export type JSONSchema6Type = any[] | boolean | number | null | object | string;
+export type JSONSchema6Type = any[] | boolean | number | null | object | string
 
 /**
  * JSON Schema V6
  * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01
  */
 export interface JSONSchema6 {
-  $id?: string;
-  $ref?: string;
+  $id?: string
+  $ref?: string
   $schema?: 'http://json-schema.org/schema#' | 'http://json-schema.org/hyper-schema#' |
-  'http://json-schema.org/draft-06/schema#' | 'http://json-schema.org/draft-06/hyper-schema#';
+  'http://json-schema.org/draft-06/schema#' | 'http://json-schema.org/draft-06/hyper-schema#'
 
   /**
    * Must be strictly greater than 0.
    * A numeric instance is valid only if division by this keyword's value results in an integer.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.1
    */
-  multipleOf?: number;
+  multipleOf?: number
 
   /**
    * Representing an inclusive upper limit for a numeric instance.
    * This keyword validates only if the instance is less than or exactly equal to "maximum".
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.2
    */
-  maximum?: number;
+  maximum?: number
 
   /**
    * Representing an exclusive upper limit for a numeric instance.
    * This keyword validates only if the instance is strictly less than (not equal to) to "exclusiveMaximum".
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.3
    */
-  exclusiveMaximum?: number;
+  exclusiveMaximum?: number
 
   /**
    * Representing an inclusive lower limit for a numeric instance.
    * This keyword validates only if the instance is greater than or exactly equal to "minimum".
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.4
    */
-  minimum?: number;
+  minimum?: number
 
   /**
    * Representing an exclusive lower limit for a numeric instance.
    * This keyword validates only if the instance is strictly greater than (not equal to) to "exclusiveMinimum".
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.5
    */
-  exclusiveMinimum?: number;
+  exclusiveMinimum?: number
 
   /**
    * Must be a non-negative integer.
    * A string instance is valid against this keyword if its length is less than, or equal to, the value of this keyword.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.6
    */
-  maxLength?: number;
+  maxLength?: number
 
   /**
    * Must be a non-negative integer.
@@ -263,20 +263,20 @@ export interface JSONSchema6 {
    * Omitting this keyword has the same behavior as a value of 0.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.7
    */
-  minLength?: number;
+  minLength?: number
 
   /**
    * Should be a valid regular expression, according to the ECMA 262 regular expression dialect.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.8
    */
-  pattern?: string;
+  pattern?: string
 
   /**
    * This keyword determines how child instances validate for arrays, and does not directly validate the immediate instance itself.
    * Omitting this keyword has the same behavior as an empty schema.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.9
    */
-  items?: boolean | JSONSchema6 | JSONSchema6[];
+  items?: boolean | JSONSchema6 | JSONSchema6[]
 
   /**
    * This keyword determines how child instances validate for arrays, and does not directly validate the immediate instance itself.
@@ -287,14 +287,14 @@ export interface JSONSchema6 {
    * Omitting this keyword has the same behavior as an empty schema.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.10
    */
-  additionalItems?: boolean | JSONSchema6;
+  additionalItems?: boolean | JSONSchema6
 
   /**
    * Must be a non-negative integer.
    * An array instance is valid against "maxItems" if its size is less than, or equal to, the value of this keyword.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.11
    */
-  maxItems?: number;
+  maxItems?: number
 
   /**
    * Must be a non-negative integer.
@@ -302,7 +302,7 @@ export interface JSONSchema6 {
    * Omitting this keyword has the same behavior as a value of 0.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.12
    */
-  minItems?: number;
+  minItems?: number
 
   /**
    * If this keyword has boolean value false, the instance validates successfully.
@@ -310,20 +310,20 @@ export interface JSONSchema6 {
    * Omitting this keyword has the same behavior as a value of false.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.13
    */
-  uniqueItems?: boolean;
+  uniqueItems?: boolean
 
   /**
    * An array instance is valid against "contains" if at least one of its elements is valid against the given schema.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.14
    */
-  contains?: boolean | JSONSchema6;
+  contains?: boolean | JSONSchema6
 
   /**
    * Must be a non-negative integer.
    * An object instance is valid against "maxProperties" if its number of properties is less than, or equal to, the value of this keyword.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.15
    */
-  maxProperties?: number;
+  maxProperties?: number
 
   /**
    * Must be a non-negative integer.
@@ -332,7 +332,7 @@ export interface JSONSchema6 {
    * Omitting this keyword has the same behavior as a value of 0.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.16
    */
-  minProperties?: number;
+  minProperties?: number
 
   /**
    * Elements of this array must be unique.
@@ -341,7 +341,7 @@ export interface JSONSchema6 {
    *
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.17
    */
-  required?: string[];
+  required?: string[]
 
   /**
    * This keyword determines how child instances validate for objects, and does not directly validate the immediate instance itself.
@@ -352,7 +352,7 @@ export interface JSONSchema6 {
    */
   properties?: {
     [k: string]: boolean | JSONSchema6
-  };
+  }
 
   /**
    * This attribute is an object that defines the schema for a set of property names of an object instance.
@@ -364,7 +364,7 @@ export interface JSONSchema6 {
    */
   patternProperties?: {
     [k: string]: boolean | JSONSchema6
-  };
+  }
 
   /**
    * This attribute defines a schema for all properties that are not explicitly defined in an object type definition.
@@ -373,7 +373,7 @@ export interface JSONSchema6 {
    * The default value is an empty schema which allows any value for additional properties.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.20
    */
-  additionalProperties?: boolean | JSONSchema6;
+  additionalProperties?: boolean | JSONSchema6
 
   /**
    * This keyword specifies rules that are evaluated if the instance is an object and contains a certain property.
@@ -384,7 +384,7 @@ export interface JSONSchema6 {
    */
   dependencies?: {
     [k: string]: boolean | JSONSchema6 | string[]
-  };
+  }
 
   /**
    * Takes a schema which validates the names of all properties rather than their values.
@@ -392,7 +392,7 @@ export interface JSONSchema6 {
    * Omitting this keyword has the same behavior as an empty schema.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.22
    */
-  propertyNames?: boolean | JSONSchema6;
+  propertyNames?: boolean | JSONSchema6
 
   /**
    * This provides an enumeration of all possible values that are valid
@@ -403,71 +403,71 @@ export interface JSONSchema6 {
    *
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.23
    */
-  enum?: JSONSchema6Type[];
+  enum?: JSONSchema6Type[]
 
   /**
    * More readible form of a one-element "enum"
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.24
    */
-  const?: JSONSchema6Type;
+  const?: JSONSchema6Type
 
   /**
    * A single type, or a union of simple types
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.25
    */
-  type?: JSONSchema6TypeName | JSONSchema6TypeName[];
+  type?: JSONSchema6TypeName | JSONSchema6TypeName[]
 
   /**
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.26
    */
-  allOf?: JSONSchema6[];
+  allOf?: JSONSchema6[]
 
   /**
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.27
    */
-  anyOf?: JSONSchema6[];
+  anyOf?: JSONSchema6[]
 
   /**
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.28
    */
-  oneOf?: JSONSchema6[];
+  oneOf?: JSONSchema6[]
 
   /**
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.29
    */
-  not?: boolean | JSONSchema6;
+  not?: boolean | JSONSchema6
 
   /**
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.1
    */
   definitions?: {
     [k: string]: boolean | JSONSchema6
-  };
+  }
 
   /**
    * This attribute is a string that provides a short description of the instance property.
    *
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.2
    */
-  title?: string;
+  title?: string
 
   /**
    * This attribute is a string that provides a full description of the of purpose the instance property.
    *
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.2
    */
-  description?: string;
+  description?: string
 
   /**
    * This keyword can be used to supply a default JSON value associated with a particular schema.
    * It is RECOMMENDED that a default value be valid against the associated schema.
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.3
    */
-  default?: JSONSchema6Type;
+  default?: JSONSchema6Type
 
   /**
-   * Array of examples with no validation effect; the value of "default" is usable as an example without repeating it under this keyword
+   * Array of examples with no validation effect the value of "default" is usable as an example without repeating it under this keyword
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.4
    */
-  examples?: JSONSchema6Type[];
+  examples?: JSONSchema6Type[]
 }

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -1,21 +1,21 @@
-// Type definitions for json-schema 4.0
+// Type definitions for json-schema 4.0 and 6.0
 // Project: https://www.npmjs.com/package/json-schema
-// Definitions by: Boris Cherny <https://github.com/bcherny>
+// Definitions by: Boris Cherny <https://github.com/bcherny>, Cyrille Tuzi <https://github.com/cyrilletuzi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.6
 
-/// <reference types="node"/>
+/* JSON Schema 4 */
 
 /**
  * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.1
  */
 export type JSONSchema4TypeName = 'string' | 'number' | 'integer' | 'boolean'
-                                | 'object' | 'array' | 'null' | 'any'
+                                | 'object' | 'array' | 'null' | 'any';
 
 /**
  * @see https://tools.ietf.org/html/draft-zyp-json-schema-04#section-3.5
  */
-export type JSONSchema4Type = any[] | boolean | number | null | object | string
+export type JSONSchema4Type = any[] | boolean | number | null | object | string;
 
 /**
  * JSON Schema V4
@@ -27,7 +27,7 @@ export interface JSONSchema4 {
   $schema?: 'http://json-schema.org/schema#' | 'http://json-schema.org/hyper-schema#'
           | 'http://json-schema.org/draft-04/schema#' | 'http://json-schema.org/draft-04/hyper-schema#'
           | 'http://json-schema.org/draft-03/schema#' | 'http://json-schema.org/draft-03/hyper-schema#'
-          | string
+          | string;
 
   /**
    * This attribute is a string that provides a short description of the
@@ -35,7 +35,7 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.21
    */
-  title?: string
+  title?: string;
 
   /**
    * This attribute is a string that provides a full description of the of
@@ -43,17 +43,17 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.22
    */
-  description?: string
+  description?: string;
 
-  default?: JSONSchema4Type
-  multipleOf?: number
-  maximum?: number
-  exclusiveMaximum?: boolean
-  minimum?: number
-  exclusiveMinimum?: boolean
-  maxLength?: number
-  minLength?: number
-  pattern?: string
+  default?: JSONSchema4Type;
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: boolean;
+  minimum?: number;
+  exclusiveMinimum?: boolean;
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
 
   /**
    * May only be defined when "items" is defined, and is a tuple of JSONSchemas.
@@ -65,7 +65,7 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.6
    */
-  additionalItems?: boolean | JSONSchema4
+  additionalItems?: boolean | JSONSchema4;
 
   /**
    * This attribute defines the allowed items in an instance array, and
@@ -86,13 +86,13 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.5
    */
-  items?: JSONSchema4 | JSONSchema4[]
+  items?: JSONSchema4 | JSONSchema4[];
 
-  maxItems?: number
-  minItems?: number
-  uniqueItems?: boolean
-  maxProperties?: number
-  minProperties?: number
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  maxProperties?: number;
+  minProperties?: number;
 
   /**
    * This attribute indicates if the instance must have a value, and not
@@ -101,7 +101,7 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.7
    */
-  required?: false | string[]
+  required?: false | string[];
 
   /**
    * This attribute defines a schema for all properties that are not
@@ -113,10 +113,10 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.4
    */
-  additionalProperties?: boolean | JSONSchema4
+  additionalProperties?: boolean | JSONSchema4;
 
   definitions?: {
-    [k: string]: JSONSchema4
+    [k: string]: JSONSchema4;
   }
 
   /**
@@ -133,7 +133,7 @@ export interface JSONSchema4 {
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.2
    */
   properties?: {
-    [k: string]: JSONSchema4
+    [k: string]: JSONSchema4;
   }
 
   /**
@@ -148,10 +148,10 @@ export interface JSONSchema4 {
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.3
    */
   patternProperties?: {
-    [k: string]: JSONSchema4
+    [k: string]: JSONSchema4;
   }
   dependencies?: {
-    [k: string]: JSONSchema4 | string[]
+    [k: string]: JSONSchema4 | string[];
   }
 
   /**
@@ -163,17 +163,17 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.19
    */
-  enum?: JSONSchema4Type[]
+  enum?: JSONSchema4Type[];
 
   /**
    * A single type, or a union of simple types
    */
-  type?: JSONSchema4TypeName | JSONSchema4TypeName[]
+  type?: JSONSchema4TypeName | JSONSchema4TypeName[];
 
-  allOf?: JSONSchema4[]
-  anyOf?: JSONSchema4[]
-  oneOf?: JSONSchema4[]
-  not?: JSONSchema4
+  allOf?: JSONSchema4[];
+  anyOf?: JSONSchema4[];
+  oneOf?: JSONSchema4[];
+  not?: JSONSchema4;
 
   /**
    * The value of this property MUST be another schema which will provide
@@ -191,10 +191,285 @@ export interface JSONSchema4 {
    *
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.26
    */
-  extends?: string | string[]
+  extends?: string | string[];
 
   /**
    * @see https://tools.ietf.org/html/draft-zyp-json-schema-04#section-5.6
    */
-  [k: string]: any
+  [k: string]: any;
+}
+
+/* JSON Schema 6 */
+
+export type JSONSchema6TypeName = 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array' | 'null' | 'any';
+
+export type JSONSchema6Type = any[] | boolean | number | null | object | string;
+
+/**
+* JSON Schema V6
+* @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01
+*/
+export interface JSONSchema6 {
+
+  $id?: string;
+  $ref?: string;
+  $schema?: 'http://json-schema.org/schema#' | 'http://json-schema.org/hyper-schema#' |
+  'http://json-schema.org/draft-06/schema#' | 'http://json-schema.org/draft-06/hyper-schema#';
+
+  /**
+   * Must be strictly greater than 0.
+   * A numeric instance is valid only if division by this keyword's value results in an integer.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.1
+   */
+  multipleOf?: number;
+
+  /**
+   * Representing an inclusive upper limit for a numeric instance.
+   * This keyword validates only if the instance is less than or exactly equal to "maximum".
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.2
+   */
+  maximum?: number;
+
+  /**
+   * Representing an exclusive upper limit for a numeric instance.
+   * This keyword validates only if the instance is strictly less than (not equal to) to "exclusiveMaximum".
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.3
+   */
+  exclusiveMaximum?: number;
+
+  /**
+   * Representing an inclusive lower limit for a numeric instance.
+   * This keyword validates only if the instance is greater than or exactly equal to "minimum".
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.4
+   */
+  minimum?: number;
+
+  /**
+   * Representing an exclusive lower limit for a numeric instance.
+   * This keyword validates only if the instance is strictly greater than (not equal to) to "exclusiveMinimum".
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.5
+   */
+  exclusiveMinimum?: number;
+
+  /**
+   * Must be a non-negative integer.
+   * A string instance is valid against this keyword if its length is less than, or equal to, the value of this keyword.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.6
+   */
+  maxLength?: number;
+
+  /**
+   * Must be a non-negative integer.
+   * A string instance is valid against this keyword if its length is greater than, or equal to, the value of this keyword.
+   * Omitting this keyword has the same behavior as a value of 0.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.7
+   */
+  minLength?: number;
+
+  /**
+   * Should be a valid regular expression, according to the ECMA 262 regular expression dialect.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.8
+   */
+  pattern?: string;
+
+  /**
+   * This keyword determines how child instances validate for arrays, and does not directly validate the immediate instance itself.
+   * Omitting this keyword has the same behavior as an empty schema.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.9
+   */
+  items?: boolean | JSONSchema6 | JSONSchema6[];
+
+  /**
+   * This keyword determines how child instances validate for arrays, and does not directly validate the immediate instance itself.
+   * If "items" is an array of schemas, validation succeeds if every instance element
+   * at a position greater than the size of "items" validates against "additionalItems".
+   * Otherwise, "additionalItems" MUST be ignored, as the "items" schema
+   * (possibly the default value of an empty schema) is applied to all elements.
+   * Omitting this keyword has the same behavior as an empty schema.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.10
+   */
+  additionalItems?: boolean | JSONSchema6;
+
+  /**
+   * Must be a non-negative integer.
+   * An array instance is valid against "maxItems" if its size is less than, or equal to, the value of this keyword.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.11
+   */
+  maxItems?: number;
+
+  /**
+   * Must be a non-negative integer.
+   * An array instance is valid against "maxItems" if its size is greater than, or equal to, the value of this keyword.
+   * Omitting this keyword has the same behavior as a value of 0.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.12
+   */
+  minItems?: number;
+
+  /**
+   * If this keyword has boolean value false, the instance validates successfully.
+   * If it has boolean value true, the instance validates successfully if all of its elements are unique.
+   * Omitting this keyword has the same behavior as a value of false.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.13
+   */
+  uniqueItems?: boolean;
+
+  /**
+   * An array instance is valid against "contains" if at least one of its elements is valid against the given schema.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.14
+   */
+  contains?: boolean | JSONSchema6;
+
+  /**
+   * Must be a non-negative integer.
+   * An object instance is valid against "maxProperties" if its number of properties is less than, or equal to, the value of this keyword.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.15
+   */
+  maxProperties?: number;
+
+  /**
+   * Must be a non-negative integer.
+   * An object instance is valid against "maxProperties" if its number of properties is greater than,
+   * or equal to, the value of this keyword.
+   * Omitting this keyword has the same behavior as a value of 0.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.16
+   */
+  minProperties?: number;
+
+  /**
+   * Elements of this array must be unique.
+   * An object instance is valid against this keyword if every item in the array is the name of a property in the instance.
+   * Omitting this keyword has the same behavior as an empty array.
+   *
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.17
+   */
+  required?: string[];
+
+  /**
+   * This keyword determines how child instances validate for objects, and does not directly validate the immediate instance itself.
+   * Validation succeeds if, for each name that appears in both the instance and as a name within this keyword's value,
+   * the child instance for that name successfully validates against the corresponding schema.
+   * Omitting this keyword has the same behavior as an empty object.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.18
+   */
+  properties?: {
+    [k: string]: boolean | JSONSchema6
+  };
+
+  /**
+   * This attribute is an object that defines the schema for a set of property names of an object instance.
+   * The name of each property of this attribute's object is a regular expression pattern in the ECMA 262, while the value is a schema.
+   * If the pattern matches the name of a property on the instance object, the value of the instance's property
+   * MUST be valid against the pattern name's schema value.
+   * Omitting this keyword has the same behavior as an empty object.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.19
+   */
+  patternProperties?: {
+    [k: string]: boolean | JSONSchema6
+  };
+
+  /**
+   * This attribute defines a schema for all properties that are not explicitly defined in an object type definition.
+   * If specified, the value MUST be a schema or a boolean.
+   * If false is provided, no additional properties are allowed beyond the properties defined in the schema.
+   * The default value is an empty schema which allows any value for additional properties.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.20
+   */
+  additionalProperties?: boolean | JSONSchema6;
+
+  /**
+   * This keyword specifies rules that are evaluated if the instance is an object and contains a certain property.
+   * Each property specifies a dependency.
+   * If the dependency value is an array, each element in the array must be unique.
+   * Omitting this keyword has the same behavior as an empty object.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.21
+   */
+  dependencies?: {
+    [k: string]: boolean | JSONSchema6 | string[]
+  };
+
+  /**
+   * Takes a schema which validates the names of all properties rather than their values.
+   * Note the property name that the schema is testing will always be a string.
+   * Omitting this keyword has the same behavior as an empty schema.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.22
+   */
+  propertyNames?: boolean | JSONSchema6;
+
+  /**
+  * This provides an enumeration of all possible values that are valid
+  * for the instance property. This MUST be an array, and each item in
+  * the array represents a possible value for the instance value. If
+  * this attribute is defined, the instance value MUST be one of the
+  * values in the array in order for the schema to be valid.
+  *
+  * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.23
+  */
+  enum?: JSONSchema6Type[];
+
+  /**
+   * More readible form of a one-element "enum"
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.24
+   */
+  const?: JSONSchema6Type;
+
+  /**
+  * A single type, or a union of simple types
+  * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.25
+  */
+  type?: JSONSchema6TypeName | JSONSchema6TypeName[];
+
+  /**
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.26
+   */
+  allOf?: JSONSchema6[];
+
+  /**
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.27
+   */
+  anyOf?: JSONSchema6[];
+
+  /**
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.28
+   */
+  oneOf?: JSONSchema6[];
+
+  /**
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.29
+   */
+  not?: boolean | JSONSchema6;
+
+  /**
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.1
+   */
+  definitions?: {
+    [k: string]: boolean | JSONSchema6
+  };
+
+  /**
+   * This attribute is a string that provides a short description of the instance property.
+   *
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.2
+   */
+  title?: string;
+
+  /**
+   * This attribute is a string that provides a full description of the of purpose the instance property.
+   *
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.2
+   */
+  description?: string;
+
+  /**
+   * This keyword can be used to supply a default JSON value associated with a particular schema.
+   * It is RECOMMENDED that a default value be valid against the associated schema.
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.3
+   */
+  default?: JSONSchema6Type;
+
+  /**
+   * Array of examples with no validation effect; the value of "default" is usable as an example without repeating it under this keyword
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.4
+   */
+  examples?: JSONSchema6Type[];
+
 }

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/json-schema
 // Definitions by: Boris Cherny <https://github.com/bcherny>, Cyrille Tuzi <https://github.com/cyrilletuzi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.2
 
 /* JSON Schema 4 */
 
@@ -22,8 +22,8 @@ export type JSONSchema4Type = any[] | boolean | number | null | object | string;
  * @see https://tools.ietf.org/html/draft-zyp-json-schema-04
  */
 export interface JSONSchema4 {
-  id?: string
-  $ref?: string
+  id?: string;
+  $ref?: string;
   $schema?: 'http://json-schema.org/schema#' | 'http://json-schema.org/hyper-schema#'
           | 'http://json-schema.org/draft-04/schema#' | 'http://json-schema.org/draft-04/hyper-schema#'
           | 'http://json-schema.org/draft-03/schema#' | 'http://json-schema.org/draft-03/hyper-schema#'
@@ -117,7 +117,7 @@ export interface JSONSchema4 {
 
   definitions?: {
     [k: string]: JSONSchema4;
-  }
+  };
 
   /**
    * This attribute is an object with property definitions that define the
@@ -134,7 +134,7 @@ export interface JSONSchema4 {
    */
   properties?: {
     [k: string]: JSONSchema4;
-  }
+  };
 
   /**
    * This attribute is an object that defines the schema for a set of
@@ -149,10 +149,10 @@ export interface JSONSchema4 {
    */
   patternProperties?: {
     [k: string]: JSONSchema4;
-  }
+  };
   dependencies?: {
     [k: string]: JSONSchema4 | string[];
-  }
+  };
 
   /**
    * This provides an enumeration of all possible values that are valid
@@ -206,11 +206,10 @@ export type JSONSchema6TypeName = 'string' | 'number' | 'integer' | 'boolean' | 
 export type JSONSchema6Type = any[] | boolean | number | null | object | string;
 
 /**
-* JSON Schema V6
-* @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01
-*/
+ * JSON Schema V6
+ * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01
+ */
 export interface JSONSchema6 {
-
   $id?: string;
   $ref?: string;
   $schema?: 'http://json-schema.org/schema#' | 'http://json-schema.org/hyper-schema#' |
@@ -396,14 +395,14 @@ export interface JSONSchema6 {
   propertyNames?: boolean | JSONSchema6;
 
   /**
-  * This provides an enumeration of all possible values that are valid
-  * for the instance property. This MUST be an array, and each item in
-  * the array represents a possible value for the instance value. If
-  * this attribute is defined, the instance value MUST be one of the
-  * values in the array in order for the schema to be valid.
-  *
-  * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.23
-  */
+   * This provides an enumeration of all possible values that are valid
+   * for the instance property. This MUST be an array, and each item in
+   * the array represents a possible value for the instance value. If
+   * this attribute is defined, the instance value MUST be one of the
+   * values in the array in order for the schema to be valid.
+   *
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.23
+   */
   enum?: JSONSchema6Type[];
 
   /**
@@ -413,9 +412,9 @@ export interface JSONSchema6 {
   const?: JSONSchema6Type;
 
   /**
-  * A single type, or a union of simple types
-  * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.25
-  */
+   * A single type, or a union of simple types
+   * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.25
+   */
   type?: JSONSchema6TypeName | JSONSchema6TypeName[];
 
   /**
@@ -471,5 +470,4 @@ export interface JSONSchema6 {
    * @see https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-7.4
    */
   examples?: JSONSchema6Type[];
-
 }

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -471,5 +471,3 @@ export interface JSONSchema6 {
    */
   examples?: JSONSchema6Type[];
 }
-
-export { JSONSchema6 as JSONSchema };

--- a/types/json-schema/json-schema-tests.ts
+++ b/types/json-schema/json-schema-tests.ts
@@ -1,24 +1,24 @@
-import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName, JSONSchema6, JSONSchema6Type, JSONSchema6TypeName } from 'json-schema';
+import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName, JSONSchema6, JSONSchema6Type, JSONSchema6TypeName } from 'json-schema'
 
 /* JSON Schema 4 */
 
 // SimpleType
 () => {
-  const a: JSONSchema4TypeName = 'string';
-  const b: JSONSchema4TypeName = 'null';
-  const c: JSONSchema4TypeName = 'any';
-};
+  const a: JSONSchema4TypeName = 'string'
+  const b: JSONSchema4TypeName = 'null'
+  const c: JSONSchema4TypeName = 'any'
+}
 
 // Type
 () => {
-  const a: JSONSchema4Type = 'foo';
-  const b: JSONSchema4Type = null;
-  const c: JSONSchema4Type = [1, 2];
-};
+  const a: JSONSchema4Type = 'foo'
+  const b: JSONSchema4Type = null
+  const c: JSONSchema4Type = [1, 2]
+}
 
 // JSONSchema4
 () => {
-  const a: JSONSchema4 = {};
+  const a: JSONSchema4 = {}
   const b: JSONSchema4 = {
     id: 'foo',
     $ref: 'foo/bar',
@@ -65,28 +65,28 @@ import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName, JSONSchema6, JSONSch
     not: {},
     extends: 'foo',
     bar: 4
-  };
-};
+  }
+}
 
 /* JSON Schema 6 */
 
 // SimpleType
 () => {
-  const a: JSONSchema6TypeName = 'string';
-  const b: JSONSchema6TypeName = 'null';
-  const c: JSONSchema6TypeName = 'any';
-};
+  const a: JSONSchema6TypeName = 'string'
+  const b: JSONSchema6TypeName = 'null'
+  const c: JSONSchema6TypeName = 'any'
+}
 
 // Type
 () => {
-  const a: JSONSchema6Type = 'foo';
-  const b: JSONSchema6Type = null;
-  const c: JSONSchema6Type = [1, 2];
-};
+  const a: JSONSchema6Type = 'foo'
+  const b: JSONSchema6Type = null
+  const c: JSONSchema6Type = [1, 2]
+}
 
 // JSONSchema4
 () => {
-  const a: JSONSchema6 = {};
+  const a: JSONSchema6 = {}
   const b: JSONSchema6 = {
     $id: 'foo',
     $ref: 'foo/bar',
@@ -135,5 +135,5 @@ import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName, JSONSchema6, JSONSch
     contains: {},
     examples: [{}],
     propertyNames: {}
-  };
-};
+  }
+}

--- a/types/json-schema/json-schema-tests.ts
+++ b/types/json-schema/json-schema-tests.ts
@@ -58,7 +58,7 @@ import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName, JSONSchema6, JSONSch
       baz: { type: 'integer' }
     },
     enum: ['foo', 42],
-    type: ['string', 'array'],
+    type: 'string',
     allOf: [{}],
     anyOf: [{}],
     oneOf: [{}],
@@ -126,7 +126,7 @@ import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName, JSONSchema6, JSONSch
       baz: { type: 'integer' }
     },
     enum: ['foo', 42],
-    type: ['string', 'array'],
+    type: 'string',
     allOf: [{}],
     anyOf: [{}],
     oneOf: [{}],

--- a/types/json-schema/json-schema-tests.ts
+++ b/types/json-schema/json-schema-tests.ts
@@ -1,22 +1,24 @@
-import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName } from 'json-schema'
+import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName, JSONSchema6, JSONSchema6Type, JSONSchema6TypeName } from 'json-schema';
+
+/* JSON Schema 4 */
 
 // SimpleType
 () => {
-  const a: JSONSchema4TypeName = 'string'
-  const b: JSONSchema4TypeName = 'null'
-  const c: JSONSchema4TypeName = 'any'
-}
+  const a: JSONSchema4TypeName = 'string';
+  const b: JSONSchema4TypeName = 'null';
+  const c: JSONSchema4TypeName = 'any';
+};
 
 // Type
 () => {
-  const a: JSONSchema4Type = 'foo'
-  const b: JSONSchema4Type = null
-  const c: JSONSchema4Type = [1, 2]
-}
+  const a: JSONSchema4Type = 'foo';
+  const b: JSONSchema4Type = null;
+  const c: JSONSchema4Type = [1, 2];
+};
 
 // JSONSchema4
 () => {
-  const a: JSONSchema4 = {}
+  const a: JSONSchema4 = {};
   const b: JSONSchema4 = {
     id: 'foo',
     $ref: 'foo/bar',
@@ -63,5 +65,75 @@ import { JSONSchema4, JSONSchema4Type, JSONSchema4TypeName } from 'json-schema'
     not: {},
     extends: 'foo',
     bar: 4
-  }
-}
+  };
+};
+
+/* JSON Schema 6 */
+
+// SimpleType
+() => {
+  const a: JSONSchema6TypeName = 'string';
+  const b: JSONSchema6TypeName = 'null';
+  const c: JSONSchema6TypeName = 'any';
+};
+
+// Type
+() => {
+  const a: JSONSchema6Type = 'foo';
+  const b: JSONSchema6Type = null;
+  const c: JSONSchema6Type = [1, 2];
+};
+
+// JSONSchema4
+() => {
+  const a: JSONSchema6 = {};
+  const b: JSONSchema6 = {
+    $id: 'foo',
+    $ref: 'foo/bar',
+    $schema: 'http://json-schema.org/schema#',
+    title: 'foo',
+    description: 'bar',
+    default: 42,
+    multipleOf: 3,
+    maximum: 4,
+    exclusiveMaximum: 4,
+    minimum: 5,
+    exclusiveMinimum: 5,
+    maxLength: 6,
+    minLength: 7,
+    pattern: 'baz',
+    additionalItems: true,
+    items: [
+      { items: [{ minLength: 4 }] }
+    ],
+    maxItems: 4,
+    minItems: 5,
+    uniqueItems: true,
+    maxProperties: 10,
+    minProperties: 11,
+    required: ['foo', 'bar'],
+    additionalProperties: false,
+    definitions: {
+      foo: { type: 'string' }
+    },
+    properties: {
+      bar: { type: 'boolean' }
+    },
+    patternProperties: {
+      foo: { type: 'integer' }
+    },
+    dependencies: {
+      baz: { type: 'integer' }
+    },
+    enum: ['foo', 42],
+    type: ['string', 'array'],
+    allOf: [{}],
+    anyOf: [{}],
+    oneOf: [{}],
+    not: {},
+    const: 'foo',
+    contains: {},
+    examples: [{}],
+    propertyNames: {}
+  };
+};

--- a/types/json-schema/tslint.json
+++ b/types/json-schema/tslint.json
@@ -1,8 +1,3 @@
 {
-  "extends": "dtslint/dt.json",
-  "rules": {
-    "semicolon": [
-      false
-    ]
-  }
+  "extends": "dtslint/dt.json"
 }

--- a/types/json-schema/tslint.json
+++ b/types/json-schema/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "dtslint/dt.json"
+  "extends": "dtslint/dt.json",
+  "rules": {
+      "semicolon": false
+  }
 }

--- a/types/json-schema/tslint.json
+++ b/types/json-schema/tslint.json
@@ -1,6 +1,8 @@
 {
   "extends": "dtslint/dt.json",
   "rules": {
-      "semicolon": false
+    "semicolon": [
+      false
+    ]
   }
 }


### PR DESCRIPTION
npm package version should now be 6.x to match the JSON spec number.

JSON Schema v4 has been kept alongside v6, as many tools are still using this version.

I was thinking to export a `JSONSchema` alias matching the last version (`JSONSchema6`), but not sure it's a good idea, would be practical, but would create breaking changes.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://tools.ietf.org/html/draft-wright-json-schema-validation-01](https://tools.ietf.org/html/draft-wright-json-schema-validation-01)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.