### PR TITLE
Parameter in callback should not be optionnal

### DIFF
--- a/types/agenda/index.d.ts
+++ b/types/agenda/index.d.ts
@@ -113,8 +113,8 @@ declare class Agenda extends EventEmitter {
      * @param options The options for the job.
      * @param handler The handler to execute.
      */
-    define(name: string, handler: (job?: Agenda.Job, done?: (err?: Error) => void) => void): void;
-    define(name: string, options: Agenda.JobOptions, handler: (job?: Agenda.Job, done?: (err?: Error) => void) => void): void;
+    define(name: string, handler: (job: Agenda.Job, done: (err?: Error) => void) => void): void;
+    define(name: string, options: Agenda.JobOptions, handler: (job: Agenda.Job, done: (err?: Error) => void) => void): void;
 
     /**
      * Runs job name at the given interval. Optionally, data and options can be passed in.


### PR DESCRIPTION
Using `?` in this situation would mean that you may, *or may not*, pass the `done` parameter to the callback. It does not mean that the callback can use it or not. You probably always pass the `done` parameter to the callback.

See https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#optional-parameters-in-callbacks

Having `?` here is annoying for the caller when they use --strictNullChecks because they have to use `!` (the non-null assertion) whenever they use `done` to tell the compiler that it actually will never be null.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#optional-parameters-in-callbacks
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.