### PR TITLE
fixed type of drawerLabel prop

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -349,7 +349,8 @@ export interface NavigationDrawerScreenOptions extends NavigationScreenOptions {
       any
     > | null));
   drawerLabel?:
-    React.ReactElement<any>
+    string
+    | React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
       any
     > | null));


### PR DESCRIPTION
according to the docs and my own test 'string' is also allowed as a type for drawerLabel