### PR TITLE
[ember-data] add ajax and ajaxOptions to RESTAdapter

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -1033,6 +1033,14 @@ declare namespace DS {
    */
   class RESTAdapter extends Adapter implements BuildURLMixin {
     /**
+     * Takes a URL, an HTTP method and a hash of data, and makes an HTTP request.
+     */
+    ajax(url: string, type: string, options: object): Promise<any>;
+    /**
+     * Generate ajax options
+     */
+    ajaxOptions(url: string, type: string, options: object): object;
+    /**
      * By default, the RESTAdapter will send the query params sorted alphabetically to the
      * server.
      */

--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -1035,11 +1035,11 @@ declare namespace DS {
     /**
      * Takes a URL, an HTTP method and a hash of data, and makes an HTTP request.
      */
-    ajax(url: string, type: string, options: object): Promise<any>;
+    ajax(url: string, type: string, options?: object): Promise<any>;
     /**
      * Generate ajax options
      */
-    ajaxOptions(url: string, type: string, options: object): object;
+    ajaxOptions(url: string, type: string, options?: object): object;
     /**
      * By default, the RESTAdapter will send the query params sorted alphabetically to the
      * server.

--- a/types/ember-data/test/adapter.ts
+++ b/types/ember-data/test/adapter.ts
@@ -44,3 +44,13 @@ const UseAjaxOptions = DS.JSONAPIAdapter.extend({
         });
     }
 });
+
+const UseAjaxOptionsWithOptionalThirdParams = DS.JSONAPIAdapter.extend({
+    query(store: DS.Store, type: string, query: object) {
+        const url = 'https://api.example.com/my-api';
+        const options = this.ajaxOptions(url, 'DELETE');
+        return Ember.$.ajax(url, {
+            ...options
+        });
+    }
+});

--- a/types/ember-data/test/adapter.ts
+++ b/types/ember-data/test/adapter.ts
@@ -23,3 +23,24 @@ const AuthTokenHeader = DS.JSONAPIAdapter.extend({
         };
     })
 });
+
+const UseAjax = DS.JSONAPIAdapter.extend({
+    query(store: DS.Store, type: string, query: object) {
+        const url = 'https://api.example.com/my-api';
+        return this.ajax(url, 'POST', {
+            param: 'foo'
+        });
+    }
+});
+
+const UseAjaxOptions = DS.JSONAPIAdapter.extend({
+    query(store: DS.Store, type: string, query: object) {
+        const url = 'https://api.example.com/my-api';
+        const options = this.ajaxOptions(url, 'DELETE', {
+            foo: 'bar'
+        });
+        return Ember.$.ajax(url, {
+            ...options
+        });
+    }
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://emberjs.com/api/ember-data/2.16/classes/DS.RESTAdapter/methods/ajax?anchor=ajax&show=inherited%2Cprotected%2Cprivate>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
