### PR TITLE
[@types/googlemaps] Fixing GeocoderRequest wrong property names

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -1158,17 +1158,17 @@ declare namespace google.maps {
     export interface GeocoderRequest {
         address?: string;
         bounds?: LatLngBounds|LatLngBoundsLiteral;
-        componentRestrictions?: GeocoderComponentRestrictions;
+        components?: GeocoderComponents;
         location?: LatLng|LatLngLiteral;
         placeId?: string;
         region?: string;
     }
 
-    export interface GeocoderComponentRestrictions {
-        administrativeArea?: string;
+    export interface GeocoderComponents {
+        administrative_area?: string;
         country?: string | string[];
         locality?: string;
-        postalCode?: string;
+        postal_code?: string;
         route?: string;
     }
 


### PR DESCRIPTION
Fixed GeocoderRequest property names:
- Renamed componentRestrictions => components
- Renamed componentRestrictions interface:
  - Renamed postalCode => postal_code
  - Renamed administrativeArea => administrative_area

Documentation:
https://developers.google.com/maps/documentation/geocoding/intro?hl=es-419#ComponentFiltering

