### PR TITLE
Add typings for redux-storage-engine-localstorage

### DIFF
--- a/types/redux-storage-engine-localstorage/index.d.ts
+++ b/types/redux-storage-engine-localstorage/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for redux-storage-engine-localstorage 1.1
+// Project: https://github.com/react-stack/redux-storage-engine-localstorage
+// Definitions by: Christian Rackerseder <https://github.com/screendriver>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { StorageEngine } from "redux-storage";
+
+export type Replacer = (key: string, value: any) => any;
+
+export type Reviver = Replacer;
+
+export default function createEngine(key: string, replacer?: Replacer, reviver?: Reviver): StorageEngine;

--- a/types/redux-storage-engine-localstorage/redux-storage-engine-localstorage-tests.ts
+++ b/types/redux-storage-engine-localstorage/redux-storage-engine-localstorage-tests.ts
@@ -1,0 +1,20 @@
+import { createLoader } from "redux-storage";
+import createEngine from "redux-storage-engine-localstorage";
+
+let engine = createEngine('test-key');
+
+createLoader(engine);
+
+engine = createEngine('test-key', (key, value) => {
+    if (typeof value === 'string') {
+        return 'foo';
+    }
+    return value;
+}, (key, value) => {
+    if (key === 'foo') {
+        return 'bar';
+    }
+    return value;
+});
+
+createLoader(engine);

--- a/types/redux-storage-engine-localstorage/tsconfig.json
+++ b/types/redux-storage-engine-localstorage/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictNullChecks": true,
+      "strictFunctionTypes": true,
+      "baseUrl": "../",
+      "typeRoots": [
+          "../"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+      "index.d.ts",
+      "redux-storage-engine-localstorage-tests.ts"
+  ]
+}

--- a/types/redux-storage-engine-localstorage/tslint.json
+++ b/types/redux-storage-engine-localstorage/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/redux-storage/index.d.ts
+++ b/types/redux-storage/index.d.ts
@@ -89,18 +89,6 @@ declare module "redux-storage-decorator-filter" {
     export default function (engine: StorageEngine, whitelist?: FilterList, blacklist?: FilterList): StorageEngine;
 }
 
-declare module "redux-storage-engine-localstorage" {
-    import { StorageEngine } from "redux-storage";
-
-    export interface LocalStorageEngine extends StorageEngine { }
-
-    /**
-     * Create local storage
-     * @param key localstorage key
-     */
-    export default function createEngine(key: string): LocalStorageEngine;
-}
-
 declare module "redux-storage-engine-reactnativeasyncstorage" {
     import { StorageEngine } from "redux-storage";
 


### PR DESCRIPTION
Removed embedded typings from redux-storage and created separate typing

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
