### PR TITLE
[recompose]: Fix missing props when inferring them

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -42,7 +42,7 @@ declare module 'recompose' {
     // Will not pass through the injected props if they are passed in during
     // render. Also adds new prop requirements from TNeedsProps.
     export interface InferableComponentEnhancerWithProps<TInjectedProps, TNeedsProps> {
-        <P extends TInjectedProps>(
+        <P extends TInjectedProps & TNeedsProps>(
             component: Component<P>
         ): React.ComponentType<Omit<P, keyof TInjectedProps> & TNeedsProps>
     }

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -189,8 +189,9 @@ function testWithStateHandlers() {
     interface Updaters { add: (n: number) => State; }
     type InnerProps = State & Updaters;
     interface OutterProps { initialCounter: number, power: number }
-    const InnerComponent: React.StatelessComponent<InnerProps> = (props) =>
+    const InnerComponent: React.StatelessComponent<InnerProps & OutterProps> = (props) =>
         <div>
+            <div>{`Counts from: ${props.initialCounter}`}</div>
             <div>{`Counter: ${props.counter}`}</div>
             <div onClick={() => props.add(2)}></div>
         </div>;
@@ -202,6 +203,28 @@ function testWithStateHandlers() {
         },
     );
     const Enhanced = enhancer(InnerComponent);
+    const rendered = (
+        <Enhanced initialCounter={4} power={2} />
+    );
+}
+
+function testWithStateHandlersInferred() {
+    interface State { counter: number; }
+    interface Updaters { add: (n: number) => State; }
+    type InnerProps = State & Updaters;
+    interface OutterProps { initialCounter: number, power: number }
+    const enhancer = withStateHandlers<State, Updaters, OutterProps>(
+        (props: OutterProps) => ({ counter: props.initialCounter }),
+        {
+            add: (state, props) => n => ({ ...state, counter: state.counter + n ** props.power }),
+        },
+    );
+    const Enhanced = enhancer((props) =>
+        <div>
+            <div>{`Counts from: ${props.initialCounter}`}</div>
+            <div>{`Counter: ${props.counter}`}</div>
+            <div onClick={() => props.add(2)}></div>
+        </div>);
     const rendered = (
         <Enhanced initialCounter={4} power={2} />
     );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Discussion below
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Recompose passes through props to the inner component which means that the inner component does not only receive the props created by the HoC but also all OuterProps