### PR TITLE
Add `MomentZone.utcOffset` to `moment-timezone` (added in 0.5.14)

### DIFF
--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -18,6 +18,7 @@ declare module "moment" {
 
         abbr(timestamp: number): string;
         offset(timestamp: number): number;
+        utcOffset(timestamp: number): number;
         parse(timestamp: number): number;
     }
 

--- a/types/moment-timezone/moment-timezone-tests.ts
+++ b/types/moment-timezone/moment-timezone-tests.ts
@@ -49,7 +49,7 @@ moment.tz(mo, "America/Los_Angeles");
 moment.tz(obj, "America/Los_Angeles");
 
 moment.tz.zone('America/Los_Angeles').abbr(1403465838805);
-moment.tz.zone('America/Los_Angeles').offset(1403465838805);
+moment.tz.zone('America/Los_Angeles').utcOffset(1403465838805);
 
 const zone = moment.tz.zone('America/New_York');
 zone.parse(Date.UTC(2012, 2, 19, 8, 30)); // 240


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/moment-timezone/blob/develop/changelog.md#0514-2017-10-30
- [x] Increase the version number in the header if appropriate.
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
