### PR TITLE
Backbone.History.route may accept string or RegExp as first argument

### DIFF
--- a/types/backbone/index.d.ts
+++ b/types/backbone/index.d.ts
@@ -392,7 +392,7 @@ declare namespace Backbone {
         decodeFragment(fragment: string): string;
         getSearch(): string;
         stop(): void;
-        route(route: string, callback: Function): number;
+        route(route: string|RegExp, callback: Function): number;
         checkUrl(e?: any): void;
         getPath(): string;
         matchRoot(): boolean;


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/jashkenas/backbone/blob/678aeee94d7802967b52ed8a9177620659b825ee/backbone.js#L1669
The above-linked line converts the route to a regular expression if it is not already one.

https://github.com/jashkenas/backbone/blob/678aeee94d7802967b52ed8a9177620659b825ee/backbone.js#L1676
The above-linked line passes the converted route to Backbone.History.route as the first parameter

https://github.com/jashkenas/backbone/blob/678aeee94d7802967b52ed8a9177620659b825ee/backbone.js#L1932
Backbone.History.route prepends the supplied argument to the handlers array 