### PR TITLE
Add type definitions for vali-date

### DIFF
--- a/types/vali-date/index.d.ts
+++ b/types/vali-date/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for vali-date 1.0
+// Project: https://github.com/SamVerschueren/vali-date
+// Definitions by: Sam Verschueren <https://github.com/SamVerschueren>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function valiDate(input: string): boolean;
+declare namespace valiDate { }
+export = valiDate;

--- a/types/vali-date/tsconfig.json
+++ b/types/vali-date/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "vali-date-tests.ts"
+    ]
+}

--- a/types/vali-date/tslint.json
+++ b/types/vali-date/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}

--- a/types/vali-date/vali-date-tests.ts
+++ b/types/vali-date/vali-date-tests.ts
@@ -1,0 +1,5 @@
+import * as valiDate from 'vali-date';
+
+valiDate('foo');
+valiDate('bar');
+valiDate('2017-05-10');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.