### PR TITLE
react-redux: fix Options generic type arguments in connect()

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -120,28 +120,28 @@ export interface Connect {
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: null | undefined,
         mergeProps: null | undefined,
-        options: Options<TStateProps, TOwnProps>
+        options: Options<State, TStateProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<DispatchProp<any> & TStateProps, TOwnProps>;
 
-    <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
+    <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
         mapStateToProps: null | undefined,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
-        options: Options<no_state, TOwnProps>
+        options: Options<{}, TStateProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>;
 
     <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = {}>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: null | undefined,
-        options: Options<TStateProps, TOwnProps>
+        options: Options<State, TStateProps, TOwnProps>
     ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
 
     <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, TMergedProps = {}, State = {}>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>,
         mergeProps: MergeProps<TStateProps, TDispatchProps, TOwnProps, TMergedProps>,
-        options: Options<TStateProps, TOwnProps, TMergedProps>
+        options: Options<State, TStateProps, TOwnProps, TMergedProps>
     ): InferableComponentEnhancerWithProps<TMergedProps, TOwnProps>;
 }
 

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -247,22 +247,26 @@ namespace MapStateAndDispatchAndMerge {
 }
 
 namespace MapStateAndOptions {
+    interface State { state: string; }
     interface OwnProps { foo: string }
     interface StateProps { bar: number }
     interface DispatchProps { dispatch: Dispatch<any> }
 
     class TestComponent extends Component<OwnProps & StateProps & DispatchProps> {}
 
-    const mapStateToProps = () => ({
+    const mapStateToProps = (state: State) => ({
         bar: 1
     })
 
-    const Test = connect(
+    const areStatePropsEqual = (next: StateProps, current: StateProps) => true;
+
+    const Test = connect<StateProps, DispatchProps, OwnProps, State>(
         mapStateToProps,
         null,
         null,
         {
-            pure: true
+            pure: true,
+            areStatePropsEqual,
         }
     )(TestComponent)
 


### PR DESCRIPTION
The connect overloads that allow `options` did not pass the type arguments in the correct order.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
