### PR TITLE
[rc-slider] Add style prop CommonApiProps

### DIFF
--- a/types/rc-slider/README.md
+++ b/types/rc-slider/README.md
@@ -5,7 +5,7 @@
 This package contains type definitions for rc-slider (https://github.com/react-component/slider).
 
 Additional Details
- * Last updated: Tue, 24 Oct 2017
+ * Last updated: Fri, 15 Dec 2017
  * Dependencies: react
  * Global values: none
 

--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Marcinkus Mantas <https://github.com/mantasmarcinkus>
 //                 Alexander Mattoni <https://github.com/mattoni>
 //                 Austin Turner <https://github.com/paustint>
+//                 Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -90,6 +91,11 @@ export interface CommonApiProps {
      * Tooltip formatter
      */
     tipFormatter?: ((value: any) => any | undefined) | null;
+
+    /**
+     * The style used for the background and container. (both for slider(Object) and range(Array of Object), the array will be used for mutli handle follow element order)
+     */
+    style?: React.CSSProperties[] | React.CSSProperties;
 
     /**
      * The style used for handle. (both for slider(Object) and range(Array of Object), the array will be used for mutli handle follow element order)

--- a/types/rc-slider/rc-slider-tests.tsx
+++ b/types/rc-slider/rc-slider-tests.tsx
@@ -35,6 +35,7 @@ ReactDOM.render(
         onAfterChange={() => { }}
         defaultValue={0.1}
         value={0.1}
+        style={{backgroundColor: 'plum'}}
         dotStyle={{backgroundColor: 'antiquewhite'}}
         activeDotStyle={{backgroundColor: 'antiquewhite'}}
     />,


### PR DESCRIPTION
`<Slider />` allows and uses a `style` prop for styling the background/container of the slider. This was unfortunately not documented in the source repo but does appear valid in the source.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Source](https://github.com/react-component/slider/blob/db32618e7afc8ce43b3ebc1fdf15415552981740/src/common/createSlider.jsx#L297)
