### PR TITLE
 Updated datatables.net for 1.10.10

### DIFF
--- a/types/datatables.net/datatables.net-tests.ts
+++ b/types/datatables.net/datatables.net-tests.ts
@@ -21,7 +21,13 @@ const lang: DataTables.LanguageSettings = {
     },
     aria: {
         sortAscending: ": activate to sort column ascending",
-        sortDescending: ": activate to sort column descending"
+        sortDescending: ": activate to sort column descending",
+        paginate: {
+            first: "First",
+            last: "Last",
+            next: "Next",
+            previous: "Previous"
+        }
     }
 };
 
@@ -98,6 +104,7 @@ let col: DataTables.ColumnSettings = {
     orderable: true,
     orderData: 10,
     orderDataType: "dom-checkbox",
+    orderFixed: [[0, 'asc'], [1, 'desc']],
     orderSequence: ['asc', 'desc'],
     render: 1,
     searchable: true,
@@ -118,6 +125,20 @@ col = {
     data: colDataFunc,
     render: colRenderFunc,
 };
+col = {
+    data: "salary",
+    render: $.fn.dataTable.render.number('\'', '.', 0, '$'),
+};
+col = {
+    data: "url",
+    render: $.fn.dataTable.render.text(),
+};
+col = {
+    orderFixed: {
+        pre: [[0, 'asc'], [1, 'desc']],
+        post: [[0, 'asc'], [1, 'desc']]
+    }
+};
 
 //#endregion "Column"
 
@@ -135,6 +156,7 @@ let colDef: DataTables.ColumnDefsSettings = {
         orderable: true,
         orderData: 10,
         orderDataType: "dom-checkbox",
+        orderFixed: [[0, 'asc'], [1, 'desc']],
         orderSequence: ['asc', 'desc'],
         render: 1,
         searchable: true,
@@ -352,6 +374,9 @@ const order_get = dt.order();
 let order_set = dt.order([0, "asc"]);
 order_set = dt.order([0, "asc"], [1, "desc"]);  // TODO: Fíx that
 order_set = dt.order([[0, "asc"], [1, "desc"]]);
+
+const fixed_get: DataTables.ObjectOrderFixed = dt.order.fixed();
+const fixed_set: DataTables.Api = dt.order.fixed({pre: [0, "asc"], post: [1, "desc"]});
 
 const orderListerner = order_set.order.listener("node", 1, () => { });
 
@@ -790,6 +815,11 @@ dt.columns.adjust().draw(false); // adjust column sizing and redraw
 
 dt.columns().every(() => { });
 dt.columns().every((colIdx, tableLoop, colLoop) => { });
+
+$('#example').on('column-visibility.dt', (e: object, settings: DataTables.Settings, column: number, state: boolean, recalc: boolean | undefined) => {
+    const widthRecalced = (recalc || recalc === undefined);
+    console.log(`Column ${column} has changed to ${(state ? 'visible' : 'hidden')} and width ${(widthRecalced) ? 'was' : 'was not'} recalculated.`);
+});
 
 //#endregion "Methods-Column"
 

--- a/types/datatables.net/index.d.ts
+++ b/types/datatables.net/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for JQuery DataTables 1.10
 // Project: http://www.datatables.net
-// Definitions by: Kiarash Ghiaseddin <https://github.com/Silver-Connection>, Omid Rad <https://github.com/omidkrad>, Armin Sander <https://github.com/pragmatrix>
+// Definitions by: Kiarash Ghiaseddin <https://github.com/Silver-Connection>
+//                 Omid Rad <https://github.com/omidkrad>
+//                 Armin Sander <https://github.com/pragmatrix>
+//                 Craig Boland <https://github.com/CNBoland>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -328,6 +331,16 @@ declare namespace DataTables {
          */
         (order?: Array<(string | number)> | Array<Array<(string | number)>>): Api;
         (order: Array<(string | number)>, ...args: any[]): Api;
+
+        /**
+         * Get the fixed ordering that is applied to the table. If there is more than one table in the API's context,
+         * the ordering of the first table will be returned only (use table() if you require the ordering of a different table in the API's context).
+         */
+        fixed(): ObjectOrderFixed;
+        /**
+         * Set the table's fixed ordering. Note this doesn't actually perform the order, but rather queues it up - use draw() to perform the ordering.
+         */
+        fixed(order: ObjectOrderFixed): Api;
 
         /**
          * Add an ordering listener to an element, for a given column.
@@ -1086,6 +1099,14 @@ declare namespace DataTables {
         isDataTable(table: string): boolean;
 
         /**
+         * Helpers for `columns.render`.
+         *
+         * The options defined here can be used with the `columns.render` initialisation
+         * option to provide a display renderer.
+         */
+        render: StaticRenderFunctions;
+
+        /**
          * Get all DataTable tables that have been initialised - optionally you can select to get only currently visible tables and / or retrieve the tables as API instances.
          *
          * @param visible As a boolean value this options is used to indicate if you want all tables on the page should be returned (false), or visible tables only (true).
@@ -1123,6 +1144,42 @@ declare namespace DataTables {
          * Default Settings
          */
         ext: ExtSettings;
+    }
+
+    interface ObjectColumnRender {
+        display(d?: number | string | object): string | object;
+    }
+
+    interface ObjectOrderFixed {
+        /**
+         * Two-element array:
+         * 0: Column index to order upon.
+         * 1: Direction so order to apply ("asc" for ascending order or "desc" for descending order).
+         */
+        pre?: any[];
+        /**
+         * Two-element array:
+         * 0: Column index to order upon.
+         * 1: Direction so order to apply ("asc" for ascending order or "desc" for descending order).
+         */
+        post?: any[];
+    }
+
+    interface StaticRenderFunctions {
+        /**
+         * Will format numeric data (defined by `columns.data`) for display, retaining the original unformatted data for sorting and filtering.
+         *
+         * @param thousands Thousands grouping separator.
+         * @param decimal Decimal point indicator.
+         * @param precision Integer number of decimal points to show.
+         * @param prefix Prefix (optional).
+         * @param postfix Postfix (/suffix) (optional).
+         */
+        number(thousands: string, decimal: string, precision: number, prefix?: string, postfix?: string): ObjectColumnRender;
+        /**
+         * Escape HTML to help prevent XSS attacks. It has no optional parameters.
+         */
+        text(): ObjectColumnRender;
     }
 
     interface StaticUtilFunctions {
@@ -1564,6 +1621,15 @@ declare namespace DataTables {
         orderDataType?: string;
 
         /**
+         * Ordering to always be applied to the table. Since 1.10
+         *
+         * Array type is prefix ordering only and is a two-element array:
+         * 0: Column index to order upon.
+         * 1: Direction so order to apply ("asc" for ascending order or "desc" for descending order).
+         */
+        orderFixed?: any[] | ObjectOrderFixed;
+
+        /**
          * Order direction application sequence. Since: 1.10
          */
         orderSequence?: string[];
@@ -1571,7 +1637,7 @@ declare namespace DataTables {
         /**
          * Render (process) the data for use in the table. Since: 1.10
          */
-        render?: number | string | ObjectColumnData | FunctionColumnRender;
+        render?: number | string | ObjectColumnData | FunctionColumnRender | ObjectColumnRender;
 
         /**
          * Enable or disable filtering on the data in this column. Since: 1.10
@@ -1727,6 +1793,7 @@ declare namespace DataTables {
     interface LanguageAriaSettings {
         sortAscending: string;
         sortDescending: string;
+        paginate?: LanguagePaginateSettings;
     }
 
     //#endregion "language-settings"


### PR DESCRIPTION
Release Notes: https://cdn.datatables.net/1.10.10/

* Created a type for static column render functions.
* Implemented $.fn.dataTable.render.text per release notes.
* Implemented language.aria.paginate per release notes.
* Added test/sample for handling column-visibility event with new parameter.
* Implemented order.fixed() method per release notes.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
