### PR TITLE
Add types for fuzzyset.js

### DIFF
--- a/types/fuzzyset.js/fuzzyset.js-tests.ts
+++ b/types/fuzzyset.js/fuzzyset.js-tests.ts
@@ -1,0 +1,10 @@
+import FuzzySet = require('fuzzyset.js');
+
+const fuzzyset: FuzzySet = FuzzySet(['coucou', 'foo', 'bar', 'toto']);
+const results = fuzzyset.get('foo');
+
+fuzzyset.length();
+
+fuzzyset.isEmpty();
+
+fuzzyset.values();

--- a/types/fuzzyset.js/index.d.ts
+++ b/types/fuzzyset.js/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface FuzzySet {
-    get<T>(candidate: string, defaultValue: T | undefined, minScore?: number): Array<[number, string]> | T | null;
+    get<T>(candidate: string, defaultValue?: T | undefined, minScore?: number): Array<[number, string]> | T | null;
   add(value: string): boolean;
   length(): number;
   isEmpty(): boolean;

--- a/types/fuzzyset.js/index.d.ts
+++ b/types/fuzzyset.js/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/Glench/fuzzyset.js
 // Definitions by: Louis Grignon <https://github.com/lgrignon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
 
 interface FuzzySet {
   get<T = undefined>(candidate: string, defaultValue?: T | undefined, minScore?: number): Array<[number, string]> | T | null;

--- a/types/fuzzyset.js/index.d.ts
+++ b/types/fuzzyset.js/index.d.ts
@@ -4,7 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface FuzzySet {
-  get(candidate: string): Array<[number, string]>;
+  get(candidate: string, defaultValue?: string, minScore?: number): Array<[number, string]> | undefined;
+  get(candidate: string, minScore?: number): Array<[number, string]> | undefined;
   add(value: string): boolean;
   length(): number;
   isEmpty(): boolean;

--- a/types/fuzzyset.js/index.d.ts
+++ b/types/fuzzyset.js/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.3
 
 interface FuzzySet {
-  get<T = undefined>(candidate: string, defaultValue?: T | undefined, minScore?: number): Array<[number, string]> | T | null;
+  get<T = undefined>(candidate: string, defaultValue?: T, minScore?: number): Array<[number, string]> | T | null;
   add(value: string): boolean;
   length(): number;
   isEmpty(): boolean;

--- a/types/fuzzyset.js/index.d.ts
+++ b/types/fuzzyset.js/index.d.ts
@@ -5,7 +5,6 @@
 
 interface FuzzySet {
   get(candidate: string, defaultValue?: string, minScore?: number): Array<[number, string]> | undefined;
-  get(candidate: string, minScore?: number): Array<[number, string]> | undefined;
   add(value: string): boolean;
   length(): number;
   isEmpty(): boolean;

--- a/types/fuzzyset.js/index.d.ts
+++ b/types/fuzzyset.js/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface FuzzySet {
-    get<T>(candidate: string, defaultValue?: T | undefined, minScore?: number): Array<[number, string]> | T | null;
+  get<T = undefined>(candidate: string, defaultValue?: T | undefined, minScore?: number): Array<[number, string]> | T | null;
   add(value: string): boolean;
   length(): number;
   isEmpty(): boolean;

--- a/types/fuzzyset.js/index.d.ts
+++ b/types/fuzzyset.js/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for fuzzyset.js 0.0
+// Project: https://github.com/Glench/fuzzyset.js
+// Definitions by: Louis Grignon <https://github.com/lgrignon>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+interface FuzzySet {
+  get(candidate: string): Array<[number, string]>;
+  add(value: string): boolean;
+  length(): number;
+  isEmpty(): boolean;
+  values(): string[];
+}
+
+declare function FuzzySet(
+  source: string[],
+  useLevenshtein?: boolean,
+  gramSizeLower?: number,
+  gramSizeUpper?: number,
+): FuzzySet;
+
+export = FuzzySet;
+export as namespace FuzzySet;

--- a/types/fuzzyset.js/index.d.ts
+++ b/types/fuzzyset.js/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface FuzzySet {
-  get(candidate: string, defaultValue?: string, minScore?: number): Array<[number, string]> | undefined;
+    get<T>(candidate: string, defaultValue: T | undefined, minScore?: number): Array<[number, string]> | T | null;
   add(value: string): boolean;
   length(): number;
   isEmpty(): boolean;

--- a/types/fuzzyset.js/tsconfig.json
+++ b/types/fuzzyset.js/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/fuzzyset.js/tsconfig.json
+++ b/types/fuzzyset.js/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fuzzyset.js-tests.ts"
+    ]
+}

--- a/types/fuzzyset.js/tslint.json
+++ b/types/fuzzyset.js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is basically a copy of `fuzzyset` types, but `fuzzyset.js` is a different npm package.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
