### PR TITLE
Extend ARTSurfaceProps to allow either an element or an array type StyleProp<ViewStyle>

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8220,7 +8220,7 @@ export interface ARTShapeProps {
 }
 
 export interface ARTSurfaceProps {
-    style: StyleProp<ViewStyle>;
+    style: StyleProp<ViewStyle> | StyleProp<ViewStyle>[];
     width: number;
     height: number;
 }


### PR DESCRIPTION
Hello!  I was running into an issue where I wanted to provide an array of StyleProps to my component.  This modification works for me but if there's a better way to do it please let me know.

You can see react-native supports either a single style or an array of styles here:
https://facebook.github.io/react-native/docs/style.html

Thanks for your time!