### PR TITLE
Removed dom library expectation from underscore

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -7,6 +7,12 @@ declare var _: _.UnderscoreStatic;
 export = _;
 export as namespace _;
 
+// The DOM is not required to be present, but these definitions reference type Element for the 
+// isElement check. If the DOM is present, this declaration will merge.
+declare global {
+    interface Element { }
+}
+
 declare module _ {
     /**
     * underscore.js _.throttle options.

--- a/types/underscore/tsconfig.json
+++ b/types/underscore/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": false,
         "noImplicitThis": false,

--- a/types/underscore/underscore-tests.ts
+++ b/types/underscore/underscore-tests.ts
@@ -1,6 +1,8 @@
 
 
-declare var $: any;
+declare var $: any, window: any;
+declare var alert: (msg: string) => any;
+declare var console: {log: any};
 
 _.each([1, 2, 3], (num) => alert(num.toString()));
 _.each({ one: 1, two: 2, three: 3 }, (value, key) => alert(value.toString()));


### PR DESCRIPTION
Certain Node.js packages depend on underscore. Underscore has an expectation that Element is defined. For a Node.js app however the "dom" library may not be present. That causes an error without this fix.

CC @RyanCavanaugh 