### PR TITLE
fix(chai-jquery): Fix assertion methods that deviate in style from others

### DIFF
--- a/types/chai-jquery/index.d.ts
+++ b/types/chai-jquery/index.d.ts
@@ -10,10 +10,10 @@
 declare namespace Chai {
 
     interface Assertion {
-        attr: (name: string, value?: string) => Assertion;
-        prop: (name: string, value?: any) => Assertion;
-        css: (name: string, value?: string) => Assertion;
-        data: (name: string, value?: string) => Assertion;
+        attr(name: string, value?: string): Assertion;
+        prop(name: string, value?: any): Assertion;
+        css(name: string, value?: string): Assertion;
+        data(name: string, value?: string): Assertion;
         class(className: string): Assertion;
         id(id: string): Assertion;
         html(html: string): Assertion;

--- a/types/chai-jquery/index.d.ts
+++ b/types/chai-jquery/index.d.ts
@@ -20,11 +20,11 @@ declare namespace Chai {
         text(text: string): Assertion;
         value(text: string): Assertion;
         descendants(selector: string): Assertion;
-        visible: Assertion;
-        hidden: Assertion;
-        selected: Assertion;
-        checked: Assertion;
-        disabled: Assertion;
+        visible(): Assertion;
+        hidden(): Assertion;
+        selected(): Assertion;
+        checked(): Assertion;
+        disabled(): Assertion;
         (selector: string): Assertion;
     }
 }


### PR DESCRIPTION
This was causing an issue with `chai-enzyme` types which also defines these methods (`attr`, `prop`, `css`, `data`). I'm not sure why these 4 assertion methods deviated from the style of the rest of assertion methods. I figured `chai-jquery` chai methods should be updated since the 4 methods in question are the ones that deviate for how the methods are defined.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/chai-enzyme/index.d.ts#L132
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
