### PR TITLE
string is an acceptable type of ssl attr

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/mysqljs/mysql
 // Definitions by:  William Johnston <https://github.com/wjohnsto>
 // 	                Kacper Polak <https://github.com/kacepe>
+// 	                Krittanan Pingclasai <https://github.com/kpping>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -422,7 +423,7 @@ export interface ConnectionConfig extends ConnectionOptions {
     /**
      * object with ssl parameters or a string containing name of ssl profile
      */
-    ssl?: tls.SecureContextOptions & { rejectUnauthorized?: boolean };
+    ssl?: string | (tls.SecureContextOptions & { rejectUnauthorized?: boolean });
 }
 
 export interface PoolConfig extends ConnectionConfig {

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -41,6 +41,11 @@ connection.query('SELECT 1', (err, rows) => {
 
 connection = mysql.createConnection({
     host: 'localhost',
+    ssl: 'Amazon RDS'
+});
+
+connection = mysql.createConnection({
+    host: 'localhost',
     ssl: {
         ca: ''
     }


### PR DESCRIPTION
As state in <https://github.com/mysqljs/mysql#ssl-options>  ...

`The ssl option in the connection options takes a string or an object. When given a string, it uses one of the predefined SSL profiles included.`

So, ssl should accept `ssl?: string | (tls.SecureContextOptions & { rejectUnauthorized?: boolean });`

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mysqljs/mysql#ssl-options>>