### PR TITLE
Fixed web-bluetooth types as filters are optionals

### DIFF
--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -16,11 +16,13 @@ interface BluetoothRequestDeviceFilter {
 	serviceDataUUID?: BluetoothServiceUUID;
 }
 
-interface RequestDeviceOptions {
-	filters?: BluetoothRequestDeviceFilter[];
+type RequestDeviceOptions = {
+	filters: BluetoothRequestDeviceFilter[];
 	optionalServices?: BluetoothServiceUUID[];
-	acceptAllDevices?: boolean;
-}
+} | {
+	acceptAllDevices: boolean;
+	optionalServices?: BluetoothServiceUUID[];
+};
 
 interface BluetoothRemoteGATTDescriptor {
 	readonly characteristic: BluetoothRemoteGATTCharacteristic;
@@ -99,11 +101,9 @@ interface BluetoothDevice extends EventTarget, BluetoothDeviceEventHandlers, Cha
 	readonly name?: string;
 	readonly gatt?: BluetoothRemoteGATTServer;
 	readonly uuids?: string[];
-
 	watchAdvertisements(): Promise<void>;
 	unwatchAdvertisements(): void;
 	readonly watchingAdvertisements: boolean;
-
 	addEventListener(type: "gattserverdisconnected", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
 	addEventListener(type: "advertisementreceived", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
 	addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
@@ -114,7 +114,6 @@ interface Bluetooth extends EventTarget, BluetoothDeviceEventHandlers, Character
 	onavailabilitychanged: (this: this, ev: Event) => any;
 	readonly referringDevice?: BluetoothDevice;
 	requestDevice(options?: RequestDeviceOptions): Promise<BluetoothDevice>;
-
 	addEventListener(type: "availabilitychanged", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
 	addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }

--- a/types/web-bluetooth/index.d.ts
+++ b/types/web-bluetooth/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for Web Bluetooth
 // Project: https://webbluetoothcg.github.io/web-bluetooth/
 // Definitions by: Uri Shaked <https://github.com/urish>
+// 								 Xavier Lozinguez <http://github.com/xlozinguez>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 type BluetoothServiceUUID = number | string;
@@ -16,7 +17,7 @@ interface BluetoothRequestDeviceFilter {
 }
 
 interface RequestDeviceOptions {
-	filters: BluetoothRequestDeviceFilter[];
+	filters?: BluetoothRequestDeviceFilter[];
 	optionalServices?: BluetoothServiceUUID[];
 	acceptAllDevices?: boolean;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  on this article https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web
```
Finally, *instead of filters you can use the acceptAllDevices* key to show all nearby Bluetooth devices. You will also need to define the optionalServices key to be able to access some services. If you don't, you'll get an error later when trying to access them.
```
