### PR TITLE
React-Router-Redux requires 2 arguments

### DIFF
--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -24,7 +24,7 @@ export interface ConnectedRouterProps<State> {
     store?: Store<State>;
     history?: History;
 }
-export class ConnectedRouter<State> extends React.Component<ConnectedRouterProps<State>> {}
+export class ConnectedRouter<State> extends React.Component<ConnectedRouterProps<State>, {}> {}
 
 export const LOCATION_CHANGE = '@@router/LOCATION_CHANGE';
 


### PR DESCRIPTION
Fixes:

>ERROR in ...\node_modules\@types\react-router-redux\index.d.ts
(27,45): error TS2314: Generic type 'Component<P, S>' requires 2 type argument(s).
