### PR TITLE
Added stop method to types/pubnub/index.d.ts definition types

### DIFF
--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -36,8 +36,8 @@ declare class Pubnub {
   unsubscribe(params: Pubnub.UnsubscribeParameters): void;
 
   unsubscribeAll(): void;
-    
-  stop():void;
+
+  stop(): void;
 
   addListener(params: Pubnub.ListenerParameters): void;
 

--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for pubnub 4.0
 // Project: https://github.com/pubnub/javascript
 // Definitions by: bitbankinc <https://github.com/bitbankinc>
+//                   rollymaduk <https://github.com/rollymaduk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // @see https://www.pubnub.com/docs/web-javascript/api-reference-configuration
 

--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for pubnub 4.0
 // Project: https://github.com/pubnub/javascript
-// Definitions by: bitbankinc <https://github.com/bitbankinc>,rollymaduk <https://github.com/rollymaduk>
+// Definitions by: bitbankinc <https://github.com/bitbankinc>, rollymaduk <https://github.com/rollymaduk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // @see https://www.pubnub.com/docs/web-javascript/api-reference-configuration
 

--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -1,7 +1,6 @@
 // Type definitions for pubnub 4.0
 // Project: https://github.com/pubnub/javascript
-// Definitions by: bitbankinc <https://github.com/bitbankinc>
-//                   rollymaduk <https://github.com/rollymaduk>
+// Definitions by: bitbankinc <https://github.com/bitbankinc>,rollymaduk <https://github.com/rollymaduk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // @see https://www.pubnub.com/docs/web-javascript/api-reference-configuration
 

--- a/types/pubnub/index.d.ts
+++ b/types/pubnub/index.d.ts
@@ -36,6 +36,8 @@ declare class Pubnub {
   unsubscribe(params: Pubnub.UnsubscribeParameters): void;
 
   unsubscribeAll(): void;
+    
+  stop():void;
 
   addListener(params: Pubnub.ListenerParameters): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.