### PR TITLE
Fix klaw types

### DIFF
--- a/types/klaw/index.d.ts
+++ b/types/klaw/index.d.ts
@@ -30,7 +30,7 @@ declare module "klaw" {
 
         type Event = "close" | "data" | "end" | "readable" | "error"
 
-        interface Walker {
+        interface Walker extends Readable {
             on(event: Event, listener: Function): this
             on(event: "close", listener: () => void): this
             on(event: "data", listener: (item: Item) => void): this

--- a/types/klaw/index.d.ts
+++ b/types/klaw/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for klaw v2.1.0
+// Type definitions for klaw v2.1.1
 // Project: https://github.com/jprichardson/node-klaw
 // Definitions by: Matthew McEachen <https://github.com/mceachen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
`klaw.Walker` is an instance of `Readable`.
The declaration even imported `Readable` but never did anything with it, it might have been an oversight.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jprichardson/node-klaw/blob/master/src/index.js#L19
- [x] Increase the version number in the header if appropriate.