### PR TITLE
Lodash: update `map` to work with record objects (known keys)

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -17098,7 +17098,7 @@ declare namespace _ {
     type ListIteratorTypeGuard<T, S extends T> = (value: T, index: number, collection: List<T>) => value is S;
 
     // Note: key should be string, not keyof T, because the actual object may contain extra properties that were not specified in the type.
-    type ObjectIterator<TObject, TResult> = (value: TObject[keyof TObject], key: string, collection: TObject) => TResult;
+    type ObjectIterator<TObject, TResult> = (value: TObject[keyof TObject], key: keyof TObject, collection: TObject) => TResult;
     type ObjectIteratee<TObject> = ObjectIterator<TObject, NotVoid> | string | [string, any] | PartialDeep<TObject[keyof TObject]>;
     type ObjectIterateeCustom<TObject, TResult> = ObjectIterator<TObject, TResult> | string | [string, any] | PartialDeep<TObject[keyof TObject]>;
     type ObjectIteratorTypeGuard<TObject, S extends TObject[keyof TObject]> = (value: TObject[keyof TObject], key: string, collection: TObject) => value is S;

--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -6102,8 +6102,8 @@ declare namespace _ {
          * @see _.map
          */
         map<T, TResult>(
-            collection: Dictionary<T> | null | undefined,
-            iteratee: DictionaryIterator<T, TResult>
+            collection: T | null | undefined,
+            iteratee: ObjectIterator<T, TResult>
         ): TResult[];
 
         /** @see _.map */

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -6078,9 +6078,13 @@ namespace TestMap {
     let list: _.List<number> | null | undefined = [] as any;
     let obj: any = {};
     let dictionary: _.Dictionary<number> | null | undefined = obj;
+    type RecordKey = 'foo' | 'bar';
+    type MyRecord = Record<RecordKey, number>;
+    let record: MyRecord = { foo: 1, bar: 2 };
 
     let listIterator: (value: number, index: number, collection: _.List<number>) => TResult = (value: number, index: number, collection: _.List<number>) => ({ a: 1, b: "", c: true });
     let dictionaryIterator: (value: number, key: string, collection: _.Dictionary<number>) => TResult = (value: number, key: string, collection: _.Dictionary<number>) => ({ a: 1, b: "", c: true });
+    let recordIterator: (value: number, key: RecordKey, collection: MyRecord) => RecordKey = (value: number, key: RecordKey, collection: MyRecord) => key;
 
     {
         _.map(array);  // $ExpectType number[]
@@ -6091,6 +6095,8 @@ namespace TestMap {
 
         _.map(dictionary);  // $ExpectType number[]
         _.map(dictionary, dictionaryIterator);  // $ExpectType TResult[]
+
+        _.map(record, recordIterator);  // $ExpectType RecordKey[]
     }
 
     {


### PR DESCRIPTION
For objects with known keys (records), we can provide the key type (using `keyof`) to the iterator function, instead of just `string`.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.