### PR TITLE
[chai] added missing include methods to Assert

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -1357,6 +1357,56 @@ suite('assert', () => {
         assert.notInclude(undefined, 'bar');
     });
 
+    test('deepInclude', () => {
+        assert.deepInclude('foobar', 'bar');
+        assert.deepInclude([1, 2, 3], 3);
+        assert.deepInclude('foobar', 'baz');
+        assert.deepInclude(undefined, 'bar');
+    });
+
+    test('notDeepInclude', () => {
+        assert.notDeepInclude('foobar', 'baz');
+        assert.notDeepInclude([1, 2, 3], 4);
+        assert.notDeepInclude('foobar', 'bar');
+        assert.notDeepInclude(undefined, 'bar');
+    });
+
+    test('nestedInclude', () => {
+        assert.nestedInclude({'.a': {'b': 'x'}}, {'\\.a.[b]': 'x'});
+        assert.nestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'x'});
+    });
+
+    test('notNestedInclude', () => {
+        assert.notNestedInclude({'.a': {'b': 'x'}}, {'\\.a.b': 'y'});
+        assert.notNestedInclude({'a': {'[b]': 'x'}}, {'a.\\[b\\]': 'y'});
+    });
+
+    test('deepNestedInclude', () => {
+        assert.deepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {x: 1}});
+        assert.deepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {x: 1}});
+    });
+
+    test('notDeepNestedInclude', () => {
+        assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {'a.b[0]': {y: 1}})
+        assert.notDeepNestedInclude({'.a': {'[b]': {x: 1}}}, {'\\.a.\\[b\\]': {y: 2}});
+    });
+
+    test('ownInclude', () => {
+        assert.ownInclude({ a: 1 }, { a: 1 });
+    });
+
+    test('notOwnInclude', () => {
+        assert.notOwnInclude({ a: 1 }, { a: 1 });
+    });
+
+    test('deepOwnInclude', () => {
+        assert.deepOwnInclude({a: {b: 2}}, {a: {b: 2}});
+    });
+
+    test('notDeepOwnInclude', () => {
+        assert.notDeepOwnInclude({a: {b: 2}}, {a: {c: 3}});
+    });
+
     test('lengthOf', () => {
         assert.lengthOf([1, 2, 3], 3);
         assert.lengthOf('foobar', 6);

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -7,6 +7,7 @@
 //                 Matt Wistrand <https://github.com/mwistrand>,
 //                 Josh Goldberg <https://github.com/joshuakgoldberg>
 //                 Shaun Luttin <https://github.com/shaunluttin>
+//                 Gintautas Miselis <https://github.com/Naktibalda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // <reference types="assertion-error"/>
@@ -706,12 +707,144 @@ declare namespace Chai {
         /**
          * Asserts that haystack does not include needle.
          *
-         * @type T   Type of values in haystack.
          * @param haystack   Container array.
          * @param needle   Potential value contained in haystack.
          * @param message   Message to display on error.
          */
         notInclude(haystack: any[], needle: any, message?: string): void;
+
+
+        /**
+         * Asserts that haystack includes needle. Can be used to assert the inclusion of a value in an array or a subset of properties in an object. Deep equality is used.
+         *
+         * @param haystack   Container string.
+         * @param needle   Potential expected substring of haystack.
+         * @param message   Message to display on error.
+         */
+        deepInclude(haystack: string, needle: string, message?: string): void;
+
+        /**
+         * Asserts that haystack includes needle. Can be used to assert the inclusion of a value in an array or a subset of properties in an object. Deep equality is used.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        deepInclude<T>(haystack: any, needle: any, message?: string): void;
+
+        /**
+         * Asserts that haystack does not include needle. Can be used to assert the absence of a value in an array or a subset of properties in an object. Deep equality is used.
+         *
+         * @param haystack   Container string.
+         * @param needle   Potential expected substring of haystack.
+         * @param message   Message to display on error.
+         */
+        notDeepInclude(haystack: string, needle: any, message?: string): void;
+
+        /**
+         * Asserts that haystack does not include needle. Can be used to assert the absence of a value in an array or a subset of properties in an object. Deep equality is used.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        notDeepInclude(haystack: any[], needle: any, message?: string): void;
+
+        /**
+         * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the inclusion of a subset of properties in an object.
+         *
+         * Enables the use of dot- and bracket-notation for referencing nested properties.
+         * ‘[]’ and ‘.’ in property names can be escaped using double backslashes.Asserts that ‘haystack’ includes ‘needle’.
+         * Can be used to assert the inclusion of a subset of properties in an object.
+         * Enables the use of dot- and bracket-notation for referencing nested properties.
+         * ‘[]’ and ‘.’ in property names can be escaped using double backslashes.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        nestedInclude(haystack: any, needle: any, message?: string): void;
+
+        /**
+         * Asserts that ‘haystack’ does not include ‘needle’. Can be used to assert the absence of a subset of properties in an object.
+         *
+         * Enables the use of dot- and bracket-notation for referencing nested properties.
+         * ‘[]’ and ‘.’ in property names can be escaped using double backslashes.Asserts that ‘haystack’ includes ‘needle’.
+         * Can be used to assert the inclusion of a subset of properties in an object.
+         * Enables the use of dot- and bracket-notation for referencing nested properties.
+         * ‘[]’ and ‘.’ in property names can be escaped using double backslashes.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        notNestedInclude(haystack: any, needle: any, message?: string): void;
+
+        /**
+         * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the inclusion of a subset of properties in an object while checking for deep equality
+         *
+         * Enables the use of dot- and bracket-notation for referencing nested properties.
+         * ‘[]’ and ‘.’ in property names can be escaped using double backslashes.Asserts that ‘haystack’ includes ‘needle’.
+         * Can be used to assert the inclusion of a subset of properties in an object.
+         * Enables the use of dot- and bracket-notation for referencing nested properties.
+         * ‘[]’ and ‘.’ in property names can be escaped using double backslashes.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        deepNestedInclude(haystack: any, needle: any, message?: string): void;
+
+        /**
+         * Asserts that ‘haystack’ does not include ‘needle’. Can be used to assert the absence of a subset of properties in an object while checking for deep equality.
+         *
+         * Enables the use of dot- and bracket-notation for referencing nested properties.
+         * ‘[]’ and ‘.’ in property names can be escaped using double backslashes.Asserts that ‘haystack’ includes ‘needle’.
+         * Can be used to assert the inclusion of a subset of properties in an object.
+         * Enables the use of dot- and bracket-notation for referencing nested properties.
+         * ‘[]’ and ‘.’ in property names can be escaped using double backslashes.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        notDeepNestedInclude(haystack: any, needle: any, message?: string): void;
+
+        /**
+         * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the inclusion of a subset of properties in an object while ignoring inherited properties.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        ownInclude(haystack: any, needle: any, message?: string): void;
+
+        /**
+         * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the absence of a subset of properties in an object while ignoring inherited properties.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        notOwnInclude(haystack: any, needle: any, message?: string): void;
+
+        /**
+         * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the inclusion of a subset of properties in an object while ignoring inherited properties and checking for deep
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        deepOwnInclude(haystack: any, needle: any, message?: string): void;
+
+        /**
+         * Asserts that ‘haystack’ includes ‘needle’. Can be used to assert the absence of a subset of properties in an object while ignoring inherited properties and checking for deep equality.
+         *
+         * @param haystack
+         * @param needle
+         * @param message   Message to display on error.
+         */
+        notDeepOwnInclude(haystack: any, needle: any, message?: string): void;
 
         /**
          * Asserts that value matches the regular expression regexp.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://chaijs.com/api/assert/#method_deepinclude
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.