### PR TITLE
Add classes option to jqueryui autocomplete

### DIFF
--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for jQueryUI 1.11
+// Type definitions for jQueryUI 1.12
 // Project: http://jqueryui.com/
 // Definitions by: Boris Yankov <https://github.com/borisyankov>, John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -51,6 +51,12 @@ declare namespace JQueryUI {
         minLength?: number;
         position?: any; // object
         source?: any; // [], string or ()
+        classes?: AutocompleteClasses;
+    }
+
+    interface AutocompleteClasses {
+        "ui-autocomplete"?: string;
+        "ui-autocomplete-input"?: string;
     }
 
     interface AutocompleteUIParams {
@@ -377,7 +383,7 @@ declare namespace JQueryUI {
 		open?: DialogEvent;
         close?: DialogEvent;
     }
-    
+
     interface DialogClasses {
         "ui-dialog"?: string;
         "ui-dialog-content"?: string;
@@ -1384,8 +1390,8 @@ interface JQuery {
       * @param optionName 'autohide'
       */
       datepicker(methodName: 'option', optionName: 'autohide'): boolean;
-    
-   
+
+
       /**
       * Get the endDate after initialization
       *

--- a/types/jqueryui/jqueryui-tests.ts
+++ b/types/jqueryui/jqueryui-tests.ts
@@ -911,7 +911,12 @@ function test_autocomplete() {
                 "Nothing selected, input was " + this.value);
         }
     });
-
+    $("#birds").autocomplete({
+        classes: {
+            'ui-autocomplete': 'foo',
+            'ui-autocomplete-input': 'bar'
+        }
+    })
 }
 
 


### PR DESCRIPTION
Signed-off-by: Sengouttouvane Shanmugam <seshanmugam@corelogic.com>

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:  http://api.jqueryui.com/autocomplete/#option-classes
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
