### PR TITLE
Changes Jest type to use array rather than Set.

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1046,6 +1046,7 @@ declare namespace jest {
         path: Path;
     }
 
+    // tslint:disable-next-line:no-empty-interface
     interface Set<T> {} // To allow non-ES6 users the Set below
     interface Reporter {
         onTestResult?(test: Test, testResult: TestResult, aggregatedResult: AggregatedResult): void;

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1050,7 +1050,7 @@ declare namespace jest {
         onTestResult?(test: Test, testResult: TestResult, aggregatedResult: AggregatedResult): void;
         onRunStart?(results: AggregatedResult, options: ReporterOnStartOptions): void;
         onTestStart?(test: Test): void;
-        onRunComplete?(contexts: Set<Context>, results: AggregatedResult): Maybe<Promise<void>>;
+        onRunComplete?(contexts: [Context], results: AggregatedResult): Maybe<Promise<void>>;
         getLastError?(): Maybe<Error>;
     }
 

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1046,11 +1046,12 @@ declare namespace jest {
         path: Path;
     }
 
+    interface Set<T> {} // To allow non-ES6 users the Set below
     interface Reporter {
         onTestResult?(test: Test, testResult: TestResult, aggregatedResult: AggregatedResult): void;
         onRunStart?(results: AggregatedResult, options: ReporterOnStartOptions): void;
         onTestStart?(test: Test): void;
-        onRunComplete?(contexts: [Context], results: AggregatedResult): Maybe<Promise<void>>;
+        onRunComplete?(contexts: Set<Context>, results: AggregatedResult): Maybe<Promise<void>>;
         getLastError?(): Maybe<Error>;
     }
 


### PR DESCRIPTION
Set may be technically stricter but as per #19662, there have been a number of associated problems with this.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: See #19662
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
