### PR TITLE
make express compatible with --strictFunctionTypes - fixes #21371

### DIFF
--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -820,7 +820,7 @@ export interface Application extends IRouter, Express.Application {
      * Express instance itself is a request handler, which could be invoked without
      * third argument.
      */
-    (req: Request, res: Response): any;
+    (req: Request | http.IncomingMessage, res: Response | http.ServerResponse): any;
 
     /**
      * Initialize the server.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This is an attempt to fix https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21371. By using union types here we can use `--strictFunctionTypes` without errors. But I'm not _100%_ sure that is the intended interface, because I'm not _that_ familiar with express itself 🤔