### PR TITLE
Fixed Leaflet.LayerGroup constructor and Leaflet.MarkerCluster options.

### DIFF
--- a/types/leaflet.markercluster/index.d.ts
+++ b/types/leaflet.markercluster/index.d.ts
@@ -29,7 +29,7 @@ declare module 'leaflet' {
         getBounds(): LatLngBounds;
     }
 
-    interface MarkerClusterGroupOptions {
+    interface MarkerClusterGroupOptions extends LayerOptions {
         /*
         * When you mouse over a cluster it shows the bounds of its markers.
         */

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -734,7 +734,6 @@ export class LayerGroup<P = any> extends Layer {
     feature?: geojson.FeatureCollection<geojson.GeometryObject, P> | geojson.Feature<geojson.MultiPoint, P> | geojson.GeometryCollection;
 }
 
-// @factory L.layerGroup(layers?: Layer[], options?: Object)
 /**
  * Create a layer group, optionally given an initial set of layers and an `options` object.
  */
@@ -1138,7 +1137,6 @@ export interface PanOptions {
 }
 
 // This is not empty, it extends two interfaces into one...
-// tslint:disable-next-line
 export interface ZoomPanOptions extends ZoomOptions, PanOptions {}
 
 export interface FitBoundsOptions extends ZoomOptions, PanOptions {

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -241,20 +241,20 @@ export abstract class Evented extends Class {
      */
     on(eventMap: LeafletEventHandlerFnMap): this;
 
-    /* tslint:disable:unified-signatures */ // With an eventMap there are no additional arguments allowed
     /**
      * Removes a previously added listener function. If no function is specified,
      * it will remove all the listeners of that particular event from the object.
      * Note that if you passed a custom context to on, you must pass the same context
      * to off in order to remove the listener.
      */
+    // tslint:disable-next-line
     off(type: string, fn?: LeafletEventHandlerFn, context?: any): this;
 
     /**
      * Removes a set of type/listener pairs.
      */
+    // tslint:disable-next-line
     off(eventMap: LeafletEventHandlerFnMap): this;
-    /* tslint:enable */
     /**
      * Removes all listeners to all events on the object.
      */
@@ -668,8 +668,10 @@ export function canvas(options?: RendererOptions): Canvas;
  */
 export class LayerGroup<P = any> extends Layer {
     constructor(layers?: Layer[]);
+    // tslint:disable-next-line
     constructor(layers: Layer[], options?: LayerOptions);
     initialize(layers?: Layer[]): this;
+    // tslint:disable-next-line
     initialize(layers: Layer[], options?: LayerOptions): this;
 
     /**
@@ -737,6 +739,7 @@ export class LayerGroup<P = any> extends Layer {
  * Create a layer group, optionally given an initial set of layers and an `options` object.
  */
 export function layerGroup(layers?: Layer[]): LayerGroup;
+// tslint:disable-next-line
 export function layerGroup(layers: Layer[], options?: LayerOptions): LayerGroup;
 
 /**
@@ -1134,9 +1137,9 @@ export interface PanOptions {
     noMoveStart?: boolean;
 }
 
-/* tslint:disable:no-empty-interface */ // This is not empty, it extends two interfaces into one...
+// This is not empty, it extends two interfaces into one...
+// tslint:disable-next-line
 export interface ZoomPanOptions extends ZoomOptions, PanOptions {}
-/* tslint:enable */
 
 export interface FitBoundsOptions extends ZoomOptions, PanOptions {
     paddingTopLeft?: PointExpression;

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -670,7 +670,6 @@ export function canvas(options?: RendererOptions): Canvas;
  */
 export class LayerGroup<P = any> extends Layer {
     constructor(layers?: Layer[], options?: LayerOptions);
-    initialize(layers?: Layer[], options?: LayerOptions): this;
 
     /**
      * Returns a GeoJSON representation of the layer group (as a GeoJSON GeometryCollection, GeoJSONFeatureCollection or Multipoint).

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -667,12 +667,8 @@ export function canvas(options?: RendererOptions): Canvas;
  * added/removed on the map as well. Extends Layer.
  */
 export class LayerGroup<P = any> extends Layer {
-    constructor(layers?: Layer[]);
-    // tslint:disable-next-line
-    constructor(layers: Layer[], options?: LayerOptions);
-    initialize(layers?: Layer[]): this;
-    // tslint:disable-next-line
-    initialize(layers: Layer[], options?: LayerOptions): this;
+    constructor(layers?: Layer[], options?: LayerOptions);
+    initialize(layers?: Layer[], options?: LayerOptions): this;
 
     /**
      * Returns a GeoJSON representation of the layer group (as a GeoJSON GeometryCollection, GeoJSONFeatureCollection or Multipoint).
@@ -737,9 +733,7 @@ export class LayerGroup<P = any> extends Layer {
 /**
  * Create a layer group, optionally given an initial set of layers and an `options` object.
  */
-export function layerGroup(layers?: Layer[]): LayerGroup;
-// tslint:disable-next-line
-export function layerGroup(layers: Layer[], options?: LayerOptions): LayerGroup;
+export function layerGroup(layers?: Layer[], options?: LayerOptions): LayerGroup;
 
 /**
  * Extended LayerGroup that also has mouse events (propagated from

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -247,13 +247,15 @@ export abstract class Evented extends Class {
      * Note that if you passed a custom context to on, you must pass the same context
      * to off in order to remove the listener.
      */
-    // tslint:disable-next-line
+     // With an eventMap there are no additional arguments allowed
+    // tslint:disable-next-line:unified-signatures
     off(type: string, fn?: LeafletEventHandlerFn, context?: any): this;
 
     /**
      * Removes a set of type/listener pairs.
      */
-    // tslint:disable-next-line
+     // With an eventMap there are no additional arguments allowed
+    // tslint:disable-next-line:unified-signatures
     off(eventMap: LeafletEventHandlerFnMap): this;
     /**
      * Removes all listeners to all events on the object.

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -668,6 +668,10 @@ export function canvas(options?: RendererOptions): Canvas;
  */
 export class LayerGroup<P = any> extends Layer {
     constructor(layers?: Layer[]);
+    constructor(layers: Layer[], options?: LayerOptions);
+    initialize(layers?: Layer[]): this;
+    initialize(layers: Layer[], options?: LayerOptions): this;
+
     /**
      * Returns a GeoJSON representation of the layer group (as a GeoJSON GeometryCollection, GeoJSONFeatureCollection or Multipoint).
      */
@@ -728,10 +732,12 @@ export class LayerGroup<P = any> extends Layer {
     feature?: geojson.FeatureCollection<geojson.GeometryObject, P> | geojson.Feature<geojson.MultiPoint, P> | geojson.GeometryCollection;
 }
 
+// @factory L.layerGroup(layers?: Layer[], options?: Object)
 /**
- * Create a layer group, optionally given an initial set of layers.
+ * Create a layer group, optionally given an initial set of layers and an `options` object.
  */
-export function layerGroup(layers: Layer[]): LayerGroup;
+export function layerGroup(layers?: Layer[]): LayerGroup;
+export function layerGroup(layers: Layer[], options?: LayerOptions): LayerGroup;
 
 /**
  * Extended LayerGroup that also has mouse events (propagated from

--- a/types/leaflet/leaflet-tests.ts
+++ b/types/leaflet/leaflet-tests.ts
@@ -496,3 +496,17 @@ interface MyProperties {
 		iconUrl: 'my-icon.png'
 	})
 }) as L.Marker<MyProperties>).feature.properties.testProperty = "test";
+
+let lg = L.layerGroup();
+lg = L.layerGroup([new L.Layer(), new L.Layer()]);
+lg = L.layerGroup([new L.Layer(), new L.Layer()], {
+	pane: 'overlayPane',
+	attribution: 'test'
+});
+
+lg = new L.LayerGroup();
+lg = new L.LayerGroup([new L.Layer(), new L.Layer()]);
+lg = new L.LayerGroup([new L.Layer(), new L.Layer()], {
+	pane: 'overlayPane',
+	attribution: 'test'
+});


### PR DESCRIPTION
* Added function overrides for constructing LayerGroup to allow options object to be passed through and for layers to be optional.
* Updated MarkerClusterGroupOptions to extend LayerOptions to ensure LayerOptions can be set for Leaflet.MarkerCluster.

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes;
* https://github.com/Leaflet/Leaflet/blob/master/src/layer/LayerGroup.js
* https://github.com/Leaflet/Leaflet.markercluster

