### PR TITLE
[webpack-dev-middleware] Added missing middleware properties

### DIFF
--- a/types/webpack-dev-middleware/index.d.ts
+++ b/types/webpack-dev-middleware/index.d.ts
@@ -1,11 +1,13 @@
-// Type definitions for webpack-dev-middleware 1.9
+// Type definitions for webpack-dev-middleware 1.12
 // Project: https://github.com/webpack/webpack-dev-middleware
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
+//                 reduckted <https://github.com/reduckted>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
 import { NextHandleFunction } from 'connect';
 import * as webpack from 'webpack';
+import MemoryFileSystem = require('memory-fs');
 
 export = WebpackDevMiddleware;
 
@@ -49,5 +51,7 @@ declare namespace WebpackDevMiddleware {
 		close(callback?: () => void): void;
 		invalidate(callback?: (stats: webpack.Stats) => void): void;
 		waitUntilValid(callback?: (stats: webpack.Stats) => void): void;
+		getFilenameFromUrl: (url: string) => string | false;
+		fileSystem: MemoryFileSystem;
 	}
 }

--- a/types/webpack-dev-middleware/webpack-dev-middleware-tests.ts
+++ b/types/webpack-dev-middleware/webpack-dev-middleware-tests.ts
@@ -29,8 +29,22 @@ webpackDevMiddlewareInstance = webpackDevMiddleware(compiler, {
 const app = express();
 app.use([webpackDevMiddlewareInstance]);
 
-webpackDevMiddlewareInstance.close();
-webpackDevMiddlewareInstance.invalidate();
-webpackDevMiddlewareInstance.waitUntilValid(() => {
-	console.log('Package is in a valid state');
+webpackDevMiddlewareInstance.close(() => {
+	console.log('closed');
 });
+
+webpackDevMiddlewareInstance.invalidate((stats) => {
+	console.log(stats.toJson());
+});
+
+webpackDevMiddlewareInstance.waitUntilValid((stats) => {
+	console.log('Package is in a valid state:' + stats.toJson());
+});
+
+const fs = webpackDevMiddlewareInstance.fileSystem;
+fs.mkdirpSync('foo');
+
+let filename = webpackDevMiddlewareInstance.getFilenameFromUrl('url');
+if (filename !== false) {
+	filename = filename.substr(0);
+}


### PR DESCRIPTION
I've added the `getFilenameFromUrl` method and the `fileSystem` property that are available on the middleware object.

I've also improved the tests for the functions that take callbacks.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack-dev-middleware/blob/8db879404f523f11f2902b1365a3ffaf6166f6a9/middleware.js#L93-L97
- [x] Increase the version number in the header if appropriate.