### PR TITLE
[Cypress] Add missing RegExp definition and fix route definition

### DIFF
--- a/types/cypress/index.d.ts
+++ b/types/cypress/index.d.ts
@@ -318,9 +318,9 @@ declare namespace Cypress {
     /**
      * @see https://on.cypress.io/api/route
      */
-    route(url: string, response?: any): Chainable;
-    route(method: string, url: string, response?: any): Chainable;
-    route(fn: () => RouteOptions | RouteOptions): Chainable;
+    route(url: string | RegExp, response?: any): Chainable;
+    route(method: string, url: string | RegExp, response?: any): Chainable;
+    route(fn: (() => RouteOptions) | RouteOptions): Chainable;
 
     /**
      * @see https://on.cypress.io/api/screenshot


### PR DESCRIPTION
Add the missing RegExp definition for the url params of the route function. Also allow to call the route with the options params.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.cypress.io/api/commands/route.html#Arguments
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
