### PR TITLE
[sharepoint] - Changes to enable extending the JSOM

### DIFF
--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -24,16 +24,16 @@ declare const enum Sods {
     loaded = 4,
     error = 5
 }
-declare interface Sod {
-    url: string,
-    key: string,
-    loaded: boolean,
-    depkeys?: string[],
-    state: Sods,
-    qfn?: any[],
-    reset?: boolean
+interface Sod {
+    url: string;
+    key: string;
+    loaded: boolean;
+    depkeys?: string[];
+    state: Sods;
+    qfn?: any[];
+    reset?: boolean;
 }
-declare var _v_dictSod : { [address: string]: Sod };
+declare var _v_dictSod: { [address: string]: Sod };
 declare namespace SP {
     interface SOD {
         execute(fileName: string, functionName: string, ...args: any[]): void;
@@ -53,7 +53,7 @@ declare namespace SP {
         get_ribbonImagePrefetchEnabled(): boolean;
         set_ribbonImagePrefetchEnabled(value: boolean): void;
     }
-    var SOD: SOD;
+    let SOD: SOD;
 
     enum ListLevelPermissionMask {
         viewListItems, // : 1,
@@ -132,7 +132,7 @@ declare namespace SP {
     interface PageContextInfoInstance {
         get_pagePersonalizationScope(): string;
     }
-    var PageContextInfo: PageContextInfo;
+    let PageContextInfo: PageContextInfo;
 
     class ContextPermissions {
         has(perm: number): boolean;
@@ -178,7 +178,7 @@ declare class JSRequest {
     static PathName: string;
 }
 
-declare interface _spPageContextInfo {
+interface _spPageContextInfo {
     alertsEnabled: boolean; // true
     allowSilverlightPrompt: string; // "True"
     blockDownloadsExperienceEnabled: boolean; // true
@@ -264,13 +264,13 @@ declare interface _spPageContextInfo {
 }
 declare var _spPageContextInfo: _spPageContextInfo;
 
-declare interface _spFriendlyUrlPageContextInfo {
+interface _spFriendlyUrlPageContextInfo {
     termId: string;
     termSetId: string;
     termStoreId: string;
     title: string;
 }
-declare var _spFriendlyUrlPageContextInfo: _spFriendlyUrlPageContextInfo
+declare var _spFriendlyUrlPageContextInfo: _spFriendlyUrlPageContextInfo;
 
 declare function STSHtmlEncode(value: string): string;
 declare function STSHtmlDecode(value: string): string;
@@ -2155,7 +2155,7 @@ declare namespace SP {
     interface ClientObjectCollectionConstructor {
         new<T>(): ClientObjectCollection<T>;
     }
-    var ClientObjectCollection: ClientObjectCollectionConstructor;
+    let ClientObjectCollection: ClientObjectCollectionConstructor;
 
     interface ClientObjectList<T> extends SP.ClientObjectCollection<T> {
         new(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any);
@@ -2165,7 +2165,7 @@ declare namespace SP {
     interface ClientObjectListConstructor {
         new<T>(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any): ClientObjectList<T>;
     }
-    var ClientObjectList: ClientObjectListConstructor;
+    let ClientObjectList: ClientObjectListConstructor;
     class ClientObjectPrototype {
         retrieve(propertyNames?: string[]): void;
         retrieveObject(propertyName: string): SP.ClientObjectPrototype;
@@ -2456,7 +2456,7 @@ declare namespace SP {
         new(serverRelativeUrlOrFullUrl?: string): ClientContext;
         get_current(): SP.ClientContext;
     }
-    var ClientContext: ClientContextConstructor;
+    let ClientContext: ClientContextConstructor;
     enum ULSTraceLevel {
         verbose,
     }
@@ -4413,7 +4413,7 @@ declare namespace SP {
         remove(roleDefinition: SP.RoleDefinition): void;
         removeAll(): void;
     }
-    var RoleDefinitionBindingCollection : RoleDefinitionBindingCollectionConstructor;
+    let RoleDefinitionBindingCollection: RoleDefinitionBindingCollectionConstructor;
     interface RoleDefinitionCollection extends SP.ClientObjectCollection<RoleDefinition> {
         itemAt(index: number): SP.RoleDefinition;
         get_item(index: number): SP.RoleDefinition;
@@ -5318,7 +5318,7 @@ declare namespace Microsoft.SharePoint.Client.Search {
         interface StringCollectionConstructor {
             new(context: SP.ClientContext): StringCollection;
         }
-        var StringCollection: StringCollectionConstructor;
+        let StringCollection: StringCollectionConstructor;
 
         class QueryPersonalizationData extends SP.ClientObject {
             // It's really empty;
@@ -6936,7 +6936,7 @@ declare namespace SP {
         interface TaxonomyFieldValueCollectionConstructor {
             new(context: SP.ClientContext, fieldValue: string, creatingField: SP.Field): TaxonomyFieldValueCollection;
         }
-        var TaxonomyFieldValueCollection: TaxonomyFieldValueCollectionConstructor;
+        let TaxonomyFieldValueCollection: TaxonomyFieldValueCollectionConstructor;
 
         class TaxonomyFieldValue extends SP.ClientValueObject {
             get_label(): string;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Microsoft SharePoint: 2016.0
+// Type definitions for Microsoft SharePoint: 2016.1
 // Project: https://msdn.microsoft.com/en-us/library/office/jj193034.aspx
 // Definitions by: Stanislav Vyshchepan <https://github.com/gandjustas>
 //                 Andrey Markeev <https://github.com/andrei-markeev>

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -17,7 +17,23 @@ declare function ExecuteOrDelayUntilBodyLoaded(initFunc: () => void): void;
 declare function ExecuteOrDelayUntilScriptLoaded(func: () => void, depScriptFileName: string): boolean;
 declare function ExecuteOrDelayUntilEventNotified(func: (...args: any[]) => void, eventName: string): boolean;
 declare var Strings: any;
-
+declare const enum Sods {
+    missing =  1,
+    loading = 2,
+    pending = 3,
+    loaded = 4,
+    error = 5
+}
+declare interface Sod {
+    url: string,
+    key: string,
+    loaded: boolean,
+    depkeys?: string[],
+    state: Sods,
+    qfn?: any[],
+    reset?: boolean
+}
+declare var _v_dictSod : { [address: string]: Sod };
 declare namespace SP {
     interface SOD {
         execute(fileName: string, functionName: string, ...args: any[]): void;
@@ -2193,8 +2209,8 @@ declare namespace SP {
     }
     class ClientRequestSucceededEventArgs extends SP.ClientRequestEventArgs {
     }
-    class ClientRuntimeContext implements Sys.IDisposable {
-        constructor(serverRelativeUrlOrFullUrl: string);
+    interface ClientRuntimeContext extends Sys.IDisposable {
+        new(serverRelativeUrlOrFullUrl: string);
         get_url(): string;
         get_viaUrl(): string;
         set_viaUrl(value: string): void;

--- a/types/sharepoint/index.d.ts
+++ b/types/sharepoint/index.d.ts
@@ -4,6 +4,7 @@
 //                 Andrey Markeev <https://github.com/andrei-markeev>
 //                 Vincent Biret <https://github.com/baywet>
 //                 Tero Arvola <https://github.com/teroarvola>
+//                 Dennis George <https://github.com/dennispg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -18,24 +19,25 @@ declare function ExecuteOrDelayUntilEventNotified(func: (...args: any[]) => void
 declare var Strings: any;
 
 declare namespace SP {
-    class SOD {
-        static execute(fileName: string, functionName: string, ...args: any[]): void;
-        static executeFunc(fileName: string, typeName: string, fn: () => void): void;
-        static executeOrDelayUntilEventNotified(func: (...args: any[]) => void, eventName: string): boolean;
-        static executeOrDelayUntilScriptLoaded(func: () => void, depScriptFileName: string): boolean;
-        static notifyScriptLoadedAndExecuteWaitingJobs(scriptFileName: string): void;
-        static notifyEventAndExecuteWaitingJobs(eventName: string, args?: any[]): void;
-        static registerSod(fileName: string, url: string): void;
-        static registerSodDep(fileName: string, dependentFileName: string): void;
-        static loadMultiple(keys: string[], fn: () => void, bSync?: boolean): void;
-        static delayUntilEventNotified(func: (...args: any[]) => void, eventName: string): void;
+    interface SOD {
+        execute(fileName: string, functionName: string, ...args: any[]): void;
+        executeFunc(fileName: string, typeName: string, fn: () => void): void;
+        executeOrDelayUntilEventNotified(func: (...args: any[]) => void, eventName: string): boolean;
+        executeOrDelayUntilScriptLoaded(func: () => void, depScriptFileName: string): boolean;
+        notifyScriptLoadedAndExecuteWaitingJobs(scriptFileName: string): void;
+        notifyEventAndExecuteWaitingJobs(eventName: string, args?: any[]): void;
+        registerSod(fileName: string, url: string): void;
+        registerSodDep(fileName: string, dependentFileName: string): void;
+        loadMultiple(keys: string[], fn: () => void, bSync?: boolean): void;
+        delayUntilEventNotified(func: (...args: any[]) => void, eventName: string): void;
 
-        static get_prefetch(): boolean;
-        static set_prefetch(value: boolean): void;
+        get_prefetch(): boolean;
+        set_prefetch(value: boolean): void;
 
-        static get_ribbonImagePrefetchEnabled(): boolean;
-        static set_ribbonImagePrefetchEnabled(value: boolean): void;
+        get_ribbonImagePrefetchEnabled(): boolean;
+        set_ribbonImagePrefetchEnabled(value: boolean): void;
     }
+    var SOD: SOD;
 
     enum ListLevelPermissionMask {
         viewListItems, // : 1,
@@ -88,27 +90,33 @@ declare namespace SP {
         static resizeImageToSquareLength(imgElement: HTMLImageElement, squareLength: number): void;
     }
 
-    class PageContextInfo {
-        static get_siteServerRelativeUrl(): string;
-        static get_webServerRelativeUrl(): string;
-        static get_webAbsoluteUrl(): string;
-        static get_serverRequestPath(): string;
-        static get_siteAbsoluteUrl(): string;
-        static get_webTitle(): string;
-        static get_tenantAppVersion(): string;
-        static get_webLogoUrl(): string;
-        static get_webLanguage(): number;
-        static get_currentLanguage(): number;
-        static get_pageItemId(): number;
-        static get_pageListId(): string;
-        static get_webPermMasks(): { High: number; Low: number; };
-        static get_currentCultureName(): string;
-        static get_currentUICultureName(): string;
-        static get_clientServerTimeDelta(): number;
-        static get_userLoginName(): string;
-        static get_webTemplate(): string;
+    interface PageContextInfo {
+        new(): PageContextInfoInstance;
+        get_siteServerRelativeUrl(): string;
+        get_webServerRelativeUrl(): string;
+        get_webAbsoluteUrl(): string;
+        get_serverRequestPath(): string;
+        get_siteAbsoluteUrl(): string;
+        get_webTitle(): string;
+        get_tenantAppVersion(): string;
+        get_isAppWeb(): boolean;
+        get_webLogoUrl(): string;
+        get_webLanguage(): number;
+        get_currentLanguage(): number;
+        get_pageItemId(): number;
+        get_pageListId(): string;
+        get_webPermMasks(): { High: number; Low: number; };
+        get_currentCultureName(): string;
+        get_currentUICultureName(): string;
+        get_clientServerTimeDelta(): number;
+        get_userLoginName(): string;
+        get_webTemplate(): string;
+    }
+
+    interface PageContextInfoInstance {
         get_pagePersonalizationScope(): string;
     }
+    var PageContextInfo: PageContextInfo;
 
     class ContextPermissions {
         has(perm: number): boolean;
@@ -154,97 +162,99 @@ declare class JSRequest {
     static PathName: string;
 }
 
-declare class _spPageContextInfo {
-    static alertsEnabled: boolean; // true
-    static allowSilverlightPrompt: string; // "True"
-    static blockDownloadsExperienceEnabled: boolean; // true
-    static canUserCreateMicrosoftForm: boolean; // true
-    static cdnPrefix: string; // "static.sharepointonline.com/bld"
-    static clientServerTimeDelta: number; // -182
-    static CorrelationId: string; // "6161f99d-10e5-4000-ad30-1016270fe31d"
-    static crossDomainPhotosEnabled: boolean; // true
-    static currentCultureName: string; // "ru-RU"
-    static currentLanguage: number; // 1049
-    static currentUICultureName: string; // "ru-RU"
-    static disableAppViews: boolean; // true
-    static disableFlows: boolean; // true
-    static env: string; // "prod"
-    static farmLabel: string; // "US_4_Content"
-    static formDigestValue: string; // "0x5F3FE84E7EE9089C7D11DCDAFFB9E69CF8241E68B9EF071FA92CD419E878AC4F7C16E34696EFA667EFD0712FC1DF4945DDC0D09B5D23153A698A727AF076B5DE,07 Jun 2017 18:55:22 -0000"
-    static formDigestTimeoutSeconds: number; // 1800
-    static groupColor: string; // "#d40ac7"
-    static groupHasHomepage: boolean; // true
-    static groupId: string; //
-    static guestsEnabled: boolean; // true
-    static hasManageWebPermissions: boolean; // true
-    static isAnonymousGuestUser: boolean; // true
-    static isAppWeb: boolean; // true
-    static isExternalGuestUser: boolean; // true
-    static isNoScriptEnabled: boolean; // true
-    static isSiteAdmin: boolean; // true
-    static isSPO: boolean; // true
-    static isTenantDevSite: boolean; // true
-    static isWebWelcomePage: boolean; // true
-    static layoutsUrl: string;  // "_layouts/15"
-    static listBaseTemplate: number; // 119
-    static listId: string; // "{06ee6d96-f27f-4160-b6bb-c18f187b18a7}"
-    static listPermsMask: { High: number; Low: number; };
-    static listTitle: string; // "Site Pages"
-    static listUrl: string; // "/sites/site/list"
-    static maximumFileSize: number; // 15360
-    static openInClient: boolean; // true
-    static pageListId: string;  // "{06ee6d96-f27f-4160-b6bb-c18f187b18a7}"
-    static pageItemId: number;
-    static pagePermsMask: { High: number; Low: number; };
-    static pagePersonalizationScope: string; // 1
-    static PreviewFeaturesEnabled: boolean; // true
-    static preferUserTimeZone: boolean; // false
-    static ProfileUrl: string; // "https://tenant-my.sharepoint.com/person.aspx"
-    static PublishingFeatureOn: boolean; // true
-    static RecycleBinItemCount: number; // -1
-    static serverRedirectedUrl: string;
-    static serverRequestPath: string; // "/SPTypeScript/Lists/ConditionalFormattingTasksList/AllItems.aspx"
-    static serverTime: string; // "2017-06-07T18:55:22.3499459Z"
-    static siteAbsoluteUrl: string; // "https:// gandjustas-7b20d3715e8ed4.sharepoint.com"
-    static siteClassification: string; //
-    static siteClientTag: string; // "0$$15.0.4454.1021"
-    static siteColor: string; // "#d40ac7"
-    static siteId: string; // "{3e09a056-f68f-44a3-8e0f-ff2c123b82cb}"
-    static sitePagesEnabled: boolean; // true
-    static siteServerRelativeUrl: string; // "/"
-    static siteSubscriptionId: string; // 4eedf5f3-f71f-4e73-82ee-e19081363c8c
-    static supportPoundStorePath: boolean; // true
-    static supportPercentStorePath: boolean; // true
-    static systemUserKey: string; // "i:0h.f|membership|10033fff84e7cb2b@live.com"
-    static tenantAppVersion: string; // "0"
-    static themeCacheToken: string; // "/sites/site::0:16.0.6525.1206"
-    static themedCssFolderUrl: string;
-    static themedImageFileNames: string;
-    static updateFormDigestPageLoaded: string; // "2017-06-07T18:55:25.821Z"
-    static userDisplayName: string; // "John Doe"
-    static userEmail: string; // "john.doe@fabrikam.onmicrosoft.com"
-    static userId: number; // 12
-    static userLoginName: string; // "john.doe@fabrikam.onmicrosoft.com"
-    static viewOnlyExperienceEnabled: boolean; // true
-    static viewId: string; // "{06ee6d96-f27f-4160-b6bb-c18f187b18a7}"
-    static webAbsoluteUrl: string; // "https:// gandjustas-7b20d3715e8ed4.sharepoint.com/SPTypeScript"
-    static webDescription: string; // "Some description"
-    static webId: string; // "{06ee6d96-f27f-4160-b6bb-c18f187b18a7}"
-    static webLanguage: number; // 1049
-    static webLogoUrl: string; // "/_layouts/15/images/siteIcon.png?rev=23"
-    static webPermMasks: { High: number; Low: number; };
-    static webServerRelativeUrl: string; // "/SPTypeScript"
-    static webTemplate: string; // "17"
-    static webTitle: string; // "SPTypeScript"
-    static webUIVersion: number; // 15
+declare interface _spPageContextInfo {
+    alertsEnabled: boolean; // true
+    allowSilverlightPrompt: string; // "True"
+    blockDownloadsExperienceEnabled: boolean; // true
+    canUserCreateMicrosoftForm: boolean; // true
+    cdnPrefix: string; // "static.sharepointonline.com/bld"
+    clientServerTimeDelta: number; // -182
+    CorrelationId: string; // "6161f99d-10e5-4000-ad30-1016270fe31d"
+    crossDomainPhotosEnabled: boolean; // true
+    currentCultureName: string; // "ru-RU"
+    currentLanguage: number; // 1049
+    currentUICultureName: string; // "ru-RU"
+    disableAppViews: boolean; // true
+    disableFlows: boolean; // true
+    env: string; // "prod"
+    farmLabel: string; // "US_4_Content"
+    formDigestValue: string; // "0x5F3FE84E7EE9089C7D11DCDAFFB9E69CF8241E68B9EF071FA92CD419E878AC4F7C16E34696EFA667EFD0712FC1DF4945DDC0D09B5D23153A698A727AF076B5DE,07 Jun 2017 18:55:22 -0000"
+    formDigestTimeoutSeconds: number; // 1800
+    groupColor: string; // "#d40ac7"
+    groupHasHomepage: boolean; // true
+    groupId: string; //
+    guestsEnabled: boolean; // true
+    hasManageWebPermissions: boolean; // true
+    isAnonymousGuestUser: boolean; // true
+    isAppWeb: boolean; // true
+    isExternalGuestUser: boolean; // true
+    isNoScriptEnabled: boolean; // true
+    isSiteAdmin: boolean; // true
+    isSPO: boolean; // true
+    isTenantDevSite: boolean; // true
+    isWebWelcomePage: boolean; // true
+    layoutsUrl: string;  // "_layouts/15"
+    listBaseTemplate: number; // 119
+    listId: string; // "{06ee6d96-f27f-4160-b6bb-c18f187b18a7}"
+    listPermsMask: { High: number; Low: number; };
+    listTitle: string; // "Site Pages"
+    listUrl: string; // "/sites/site/list"
+    maximumFileSize: number; // 15360
+    openInClient: boolean; // true
+    pageListId: string;  // "{06ee6d96-f27f-4160-b6bb-c18f187b18a7}"
+    pageItemId: number;
+    pagePermsMask: { High: number; Low: number; };
+    pagePersonalizationScope: string; // 1
+    PreviewFeaturesEnabled: boolean; // true
+    preferUserTimeZone: boolean; // false
+    ProfileUrl: string; // "https://tenant-my.sharepoint.com/person.aspx"
+    PublishingFeatureOn: boolean; // true
+    RecycleBinItemCount: number; // -1
+    serverRedirectedUrl: string;
+    serverRequestPath: string; // "/SPTypeScript/Lists/ConditionalFormattingTasksList/AllItems.aspx"
+    serverTime: string; // "2017-06-07T18:55:22.3499459Z"
+    siteAbsoluteUrl: string; // "https:// gandjustas-7b20d3715e8ed4.sharepoint.com"
+    siteClassification: string; //
+    siteClientTag: string; // "0$$15.0.4454.1021"
+    siteColor: string; // "#d40ac7"
+    siteId: string; // "{3e09a056-f68f-44a3-8e0f-ff2c123b82cb}"
+    sitePagesEnabled: boolean; // true
+    siteServerRelativeUrl: string; // "/"
+    siteSubscriptionId: string; // 4eedf5f3-f71f-4e73-82ee-e19081363c8c
+    supportPoundStorePath: boolean; // true
+    supportPercentStorePath: boolean; // true
+    systemUserKey: string; // "i:0h.f|membership|10033fff84e7cb2b@live.com"
+    tenantAppVersion: string; // "0"
+    themeCacheToken: string; // "/sites/site::0:16.0.6525.1206"
+    themedCssFolderUrl: string;
+    themedImageFileNames: string;
+    updateFormDigestPageLoaded: string; // "2017-06-07T18:55:25.821Z"
+    userDisplayName: string; // "John Doe"
+    userEmail: string; // "john.doe@fabrikam.onmicrosoft.com"
+    userId: number; // 12
+    userLoginName: string; // "john.doe@fabrikam.onmicrosoft.com"
+    viewOnlyExperienceEnabled: boolean; // true
+    viewId: string; // "{06ee6d96-f27f-4160-b6bb-c18f187b18a7}"
+    webAbsoluteUrl: string; // "https:// gandjustas-7b20d3715e8ed4.sharepoint.com/SPTypeScript"
+    webDescription: string; // "Some description"
+    webId: string; // "{06ee6d96-f27f-4160-b6bb-c18f187b18a7}"
+    webLanguage: number; // 1049
+    webLogoUrl: string; // "/_layouts/15/images/siteIcon.png?rev=23"
+    webPermMasks: { High: number; Low: number; };
+    webServerRelativeUrl: string; // "/SPTypeScript"
+    webTemplate: string; // "17"
+    webTitle: string; // "SPTypeScript"
+    webUIVersion: number; // 15
 }
+declare var _spPageContextInfo: _spPageContextInfo;
 
-declare class _spFriendlyUrlPageContextInfo {
-    static termId: string;
-    static termSetId: string;
-    static termStoreId: string;
-    static title: string;
+declare interface _spFriendlyUrlPageContextInfo {
+    termId: string;
+    termSetId: string;
+    termStoreId: string;
+    title: string;
 }
+declare var _spFriendlyUrlPageContextInfo: _spFriendlyUrlPageContextInfo
 
 declare function STSHtmlEncode(value: string): string;
 declare function STSHtmlDecode(value: string): string;
@@ -2113,7 +2123,7 @@ declare namespace SP {
         constructor();
     }
     /** Provides a base class for a collection of objects on a remote client. */
-    class ClientObjectCollection<T> extends SP.ClientObject implements IEnumerable<T> {
+    interface ClientObjectCollection<T> extends SP.ClientObject, IEnumerable<T> {
         get_areItemsAvailable(): boolean;
         /** Gets the data for all of the items in the collection. */
         retrieveItems(): SP.ClientObjectPrototype;
@@ -2126,12 +2136,20 @@ declare namespace SP {
         getItemAtIndex(index: number): T;
         fromJson(obj: any): void;
     }
+    interface ClientObjectCollectionConstructor {
+        new<T>(): ClientObjectCollection<T>;
+    }
+    var ClientObjectCollection: ClientObjectCollectionConstructor;
 
-    class ClientObjectList<T> extends SP.ClientObjectCollection<T> {
-        constructor(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any);
+    interface ClientObjectList<T> extends SP.ClientObjectCollection<T> {
+        new(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any);
         fromJson(initValue: any): void;
         customFromJson(initValue: any): boolean;
     }
+    interface ClientObjectListConstructor {
+        new<T>(context: SP.ClientRuntimeContext, objectPath: SP.ObjectPath, childItemType: any): ClientObjectList<T>;
+    }
+    var ClientObjectList: ClientObjectListConstructor;
     class ClientObjectPrototype {
         retrieve(propertyNames?: string[]): void;
         retrieveObject(propertyName: string): SP.ClientObjectPrototype;
@@ -2413,13 +2431,16 @@ declare namespace SP {
         assemblyVersion: string;
         wssMajorVersion: string;
     }
-    class ClientContext extends SP.ClientRuntimeContext {
-        constructor(serverRelativeUrlOrFullUrl?: string);
-        static get_current(): SP.ClientContext;
+    interface ClientContext extends SP.ClientRuntimeContext {
         get_web(): SP.Web;
         get_site(): SP.Site;
         get_serverVersion(): string;
     }
+    interface ClientContextConstructor {
+        new(serverRelativeUrlOrFullUrl?: string): ClientContext;
+        get_current(): SP.ClientContext;
+    }
+    var ClientContext: ClientContextConstructor;
     enum ULSTraceLevel {
         verbose,
     }
@@ -2557,7 +2578,7 @@ declare namespace SP {
         get_serverRelativeUrl(): string;
         deleteObject(): void;
     }
-    class AttachmentCollection extends SP.ClientObjectCollection<Attachment> {
+    interface AttachmentCollection extends SP.ClientObjectCollection<Attachment> {
         itemAt(index: number): SP.Attachment;
         get_item(index: number): SP.Attachment;
         getByFileName(fileName: string): SP.Attachment;
@@ -2654,7 +2675,7 @@ declare namespace SP {
         get_alertId(): SP.Guid;
         get_webId(): SP.Guid;
     }
-    class ChangeCollection extends SP.ClientObjectCollection<Change> {
+    interface ChangeCollection extends SP.ClientObjectCollection<Change> {
         itemAt(index: number): SP.Change;
         get_item(index: number): SP.Change;
     }
@@ -2874,7 +2895,7 @@ declare namespace SP {
         update(updateChildren: boolean): void;
         deleteObject(): void;
     }
-    class ContentTypeCollection extends SP.ClientObjectCollection<ContentType> {
+    interface ContentTypeCollection extends SP.ClientObjectCollection<ContentType> {
         itemAt(index: number): SP.ContentType;
         get_item(index: number): SP.ContentType;
         getById(contentTypeId: string): SP.ContentType;
@@ -2932,7 +2953,7 @@ declare namespace SP {
         update(): void;
         deleteObject(): void;
     }
-    class EventReceiverDefinitionCollection extends SP.ClientObjectCollection<EventReceiverDefinition> {
+    interface EventReceiverDefinitionCollection extends SP.ClientObjectCollection<EventReceiverDefinition> {
         itemAt(index: number): SP.EventReceiverDefinition;
         get_item(index: number): SP.EventReceiverDefinition;
         getById(eventReceiverId: SP.Guid): SP.EventReceiverDefinition;
@@ -3043,7 +3064,7 @@ declare namespace SP {
     class Feature extends SP.ClientObject {
         get_definitionId(): SP.Guid;
     }
-    class FeatureCollection extends SP.ClientObjectCollection<Feature> {
+    interface FeatureCollection extends SP.ClientObjectCollection<Feature> {
         itemAt(index: number): SP.Feature;
         get_item(index: number): SP.Feature;
         getById(featureId: SP.Guid): SP.Feature;
@@ -3136,7 +3157,7 @@ declare namespace SP {
         get_editFormat(): SP.ChoiceFormatType;
         set_editFormat(value: SP.ChoiceFormatType): void;
     }
-    class FieldCollection extends SP.ClientObjectCollection<Field> {
+    interface FieldCollection extends SP.ClientObjectCollection<Field> {
         itemAt(index: number): SP.Field;
         get_item(index: number): SP.Field;
         get_schemaXml(): string;
@@ -3195,7 +3216,7 @@ declare namespace SP {
         set_required(value: boolean): void;
         deleteObject(): void;
     }
-    class FieldLinkCollection extends SP.ClientObjectCollection<FieldLink> {
+    interface FieldLinkCollection extends SP.ClientObjectCollection<FieldLink> {
         itemAt(index: number): SP.FieldLink;
         get_item(index: number): SP.FieldLink;
         getById(id: SP.Guid): SP.FieldLink;
@@ -3408,7 +3429,7 @@ declare namespace SP {
         recycle(): SP.GuidResult;
         checkOut(): void;
     }
-    class FileCollection extends SP.ClientObjectCollection<File> {
+    interface FileCollection extends SP.ClientObjectCollection<File> {
         itemAt(index: number): SP.File;
         get_item(index: number): SP.File;
         getByUrl(url: string): SP.File;
@@ -3461,7 +3482,7 @@ declare namespace SP {
         get_versionLabel(): string;
         deleteObject(): void;
     }
-    class FileVersionCollection extends SP.ClientObjectCollection<FileVersion> {
+    interface FileVersionCollection extends SP.ClientObjectCollection<FileVersion> {
         itemAt(index: number): SP.FileVersion;
         get_item(index: number): SP.FileVersion;
         getById(versionid: number): SP.FileVersion;
@@ -3488,7 +3509,7 @@ declare namespace SP {
         deleteObject(): void;
         recycle(): SP.GuidResult;
     }
-    class FolderCollection extends SP.ClientObjectCollection<Folder> {
+    interface FolderCollection extends SP.ClientObjectCollection<Folder> {
         itemAt(index: number): SP.Folder;
         get_item(index: number): SP.Folder;
         getByUrl(url: string): SP.Folder;
@@ -3499,7 +3520,7 @@ declare namespace SP {
         get_serverRelativeUrl(): string;
         get_formType(): SP.PageType;
     }
-    class FormCollection extends SP.ClientObjectCollection<Form> {
+    interface FormCollection extends SP.ClientObjectCollection<Form> {
         itemAt(index: number): SP.Form;
         get_item(index: number): SP.Form;
         getByPageType(formType: SP.PageType): SP.Form;
@@ -3535,7 +3556,7 @@ declare namespace SP {
         get_users(): SP.UserCollection;
         update(): void;
     }
-    class GroupCollection extends SP.ClientObjectCollection<Group> {
+    interface GroupCollection extends SP.ClientObjectCollection<Group> {
         itemAt(index: number): SP.Group;
         get_item(index: number): SP.Group;
         getByName(name: string): SP.Group;
@@ -3826,7 +3847,7 @@ declare namespace SP {
         addItem(parameters: SP.ListItemCreationInformation): SP.ListItem<T>;
     }
     /** Represents a collection of SP.List objects */
-    class ListCollection extends SP.ClientObjectCollection<List> {
+    interface ListCollection extends SP.ClientObjectCollection<List> {
         /** Gets the list at the specified index in the collection. */
         itemAt<T = any>(index: number): SP.List<T>;
         /** Gets the list at the specified index in the collection. */
@@ -3949,7 +3970,7 @@ declare namespace SP {
         /** Validates form values specified for the list item. Errors are returned through hasException and errorMessage properties of the ListItemFormUpdateValue objects */
         validateUpdateListItem(formValues: SP.ListItemFormUpdateValue[], bNewDocumentUpdate: boolean): SP.ListItemFormUpdateValue[];
     }
-    class ListItemCollection<T = any> extends SP.ClientObjectCollection<ListItem<T>> {
+    interface ListItemCollection<T = any> extends SP.ClientObjectCollection<ListItem<T>> {
         itemAt(index: number): SP.ListItem<T>;
         get_item(index: number): SP.ListItem<T>;
         getById(id: number | string): SP.ListItem<T>;
@@ -3977,7 +3998,7 @@ declare namespace SP {
         writeToXml(writer: SP.XmlWriter, serializationContext: SP.SerializationContext): void;
         constructor();
     }
-    class ListItemEntityCollection<T> extends SP.ClientObjectCollection<ListItem<T>> {
+    interface ListItemEntityCollection<T> extends SP.ClientObjectCollection<ListItem<T>> {
         itemAt(index: number): SP.ListItem<T>;
         get_item(index: number): SP.ListItem<T>;
     }
@@ -4008,7 +4029,7 @@ declare namespace SP {
         get_listTemplateTypeKind(): number;
         get_unique(): boolean;
     }
-    class ListTemplateCollection extends SP.ClientObjectCollection<ListTemplate> {
+    interface ListTemplateCollection extends SP.ClientObjectCollection<ListTemplate> {
         itemAt(index: number): SP.ListTemplate;
         get_item(index: number): SP.ListTemplate;
         getByName(name: string): SP.ListTemplate;
@@ -4102,7 +4123,7 @@ declare namespace SP {
         update(): void;
         deleteObject(): void;
     }
-    class NavigationNodeCollection extends SP.ClientObjectCollection<NavigationNode> {
+    interface NavigationNodeCollection extends SP.ClientObjectCollection<NavigationNode> {
         itemAt(index: number): SP.NavigationNode;
         get_item(index: number): SP.NavigationNode;
         add(parameters: SP.NavigationNodeCreationInformation): SP.NavigationNode;
@@ -4192,7 +4213,7 @@ declare namespace SP {
         get_user(): SP.User;
         update(): void;
     }
-    class PushNotificationSubscriberCollection extends SP.ClientObjectCollection<PushNotificationSubscriber> {
+    interface PushNotificationSubscriberCollection extends SP.ClientObjectCollection<PushNotificationSubscriber> {
         itemAt(index: number): SP.PushNotificationSubscriber;
         get_item(index: number): SP.PushNotificationSubscriber;
         getByStoreId(id: string): SP.PushNotificationSubscriber;
@@ -4216,7 +4237,7 @@ declare namespace SP {
         deleteObject(): void;
         restore(): void;
     }
-    class RecycleBinItemCollection extends SP.ClientObjectCollection<RecycleBinItem> {
+    interface RecycleBinItemCollection extends SP.ClientObjectCollection<RecycleBinItem> {
         itemAt(index: number): SP.RecycleBinItem;
         get_item(index: number): SP.RecycleBinItem;
         getById(id: SP.Guid): SP.RecycleBinItem;
@@ -4281,7 +4302,7 @@ declare namespace SP {
         get_relationshipDeleteBehavior(): SP.RelationshipDeleteBehaviorType;
         get_webId(): SP.Guid;
     }
-    class RelatedFieldCollection extends SP.ClientObjectCollection<RelatedField> {
+    interface RelatedFieldCollection extends SP.ClientObjectCollection<RelatedField> {
         itemAt(index: number): SP.RelatedField;
         get_item(index: number): SP.RelatedField;
     }
@@ -4293,7 +4314,7 @@ declare namespace SP {
         get_toolTipDescription(): string;
         get_webId(): SP.Guid;
     }
-    class RelatedFieldExtendedDataCollection extends SP.ClientObjectCollection<RelatedFieldExtendedData> {
+    interface RelatedFieldExtendedDataCollection extends SP.ClientObjectCollection<RelatedFieldExtendedData> {
         itemAt(index: number): SP.RelatedFieldExtendedData;
         get_item(index: number): SP.RelatedFieldExtendedData;
     }
@@ -4342,7 +4363,7 @@ declare namespace SP {
         update(): void;
         deleteObject(): void;
     }
-    class RoleAssignmentCollection extends SP.ClientObjectCollection<RoleAssignment> {
+    interface RoleAssignmentCollection extends SP.ClientObjectCollection<RoleAssignment> {
         itemAt(index: number): SP.RoleAssignment;
         get_item(index: number): SP.RoleAssignment;
         get_groups(): SP.GroupCollection;
@@ -4365,16 +4386,19 @@ declare namespace SP {
         update(): void;
         deleteObject(): void;
     }
-    class RoleDefinitionBindingCollection extends SP.ClientObjectCollection<RoleDefinition> {
+    interface RoleDefinitionBindingCollectionConstructor {
+        new(context: SP.ClientRuntimeContext): SP.RoleDefinitionBindingCollection;
+        newObject(context: SP.ClientRuntimeContext): SP.RoleDefinitionBindingCollection;
+    }
+    interface RoleDefinitionBindingCollection extends SP.ClientObjectCollection<RoleDefinition> {
         itemAt(index: number): SP.RoleDefinition;
         get_item(index: number): SP.RoleDefinition;
-        constructor(context: SP.ClientRuntimeContext);
-        static newObject(context: SP.ClientRuntimeContext): SP.RoleDefinitionBindingCollection;
         add(roleDefinition: SP.RoleDefinition): void;
         remove(roleDefinition: SP.RoleDefinition): void;
         removeAll(): void;
     }
-    class RoleDefinitionCollection extends SP.ClientObjectCollection<RoleDefinition> {
+    var RoleDefinitionBindingCollection : RoleDefinitionBindingCollectionConstructor;
+    interface RoleDefinitionCollection extends SP.ClientObjectCollection<RoleDefinition> {
         itemAt(index: number): SP.RoleDefinition;
         get_item(index: number): SP.RoleDefinition;
         getByName(name: string): SP.RoleDefinition;
@@ -4487,7 +4511,7 @@ declare namespace SP {
         localTimeToUTC(date: Date): SP.DateTimeResult;
         utcToLocalTime(date: Date): SP.DateTimeResult;
     }
-    class TimeZoneCollection extends SP.ClientObjectCollection<TimeZone> {
+    interface TimeZoneCollection extends SP.ClientObjectCollection<TimeZone> {
         itemAt(index: number): SP.TimeZone;
         get_item(index: number): SP.TimeZone;
         getById(id: number): SP.TimeZone;
@@ -4556,7 +4580,7 @@ declare namespace SP {
         get_userId(): SP.UserIdInfo;
         update(): void;
     }
-    class UserCollection extends SP.ClientObjectCollection<User> {
+    interface UserCollection extends SP.ClientObjectCollection<User> {
         itemAt(index: number): SP.User;
         get_item(index: number): SP.User;
         getByLoginName(loginName: string): SP.User;
@@ -4614,7 +4638,7 @@ declare namespace SP {
         update(): void;
         deleteObject(): void;
     }
-    class UserCustomActionCollection extends SP.ClientObjectCollection<UserCustomAction> {
+    interface UserCustomActionCollection extends SP.ClientObjectCollection<UserCustomAction> {
         itemAt(index: number): SP.UserCustomAction;
         get_item(index: number): SP.UserCustomAction;
         getById(id: SP.Guid): SP.UserCustomAction;
@@ -4707,7 +4731,7 @@ declare namespace SP {
         renderAsHtml(): SP.StringResult;
         update(): void;
     }
-    class ViewCollection extends SP.ClientObjectCollection<View> {
+    interface ViewCollection extends SP.ClientObjectCollection<View> {
         itemAt(index: number): SP.View;
         get_item(index: number): SP.View;
         getByTitle(strTitle: string): SP.View;
@@ -4735,7 +4759,7 @@ declare namespace SP {
         writeToXml(writer: SP.XmlWriter, serializationContext: SP.SerializationContext): void;
         constructor();
     }
-    class ViewFieldCollection extends SP.ClientObjectCollection<string> {
+    interface ViewFieldCollection extends SP.ClientObjectCollection<string> {
         itemAt(index: number): string;
         get_item(index: number): string;
         get_schemaXml(): string;
@@ -4867,7 +4891,7 @@ declare namespace SP {
         /** Available after March 2015 CU for SharePoint 2013*/
         getList(url: string): List;
     }
-    class WebCollection extends SP.ClientObjectCollection<Web> {
+    interface WebCollection extends SP.ClientObjectCollection<Web> {
         itemAt(index: number): SP.Web;
         get_item(index: number): SP.Web;
         add(parameters: SP.WebCreationInformation): SP.Web;
@@ -4940,7 +4964,7 @@ declare namespace SP {
         get_name(): string;
         get_title(): string;
     }
-    class WebTemplateCollection extends SP.ClientObjectCollection<WebTemplate> {
+    interface WebTemplateCollection extends SP.ClientObjectCollection<WebTemplate> {
         itemAt(index: number): SP.WebTemplate;
         get_item(index: number): SP.WebTemplate;
         getByName(name: string): SP.WebTemplate;
@@ -5268,14 +5292,17 @@ declare namespace Microsoft.SharePoint.Client.Search {
             exportPopularQueries: (web: SP.Web, sourceId: SP.Guid) => SP.JsonObjectResult;
         }
 
-        class StringCollection extends SP.ClientObjectCollection<string> {
-            constructor(context: SP.ClientContext);
+        interface StringCollection extends SP.ClientObjectCollection<string> {
             itemAt: (index: number) => string;
             get_item: (index: number) => string;
             get_childItemType: () => typeof String;
             add: (property: string) => void;
             clear: () => void;
         }
+        interface StringCollectionConstructor {
+            new(context: SP.ClientContext): StringCollection;
+        }
+        var StringCollection: StringCollectionConstructor;
 
         class QueryPersonalizationData extends SP.ClientObject {
             // It's really empty;
@@ -5349,7 +5376,7 @@ declare namespace Microsoft.SharePoint.Client.Search {
             static getQueryPropertyValueType: (val: QueryPropertyValue) => QueryPropertyValueType;
             static queryPropertyValueToObject: (val: QueryPropertyValue) => any;
         }
-        class ReorderingRuleCollection extends SP.ClientObjectCollection<ReorderingRule> {
+        interface ReorderingRuleCollection extends SP.ClientObjectCollection<ReorderingRule> {
             itemAt: (index: number) => ReorderingRule;
             get_item: (index: number) => ReorderingRule;
             get_childItemType: () => typeof ReorderingRule;
@@ -5380,7 +5407,7 @@ declare namespace Microsoft.SharePoint.Client.Search {
             set_matchValue: (value: string) => void;
         }
 
-        class SortCollection extends SP.ClientObjectCollection<Sort> {
+        interface SortCollection extends SP.ClientObjectCollection<Sort> {
             itemAt: (index: number) => Sort;
             get_item: (index: number) => Sort;
             get_childItemType: () => typeof Sort;
@@ -5714,7 +5741,7 @@ declare namespace SP {
         class MethodExecutionResult extends SP.ClientObject {
             get_returnParameterCollection(): SP.BusinessData.ReturnParameterCollection;
         }
-        class ReturnParameterCollection extends SP.ClientObjectCollection<SP.BusinessData.Runtime.EntityFieldValueDictionary> {
+        interface ReturnParameterCollection extends SP.ClientObjectCollection<SP.BusinessData.Runtime.EntityFieldValueDictionary> {
             itemAt(index: number): SP.BusinessData.Runtime.EntityFieldValueDictionary;
             get_item(index: number): SP.BusinessData.Runtime.EntityFieldValueDictionary;
         }
@@ -5733,28 +5760,28 @@ declare namespace SP {
             getParentTypeDescriptor(): SP.BusinessData.TypeDescriptor;
         }
         namespace Collections {
-            class EntityFieldCollection extends SP.ClientObjectCollection<SP.BusinessData.EntityField> {
+            interface EntityFieldCollection extends SP.ClientObjectCollection<SP.BusinessData.EntityField> {
                 itemAt(index: number): SP.BusinessData.EntityField;
                 get_item(index: number): SP.BusinessData.EntityField;
             }
-            class EntityIdentifierCollection extends SP.ClientObjectCollection<SP.BusinessData.EntityIdentifier> {
+            interface EntityIdentifierCollection extends SP.ClientObjectCollection<SP.BusinessData.EntityIdentifier> {
                 itemAt(index: number): SP.BusinessData.EntityIdentifier;
                 get_item(index: number): SP.BusinessData.EntityIdentifier;
             }
-            class EntityInstanceCollection extends SP.ClientObjectCollection<SP.BusinessData.Runtime.EntityInstance> {
+            interface EntityInstanceCollection extends SP.ClientObjectCollection<SP.BusinessData.Runtime.EntityInstance> {
                 itemAt(index: number): SP.BusinessData.Runtime.EntityInstance;
                 get_item(index: number): SP.BusinessData.Runtime.EntityInstance;
             }
-            class FilterCollection extends SP.ClientObjectCollection<SP.BusinessData.Filter> {
+            interface FilterCollection extends SP.ClientObjectCollection<SP.BusinessData.Filter> {
                 itemAt(index: number): SP.BusinessData.Filter;
                 get_item(index: number): SP.BusinessData.Filter;
                 setFilterValue(inputFilterName: string, valueIndex: number, value: any): void;
             }
-            class LobSystemInstanceCollection extends SP.ClientObjectCollection<SP.BusinessData.LobSystemInstance> {
+            interface LobSystemInstanceCollection extends SP.ClientObjectCollection<SP.BusinessData.LobSystemInstance> {
                 itemAt(index: number): SP.BusinessData.LobSystemInstance;
                 get_item(index: number): SP.BusinessData.LobSystemInstance;
             }
-            class TypeDescriptorCollection extends SP.ClientObjectCollection<SP.BusinessData.TypeDescriptor> {
+            interface TypeDescriptorCollection extends SP.ClientObjectCollection<SP.BusinessData.TypeDescriptor> {
                 itemAt(index: number): SP.BusinessData.TypeDescriptor;
                 get_item(index: number): SP.BusinessData.TypeDescriptor;
             }
@@ -6563,7 +6590,7 @@ declare namespace SP {
             getDefaultSiteCollectionTermStore(): TermStore;
         }
 
-        class TermStoreCollection extends SP.ClientObjectCollection<TermStore> {
+        interface TermStoreCollection extends SP.ClientObjectCollection<TermStore> {
             itemAt(index: number): TermStore;
             get_item(index: number): TermStore;
             getById(id: SP.Guid): TermStore;
@@ -6624,7 +6651,7 @@ declare namespace SP {
             deleteObject(): void;
         }
 
-        class TermGroupCollection extends SP.ClientObjectCollection<TermGroup> {
+        interface TermGroupCollection extends SP.ClientObjectCollection<TermGroup> {
             itemAt(index: number): TermGroup;
             get_item(index: number): TermGroup;
             getById(id: SP.Guid): TermGroup;
@@ -6661,7 +6688,7 @@ declare namespace SP {
             setCustomProperty(name: string, value: string): void;
         }
 
-        class TermSetCollection extends SP.ClientObjectCollection<TermSet> {
+        interface TermSetCollection extends SP.ClientObjectCollection<TermSet> {
             itemAt(index: number): TermSet;
             get_item(index: number): TermSet;
             getById(id: SP.Guid): TermSet;
@@ -6691,7 +6718,7 @@ declare namespace SP {
             move(targetGroup: TermGroup): void;
         }
 
-        class TermCollection extends SP.ClientObjectCollection<Term> {
+        interface TermCollection extends SP.ClientObjectCollection<Term> {
             itemAt(index: number): Term;
             get_item(index: number): Term;
             getById(id: SP.Guid): Term;
@@ -6745,7 +6772,7 @@ declare namespace SP {
             getPath(lcid: number): SP.StringResult;
         }
 
-        class LabelCollection extends SP.ClientObjectCollection<Label> {
+        interface LabelCollection extends SP.ClientObjectCollection<Label> {
             itemAt(index: number): Label;
             get_item(index: number): Label;
             getByValue(name: string): Label;
@@ -6808,7 +6835,7 @@ declare namespace SP {
             set_withinTimeSpan(value: number): void;
         }
 
-        class ChangedItemCollection extends SP.ClientObjectCollection<ChangedItem> {
+        interface ChangedItemCollection extends SP.ClientObjectCollection<ChangedItem> {
             itemAt(index: number): ChangedItem;
             get_item(index: number): ChangedItem;
         }
@@ -6885,12 +6912,15 @@ declare namespace SP {
             getValidatedString(value: TaxonomyFieldValue): SP.StringResult;
         }
 
-        class TaxonomyFieldValueCollection extends SP.ClientObjectCollection<TaxonomyFieldValue> {
-            constructor(context: SP.ClientContext, fieldValue: string, creatingField: SP.Field);
+        interface TaxonomyFieldValueCollection extends SP.ClientObjectCollection<TaxonomyFieldValue> {
             itemAt(index: number): TaxonomyFieldValue;
             get_item(index: number): TaxonomyFieldValue;
             populateFromLabelGuidPairs(text: string): void;
         }
+        interface TaxonomyFieldValueCollectionConstructor {
+            new(context: SP.ClientContext, fieldValue: string, creatingField: SP.Field): TaxonomyFieldValueCollection;
+        }
+        var TaxonomyFieldValueCollection: TaxonomyFieldValueCollectionConstructor;
 
         class TaxonomyFieldValue extends SP.ClientValueObject {
             get_label(): string;
@@ -7509,7 +7539,7 @@ declare namespace SP {
             get_useCount(): number;
         }
 
-        class HashTagCollection extends SP.ClientObjectCollection<HashTag> {
+        interface HashTagCollection extends SP.ClientObjectCollection<HashTag> {
             itemAt(index: number): HashTag;
             get_item(index: number): HashTag;
         }
@@ -8141,7 +8171,7 @@ declare namespace SP {
             deleteWebPart(): void;
             moveWebPartTo(zoneID: string, zoneIndex: number): void;
         }
-        class WebPartDefinitionCollection extends SP.ClientObjectCollection<WebPartDefinition> {
+        interface WebPartDefinitionCollection extends SP.ClientObjectCollection<WebPartDefinition> {
             itemAt(index: number): SP.WebParts.WebPartDefinition;
             get_item(index: number): SP.WebParts.WebPartDefinition;
             getById(id: SP.Guid): SP.WebParts.WebPartDefinition;
@@ -8183,7 +8213,7 @@ declare namespace SP {
             update(): void;
             deleteObject(): void;
         }
-        class WorkflowAssociationCollection extends SP.ClientObjectCollection<WorkflowAssociation> {
+        interface WorkflowAssociationCollection extends SP.ClientObjectCollection<WorkflowAssociation> {
             itemAt(index: number): SP.Workflow.WorkflowAssociation;
             get_item(index: number): SP.Workflow.WorkflowAssociation;
             getById(associationId: SP.Guid): SP.Workflow.WorkflowAssociation;
@@ -8218,7 +8248,7 @@ declare namespace SP {
             get_name(): string;
             get_permissionsManual(): SP.BasePermissions;
         }
-        class WorkflowTemplateCollection extends SP.ClientObjectCollection<WorkflowTemplate> {
+        interface WorkflowTemplateCollection extends SP.ClientObjectCollection<WorkflowTemplate> {
             itemAt(index: number): SP.Workflow.WorkflowTemplate;
             get_item(index: number): SP.Workflow.WorkflowTemplate;
             getById(templateId: SP.Guid): SP.Workflow.WorkflowTemplate;
@@ -8314,7 +8344,7 @@ declare namespace SP.WorkflowServices {
     }
 
     /** Represents a collection of WorkflowDefinition objects */
-    class WorkflowDefinitionCollection extends SP.ClientObjectCollection<WorkflowDefinition> {
+    interface WorkflowDefinitionCollection extends SP.ClientObjectCollection<WorkflowDefinition> {
         itemAt(index: number): WorkflowDefinition;
         get_item(index: number): WorkflowDefinition;
         /** returns SP.WorkflowDefinition class */
@@ -8391,7 +8421,7 @@ declare namespace SP.WorkflowServices {
     }
 
     /** Represents a collection of WorkflowInstance objects */
-    class WorkflowInstanceCollection extends SP.ClientObjectCollection<WorkflowInstance> {
+    interface WorkflowInstanceCollection extends SP.ClientObjectCollection<WorkflowInstance> {
         itemAt(index: number): WorkflowInstance;
         get_item(index: number): WorkflowInstance;
         /** returns SP.WorkflowInstance class */
@@ -8504,7 +8534,7 @@ declare namespace SP.WorkflowServices {
     }
 
     /** Represents a collection of WorkflowSubscription objects */
-    class WorkflowSubscriptionCollection extends SP.ClientObjectCollection<WorkflowSubscription> {
+    interface WorkflowSubscriptionCollection extends SP.ClientObjectCollection<WorkflowSubscription> {
         itemAt(index: number): WorkflowSubscription;
         get_item(index: number): WorkflowSubscription;
         /** returns SP.WorkflowInstance class */
@@ -8772,7 +8802,7 @@ declare namespace SP {
                 getResolvedDisplayUrl(browserQueryString: string): StringResult;
             }
 
-            class NavigationTermCollection extends ClientObjectCollection<NavigationTerm> {
+            interface NavigationTermCollection extends ClientObjectCollection<NavigationTerm> {
             }
 
             class NavigationTerm extends NavigationTermSetItem {
@@ -8860,7 +8890,7 @@ declare namespace SP {
                 static getAsResolvedByView(context: ClientContext, termSet: Taxonomy.TermSet, view: NavigationTermSetView): NavigationTermSet;
             }
 
-            class NavigationTermProviderNameCollection extends ClientObjectCollection<string> {
+            interface NavigationTermProviderNameCollection extends ClientObjectCollection<string> {
                 Add(item: string): void;
                 Clear(): void;
                 Remove(item: string): BooleanResult;


### PR DESCRIPTION
* [x] Use a meaningful title for the pull request. Include the name of the package modified.
* [x] Test the change in your own code. (Compile and run.)
* [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
* [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
* [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
* [x] Provide source code which provides context for the suggested changes
* [x] Increase the version number in the header if appropriate.
* [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I am writing some extensions to SharePoint's JSOM. I will limit to one example where I am implementing an import method on the SP.SOD object which wraps the SP.SOD loader song and dance and returns a promise. I would like to provide my implementation as a package with its own typings like so (stripped down to this single example):

``` ts
declare global {
    namespace SP {
        export interface SOD {
            import(sod: string | string[]): Promise<any>;
        }
    }
}
```
The above should extend upon the declaration that comes from `@types/sharepoint` and simply add the `import` method. The problem is the current declaration uses `class` everywhere and makes its near impossible to extend those classes with new static methods.

For example, if we change the following:
``` ts
declare namespace SP {
    class SOD {
        static execute(fileName: string, functionName: string, ...args: any[]): void;
        static executeFunc(fileName: string, typeName: string, fn: () => void): void;
        static executeOrDelayUntilEventNotified(func: (...args: any[]) => void, eventName: string): boolean;
        static executeOrDelayUntilScriptLoaded(func: () => void, depScriptFileName: string): boolean;
        static notifyScriptLoadedAndExecuteWaitingJobs(scriptFileName: string): void;
        static notifyEventAndExecuteWaitingJobs(eventName: string, args?: any[]): void;
        static registerSod(fileName: string, url: string): void;
        static registerSodDep(fileName: string, dependentFileName: string): void;
        static loadMultiple(keys: string[], fn: () => void, bSync?: boolean): void;
        static delayUntilEventNotified(func: (...args: any[]) => void, eventName: string): void;

        static get_prefetch(): boolean;
        static set_prefetch(value: boolean): void;

        static get_ribbonImagePrefetchEnabled(): boolean;
        static set_ribbonImagePrefetchEnabled(value: boolean): void;
    }
}
```

and remove the `class` declaration in favor of an `instance` declaration:
``` ts
declare namespace SP {
    interface SOD {
        execute(fileName: string, functionName: string, ...args: any[]): void;
        executeFunc(fileName: string, typeName: string, fn: () => void): void;
        executeOrDelayUntilEventNotified(func: (...args: any[]) => void, eventName: string): boolean;
        executeOrDelayUntilScriptLoaded(func: () => void, depScriptFileName: string): boolean;
        notifyScriptLoadedAndExecuteWaitingJobs(scriptFileName: string): void;
        notifyEventAndExecuteWaitingJobs(eventName: string, args?: any[]): void;
        registerSod(fileName: string, url: string): void;
        registerSodDep(fileName: string, dependentFileName: string): void;
        loadMultiple(keys: string[], fn: () => void, bSync?: boolean): void;
        delayUntilEventNotified(func: (...args: any[]) => void, eventName: string): void;

        get_prefetch(): boolean;
        set_prefetch(value: boolean): void;

        get_ribbonImagePrefetchEnabled(): boolean;
        set_ribbonImagePrefetchEnabled(value: boolean): void;
    }
    var SOD: SOD;
}
```

The object declaration now becomes extendable and my declaration from above works. This pull request is a start at converting the entire file to use `interface` instead of `class` where appropriate.

As I mentioned earlier, the main problem is when trying to add new 'static' methods to declared classes. I have been able to successfully extend declarations like the following without any changes to the current declarations:
```ts
declare global {
    namespace SP {
        export interface ClientRuntimeContext {
            /** A shorthand for context.executeQueryAsync except wrapped as a JS Promise object */
            executeQuery(): Promise<ClientRequestSucceededEventArgs>;
        }
    }
}
```

This works because I can extend the `ClientRuntimeContext` *type* with new methods this way. But the `import` method from above is trying to extend what is basically an already created *instance* of the SP.SOD object. Therefore all the changes I have made from line 2116 to the end were not really necessary for my purposes, but might be useful for others.

I've run these changes through several live tests and it seems to work drop-in. I bumped the version number since there could be other as yet undiscovered consequences.