### PR TITLE
fix(restify/req.time): correct return type

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -439,9 +439,10 @@ export interface Request extends http.IncomingMessage {
     // query(): string;
 
     /**
-     * returns ms since epoch when request was setup.
+     * returns the high-resolution time since epoch when request was setup in a [seconds, nanoseconds] tuple Array,
+     * where nanoseconds is the remaining part of the real time that can't be represented in second precision.
      */
-    time(): number;
+    time(): [number, number];
 
     /**
      * returns a parsed URL object.


### PR DESCRIPTION
restify's req.time function is using node's process.hrtime which is not a number, but a tuple array of two numbers

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
