### PR TITLE
@types/math3d fix incorrect Transform.rotation type

### DIFF
--- a/types/math3d/index.d.ts
+++ b/types/math3d/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for math3d 0.2
 // Project: https://github.com/adragonite/math3d
 // Definitions by: Laszlo Jakab <https://github.com/laszlojakab>
+//                 Jim Smart <https://github.com/jimsmart>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export class Vector3 {

--- a/types/math3d/index.d.ts
+++ b/types/math3d/index.d.ts
@@ -148,7 +148,7 @@ export class Transform {
     position: Vector3;
     right: Vector3;
     root: Transform;
-    rotation: Vector3;
+    rotation: Quaternion;
     up: Vector3;
     worldToLocalMatrix: Matrix4x4;
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
— Here is the source, [showing where _rotation is initialised](https://github.com/adragonite/math3d/blob/master/src/Transform.js#L152) to a Quaternion, and [the .rotation setter](https://github.com/adragonite/math3d/blob/master/src/Transform.js#L187), which explicitly checks for Quaternion type before performing the set operation.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Hi, 
Here is a pull request to correct the declared type of Transform.rotation. It is erroneously declared as being Vector3, whereas in the Javscript all rotations are actually Quaternions.

[Edit: added a second link and better link description, above]
[Edit: @laszlojakab ]