### PR TITLE
Added type definitions for webpack-cleanup-plugin

### DIFF
--- a/types/webpack-cleanup-plugin/index.d.ts
+++ b/types/webpack-cleanup-plugin/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for webpack-cleanup-plugin 0.5
+// Project: https://github.com/gpbl/webpack-cleanup-plugin#readme
+// Definitions by: Luka Maljic <https://github.com/malj>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import webpack = require('webpack');
+
+export = WebpackCleanupPlugin;
+
+declare class WebpackCleanupPlugin extends webpack.Plugin {
+    constructor(options?: WebpackCleanupPlugin.Options);
+}
+
+declare namespace WebpackCleanupPlugin {
+    interface Options {
+        /**
+         * Keep some files in the output path. It accepts globbing as in [minimatch](https://github.com/isaacs/minimatch).
+         */
+        exclude?: string[];
+
+        /**
+         * Print the list of the files that will be deleted without actually deleting them.
+         */
+        preview?: boolean;
+
+        /**
+         * Mute the console output.
+         */
+        quiet?: boolean;
+    }
+}

--- a/types/webpack-cleanup-plugin/tsconfig.json
+++ b/types/webpack-cleanup-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-cleanup-plugin-tests.ts"
+    ]
+}

--- a/types/webpack-cleanup-plugin/tslint.json
+++ b/types/webpack-cleanup-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-cleanup-plugin/webpack-cleanup-plugin-tests.ts
+++ b/types/webpack-cleanup-plugin/webpack-cleanup-plugin-tests.ts
@@ -1,0 +1,7 @@
+import WebpackCleanupPlugin = require('webpack-cleanup-plugin');
+
+new WebpackCleanupPlugin({
+    exclude: ["stats.json", "important.js", "folder/**/*"],
+    preview: true,
+    quiet: true
+});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
