### PR TITLE
Cheerio: Add placeholder document type

### DIFF
--- a/types/cheerio/index.d.ts
+++ b/types/cheerio/index.d.ts
@@ -271,6 +271,8 @@ interface CheerioAPI extends CheerioSelector, CheerioStatic {
   load(element: CheerioElement, options?: CheerioOptionsInterface): CheerioStatic;
 }
 
+interface Document { }
+
 declare var cheerio:CheerioAPI;
 
 declare module "cheerio" {


### PR DESCRIPTION
Currently, if you compile typescript without the "dom" lib, there is no 'Document' type available, and so the cheerio type definitions will output an error: `error TS2304: Cannot find name 'Document'.` This adds a blank Document interface so no error is produced.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: not compiling for me using typescript 2.6
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
