### PR TITLE
[electron-store] add namespace to electron-store

### DIFF
--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -76,4 +76,6 @@ declare class ElectronStore implements Iterable<[string, string | number | boole
   [Symbol.iterator](): Iterator<[string, string | number | boolean | symbol | {}]>;
 }
 
+declare namespace ElectronStore {} // https://github.com/Microsoft/TypeScript/issues/5073
+                                                
 export = ElectronStore;

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -77,5 +77,5 @@ declare class ElectronStore implements Iterable<[string, string | number | boole
 }
 
 declare namespace ElectronStore {} // https://github.com/Microsoft/TypeScript/issues/5073
-                                                
+
 export = ElectronStore;


### PR DESCRIPTION
Add Namespace to the electron-store package

This enable 
the following syntax
```ts
import * as Store from 'electron-store'
```
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x  Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/issues/5073
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

