### PR TITLE
added missing html5InputTypes option to configuration of knockout.validation

### DIFF
--- a/types/knockout.validation/index.d.ts
+++ b/types/knockout.validation/index.d.ts
@@ -100,7 +100,7 @@ interface KnockoutValidationConfiguration {
      * Supply the HTML5 input types validation will be
      * added to. Defaults to ["email", "number", "date"]
      */
-    html5InputTypes: string[];
+    html5InputTypes?: string[];
 }
 
 interface KnockoutValidationUtils {

--- a/types/knockout.validation/index.d.ts
+++ b/types/knockout.validation/index.d.ts
@@ -96,6 +96,11 @@ interface KnockoutValidationConfiguration {
      * that ko observable's are bound to
      */
     writeInputAttributes?: boolean;
+    /**
+     * Supply the HTML5 input types validation will be
+     * added to. Defaults to ["email", "number", "date"]
+     */
+    html5InputTypes: string[];
 }
 
 interface KnockoutValidationUtils {


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Knockout-Contrib/Knockout-Validation/blob/master/src/configuration.js>>

