### PR TITLE
[passport] add generics

### DIFF
--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -77,10 +77,46 @@ declare namespace passport {
     }
 
     interface StrategyCreatedStatic {
+        /**
+         * Authenticate `user`, with optional `info`.
+         *
+         * Strategies should call this function to successfully authenticate a
+         * user.  `user` should be an object supplied by the application after it
+         * has been given an opportunity to verify credentials.  `info` is an
+         * optional argument containing additional user information.  This is
+         * useful for third-party authentication strategies to pass profile
+         * details.
+         */
         success(user: object, info?: object): void;
-        fail(challenge: string, status?: number): void;
+        /**
+         * Fail authentication, with optional `challenge` and `status`, defaulting
+         * to 401.
+         *
+         * Strategies should call this function to fail an authentication attempt.
+         */
+        fail(challenge?: string | number, status?: number): void;
+        /**
+         * Redirect to `url` with optional `status`, defaulting to 302.
+         *
+         * Strategies should call this function to redirect the user (via their
+         * user agent) to a third-party website for authentication.
+         */
         redirect(url: string, status?: number): void;
+        /**
+         * Pass without making a success or fail decision.
+         *
+         * Under most circumstances, Strategies should not need to call this
+         * function.  It exists primarily to allow previous authentication state
+         * to be restored, for example from an HTTP session.
+         */
         pass(): void;
+        /**
+         * Internal error while performing authentication.
+         *
+         * Strategies should call this function when an internal error occurs
+         * during the process of performing authentication; for example, if the
+         * user directory is not available.
+         */
         error(err: any): void;
     }
 

--- a/types/passport/index.d.ts
+++ b/types/passport/index.d.ts
@@ -49,7 +49,7 @@ declare namespace passport {
         passReqToCallback?: boolean;
     }
 
-    interface Authenticator<InitializeRet=express.Handler, AuthenticateRet=any, AuthorizeRet=AuthenticateRet> {
+    interface Authenticator<InitializeRet = express.Handler, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {
         use(strategy: Strategy): this;
         use(name: string, strategy: Strategy): this;
         unuse(name: string): this;
@@ -76,7 +76,7 @@ declare namespace passport {
         authenticate(this: StrategyCreated<this>, req: express.Request, options?: any): any;
     }
 
-    type StrategyCreatedStatic = {
+    interface StrategyCreatedStatic {
         success(user: object, info?: object): void;
         fail(challenge: string, status?: number): void;
         redirect(url: string, status?: number): void;
@@ -86,7 +86,7 @@ declare namespace passport {
 
     type StrategyCreated<T, O = T & StrategyCreatedStatic> = {
         [P in keyof O]: O[P];
-    }
+    };
 
     interface Profile {
         provider: string;
@@ -107,7 +107,7 @@ declare namespace passport {
         }>;
     }
 
-    interface Framework<InitializeRet=any, AuthenticateRet=any, AuthorizeRet=AuthenticateRet> {
+    interface Framework<InitializeRet = any, AuthenticateRet = any, AuthorizeRet = AuthenticateRet> {
         initialize(passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>, options?: any): (...args: any[]) => InitializeRet;
         authenticate(passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>, name: string, options?: any, callback?: (...args: any[]) => any): (...args: any[]) => AuthenticateRet;
         authorize?(passport: Authenticator<InitializeRet, AuthenticateRet, AuthorizeRet>, name: string, options?: any, callback?: (...args: any[]) => any): (...args: any[]) => AuthorizeRet;

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -127,8 +127,8 @@ function ensureAuthenticated(req: express.Request, res: express.Response, next: 
   }
 }
 
-const passportInstance: passport.Passport = new passport.Passport();
+const passportInstance: passport.Authenticator = new passport.Authenticator();
 passportInstance.use(new TestStrategy());
 
-const authenticator: passport.Passport = new passport.Authenticator();
+const authenticator: passport.Authenticator = new passport.Authenticator();
 authenticator.use(new TestStrategy());

--- a/types/passport/passport-tests.ts
+++ b/types/passport/passport-tests.ts
@@ -3,132 +3,137 @@ import * as express from 'express';
 import 'express-session';
 
 class TestStrategy implements passport.Strategy {
-  name = 'test';
-  constructor() { }
-  authenticate(req: express.Request) { }
+    name = 'test';
+    constructor() { }
+    authenticate(this: passport.StrategyCreated<this>, req: express.Request) {
+        const user: TestUser = {
+            id: 0,
+        };
+        this.success(user);
+    }
 }
 
 const newFramework: passport.Framework = {
-  initialize() {
-    return () => { };
-  },
-  authenticate(passport, name, options) {
-    return () => {
-      return `authenticate(): ${name} ${options}`;
-    };
-  },
-  authorize(passport, name, options) {
-    return () => {
-      return `authorize(): ${name} ${options}`;
-    };
-  }
+    initialize() {
+        return () => { };
+    },
+    authenticate(passport, name, options) {
+        return () => {
+            return `authenticate(): ${name} ${options}`;
+        };
+    },
+    authorize(passport, name, options) {
+        return () => {
+            return `authorize(): ${name} ${options}`;
+        };
+    }
 };
 passport.use(new TestStrategy());
 passport.framework(newFramework);
 
 interface TestUser {
-  id: number;
+    id: number;
 }
 passport.serializeUser((user: TestUser, done: (err: any, id?: number) => void) => {
-  done(null, user.id);
+    done(null, user.id);
 });
 passport.serializeUser<TestUser, number>((user, done) => {
-  if (user.id > 0) {
-    done(null, user.id);
-  } else {
-    done(new Error('user ID is invalid'));
-  }
+    if (user.id > 0) {
+        done(null, user.id);
+    } else {
+        done(new Error('user ID is invalid'));
+    }
 });
 passport.deserializeUser((id, done) => {
-  done(null, {id});
+    done(null, { id });
 });
 passport.deserializeUser<TestUser, number>((id, done) => {
-  const fetchUser = (id: number): Promise<TestUser> => {
-    return Promise.reject(new Error(`user not found: ${id}`));
-  };
+    const fetchUser = (id: number): Promise<TestUser> => {
+        return Promise.reject(new Error(`user not found: ${id}`));
+    };
 
-  fetchUser(id)
-    .then((user) => done(null, user))
-    .catch(done);
+    fetchUser(id)
+        .then((user) => done(null, user))
+        .catch(done);
 });
 
 passport.use(new TestStrategy())
-  .unuse('test')
-  .use(new TestStrategy())
-  .framework(newFramework);
+    .unuse('test')
+    .use(new TestStrategy())
+    .framework(newFramework);
 
 const app = express();
 app.configure(() => {
-  app.use(passport.initialize());
-  app.use(passport.session());
+    app.use(passport.initialize());
+    app.use(passport.session());
 });
 
 app.post('/login',
-  passport.authenticate('local', { failureRedirect: '/login', failureFlash: true }),
-  (req, res) => {
-    res.redirect('/');
-  });
+    passport.authenticate('local', { failureRedirect: '/login', failureFlash: true }),
+    (req, res) => {
+        res.redirect('/');
+    });
 
 app.post('/login', (req, res, next) => {
-  passport.authenticate('local', (err: any, user: { username: string; }, info: { message: string; }) => {
-    if (err) { return next(err); }
-    if (!user) {
-      if (req.session) {
-        req.session['error'] = info.message;
-      }
-      return res.redirect('/login');
-    }
-    req.logIn(user, (err) => {
-      if (err) { return next(err); }
-      return res.redirect('/users/' + user.username);
-    });
-  })(req, res, next);
+    passport.authenticate('local', (err: any, user: { username: string; }, info: { message: string; }) => {
+        if (err) { return next(err); }
+        if (!user) {
+            if (req.session) {
+                req.session['error'] = info.message;
+            }
+            return res.redirect('/login');
+        }
+        req.logIn(user, (err) => {
+            if (err) { return next(err); }
+            return res.redirect('/users/' + user.username);
+        });
+    })(req, res, next);
 });
 
 app.get('/logout', (req, res) => {
-  req.logout();
-  res.redirect('/');
+    req.logout();
+    res.redirect('/');
 });
 
 app.post('/auth/token', passport.authenticate(['basic', 'oauth2-client-password'], { session: false }));
 
 function authSetting(): void {
-  const authOption = {
-    successRedirect: '/',
-    failureRedirect: '/login',
-  };
-  const successCallback = (req: express.Request, res: express.Response) => {
-    res.redirect('/');
-  };
+    const authOption = {
+        successRedirect: '/',
+        failureRedirect: '/login',
+    };
+    const successCallback = (req: express.Request, res: express.Response) => {
+        res.redirect('/');
+    };
 
-  app.get('/auth/facebook',
-      passport.authenticate('facebook'));
-  app.get('/auth/facebook/callback',
-      passport.authenticate('facebook', authOption), successCallback);
+    app.get('/auth/facebook',
+        passport.authenticate('facebook'));
+    app.get('/auth/facebook/callback',
+        passport.authenticate('facebook', authOption), successCallback);
 
-  app.get('/auth/twitter',
-      passport.authenticate('twitter'));
-  app.get('/auth/twitter/callback',
-      passport.authenticate('twitter', authOption));
+    app.get('/auth/twitter',
+        passport.authenticate('twitter'));
+    app.get('/auth/twitter/callback',
+        passport.authenticate('twitter', authOption));
 
-  app.get('/auth/google',
-    passport.authenticate('google', {
-      scope:
-      ['https://www.googleapis.com/auth/userinfo.profile']
-    }));
-  app.get('/auth/google/callback',
-      passport.authenticate('google', authOption), successCallback);
+    app.get('/auth/google',
+        passport.authenticate('google', {
+            scope:
+                ['https://www.googleapis.com/auth/userinfo.profile']
+        }));
+    app.get('/auth/google/callback',
+        passport.authenticate('google', authOption), successCallback);
 }
 
 function ensureAuthenticated(req: express.Request, res: express.Response, next: (err?: any) => void) {
-  if (req.isAuthenticated()) { return next(); }
-  if (req.isUnauthenticated()) {
-    res.redirect('/login');
-  }
+    if (req.isAuthenticated()) { return next(); }
+    if (req.isUnauthenticated()) {
+        res.redirect('/login');
+    }
 }
 
-const passportInstance: passport.Authenticator = new passport.Authenticator();
+const passportInstance = new passport.Passport();
 passportInstance.use(new TestStrategy());
 
-const authenticator: passport.Authenticator = new passport.Authenticator();
+const authenticator = new passport.Authenticator();
 authenticator.use(new TestStrategy());


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/jaredhanson/passport/blob/master/lib/authenticator.js>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## description
While making changes to the `koa-passport` typings I've noticed that the `passport` package relies fully on used `Framework`.
So why don't make this `Framework` generic?