### PR TITLE
[iltorb] Added .flush() to compress stream

### DIFF
--- a/types/iltorb/iltorb-tests.ts
+++ b/types/iltorb/iltorb-tests.ts
@@ -20,8 +20,11 @@ br.compress(Buffer.from('foo', 'utf8'), onCompress);
 
 br.compress(Buffer.from('foo', 'utf8'), opts, onCompress);
 
+const stream = br.compressStream();
+stream.flush();
+
 createReadStream(__filename)
-    .pipe(br.compressStream())
+    .pipe(stream)
     .pipe(createWriteStream('foo.ts'));
 
 createReadStream(__dirname)

--- a/types/iltorb/index.d.ts
+++ b/types/iltorb/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/MayhemYDG/iltorb
 // Definitions by: Arturas Molcanovas <https://github.com/Alorel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /// <reference types="node"/>
 
@@ -16,6 +17,10 @@ export interface BrotliEncodeParams {
     size_hint?: number;
 }
 
+export interface BrotliFlushable {
+	flush(): void;
+}
+
 export type IltorbCallback = (err: Error | null | undefined, output: Buffer) => void;
 
 export function compress(buffer: Buffer, options: BrotliEncodeParams, callback: IltorbCallback): void;
@@ -26,5 +31,5 @@ export function decompress(buffer: Buffer, callback: IltorbCallback): void;
 export function compressSync(buffer: Buffer, options?: BrotliEncodeParams): Buffer;
 export function decompressSync(buffer: Buffer): Buffer;
 
-export function compressStream(options?: BrotliEncodeParams): Transform;
+export function compressStream(options?: BrotliEncodeParams): Transform & BrotliFlushable;
 export function decompressStream(): Transform;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/iltorb#compressionstreamflush
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The `flush()` method was missing from the compress stream