### PR TITLE
[react-beautiful-dnd] Added  missing prop disableInteractiveElementBlocking

### DIFF
--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -99,6 +99,7 @@ export interface DraggableProps {
     draggableId: DroppableId;
     type?: TypeId;
     isDragDisabled?: boolean;
+    disableInteractiveElementBlocking?: boolean;
     children(provided: DraggableProvided, snapshot: DraggableStateSnapshot): React.ReactElement<any>;
 }
 

--- a/types/react-beautiful-dnd/react-beautiful-dnd-tests.tsx
+++ b/types/react-beautiful-dnd/react-beautiful-dnd-tests.tsx
@@ -73,7 +73,7 @@ class App extends React.Component<{}, AppState> {
               style={getListStyle(snapshot.isDraggingOver)}
             >
               {this.state.items.map(item => (
-                <Draggable key={item.id} draggableId={item.id}>
+                <Draggable key={item.id} draggableId={item.id} disableInteractiveElementBlocking={true}>
                   {(provided, snapshot) => (
                     <div>
                       <div


### PR DESCRIPTION
See docs:

Props of ```<Draggable>```

> disableInteractiveElementBlocking: An optional flag to opt out of blocking a drag from interactive elements. For more information refer to the section Interactive child elements within a Draggable
