### PR TITLE
Add missing type (customInputRef) on react-datepicker (introduced in 0.62.0)

### DIFF
--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-datepicker 0.55
+// Type definitions for react-datepicker 0.62
 // Project: https://github.com/Hacker0x01/react-datepicker
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>,
 //                 Andrey Balokha <https://github.com/andrewBalekha>,
@@ -19,6 +19,7 @@ export interface ReactDatePickerProps {
 	children?: any;
 	className?: string;
 	customInput?: React.ReactNode;
+	customInputRef?: string;
 	dateFormat?: string | string[];
 	dateFormatCalendar?: string;
 	dayClassName?(date: moment.Moment): string | null;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Hacker0x01/react-datepicker/commit/f49251167b6f0fb9cb356736cf4dbac0247856f1
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

