### PR TITLE
Add missing Elements props to react-stripe-elements

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-stripe-elements 1.0
 // Project: https://github.com/stripe/react-stripe-elements#readme
 // Definitions by: dan-j <https://github.com/dan-j>
+//                 Santiago Doldan <https://github.com/santiagodoldan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -37,7 +38,7 @@ export namespace ReactStripeElements {
 	}
 
 	interface InjectedStripeProps {
-		stripe: StripeProps;
+		stripe?: StripeProps;
 	}
 
 	interface ElementProps extends ElementsOptions {
@@ -58,7 +59,7 @@ export namespace ReactStripeElements {
 export class StripeProvider extends React.Component<ReactStripeElements.StripeProviderProps> {
 }
 
-export class Elements extends React.Component {
+export class Elements extends React.Component<stripe.elements.ElementsCreateOptions> {
 }
 
 export function injectStripe<P extends object>(

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -14,6 +14,7 @@ import InjectedStripeProps = ReactStripeElements.InjectedStripeProps;
 
 import ElementChangeResponse = stripe.elements.ElementChangeResponse;
 import ElementsOptions = stripe.elements.ElementsOptions;
+import ElementsCreateOptions = stripe.elements.ElementsCreateOptions;
 import PatchedTokenResponse = ReactStripeElements.PatchedTokenResponse;
 
 const cardElementProps: ElementsOptions = {
@@ -44,6 +45,22 @@ const cardElementProps: ElementsOptions = {
         webkitAutofill: 'webkit-autofill',
     },
     hideIcon: true,
+};
+
+const fontElementsProps: ElementsCreateOptions = {
+  fonts: [
+    {
+      cssSrc: "https://fonts.googleapis.com/css?family=Dosis"
+    },
+    {
+      family: "Dosis, sanz",
+      src: "url(https://somewebsite.com/path/to/font.woff)",
+      style: "normal",
+      weight: "bold",
+      unicodeRange: "U+26"
+    }
+  ],
+  locale: "es"
 };
 
 const ElementsWithPropsTest: React.SFC = () => (
@@ -92,7 +109,7 @@ interface ComponentProps {
 
 class WrappedComponent extends React.Component<ComponentProps & InjectedStripeProps> {
     onSubmit = () => {
-        this.props.stripe.createToken({
+        this.props.stripe!.createToken({
             name: '',
             address_line1: '',
             address_line2: '',
@@ -133,7 +150,7 @@ class TestHOCs extends React.Component {
     render() {
         return (
             <StripeProvider apiKey="">
-                <Elements>
+                <Elements {...fontElementsProps}>
                     <MainComponent />
                 </Elements>
             </StripeProvider>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/stripe-js/reference#stripe-elements
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.