### PR TITLE
kolite DirtyFlag does not have methods it is a method

### DIFF
--- a/types/kolite/knockout.dirtyFlag.d.ts
+++ b/types/kolite/knockout.dirtyFlag.d.ts
@@ -10,9 +10,14 @@
 // DirtyFlag /////////////////////////////////////////////
 
 interface DirtyFlag {
-    isDirty: KnockoutComputed<boolean>;
     new (objectToTrack: any, isInitiallyDirty?: boolean, hashFunction?: () => any): any;
+    (): DirtyFlagResult;
+}
+
+interface DirtyFlagResult {
+    isDirty: KnockoutComputed<boolean>;
     reset(): void;
+    forceDirty(): void; 
 }
 
 interface KnockoutStatic {


### PR DESCRIPTION
The result of newing a DirtyFlag is a function that returns a result with methods. This result also has another function forceDirty() that is not included.  

Explanation / cite: https://github.com/CodeSeven/KoLite/blob/master/knockout.dirtyFlag.js that the return is result, not self.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
