### PR TITLE
Revert "chai: Use `export as namespace` instead of `declare module`"

### DIFF
--- a/types/chai/chai-tests.ts
+++ b/types/chai/chai-tests.ts
@@ -432,8 +432,8 @@ function empty() {
     [].should.be.empty;
     expect(['foo']).not.to.be.empty;
     ['foo'].should.not.be.empty;
-    expect(new FakeArgs()).to.be.empty;
-    (new FakeArgs()).should.be.empty;
+    expect(new FakeArgs).to.be.empty;
+    (new FakeArgs).should.be.empty;
     expect({ arguments: 0 }).not.to.be.empty;
     ({ arguments: 0 }).should.not.be.empty;
     expect({}).to.be.empty;
@@ -454,8 +454,8 @@ function empty() {
     expect(['foo']).to.be.empty;
     ['foo'].should.be.empty;
 
-    expect(new FakeArgs()).not.to.be.empty;
-    (new FakeArgs()).should.not.be.empty;
+    expect(new FakeArgs).not.to.be.empty;
+    (new FakeArgs).should.not.be.empty;
 
     expect({ arguments: 0 }).to.be.empty;
     ({ arguments: 0 }).should.be.empty;

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -26,20 +26,20 @@ declare namespace Chai {
         version: string;
     }
 
-    interface ExpectStatic extends AssertionStatic {
+    export interface ExpectStatic extends AssertionStatic {
         fail(actual?: any, expected?: any, message?: string, operator?: Operator): void;
     }
 
-    interface AssertStatic extends Assert {
+    export interface AssertStatic extends Assert {
     }
 
-    interface AssertionStatic {
+    export interface AssertionStatic {
         (target: any, message?: string): Assertion;
     }
 
-    type Operator = string; // "==" | "===" | ">" | ">=" | "<" | "<=" | "!=" | "!==";
+    export type Operator = string; // "==" | "===" | ">" | ">=" | "<" | "<=" | "!=" | "!==";
 
-    type OperatorComparable = boolean | null | number | string | undefined | Date;
+    export type OperatorComparable = boolean | null | number | string | undefined | Date;
 
     interface ShouldAssertion {
         equal(value1: any, value2: any, message?: string): void;
@@ -256,7 +256,7 @@ declare namespace Chai {
         (object: Object, property: string, message?: string): Assertion;
     }
 
-    interface Assert {
+    export interface Assert {
         /**
          * @param expression    Expression to test for truthiness.
          * @param message    Message to display on error.
@@ -1587,7 +1587,7 @@ declare namespace Chai {
         doesNotHaveAllDeepKeys<T>(object: T, keys: Array<Object | string> | { [key: string]: any }, message?: string): void;
     }
 
-    interface Config {
+    export interface Config {
         /**
          * Default: false
          */
@@ -1604,7 +1604,7 @@ declare namespace Chai {
         truncateThreshold: number;
     }
 
-    class AssertionError {
+    export class AssertionError {
         constructor(message: string, _props?: any, ssf?: Function);
         name: string;
         message: string;
@@ -1614,11 +1614,11 @@ declare namespace Chai {
 }
 
 declare const chai: Chai.ChaiStatic;
-export = chai;
-export as namespace chai;
 
-declare global {
-    interface Object {
-        should: Chai.Assertion;
-    }
+declare module "chai" {
+    export = chai;
+}
+
+interface Object {
+    should: Chai.Assertion;
 }

--- a/types/chai/tslint.json
+++ b/types/chai/tslint.json
@@ -3,8 +3,12 @@
     "rules": {
         "ban-types": false,
         "callable-types": false,
+        "new-parens": false,
+        "no-declare-current-package": false,
         "no-empty-interface": false,
         "no-redundant-jsdoc-2": false,
-        "no-unnecessary-generics": false
+        "no-single-declare-module": false,
+        "no-unnecessary-generics": false,
+        "strict-export-declare-modifiers": false
     }
 }


### PR DESCRIPTION
Reverts DefinitelyTyped/DefinitelyTyped#21951

