### PR TITLE
Export default class instead of namespace

### DIFF
--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -11,41 +11,39 @@
 
 import { CSSProperties, Component, DragEvent, InputHTMLAttributes } from "react";
 
-declare namespace Dropzone {
-    export interface ImageFile extends File {
-        preview?: string;
-    }
-
-    export type DropFileEventHandler = (acceptedOrRejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
-    export type DropFilesEventHandler = (accepted: ImageFile[], rejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
-
-    type PickedAttributes = "accept" | "className" | "multiple" | "name" | "onClick" | "onDragStart" | "onDragEnter" | "onDragOver" | "onDragLeave" | "style";
-
-    export interface DropzoneProps extends Pick<InputHTMLAttributes<HTMLDivElement>, PickedAttributes> {
-        disableClick?: boolean;
-        disabled?: boolean;
-        disablePreview?: boolean;
-        preventDropOnDocument?: boolean;
-        inputProps?: InputHTMLAttributes<HTMLInputElement>;
-        maxSize?: number;
-        minSize?: number;
-        activeClassName?: string;
-        acceptClassName?: string;
-        rejectClassName?: string;
-        disabledClassName?: string;
-        activeStyle?: CSSProperties;
-        acceptStyle?: CSSProperties;
-        rejectStyle?: CSSProperties;
-        disabledStyle?: CSSProperties;
-        onDrop?: DropFilesEventHandler;
-        onDropAccepted?: DropFileEventHandler;
-        onDropRejected?: DropFileEventHandler;
-        onFileDialogCancel?: () => void;
-    }
+interface ImageFile extends File {
+    preview?: string;
 }
 
-declare class Dropzone extends Component<Dropzone.DropzoneProps> {
+type DropFileEventHandler = (acceptedOrRejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
+type DropFilesEventHandler = (accepted: ImageFile[], rejected: ImageFile[], event: DragEvent<HTMLDivElement>) => void;
+
+type PickedAttributes = "accept" | "className" | "multiple" | "name" | "onClick" | "onDragStart" | "onDragEnter" | "onDragOver" | "onDragLeave" | "style";
+
+interface DropzoneProps extends Pick<InputHTMLAttributes<HTMLDivElement>, PickedAttributes> {
+    disableClick?: boolean;
+    disabled?: boolean;
+    disablePreview?: boolean;
+    preventDropOnDocument?: boolean;
+    inputProps?: InputHTMLAttributes<HTMLInputElement>;
+    maxSize?: number;
+    minSize?: number;
+    activeClassName?: string;
+    acceptClassName?: string;
+    rejectClassName?: string;
+    disabledClassName?: string;
+    activeStyle?: CSSProperties;
+    acceptStyle?: CSSProperties;
+    rejectStyle?: CSSProperties;
+    disabledStyle?: CSSProperties;
+    onDrop?: DropFilesEventHandler;
+    onDropAccepted?: DropFileEventHandler;
+    onDropRejected?: DropFileEventHandler;
+    onFileDialogCancel?: () => void;
+}
+
+declare class Dropzone extends Component<DropzoneProps> {
     open(): void;
 }
 
-export = Dropzone;
+export default Dropzone;


### PR DESCRIPTION
The latest react-dropzone export the component class as the default export, if use namespace that causes a problem, as we need to import it as import Dropzone from "react-dropzone"

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
