### PR TITLE
fix(prettier): add missing `getSupportInfo()`

### DIFF
--- a/types/prettier/index.d.ts
+++ b/types/prettier/index.d.ts
@@ -161,6 +161,33 @@ export namespace resolveConfig {
  */
 export function clearConfigCache(): void;
 
+export interface SupportLanguage {
+    name: string;
+    since: string;
+    parsers: string[];
+    group?: string;
+    tmScope: string;
+    aceMode: string;
+    codemirrorMode: string;
+    codemirrorMimeType: string;
+    aliases?: string[];
+    extensions: string[];
+    filenames?: string[];
+    linguistLanguageId: number;
+    vscodeLanguageIds: string[];
+}
+
+export interface SupportInfo {
+    languages: SupportLanguage[];
+}
+
+/**
+ * Returns an object representing the parsers, languages and file types Prettier supports.
+ * If `version` is provided (e.g. `"1.5.0"`), information for that version will be returned,
+ * otherwise information for the current version will be returned.
+ */
+export function getSupportInfo(version?: string): SupportInfo;
+
 /**
  * `version` field in `package.json`
  */

--- a/types/prettier/prettier-tests.ts
+++ b/types/prettier/prettier-tests.ts
@@ -33,3 +33,6 @@ if (options !== null) {
 }
 
 prettier.clearConfigCache();
+
+const currentSupportInfo = prettier.getSupportInfo();
+const specificSupportInfo = prettier.getSupportInfo("1.8.0");


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://prettier.io/docs/en/api.html#prettiergetsupportinfo-version>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.