### PR TITLE
Replaced onActionTouchTap w/ onActionClick

### DIFF
--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1628,7 +1628,7 @@ declare namespace __MaterialUI {
         className?: string;
         contentStyle?: React.CSSProperties;
         message: React.ReactNode;
-        onActionTouchTap?: React.TouchEventHandler<{}>;
+        onActionClick?: React.MouseEventHandler<{}>;
         onRequestClose?(reason: string): void;
         open: boolean;
         style?: React.CSSProperties;
@@ -1684,7 +1684,7 @@ declare namespace __MaterialUI {
             bodyStyle?: React.CSSProperties;
             className?: string;
             message: string | JSX.Element;
-            onActionTouchTap?: React.TouchEventHandler<{}>;
+            onActionClick?: React.MouseEventHandler<{}>;
             /** @deprecated Use the open property to control the component instead */
             onDismiss?(): void; // DEPRECATED
             onRequestClose(reason: string): void;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for material-ui v0.18.17
+// Type definitions for material-ui v0.20.0
 // Project: https://github.com/callemall/material-ui
 // Definitions by: Nathan Brown <https://github.com/ngbrown>
 //                 Igor Beagorudsky <https://github.com/theigor>

--- a/types/material-ui/material-ui-tests.tsx
+++ b/types/material-ui/material-ui-tests.tsx
@@ -5736,7 +5736,7 @@ class SnackbarExampleAction extends Component<{}, {open?: boolean, autoHideDurat
     });
   }
 
-  handleActionTouchTap = () => {
+  handleActionClick = () => {
     this.setState({
       open: false,
     });
@@ -5774,7 +5774,7 @@ class SnackbarExampleAction extends Component<{}, {open?: boolean, autoHideDurat
           message={this.state.message}
           action="undo"
           autoHideDuration={this.state.autoHideDuration}
-          onActionTouchTap={this.handleActionTouchTap}
+          onActionClick={this.handleActionClick}
           onRequestClose={this.handleRequestClose}
         />
       </div>


### PR DESCRIPTION
Snackbar property `onActionTouchTap` was replaced with `onActionClick` in [release 0.20.0](https://github.com/mui-org/material-ui/releases/tag/v0.20.0).

This relates to [pull request 9058](https://github.com/mui-org/material-ui/pull/9058) and specifically [this commit](https://github.com/mui-org/material-ui/pull/9058/commits/bc97082dd318f8d4f872fc0c65cdc8539f7ea981).
