### PR TITLE
Remove unnecessary `/// <reference types="redux" />` for redux-immutable-state-invariant

### DIFF
--- a/types/redux-immutable-state-invariant/index.d.ts
+++ b/types/redux-immutable-state-invariant/index.d.ts
@@ -3,8 +3,6 @@
 // Definitions by: Remo H. Jansen <https://github.com/remojansen>, Ben Rogers <https://github.com/highflying>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference types="redux" />
-
 import * as Redux from "redux";
 
 type isImmutableDefault = (value: any) => boolean;


### PR DESCRIPTION
In the [DefinitelyTyped README.md](https://github.com/DefinitelyTyped/DefinitelyTyped#im-writing-a-definition-that-depends-on-another-definition-should-i-use-reference-types--or-an-import):

> If the module you're referencing is an external module (uses `export`), use an import.
> If the module you're referencing is an ambient module (uses `declare module`, or just declares globals), use `<reference types="" />`.

As the redux typings use `export`, not `declare module`, the redux-immutable-state-invariant typings don't need `/// <reference types="redux" />` as well as the import.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [DefinitelyTyped README.md](https://github.com/DefinitelyTyped/DefinitelyTyped#im-writing-a-definition-that-depends-on-another-definition-should-i-use-reference-types--or-an-import)
~- [ ] Increase the version number in the header if appropriate.~ N/A
~- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ N/A
