### PR TITLE
Add missing _.matches iteratee shorthard to Lodash

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -17094,7 +17094,7 @@ declare namespace _ {
     type ArrayIterator<T, TResult> = (value: T, index: number, collection: T[]) => TResult;
     type ListIterator<T, TResult> = (value: T, index: number, collection: List<T>) => TResult;
     type ListIteratee<T> = ListIterator<T, NotVoid> | string | [string, any] | PartialDeep<T>;
-    type ListIterateeCustom<T, TResult> = ListIterator<T, TResult> | string | [string, any] | PartialDeep<T>;
+    type ListIterateeCustom<T, TResult> = ListIterator<T, TResult> | string | object | [string, any] | PartialDeep<T>;
     type ListIteratorTypeGuard<T, S extends T> = (value: T, index: number, collection: List<T>) => value is S;
 
     // Note: key should be string, not keyof T, because the actual object may contain extra properties that were not specified in the type.

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -17100,7 +17100,7 @@ declare namespace _ {
     // Note: key should be string, not keyof T, because the actual object may contain extra properties that were not specified in the type.
     type ObjectIterator<TObject, TResult> = (value: TObject[keyof TObject], key: string, collection: TObject) => TResult;
     type ObjectIteratee<TObject> = ObjectIterator<TObject, NotVoid> | string | [string, any] | PartialDeep<TObject[keyof TObject]>;
-    type ObjectIterateeCustom<TObject, TResult> = ObjectIterator<TObject, TResult> | string | {} | [string, any] | PartialDeep<TObject[keyof TObject]>;
+    type ObjectIterateeCustom<TObject, TResult> = ObjectIterator<TObject, TResult> | string | object | [string, any] | PartialDeep<TObject[keyof TObject]>;
     type ObjectIteratorTypeGuard<TObject, S extends TObject[keyof TObject]> = (value: TObject[keyof TObject], key: string, collection: TObject) => value is S;
 
     type DictionaryIterator<T, TResult> = ObjectIterator<Dictionary<T>, TResult>;

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -17100,7 +17100,7 @@ declare namespace _ {
     // Note: key should be string, not keyof T, because the actual object may contain extra properties that were not specified in the type.
     type ObjectIterator<TObject, TResult> = (value: TObject[keyof TObject], key: string, collection: TObject) => TResult;
     type ObjectIteratee<TObject> = ObjectIterator<TObject, NotVoid> | string | [string, any] | PartialDeep<TObject[keyof TObject]>;
-    type ObjectIterateeCustom<TObject, TResult> = ObjectIterator<TObject, TResult> | string | [string, any] | PartialDeep<TObject[keyof TObject]>;
+    type ObjectIterateeCustom<TObject, TResult> = ObjectIterator<TObject, TResult> | string | {} | [string, any] | PartialDeep<TObject[keyof TObject]>;
     type ObjectIteratorTypeGuard<TObject, S extends TObject[keyof TObject]> = (value: TObject[keyof TObject], key: string, collection: TObject) => value is S;
 
     type DictionaryIterator<T, TResult> = ObjectIterator<Dictionary<T>, TResult>;


### PR DESCRIPTION
This PR was basically to highlight an issue I had with the lodash type definitions. The _.matches iteratee shorthand was throwing the error below when I updated to Typescript 2.6.2: 

```
[ts]
Argument of type '{ 'global-party-identifier': string; }' is not assignable to parameter of type 'ObjectIterateeCustom<any, boolean>'.
  Type '{ 'global-party-identifier': string; }' is not assignable to type 'PartialDeep<any>'.
    Property ''global-party-identifier'' is incompatible with index signature.
      Type 'string' is not assignable to type 'PartialDeep<any>'.`
```

I saw that the tuple ```[string, any]``` was allowing for the _.matchesProperty shorthand, so I just added an object to the ObjectIterateeCustom type union.

I scanned through the other types that allow _.matches shorthand and they looked to be using the same ObjectIterateeCustom type, so I think this change is in the right place.

I'm not a Typescript expert, so I wasn't sure how else to represent an arbitrarily-keyed object, so there's probably a better implementation.