### PR TITLE
[d3-geo] Remove crs from Extended GeoJSON feature

### DIFF
--- a/types/d3-geo/index.d.ts
+++ b/types/d3-geo/index.d.ts
@@ -36,7 +36,6 @@ export type GeoGeometryObjects = GeoJSON.GeometryObject | GeoSphere;
 export interface ExtendedGeometryCollection<GeometryType extends GeoGeometryObjects> {
     type: string;
     bbox?: number[];
-    crs?: GeoJSON.CoordinateReferenceSystem;
     geometries: GeometryType[];
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://tools.ietf.org/html/rfc7946#section-4
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

According to the [RFC section 4](https://tools.ietf.org/html/rfc7946#section-4) of the GeoJSON specification @JeffJacobson apply the changes to the GeoJSON type definition in PR #21590.

In #21794 the change of removing the `CoordinateReferenceSystem` interface was mentioned as a fault, but it is not. In addition I can not find [any hint](https://github.com/d3/d3-geo/search?utf8=%E2%9C%93&q=crs&type=) that `d3-geo` implements a `crs` property on its own. As result I removed the `crs` property in `d3-geo` to have no conflicts anymore.

---

Closes #21794 