### PR TITLE
Add types for defer-promise

### DIFF
--- a/types/defer-promise/defer-promise-tests.ts
+++ b/types/defer-promise/defer-promise-tests.ts
@@ -1,0 +1,23 @@
+import defer = require('defer-promise');
+
+// $ExpectType Deferred<number>
+const a = defer<number>();
+// $ExpectType void
+a.resolve(5);
+// $ExpectError
+a.resolve('foo');
+// $ExpectError
+a.resolve();
+
+// $ExpectType Deferred<void>
+const b = defer<void>();
+// $ExpectType void
+b.resolve();
+// $ExpectError
+b.resolve(5);
+
+const c: DeferPromise.Deferred<string> = defer();
+// $ExpectType void
+c.resolve('foo');
+// $ExpectType Promise<string>
+c.promise;

--- a/types/defer-promise/index.d.ts
+++ b/types/defer-promise/index.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for defer-promise 1.0
+// Project: https://github.com/75lb/defer-promise#readme
+// Definitions by: Niklas Fiekas <https://github.com/niklasf>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+// tslint:disable-next-line no-unnecessary-generics
+declare function defer<T>(): DeferPromise.Deferred<T>;
+
+export = defer;
+
+declare global {
+    namespace DeferPromise {
+        interface Deferred<T> {
+            promise: Promise<T>;
+            resolve(value: T | PromiseLike<T>): void;
+            resolve(this: Deferred<void>): void;
+            reject(reason?: any): void;
+        }
+    }
+}

--- a/types/defer-promise/tsconfig.json
+++ b/types/defer-promise/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es5",
+            "es2015.Promise"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "defer-promise-tests.ts"
+    ]
+}

--- a/types/defer-promise/tslint.json
+++ b/types/defer-promise/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
  * I think the exception to `no-unnecessary-generics` generics is justified. The function `defer()` makes a new `Deferred<T>`, not just any `T`.
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.