### PR TITLE
package chart.js: Fix TickOptions.autoSkipPadding type

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -364,7 +364,7 @@ declare namespace Chart {
 
     interface TickOptions {
         autoSkip?: boolean;
-        autoSkipPadding?: boolean;
+        autoSkipPadding?: number;
         callback?(value: any, index: any, values: any): string|number;
         display?: boolean;
         fontColor?: ChartColor;


### PR DESCRIPTION
According to [chart.js docs](http://www.chartjs.org/docs/latest/axes/cartesian/#tick-configuration) `TickOptions` property `autoSkipPadding` has type `number`.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.chartjs.org/docs/latest/axes/cartesian/#tick-configuration
