### PR TITLE
[lodash] add array destructure overload for _.zipWith fixes #21884

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -3954,6 +3954,10 @@ declare namespace _ {
             arrays3: List<T> | null | undefined,
             arrays4: List<T> | null | undefined,
             arrays5: List<T> | null | undefined,
+            iteratee: (value1: T, value2: T, value3: T, value4: T, value5: T) => TResult
+        ): TResult[];
+
+        zipWith<T, TResult>(
             ...iteratee: Array<((...group: T[]) => TResult) | List<T> | null | undefined>
         ): TResult[];
     }

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3513,6 +3513,9 @@ namespace TestZipWith {
             return 1;
         });
 
+        let mat = [[1, 2], [1, 2], [1, 2]];
+        result = _.zipWith(...mat, (...group: number[]) => 1);
+
         result = _([1, 2]).zipWith((value1) => {
             value1; // $ExpectType number
             return 1;


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/lodash/lodash/blob/master/zipWith.js)
- [x] Increase the version number in the header if appropriate.

This fixes #21884 by having a base case for the overloaded method. It seems the base case was added to the 5 argument overload, but that meant specifying 5 arrays before being able to use the array destructuring. Added a relevant test case as well.

Side note: how do I "increase the version number in the header"? This should just be a patch bump (which is automatically done for me, I believe), but in the case that I wanted to make this a minor bump how would I go about it?