### PR TITLE
Expand gzip-size types for 4.1

### DIFF
--- a/types/gzip-size/gzip-size-tests.ts
+++ b/types/gzip-size/gzip-size-tests.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as gzipSize from 'gzip-size';
+import fs = require('fs');
+import gzipSize = require('gzip-size');
 
 const string = 'Lorem ipsum dolor sit amet.';
 

--- a/types/gzip-size/gzip-size-tests.ts
+++ b/types/gzip-size/gzip-size-tests.ts
@@ -1,7 +1,16 @@
-import gzipSize = require('gzip-size');
+import * as fs from 'fs';
+import * as gzipSize from 'gzip-size';
 
 const string = 'Lorem ipsum dolor sit amet.';
 
 console.log(string.length);
 
+gzipSize(string).then(size => console.log(size));
+
 console.log(gzipSize.sync(string));
+
+const stream = fs.createReadStream("index.d.ts");
+const gstream = stream.pipe(gzipSize.stream()).on("gzip-size", size => console.log(size));
+console.log(gstream.gzipSize); // Could be a number or undefined. Recommended to use "gzip-size" event instead
+
+gzipSize.file("index.d.ts").then(size => console.log(size));

--- a/types/gzip-size/index.d.ts
+++ b/types/gzip-size/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for gzip-size 4.0
+// Type definitions for gzip-size 4.1
 // Project: https://github.com/sindresorhus/gzip-size
 // Definitions by: York Yao <https://github.com/plantain-00>
 //                 Jimi van der Woning <https://github.com/jimivdw>
+//                 Andre Wiggins <https://github.com/andrewiggins>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -9,11 +10,45 @@
 import * as stream from 'stream';
 import * as zlib from 'zlib';
 
+interface GzipSizeStream extends stream.PassThrough {
+    on(event: string, listener: (...args: any[]) => void): this;
+    on(event: "gzip-size", listener: (size: number) => void): this;
+
+    /**
+     * Contains the gzip size of the stream after it is finished.
+     * Since this happens asynchronously, it is recommended you use
+     * the `.on("gzip-size", size => console.log(size))` method instead
+     */
+    gzipSize?: number;
+}
+
+/**
+ * Returns a Promise for the size.
+ * @param input A string or Buffer to determine the gzip size of
+ * @param options Any zlib option
+ */
 declare function gzipSize(input: string | Buffer, options?: zlib.ZlibOptions): Promise<number>;
 
 declare namespace gzipSize {
+    /**
+     * Returns the size synchronously
+     * @param input A string or Buffer to determine the gzip size of
+     * @param options Any zlib option
+     */
     function sync(input: string | Buffer, options?: zlib.ZlibOptions): number;
-    function stream(options?: zlib.ZlibOptions): stream.PassThrough;
+
+    /**
+     * Returns a stream.PassThrough. The stream emits a gzip-size event and has a gzipSize property.
+     * @param options Any zlib option
+     */
+    function stream(options?: zlib.ZlibOptions): GzipSizeStream;
+
+    /**
+     * Returns a Promise for the size of the file.
+     * @param path The path to the file
+     * @param options Any zlib option
+     */
+    function file(path: string, options?: zlib.ZlibOptions): Promise<number>;
 }
 
 export = gzipSize;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/gzip-size/blob/v4.1.0/index.js#L47
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.