### PR TITLE
[react] fix React.Component constructor definition

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -278,7 +278,7 @@ declare namespace React {
     // tslint:disable-next-line:no-empty-interface
     interface Component<P = {}, S = {}> extends ComponentLifecycle<P, S> { }
     class Component<P, S> {
-        constructor(props: P, context?: any);
+        constructor(props?: P, context?: any);
 
         // Disabling unified-signatures to have separate overloads. It's easier to understand this way.
         // tslint:disable-next-line:unified-signatures


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Related issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21685

The error `"Expected 1-2 arguments, but got 0."` was popping up with the following code:

```typescript
export class App extends React.Component {
  constructor () {
    super();
  }
}
```

Which is totally fine.