### PR TITLE
@types/siema : Trying to address missing configuration options in the definition file interfaces

### DIFF
--- a/types/siema/index.d.ts
+++ b/types/siema/index.d.ts
@@ -22,7 +22,7 @@ interface perPageInterface {
 }
 
 interface SiemaOptions {
-    selector?: string;
+    selector?: string | HTMLElement;
     duration?: number;
     easing?: string;
     perPage?: number | perPageInterface;

--- a/types/siema/index.d.ts
+++ b/types/siema/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for siema 1.4
 // Project: https://github.com/pawelgrzybek/siema
 // Definitions by: Irmantas Zenkus <https://github.com/Irmiz>
+//                 Sam Nau <https://github.com/samnau>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 declare class Siema {
     currentSlide: number;

--- a/types/siema/index.d.ts
+++ b/types/siema/index.d.ts
@@ -17,17 +17,21 @@ declare class Siema {
     destroy(restoreMarkup: boolean, callback?: () => void): void;
 }
 
+interface perPageInterface {
+  [key : number] : number;
+}
+
 interface SiemaOptions {
     selector?: string;
     duration?: number;
     easing?: string;
-    perPage?: number;
+    perPage?: number | perPageInterface;
     startIndex?: number;
     draggable?: boolean;
     multipleDrag?: boolean;
     threshold?: number;
     loop?: boolean;
-    onInit(): void;
+    onInit?(): void;
     onChange?(): void;
 }
 

--- a/types/siema/index.d.ts
+++ b/types/siema/index.d.ts
@@ -18,7 +18,7 @@ declare class Siema {
 }
 
 interface perPageInterface {
-  [key : number] : number;
+  [key: number]: number;
 }
 
 interface SiemaOptions {

--- a/types/siema/tsconfig.json
+++ b/types/siema/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
**Trying to address missing configuration options in the definition file interfaces**

* changed `onInit` to optional so that standard javascript objects could be used for Siema configration without having `onInit` defined
* According to the Siema documentation, `perPage` can be either a number or a object with breakpoint values as keys and number of slides as values:
    * <https://github.com/pawelgrzybek/siema>
    * <https://codepen.io/pawelgrzybek/pen/dWbGyZ>
    * added a new interface to accommodate the other type of configuration
