### PR TITLE
Update auth0-js RenewAuthOptions

### DIFF
--- a/types/auth0-js/auth0-js-tests.ts
+++ b/types/auth0-js/auth0-js-tests.ts
@@ -109,7 +109,9 @@ webAuth.renewAuth({}, (err, authResult) => {});
 webAuth.renewAuth({
 	nonce: '123',
     state: '456',
-    postMessageDataType: 'auth0:silent-authentication'
+    postMessageDataType: 'auth0:silent-authentication',
+    usePostMessage: true,
+    timeout: 30 * 1000
 }, (err, authResult) => {
       // Renewed tokens or error
 });

--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -667,17 +667,72 @@ export interface ParseHashOptions {
 }
 
 export interface RenewAuthOptions {
+    /**
+     * your Auth0 domain
+     */
     domain?: string;
+    /**
+     * your Auth0 client identifier obtained when creating the client in the Auth0 Dashboard
+     */
     clientID?: string;
+    /**
+     * url that the Auth0 will redirect after Auth with the Authorization Response
+     */
     redirectUri?: string;
+    /**
+     * type of the response used by OAuth 2.0 flow. It can be any space separated
+     * list of the values `code`, `token`, `id_token`.
+     * {@link https://openid.net/specs/oauth-v2-multiple-response-types-1_0}
+     */
     responseType?: string;
+    /**
+     * how the Auth response is encoded and redirected back to the client.
+     * Supported values are `query`, `fragment` and `form_post`.
+     * The `query` value is only supported when `responseType` is `code`.
+     * {@link https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes}
+     */
     responseMode?: string;
+    /**
+     * value used to mitigate XSRF attacks.
+     * {@link https://auth0.com/docs/protocols/oauth2/oauth-state}
+     */
     state?: string;
+    /**
+     * value used to mitigate replay attacks when using Implicit Grant.
+     * {@link https://auth0.com/docs/api-auth/tutorials/nonce}
+     */
     nonce?: string;
+    /**
+     * scopes to be requested during Auth. e.g. `openid email`
+     */
     scope?: string;
+    /**
+     * identifier of the resource server who will consume the access token issued after Auth
+     */
     audience?: string;
-    usePostMessage?: boolean;
+    /**
+     * identifier data type to look for in postMessage event data, where events are initiated
+     * from silent callback urls, before accepting a message event is the event expected.
+     * A value of false means any postMessage event will trigger a callback.
+     */
     postMessageDataType?: string;
+    /**
+     * origin of redirectUri to expect postMessage response from.
+     * Defaults to the origin of the receiving window. Only used if usePostMessage is truthy.
+     */
+    postMessageOrigin?: string;
+    /**
+     * value in milliseconds used to timeout when the `/authorize` call is failing
+     * as part of the silent authentication with postmessage enabled due to a configuration.
+     */
+    timeout?: number;
+    /**
+     * use postMessage to comunicate between the silent callback and the SPA.
+     * When false the SDK will attempt to parse the url hash should ignore the url hash
+     * and no extra behaviour is needed
+     * @default false
+     */
+    usePostMessage?: boolean;
 }
 
 export interface AuthorizeOptions {


### PR DESCRIPTION
This commit adds:
- documentation for existing interface options
- missing options from current v.8 of Auth0 for RenewAuthOptions

The documentation and missing fields are based on existing Auth0 documentation
here:
- https://git.io/vFxy3
- https://github.com/auth0/auth0.js/pull/572

Thanks!