### PR TITLE
[cassandra-driver] Add signature for Promise-based connect/shutdown

### DIFF
--- a/types/cassandra-driver/index.d.ts
+++ b/types/cassandra-driver/index.d.ts
@@ -513,6 +513,7 @@ export interface Client extends events.EventEmitter {
   batch(queries: Array<string> | Array<{ query: string, params?: any }>, options?: QueryOptions): Promise<types.ResultSet>;
 
   connect(callback: Callback): void;
+  connect(): Promise<void>;
   eachRow(query: string, params?: any, options?: QueryOptions, rowCallback?: Callback, callback?: Callback): void;
   execute(query: string, params: any, options: QueryOptions, callback: ResultCallback): void;
   execute(query: string, params: any, callback: ResultCallback): void;
@@ -520,6 +521,7 @@ export interface Client extends events.EventEmitter {
   execute(query: string, params?: any, options?: QueryOptions): Promise<types.ResultSet>;
   getReplicas(keyspace: string, token: Buffer): Array<any>; // TODO: Should this be a more explicit return?
   shutdown(callback?: Callback): void;
+  shutdown(): Promise<void>;
   stream(query: string, params?: any, options?: QueryOptions, callback?: Callback): NodeJS.ReadableStream;
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/datastax/nodejs-driver/blob/master/lib/client.js#L362
https://github.com/datastax/nodejs-driver/blob/master/lib/client.js#L708

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
