### PR TITLE
Flot: Add timezone, timeformat, twelveHourClock to axisOptions

### DIFF
--- a/types/flot/index.d.ts
+++ b/types/flot/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for Flot
 // Project: http://www.flotcharts.org/
-// Definitions by: Matt Burland <https://github.com/burlandm>, Timo Mühlbach <https://github.com/Anticom>
+// Definitions by:  Matt Burland <https://github.com/burlandm>
+//                  Timo Mühlbach <https://github.com/Anticom>
+//                  Ariel Kuechler <https://github.com/admiralsmaster> 
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -120,6 +122,10 @@ declare namespace jquery.flot {
         tickLength?: number;
 
         alignTicksWithAxis?: number;
+        
+        timezone?: string;                      // "browser" or timezone (only makes sense for mode: "time")
+        timeformat?: string;                    // null or format string
+        twelveHourClock?: boolean;
     }
 
     interface seriesTypeBase {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/flot/flot/blob/master/API.md#time-series-data
https://github.com/flot/flot/blob/master/API.md#customizing-the-axes
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


