### PR TITLE
[react] Allow more return values from stateless components

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -14,6 +14,7 @@
 //                 Stéphane Goetz <https://github.com/onigoetz>
 //                 Rich Seviora <https://github.com/richseviora>
 //                 Josh Rutherford <https://github.com/theruther4d>
+//                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -167,7 +168,8 @@ declare namespace React {
 
     // Should be Array<ReactNode> but type aliases cannot be recursive
     type ReactFragment = {} | Array<ReactChild | any[] | boolean>;
-    type ReactNode = ReactChild | ReactFragment | ReactPortal | string | number | boolean | null | undefined;
+    type ReactRenderResult = ReactChild | ReactFragment | ReactPortal | string | number | boolean | null;
+    type ReactNode = ReactRenderResult | undefined;
 
     //
     // Top Level API
@@ -287,7 +289,7 @@ declare namespace React {
         setState<K extends keyof S>(state: Pick<S, K>, callback?: () => any): void;
 
         forceUpdate(callBack?: () => any): void;
-        render(): ReactNode;
+        render(): ReactRenderResult;
 
         // React.Props<T> is now deprecated, which means that the `children`
         // property is not available on `P` by default, even though you can
@@ -320,7 +322,7 @@ declare namespace React {
 
     type SFC<P = {}> = StatelessComponent<P>;
     interface StatelessComponent<P = {}> {
-        (props: P & { children?: ReactNode }, context?: any): ReactElement<any> | null;
+        (props: P & { children?: ReactNode }, context?: any): ReactRenderResult;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
         defaultProps?: Partial<P>;
@@ -3527,7 +3529,7 @@ declare global {
         // tslint:disable-next-line:no-empty-interface
         interface Element extends React.ReactElement<any> { }
         interface ElementClass extends React.Component<any> {
-            render(): React.ReactNode;
+            render(): React.ReactRenderResult;
         }
         interface ElementAttributesProperty { props: {}; }
         interface ElementChildrenAttribute { children: {}; }

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -708,3 +708,13 @@ class RenderChildren extends React.Component {
         return children !== undefined ? children : null;
     }
 }
+
+// Stateless functional components should be able to return bare arrays
+const ArrayElement: React.SFC = () => ([ 'Hello, ', 1337, '!']);
+const NullElement: React.SFC = () => null;
+
+// Render methods should not be allowed to return undefined
+// $ExpectError
+class NoUndefined extends React.Component {
+    render() { return undefined; }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

-----

Opening this for some early feedback since I can't figure out how to tackle my last problem.

Basically, my original problem is that I have a stateless component that returns an array (it returns the return value of `React.Children.map`).

When fixing this I stumbled onto another problem; it's illegal to return `undefined` from a `render`-function, or from a stateless component. Yet this is currently allowed for normal components.

I think I got most of it right now, but for some reason I'm getting the following error:

```text
test/tsx.tsx(13,1): error TS2605: JSX element type 'ReactRenderResult' is not a constructor function for JSX elements.
  Type 'null' is not assignable to type 'ElementClass'.
```

whenever a stateless component is used in JSX:

```js
<StatelessComponent />;
```

Any help would be much appreciated! 🍻 