### PR TITLE
p2 - ContactMaterialOptions properties should all be optional

### DIFF
--- a/types/p2/index.d.ts
+++ b/types/p2/index.d.ts
@@ -361,13 +361,13 @@ declare namespace p2 {
 
     export class ContactMaterialOptions {
 
-        friction: number;
-        restitution: number;
-        stiffness: number;
-        relaxation: number;
-        frictionStiffness: number;
-        frictionRelaxation: number;
-        surfaceVelocity: number;
+        friction?: number;
+        restitution?: number;
+        stiffness?: number;
+        relaxation?: number;
+        frictionStiffness?: number;
+        frictionRelaxation?: number;
+        surfaceVelocity?: number;
 
     }
 

--- a/types/p2/index.d.ts
+++ b/types/p2/index.d.ts
@@ -624,8 +624,8 @@ declare namespace p2 {
 
     export interface ConvexOptions extends SharedShapeOptions {
 
-      length?: number;
-      radius?: number;
+        vertices?: ArrayLike<number>[];
+        axes?: ArrayLike<number>[];
 
     }
 
@@ -636,7 +636,7 @@ declare namespace p2 {
         constructor(options?: ConvexOptions);
 
         vertices: number[][];
-        axes: number[];
+        axes: number[][];
         centerOfMass: number[];
         triangles: number[];
         boundingRadius: number;

--- a/types/p2/p2-tests.ts
+++ b/types/p2/p2-tests.ts
@@ -32,6 +32,20 @@ var groundShape = new p2.Plane();
 groundBody.addShape(groundShape);
 world.addBody(groundBody);
 
+// Create a convex shape. Can use various array types.
+const convex = new p2.Convex({
+    vertices: [
+        new Float32Array([-1, 1]),
+        new Uint32Array([0, -1]),
+        [1, 1]
+    ],
+    axes: [
+        new Float32Array([-1, 1]),
+        new Int32Array([0, -1]),
+        [1, 1]
+    ]
+})
+
 // To get the trajectories of the bodies,
 // we must step the world forward in time.
 // This is done using a fixed time step size.

--- a/types/p2/p2-tests.ts
+++ b/types/p2/p2-tests.ts
@@ -4,6 +4,12 @@ var world = new p2.World({
     gravity:[0, -9.82]
 });
 
+// Set default contact material
+world.defaultContactMaterial = new p2.ContactMaterial(
+    new p2.Material(1), new p2.Material(2),
+    { friction: 1, restitution: 0 }
+)
+
 // Create an empty dynamic body
 var circleBody = new p2.Body({
     mass: 5,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

As per documentation ContactMaterialOptions properties should all be optional:
http://schteppe.github.io/p2.js/docs/classes/ContactMaterial.html

ConvexOptions should be an object with optional vertices and axes properties:
http://schteppe.github.io/p2.js/docs/classes/Convex.html

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
