### PR TITLE
Change gapi.client HttpRequestPromise definition to have valid TS syntax for older versions

### DIFF
--- a/types/gapi/index.d.ts
+++ b/types/gapi/index.d.ts
@@ -264,7 +264,7 @@ declare namespace gapi.client {
      */
      class HttpRequestPromise<T> {
         // Taken and adapted from https://github.com/Microsoft/TypeScript/blob/v2.3.1/lib/lib.es5.d.ts#L1343
-        then<TResult1 = T, TResult2 = never>(
+        then<TResult1, T, TResult2, never>(
             onfulfilled?: ((response: HttpRequestFulfilled<T>) => TResult1 | PromiseLike<TResult1>) | undefined | null,
             onrejected?: ((reason: HttpRequestRejected) => TResult2 | PromiseLike<TResult2>) | undefined | null,
             opt_context?: any


### PR DESCRIPTION
Without this change, typescript versions lower than 2.3 will fail to compile.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [X] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
