### PR TITLE
[react-infinite-scroller] fix TS2497

### DIFF
--- a/types/react-infinite-scroller/index.d.ts
+++ b/types/react-infinite-scroller/index.d.ts
@@ -19,7 +19,7 @@ declare namespace InfiniteScroll {
         element?: string;
         /**
          * Whether there are more items to be loaded. Event listeners are removed if false.
-         * Defaults to false.
+             * Defaults to false.
          */
         hasMore?: boolean;
         /**
@@ -63,6 +63,7 @@ declare namespace InfiniteScroll {
         loader?: React.ReactElement<any>;
     }
     class InfiniteScroll extends React.Component<InfiniteScrollProps> { }
+    namespace InfiniteScroll {}
 }
 
 export = InfiniteScroll.InfiniteScroll;

--- a/types/react-infinite-scroller/index.d.ts
+++ b/types/react-infinite-scroller/index.d.ts
@@ -19,7 +19,7 @@ declare namespace InfiniteScroll {
         element?: string;
         /**
          * Whether there are more items to be loaded. Event listeners are removed if false.
-             * Defaults to false.
+         * Defaults to false.
          */
         hasMore?: boolean;
         /**


### PR DESCRIPTION
I get this error when importing the module with `import * as InfiniteScroll from 'react-infinite-scroller`:

    Error:(9, 33) TS2497: Module '".../@types/react-infinite-scroller/index"' resolves to a non-module entity and cannot be imported using this construct.

This PR fixes that error by merging the exported class with an empty namespace.