### PR TITLE
[rbac-a] new difinitions

### DIFF
--- a/types/rbac-a/index.d.ts
+++ b/types/rbac-a/index.d.ts
@@ -31,7 +31,7 @@ export class Provider {
      * The method mey return a promise resolving with the
      * expected return value.
      */
-    getRoles(use: any): Roles | Promise<Roles>;
+    getRoles(user: any): Roles | Promise<Roles>;
     /**
      * Return all permissions for the specified role. The return value
      * must be an array. Return an empty array if role is missing or

--- a/types/rbac-a/index.d.ts
+++ b/types/rbac-a/index.d.ts
@@ -40,7 +40,7 @@ export class Provider {
      * The method mey return a promise resolving with the
      * expected return value.
      */
-    getPermission(role: any): string[] | Promise<string[]>;
+    getPermission(role: string): string[] | Promise<string[]>;
     /**
      * Return all attributes for the specified role. The return value must
      * be an array. Return an empty array if role is missing or if no
@@ -49,7 +49,7 @@ export class Provider {
      * The method mey return a promise resolving with the
      * expected return value.
      */
-    getAttributes(role: any): string[] | Promise<string[]>;
+    getAttributes(role: string): string[] | Promise<string[]>;
 }
 
 export type AttributeFunction = (user: any, role: string, params: object) => any;

--- a/types/rbac-a/index.d.ts
+++ b/types/rbac-a/index.d.ts
@@ -1,0 +1,101 @@
+// Type definitions for rbac-a 0.2
+// Project: https://github.com/yanickrochon/rbac-a#readme
+// Definitions by: Tomek Łaziuk <https://github.com/tlaziuk>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="node"/>
+
+import {
+    EventEmitter,
+} from "events";
+
+export interface Roles {
+    [_: string]: number | Roles;
+}
+
+export class Provider {
+    /**
+     * Return all the roles available for the given user. The return value
+     * must be an object, recursively defining the associated roles for the
+     * specified user. Return an empty object if user has no roles.
+     * Ex: {
+     *       "role1": {
+     *         "role1.1": null,
+     *         "role1.2": { ... },
+     *         ...
+     *       },
+     *       "secondary": ...,
+     *       ...
+     *     }
+     * The method mey return a promise resolving with the
+     * expected return value.
+     */
+    getRoles(use: any): Roles | Promise<Roles>;
+    /**
+     * Return all permissions for the specified role. The return value
+     * must be an array. Return an empty array if role is missing or
+     * no permission for the specified role.
+     * Ex: ['permission1', 'permission2', ... ]
+     * The method mey return a promise resolving with the
+     * expected return value.
+     */
+    getPermission(role: any): string[] | Promise<string[]>;
+    /**
+     * Return all attributes for the specified role. The return value must
+     * be an array. Return an empty array if role is missing or if no
+     * attributes for the specified role.
+     * Ex: ['attribute1', 'attribute2', ... ]
+     * The method mey return a promise resolving with the
+     * expected return value.
+     */
+    getAttributes(role: any): string[] | Promise<string[]>;
+}
+
+export type AttributeFunction = (user: any, role: string, params: object) => any;
+
+/**
+ * Attributes Manager
+ * This class encapsulate attributes definition and validation.
+ * Usage
+ *   var roleValid = attributesManager.validate(attribute, user, role, params);
+ */
+export class AttributesManager {
+    protected _attributes: { [_: string]: AttributeFunction };
+    /** Define an attribute. The returned value is self for chaining. */
+    set(attribute: AttributeFunction): this;
+    /**
+     * Undefine an attribute, by name or function and return removed
+     * attribute function if one was found.
+     */
+    remove(attribute: string | AttributeFunction): AttributeFunction;
+    /**
+     * Validate the attribute with the specified user, role and parameters.
+     * The method will return a truthy value if the attribute valid, or a
+     * falsy otherwise.
+     * The method may also return a promise resolivng to the expected returne
+     * value, or reject. A rejected promise should be considered falsy.
+     * If the specified attribute does not exist, false is returned.
+     */
+    validate(attribute: string, user: any, role: string, params: object): any;
+}
+
+export class RBAC<P extends Provider, AM extends AttributesManager = AttributesManager> extends EventEmitter {
+    readonly provider: P;
+    readonly attributes: AM;
+    constructor(opts: { provider: P, attributes?: AM });
+    /**
+     * Check the user for the given permissions. The method will return
+     * a Promise resolving with a number. If the user has sufficient
+     * access to the specified permissions, the promise should resolve
+     * with a positive, non-zero value, or with NaN otherwise. If the
+     * Promise is rejected, it should be considered as if the user has
+     * insufficient access to the specified ressources.
+     */
+    check(user: any, permission: string | string[], params?: object): Promise<number>;
+}
+
+export const Providers: {
+    /** Basic JSON permissions provider */
+    JsonProvider: { new(roles: object): Provider };
+};

--- a/types/rbac-a/lib/attributes-manager.d.ts
+++ b/types/rbac-a/lib/attributes-manager.d.ts
@@ -1,0 +1,2 @@
+import { AttributesManager } from "..";
+export = AttributesManager;

--- a/types/rbac-a/lib/provider.d.ts
+++ b/types/rbac-a/lib/provider.d.ts
@@ -1,0 +1,2 @@
+import { Provider } from "..";
+export = Provider;

--- a/types/rbac-a/lib/rbac.d.ts
+++ b/types/rbac-a/lib/rbac.d.ts
@@ -1,0 +1,2 @@
+import { RBAC } from "..";
+export = RBAC;

--- a/types/rbac-a/rbac-a-tests.ts
+++ b/types/rbac-a/rbac-a-tests.ts
@@ -1,0 +1,40 @@
+import {
+    Provider,
+    RBAC,
+} from "rbac-a";
+
+class CustomProvider extends Provider { }
+
+const rbac = new RBAC({
+    provider: new CustomProvider()
+});
+
+const user = "ExampleUser";
+
+rbac.on('error', (err) => {
+    console.error('Error while checking $s/%s', err.role, err.user);
+    console.error(err.stack);
+});
+
+rbac.check(user, 'create').then((allowed) => {
+    if (allowed) {
+        console.log('User can create!');
+    } else {
+        console.log('User cannot create.');
+        console.info('Please contact your system admin for more information');
+    }
+}).catch((err) => {
+    console.error(err && err.stack || err || 'ERROR');
+});
+
+// specify attributes arguments
+rbac.check(user, 'edit', { time: Date.now() }).then((allowed) => {
+    if (allowed) {
+        console.log('User can edit!');
+    } else {
+        console.log('User cannot edit.');
+        console.info('Please contact your system admin for more information');
+    }
+}).catch((err) => {
+    console.error(err && err.stack || err || 'ERROR');
+});

--- a/types/rbac-a/tsconfig.json
+++ b/types/rbac-a/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/rbac-a/tsconfig.json
+++ b/types/rbac-a/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "lib/attributes-manager.d.ts",
+        "lib/provider.d.ts",
+        "lib/rbac.d.ts",
+        "rbac-a-tests.ts"
+    ]
+}

--- a/types/rbac-a/tsconfig.json
+++ b/types/rbac-a/tsconfig.json
@@ -4,7 +4,10 @@
         "lib": [
             "es6"
         ],
-        "strict": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/rbac-a/tsconfig.json
+++ b/types/rbac-a/tsconfig.json
@@ -4,9 +4,7 @@
         "lib": [
             "es6"
         ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictFunctionTypes": true,
+        "strict": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/rbac-a/tslint.json
+++ b/types/rbac-a/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

## additional

although those definitions are not perfect (I couldn't made to `export === RBAC` - see https://github.com/yanickrochon/rbac-a/blob/master/index.js) I'd like to make this PR

so when doing something like that:
```
declare namespace RBAC {
    class RBAC ...
}
declare const RBAC: typeof RBAC.RBAC;
export = RBAC;
```
I'm getting following error: `TypeScript compile error: Duplicate identifier 'RBAC'.`