### PR TITLE
daterangepicker: callback arguments are always of type moment.Moment

### DIFF
--- a/types/daterangepicker/daterangepicker-tests.ts
+++ b/types/daterangepicker/daterangepicker-tests.ts
@@ -34,7 +34,7 @@ function tests_simple() {
     $('#demo').daterangepicker({
         "startDate": "05/06/2016",
         "endDate": "05/12/2016"
-    }, function (start: string, end: string, label: string) {
+    }, function (start: moment.Moment, end: moment.Moment, label: string) {
         console.log("New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')");
     });
 

--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for Date Range Picker v2.1.25
+// Type definitions for Date Range Picker v2.1.30
 // Project: http://www.daterangepicker.com/
 // Definitions by: SirMartin <https://github.com/SirMartin>
 //                 Steven Masala <https://github.com/smasala>
+//                 Grant Hutchins <https://github.com/nertzy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -18,7 +19,7 @@ declare global {
 declare const daterangepicker: daterangepicker.DateRangePicker;
 
 declare namespace daterangepicker {
-    type DataRangePickerCallback = (start?: string | Date | moment.Moment, end?: string | Date | moment.Moment, label?: string) => any;
+    type DataRangePickerCallback = (start: moment.Moment, end: moment.Moment, label: string) => any;
 
     interface DateRangePicker {
         new (element: HTMLElement, settings?: daterangepicker.Settings, callback?: DataRangePickerCallback): DateRangePicker;
@@ -26,7 +27,7 @@ declare namespace daterangepicker {
         startDate: moment.Moment;
         endDate: moment.Moment;
         container: JQuery;
-        
+
         setStartDate(date: Date | moment.Moment | string): void;
         setEndDate(date: Date | moment.Moment | string): void;
         remove(): void;

--- a/types/daterangepicker/index.d.ts
+++ b/types/daterangepicker/index.d.ts
@@ -19,7 +19,7 @@ declare global {
 declare const daterangepicker: daterangepicker.DateRangePicker;
 
 declare namespace daterangepicker {
-    type DataRangePickerCallback = (start: moment.Moment, end: moment.Moment, label: string) => any;
+    type DataRangePickerCallback = (start: moment.Moment, end: moment.Moment, label: string | null) => any;
 
     interface DateRangePicker {
         new (element: HTMLElement, settings?: daterangepicker.Settings, callback?: DataRangePickerCallback): DateRangePicker;


### PR DESCRIPTION
The start and end date can be assigned from moment.Moment, string, or Date, but
the internal representation is always coerced into a moment.Moment.

Thus, when the callback is called, the first two arguments are of type moment.Moment.

Signed-off-by: Michael Stuart <mistuart@corelogic.com>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/dangrossman/bootstrap-daterangepicker/blob/9670cb08601d0fd7d9fa39734ab6f9f1ef354e8c/daterangepicker.js#L36-L37
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
