### PR TITLE
Added WordArray to key Parameter for Hash type definition

### DIFF
--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -8,7 +8,7 @@ export as namespace CryptoJS;
 
 declare var CryptoJS: CryptoJS.Hashes;
 declare namespace CryptoJS {
-	type Hash = (message: string | LibWordArray, key?: string, ...options: any[]) => WordArray;
+	type Hash = (message: string | LibWordArray, key?: string | WordArray, ...options: any[]) => WordArray;
 	interface Cipher {
 		encrypt(message: string, secretPassphrase: string | WordArray, option?: CipherOption): WordArray;
 		decrypt(encryptedMessage: string | WordArray, secretPassphrase: string | WordArray, option?: CipherOption): DecryptedMessage;


### PR DESCRIPTION
For the AWS Hashing Mechanism with the HmacSHA256 in Typescript the key parameter of the Hash type needs to be extended to allow using a WordArray.

Added the WordArray type to the Hash type.
Sample Code from Amazon with issue: 
var kDate = Crypto.HmacSHA256(dateStamp, "AWS4" + key);
    var kRegion = Crypto.HmacSHA256(regionName, kDate); **<=== Issue because kDate is typeof WordArray and not string as the key should be supposed to.** 
With adding the WordArray type the Hashing Procedure works fine (when using the toString it doesn't work correctly there).

Sample for JS from Amazon:
https://docs.aws.amazon.com/de_de/general/latest/gr/signature-v4-examples.html#signature-v4-examples-javascript