### PR TITLE
Updating type definitions for nes >= 7.0.0 and hapi-auth-basic >= 5.0.0

### DIFF
--- a/types/hapi-auth-basic/hapi-auth-basic-tests.ts
+++ b/types/hapi-auth-basic/hapi-auth-basic-tests.ts
@@ -22,21 +22,22 @@ const users: {[index: string]: User} = {
     }
 };
 
-const validate: Basic.ValidateFunc = function (request, username, password, callback) {
+const validate: Basic.Validate = async (request, username, password, h) => {
 
     const user = users[username];
     if (!user) {
-        return callback(null, false);
+        return { isValid: false, credentials: null };
     }
 
-    Bcrypt.compare(password, user.password, (err, isValid) => {
+    let isValid = await Bcrypt.compare(password, user.password)
 
-        callback(err, isValid, { id: user.id, name: user.name });
-    });
+    return { isValid, credentials: { id: user.id, name: user.name } };
 };
 
-server.register(Basic, (err) => {
+server.register(Basic).then(() => {
 
-    server.auth.strategy('simple', 'basic', { validateFunc: validate });
+    server.auth.strategy('simple', 'basic', { validate });
+	server.auth.default('simple');
+
     server.route({ method: 'GET', path: '/', config: { auth: 'simple' } });
 });

--- a/types/hapi-auth-basic/index.d.ts
+++ b/types/hapi-auth-basic/index.d.ts
@@ -1,18 +1,24 @@
-// Type definitions for hapi 4.2
+// Type definitions for hapi-bauth-basic 5.0.0
 // Project: https://github.com/hapijs/hapi-auth-basic
 // Definitions by: AJP <https://github.com/AJamesPhillips>
+//                 Rodrigo Saboya <https://github.com/saboya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
 import * as Hapi from 'hapi';
 
 declare namespace Basic {
-    interface ValidateFuncCallback {
-        (err: Error | null, isValid: boolean, userCredentials?: any): void;
+    interface ValidateCustomResponse {
+        response: any,
     }
 
-    interface ValidateFunc {
-        (request: Hapi.Request, username: string, password: string, callback: ValidateFuncCallback): void;
+    interface ValidateResponse {
+        isValid: boolean,
+        credentials?: any,
+    }
+
+    interface Validate {
+        (request: Hapi.Request, username: string, password: string, h: object): Promise<ValidateResponse | ValidateCustomResponse>;
     }
 }
 

--- a/types/nes/client.d.ts
+++ b/types/nes/client.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for nes 6.4.2
+// Type definitions for nes 7.0.0
 // Project: https://github.com/hapijs/nes
 // Definitions by: Ivo Stratev <https://github.com/NoHomey>
+//                 Rodrigo Saboya <https://github.com/saboya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare class Client {
@@ -9,14 +10,14 @@ declare class Client {
     onConnect: () => void;
     onDisconnect: () => void;
     onUpdate: (message: any) => void;
-    connect(options: Client.ClientConnectOptions, callback: (err?: any) => void): void;
-    connect(callback: (err?: any) => void): void;
-    disconnect(): void;
+    connect(options: Client.ClientConnectOptions): Promise<any>;
+    connect(): Promise<any>;
+    disconnect(): Promise<any>;
     id: any;  // can be `null | number` but also the "socket" value from websocket message data.
-    request(options: string | Client.ClientRequestOptions, callback: (err: any, payload: any, statusCode?: number, headers?: Object) => void): void;
-    message(message: any, callback: (err: any, message: any) => void): void;
-    subscribe(path: string, handler: Client.Handler, callback: (err?: any) => void): void;
-    unsubscribe(path: string, handler: Client.Handler, callback: (err?: any) => void): void;
+    request(options: string | Client.ClientRequestOptions): Promise<any>;
+    message(message: any): Promise<any>;
+    subscribe(path: string, handler: Client.Handler): Promise<any>;
+    unsubscribe(path: string, handler: Client.Handler): Promise<any>;
     subscriptions(): string[];
     overrideReconnectionAuth(auth: any): void;
 }

--- a/types/nes/index.d.ts
+++ b/types/nes/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for nes 6.2.1
+// Type definitions for nes 7.0.0
 // Project: https://github.com/hapijs/nes
 // Definitions by: Ivo Stratev <https://github.com/NoHomey>
+//                 Rodrigo Saboya <https://github.com/saboya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -62,12 +63,12 @@ declare module nes {
         index?: boolean;
     }
 
-    export type ServerOnSubscribeWithParams = (socket: Socket, path: string, params: any, next: (err?: any) => void) => void;
-    export type ServerOnSubscribeWithoutParams = (socket: Socket, path: string, next: (err?: any) => void) => void;
+    export type ServerOnSubscribeWithParams = (socket: Socket, path: string, params: any) => Promise<any>;
+    export type ServerOnSubscribeWithoutParams = (socket: Socket, path: string) => Promise<any>;
     export type ServerOnSubscribe = ServerOnSubscribeWithParams | ServerOnSubscribeWithoutParams;
 
-    export type ServerOnUnSubscribeWithParams = (socket: Socket, path: string, params: any, next: () => void) => void;
-    export type ServerOnUnSubscribeWithoutParams = (socket: Socket, path: string, next: () => void) => void;
+    export type ServerOnUnSubscribeWithParams = (socket: Socket, path: string, params: any) => void;
+    export type ServerOnUnSubscribeWithoutParams = (socket: Socket, path: string) => void;
     export type ServerOnUnSubscribe = ServerOnUnSubscribeWithParams | ServerOnUnSubscribeWithoutParams;
 
     interface ServerSubscriptionOptions {
@@ -91,10 +92,10 @@ declare module nes {
         id: string;
         app: Object;
         auth: nes.SocketAuthObject;
-        disconnect(callback?: () => void): void;
-        send(message: any, callback?: (err?: any) => void): void;
-        publish(path: string, message: any, callback?: (err?: any) => void): void;
-        revoke(path: string, message: any, callback?: (err?: any) => void): void;
+        disconnect(): Promise<any>;
+        send(message: any): Promise<any>;
+        publish(path: string, message: any): Promise<any>;
+        revoke(path: string, message: any): Promise<any>;
     }
 
     /**

--- a/types/nes/test/broadcast-client.ts
+++ b/types/nes/test/broadcast-client.ts
@@ -3,7 +3,7 @@
 import Nes = require('nes');
 
 var client = new Nes.Client('ws://localhost');
-client.connect(function (err) {
+client.connect().then(() => {
 
     client.onUpdate = function (update) {
 
@@ -16,7 +16,7 @@ client.connect(function (err) {
 import NesClient = require('nes/client');
 
 var client = new NesClient('ws://localhost');
-client.connect(function (err) {
+client.connect().then(() => {
 
     client.onUpdate = function (update) {
 

--- a/types/nes/test/broadcast-server.ts
+++ b/types/nes/test/broadcast-server.ts
@@ -4,11 +4,10 @@ import Hapi = require('hapi');
 import Nes = require('nes');
 
 var server = new Hapi.Server();
-server.connection();
 
-server.register(Nes, function (err) {
+server.register(Nes).then(() => {
 
-    server.start(function (err) {
+    return server.start().then(() => {
 
         server.broadcast('welcome!');
     });

--- a/types/nes/test/nes-tests.ts
+++ b/types/nes/test/nes-tests.ts
@@ -2,66 +2,55 @@ import Hapi = require('hapi');
 import Nes = require('nes');
 
 var server: Hapi.Server = new Hapi.Server();
-server.connection({port: 8080});
 
-server.register(Nes, (regErr) => {
-    if(regErr) {
-        console.log('register err');
-        console.log(regErr);
-    } else {
-        // No longer need to cast to Nes.Server as Hapi.Server has been modified directly.
-        // let wsServer: Nes.Server = server as Nes.Server;
-        let wsServer: Hapi.Server = server;
-        wsServer.subscription('/item/{id}');
-        wsServer.route( {
-            method: 'GET',
-            path: '/test',
-            config: {
-                handler: (request, reply) => {
-                    reply({test: 'passes ' + request.socket.id});
-                }
+server.register(Nes).then(() => {
+    // No longer need to cast to Nes.Server as Hapi.Server has been modified directly.
+    // let wsServer: Nes.Server = server as Nes.Server;
+    let wsServer: Hapi.Server = server;
+    wsServer.subscription('/item/{id}');
+    wsServer.route( {
+        method: 'GET',
+        path: '/test',
+        config: {
+            handler: (request, h) => {
+                return {test: 'passes ' + request.socket.id};
             }
-        });
-        wsServer.start((err: any) => {
-            if(err) {
-                console.log('start err');
-                console.log(err);
-            } else {
-                setTimeout(() => {
-                    wsServer.publish('/item/5', { id: 5, status: 'complete' });
-                    wsServer.publish('/item/6', { id: 6, status: 'initial' });
-                }, 100);
-            }
-        });
-    }
+        }
+    });
+    wsServer.start().then(() => {
+        setTimeout(() => {
+            wsServer.publish('/item/5', { id: 5, status: 'complete' });
+            wsServer.publish('/item/6', { id: 6, status: 'initial' });
+        }, 100);
+    }).catch((err) => {
+        console.log('start err');
+        console.log(err);
+    });
+}).catch((regErr: any) => {
+    console.log('register err');
+    console.log(regErr);
 });
 
 let options: Nes.ClientConnectOptions = {delay: 3};
 
-let wsClient: Nes.Client = new Nes.Client('ws://localhost:8080', options);
-wsClient.connect((err: any) => {
-    if(err) {
-        console.log('start err');
-        console.log(err);
-    } else {
-        wsClient.subscribe('/item/5', (update) => {
-            wsClient.request('/test', (reqErr, payload, statusCode) => {
-                if(reqErr) {
-                    console.log('request err');
-                    console.log(reqErr);
-                } else {
-                    console.log(update);
-                    console.log(payload);
-                    if(payload.test === 'passes') {
-                        process.exit(0);
-                    }
-                }
-            })
-        }, (subErr) => {
-            if(subErr) {
-                console.log('subscribe err');
-                console.log(subErr);
+let wsClient: Nes.Client = new Nes.Client('ws://localhost', options);
+wsClient.connect().then(() => {
+    wsClient.subscribe('/item/5', (update) => {
+        wsClient.request('/test').then(({ payload, statusCode }) => {
+            console.log(update);
+            console.log(payload);
+            if(payload.test === 'passes') {
+                process.exit(0);
             }
-        });
-    }
+        }).catch((reqErr: any) => {
+            console.log('request err');
+            console.log(reqErr);
+        })
+    }).catch((subErr: any) => {
+        console.log('subscribe err');
+        console.log(subErr);
+    });
+}).catch((err: any) => {
+    console.log('start err');
+    console.log(err);
 });

--- a/types/nes/test/route-authentication-client.ts
+++ b/types/nes/test/route-authentication-client.ts
@@ -3,12 +3,9 @@
 import Nes = require('nes');
 
 var client = new Nes.Client('ws://localhost');
-client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }, function (err) {
+client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }).then(() => {
 
-    client.request('hello', function (err, payload) {   // Can also request '/h'
-
-        // payload -> 'Hello John Doe'
-    });
+    client.request('hello');
 });
 
 // Added in addition to nes doc example code
@@ -16,10 +13,7 @@ client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } 
 import NesClient = require('nes/client');
 
 var client = new NesClient('ws://localhost');
-client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }, function (err) {
+client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }).then(() => {
 
-    client.request('hello', function (err, payload) {   // Can also request '/h'
-
-        // payload -> 'Hello John Doe'
-    });
+    return client.request('hello');
 });

--- a/types/nes/test/route-invocation-client.ts
+++ b/types/nes/test/route-invocation-client.ts
@@ -3,12 +3,9 @@
 import Nes = require('nes');
 
 var client = new Nes.Client('ws://localhost');
-client.connect(function (err) {
+client.connect().then(() => {
 
-    client.request('hello', function (err, payload) {   // Can also request '/h'
-
-        // payload -> 'world!'
-    });
+    return client.request('hello');
 });
 
 // Added in addition to nes doc example code
@@ -16,10 +13,7 @@ client.connect(function (err) {
 import NesClient = require('nes/client');
 
 var client = new NesClient('ws://localhost');
-client.connect(function (err) {
+client.connect().then(() => {
 
-    client.request('hello', function (err, payload) {   // Can also request '/h'
-
-        // payload -> 'world!'
-    });
+    return client.request('hello');
 });

--- a/types/nes/test/route-invocation-server.ts
+++ b/types/nes/test/route-invocation-server.ts
@@ -4,21 +4,20 @@ import Hapi = require('hapi');
 import Nes = require('nes');
 
 var server = new Hapi.Server();
-server.connection();
 
-server.register(Nes, function (err) {
+server.register(Nes).then(() => {
 
     server.route({
         method: 'GET',
         path: '/h',
         config: {
             id: 'hello',
-            handler: function (request, reply) {
+            handler: (request, h) => {
 
-                return reply('world!');
+                return 'world!';
             }
         }
     });
 
-    server.start(function (err) { /* ... */ });
+    return server.start();
 });

--- a/types/nes/test/socket.ts
+++ b/types/nes/test/socket.ts
@@ -4,13 +4,11 @@ import Nes = require('nes');
 
 const socket: Nes.Socket = undefined;
 
-const cb = () => { };
-socket.disconnect(cb);
+socket.disconnect();
 const s: string = socket.id;
 const o: Object = socket.app;
 const auth: Nes.SocketAuthObject = socket.auth;
 
-const cb2 = (err?: any) => { };
-socket.send('message', (err?: any) => { });
-socket.publish('path', 'message', cb2);
-socket.revoke('path', 'message', cb2);
+socket.send('message');
+socket.publish('path', 'message');
+socket.revoke('path', 'message');

--- a/types/nes/test/subscription-filter-client.ts
+++ b/types/nes/test/subscription-filter-client.ts
@@ -6,15 +6,15 @@ var client = new Nes.Client('ws://localhost');
 
 // Authenticate as 'john'
 
-client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }, function (err) {
+client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }).then(() => {
 
-    var handler: Nes.Handler = function (err, update) {
+    var handler: Nes.Handler = (update) => {
 
         // First publish is not received (filtered due to updater key)
         // update -> { id: 6, status: 'initial', updater: 'steve' }
     };
 
-    client.subscribe('/items', handler, function (err) { });
+    return client.subscribe('/items', handler);
 });
 
 // Added in addition to nes doc example code
@@ -25,13 +25,13 @@ var client = new NesClient('ws://localhost');
 
 // Authenticate as 'john'
 
-client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }, function (err) {
+client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }).then(() => {
 
-    var handler: NesClient.Handler = function (err, update) {
+    var handler: NesClient.Handler = (update) => {
 
         // First publish is not received (filtered due to updater key)
         // update -> { id: 6, status: 'initial', updater: 'steve' }
     };
 
-    client.subscribe('/items', handler, function (err) { });
+    return client.subscribe('/items', handler);
 });

--- a/types/nes/test/subscriptions-client.ts
+++ b/types/nes/test/subscriptions-client.ts
@@ -3,15 +3,15 @@
 import Nes = require('nes');
 
 var client = new Nes.Client('ws://localhost');
-client.connect(function (err) {
+    client.connect().then(() => {;
 
-    var handler: Nes.Handler = function (update, flags) {
+    var handler: Nes.Handler = (update, flags) => {
 
         // update -> { id: 5, status: 'complete' }
         // Second publish is not received (doesn't match)
     };
 
-    client.subscribe('/item/5', handler, function (err) { });
+    return client.subscribe('/item/5', handler);
 });
 
 // Added in addition to nes doc example code
@@ -19,13 +19,13 @@ client.connect(function (err) {
 import NesClient = require('nes/client');
 
 var client = new NesClient('ws://localhost');
-client.connect(function (err) {
+client.connect().then(() => {
 
-    var handler: NesClient.Handler = function (update, flags) {
+    var handler: NesClient.Handler = (update, flags) => {
 
         // update -> { id: 5, status: 'complete' }
         // Second publish is not received (doesn't match)
     };
 
-    client.subscribe('/item/5', handler, function (err) { });
+    return client.subscribe('/item/5', handler);
 });

--- a/types/nes/test/subscriptions-server.ts
+++ b/types/nes/test/subscriptions-server.ts
@@ -4,15 +4,14 @@ import Hapi = require('hapi');
 import Nes = require('nes');
 
 var server = new Hapi.Server();
-server.connection();
 
-server.register(Nes, function (err) {
+server.register(Nes).then(() =>{;
 
     server.subscription('/item/{id}');
 
-    server.start(function (err) {
+    return server.start().then(() => {
 
-        server.publish('/item/5', { id: 5, status: 'complete' });
-        server.publish('/item/6', { id: 6, status: 'initial' });
+        server.publish('/item/5', {id: 5, status: 'complete'});
+        server.publish('/item/6', {id: 6, status: 'initial'});
     });
-});
+})


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/nes/commit/9b08d91b19b35d9c340a61605be025304603aa88
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

~Running tests on this PR by itself isn't possible because the tests won't run unless types for [hapi](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/hapi) and [hapi-auth-basic](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/hapi-auth-basic) are updated accordingly, which I'm currently unable to do so.~

~However I did test the changes I made to the code via another project that depends on the Nes.Client type definitions, which worked just fine.~

Updated hapi-auth-basic as well, don't know if it should fit a separate PR. Still depends on Hapi v17 definitions. Apparently there's some work going on here: https://github.com/rafaelsouzaf/DefinitelyTyped/pull/1

Tests pass nonetheless.