### PR TITLE
Puppeteer - fix return type for page.select to match documentation

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -968,7 +968,7 @@ export interface Page extends EventEmitter, FrameBase {
    * @param values Values of options to select. If the `<select>` has the `multiple` attribute,
    * all values are considered, otherwise only the first one is taken into account.
    */
-  select(selector: string, ...values: string[]): Promise<Array<string>>;
+  select(selector: string, ...values: string[]): Promise<string[]>;
 
   /**
    * Sets the page content.

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -968,7 +968,7 @@ export interface Page extends EventEmitter, FrameBase {
    * @param values Values of options to select. If the `<select>` has the `multiple` attribute,
    * all values are considered, otherwise only the first one is taken into account.
    */
-  select(selector: string, ...values: string[]): Promise<void>;
+  select(selector: string, ...values: string[]): Promise<Array<string>>;
 
   /**
    * Sets the page content.


### PR DESCRIPTION
Puppeteer - fix return type for page.select to match documentation at puppeteer
Puppeteer documentation: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageselectselector-values

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageselectselector-values
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
