### PR TITLE
Fix definition of ReactModal.setAppElement in @types/react-modal

### DIFF
--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -4,7 +4,8 @@
 //                 Drew Noakes <https://github.com/drewnoakes>,
 //                 Thomas B Homburg <https://github.com/homburg>,
 //                 Tatu Tamminen <https://github.com/ttamminen>,
-//                 Uwe Wiemer <https://github.com/hallowatcher>
+//                 Uwe Wiemer <https://github.com/hallowatcher>,
+//                 Peter Blazejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -97,6 +98,9 @@ declare namespace ReactModal {
 declare class ReactModal extends React.Component<ReactModal.Props> {
     /* Override base styles for all instances of this component. */
     static defaultStyles: ReactModal.Styles;
-    /* Call this to properly hide your application from assistive screenreaders and other assistive technologies while the modal is open. */
-    static setAppElement(appElement: HTMLElement): void;
+    /**
+     * Call this to properly hide your application from assistive screenreaders
+     * and other assistive technologies while the modal is open.
+     */
+    static setAppElement(appElement: string | HTMLElement): void;
 }

--- a/types/react-modal/react-modal-tests.tsx
+++ b/types/react-modal/react-modal-tests.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import ReactModal = require('react-modal');
 
+// tests for static method
+// string
+ReactModal.setAppElement("#main");
+// HTMLElement
+ReactModal.setAppElement(document.getElementById("#main"));
+
 class ExampleOfUsingReactModal extends React.Component {
   render() {
     const onAfterOpenFn = () => { };


### PR DESCRIPTION
This comit changes:
- definition of static setAppElement method to support string type - as
ReactModal allows to use selector instead of element reference
- sample tests to include static method coverage

Someone starting with React documentation will hit this error:

```sh
(11,26): error TS2345: Argument of type '"#main"' is not assignable to parameter of type 'HTMLElement'.
```

The `react-modal` source for internal helper impl:
https://github.com/reactjs/react-modal/blob/42d724cf759b1a18ab098904a4f44d0b12023372/src/helpers/ariaAppHider.js#L11-L20


Thanks!

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
