### PR TITLE
[atom] Added TextEditorElement and TextEditorComponent

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -14,7 +14,6 @@ declare let elements: HTMLElement[];
 declare const div: HTMLDivElement;
 declare const event: KeyboardEvent;
 declare const mouseEvent: MouseEvent;
-declare let pixelPos: {left: number, top: number};
 
 declare let buffer: Atom.TextBuffer;
 declare const color: Atom.Color;
@@ -67,6 +66,7 @@ declare let subscription: Atom.Disposable;
 declare let subscriptions: Atom.CompositeDisposable;
 declare let tooltips: Atom.Tooltip[];
 declare let workspaceCenter: Atom.WorkspaceCenter;
+declare let pixelPos: Atom.PixelPosition;
 declare let textEditorElement: Atom.TextEditorElement;
 declare let textEditorComponent: Atom.TextEditorComponent;
 

--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -13,6 +13,8 @@ declare let element: HTMLElement;
 declare let elements: HTMLElement[];
 declare const div: HTMLDivElement;
 declare const event: KeyboardEvent;
+declare const mouseEvent: MouseEvent;
+declare let pixelPos: {left: number, top: number};
 
 declare let buffer: Atom.TextBuffer;
 declare const color: Atom.Color;
@@ -65,6 +67,8 @@ declare let subscription: Atom.Disposable;
 declare let subscriptions: Atom.CompositeDisposable;
 declare let tooltips: Atom.Tooltip[];
 declare let workspaceCenter: Atom.WorkspaceCenter;
+declare let textEditorElement: Atom.TextEditorElement;
+declare let textEditorComponent: Atom.TextEditorComponent;
 
 // AtomEnvironment ============================================================
 function testAtomEnvironment() {
@@ -266,6 +270,10 @@ function testCommandRegistry() {
         didDispatch: (event) => event.stopImmediatePropagation(),
         description: "A Command Test",
         displayName: "Command: Test",
+    });
+    atom.commands.add("atom-text-editor", {
+        "test-function": (event) => event.currentTarget.getModel(),
+        "test-function2": (event) => event.currentTarget.getComponent(),
     });
 
     const commands = atom.commands.findCommands({ target: element });
@@ -2981,6 +2989,7 @@ function testViewRegistry() {
     });
 
     element = atom.views.getView(element);
+    textEditorElement = atom.views.getView(editor);
 }
 
 // Workspace ==================================================================
@@ -3220,3 +3229,39 @@ const pathWatcher = Atom.watchPath("/var/test", {}, (events) => {
         if (event.oldPath) str = event.oldPath;
     }
 });
+
+// TextEditorElement ==========================================================
+function testTextEditorElement() {
+  textEditorComponent = textEditorElement.getComponent();
+  editor = textEditorElement.getModel();
+
+  textEditorElement.getNextUpdatePromise().then(() => {});
+  let num: number = textEditorElement.getBaseCharacterWidth();
+
+  textEditorElement.scrollToTop();
+  textEditorElement.scrollToBottom();
+  textEditorElement.setScrollTop(num);
+  num = textEditorElement.getScrollTop();
+  textEditorElement.setScrollLeft(num);
+  num = textEditorElement.getScrollLeft();
+  num = textEditorElement.getScrollHeight();
+
+  pixelPos = textEditorElement.pixelPositionForBufferPosition(pos);
+  pixelPos = textEditorElement.pixelPositionForScreenPosition({row: 1, column: 2});
+  pixelPos = textEditorElement.pixelPositionForScreenPosition(pos);
+
+  subscription = textEditorElement.onDidChangeScrollTop((scrollTop: number) => {});
+  subscription = textEditorElement.onDidChangeScrollLeft((scrollLeft: number) => {});
+  subscription = textEditorElement.onDidAttach(() => {});
+  subscription = textEditorElement.onDidDetach(() => {});
+
+  textEditorElement = document.createElement('atom-text-editor');
+}
+
+// TextEditorComponent ========================================================
+function testTextEditorComponent() {
+  pixelPos = textEditorComponent.pixelPositionForMouseEvent(mouseEvent);
+  pixelPos = textEditorComponent.pixelPositionForScreenPosition(pos);
+  pos = textEditorComponent.screenPositionForMouseEvent(mouseEvent);
+  pos = textEditorComponent.screenPositionForPixelPosition(pixelPos);
+}

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -1,7 +1,8 @@
 // Type definitions for Atom 1.22
 // Project: https://github.com/atom/atom
-// Definitions by: GlenCFL <https://github.com/GlenCFL>,
+// Definitions by: GlenCFL <https://github.com/GlenCFL>
 //                 smhxx <https://github.com/smhxx>
+//                 lierdakil <https://github.com/lierdakil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -2401,16 +2401,21 @@ export class TextEditor {
     setPlaceholderText(placeholderText: string): void;
 }
 
+export interface PixelPosition {
+    left: number;
+    top: number;
+}
+
 /**
  *  Undocumented: Rendering component for TextEditor
  */
 export interface TextEditorComponent {
   /** Does not clip screenPosition, unlike similar method on TextEditorElement */
-  pixelPositionForScreenPosition(screenPosition: PointLike): {left: number, top: number};
-  screenPositionForPixelPosition(pos: {top: number, left: number}): Point;
+  pixelPositionForScreenPosition(screenPosition: PointLike): PixelPosition;
+  screenPositionForPixelPosition(pos: PixelPosition): Point;
   pixelPositionForMouseEvent(event: {
     clientX: number, clientY: number
-  }): {top: number, left: number};
+  }): PixelPosition;
   screenPositionForMouseEvent(event: {clientX: number, clientY: number}): Point;
 }
 
@@ -2444,10 +2449,10 @@ export interface TextEditorElement extends HTMLElement {
   getScrollHeight(): number;
 
   /** Extended: Converts a buffer position to a pixel position. */
-  pixelPositionForBufferPosition(bufferPosition: PointLike): {left: number, top: number};
+  pixelPositionForBufferPosition(bufferPosition: PointLike): PixelPosition;
 
   /** Extended: Converts a screen position to a pixel position. */
-  pixelPositionForScreenPosition(screenPosition: PointLike): {left: number, top: number};
+  pixelPositionForScreenPosition(screenPosition: PointLike): PixelPosition;
 
   // Event subscription
   onDidChangeScrollTop(callback: (scrollTop: number) => void): Disposable;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/atom/atom/blob/b96141905f5f40b6c939fca8f64a23e60b785af5/src/text-editor-element.js
    - https://github.com/atom/atom/blob/b96141905f5f40b6c939fca8f64a23e60b785af5/src/text-editor-component.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Should close https://github.com/DefinitelyTyped/DefinitelyTyped/issues/22211

---

First of all, this is a separate PR because it probably needs more discussion then the other ones.

So, I thought I should explain my rationale a bit.

Adding `atom-text-editor` to `HTMLElementTagNameMap` is a no-brainer, I hope.

`CommandRegistryTargetMap` exists mostly because it needed a string index, but this has a nice benefit: it's possible to define more selectors there via interface augmentation (f.ex. `'atom-text-editor.some-class': TextEditorElement`)

`CommandRegistryListener` exists for the sole purpose of reducing code duplication in `CommandRegistry.add`.

`CommandEvent` is templated (i.e. has a generic argument) to allow specifying more specific `currentTarget` type (unlike `target`, `currentTarget` is guaranteed to have the expected type). It still defaults to `EventTarget` for compatibility reasons, and has to extend `EventTarget` because TS says so (which is, of course, reasonable).

`CommandRegistry.add` is redefined in such a way, that `CommandEvent` has `currentTarget` type inferred from the `target` argument. If `target` extends `Node`, then `currentTarget` is the same. If `target` is a string selector, lookup in `CommandRegistryTargetMap` is done, which yields `EventTarget` by default.

`ViewRegistry.getView` is overloaded to return `TextEditorElement` for `atom.views.getView(editor: TextEditor)` queries, should be rather straightforward.

Finally, this adds `TextEditorElement` and `TextEditorComponent` classes. I did reference both Atom sources and atom-languageclient Flow definitions:

* [TextEditorElement](https://github.com/atom/atom-languageclient/blob/7498c3b227e497e4d9b75d2e04c38a6bad3da142/flow-libs/atom.js.flow#L956)
* [TextEditorComponent](https://github.com/atom/atom-languageclient/blob/7498c3b227e497e4d9b75d2e04c38a6bad3da142/flow-libs/atom.js.flow#L916)

I have to note though, languageclient's definitions are not entirely correct (optional arguments from those definitions are often ignored in the code), and I find those expose a bit more than they should. For example, using `TextEditorElement.setModel` directly from user code will lead to a lot of shenanigans, and is supposed to be used during `TextEditorElement` instantiation, before it's attached to DOM. I would argue we shouldn't expose such methods, and if someone actually uses them (in some dirty hacks no doubt), it's easy enough to augment the interface.

/cc @GlenCFL, @smhxx