### PR TITLE
Re-added exports and "chai" module to chai types

### DIFF
--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -26,20 +26,20 @@ declare namespace Chai {
         version: string;
     }
 
-    interface ExpectStatic extends AssertionStatic {
+    export interface ExpectStatic extends AssertionStatic {
         fail(actual?: any, expected?: any, message?: string, operator?: Operator): void;
     }
 
-    interface AssertStatic extends Assert {
+    export interface AssertStatic extends Assert {
     }
 
-    interface AssertionStatic {
+    export interface AssertionStatic {
         (target: any, message?: string): Assertion;
     }
 
-    type Operator = string; // "==" | "===" | ">" | ">=" | "<" | "<=" | "!=" | "!==";
+    export type Operator = string; // "==" | "===" | ">" | ">=" | "<" | "<=" | "!=" | "!==";
 
-    type OperatorComparable = boolean | null | number | string | undefined | Date;
+    export type OperatorComparable = boolean | null | number | string | undefined | Date;
 
     interface ShouldAssertion {
         equal(value1: any, value2: any, message?: string): void;
@@ -256,7 +256,7 @@ declare namespace Chai {
         (object: Object, property: string, message?: string): Assertion;
     }
 
-    interface Assert {
+    export interface Assert {
         /**
          * @param expression    Expression to test for truthiness.
          * @param message    Message to display on error.
@@ -1587,7 +1587,7 @@ declare namespace Chai {
         doesNotHaveAllDeepKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
     }
 
-    interface Config {
+    export interface Config {
         /**
          * Default: false
          */
@@ -1604,7 +1604,7 @@ declare namespace Chai {
         truncateThreshold: number;
     }
 
-    class AssertionError {
+    export class AssertionError {
         constructor(message: string, _props?: any, ssf?: Function);
         name: string;
         message: string;
@@ -1615,10 +1615,10 @@ declare namespace Chai {
 
 declare const chai: Chai.ChaiStatic;
 
-export = chai;
+declare module "chai" {
+    export = chai;
+}
 
-declare global {
-    interface Object {
-        should: Chai.Assertion;
-    }
+interface Object {
+    should: Chai.Assertion;
 }

--- a/types/chai/tslint.json
+++ b/types/chai/tslint.json
@@ -4,8 +4,11 @@
         "ban-types": false,
         "callable-types": false,
         "new-parens": false,
+        "no-declare-current-package": false,
         "no-empty-interface": false,
         "no-redundant-jsdoc-2": false,
-        "no-unnecessary-generics": false
+        "no-single-declare-module": false,
+        "no-unnecessary-generics": false,
+        "strict-export-declare-modifiers": false
     }
 }


### PR DESCRIPTION
Fixes issues with downstream typings and projects that relied on the chai module (partially reverts DefinitelyTyped/DefinitelyTyped#21879).

A bunch of downstream dependencies are broken. IMO we should wait until https://github.com/Microsoft/TypeScript/issues/14844 is to resolved to reconsider how best to do this.

@mceachen @segayuu can you confirm this fixes the issues for you?