### PR TITLE
Ref: @place_id --> wrong property "placeID" instead of "place_id" in GeocoderResult | @types/googlemaps

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1160,7 +1160,7 @@ declare namespace google.maps {
         bounds?: LatLngBounds|LatLngBoundsLiteral;
         componentRestrictions?: GeocoderComponentRestrictions;
         location?: LatLng|LatLngLiteral;
-        placeId?: string;
+        place_id?: string;
         region?: string;
     }
 


### PR DESCRIPTION
If i call a request (reverseGeocode) using the property placeID as GeocoderRequest i get this error --> `Error: failed: InvalidValueError: unexpected property "placeId"
    at Googlemaps.<anonymous>`

i just checked the [test](https://github.com/googlemaps/google-maps-services-js/blob/012e4435952fcea28338daec65d7c66911bdf998/spec/e2e/places-spec.js) of [@google/maps](https://www.npmjs.com/package/@google/maps) i can see that the `placeID` is written in the test as `place_id`.

If i run my code with the property `place_id` it will work fine!

However, this property is fine in `GeocoderResult` --->

```
export interface GeocoderResult {
        address_components: GeocoderAddressComponent[];
        formatted_address: string;
        geometry: GeocoderGeometry;
        partial_match: boolean;
        place_id: string;
        postcode_localities: string[];
        types: string[];
    }