### PR TITLE
Update react-native PushNotificationIOS Typings

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7160,7 +7160,7 @@ export interface PushNotification {
      * Gets the data object on the notif
      */
     getData(): Object;
-                                                                                     
+
     /**
      * iOS Only
      * Signifies remote notification handling is complete
@@ -7188,7 +7188,7 @@ type ScheduleLocalNotificationDetails = {
 };
 
 export type PushNotificationEventName = "notification" | "localNotification" | "register" | "registrationError";
-                                                                                     
+
 type FetchResult = {
     NewData: "UIBackgroundFetchResultNewData",
     NoData: "UIBackgroundFetchResultNoData",
@@ -7308,7 +7308,7 @@ export interface PushNotificationIOSStatic {
      * object if the app was launched by a push notification, or `null` otherwise.
      */
     getInitialNotification(): Promise<PushNotification>;
-                                                                                     
+
     /**
      * iOS fetch results that best describe the result of a finished remote notification handler.
      * For a list of possible values, see `PushNotificationIOS.FetchResult`.

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7160,6 +7160,12 @@ export interface PushNotification {
      * Gets the data object on the notif
      */
     getData(): Object;
+                                                                                     
+    /**
+     * iOS Only
+     * Signifies remote notification handling is complete
+     */
+    finish(result: string): void;
 }
 
 type PresentLocalNotificationDetails = {
@@ -7182,6 +7188,12 @@ type ScheduleLocalNotificationDetails = {
 };
 
 export type PushNotificationEventName = "notification" | "localNotification" | "register" | "registrationError";
+                                                                                     
+type FetchResult = {
+    NewData: "UIBackgroundFetchResultNewData",
+    NoData: "UIBackgroundFetchResultNoData",
+    ResultFailed: "UIBackgroundFetchResultFailed"
+};
 
 /**
  * Handle push notifications for your app, including permission handling and icon badge number.
@@ -7296,6 +7308,12 @@ export interface PushNotificationIOSStatic {
      * object if the app was launched by a push notification, or `null` otherwise.
      */
     getInitialNotification(): Promise<PushNotification>;
+                                                                                     
+    /**
+     * iOS fetch results that best describe the result of a finished remote notification handler.
+     * For a list of possible values, see `PushNotificationIOS.FetchResult`.
+     */
+    FetchResult: FetchResult;
 }
 
 export interface SettingsStatic {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/pushnotificationios.html#finish
https://github.com/facebook/react-native/blob/master/Libraries/PushNotificationIOS/PushNotificationIOS.js#L133
https://github.com/facebook/react-native/blob/master/Libraries/PushNotificationIOS/PushNotificationIOS.js#L454

Additional info:
React-Native typings are currently missing two crucial definitions when implementing iOS notifications: finish function and FetchResult strings. If a finish function is not called, the background remote notifications could be throttled.