### PR TITLE
Add missing exports for type-is

### DIFF
--- a/types/type-is/index.d.ts
+++ b/types/type-is/index.d.ts
@@ -13,7 +13,9 @@ declare function typeIs(request: IncomingMessage, types: string[]): string | fal
 declare function typeIs(request: IncomingMessage, ...types: string[]): string | false | null;
 
 declare namespace typeIs {
+    function normalize (type: string): string | false;
     function hasBody(request: IncomingMessage): boolean;
     function is(mediaType: string, types: string[]): string | false;
     function is(mediaType: string, ...types: string[]): string | false;
+    function mimeMatch (expected: false | string, actual: string): boolean;
 }

--- a/types/type-is/index.d.ts
+++ b/types/type-is/index.d.ts
@@ -13,9 +13,9 @@ declare function typeIs(request: IncomingMessage, types: string[]): string | fal
 declare function typeIs(request: IncomingMessage, ...types: string[]): string | false | null;
 
 declare namespace typeIs {
-    function normalize (type: string): string | false;
+    function normalize(type: string): string | false;
     function hasBody(request: IncomingMessage): boolean;
     function is(mediaType: string, types: string[]): string | false;
     function is(mediaType: string, ...types: string[]): string | false;
-    function mimeMatch (expected: false | string, actual: string): boolean;
+    function mimeMatch(expected: false | string, actual: string): boolean;
 }


### PR DESCRIPTION
Add the missing `normalize` and `match` functions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
