### PR TITLE
quill: add scroll and getBounds definition

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -2,7 +2,10 @@
 // Project: https://github.com/quilljs/quill/
 // Definitions by: Sumit <https://github.com/sumitkm>
 //                 Guillaume <https://github.com/guillaume-ro-fr>
+//                 James Garbutt <https://github.com/43081j>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Blot } from 'parchment/src/blot/abstract/blot';
 
 /**
  * A stricter type definition would be:
@@ -56,7 +59,9 @@ export interface QuillOptionsStatic {
 }
 
 export interface BoundsStatic {
+    bottom: number;
     left: number;
+    right: number;
     top: number;
     height: number;
     width: number;
@@ -136,6 +141,7 @@ export class Quill implements EventEmitter {
      */
     root: HTMLDivElement;
     clipboard: ClipboardStatic;
+    scroll: Blot;
     constructor(container: string | Element, options?: QuillOptionsStatic);
     deleteText(index: number, length: number, source?: Sources): DeltaStatic;
     disable(): void;

--- a/types/quill/package.json
+++ b/types/quill/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "parchment": "^1.1.2"
+    }
+}

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -1,4 +1,5 @@
 import { Quill, Delta, DeltaStatic, RangeStatic, StringMap } from 'quill';
+import { Blot } from 'parchment/src/blot/abstract/blot';
 
 function test_quill() {
     const quillEditor = new Quill('#editor', {
@@ -8,6 +9,11 @@ function test_quill() {
         },
         theme: 'snow'
     });
+}
+
+function test_scroll() {
+    const quillEditor = new Quill('#editor');
+    const blot: Blot = quillEditor.scroll;
 }
 
 function test_deleteText() {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [here](https://github.com/quilljs/quill/blob/07d9597b156ff880e724843f65be3b80d1273159/core/quill.js#L77)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fixes #21899.

* Added missing properties to the bounds interface.
* Added `scroll` (a parchment blot)

Is this package.json ok? we need `parchment` for the `Blot` definition.