### PR TITLE
Add type for asynchronous nightwatch test hooks

### DIFF
--- a/types/nightwatch/index.d.ts
+++ b/types/nightwatch/index.d.ts
@@ -2160,15 +2160,22 @@ export interface NightwatchCustomAssertions {}
 
 export interface NightwatchBrowser extends NightwatchAPI, NightwatchCustomCommands, NightwatchCustomAssertions, NightwatchCustomPageObjects { }
 
-/**
- * Performs an assertion
- *
- */
 export type NightwatchTest = (browser: NightwatchBrowser) => void;
 
-export interface NightwatchTests {
+export interface NightwatchTestFunctions {
     [key: string]: NightwatchTest;
 }
+
+export type NightwatchTestHook = (browser: NightwatchBrowser, done: () => void) => void;
+
+export interface NightwatchTestHooks {
+    before?: NightwatchTestHook;
+    after?: NightwatchTestHook;
+    beforeEach?: NightwatchTestHook;
+    afterEach?: NightwatchTestHook;
+}
+
+export type NightwatchTests = NightwatchTestFunctions | NightwatchTestHooks;
 
 /**
  * Performs an assertion

--- a/types/nightwatch/nightwatch-tests.ts
+++ b/types/nightwatch/nightwatch-tests.ts
@@ -1,6 +1,9 @@
 import { NightwatchAPI, NightwatchTests } from 'nightwatch';
 
 const test: NightwatchTests = {
+  before: (browser, done) => {
+    done();
+  },
   'Demo test Google': (browser) => {
     browser
       .url('http://www.google.com')


### PR DESCRIPTION
Adds a new type `NightwatchTestHooks` which allows using asynchronous test hooks. I didn't just extend the `NightwatchTest` type with the `done` callback because that is only available for hooks, but not regular tests.

~~In order to use asynchronous test hooks one must explicitly use the `NightwatchTestHooks` type like this:~~
~~const tests: NightwatchTests | NightwatchTestHooks = {
    before: (browser, done) => { done(); },
    // ...
};~~

update1: I now re-defined `NightwatchTests` as a new type containing `NightwatchTestHooks`, so it doesn't have to be explicitly used.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://nightwatchjs.org/guide#asynchronous-before-each-and-after-each-
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.