### PR TITLE
Package: amcharts. Fix type on showCursorAt method.

### DIFF
--- a/types/amcharts/index.d.ts
+++ b/types/amcharts/index.d.ts
@@ -1549,7 +1549,7 @@ If you do not set properties such as dashLength, lineAlpha, lineColor, etc - val
         /** Hides cursor. */
         hideCursor(): void;
         /** You can force cursor to appear at specified cateogry or date. */
-        showCursorAt(category: string): void;
+        showCursorAt(category: string | Date): void;
         /** Adds event listener of the type "changed" to the object.
             @param type Always "changed".
             @param handler Dispatched when cursor position is changed. "index" is a series index over which chart cursors currently is. "zooming" specifies if user is currently zooming (is selecting) the chart. mostCloseGraph property is set only when oneBalloonOnly is set to true.*/


### PR DESCRIPTION
According to this page on the [documentation](https://docs.amcharts.com/3/javascriptcharts/ChartCursor#showCursorAt) and the package type, the method showCursorAt should accept either a string or a Date. 

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.amcharts.com/3/javascriptcharts/ChartCursor#showCursorAt
