### PR TITLE
puppeteer: fix setCookie typing

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -200,6 +200,8 @@ export interface SetCookie {
   name: string;
   /** The cookie value. */
   value: string;
+  /** The request-URI to associate with the setting of the cookie. This value can affect the default domain and path values of the created cookie. */
+  url?: string;
   /** The cookie domain. */
   domain?: string;
   /** The cookie path. */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [puppeteer](https://github.com/GoogleChrome/puppeteer/blob/v0.13.0/docs/api.md#pagesetcookiecookies), [cookie param](https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-CookieParam)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
