### PR TITLE
Koa static add setHeaders option

### DIFF
--- a/types/koa-static/index.d.ts
+++ b/types/koa-static/index.d.ts
@@ -14,11 +14,10 @@
 
  =============================================== */
 
-import * as Koa from "koa";
-import {Context} from "koa";
-import {Stats} from "fs";
+import { Context, Middleware } from "koa";
+import { Stats } from "fs";
 
-declare function serve(root: string, opts?: serve.ServeOptions): Koa.Middleware;
+declare function serve(root: string, opts?: serve.ServeOptions): Middleware;
 declare namespace serve {
     type SetHeaders = (res: Context["res"], path: string, stats: Stats) => any;
 
@@ -27,32 +26,32 @@ declare namespace serve {
          * Default file name, defaults to 'index.html'
          */
         index?: boolean | string;
-    
+
         /**
          * If true, serves after return next(),allowing any downstream middleware to respond first.
          */
         defer?: boolean;
-    
+
         /**
          * Browser cache max-age in milliseconds. defaults to 0
          */
         maxage?: number;
-    
+
         /**
          * Allow transfer of hidden files. defaults to false
          */
         hidden?: boolean;
-    
+
         /**
          * Try to serve the gzipped version of a file automatically when gzip is supported by a client and if the requested file with .gz extension exists. defaults to true.
          */
         gzip?: boolean;
-    
+
         /**
          * Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
          */
         extensions?: string[];
-    
+
         /**
          * Function to set custom headers on response.
          */

--- a/types/koa-static/index.d.ts
+++ b/types/koa-static/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/koajs/static
 // Definitions by: Jerry Chin <https://github.com/hellopao>
 // Definitions: https://github.com/hellopao/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/koa-static/index.d.ts
+++ b/types/koa-static/index.d.ts
@@ -1,8 +1,8 @@
-// Type definitions for koa-static 3.0
+// Type definitions for koa-static 4.0
 // Project: https://github.com/koajs/static
 // Definitions by: Jerry Chin <https://github.com/hellopao>
 // Definitions: https://github.com/hellopao/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.4
 
 /* =================== USAGE ===================
 
@@ -15,37 +15,48 @@
  =============================================== */
 
 import * as Koa from "koa";
+import {Context} from "koa";
+import {Stats} from "fs";
 
-declare function serve(root: string, opts?: {
-    /**
-     * Default file name, defaults to 'index.html'
-     */
-    index?: boolean | string;
+declare function serve(root: string, opts?: serve.ServeOptions): Koa.Middleware;
+declare namespace serve {
+    type SetHeaders = (res: Context["res"], path: string, stats: Stats) => any;
 
-    /**
-     * If true, serves after return next(),allowing any downstream middleware to respond first.
-     */
-    defer?: boolean;
-
-    /**
-     * Browser cache max-age in milliseconds. defaults to 0
-     */
-    maxage?: number;
-
-    /**
-     * Allow transfer of hidden files. defaults to false
-     */
-    hidden?: boolean;
-
-    /**
-     * Try to serve the gzipped version of a file automatically when gzip is supported by a client and if the requested file with .gz extension exists. defaults to true.
-     */
-    gzip?: boolean;
-
-    /**
-     * Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
-     */
-    extensions?: string[];
-}): Koa.Middleware;
-declare namespace serve {}
+    interface ServeOptions {
+        /**
+         * Default file name, defaults to 'index.html'
+         */
+        index?: boolean | string;
+    
+        /**
+         * If true, serves after return next(),allowing any downstream middleware to respond first.
+         */
+        defer?: boolean;
+    
+        /**
+         * Browser cache max-age in milliseconds. defaults to 0
+         */
+        maxage?: number;
+    
+        /**
+         * Allow transfer of hidden files. defaults to false
+         */
+        hidden?: boolean;
+    
+        /**
+         * Try to serve the gzipped version of a file automatically when gzip is supported by a client and if the requested file with .gz extension exists. defaults to true.
+         */
+        gzip?: boolean;
+    
+        /**
+         * Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
+         */
+        extensions?: string[];
+    
+        /**
+         * Function to set custom headers on response.
+         */
+        setHeaders?: SetHeaders;
+    }
+}
 export = serve;

--- a/types/koa-static/koa-static-tests.ts
+++ b/types/koa-static/koa-static-tests.ts
@@ -6,7 +6,12 @@ const app = new Koa();
 app.use(serve('.', {
   index: false,
   defer: false,
-  extensions: ['html']
+  extensions: ['html'],
+  setHeaders: (res, path, stats) => {
+    if(path.endsWith('.html')){
+      res.setHeader('Cache-Control', 'public, max-age=0');
+    }
+  }
 }));
 
 app.listen(80);

--- a/types/koa-static/koa-static-tests.ts
+++ b/types/koa-static/koa-static-tests.ts
@@ -8,7 +8,7 @@ app.use(serve('.', {
   defer: false,
   extensions: ['html'],
   setHeaders: (res, path, stats) => {
-    if(path.endsWith('.html')){
+    if (path.endsWith('.html')) {
       res.setHeader('Cache-Control', 'public, max-age=0');
     }
   }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
[https://github.com/koajs/static](https://github.com/koajs/static)
- [x] Increase the version number in the header if appropriate.

I eventually got around to adding the setHeaders option to koa-static, as per this thread - [https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21449#issuecomment-343944177](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/21449#issuecomment-343944177).

I basically copied the code from `@types/koa-send` and also refactored it slightly to match `@types/koa-send` - see [https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4636219b8deb463f9b8620387cbfbf693b312a73/types/koa-send/index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4636219b8deb463f9b8620387cbfbf693b312a73/types/koa-send/index.d.ts).