### PR TITLE
fix(rollup): `globals` in `BundleOptions` can be a method

### DIFF
--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -7,6 +7,7 @@ import { RawSourceMap } from 'source-map'
 import * as acorn from 'acorn'
 
 export type Format = 'amd' | 'cjs' | 'es' | 'iife' | 'umd'
+export const VERSION: string;
 
 export interface SourceMap extends RawSourceMap {
 	toString(): string

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -31,7 +31,7 @@ export interface BundleOptions {
 	/** The name to use for the module for UMD/IIFE bundles (required for bundles with exports). */
 	name?: string
 	/** Mapping of IDs → global variable names. Used for UMD/IIFE bundles. */
-	globals?: { [id: string]: string }
+	globals?: ((id: string) => string) | { [id: string]: string }
 	/**
 	 * Function that takes an ID and returns a path, or Object of id: path pairs.
 	 * Where supplied, these paths will be used in the generated bundle instead of the module ID, allowing you to (for example) load dependencies from a CDN.

--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -7,7 +7,7 @@ import { RawSourceMap } from 'source-map'
 import * as acorn from 'acorn'
 
 export type Format = 'amd' | 'cjs' | 'es' | 'iife' | 'umd'
-export const VERSION: string;
+export const VERSION: string
 
 export interface SourceMap extends RawSourceMap {
 	toString(): string

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -87,6 +87,22 @@ async function main() {
         strict: true,
     })
 
+    await bundle.write({
+        format: 'cjs',
+        file: 'bundle.js',
+        name: 'myLib',
+        interop: false,
+        globals: (x: string) => x.replace("", "/"),
+        banner: '/* Banner */',
+        footer: '/* Footer */',
+        intro: 'var ENV = "production";',
+        outro: 'var VERSION = "1.0.0";',
+        indent: '  ',
+        sourcemap: 'inline',
+        sourcemapFile: 'bundle.js.map',
+        strict: true,
+    })
+
     const watcher = watch({
         input: 'main.js',
         output: {


### PR DESCRIPTION
https://github.com/rollup/rollup/blob/d92f07262715a86a1189147a549af63d0fd9ccfe/src/finalisers/shared/setupNamespace.js#L6

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/rollup/rollup/blob/d92f07262715a86a1189147a549af63d0fd9ccfe/src/finalisers/shared/setupNamespace.js#L6

https://github.com/rollup/rollup/blob/675aabb5d7e04402f0ad876b29250d496b9a9911/src/rollup/index.js#L11

- [x] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.