### PR TITLE
lodash: fix partition, pick, and iteratee functions like trim

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -6263,7 +6263,7 @@ declare namespace _ {
         partition<T>(
             collection: List<T> | null | undefined,
             callback: ValueIteratee<T>
-        ): T[][];
+        ): [T[], T[]];
 
         /**
          * @see _.partition
@@ -6271,7 +6271,7 @@ declare namespace _ {
         partition<T extends object>(
             collection: T | null | undefined,
             callback: ValueIteratee<T[keyof T]>
-        ): Array<Array<T[keyof T]>>;
+        ): [Array<T[keyof T]>, Array<T[keyof T]>];
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -6281,7 +6281,7 @@ declare namespace _ {
         partition<T>(
             this: LoDashImplicitWrapper<List<T> | null | undefined>,
             callback: ValueIteratee<T>
-        ): LoDashImplicitWrapper<T[][]>;
+        ): LoDashImplicitWrapper<[T[], T[]]>;
 
         /**
          * @see _.partition
@@ -6289,7 +6289,7 @@ declare namespace _ {
         partition<T>(
             this: LoDashImplicitWrapper<T | null | undefined>,
             callback: ValueIteratee<T[keyof T]>
-        ): LoDashImplicitWrapper<Array<Array<T[keyof T]>>>;
+        ): LoDashImplicitWrapper<[Array<T[keyof T]>, Array<T[keyof T]>]>;
     }
 
     interface LoDashExplicitWrapper<TValue> {
@@ -6299,7 +6299,7 @@ declare namespace _ {
         partition<T>(
             this: LoDashExplicitWrapper<List<T> | null | undefined>,
             callback: ValueIteratee<T>
-        ): LoDashExplicitWrapper<T[][]>;
+        ): LoDashExplicitWrapper<[T[], T[]]>;
 
         /**
          * @see _.partition
@@ -6307,7 +6307,7 @@ declare namespace _ {
         partition<T>(
             this: LoDashExplicitWrapper<T | null | undefined>,
             callback: ValueIteratee<T[keyof T]>
-        ): LoDashExplicitWrapper<Array<Array<T[keyof T]>>>;
+        ): LoDashExplicitWrapper<[Array<T[keyof T]>, Array<T[keyof T]>]>;
     }
 
     //_.reduce

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -11667,14 +11667,30 @@ declare namespace _ {
          * @see _.random
          */
         random(
-            min?: number,
-            floating?: boolean
+            max: number,
+            floating: boolean
         ): number;
 
         /**
          * @see _.random
          */
-        random(floating?: boolean): number;
+        random(floating: boolean): number;
+
+        /**
+         * Produces a random number between min and max (inclusive). If only one argument is provided a number between
+         * 0 and the given number is returned. If floating is true, or either min or max are floats, a floating-point
+         * number is returned instead of an integer.
+         *
+         * @param min The minimum possible value.
+         * @param index Not used in this overload.
+         * @param guard Enables use as an iteratee for methods like _.map. You should not pass this parameter directly in your code.
+         * @return Returns the random number.
+         */
+        random(
+            min: number,
+            index: string | number,
+            guard: object
+        ): number;
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -14394,7 +14410,7 @@ declare namespace _ {
          * // => { 'a': 1, 'c': 3 }
          */
         pick<T extends object, U extends keyof T>(
-            object: T | null | undefined,
+            object: T,
              ...props: Array<Many<U>>
         ): Pick<T, U>;
 
@@ -14412,7 +14428,7 @@ declare namespace _ {
          * @see _.pick
          */
         pick<T extends object, U extends keyof T>(
-            this: LoDashImplicitWrapper<T | null | undefined>,
+            this: LoDashImplicitWrapper<T>,
             ...props: Array<Many<U>>
         ): LoDashImplicitWrapper<Pick<T, U>>;
 
@@ -14430,7 +14446,7 @@ declare namespace _ {
          * @see _.pick
          */
         pick<T extends object, U extends keyof T>(
-            this: LoDashExplicitWrapper<T | null | undefined>,
+            this: LoDashExplicitWrapper<T>,
             ...props: Array<Many<U>>
         ): LoDashExplicitWrapper<Pick<T, U>>;
 
@@ -15667,12 +15683,31 @@ declare namespace _ {
          *
          * Note: This method is based on String#split.
          *
+         * @param string The string to trim.
+         * @param separator The separator pattern to split by.
+         * @param limit The length to truncate results to.
          * @return Returns the new array of string segments.
          */
         split(
             string: string,
             separator?: RegExp|string,
             limit?: number
+        ): string[];
+
+        /**
+         * Splits string by separator.
+         *
+         * Note: This method is based on String#split.
+         *
+         * @param string The string to trim.
+         * @param index Not used in this overload.
+         * @param guard Enables use as an iteratee for methods like _.map. You should not pass this parameter directly in your code.
+         * @return Returns the new array of string segments.
+         */
+        split(
+            string: string,
+            index: string | number,
+            guard: object
         ): string[];
     }
 
@@ -15881,6 +15916,20 @@ declare namespace _ {
             string?: string,
             chars?: string
         ): string;
+
+        /**
+         * Removes leading and trailing whitespace or specified characters from string.
+         *
+         * @param string The string to trim.
+         * @param index Not used in this overload.
+         * @param guard Enables use as an iteratee for methods like _.map. You should not pass this parameter directly in your code.
+         * @return Returns the trimmed string.
+         */
+        trim(
+            string: string,
+            index: string | number,
+            guard: object
+        ): string;
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -15910,6 +15959,20 @@ declare namespace _ {
             string?: string,
             chars?: string
         ): string;
+
+        /**
+         * Removes trailing whitespace or specified characters from string.
+         *
+         * @param string The string to trim.
+         * @param index Not used in this overload.
+         * @param guard Enables use as an iteratee for methods like _.map. You should not pass this parameter directly in your code.
+         * @return Returns the trimmed string.
+         */
+        trimEnd(
+            string: string,
+            index: string | number,
+            guard: object
+        ): string;
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -15938,6 +16001,20 @@ declare namespace _ {
         trimStart(
             string?: string,
             chars?: string
+        ): string;
+
+        /**
+         * Removes leading whitespace or specified characters from string.
+         *
+         * @param string The string to trim.
+         * @param index Not used in this overload.
+         * @param guard Enables use as an iteratee for methods like _.map. You should not pass this parameter directly in your code.
+         * @return Returns the trimmed string.
+         */
+        trimStart(
+            string: string,
+            index: string | number,
+            guard: object
         ): string;
     }
 
@@ -16085,6 +16162,20 @@ declare namespace _ {
         words(
             string?: string,
             pattern?: string|RegExp
+        ): string[];
+
+        /**
+         * Splits `string` into an array of its words.
+         *
+         * @param string The string to inspect.
+         * @param index Not used in this overload.
+         * @param guard Enables use as an iteratee for methods like _.map. You should not pass this parameter directly in your code.
+         * @return Returns the words of `string`.
+         */
+        words(
+            string: string,
+            index: string | number,
+            guard: object
         ): string[];
     }
 
@@ -16746,6 +16837,22 @@ declare namespace _ {
             end?: number,
             step?: number
         ): number[];
+
+        /**
+         * Creates an array of numbers (positive and/or negative) progressing from start up to, but not including, end.
+         * If end is not specified it’s set to start with start then set to 0. If end is less than start a zero-length
+         * range is created unless a negative step is specified.
+         *
+         * @param start The start of the range.
+         * @param index Not used in this overload.
+         * @param guard Enables use as an iteratee for methods like _.map. You should not pass this parameter directly in your code.
+         * @return Returns a new range array.
+         */
+        range(
+            end: number,
+            index: string | number,
+            guard: object
+        ): number[];
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -16775,9 +16882,9 @@ declare namespace _ {
          * descending order.
          *
          * @category Util
-         * @param [start=0] The start of the range.
+         * @param start The start of the range.
          * @param end The end of the range.
-         * @param [step=1] The value to increment or decrement by.
+         * @param step The value to increment or decrement by.
          * @returns Returns the new array of numbers.
          * @example
          *
@@ -16806,6 +16913,21 @@ declare namespace _ {
             start: number,
             end?: number,
             step?: number
+        ): number[];
+
+        /**
+         * This method is like _.range except that it populates values in
+         * descending order.
+         *
+         * @param start The start of the range.
+         * @param index Not used in this overload.
+         * @param guard Enables use as an iteratee for methods like _.map. You should not pass this parameter directly in your code.
+         * @return Returns a new range array.
+         */
+        rangeRight(
+            end: number,
+            index: string | number,
+            guard: object
         ): number[];
     }
 

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -11658,8 +11658,6 @@ declare namespace _ {
          * @return Returns the random number.
          */
         random(
-            min?: number,
-            max?: number,
             floating?: boolean
         ): number;
 
@@ -11668,13 +11666,17 @@ declare namespace _ {
          */
         random(
             max: number,
-            floating: boolean
+            floating?: boolean
         ): number;
 
         /**
          * @see _.random
          */
-        random(floating: boolean): number;
+        random(
+            min: number,
+            max: number,
+            floating?: boolean
+        ): number;
 
         /**
          * Produces a random number between min and max (inclusive). If only one argument is provided a number between
@@ -11697,30 +11699,30 @@ declare namespace _ {
         /**
          * @see _.random
          */
-        random(
-            max?: number,
-            floating?: boolean
-        ): number;
+        random(floating?: boolean): number;
 
         /**
          * @see _.random
          */
-        random(floating?: boolean): number;
+        random(
+            max: number,
+            floating?: boolean
+        ): number;
     }
 
     interface LoDashExplicitWrapper<TValue> {
         /**
          * @see _.random
          */
-        random(
-            max?: number,
-            floating?: boolean
-        ): LoDashExplicitWrapper<number>;
+        random(floating?: boolean): LoDashExplicitWrapper<number>;
 
         /**
          * @see _.random
          */
-        random(floating?: boolean): LoDashExplicitWrapper<number>;
+        random(
+            max: number,
+            floating?: boolean
+        ): LoDashExplicitWrapper<number>;
     }
 
     /**********

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -9861,6 +9861,9 @@ namespace TestRandom {
         result = _(1).chain().random(true);
         result = _(true).chain().random();
     }
+
+    // $ExpectType number[]
+    _.map([5, 5], _.random);
 }
 
 /**********
@@ -11808,50 +11811,51 @@ namespace TestOmitBy {
 
 // _.pick
 namespace TestPick {
-    let obj: TResult | null | undefined = any;
+    let obj1: TResult | null | undefined = any;
+    let obj2: TResult = any;
 
     {
         let result: Partial<TResult>;
 
-        result = _.pick(obj, 'a');
-        result = _.pick(obj, 0, 'a');
-        result = _.pick(obj, ['b', 1], 0, 'a');
+        result = _.pick(obj1, 'a');
+        result = _.pick(obj1, 0, 'a');
+        result = _.pick(obj1, ['b', 1], 0, 'a');
     }
 
     {
         let result: Pick<TResult, 'a' | 'b'>;
-        result = _.pick(obj, 'a', 'b');
-        result = _.pick(obj, ['a' as 'a', 'b' as 'b']);
+        result = _.pick(obj2, 'a', 'b');
+        result = _.pick(obj2, ['a' as 'a', 'b' as 'b']);
     }
 
     {
         let result: _.LoDashImplicitWrapper<Partial<TResult>>;
 
-        result = _(obj).pick<TResult>('a');
-        result = _(obj).pick<TResult>(0, 'a');
-        result = _(obj).pick<TResult>(['b', 1], 0, 'a');
+        result = _(obj1).pick('a');
+        result = _(obj1).pick(0, 'a');
+        result = _(obj1).pick(['b', 1], 0, 'a');
     }
 
     {
         let result: _.LoDashImplicitWrapper<Pick<TResult, 'a' | 'b'>>;
 
-        result = _(obj).pick('a', 'b');
-        result = _(obj).pick(['a' as 'a', 'b' as 'b']);
+        result = _(obj2).pick('a', 'b');
+        result = _(obj2).pick(['a' as 'a', 'b' as 'b']);
     }
 
     {
         let result: _.LoDashExplicitWrapper<Partial<TResult>>;
 
-        result = _(obj).chain().pick<TResult>('a');
-        result = _(obj).chain().pick<TResult>(0, 'a');
-        result = _(obj).chain().pick<TResult>(['b', 1], 0, 'a');
+        result = _(obj1).chain().pick('a');
+        result = _(obj1).chain().pick(0, 'a');
+        result = _(obj1).chain().pick(['b', 1], 0, 'a');
     }
 
     {
         let result: _.LoDashExplicitWrapper<Pick<TResult, 'a' | 'b'>>;
 
-        result = _(obj).chain().pick('a', 'b');
-        result = _(obj).chain().pick(['a' as 'a', 'b' as 'b']);
+        result = _(obj2).chain().pick('a', 'b');
+        result = _(obj2).chain().pick(['a' as 'a', 'b' as 'b']);
     }
 }
 
@@ -12754,6 +12758,9 @@ namespace TestSplit {
         result = _('a-b-c').chain().split('-');
         result = _('a-b-c').chain().split('-', 2);
     }
+
+    // $ExpectType string[][]
+    _.map(['abc', 'def'], _.split);
 }
 
 // _.startCase
@@ -12877,6 +12884,9 @@ namespace TestTrim {
         result = _('-_-abc-_-').chain().trim();
         result = _('-_-abc-_-').chain().trim('_-');
     }
+
+    // $ExpectType string[]
+    _.map(['  foo  ', '  bar  '], _.trim);
 }
 
 // _.trimEnd
@@ -13013,6 +13023,9 @@ namespace TestWords {
         result = _('fred, barney, & pebbles').chain().words();
         result = _('fred, barney, & pebbles').chain().words(/[^, ]+/g);
     }
+
+    // $ExpectType string[][]
+    _.map(['fred, barney', 'pebbles'], _.words);
 }
 
 /***********
@@ -13831,6 +13844,9 @@ namespace TestRange {
         result = _(1).chain().range(11);
         result = _(0).chain().range(30, 5);
     }
+
+    // $ExpectType number[][]
+    _.map([5, 5], _.range);
 }
 
 // _.rangeRight
@@ -13858,6 +13874,9 @@ namespace TestRangeRight {
         result = _(1).chain().rangeRight(11);
         result = _(0).chain().rangeRight(30, 5);
     }
+
+    // $ExpectType number[][]
+    _.map([5, 5], _.rangeRight);
 }
 
 // _.runInContext


### PR DESCRIPTION
This PR is for a few small fixes:

- fixes #18350: `_.partition` should return a tuple instead of an array
- fixes #18774: `trim()` as Iterator
- `_.pick` should not allow `null`/`undefined` inputs to return a `Pick<>` type. We don't have an issue for this, but it's discussed [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21291#issuecomment-342529138). I'm fixing this here because there seems to be no progress on that PR.

Quick guide to the changes in this PR:

- Any change that adds a `guard` parameter is for #18774.
- Changes to `_.partition` are for #18350.
- Changes to `_.pick` are for the last issue mentioned above.

Checklist:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:   
  - partition: https://lodash.com/docs/4.17.4#partition
  - `trim()` as Iterator: https://lodash.com/docs/4.17.4#map
    > Many lodash methods are guarded to work as iteratees for methods like _.every, _.filter, _.map, _.mapValues, _.reject, and _.some.
    > The guarded methods are:
    > ary, chunk, curry, curryRight, drop, dropRight, every, fill, invert, parseInt, random, range, rangeRight, repeat, sampleSize, slice, some, sortBy, split, take, takeRight, template, trim, trimEnd, trimStart, and words
- [ ] Increase the version number in the header if appropriate. N/A
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
