### PR TITLE
node: added perf_hooks module definition

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -7014,10 +7014,10 @@ declare module "perf_hooks" {
 		 * A PerformanceObserver must be subscribed to the 'function' event type in order for the timing details to be accessed.
 		 * @param fn
 		 */
-		timerify?(fn: (...optionalParams: any[]) => any): (...optionalParams: any[]) => any;
+		timerify<T extends (...optionalParams: any[]) => any>(fn: T) => T;
 	}
 
-	var performance: Performance;
-	var performanceEntry: PerformanceEntry;
-	var performanceNodeTiming: PerformanceNodeTiming;
+	const performance: Performance;
+	const performanceEntry: PerformanceEntry;
+	const performanceNodeTiming: PerformanceNodeTiming;
 }

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Node.js 8.x
+// Type definitions for Node.js 8.5.x
 // Project: http://nodejs.org/
 // Definitions by: Microsoft TypeScript <http://typescriptlang.org>
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
@@ -21,7 +21,7 @@
 
 /************************************************
 *                                               *
-*               Node.js v8.x API                *
+*               Node.js v8.5.x API              *
 *                                               *
 ************************************************/
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -6821,134 +6821,130 @@ declare module "http2" {
 }
 
 declare module "perf_hooks" {
-	interface PerformanceEntry {
+	export interface PerformanceEntry {
 		/**
 		 * The total number of milliseconds elapsed for this entry.
 		 * This value will not be meaningful for all Performance Entry types.
 		 */
-		readonly duration?: number;
+		readonly duration: number;
 
 		/**
 		 * The name of the performance entry.
 		 */
-		readonly name?: string;
+		readonly name: string;
 
 		/**
 		 * The high resolution millisecond timestamp marking the starting time of the Performance Entry.
 		 */
-		readonly startTime?: number;
+		readonly startTime: number;
 
 		/**
 		 * The type of the performance entry.
 		 * Currently it may be one of: 'node', 'mark', 'measure', 'gc', or 'function'.
 		 */
-		readonly entryType?: string;
+		readonly entryType: string;
 
 		/**
 		 * When performanceEntry.entryType is equal to 'gc', the performance.kind property identifies
 		 * the type of garbage collection operation that occurred.
-		 * The value may be one of:
-		 * - perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR
-		 * - perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR
-		 * - perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL
-		 * - perf_hooks.constants.NODE_PERFORMANCE_GC_WEAKCB
+		 * The value may be one of perf_hooks.constants.
 		 */
 		readonly kind?: number;
 	}
 
-	interface PerformanceNodeTiming extends PerformanceEntry {
+	export interface PerformanceNodeTiming extends PerformanceEntry {
 		/**
 		 * The high resolution millisecond timestamp at which the Node.js process completed bootstrap.
 		 */
-		readonly bootstrapComplete?: number;
+		readonly bootstrapComplete: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which cluster processing ended.
 		 */
-		readonly clusterSetupEnd?: number;
+		readonly clusterSetupEnd: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which cluster processing started.
 		 */
-		readonly clusterSetupStart?: number;
+		readonly clusterSetupStart: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which the Node.js event loop exited.
 		 */
-		readonly loopExit?: number;
+		readonly loopExit: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which the Node.js event loop started.
 		 */
-		readonly loopStart?: number;
+		readonly loopStart: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which main module load ended.
 		 */
-		readonly moduleLoadEnd?: number;
+		readonly moduleLoadEnd: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which main module load started.
 		 */
-		readonly moduleLoadStart?: number;
+		readonly moduleLoadStart: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which the Node.js process was initialized.
 		 */
-		readonly nodeStart?: number;
+		readonly nodeStart: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which preload module load ended.
 		 */
-		readonly preloadModuleLoadEnd?: number;
+		readonly preloadModuleLoadEnd: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which preload module load started.
 		 */
-		readonly preloadModuleLoadStart?: number;
+		readonly preloadModuleLoadStart: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which third_party_main processing ended.
 		 */
-		readonly thirdPartyMainEnd?: number;
+		readonly thirdPartyMainEnd: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which third_party_main processing started.
 		 */
-		readonly thirdPartyMainStart?: number;
+		readonly thirdPartyMainStart: number;
 
 		/**
 		 * The high resolution millisecond timestamp at which the V8 platform was initialized.
 		 */
-		readonly v8Start?: number;
+		readonly v8Start: number;
     }
 
-	interface Performance {
+	export interface Performance {
 		/**
 		 * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
 		 * If name is provided, removes entries with name.
 		 * @param name
 		 */
-		clearFunctions?(name?: string): void;
+		clearFunctions(name?: string): void;
 
 		/**
 		 * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
 		 * If name is provided, removes only the named mark.
 		 * @param name
 		 */
-		clearMarks?(name?: string): void;
+		clearMarks(name?: string): void;
 
 		/**
 		 * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
 		 * If name is provided, removes only objects whose performanceEntry.name matches name.
 		 */
-		clearMeasures?(name?: string): void;
+		clearMeasures(name?: string): void;
 
 		/**
 		 * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
 		 * @return list of all PerformanceEntry objects
 		 */
-		getEntries?(): PerformanceEntry[];
+		getEntries(): PerformanceEntry[];
 
 		/**
 		 * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
@@ -6957,7 +6953,7 @@ declare module "perf_hooks" {
 		 * @param type
 		 * @return list of all PerformanceEntry objects
 		 */
-		getEntriesByName?(name: string, type?: string): PerformanceEntry[];
+		getEntriesByName(name: string, type?: string): PerformanceEntry[];
 
 		/**
 		 * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
@@ -6965,7 +6961,7 @@ declare module "perf_hooks" {
 		 * @param type
 		 * @return list of all PerformanceEntry objects
 		 */
-		getEntriesByType?(type: string): PerformanceEntry[];
+		getEntriesByType(type: string): PerformanceEntry[];
 
 		/**
 		 * Creates a new PerformanceMark entry in the Performance Timeline.
@@ -6974,7 +6970,7 @@ declare module "perf_hooks" {
 		 * Performance marks are used to mark specific significant moments in the Performance Timeline.
 		 * @param name
 		 */
-		mark?(name?: string): void;
+		mark(name?: string): void;
 
 		/**
 		 * Creates a new PerformanceMeasure entry in the Performance Timeline.
@@ -6991,33 +6987,75 @@ declare module "perf_hooks" {
 		 * @param startMark
 		 * @param endMark
 		 */
-		measure?(name: string, startMark: string, endMark: string): void;
+		measure(name: string, startMark: string, endMark: string): void;
 
 		/**
 		 * An instance of the PerformanceNodeTiming class that provides performance metrics for specific Node.js operational milestones.
 		 */
-		readonly nodeTiming?: PerformanceNodeTiming;
+		readonly nodeTiming: PerformanceNodeTiming;
 
 		/**
-		 * Returns the current high resolution millisecond timestamp.
-		 * @return timestamp in ms
+		 * @return the current high resolution millisecond timestamp
 		 */
-		now?(): number;
+		now(): number;
 
 		/**
 		 * The timeOrigin specifies the high resolution millisecond timestamp from which all performance metric durations are measured.
 		 */
-		readonly timeOrigin?: number;
+		readonly timeOrigin: number;
 
 		/**
 		 * Wraps a function within a new function that measures the running time of the wrapped function.
 		 * A PerformanceObserver must be subscribed to the 'function' event type in order for the timing details to be accessed.
 		 * @param fn
 		 */
-		timerify<T extends (...optionalParams: any[]) => any>(fn: T) => T;
-	}
+		timerify<T extends (...optionalParams: any[]) => any>(fn: T): T;
+    }
+
+    export interface PerformanceObserverEntryList {
+        /**
+         * @return a list of PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
+         */
+        getEntries(): PerformanceEntry[];
+
+        /**
+         * @return a list of PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
+         * whose performanceEntry.name is equal to name, and optionally, whose performanceEntry.entryType is equal to type.
+         */
+        getEntriesByName(name: string, type?: string): PerformanceEntry[];
+
+        /**
+         * @return Returns a list of PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
+         * whose performanceEntry.entryType is equal to type.
+         */
+        getEntriesByType(type: string): PerformanceEntry[];
+    }
+
+    export type PerformanceObserverCallback = (list: PerformanceObserverEntryList, observer: PerformanceObserver) => void;
+
+    export class PerformanceObserver {
+        constructor(callback: PerformanceObserverCallback);
+
+        /**
+         * Disconnects the PerformanceObserver instance from all notifications.
+         */
+        disconnect(): void;
+
+        /**
+         * Subscribes the PerformanceObserver instance to notifications of new PerformanceEntry instances identified by options.entryTypes.
+         * When options.buffered is false, the callback will be invoked once for every PerformanceEntry instance.
+         * Property buffered defaults to false.
+         * @param options
+         */
+        observe(options: { entryTypes: string[], buffered: boolean }): void;
+    }
+
+    export namespace constants {
+        export const NODE_PERFORMANCE_GC_MAJOR: number;
+        export const NODE_PERFORMANCE_GC_MINOR: number;
+        export const NODE_PERFORMANCE_GC_INCREMENTAL: number;
+        export const NODE_PERFORMANCE_GC_WEAKCB: number;
+    }
 
 	const performance: Performance;
-	const performanceEntry: PerformanceEntry;
-	const performanceNodeTiming: PerformanceNodeTiming;
 }

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -7047,7 +7047,7 @@ declare module "perf_hooks" {
          * Property buffered defaults to false.
          * @param options
          */
-        observe(options: { entryTypes: string[], buffered: boolean }): void;
+        observe(options: { entryTypes: string[], buffered?: boolean }): void;
     }
 
     export namespace constants {

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -16,6 +16,7 @@
 //                 Oliver Joseph Ash <https://github.com/OliverJAsh>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 //                 Hannes Magnusson <https://github.com/Hannes-Magnusson-CK>
+//                 Alberto Schiabel <https://github.com/jkomyno>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /************************************************
@@ -6817,4 +6818,206 @@ declare module "http2" {
 
     export function connect(authority: string | url.URL, listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;
     export function connect(authority: string | url.URL, options?: ClientSessionOptions | SecureClientSessionOptions, listener?: (session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void): ClientHttp2Session;
+}
+
+declare module "perf_hooks" {
+	interface PerformanceEntry {
+		/**
+		 * The total number of milliseconds elapsed for this entry.
+		 * This value will not be meaningful for all Performance Entry types.
+		 */
+		readonly duration?: number;
+
+		/**
+		 * The name of the performance entry.
+		 */
+		readonly name?: string;
+
+		/**
+		 * The high resolution millisecond timestamp marking the starting time of the Performance Entry.
+		 */
+		readonly startTime?: number;
+
+		/**
+		 * The type of the performance entry.
+		 * Currently it may be one of: 'node', 'mark', 'measure', 'gc', or 'function'.
+		 */
+		readonly entryType?: string;
+
+		/**
+		 * When performanceEntry.entryType is equal to 'gc', the performance.kind property identifies
+		 * the type of garbage collection operation that occurred.
+		 * The value may be one of:
+		 * - perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR
+		 * - perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR
+		 * - perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL
+		 * - perf_hooks.constants.NODE_PERFORMANCE_GC_WEAKCB
+		 */
+		readonly kind?: number;
+	}
+
+	interface PerformanceNodeTiming extends PerformanceEntry {
+		/**
+		 * The high resolution millisecond timestamp at which the Node.js process completed bootstrap.
+		 */
+		readonly bootstrapComplete?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which cluster processing ended.
+		 */
+		readonly clusterSetupEnd?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which cluster processing started.
+		 */
+		readonly clusterSetupStart?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which the Node.js event loop exited.
+		 */
+		readonly loopExit?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which the Node.js event loop started.
+		 */
+		readonly loopStart?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which main module load ended.
+		 */
+		readonly moduleLoadEnd?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which main module load started.
+		 */
+		readonly moduleLoadStart?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which the Node.js process was initialized.
+		 */
+		readonly nodeStart?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which preload module load ended.
+		 */
+		readonly preloadModuleLoadEnd?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which preload module load started.
+		 */
+		readonly preloadModuleLoadStart?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which third_party_main processing ended.
+		 */
+		readonly thirdPartyMainEnd?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which third_party_main processing started.
+		 */
+		readonly thirdPartyMainStart?: number;
+
+		/**
+		 * The high resolution millisecond timestamp at which the V8 platform was initialized.
+		 */
+		readonly v8Start?: number;
+    }
+
+	interface Performance {
+		/**
+		 * If name is not provided, removes all PerformanceFunction objects from the Performance Timeline.
+		 * If name is provided, removes entries with name.
+		 * @param name
+		 */
+		clearFunctions?(name?: string): void;
+
+		/**
+		 * If name is not provided, removes all PerformanceMark objects from the Performance Timeline.
+		 * If name is provided, removes only the named mark.
+		 * @param name
+		 */
+		clearMarks?(name?: string): void;
+
+		/**
+		 * If name is not provided, removes all PerformanceMeasure objects from the Performance Timeline.
+		 * If name is provided, removes only objects whose performanceEntry.name matches name.
+		 */
+		clearMeasures?(name?: string): void;
+
+		/**
+		 * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime.
+		 * @return list of all PerformanceEntry objects
+		 */
+		getEntries?(): PerformanceEntry[];
+
+		/**
+		 * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
+		 * whose performanceEntry.name is equal to name, and optionally, whose performanceEntry.entryType is equal to type.
+		 * @param name
+		 * @param type
+		 * @return list of all PerformanceEntry objects
+		 */
+		getEntriesByName?(name: string, type?: string): PerformanceEntry[];
+
+		/**
+		 * Returns a list of all PerformanceEntry objects in chronological order with respect to performanceEntry.startTime
+		 * whose performanceEntry.entryType is equal to type.
+		 * @param type
+		 * @return list of all PerformanceEntry objects
+		 */
+		getEntriesByType?(type: string): PerformanceEntry[];
+
+		/**
+		 * Creates a new PerformanceMark entry in the Performance Timeline.
+		 * A PerformanceMark is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'mark',
+		 * and whose performanceEntry.duration is always 0.
+		 * Performance marks are used to mark specific significant moments in the Performance Timeline.
+		 * @param name
+		 */
+		mark?(name?: string): void;
+
+		/**
+		 * Creates a new PerformanceMeasure entry in the Performance Timeline.
+		 * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
+		 * and whose performanceEntry.duration measures the number of milliseconds elapsed since startMark and endMark.
+		 *
+		 * The startMark argument may identify any existing PerformanceMark in the the Performance Timeline, or may identify
+		 * any of the timestamp properties provided by the PerformanceNodeTiming class. If the named startMark does not exist,
+		 * then startMark is set to timeOrigin by default.
+		 *
+		 * The endMark argument must identify any existing PerformanceMark in the the Performance Timeline or any of the timestamp
+		 * properties provided by the PerformanceNodeTiming class. If the named endMark does not exist, an error will be thrown.
+		 * @param name
+		 * @param startMark
+		 * @param endMark
+		 */
+		measure?(name: string, startMark: string, endMark: string): void;
+
+		/**
+		 * An instance of the PerformanceNodeTiming class that provides performance metrics for specific Node.js operational milestones.
+		 */
+		readonly nodeTiming?: PerformanceNodeTiming;
+
+		/**
+		 * Returns the current high resolution millisecond timestamp.
+		 * @return timestamp in ms
+		 */
+		now?(): number;
+
+		/**
+		 * The timeOrigin specifies the high resolution millisecond timestamp from which all performance metric durations are measured.
+		 */
+		readonly timeOrigin?: number;
+
+		/**
+		 * Wraps a function within a new function that measures the running time of the wrapped function.
+		 * A PerformanceObserver must be subscribed to the 'function' event type in order for the timing details to be accessed.
+		 * @param fn
+		 */
+		timerify?(fn: (...optionalParams: any[]) => any): (...optionalParams: any[]) => any;
+	}
+
+	var performance: Performance;
+	var performanceEntry: PerformanceEntry;
+	var performanceNodeTiming: PerformanceNodeTiming;
 }

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2932,6 +2932,7 @@ namespace dns_tests {
 ///////////////////////////////////////////////////////////
 
 import * as constants from 'constants';
+import { PerformanceObserver, PerformanceObserverCallback } from "perf_hooks";
 namespace constants_tests {
     var str: string;
     var num: number;
@@ -3099,24 +3100,22 @@ namespace perf_hooks_tests {
 
     const { duration } = perf_hooks.performance.getEntriesByName('discover')[0];
     const timeOrigin = perf_hooks.performance.timeOrigin;
-    const {
-        bootstrapComplete,
-        clusterSetupEnd,
-        clusterSetupStart,
-        duration: dur,
-        entryType,
-        kind,
-        loopExit,
-        loopStart,
-        moduleLoadEnd,
-        moduleLoadStart,
-        preloadModuleLoadEnd,
-        preloadModuleLoadStart,
-        startTime,
-        thirdPartyMainEnd,
-        thirdPartyMainStart,
-        v8Start,
-    } = perf_hooks.performanceNodeTiming;
+
+    const performanceObserverCallback: PerformanceObserverCallback = (list, obs) => {
+        const {
+            duration,
+            entryType,
+            name,
+            startTime,
+        } = list.getEntries()[0];
+        obs.disconnect();
+        perf_hooks.performance.clearFunctions();
+    };
+    const obs = new perf_hooks.PerformanceObserver(performanceObserverCallback);
+    obs.observe({
+        entryTypes: ['function'],
+        buffered: true,
+    });
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -29,6 +29,7 @@ import * as dns from "dns";
 import * as async_hooks from "async_hooks";
 import * as http2 from "http2";
 import * as inspector from "inspector";
+import * as perf_hooks from "perf_hooks";
 import Module = require("module");
 
 // Specifically test buffer module regression.
@@ -3084,6 +3085,38 @@ namespace v8_tests {
     const zapsGarbage: number = heapStats.does_zap_garbage;
 
     v8.setFlagsFromString('--collect_maps');
+}
+
+////////////////////////////////////////////////////
+/// PerfHooks tests : https://nodejs.org/api/perf_hooks.html
+////////////////////////////////////////////////////
+namespace perf_hooks_tests {
+    perf_hooks.performance.mark('start');
+    (
+        () => {}
+    )();
+    perf_hooks.performance.mark('end');
+
+    const { duration } = perf_hooks.performance.getEntriesByName('discover')[0];
+    const timeOrigin = perf_hooks.performance.timeOrigin;
+    const {
+        bootstrapComplete,
+        clusterSetupEnd,
+        clusterSetupStart,
+        duration: dur,
+        entryType,
+        kind,
+        loopExit,
+        loopStart,
+        moduleLoadEnd,
+        moduleLoadStart,
+        preloadModuleLoadEnd,
+        preloadModuleLoadStart,
+        startTime,
+        thirdPartyMainEnd,
+        thirdPartyMainStart,
+        v8Start,
+    } = perf_hooks.performanceNodeTiming;
 }
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://nodejs.org/api/perf_hooks.html>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Note that I've added the definitions for the interfaces Performance, PerformanceEntry and PerformanceNodeTiming. PerformanceObserver is not included in this commit
