### PR TITLE
[Quill] Import Parchment's Blot from TypeScript definition file instead

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -5,7 +5,7 @@
 //                 James Garbutt <https://github.com/43081j>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { Blot } from 'parchment/src/blot/abstract/blot';
+import { Blot } from 'parchment/dist/src/blot/abstract/blot';
 
 /**
  * A stricter type definition would be:


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/quilljs/parchment/blob/19d25ef97fba8ce95d8bcfcad77aba2b5204971c/package.json#L9
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This PR imports Blot class from TypeScript definition file (`.d.ts`), which resides in `/dist/src`, instead of normal TypeScript file (`.ts`).

My motivation is that I use TSLint in my project, and it seems like TSLint lints all `.ts` files in the project, including the `.ts` file imported by `node_modules/@types/quill/index.d.ts` (the file that this PR changes).

I think TSLint should ignore all `.ts` files in `node_modules` by default (or should it?), so this PR is just a workaround. Still, I think importing from definition file is the correct way, assuming that the fix is correct. :)