### PR TITLE
Adding "invertAxis" to "VictoryAxisProps" definition

### DIFF
--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -765,6 +765,10 @@ declare module "victory" {
          */
         gridComponent?: React.ReactElement<any>;
         /**
+         * If true, this value will flip the domain of a given axis.
+         */
+        invertAxis?: boolean;
+        /**
          * The label prop defines the label that will appear along the axis. This
          * prop should be given as a value or an entire, HTML-complete label
          * component. If a label component is given, it will be cloned. The new


### PR DESCRIPTION
On https://github.com/FormidableLabs/victory-chart/pull/527 a new prop was added to VictoryAxisProps - invertAxis.

Updating the definition of VictoryAxisProps with the new prop
