### PR TITLE
[node] Add Buffer.alloc methods to node v4

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -104,8 +104,8 @@ declare namespace setImmediate {
 declare function clearImmediate(immediateId: any): void;
 
 // TODO: change to `type NodeRequireFunction = (id: string) => any;` in next mayor version.
-/* tslint:disable:callable-types */
 interface NodeRequireFunction {
+    /* tslint:disable-next-line:callable-types */
     (id: string): any;
 }
 

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -405,6 +405,20 @@ function bufferTests() {
         const buf1: Buffer = Buffer.from('this is a tést');
         const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
     }
+    // Class Method: Buffer.alloc(size[, fill[, encoding]])
+    {
+        const buf1: Buffer = Buffer.alloc(5);
+        const buf2: Buffer = Buffer.alloc(5, 'a');
+        const buf3: Buffer = Buffer.alloc(11, 'aGVsbG8gd29ybGQ=', 'base64');
+    }
+    // Class Method: Buffer.allocUnsafe(size)
+    {
+        const buf: Buffer = Buffer.allocUnsafe(5);
+    }
+    // Class Method: Buffer.allocUnsafeSlow(size)
+    {
+        const buf: Buffer = Buffer.allocUnsafeSlow(10);
+    }
 
     // Class Method byteLenght
     {

--- a/types/node/tslint.json
+++ b/types/node/tslint.json
@@ -21,6 +21,7 @@
     "prefer-const": false,
     "prefer-method-signature": false,
     "strict-export-declare-modifiers": false,
-    "unified-signatures": false
+    "unified-signatures": false,
+    "void-return": false
   }
 }

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Node.js 4.2
+// Type definitions for Node.js 4.x
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <http://typescriptlang.org>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
@@ -214,6 +214,29 @@ declare var Buffer: {
      * The same as buf1.compare(buf2).
      */
     compare(buf1: Buffer, buf2: Buffer): number;
+    /**
+     * Allocates a new buffer of {size} octets.
+     *
+     * @param size count of octets to allocate.
+     * @param fill if specified, buffer will be initialized by calling buf.fill(fill).
+     *    If parameter is omitted, buffer will be filled with zeros.
+     * @param encoding encoding used for call to buf.fill while initalizing
+     */
+    alloc(size: number, fill?: string | Buffer | number, encoding?: string): Buffer;
+    /**
+     * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents
+     * of the newly created Buffer are unknown and may contain sensitive data.
+     *
+     * @param size count of octets to allocate
+     */
+    allocUnsafe(size: number): Buffer;
+    /**
+     * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents
+     * of the newly created Buffer are unknown and may contain sensitive data.
+     *
+     * @param size count of octets to allocate
+     */
+    allocUnsafeSlow(size: number): Buffer;
 };
 
 /************************************************

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -268,6 +268,21 @@ function bufferTests() {
         const buf1: Buffer = Buffer.from('this is a tést');
         const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
     }
+    // Class Method: Buffer.alloc(size[, fill[, encoding]])
+    {
+        const buf1: Buffer = Buffer.alloc(5);
+        const buf2: Buffer = Buffer.alloc(5, 'a');
+        const buf3: Buffer = Buffer.alloc(11, 'aGVsbG8gd29ybGQ=', 'base64');
+
+    }
+    // Class Method: Buffer.allocUnsafe(size)
+    {
+        const buf: Buffer = Buffer.allocUnsafe(5);
+    }
+    // Class Method: Buffer.allocUnsafeSlow(size)
+    {
+        const buf: Buffer = Buffer.allocUnsafeSlow(10);
+    }
 
     // Test that TS 1.6 works with the 'as Buffer' annotation
     // on isBuffer.

--- a/types/node/v4/tslint.json
+++ b/types/node/v4/tslint.json
@@ -40,6 +40,7 @@
     "strict-export-declare-modifiers": false,
     "typedef-whitespace": false,
     "unified-signatures": false,
+    "void-return": false,
     "whitespace": false
   }
 }

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -330,6 +330,20 @@ function bufferTests() {
         const buf1: Buffer = Buffer.from('this is a tést');
         const buf2: Buffer = Buffer.from('7468697320697320612074c3a97374', 'hex');
     }
+    // Class Method: Buffer.alloc(size[, fill[, encoding]])
+    {
+        const buf1: Buffer = Buffer.alloc(5);
+        const buf2: Buffer = Buffer.alloc(5, 'a');
+        const buf3: Buffer = Buffer.alloc(11, 'aGVsbG8gd29ybGQ=', 'base64');
+    }
+    // Class Method: Buffer.allocUnsafe(size)
+    {
+        const buf: Buffer = Buffer.allocUnsafe(5);
+    }
+    // Class Method: Buffer.allocUnsafeSlow(size)
+    {
+        const buf: Buffer = Buffer.allocUnsafeSlow(10);
+    }
 
     // Test that TS 1.6 works with the 'as Buffer' annotation
     // on isBuffer.

--- a/types/node/v6/tslint.json
+++ b/types/node/v6/tslint.json
@@ -40,6 +40,7 @@
     "strict-export-declare-modifiers": false,
     "typedef-whitespace": false,
     "unified-signatures": false,
+    "void-return": false,
     "whitespace": false
   }
 }

--- a/types/node/v7/node-tests.ts
+++ b/types/node/v7/node-tests.ts
@@ -319,6 +319,20 @@ function bufferTests() {
         buf = Buffer.from(arr.buffer, 1);
         buf = Buffer.from(arr.buffer, 0, 1);
     }
+    // Class Method: Buffer.alloc(size[, fill[, encoding]])
+    {
+        const buf1: Buffer = Buffer.alloc(5);
+        const buf2: Buffer = Buffer.alloc(5, 'a');
+        const buf3: Buffer = Buffer.alloc(11, 'aGVsbG8gd29ybGQ=', 'base64');
+    }
+    // Class Method: Buffer.allocUnsafe(size)
+    {
+        const buf: Buffer = Buffer.allocUnsafe(5);
+    }
+    // Class Method: Buffer.allocUnsafeSlow(size)
+    {
+        const buf: Buffer = Buffer.allocUnsafeSlow(10);
+    }
 
     // Class Method: Buffer.from(buffer)
     {

--- a/types/node/v7/tslint.json
+++ b/types/node/v7/tslint.json
@@ -40,6 +40,7 @@
     "strict-export-declare-modifiers": false,
     "typedef-whitespace": false,
     "unified-signatures": false,
+    "void-return": false,
     "whitespace": false
   }
 }


### PR DESCRIPTION
Add `Buffer.alloc` `Buffer.allocUnsafe` and `Buffer.allocUnsafeSlow`
class methods that were backported to node v4 (starting with v4.5).

In addition add tests to all node versions for these class methods

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#2016-08-15-version-450-argon-lts-thealphanerd
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.