### PR TITLE
@types/sequelize: Add sourceKey property to AssociationOptionsHasMany interface

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -7,6 +7,7 @@
 //                 Patsakol Tangjitcharoenchai <https://github.com/kukoo1>
 //                 Sebastien Bramille <https://github.com/oktapodia>
 //                 Nick Mueller <https://github.com/morpheusxaut>
+//                 Philippe D'Alva <https://github.com/TitaneBoy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -1329,7 +1330,13 @@ declare namespace sequelize {
          * A string or a data type to represent the identifier in the table
          */
         keyType?: DataTypeAbstract;
-
+        /**
+         * A string to represent the name of the field to use as the key for an 1 to many association in the source table. 
+         * 
+         * @see http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-hasMany
+         * @see https://github.com/sequelize/sequelize/blob/b4fd46426db9cdbb97074bea121203d565e4195d/lib/associations/has-many.js#L81
+         */
+        sourceKey?: string;
     }
 
     /**


### PR DESCRIPTION
According to http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-hasMany, Model.hasMany should have an sourceKey property. But for now, no sourceKey property for an 1 to Many association exists. This PR add the missing "sourceKey" property

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-hasMany>>
