### PR TITLE
[@types/mocha] IRunner declared as extending Node EventEmitter

### DIFF
--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Kazi Manzur Rashid <https://github.com/kazimanzurrashid>, otiai10 <https://github.com/otiai10>, jt000 <https://github.com/jt000>, Vadim Macagon <https://github.com/enlight>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 interface MochaSetupOptions {
     //milliseconds to wait before considering a test slow
     slow?: number;
@@ -172,7 +174,7 @@ declare namespace Mocha {
 
 
     /** Partial interface for Mocha's `Runner` class. */
-    interface IRunner { }
+    interface IRunner extends NodeJS.EventEmitter { }
 
     interface IContextDefinition {
         (description: string, callback: (this: ISuiteCallbackContext) => void): ISuite;

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -456,14 +456,8 @@ function test_throwError() {
     mocha.throwError(new Error("I'm an error!"));
 }
 
-
-
-
-
-
-// dtslint
-
-import * as Mocha from "mocha";
-
-new Mocha().run(); // $ExpectType IRunner
-new Mocha().run().on("", function() {}); // $ExpectType IRunner
+function test_runner_fluentParams() {
+    new MochaDef().run(); // $ExpectType IRunner
+    new MochaDef().run().on("event-string", function() {}); // $ExpectType IRunner
+    new MochaDef().run().on(Symbol("event-symbol"), function() {}); // $ExpectType IRunner
+}

--- a/types/mocha/mocha-tests.ts
+++ b/types/mocha/mocha-tests.ts
@@ -455,3 +455,15 @@ function test_run_withOnComplete() {
 function test_throwError() {
     mocha.throwError(new Error("I'm an error!"));
 }
+
+
+
+
+
+
+// dtslint
+
+import * as Mocha from "mocha";
+
+new Mocha().run(); // $ExpectType IRunner
+new Mocha().run().on("", function() {}); // $ExpectType IRunner


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mochajs/mocha/blob/master/lib/runner.js#L92

Other remarks: 
I wasn't sure how `mocha-tests.ts` was being consumed. I've appeneded some dtslint tests to the end, they seem to work (and fail when they should too)