### PR TITLE
Update contract for Auth0DecodedHash of auth0-js

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Auth0.js 8.11.3
+// Type definitions for Auth0.js 8.11
 // Project: https://github.com/auth0/auth0.js
 // Definitions by: Adrian Chia <https://github.com/adrianchia>
 //                 Matt Durrant <https://github.com/mdurrant>
@@ -528,8 +528,6 @@ export interface Auth0Error {
 
 /**
  * The contents of the authResult object returned by {@link WebAuth#parseHash }
- * @export
- * @interface Auth0DecodedHash
  */
 export interface Auth0DecodedHash {
     accessToken?: string;

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/auth0/auth0.js
 // Definitions by: Adrian Chia <https://github.com/adrianchia>
 //                 Matt Durrant <https://github.com/mdurrant>
+//                 Peter Blazejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace auth0;
@@ -525,14 +526,21 @@ export interface Auth0Error {
     statusText?: string;
 }
 
+/**
+ * The contents of the authResult object returned by {@link WebAuth#parseHash }
+ * @export
+ * @interface Auth0DecodedHash
+ */
 export interface Auth0DecodedHash {
     accessToken?: string;
     idToken?: string;
     idTokenPayload?: any;
+    appState?: any;
     refreshToken?: string;
     state?: string;
     expiresIn?: number;
     tokenType?: string;
+    scope?: string;
 }
 
 /** Represents the response from an API Token Delegation request. */

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Auth0.js 8.10
+// Type definitions for Auth0.js 8.11.3
 // Project: https://github.com/auth0/auth0.js
 // Definitions by: Adrian Chia <https://github.com/adrianchia>
 //                 Matt Durrant <https://github.com/mdurrant>


### PR DESCRIPTION
This commit updates contract for results of the  WebAuth.parseHash call to v.8 of auth0-js.
Here is a link to relevant vanilla JS implementation:
https://git.io/vFNdC

I also changed the version to 8.11.3 as the version I've used the definition file with.

Thanks!