### PR TITLE
yargs: Add false to command description type

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -87,12 +87,12 @@ declare namespace yargs {
         usage(message: string, options?: { [key: string]: Options }): Argv;
         usage(options?: { [key: string]: Options }): Argv;
 
-        command(command: string | string[], description: string): Argv;
-        command(command: string | string[], description: string, builder: (args: Argv) => Argv): Argv;
-        command(command: string | string[], description: string, builder: { [optionName: string]: Options }): Argv;
-        command(command: string | string[], description: string, builder: { [optionName: string]: Options }, handler: (args: Arguments) => void): Argv;
-        command(command: string | string[], description: string, builder: (args: Argv) => Argv, handler: (args: Arguments) => void): Argv;
-        command(command: string | string[], description: string, module: CommandModule): Argv;
+        command(command: string | string[], description: string | false): Argv;
+        command(command: string | string[], description: string | false, builder: (args: Argv) => Argv): Argv;
+        command(command: string | string[], description: string | false, builder: { [optionName: string]: Options }): Argv;
+        command(command: string | string[], description: string | false, builder: { [optionName: string]: Options }, handler: (args: Arguments) => void): Argv;
+        command(command: string | string[], description: string | false, builder: (args: Argv) => Argv, handler: (args: Arguments) => void): Argv;
+        command(command: string | string[], description: string | false, module: CommandModule): Argv;
         command(module: CommandModule): Argv;
 
         commandDir(dir: string, opts?: RequireDirectoryOptions): Argv;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yargs/yargs/blob/master/docs/api.md#commandmodule as stated here, desc can either be a string, or false to mark it as a hidden command
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

