### PR TITLE
keypress.js: Added correct return types for register_many and register_combo functions

### DIFF
--- a/types/keypress.js/index.d.ts
+++ b/types/keypress.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Keypress 2.0
+// Type definitions for Keypress 2.1.4
 // Project: https://github.com/dmauro/Keypress/
 // Definitions by: Roger Chen <https://github.com/rcchen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/keypress.js/index.d.ts
+++ b/types/keypress.js/index.d.ts
@@ -39,9 +39,9 @@ export class Listener {
     simple_combo(keys: string, on_keydown_callback: (event?: KeyboardEvent, count?: number) => any): void;
     counting_combo(keys: string, on_count_callback: (event?: KeyboardEvent, count?: number) => any): void;
     sequence_combo(keys: string, callback: (event?: KeyboardEvent, count?: number) => any): void;
-    register_combo(combo: Combo): void;
+    register_combo(combo: Combo): Combo;
     unregister_combo(combo: Combo | string): void;
-    register_many(combos: Combo[]): void;
+    register_many(combos: Combo[]): Combo[];
     unregister_many(combos: Combo[] | string[]): void;
     get_registered_combos(): Combo[];
     destroy(): void;

--- a/types/keypress.js/index.d.ts
+++ b/types/keypress.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Keypress 2.1.4
+// Type definitions for Keypress 2.1
 // Project: https://github.com/dmauro/Keypress/
 // Definitions by: Roger Chen <https://github.com/rcchen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dmauro/Keypress/blob/master/keypress.coffee#L565-L567
as well as
https://github.com/dmauro/Keypress/blob/master/keypress.coffee#L552-L563
- [x] Increase the version number in the header if appropriate.