### PR TITLE
Extends aws-lambda callback signature to accept primitive types (boolean, number and string) as result

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -294,6 +294,9 @@ function callback(cb: AWSLambda.Callback) {
     cb(null);
     cb(error);
     cb(null, anyObj);
+    cb(null, b);
+    cb(null, str);
+    cb(null, num);
 }
 
 /* Proxy Callback */

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -9,6 +9,7 @@
 //                 wwwy3y3 <https://github.com/wwwy3y3>
 //                 Ishaan Malhi <https://github.com/OrthoDex>
 //                 Daniel Cottone <https://github.com/daniel-cottone>
+//                 Kostya Misura <https://github.com/kostya-misura>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -364,7 +365,7 @@ export type CustomAuthorizerHandler = (event: CustomAuthorizerEvent, context: Co
  * @param error – an optional parameter that you can use to provide results of the failed Lambda function execution.
  * @param result – an optional parameter that you can use to provide the result of a successful function execution. The result provided must be JSON.stringify compatible.
  */
-export type Callback = (error?: Error | null, result?: object) => void;
+export type Callback = (error?: Error | null, result?: object | boolean | number | string) => void;
 export type ProxyCallback = (error?: Error | null, result?: ProxyResult) => void;
 export type CustomAuthorizerCallback = (error?: Error | null, result?: AuthResponse) => void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Example from AWS below shows usage of string as result of Lambda execution. Judging from manual testing other primitive types are accepted as lambda execution result as-well. http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html 
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
