### PR TITLE
react-measure: Extend ChildrenOpts with type passed to withContentType

### DIFF
--- a/types/react-measure/index.d.ts
+++ b/types/react-measure/index.d.ts
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-type MeasurementType = "client" | "offset" | "scroll" | "bounds" | "margin";
+export type MeasurementType = "client" | "offset" | "scroll" | "bounds" | "margin";
 
 interface TopLeft {
     readonly top: number;
@@ -38,11 +38,13 @@ export interface ContentRect {
     entry?: any;
 }
 
-export interface ChildrenOpts {
+export interface MeasuredComponentProps {
     measureRef(ref: Element | null): void;
     measure(): void;
     contentRect: ContentRect;
 }
+
+type MeasuredComponent<T> = React.ComponentType<T & MeasuredComponentProps>;
 
 export interface MeasureProps<T> {
     client?: boolean;
@@ -52,9 +54,11 @@ export interface MeasureProps<T> {
     margin?: boolean;
     innerRef?(ref: Element | null): void;
     onResize?(contentRect: ContentRect): void;
-    children?(arg: ChildrenOpts): React.ReactElement<T>;
+    children?: React.SFC<MeasuredComponentProps>;
 }
 
-export declare function withContentRect(types: MeasurementType | MeasurementType[]): <T>(fn: (arg: ChildrenOpts) => React.ReactElement<T>) => React.ComponentClass<T>;
+export declare function withContentRect(types: ReadonlyArray<MeasurementType> | MeasurementType):
+    <T extends {}>(fn: MeasuredComponent<T>) => React.ComponentType<T>;
+
 declare class Measure<T> extends React.Component<MeasureProps<T>> {}
 export default Measure;

--- a/types/react-measure/react-measure-tests.tsx
+++ b/types/react-measure/react-measure-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Measure, { ContentRect, withContentRect } from "react-measure";
+import Measure, { ContentRect, withContentRect, MeasuredComponentProps, MeasurementType } from "react-measure";
 
 class Test extends React.Component {
     render() {
@@ -63,7 +63,26 @@ class Test2 extends React.Component {
     }
 }
 
-function testHocComponent<T>(): React.ComponentClass<T> {
+interface Props {
+    a: string;
+}
+
+const TestFunctionalComponentWithProps: React.SFC<Props & MeasuredComponentProps> = ({a, contentRect, measureRef}) => {
+    return (
+        <div ref={measureRef}>{a}</div>
+    );
+};
+
+class TestClassComponentWithProps extends React.Component<Props & MeasuredComponentProps> {
+    render() {
+        const {a, contentRect, measureRef} = this.props;
+        return (
+            <div ref={measureRef}>{a}</div>
+        );
+    }
+}
+
+function testHocComponent() {
     return withContentRect('bounds')(({measureRef, measure, contentRect}) => (
         <div ref={measureRef}>
             Some content here
@@ -74,11 +93,17 @@ function testHocComponent<T>(): React.ComponentClass<T> {
     ));
 }
 
-function testHocComponent2<T>(): React.ComponentClass<T> {
-    return withContentRect(['scroll', 'margin'])(({measureRef}) => (
+function testHocComponent2<T>() {
+    return withContentRect(['scroll', 'margin'] as ReadonlyArray<MeasurementType>)(({measureRef}) => (
         <div ref={measureRef}>Some content here</div>
     ));
 }
 
 const HocComponent = testHocComponent();
-const el = <HocComponent/>;
+const el = <HocComponent />;
+
+const MeasuredFunctionalComponent = withContentRect('bounds')<Props>(TestFunctionalComponentWithProps);
+const funcEl = <MeasuredFunctionalComponent a="test" />;
+
+const MeasuredClassComponent = withContentRect('bounds')<Props>(TestClassComponentWithProps);
+const classEl = <MeasuredClassComponent a="test" />;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/souporserious/react-measure/blob/master/src/with-content-rect.js#L69

You can see here that `withContentRect` passes any props through. I have attempted to describe this in types.
