### PR TITLE
[recompose]: Improve withHandler & withStateHandlers

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -134,7 +134,7 @@ declare module 'recompose' {
 
     // withStateHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
     type StateHandler<TState> = (...payload: any[]) => TState | undefined;
-    type StateUpdaters<TOutter, TStatem,  TUpdaters> = {
+    type StateUpdaters<TOutter, TState,  TUpdaters> = {
       [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => StateHandler<TState>;
     };
     export function withStateHandlers<TState, TUpdaters, TOutter>(

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -134,7 +134,7 @@ declare module 'recompose' {
 
     // withStateHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
     type StateHandler<TState> = (...payload: any[]) => TState | undefined;
-    type StateUpdaters<TOutter, TState,  TUpdaters> = {
+    type StateUpdaters<TOutter, TState, TUpdaters> = {
       [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => StateHandler<TState>;
     };
     export function withStateHandlers<TState, TUpdaters, TOutter>(

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -134,20 +134,13 @@ declare module 'recompose' {
 
     // withStateHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
     type StateHandler<TState> = (...payload: any[]) => TState | undefined;
-
     type StateHandlerMap<TState> = {
       [updaterName: string]: StateHandler<TState>;
     };
-
     type StateUpdaters<TOutter, TState, TUpdaters> = {
       [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => StateHandler<TState>;
     };
-
-    export function withStateHandlers<
-        TState,
-        TUpdaters extends StateHandlerMap<TState>,
-        TOutter extends {} = {}
-      >(
+    export function withStateHandlers<TState, TUpdaters extends StateHandlerMap<TState>, TOutter = {}>(
       createProps: TState | mapper<TOutter, TState>,
       stateUpdaters: StateUpdaters<TOutter, TState, TUpdaters>,
     ): InferableComponentEnhancerWithProps<TOutter & TState & TUpdaters, TOutter>;

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -84,7 +84,7 @@ declare module 'recompose' {
     type HandleCreatorsFactory<TOutter, THandlers> = (initialProps: TOutter) => HandleCreators<TOutter, THandlers>;
     export function withHandlers<TOutter, THandlers>(
         handlerCreators: HandleCreators<TOutter, THandlers> | HandleCreatorsFactory<TOutter, THandlers>
-    ): InferableComponentEnhancerWithProps<THandlers, TOutter>;
+    ): InferableComponentEnhancerWithProps<TOutter & THandlers, TOutter>;
 
     // defaultProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#defaultprops
     export function defaultProps<T = {}>(

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -134,13 +134,42 @@ declare module 'recompose' {
 
     // withStateHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
     type StateHandler<TState> = (...payload: any[]) => TState | undefined;
-    type StateUpdaters<TOutter, TState, TUpdaters> = {
-      [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => StateHandler<TState>;
+    type StateUpdaters<
+        TOutter,
+        TState,
+        TUpdater1 extends string,
+        TUpdater2 extends string = TUpdater1,
+        TUpdater3 extends string = TUpdater2,
+        TUpdater4 extends string = TUpdater3,
+        TUpdater5 extends string = TUpdater4
+    > = { [updaterName in
+            | TUpdater1
+            | TUpdater2
+            | TUpdater3
+            | TUpdater4
+            | TUpdater5
+          ]: (state: TState, props: TOutter) => StateHandler<TState>;
     };
-    export function withStateHandlers<TState, TUpdaters, TOutter>(
+    export function withStateHandlers<
+        TState,
+        TOutter extends {} = {},
+        TUpdater1 extends string = "update",
+        TUpdater2 extends string = TUpdater1,
+        TUpdater3 extends string = TUpdater2,
+        TUpdater4 extends string = TUpdater3,
+        TUpdater5 extends string = TUpdater4
+      >(
       createProps: TState | mapper<TOutter, TState>,
-      stateUpdaters: StateUpdaters<TOutter, TState, TUpdaters>,
-    ): InferableComponentEnhancerWithProps<TUpdaters & TState, TOutter>;
+      stateUpdaters: StateUpdaters<TOutter, TState, TUpdater1, TUpdater2, TUpdater3, TUpdater4, TUpdater5>,
+    ): InferableComponentEnhancerWithProps<
+        { [updaterName in
+            | TUpdater1
+            | TUpdater2
+            | TUpdater3
+            | TUpdater4
+            | TUpdater5
+          ]: StateHandler<TState>
+        } & TState & TOutter, TOutter>;
 
     // withReducer: https://github.com/acdlite/recompose/blob/master/docs/API.md#withReducer
     type reducer<TState, TAction> = (s: TState, a: TAction) => TState;

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -78,12 +78,12 @@ declare module 'recompose' {
 
     // withHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withhandlers
     type EventHandler = Function;
-    type HandleCreators<TOutter> = {
-        [handlerName: string]: mapper<TOutter, EventHandler>;
+    type HandleCreators<TOutter, THandlers> = {
+        [handlerName in keyof THandlers]: mapper<TOutter, EventHandler>;
     };
-    type HandleCreatorsFactory<TOutter, THandlers> = (initialProps: TOutter) => HandleCreators<TOutter>;
+    type HandleCreatorsFactory<TOutter, THandlers> = (initialProps: TOutter) => HandleCreators<TOutter, THandlers>;
     export function withHandlers<TOutter, THandlers>(
-        handlerCreators: HandleCreators<TOutter> | HandleCreatorsFactory<TOutter, THandlers>
+        handlerCreators: HandleCreators<TOutter, THandlers> | HandleCreatorsFactory<TOutter, THandlers>
     ): InferableComponentEnhancerWithProps<THandlers, TOutter>;
 
     // defaultProps: https://github.com/acdlite/recompose/blob/master/docs/API.md#defaultprops
@@ -134,12 +134,12 @@ declare module 'recompose' {
 
     // withStateHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
     type StateHandler<TState> = (...payload: any[]) => TState | undefined;
-    type StateUpdaters<TOutter, TState> = {
-      [updaterName: string]: (state: TState, props: TOutter) => StateHandler<TState>;
+    type StateUpdaters<TOutter, TStatem,  TUpdaters> = {
+      [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => StateHandler<TState>;
     };
     export function withStateHandlers<TState, TUpdaters, TOutter>(
       createProps: TState | mapper<TOutter, TState>,
-      stateUpdaters: StateUpdaters<TOutter, TState>,
+      stateUpdaters: StateUpdaters<TOutter, TState, TUpdaters>,
     ): InferableComponentEnhancerWithProps<TUpdaters & TState, TOutter>;
 
     // withReducer: https://github.com/acdlite/recompose/blob/master/docs/API.md#withReducer

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -134,42 +134,23 @@ declare module 'recompose' {
 
     // withStateHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
     type StateHandler<TState> = (...payload: any[]) => TState | undefined;
-    type StateUpdaters<
-        TOutter,
-        TState,
-        TUpdater1 extends string,
-        TUpdater2 extends string = TUpdater1,
-        TUpdater3 extends string = TUpdater2,
-        TUpdater4 extends string = TUpdater3,
-        TUpdater5 extends string = TUpdater4
-    > = { [updaterName in
-            | TUpdater1
-            | TUpdater2
-            | TUpdater3
-            | TUpdater4
-            | TUpdater5
-          ]: (state: TState, props: TOutter) => StateHandler<TState>;
+
+    type StateHandlerMap<TState> = {
+      [updaterName: string]: StateHandler<TState>;
     };
+
+    type StateUpdaters<TOutter, TState, TUpdaters> = {
+      [updaterName in keyof TUpdaters]: (state: TState, props: TOutter) => StateHandler<TState>;
+    };
+
     export function withStateHandlers<
         TState,
-        TOutter extends {} = {},
-        TUpdater1 extends string = "update",
-        TUpdater2 extends string = TUpdater1,
-        TUpdater3 extends string = TUpdater2,
-        TUpdater4 extends string = TUpdater3,
-        TUpdater5 extends string = TUpdater4
+        TUpdaters extends StateHandlerMap<TState>,
+        TOutter extends {} = {}
       >(
       createProps: TState | mapper<TOutter, TState>,
-      stateUpdaters: StateUpdaters<TOutter, TState, TUpdater1, TUpdater2, TUpdater3, TUpdater4, TUpdater5>,
-    ): InferableComponentEnhancerWithProps<
-        { [updaterName in
-            | TUpdater1
-            | TUpdater2
-            | TUpdater3
-            | TUpdater4
-            | TUpdater5
-          ]: StateHandler<TState>
-        } & TState & TOutter, TOutter>;
+      stateUpdaters: StateUpdaters<TOutter, TState, TUpdaters>,
+    ): InferableComponentEnhancerWithProps<TOutter & TState & TUpdaters, TOutter>;
 
     // withReducer: https://github.com/acdlite/recompose/blob/master/docs/API.md#withReducer
     type reducer<TState, TAction> = (s: TState, a: TAction) => TState;

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -119,6 +119,11 @@ function testWithHandlers() {
             out={42}
         />
     )
+
+    const handlerNameTypecheckProof = withHandlers<OutterProps, HandlerProps>((props) => ({ // $ExpectError
+      onChange: () => () => {},  // $ExpectError
+      notAKeyOnHandlerProps: () => () => {},  // $ExpectError
+    })); // $ExpectError
 }
 
 function testDefaultProps() {
@@ -211,7 +216,7 @@ function testWithStateHandlers() {
         <Enhanced initialCounter={4} power={2} />
     );
 
-    const broken = withStateHandlers<State, Updaters, OutterProps>(
+    const updateNameTypecheckProof = withStateHandlers<State, Updaters, OutterProps>(
         (props: OutterProps) => ({ counter: props.initialCounter }),
         { notAKeyOfUpdaters: (state, props) => n => ({ ...state, counter: state.counter + n ** props.power }), }, // $ExpectError
     );

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -18,6 +18,8 @@ import {
     createEventHandlerWithConfig,
     componentFromStreamWithConfig, mapPropsStreamWithConfig,
     setObservableConfig,
+    StateHandler,
+    StateHandlerMap,
 } from "recompose";
 import rxjsconfig from "recompose/rxjsObservableConfig";
 import rxjs4config from "recompose/rxjs4ObservableConfig";
@@ -186,11 +188,14 @@ function testWithState() {
 
 function testWithStateHandlers() {
     interface State { counter: number; }
-    interface Updaters { add: (n: number) => State; }
-    type InnerProps = State & Updaters;
+    interface Updaters extends StateHandlerMap<State> {
+      add: StateHandler<State>;
+    }
     interface OutterProps { initialCounter: number, power: number }
+    type InnerProps = State & Updaters & OutterProps;
     const InnerComponent: React.StatelessComponent<InnerProps> = (props) =>
         <div>
+            <div>{`Initial counter: ${props.initialCounter}`}</div>
             <div>{`Counter: ${props.counter}`}</div>
             <div onClick={() => props.add(2)}></div>
         </div>;

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -120,10 +120,10 @@ function testWithHandlers() {
         />
     )
 
-    const handlerNameTypecheckProof = withHandlers<OutterProps, HandlerProps>((props) => ({ // $ExpectError
-      onChange: () => () => {},  // $ExpectError
+    const handlerNameTypecheckProof = withHandlers<OutterProps, HandlerProps>({
+      onChange: () => () => {},
       notAKeyOnHandlerProps: () => () => {},  // $ExpectError
-    })); // $ExpectError
+    });
 }
 
 function testDefaultProps() {

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -210,7 +210,12 @@ function testWithStateHandlers() {
     const rendered = (
         <Enhanced initialCounter={4} power={2} />
     );
-}
+
+    const broken = withStateHandlers<State, Updaters, OutterProps>(
+        (props: OutterProps) => ({ counter: props.initialCounter }),
+        { notAKeyOfUpdaters: (state, props) => n => ({ ...state, counter: state.counter + n ** props.power }), }, // $ExpectError
+    );
+  }
 
 function testWithReducer() {
     interface State { count: number }

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -83,20 +83,20 @@ function testWithPropsOnChange() {
 }
 
 function testWithHandlers() {
+    interface OutterProps {
+        out: number;
+    }
     interface InnerProps {
-        onSubmit: React.MouseEventHandler<HTMLDivElement>;
-        onChange: Function;
         foo: string;
     }
     interface HandlerProps {
         onSubmit: React.MouseEventHandler<HTMLDivElement>;
         onChange: Function;
     }
-    interface OutterProps { out: number; }
-    const InnerComponent: React.StatelessComponent<InnerProps> = ({onChange, onSubmit}) =>
-      <div onClick={onSubmit}></div>;
+    const InnerComponent: React.StatelessComponent<InnerProps & HandlerProps> = ({onChange, onSubmit, foo}) =>
+      <div onClick={onSubmit}>{foo}</div>;
 
-    const enhancer = withHandlers<OutterProps, HandlerProps>({
+    const enhancer = withHandlers<OutterProps & InnerProps, HandlerProps>({
       onChange: (props) => (e: any) => {},
       onSubmit: (props) => (e: React.MouseEvent<any>) => {},
     });
@@ -108,7 +108,7 @@ function testWithHandlers() {
         />
     )
 
-    const enhancer2 = withHandlers<OutterProps, HandlerProps>((props) => ({
+    const enhancer2 = withHandlers<OutterProps & InnerProps, HandlerProps>((props) => ({
       onChange: (props) => (e: any) => {},
       onSubmit: (props) => (e: React.MouseEvent<any>) => {},
     }));


### PR DESCRIPTION
Improve `withHandler` & `withStateHandlers` to typecheck keys of updaterName/handlerName against the types provided. This helps to prevent typos from making it into the codebase, and also lets intellisense be a guide to the developer by letting them know what keys to add.

This improves on the work originally provided by @alatushkin in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/19496 and adds tests to prove that it does what it says it does, as requested by @minestarks.

