### PR TITLE
[@types/react] Use ComponentType for React.Fragment

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -281,8 +281,10 @@ declare namespace React {
         constructor(props: P, context?: any);
 
         // Disabling unified-signatures to have separate overloads. It's easier to understand this way.
-        setState<K extends keyof S>(f: (prevState: Readonly<S>, props: P) => Pick<S, K>, callback?: () => any): void; // tslint:disable-line:unified-signatures
-        setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void; // tslint:disable-line:unified-signatures
+        // tslint:disable-next-line:unified-signatures
+        setState<K extends keyof S>(f: (prevState: Readonly<S>, props: P) => Pick<S, K>, callback?: () => any): void;
+        // tslint:disable-next-line:unified-signatures
+        setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
 
         forceUpdate(callBack?: () => any): void;
         render(): ReactNode;
@@ -3517,15 +3519,18 @@ declare namespace React {
 
 declare global {
     namespace JSX {
-        interface Element extends React.ReactElement<any> { } // tslint:disable-line:no-empty-interface
+        // tslint:disable-next-line:no-empty-interface
+        interface Element extends React.ReactElement<any> { }
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;
         }
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }
 
-        interface IntrinsicAttributes extends React.Attributes { } // tslint:disable-line:no-empty-interface
-        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { } // tslint:disable-line:no-empty-interface
+        // tslint:disable-next-line:no-empty-interface
+        interface IntrinsicAttributes extends React.Attributes { }
+        // tslint:disable-next-line:no-empty-interface
+        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
 
         interface IntrinsicElements {
             // HTML

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -88,7 +88,7 @@ declare namespace React {
     }
 
     interface ReactElement<P> {
-        type: string | symbol | number | ComponentClass<P> | SFC<P>;
+        type: string | ComponentClass<P> | SFC<P>;
         props: P;
         key: Key | null;
     }
@@ -222,7 +222,7 @@ declare namespace React {
         props?: ClassAttributes<T> & P,
         ...children: ReactNode[]): CElement<P, T>;
     function createElement<P>(
-        type: SFC<P> | ComponentClass<P> | string | symbol | number,
+        type: SFC<P> | ComponentClass<P> | string,
         props?: Attributes & P,
         ...children: ReactNode[]): ReactElement<P>;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -265,7 +265,7 @@ declare namespace React {
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 
     const Children: ReactChildren;
-    const Fragment: symbol | number;
+    const Fragment: ComponentType;
     const version: string;
 
     //
@@ -281,10 +281,8 @@ declare namespace React {
         constructor(props: P, context?: any);
 
         // Disabling unified-signatures to have separate overloads. It's easier to understand this way.
-        // tslint:disable:unified-signatures
-        setState<K extends keyof S>(f: (prevState: Readonly<S>, props: P) => Pick<S, K>, callback?: () => any): void;
-        setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
-        // tslint:enable:unified-signatures
+        setState<K extends keyof S>(f: (prevState: Readonly<S>, props: P) => Pick<S, K>, callback?: () => any): void; // tslint:disable-line:unified-signatures
+        setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void; // tslint:disable-line:unified-signatures
 
         forceUpdate(callBack?: () => any): void;
         render(): ReactNode;
@@ -3519,17 +3517,15 @@ declare namespace React {
 
 declare global {
     namespace JSX {
-        // tslint:disable:no-empty-interface
-        interface Element extends React.ReactElement<any> { }
+        interface Element extends React.ReactElement<any> { } // tslint:disable-line:no-empty-interface
         interface ElementClass extends React.Component<any> {
             render(): React.ReactNode;
         }
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }
 
-        interface IntrinsicAttributes extends React.Attributes { }
-        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { }
-        // tslint:enable:no-empty-interface
+        interface IntrinsicAttributes extends React.Attributes { } // tslint:disable-line:no-empty-interface
+        interface IntrinsicClassAttributes<T> extends React.ClassAttributes<T> { } // tslint:disable-line:no-empty-interface
 
         interface IntrinsicElements {
             // HTML

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -164,7 +164,7 @@ const statelessElement: React.SFCElement<SCProps> = React.createElement(Stateles
 const domElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> = React.createElement("div");
 const htmlElement = React.createElement("input", { type: "text" });
 const svgElement = React.createElement("svg", { accentHeight: 12 });
-const fragmentElement: React.ReactElement<undefined> = React.createElement(React.Fragment, undefined, [React.createElement("div"), React.createElement("div")]);
+const fragmentElement: React.ReactElement<{}> = React.createElement(React.Fragment, {}, [React.createElement("div"), React.createElement("div")]);
 
 const customProps: React.HTMLProps<HTMLElement> = props;
 const customDomElement = "my-element";
@@ -229,7 +229,7 @@ const notValid: boolean = React.isValidElement(props); // false
 const isValid = React.isValidElement(element); // true
 let domNode: Element = ReactDOM.findDOMNode(component);
 domNode = ReactDOM.findDOMNode(domNode);
-const fragmentType: symbol | number = React.Fragment;
+const fragmentType: React.ComponentType = React.Fragment;
 
 //
 // React Elements
@@ -255,7 +255,7 @@ myComponent.reset();
 // Refs
 // --------------------------------------------------------------------------
 
-// tslint:disable:no-empty-interface
+// tslint:disable-next-line:no-empty-interface
 interface RCProps { }
 
 class RefComponent extends React.Component<RCProps> {

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -63,3 +63,17 @@ const StatelessComponentWithoutProps: React.SFC = (props) => {
     return <div />;
 };
 <StatelessComponentWithoutProps />;
+
+// Fragments
+<div>
+    <React.Fragment>
+        <React.Fragment key="foo">
+            <span>Child 1</span>
+            <span>Child 2</span>
+        </React.Fragment>
+        <React.Fragment key="bar">
+            <span>Child 3</span>
+            <span>Child 4</span>
+        </React.Fragment>
+    </React.Fragment>
+</div>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html#keyed-fragments

Fixes #21923 by using `ComponentType` as the type for `React.Fragment`.

Also:
- Updated existing `React.Fragment` tests
- Added TSX test for `React.Fragment` (but omitted `<></>` to preserve TS version compatibility)
- Fixed lint errors (`tslint:disable` is not allowed, prefer `disable-line` or `disable-next-line`)