### PR TITLE
Reactstrap: Updating Popover and Tooltip definitions

### DIFF
--- a/types/reactstrap/index.d.ts
+++ b/types/reactstrap/index.d.ts
@@ -5,6 +5,7 @@
 //                 Danilo Barros <https://github.com/danilobjr>
 //                 Fábio Paiva <https://github.com/fabiopaiva>
 //                 FaithForHumans <https://github.com/FaithForHumans>
+//                 Kurt Preston <https://github.com/KurtPreston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/reactstrap/lib/Popover.d.ts
+++ b/types/reactstrap/lib/Popover.d.ts
@@ -1,33 +1,37 @@
-/// <reference types='tether' />
+/// <reference types='react' />
 
 import { CSSModule } from '../index';
 
-type Placement
-  = 'top'
-  | 'bottom'
-  | 'left'
+export type Placement
+  = 'auto'
+  | 'auto-start'
+  | 'auto-end'
+  | 'top'
+  | 'top-start'
+  | 'top-end'
   | 'right'
-  | 'top left'
-  | 'top center'
-  | 'top right'
-  | 'right top'
-  | 'right middle'
-  | 'right bottom'
-  | 'bottom right'
-  | 'bottom center'
-  | 'bottom left'
-  | 'left top'
-  | 'left middle'
-  | 'left bottom';
+  | 'right-start'
+  | 'right-end'
+  | 'bottom'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left'
+  | 'left-start'
+  | 'left-end';
 
-export interface PopoverProps {
-  placement?: Placement;
-  target: string;
+export interface PopoverProps extends React.HTMLAttributes<HTMLElement> {
   isOpen?: boolean;
-  tether?: Tether.ITetherOptions;
-  className?: string;
-  cssModule?: CSSModule;
   toggle?: () => void;
+  target: string | HTMLElement;
+  container?: string | HTMLElement;
+  className?: string;
+  placement?: Placement;
+  innerClassName?: string;
+  disabled?: boolean;
+  placementPrefix?: string;
+  delay?: number | {show: number, hide: number};
+  modifiers?: object;
+  cssModule?: CSSModule;
 }
 
 declare const Popover: React.StatelessComponent<PopoverProps>;

--- a/types/reactstrap/lib/Tooltip.d.ts
+++ b/types/reactstrap/lib/Tooltip.d.ts
@@ -1,35 +1,34 @@
-/// <reference types='tether' />
+/// <reference types='react' />
 
 import { CSSModule } from '../index';
 
-type Placement
-  = 'top'
-  | 'bottom'
-  | 'left'
+export type Placement
+  = 'auto'
+  | 'auto-start'
+  | 'auto-end'
+  | 'top'
+  | 'top-start'
+  | 'top-end'
   | 'right'
-  | 'top left'
-  | 'top center'
-  | 'top right'
-  | 'right top'
-  | 'right middle'
-  | 'right bottom'
-  | 'bottom right'
-  | 'bottom center'
-  | 'bottom left'
-  | 'left top'
-  | 'left middle'
-  | 'left bottom';
+  | 'right-start'
+  | 'right-end'
+  | 'bottom'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left'
+  | 'left-start'
+  | 'left-end';
 
-export interface UncontrolledProps {
-  placement?: Placement;
-  target: string;
-  disabled?: boolean;
-  tether?: Tether.ITetherOptions;
-  tetherRef?: (tether: Tether) => void;
+export interface UncontrolledProps extends React.HTMLAttributes<HTMLElement> {
+  target: string | HTMLElement;
+  container?: string | HTMLElement;
+  delay?: number | {show: number, hide: number};
   className?: string;
-  cssModule?: CSSModule;
+  innerClassName?: string;
   autohide?: boolean;
-  delay?: number | { show: number, hide: number };
+  placement?: Placement;
+  modifiers?: object;
+  cssModule?: CSSModule;
 }
 export interface UncontrolledTooltipProps extends UncontrolledProps {
   /* intentionally blank */

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -2479,7 +2479,7 @@ class Example85 extends React.Component<any, any> {
         <Button id="Popover1" onClick={this.toggle}>
           Launch Popover
         </Button>
-        <Popover placement="bottom" isOpen={this.state.popoverOpen} target="Popover1" toggle={this.toggle}>
+        <Popover placement="bottom" isOpen={this.state.popoverOpen} target="Popover1" toggle={this.toggle} onClick={() => {}}>
           <PopoverHeader>Popover Title</PopoverHeader>
           <PopoverBody>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</PopoverBody>
         </Popover>
@@ -3500,3 +3500,24 @@ const Example113 = (props: any) => {
       </div>
     );
   };
+
+class Example114 extends React.Component<any, any> {
+private element: HTMLElement;
+
+refFn(r: HTMLElement | null) {
+    if (r) {
+        this.element = r;
+    }
+}
+
+render() {
+    return (
+    <div>
+        <p>Somewhere in here is a <a href="#" ref={this.refFn}>tooltip</a>.</p>
+        <Tooltip placement="bottom-start" isOpen={this.state.tooltipOpen} target={this.element}>
+        Hello world!
+        </Tooltip>
+    </div>
+    );
+}
+}


### PR DESCRIPTION
Synchronizing definitions with the Reactstrap docs, including the change from `tether` to `popper.js`.
Adding `HTMLAttributes` to Tooltips and Popovers, since they do seem to take these properties, such as `style` and `onClick` props.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactstrap.github.io/components/tooltips/
https://reactstrap.github.io/components/popovers/
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
