### PR TITLE
Jasmine matchers can accept many arguments

### DIFF
--- a/types/jasmine/index.d.ts
+++ b/types/jasmine/index.d.ts
@@ -219,8 +219,8 @@ declare namespace jasmine {
     type CustomEqualityTester = (first: any, second: any) => boolean | void;
 
     interface CustomMatcher {
-        compare<T>(actual: T, expected: T): CustomMatcherResult;
-        compare(actual: any, expected: any): CustomMatcherResult;
+        compare<T>(actual: T, expected: T, ...args: any[]): CustomMatcherResult;
+        compare(actual: any, ...expected: any[]): CustomMatcherResult;
     }
 
     type CustomMatcherFactory = (util: MatchersUtil, customEqualityTesters: CustomEqualityTester[]) => CustomMatcher;

--- a/types/jasmine/jasmine-tests.ts
+++ b/types/jasmine/jasmine-tests.ts
@@ -963,6 +963,15 @@ var customMatchers: jasmine.CustomMatcherFactories = {
                 return result;
             }
         };
+    },
+    toBeWithinRange: (util: jasmine.MatchersUtil, customEqualityTesters: jasmine.CustomEqualityTester[]) => {
+        return {
+            compare: (actual: any, floor: number, ceiling: number): jasmine.CustomMatcherResult => {
+                const pass = actual >= floor && actual <= ceiling;
+                const message = `expected ${actual} ${pass ? 'not ' : ''} to be within range ${floor}-${ceiling}`;
+                return { message, pass };
+            }
+        };
     }
 };
 // add the custom matchers to interface jasmine.Matchers via TypeScript declaration merging
@@ -977,6 +986,7 @@ var customMatchers: jasmine.CustomMatcherFactories = {
 declare namespace jasmine {
     interface Matchers<T> {
         toBeGoofy(expected?: jasmine.Expected<T>): boolean;
+        toBeWithinRange(expected?: jasmine.Expected<T>, floor?: number, ceiling?: number): boolean;
     }
 }
 
@@ -995,6 +1005,10 @@ describe("Custom matcher: 'toBeGoofy'", () => {
         expect({
             hyuk: 'gawrsh is fun'
         }).toBeGoofy({ hyuk: ' is fun' });
+    });
+
+    it("can take many 'expected' parameters", () => {
+        expect(2).toBeWithinRange(1, 3);
     });
 
     it("can be negated", () => {

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -714,8 +714,8 @@ declare namespace jasmine {
     type CustomEqualityTester = (first: any, second: any) => boolean;
 
     interface CustomMatcher {
-        compare<T>(actual: T, expected: T): CustomMatcherResult;
-        compare(actual: any, expected: any): CustomMatcherResult;
+        compare<T>(actual: T, expected: T, ...args: any[]): CustomMatcherResult;
+        compare(actual: any, ...expected: any[]): CustomMatcherResult;
     }
 
     interface CustomMatcherResult {

--- a/types/jest/v16/index.d.ts
+++ b/types/jest/v16/index.d.ts
@@ -287,8 +287,8 @@ declare namespace jasmine {
     }
 
     interface CustomMatcher {
-        compare<T>(actual: T, expected: T): CustomMatcherResult;
-        compare(actual: any, expected: any): CustomMatcherResult;
+        compare<T>(actual: T, expected: T, ...args: any[]): CustomMatcherResult;
+        compare(actual: any, ...expected: any[]): CustomMatcherResult;
     }
 
     interface CustomMatcherResult {


### PR DESCRIPTION
Refs #21327. 

In Jasmine (and Jest's older API which uses `jasmine.addMatchers`), custom matchers can accept any number of arguments.

Jasmine allows you to define the following custom matcher for example which accepts 2 arguments:

```js
jasmine.addMatchers({
    toBeWithinRange: (util, customEqualityTesters) => {
        return {
            compare: (actual, floor, ceiling) => {
                // implementation...
            }
        };
    }
});
```

The Jasmine and Jest typings currently state that a custom matcher can only accept one argument.

A URL to documentation or source code which provides context for the suggested changes: https://jasmine.github.io/2.0/custom_matcher.html.

Thanks.