### PR TITLE
Add 'liveQueryServerURL' option to 'parse'

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -17,6 +17,7 @@ declare namespace Parse {
     let javaScriptKey: string | undefined;
     let masterKey: string | undefined;
     let serverURL: string;
+    let liveQueryServerURL: string;
     let VERSION: string;
 
     interface SuccessOption {


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  http://docs.parseplatform.org/js/guide/#setup-server-url
