### PR TITLE
Created typings for word-list-json npm package

### DIFF
--- a/types/word-list-json/index.d.ts
+++ b/types/word-list-json/index.d.ts
@@ -1,39 +1,15 @@
 // Type definitions for word-list-json 0.2
 // Project: https://github.com/sindresorhus/word-list
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Dovid Meiseles <https://github.com/dovidm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
-export as namespace myLib;
-
-/*~ If this module has methods, declare them as functions like so.
- */
-export function myMethod(a: string): string;
-export function myOtherMethod(a: number): number;
-
 /*~ You can declare types that are available via importing the module */
-export interface someType {
-    name: string;
-    length: number;
-    extras?: string[];
+interface Lengths {
+    [key: string]: number;
 }
+export const words: string[];
+export const lengths: Lengths;
 
-/*~ You can declare properties of the module using const, let, or var */
-export const myField: number;
-
-/*~ If there are types, properties, or methods inside dotted names
- *~ of the module, declare them inside a 'namespace'.
- */
-export namespace subProp {
-    /*~ For example, given this definition, someone could write:
-     *~   import { subProp } from 'yourModule';
-     *~   subProp.foo();
-     *~ or
-     *~   import * as yourMod from 'yourModule';
-     *~   yourMod.subProp.foo();
-     */
-    export function foo(): void;
+export default interface Words {
+    words: typeof words & typeof lengths;
 }

--- a/types/word-list-json/index.d.ts
+++ b/types/word-list-json/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for word-list-json 0.2
+// Project: https://github.com/sindresorhus/word-list
+// Definitions by: My Self <https://github.com/me>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/*~ If this module is a UMD module that exposes a global variable 'myLib' when
+ *~ loaded outside a module loader environment, declare that global here.
+ *~ Otherwise, delete this declaration.
+ */
+export as namespace myLib;
+
+/*~ If this module has methods, declare them as functions like so.
+ */
+export function myMethod(a: string): string;
+export function myOtherMethod(a: number): number;
+
+/*~ You can declare types that are available via importing the module */
+export interface someType {
+    name: string;
+    length: number;
+    extras?: string[];
+}
+
+/*~ You can declare properties of the module using const, let, or var */
+export const myField: number;
+
+/*~ If there are types, properties, or methods inside dotted names
+ *~ of the module, declare them inside a 'namespace'.
+ */
+export namespace subProp {
+    /*~ For example, given this definition, someone could write:
+     *~   import { subProp } from 'yourModule';
+     *~   subProp.foo();
+     *~ or
+     *~   import * as yourMod from 'yourModule';
+     *~   yourMod.subProp.foo();
+     */
+    export function foo(): void;
+}

--- a/types/word-list-json/index.d.ts
+++ b/types/word-list-json/index.d.ts
@@ -2,15 +2,19 @@
 // Project: https://github.com/sindresorhus/word-list
 // Definitions by: Dovid Meiseles <https://github.com/dovidm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-/*~ You can declare types that are available via importing the module */
+// TypeScript Version: 2.4
 
 interface Lengths {
     [key: string]: number;
 }
 
-type words = string[];
+export const lengths: Lengths;
 
-export default interface Words extends words {
+type wordsArray = string[];
+interface Words extends wordsArray {
     lengths: Lengths;
 }
+
+declare const words: Words;
+
+export default words;

--- a/types/word-list-json/index.d.ts
+++ b/types/word-list-json/index.d.ts
@@ -4,12 +4,13 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /*~ You can declare types that are available via importing the module */
+
 interface Lengths {
     [key: string]: number;
 }
-export const words: string[];
-export const lengths: Lengths;
 
-export default interface Words {
-    words: typeof words & typeof lengths;
+type words = string[];
+
+export default interface Words extends words {
+    lengths: Lengths;
 }

--- a/types/word-list-json/tsconfig.json
+++ b/types/word-list-json/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/word-list-json/tsconfig.json
+++ b/types/word-list-json/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "word-list-json-tests.ts"
+    ]
+}

--- a/types/word-list-json/tslint.json
+++ b/types/word-list-json/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/word-list-json/word-list-json-tests.ts
+++ b/types/word-list-json/word-list-json-tests.ts
@@ -1,0 +1,5 @@
+import wordListJson from 'word-list-json';
+
+wordListJson.lengths; // $ExpectType Lengths
+
+wordListJson; // $ExpectType Words

--- a/types/word-list-json/word-list-json-tests.ts
+++ b/types/word-list-json/word-list-json-tests.ts
@@ -1,0 +1,3 @@
+import wordListJson from 'word-list-json';
+
+const words: wordListJson['lengths'] = { '123': 123 };

--- a/types/word-list-json/word-list-json-tests.ts
+++ b/types/word-list-json/word-list-json-tests.ts
@@ -1,3 +1,0 @@
-import wordListJson from 'word-list-json';
-
-const words: wordListJson['lengths'] = { '123': 123 };


### PR DESCRIPTION
Please fill in this template.

- [x] Test the change in your own code. (Compile and run.)
Possible problem: When use `import wordList from 'word-list-json';` `wordList` is undefined, but when I do `import * as wordList from 'word-list-json';` everything works, and `wordList.default` is correct. I don't know why that is.

- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
