### PR TITLE
[@types/puppeteer] fix $eval argument from ElementHandler to Element

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -667,7 +667,7 @@ export interface FrameBase {
    */
   $eval(
     selector: string,
-    fn: (element: ElementHandle | null, ...args: any[]) => any,
+    fn: (element: Element | null, ...args: any[]) => any,
     ...args: any[]
   ): Promise<any>;
 
@@ -681,7 +681,7 @@ export interface FrameBase {
    */
   $$eval(
     selector: string,
-    fn: (elements: ElementHandle[], ...args: any[]) => any,
+    fn: (elements: NodeListOf<Element>, ...args: any[]) => any,
     ...args: any[]
   ): Promise<any>;
 

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -667,7 +667,7 @@ export interface FrameBase {
    */
   $eval(
     selector: string,
-    fn: (element: Element | null, ...args: any[]) => any,
+    pageFunction: (element: Element, ...args: any[]) => any,
     ...args: any[]
   ): Promise<any>;
 
@@ -681,7 +681,7 @@ export interface FrameBase {
    */
   $$eval(
     selector: string,
-    fn: (elements: NodeListOf<Element>, ...args: any[]) => any,
+    pageFunction: (elements: NodeListOf<Element>, ...args: any[]) => any,
     ...args: any[]
   ): Promise<any>;
 

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -270,9 +270,6 @@ puppeteer.launch().then(async browser => {
   const page = await browser.newPage();
   await page.goto("https://example.com");
   let elementText = await page.$eval('#someElement', (element) => {
-    if (element == null) {
-      return '';
-    }
     return element.innerHTML;
   });
 

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -263,3 +263,24 @@ puppeteer.launch().then(async browser => {
 
   browser.close();
 })();
+
+// test $eval and $$eval
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.goto("https://example.com");
+  let elementText = await page.$eval('#someElement', (element) => {
+    if (element == null) {
+      return '';
+    }
+    return element.innerHTML;
+  });
+
+  elementText = await page.$$eval('.someClassName', (elements) => {
+    console.log(elements.length);
+    console.log(elements.item(0).outerHTML);
+    return elements[3].innerHTML;
+  });
+
+  browser.close();
+})();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pageevalselector-pagefunction-args
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.