### PR TITLE
[react-bootstrap-table] Add renderAlert to BootstrapTableProps

### DIFF
--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -400,6 +400,10 @@ export interface BootstrapTableProps extends Props<BootstrapTable> {
 	 * Table footer custom class
 	 */
 	tableFooterClass?: string;
+	/**
+	 * Render react-s-alert notifications
+	 */
+    renderAlert?: boolean;
 }
 
 /**


### PR DESCRIPTION
`react-bootstrap-table` 4.2.0 added the `renderAlert` prop to the `BootstrapTable` components in order to  disable rendering of the `react-s-alert` `<Alert>` component.

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/AllenFang/react-bootstrap-table/issues/1771

