### PR TITLE
tinymce - Update dom.remove typing to include Element

### DIFF
--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -826,7 +826,7 @@ export namespace dom {
 
     parseStyle(cssText: string): {};
 
-    remove<T>(node: string, keepChildren?: boolean): Element | T[];
+    remove<T>(node: string | Element, keepChildren?: boolean): Element | T[];
 
     removeAllAttribs(e: Element): void;
 


### PR DESCRIPTION
According to https://github.com/tinymce/tinymce/blob/4.5.x/js/tinymce/classes/dom/DOMUtils.js#L624

DOM.remove should accept the Element type for it's node. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/tinymce/tinymce/blob/4.5.x/js/tinymce/classes/dom/DOMUtils.js#L624
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
