### PR TITLE
Add type definitions for electron-spellchecker 1.1

### DIFF
--- a/types/electron-spellchecker/electron-spellchecker-tests.ts
+++ b/types/electron-spellchecker/electron-spellchecker-tests.ts
@@ -1,0 +1,15 @@
+import {
+  SpellCheckHandler,
+  ContextMenuListener,
+  ContextMenuBuilder
+} from "electron-spellchecker";
+
+const spellCheckHandler = new SpellCheckHandler();
+spellCheckHandler.attachToInput();
+
+spellCheckHandler.switchLanguage("en-US");
+
+const contextMenuBuilder = new ContextMenuBuilder(spellCheckHandler);
+const contextMenuListener = new ContextMenuListener(info => {
+  contextMenuBuilder.showPopupMenu(info);
+});

--- a/types/electron-spellchecker/index.d.ts
+++ b/types/electron-spellchecker/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for electron-spellchecker 1.1
+// Project: https://github.com/paulcbetts/electron-spellchecker
+// Definitions by: Daniel Perez Alvarez <https://github.com/unindented>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="electron"/>
+
+export type ContextMenuFormatter = (options: { word: string }) => string;
+
+export class SpellCheckHandler {
+  currentSpellchecker: this;
+
+  attachToInput(): void;
+  autoUnloadDictionariesOnBlur(): void;
+  provideHintText(inputText: string): void;
+  switchLanguage(language: string): void;
+  getCorrectionsForMisspelling(misspelledWord: string): Promise<string[]>;
+  addToDictionary(text: string): void;
+
+  unsubscribe(): void;
+}
+
+export class ContextMenuBuilder {
+  constructor(
+    spellCheckHandler?: SpellCheckHandler,
+    target?: Electron.BrowserWindow | Electron.WebviewTag | null,
+    debugMode?: boolean,
+    processMenu?: (menu: Electron.Menu) => Electron.Menu
+  );
+
+  setAlternateStringFormatter(formatter: {
+    [key: string]: ContextMenuFormatter;
+  }): void;
+
+  showPopupMenu: (info: Electron.ContextMenuParams) => void;
+}
+
+export class ContextMenuListener {
+  constructor(
+    handler: (info: Electron.ContextMenuParams) => void,
+    target?: Electron.BrowserWindow | Electron.WebviewTag | null
+  );
+
+  unsubscribe(): void;
+}

--- a/types/electron-spellchecker/package.json
+++ b/types/electron-spellchecker/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "electron": ">=1.6.10"
+  }
+}

--- a/types/electron-spellchecker/tsconfig.json
+++ b/types/electron-spellchecker/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "electron-spellchecker-tests.ts"
+    ]
+}

--- a/types/electron-spellchecker/tslint.json
+++ b/types/electron-spellchecker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
