### PR TITLE
Update index.d.ts for Kendo-UI GridColumn definition

### DIFF
--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -3748,7 +3748,7 @@ declare namespace kendo.ui {
         aggregates?: any;
         attributes?: any;
         columns?: any;
-        command?: (string|GridColumnCommandItem)[];
+        command?: string|(string|GridColumnCommandItem)[];
         editable?: Function;
         encoded?: boolean;
         field?: string;

--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -3748,7 +3748,7 @@ declare namespace kendo.ui {
         aggregates?: any;
         attributes?: any;
         columns?: any;
-        command?: GridColumnCommandItem[];
+        command?: (string|GridColumnCommandItem)[];
         editable?: Function;
         encoded?: boolean;
         field?: string;


### PR DESCRIPTION
Since the command property of a GridColumn can be an array of strings, for example:

{ command: ["edit", "destroy"], title: "&nbsp;", width: "250px" }

The current definition is

command?: GridColumnCommandItem[];

but it should be

command?: (string|GridColumnCommandItem)[];

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.telerik.com/kendo-ui/api/javascript/ui/grid#configuration-columns.command>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

