### PR TITLE
[atom] setTextInBufferRange fix and missing definitions

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -2352,14 +2352,14 @@ function testTextEditor() {
     // Mutating Text
     editor.setText("Test");
 
-    editor.setTextInBufferRange(range, "Test");
-    editor.setTextInBufferRange([pos, pos], "Test");
-    editor.setTextInBufferRange([pos, [0, 0]], "Test");
-    editor.setTextInBufferRange([[0, 0], pos], "Test");
-    editor.setTextInBufferRange([[0, 0], [0, 0]], "Test");
-    editor.setTextInBufferRange(range, "Test", {});
-    editor.setTextInBufferRange([pos, pos], "Test", { normalizeLineEndings: true });
-    editor.setTextInBufferRange(range, "Test", { normalizeLineEndings: true,
+    range = editor.setTextInBufferRange(range, "Test");
+    range = editor.setTextInBufferRange([pos, pos], "Test");
+    range = editor.setTextInBufferRange([pos, [0, 0]], "Test");
+    range = editor.setTextInBufferRange([[0, 0], pos], "Test");
+    range = editor.setTextInBufferRange([[0, 0], [0, 0]], "Test");
+    range = editor.setTextInBufferRange(range, "Test", {});
+    range = editor.setTextInBufferRange([pos, pos], "Test", { normalizeLineEndings: true });
+    range = editor.setTextInBufferRange(range, "Test", { normalizeLineEndings: true,
         undo: "skip" });
 
     editor.insertText("Test");

--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -196,6 +196,8 @@ function testAtomEnvironment() {
     }
 
     atom.executeJavaScriptInDevTools("Test");
+
+    const path: string = atom.getConfigDirPath();
 }
 
 // BufferedNodeProcess ========================================================
@@ -1056,6 +1058,10 @@ function testGrammar() {
     tokenizeLineResult.tokens;
     grammar.tokenizeLine("Test String", tokenizeLineResult.ruleStack);
     grammar.tokenizeLine("Test String", tokenizeLineResult.ruleStack, false);
+
+    let str: string;
+    str = grammar.name;
+    str = grammar.scopeName;
 }
 
 // GrammarRegistry ============================================================
@@ -1396,6 +1402,9 @@ function testPackageManager() {
     subscription = atom.packages.onDidDeactivatePackage(pack => pack.path);
     subscription = atom.packages.onDidLoadPackage(pack => pack.isCompatible());
     subscription = atom.packages.onDidUnloadPackage(pack => pack.name);
+    subscription = atom.packages.onDidTriggerActivationHook(
+      'language-javascript:grammar-used', () => {}
+    );
 
     // Package system data
     str = atom.packages.getApmPath();
@@ -2922,6 +2931,15 @@ function testTextEditor() {
     // TextEditor Rendering
     str = editor.getPlaceholderText();
     editor.setPlaceholderText("Test");
+
+    range = editor.bufferRangeForScopeAtPosition('source.js', [0, 0]);
+    range = editor.bufferRangeForScopeAtPosition('source.js', {row: 10, column: 11});
+    range = editor.bufferRangeForScopeAtPosition('source.js', pos);
+
+    let token: {value: string, scopes: string[]};
+    token = editor.tokenForBufferPosition([5, 6]);
+    token = editor.tokenForBufferPosition({row: 0, column: 1});
+    token = editor.tokenForBufferPosition(pos);
 }
 
 // ThemeManager ===============================================================

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -1456,7 +1456,7 @@ export class TextEditor {
 
     /** Set the text in the given Range in buffer coordinates. */
     setTextInBufferRange(range: RangeCompatible, text: string, options?:
-        { normalizeLineEndings?: boolean, undo?: "skip" }): void;
+        { normalizeLineEndings?: boolean, undo?: "skip" }): Range;
 
     /* For each selection, replace the selected text with the given text. */
     insertText(text: string, options?: {

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -238,6 +238,9 @@ export interface AtomEnvironment {
 
     /** Execute code in dev tools. */
     executeJavaScriptInDevTools(code: string): void;
+
+    /** Undocumented: get Atom config directory path */
+    getConfigDirPath(): string;
 }
 
 /**
@@ -2379,6 +2382,12 @@ export class TextEditor {
      *  displayed when the editor has no content.
      */
     setPlaceholderText(placeholderText: string): void;
+
+    /** Undocumented: Buffer range for syntax scope at position */
+    bufferRangeForScopeAtPosition(scope: string, point: PointCompatible): Range;
+
+    /** Undocumented: Get syntax token at buffer position */
+    tokenForBufferPosition(pos: PointCompatible): {value: string, scopes: string[]};
 }
 
 /** Experimental: This global registry tracks registered TextEditors. */
@@ -3610,7 +3619,10 @@ export class GitRepository {
 /** Grammar that tokenizes lines of text. */
 export interface Grammar {
     /** The name of the Grammar. */
-    name: string;
+    readonly name: string;
+
+    /** Undocumented: scope name of the Grammar. */
+    readonly scopeName: string;
 
     // Event Subscription
     onDidUpdate(callback: () => void): Disposable;
@@ -3937,6 +3949,9 @@ export interface PackageManager {
 
     /** Invoke the given callback when a package is unloaded. */
     onDidUnloadPackage(callback: (package: Package) => void): Disposable;
+
+    /** Undocumented: invoke the given callback when an activation hook is triggered */
+    onDidTriggerActivationHook(hook: string, callback: () => void): Disposable;
 
     // Package System Data
     /** Get the path to the apm command. */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://atom.io/docs/api/v1.22.1/TextEditor#instance-setTextInBufferRange and see OP in #22211 for context on added definitions.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

This fixes #22212 
This also adds simpler missing definitions mentioned in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/22211 -- all of those except `TextEditorElement` and `TextEditorComponent`.

One change that might be somewhat controversial, is `Grammar.name` has been marked as `readonly`. But it should pretty much follow the same rules as `scopeName`, and it was suggested that latter *should* be marked as such, so I would argue that former also deserves such treatment (technically, you could change either, but that would more often than not be on accident, and will lead to shenanigans)