### PR TITLE
React i18next context exports

### DIFF
--- a/types/react-i18next/index.d.ts
+++ b/types/react-i18next/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-i18next 4.6
+// Type definitions for react-i18next 7.0
 // Project: https://github.com/i18next/react-i18next
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -21,6 +21,8 @@ export {
     // Exports for TypeScript only
     TranslationFunction
 };
+
+export { reactI18nextModule, setDefaults, getDefaults, setI18n, getI18n } from './src/context';
 
 /**
  * Extend your component's Prop interface with this one to get access to `this.props.t`

--- a/types/react-i18next/src/context.d.ts
+++ b/types/react-i18next/src/context.d.ts
@@ -1,0 +1,18 @@
+import {i18n as I18n} from "i18next";
+import {TranslateOptions} from "./translate";
+
+export function setDefaults(options: TranslateOptions): void;
+
+export function getDefaults(): TranslateOptions;
+
+export function setI18n(instance: I18n): void;
+
+export function getI18n(): I18n;
+
+export interface ReactI18NextModule {
+    type: "3rdParty";
+
+    init(i18n: I18n): void;
+}
+
+export const reactI18nextModule: ReactI18NextModule;

--- a/types/react-i18next/src/translate.d.ts
+++ b/types/react-i18next/src/translate.d.ts
@@ -12,4 +12,5 @@ export interface TranslateOptions {
 }
 
 // tslint:disable-next-line:ban-types
-export default function translate<TKey extends string = string>(namespaces?: TKey[] | TKey, options?: TranslateOptions): <C extends Function>(WrappedComponent: C) => C;
+type ComponentWrapper = <C extends Function>(WrappedComponent: C) => C;
+export default function translate<TNamespace extends string = string>(namespaces?: TNamespace | TNamespace[], options?: TranslateOptions): ComponentWrapper;

--- a/types/react-i18next/test/react-i18next-tests.tsx
+++ b/types/react-i18next/test/react-i18next-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as i18n from 'i18next';
-import { translate, I18nextProvider, Interpolate, InjectedTranslateProps, TranslationFunction, loadNamespaces, Trans } from 'react-i18next';
+import { translate, I18nextProvider, Interpolate, InjectedTranslateProps, TranslationFunction, loadNamespaces, Trans, reactI18nextModule } from 'react-i18next';
 
 interface InnerAnotherComponentProps {
   _?: TranslationFunction;
@@ -90,3 +90,5 @@ class GenericsTest extends React.Component<InjectedTranslateProps> {
 class GenericsTest2 extends React.Component<InjectedTranslateProps> {
   render() { return null; }
 }
+
+i18n.use(reactI18nextModule);


### PR DESCRIPTION
Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [context.js](https://github.com/i18next/react-i18next/blob/master/src/context.js)
- [x] Increase the version number in the header if appropriate. 
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. -> already exists

There are still some typings missing to fully cover react-i18next. I will add them when needed.