### PR TITLE
fix the wrong type of owl.carousel

### DIFF
--- a/types/owl.carousel/index.d.ts
+++ b/types/owl.carousel/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for owl.carousel 2.2
+// Type definitions for owl.carousel 2.2.1
 // Project: https://github.com/OwlCarousel2/OwlCarousel2
 // Definitions by: Ismael Gorissen <https://github.com/igorissen>
+// Updated by: Kenneth Ceyer <https://github.com/KennethanCeyer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -36,8 +37,8 @@ declare namespace OwlCarousel {
         autoplay?: boolean;
         autoplayTimeout?: number;
         autoplayHoverPause?: boolean;
-        smartSpeed?: boolean;
-        fluidSpeed?: boolean;
+        smartSpeed?: number | boolean;
+        fluidSpeed?: number | boolean;
         autoplaySpeed?: number | boolean;
         navSpeed?: number | boolean;
         dotsSpeed?: number | boolean;

--- a/types/owl.carousel/index.d.ts
+++ b/types/owl.carousel/index.d.ts
@@ -1,7 +1,7 @@
-// Type definitions for owl.carousel 2.2.1
+// Type definitions for owl.carousel 2.2
 // Project: https://github.com/OwlCarousel2/OwlCarousel2
 // Definitions by: Ismael Gorissen <https://github.com/igorissen>
-// Updated by: Kenneth Ceyer <https://github.com/KennethanCeyer>
+//                 Kenneth Ceyer <https://github.com/KennethanCeyer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [owl carousel doc link](https://owlcarousel2.github.io/OwlCarousel2/docs/api-options.html)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.