### PR TITLE
[react-bootstrap-table] Update trClassName signature

### DIFF
--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -217,7 +217,7 @@ export interface BootstrapTableProps extends Props<BootstrapTable> {
 	 *      return rowIndex % 2 == 0 ? "tr-odd" : "tr-even"; // return a class name.
 	 *    }
 	 */
-	trClassName?: string | ((rowData: ReadonlyArray<any>, rowIndex: number) => string);
+	trClassName?: string | ((rowData: any, rowIndex: number) => string);
 	/**
 	 * Enable row insertion by setting insertRow to true, default is false.
 	 * If you enable row insertion, there's a button on the upper left side of table.


### PR DESCRIPTION
The `trClassName` signature for the callback uses `ReadonlyArray<any>` to type the row, but it should be `any` as its just one row that is passed, not an array.

Please fill in this template.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/AllenFang/react-bootstrap-table/blob/2b7e5bf8992165035b178b8eef7f533772eb805a/src/TableBody.js#L172