### PR TITLE
fix(rc-slider): allow null for step prop

### DIFF
--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -41,7 +41,7 @@ export interface CommonApiProps {
      * Value to be added or subtracted on each step the slider makes. Must be greater than zero, and max - min should be evenly divisible by the step value.
      *  @default 1
      */
-    step?: number;
+    step?: number | null;
     /**
      * If vertical is true, the slider will be vertical.
      * @default false


### PR DESCRIPTION
According to the documentation of [rc-slider](https://github.com/react-component/slider#common-api) `null` is allowed for the step property and has different functionality than passing in `undefined`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-component/slider#common-api
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
