### PR TITLE
[chai-http] Added namespace to allow es6 import

### DIFF
--- a/types/chai-http/chai-http-tests.ts
+++ b/types/chai-http/chai-http-tests.ts
@@ -1,10 +1,11 @@
 import fs = require('fs');
 import http = require('http');
 import chai = require('chai');
-import ChaiHttp = require('chai-http');
+import ch = require('chai-http');
 import when = require('when');
+import * as chttp from 'chai-http';
 
-chai.use(ChaiHttp);
+chai.use(ch);
 
 // ReSharper disable WrongExpressionStatement
 

--- a/types/chai-http/index.d.ts
+++ b/types/chai-http/index.d.ts
@@ -86,5 +86,7 @@ declare global {
 	}
 }
 
+/** Namespace added to allow `import * as ch from 'chai-http` */
+declare namespace chaiHttp { }
 declare function chaiHttp(chai: any, utils: any): void;
 export = chaiHttp;


### PR DESCRIPTION
Added a fake namespace to the definition to allow the es6 style import.


I'm not aware if there is a guideline against this. If there's one in place I'll close this pr
Closes #19480
