### PR TITLE
redis: add_command method & small rename_commands fix

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -5,6 +5,7 @@
 //                 TANAKA Koichi <https://github.com/MugeSo>
 //                 Stuart Schechter <https://github.com/UppaJung>
 //                 Junyoung Choi <https://github.com/Rokt33r>
+//                 James Garbutt <https://github.com/43081j>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/types/npm-redis
@@ -43,7 +44,7 @@ export interface ClientOpts {
     password?: string;
     db?: string | number;
     family?: string;
-    rename_commands?: { [command: string]: string };
+    rename_commands?: { [command: string]: string } | null;
     tls?: any;
     prefix?: string;
     retry_strategy?: RetryStrategy;
@@ -1201,6 +1202,9 @@ export interface RedisClient extends Commands<boolean>, EventEmitter {
     sendCommand(command: string, args?: any[], cb?: Callback<any>): boolean;
     send_command(command: string, cb?: Callback<any>): boolean;
     send_command(command: string, args?: any[], cb?: Callback<any>): boolean;
+
+    addCommand(command: string): void;
+    add_command(command: string): void;
 
     /**
      * Mark the start of a transaction block.

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -6,10 +6,10 @@ const num = 0;
 const str = 'any string';
 const err: Error = new Error();
 const args: any[] = [];
-const resCallback: (err: Error, res: any) => void = () => null;
-const numCallback: (err: Error, res: number) => void = () => null;
-const strCallback: (err: Error, res: string) => void = () => null;
-const messageHandler: (channel: string, message: any) => void = () => null;
+const resCallback: (err: Error | null, res: any) => void = () => {};
+const numCallback: (err: Error | null, res: number) => void = () => {};
+const strCallback: (err: Error | null, res: string) => void = () => {};
+const messageHandler: (channel: string, message: any) => void = () => {};
 
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ----
 
@@ -117,3 +117,7 @@ client.cork();
 client.set("abc", "fff", strCallback);
 client.get("abc", resCallback);
 client.uncork();
+
+// Add command
+client.add_command('my command');
+client.addCommand('my other command');

--- a/types/redis/tsconfig.json
+++ b/types/redis/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/NodeRedis/node_redis (README)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This adds `add_command` which allows you to.. add a command. introduced in 2.8.

It also makes a slight change to `rename_commands` in that, as per the docs, it can take a value of `null`. This means the resulting type is actually `{[command: string]: string} | null | undefined` pretty much.