### PR TITLE
@types/jsonwebtoken: Added clockTimestamp member to VerifyOptions

### DIFF
--- a/types/jsonwebtoken/index.d.ts
+++ b/types/jsonwebtoken/index.d.ts
@@ -58,6 +58,7 @@ export interface SignOptions {
 export interface VerifyOptions {
     algorithms?: string[];
     audience?: string | string[];
+    clockTimestamp?: number;
     clockTolerance?: number;
     issuer?: string | string[];
     ignoreExpiration?: boolean;

--- a/types/jsonwebtoken/jsonwebtoken-tests.ts
+++ b/types/jsonwebtoken/jsonwebtoken-tests.ts
@@ -57,6 +57,13 @@ jwt.verify(token, 'shhhhh', function(err, decoded) {
   console.log(result.foo) // bar
 });
 
+// use external time for verifying
+jwt.verify(token, 'shhhhh', { clockTimestamp: 1 }, function(err, decoded) {
+  const result = decoded as ITestObject
+
+  console.log(result.foo) // bar
+});
+
 // invalid token
 jwt.verify(token, 'wrong-secret', function(err, decoded) {
   // err


### PR DESCRIPTION
@SomaticIT, @danielheim, @brikou please consider this pull request that adds a new member to the VerifyOptions interface.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback
- [?] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
