### PR TITLE
[d3-geo] URGENT PATCH (Broken Definition) `geojson` dependency to 1.0.6

### DIFF
--- a/types/d3-geo/index.d.ts
+++ b/types/d3-geo/index.d.ts
@@ -36,7 +36,10 @@ export type GeoGeometryObjects = GeoJSON.GeometryObject | GeoSphere;
 export interface ExtendedGeometryCollection<GeometryType extends GeoGeometryObjects> {
     type: string;
     bbox?: number[];
-    crs?: GeoJSON.CoordinateReferenceSystem;
+    crs?: {
+        type: string;
+        properties: any;
+    };
     geometries: GeometryType[];
 }
 

--- a/types/d3-geo/package.json
+++ b/types/d3-geo/package.json
@@ -1,3 +1,4 @@
 {
+    "private": true,
     "dependencies": { "@types/geojson": "1.0.6" }
 }

--- a/types/d3-geo/package.json
+++ b/types/d3-geo/package.json
@@ -1,4 +1,0 @@
-{
-    "private": true,
-    "dependencies": { "@types/geojson": "1.0.6" }
-}

--- a/types/d3-geo/package.json
+++ b/types/d3-geo/package.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": { "@types/geojson": "1.0.6" }
+}


### PR DESCRIPTION
IMMEDIATE ATTENTION REQUIRED.

The latest version of the `geojson` definitions breaks  **d3-geo**. Multiple builds have already been affected.

Pin to the last working version for now until more thorough change impact assessment is complete.

Takes precedence over PR #21801 and PR #21806

Addresses breaking change introduced through PR #21590 until more comprehensive change impact assessment of removing `CoordinateReferenceSystem` is completed.

@gustavderdrache or @Ledragon Please review asap
cc @atd-schubert @j4ys0n

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

EDIT: Added missing PR cross-reference.