### PR TITLE
Lodash: wrong overload picked for `flow`/`flowRight` when function has optional parameter and `strictFunctionTypes` is disabled

### DIFF
--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -7439,6 +7439,13 @@ namespace TestFlow {
     let Fn2 = (m: number, n: number) => 0;
     let Fn3 = (a: number) => "";
     let Fn4 = (a: string) => 0;
+    let Fn5 = (a?: string) => 0;
+
+    {
+        const result = _.flow(Fn5, Fn1);
+
+        result('foo');
+    }
 
     {
         // type infer test


### PR DESCRIPTION
If the first function provided to `flow` or `flowRight` has an optional or nullable parameter, and `strictFunctionTypes` is disabled, the wrong overload will be picked.

``` ts
{
  const fn1 = (a?: string) => a;
  const fn2 = (a: string) => a;

  const fn3 = _.flow(fn1, fn2);

  // Unexpected error: Expected 0 arguments, but got 1.
  fn3('foo');
}
```

This is because the "0-argument first function" overload was picked instead of the "1-argument first function" overload.

This PR contains a failing test to demonstrate the problem.

I haven't fixed the issue in this PR—I wanted to discuss ideas first.

Perhaps this could be fixed by reversing the order of the overloads, from most specific to least specific?

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.