### PR TITLE
Fix typing for react-redux Options to pass State correctly

### DIFF
--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -273,6 +273,30 @@ namespace MapStateAndOptions {
     const verify = <Test foo='bar' />
 }
 
+namespace AreStatesEqual {
+    interface State { stuff: string; }
+    interface OwnProps { foo: string }
+    interface StateProps { bar: number }
+    interface DispatchProps { dispatch: Dispatch<any> }
+
+    class TestComponent extends Component<OwnProps & StateProps & DispatchProps> {}
+
+    const mapStateToProps = (state: State) => ({
+        bar: 1
+    })
+
+    const Test = connect(
+        mapStateToProps,
+        null,
+        null,
+        {
+            areStatesEqual: (state: State, previousState: State) => state === previousState
+        }
+    )(TestComponent)
+
+    const verify = <Test foo='bar' />
+}
+
 interface CounterState {
     counter: number;
 }


### PR DESCRIPTION
This change fixes a bug in consumption of the `Options<>` type within the `react-redux` typings.
The overloads for `connect` were not correctly passing the generic for `State` as the first generic for `Options<>`, causing `State` to be treated as `TStateProps` and `TStateProps` to be treated as `TOwnProps`. This prevented the `areStatesEqual` option from being used since it would have no overlap with any of the `Props` types.

*Update:* This change now only adds a unit test to `react-redux` to enforce the typings for `Options`.

Issue #18951 has the context for this change.