### PR TITLE
[puppeteer] NavigationOptions.waitUntil fix

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -249,6 +249,12 @@ export interface EmulateOptions {
 
 export type EvaluateFn = string | ((...args: any[]) => any);
 
+export type LoadEvent =
+  | "load"
+  | "domcontentloaded"
+  | "networkidle0"
+  | "networkidle2";
+
 /** The navigation options. */
 export interface NavigationOptions {
   /**
@@ -260,7 +266,7 @@ export interface NavigationOptions {
    * When to consider navigation succeeded.
    * @default load Navigation is consider when the `load` event is fired.
    */
-  waitUntil?: "load" | "domcontentloaded" | "networkidle0" | "networkidle2";
+  waitUntil?: LoadEvent | LoadEvent[];
 }
 
 export type PDFFormat =


### PR DESCRIPTION
NavigationOptions.waitUntil could be array according to https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegobackoptions

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
