### PR TITLE
[react-virtualized] Fix Table exports and row renderer props

### DIFF
--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -43,6 +43,7 @@ export type TableRowProps = {
     onRowDoubleClick?: (params: RowMouseEventHandlerParams) => void,
     onRowMouseOver?: (params: RowMouseEventHandlerParams) => void,
     onRowMouseOut?: (params: RowMouseEventHandlerParams) => void,
+    onRowRightClick?: (params: RowMouseEventHandlerParams) => void,
     rowData: any,
     style: any
 };

--- a/types/react-virtualized/dist/es/Table.d.ts
+++ b/types/react-virtualized/dist/es/Table.d.ts
@@ -291,11 +291,11 @@ export type TableProps = GridCoreProps & {
     width?: number;
 }
 
-export const defaultTableCellDataGetter: TableCellDataGetter;
-export const defaultTableCellRenderer: TableCellRenderer;
-export const defaultTableHeaderRenderer: () => React.ReactElement<TableHeaderProps>[];
-export const defaultTableHeaderRowRenderer: TableHeaderRowRenderer;
-export const defaultTableRowRenderer: TableRowRenderer;
+export const defaultCellDataGetter: TableCellDataGetter;
+export const defaultCellRenderer: TableCellRenderer;
+export const defaultHeaderRenderer: () => React.ReactElement<TableHeaderProps>[];
+export const defaultHeaderRowRenderer: TableHeaderRowRenderer;
+export const defaultRowRenderer: TableRowRenderer;
 
 export type SortDirectionStatic = {
     /**

--- a/types/react-virtualized/index.d.ts
+++ b/types/react-virtualized/index.d.ts
@@ -99,11 +99,11 @@ export {
     ScrollSyncState
 } from './dist/es/ScrollSync'
 export {
-    defaultTableCellDataGetter,
-    defaultTableCellRenderer,
-    defaultTableHeaderRenderer,
-    defaultTableHeaderRowRenderer,
-    defaultTableRowRenderer,
+    defaultCellDataGetter as defaultTableCellDataGetter,
+    defaultCellRenderer as defaultTableCellRenderer,
+    defaultHeaderRenderer as defaultTableHeaderRenderer,
+    defaultHeaderRowRenderer as defaultTableHeaderRowRenderer,
+    defaultRowRenderer as defaultTableRowRenderer,
     Table,
     Column,
     SortDirection,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/bvaughn/react-virtualized/blob/master/source/index.js#L21-L25
  - https://github.com/bvaughn/react-virtualized/blob/master/source/Table/defaultRowRenderer.js#L17
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Issues resolved:
- Incorrect export names for default renderers in `Table.d.ts`; re-exported from index with current names (as per the project)
- `TableRowProps` missing `onRowRightClick` property (this is an issue in `react-virtualized` `Table/types.js` too).