### PR TITLE
Add ansi-regex package

### DIFF
--- a/types/ansi-regex/ansi-regex-tests.ts
+++ b/types/ansi-regex/ansi-regex-tests.ts
@@ -1,0 +1,13 @@
+import ansiRegex = require("ansi-regex");
+
+ansiRegex(); // $ExpectType RegExp
+
+// From the ansi-regex README.md
+ansiRegex().test('\u001B[4mcake\u001B[0m'); // $ExpectType boolean
+// => true
+
+ansiRegex().test('cake'); // $ExpectType boolean
+// => false
+
+'\u001B[4mcake\u001B[0m'.match(ansiRegex()); // $ExpectType RegExpMatchArray | null
+// => ['\u001B[4m', '\u001B[0m']

--- a/types/ansi-regex/index.d.ts
+++ b/types/ansi-regex/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for ansi-regex 3.0
+// Project: https://github.com/chalk/ansi-regex#readme
+// Definitions by: Manish Vachharajani <https://github.com/mvachhar>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function r(): RegExp;
+export = r;

--- a/types/ansi-regex/tsconfig.json
+++ b/types/ansi-regex/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+	"strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "ansi-regex-tests.ts"
+    ]
+}

--- a/types/ansi-regex/tslint.json
+++ b/types/ansi-regex/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
I tried to get this added to the package but the maintainer does not use typescript and would rather not maintain the types file.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

