### PR TITLE
[mongodb] Adds ReplaceWriteOpResult

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -607,9 +607,9 @@ export interface Collection<TSchema = Default> {
     rename(newName: string, options?: { dropTarget?: boolean }): Promise<Collection<TSchema>>;
     rename(newName: string, options: { dropTarget?: boolean }, callback: MongoCallback<Collection<TSchema>>): void;
     //http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#replaceOne
-    replaceOne(filter: Object, doc: Object, callback: MongoCallback<UpdateWriteOpResult & { ops: Array<any> }>): void;
-    replaceOne(filter: Object, doc: Object, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult & { ops: Array<any> }>;
-    replaceOne(filter: Object, doc: Object, options: ReplaceOneOptions, callback: MongoCallback<UpdateWriteOpResult & { ops: Array<any> }>): void;
+    replaceOne(filter: Object, doc: Object, callback: MongoCallback<ReplaceWriteOpResult>): void;
+    replaceOne(filter: Object, doc: Object, options?: ReplaceOneOptions): Promise<ReplaceWriteOpResult>;
+    replaceOne(filter: Object, doc: Object, options: ReplaceOneOptions, callback: MongoCallback<ReplaceWriteOpResult>): void;
     //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#save
     /** @deprecated Use insertOne, insertMany, updateOne or updateMany */
     save(doc: Object, callback: MongoCallback<WriteOpResult>): void;
@@ -1132,6 +1132,11 @@ export interface UpdateWriteOpResult {
     modifiedCount: number;
     upsertedCount: number;
     upsertedId: { _id: ObjectID };
+}
+
+// https://github.com/mongodb/node-mongodb-native/blob/2.2/lib/collection.js#L957
+export interface ReplaceWriteOpResult extends UpdateWriteOpResult {
+    ops: Array<any>
 }
 
 //http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#mapReduce


### PR DESCRIPTION
### Tiny fix

Just made a tiny tiny tiny fix for `collection.replaceOne()` command output interface.
New interface isn't documented by api reference itself but it exists as implementation of extension of the `update` result. 
I justified its introduction because of difficulties I faced when tried to use `UpdateWriteOpResult ` type separately.
Every time you use it you need to add `& { ops: ... }` intersection at the end. 
That's quite frustrating If you do it several times.

before: 
```typescript
replaceOne(...) : UpdateWriteOpResult & { ops: ... }
```

after: 
```typescript
replaceOne(...) : ReplaceWriteOpResult
```
<hr>


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[node-mongodb-native/2.2/lib/collection.](https://github.com/mongodb/node-mongodb-native/blob/2.2/lib/collection.js#L957)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
