### PR TITLE
[index.d.ts]: added declaration with package name

### DIFF
--- a/types/is/index.d.ts
+++ b/types/is/index.d.ts
@@ -1321,3 +1321,7 @@ declare var is: Is;
 declare module 'is' {
     export = is;
 }
+
+declare module 'is_js' {
+    export = is;
+}


### PR DESCRIPTION
Problem:
The package for this typed definition is titled 'is_js' on npm.com. Because of this, the definitions are not found unless package folder is renamed.

Solution:
By declaring additional block with the package's name, the types will be found without the need for a proxy declaration of renaming the package file.