### PR TITLE
added types for docker-file-parser@1.0

### DIFF
--- a/types/docker-file-parser/docker-file-parser-tests.ts
+++ b/types/docker-file-parser/docker-file-parser-tests.ts
@@ -1,0 +1,25 @@
+import { parse, CommandEntry, ParseOptions } from 'docker-file-parser';
+
+const file = `
+FROM node:8
+
+ADD . /opt/
+WORKDIR /opt
+
+RUN npm install --production
+
+EXPOSE 8080
+VOLUME /opt/scripts
+
+CMD ["npm", "start"]
+`;
+
+const options: ParseOptions = {
+    includeComments: false
+};
+
+const result: CommandEntry[] = parse(file, options);
+const line1Name = result[0].name;
+const line1Number = result[0].lineno;
+const line1Args = result[0].args;
+const line1Raw = result[0].raw;

--- a/types/docker-file-parser/index.d.ts
+++ b/types/docker-file-parser/index.d.ts
@@ -3,21 +3,19 @@
 // Definitions by: Yash Kulshrestha <https://github.com/yashdalfthegray>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "docker-file-parser" {
-    export interface CommandEntry {
-        name: string;
-        args: string[];
-        lineno: number;
-        raw: string;
-        error?: string;
-    }
-
-    export interface ParseOptions {
-        includeComments: boolean;
-    }
-
-    export function parse(
-        contents: string,
-        options?: ParseOptions
-    ): CommandEntry[];
+export interface CommandEntry {
+    name: string;
+    args: string[];
+    lineno: number;
+    raw: string;
+    error?: string;
 }
+
+export interface ParseOptions {
+    includeComments: boolean;
+}
+
+export function parse(
+    contents: string,
+    options?: ParseOptions
+): CommandEntry[];

--- a/types/docker-file-parser/index.d.ts
+++ b/types/docker-file-parser/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for docker-file-parser 1.0
+// Project: https://github.com/joyent/docker-file-parse
+// Definitions by: Yash Kulshrestha <https://github.com/yashdalfthegray>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "docker-file-parser" {
+    export interface CommandEntry {
+        name: string;
+        args: string[];
+        lineno: number;
+        raw: string;
+        error?: string;
+    }
+
+    export interface ParseOptions {
+        includeComments: boolean;
+    }
+
+    export function parse(
+        contents: string,
+        options?: ParseOptions
+    ): CommandEntry[];
+}

--- a/types/docker-file-parser/tsconfig.json
+++ b/types/docker-file-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "docker-file-parser-tests.ts"
+    ]
+}

--- a/types/docker-file-parser/tslint.json
+++ b/types/docker-file-parser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Added typings for `docker-file-parser@1.0` because I don't own the package. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
