### PR TITLE
Fix typings of sinon.stub(obj: T)

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -150,7 +150,7 @@ declare namespace Sinon {
 
     interface SinonStubStatic {
         (): SinonStub;
-        (obj: any): SinonStub;
+        <T>(obj: T): SinonStubbedInstance<T>;
         <T>(obj: T, method: keyof T): SinonStub;
         <T>(obj: T, method: keyof T, func: Function): SinonStub;
     }

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -559,6 +559,8 @@ declare namespace Sinon {
      * @template TType Object type being stubbed.
      */
     type SinonStubbedInstance<TType> = {
+        // TODO: this should really only replace functions on TType with SinonStubs, not all properties
+        // Likely infeasible without mapped conditional types, per https://github.com/Microsoft/TypeScript/issues/12424
         [P in keyof TType]: SinonStub;
     };
 }

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -239,6 +239,16 @@ function testFakeServer() {
     });
 }
 
+function testStubObject() {
+    const myObj = {
+        setStatus() {},
+        json() {}
+    };
+    const stub = sinon.stub(myObj);
+    stub.setStatus.returns(stub);
+    stub.json.callCount;
+}
+
 testOne();
 testTwo();
 testThree();


### PR DESCRIPTION
`sinon.stub(obj: T)` returns a whole object, with each function in the object replaced with a stub, but the current typings claim that it only returns a single stub.

---

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I couldn't get the `dtslint` to run without erroring, even before I made any changes  ("Unexpected compiler option strictFunctionTypes") I'm pretty confident in this change without it, but if anyone knows how to fix that, let me know.  

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://sinonjs.org/releases/v4.1.2/stubs/#var-stub--sinonstubobj
- [ ] Increase the version number in the header if appropriate.

I'd think this would be a patch version, as the previous typing was just incorrect, but I do a version bump, if that's preferred.