### PR TITLE
@types/atom: watchPath returns a Promise

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -1587,7 +1587,8 @@ function testPanel() {
 }
 
 // PathWatcher ================================================================
-function testPathWatcher() {
+async function testPathWatcher() {
+    const pathWatcher = await pathWatcherPromise;
     pathWatcher.dispose();
     subscription = pathWatcher.onDidError((error) => str = error.name);
 
@@ -3213,7 +3214,7 @@ function testWorkspaceCenter() {
 }
 
 // watchPath ==================================================================
-const pathWatcher = Atom.watchPath("/var/test", {}, (events) => {
+const pathWatcherPromise = Atom.watchPath("/var/test", {}, (events) => {
     for (const event of events) {
         str = event.path;
         str = event.action;

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -24,7 +24,7 @@ declare global {
  *  Project::onDidChangeFiles instead.
  */
 export function watchPath(rootPath: string, options: {}, eventCallback: (events:
-    FilesystemChangeEvent) => void): PathWatcher;
+    FilesystemChangeEvent) => void): Promise<PathWatcher>;
 
 // Essential Classes ==========================================================
 


### PR DESCRIPTION
I don't do well with issue templates apparently... anyway, as per subject, https://github.com/atom/atom/blob/aee6b374c2b26695e1d088c519c05c126eafdc98/src/path-watcher.js#L640 returns a `Promise<PathWatcher>`, while current typing insists it returns `PathWatcher`.

/cc @GlenCFL, @smhxx 