### PR TITLE
[react-router] Remove useless definition for `withRouter` as decorator

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -104,11 +104,9 @@ export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P i
 export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
 export function matchPath<P>(pathname: string, props: RouteProps): match<P> | null;
-export function withRouter<P extends RouteComponentProps<any>>(component: React.ComponentType<P>): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>>>;
 
-// decorator signature
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @withRouter decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
-export function withRouter<P, TFunction extends React.ComponentClass<P>>(target: TFunction): TFunction;
+export function withRouter<P extends RouteComponentProps<any>>(component: React.ComponentType<P>): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>>>;

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -2,13 +2,23 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 interface TOwnProps extends RouteComponentProps<{}> {
-  username: string;
+    username: string;
 }
 
-const Component = (props: TOwnProps) => <h2>Welcome {props.username}</h2>;
+const ComponentFunction = (props: TOwnProps) => (
+    <h2>Welcome {props.username}</h2>
+);
 
-const WithRouterComponent = withRouter(Component);
+class ComponentClass extends React.Component<TOwnProps> {
+    render() {
+        return <h2>Welcome {this.props.username}</h2>;
+    }
+}
 
-const WithRouterTest = () => (<WithRouterComponent username="John" />);
+const WithRouterComponentFunction = withRouter(ComponentFunction);
+const WithRouterComponentClass = withRouter(ComponentClass);
 
-export default WithRouterTest;
+const WithRouterTestFunction = () => (
+    <WithRouterComponentFunction username="John" />
+);
+const WithRouterTestClass = () => <WithRouterComponentClass username="John" />;


### PR DESCRIPTION
This useless definition creates conflicts.
It was used for class components instead of the new one definition.