### PR TITLE
fix @types/puppeteer $eval type error

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -667,7 +667,7 @@ export interface FrameBase {
    */
   $eval(
     selector: string,
-    fn: (ele: ElementHandle | null, ...args: any[]) => any,
+    fn: (element: ElementHandle | null, ...args: any[]) => any,
     ...args: any[]
   ): Promise<any>;
 
@@ -681,7 +681,7 @@ export interface FrameBase {
    */
   $$eval(
     selector: string,
-    fn: (eles: ElementHandle[], ...args: any[]) => any,
+    fn: (elements: ElementHandle[], ...args: any[]) => any,
     ...args: any[]
   ): Promise<any>;
 

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -667,7 +667,8 @@ export interface FrameBase {
    */
   $eval(
     selector: string,
-    fn: (...args: any[]) => void
+    fn: (ele: ElementHandle | null, ...args: any[]) => any,
+    ...args: any[]
   ): Promise<any>;
 
   /**
@@ -680,7 +681,7 @@ export interface FrameBase {
    */
   $$eval(
     selector: string,
-    fn: (...args: any[]) => void,
+    fn: (eles: ElementHandle[], ...args: any[]) => any,
     ...args: any[]
   ): Promise<any>;
 


### PR DESCRIPTION
Hi, According to [the document of puppeteer](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageevalselector-pagefunction-args), the type of $eval's second parameter should be `(ele: ElementHandle | null, ...args: any[]) => any`. I fix it.

Thanks.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageevalselector-pagefunction-args
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
