### PR TITLE
Add undocumented settings for angular-strap

### DIFF
--- a/types/angular-strap/index.d.ts
+++ b/types/angular-strap/index.d.ts
@@ -194,6 +194,8 @@ declare namespace mgcrea.ngStrap {
             onHide?(tooltip: ITooltip): void;
             onBeforeHide?(tooltip: ITooltip): void;
             viewport?: string | { selector: string; padding: string | number };
+            show?: boolean; // Not documented
+            scope?: ng.IScope; // Not documented
         }
 
         interface ITooltipScope extends ng.IScope {

--- a/types/angular-strap/index.d.ts
+++ b/types/angular-strap/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://mgcrea.github.io/angular-strap/
 // Definitions by: Sam Herrmann <https://github.com/samherrmann>
 //                 Matthias Kannwischer <https://github.com/mkannwischer>
+//                 Gilles Waeber <https://github.com/gilleswaeber>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -242,6 +243,8 @@ declare namespace mgcrea.ngStrap {
             onHide?(popover: IPopover): void;
             onBeforeHide?(popover: IPopover): void;
             viewport?: string | { selector: string; padding: string | number };
+            show?: boolean; // Not documented
+            scope?: ng.IScope; // Not documented
         }
 
         interface IPopoverScope extends ng.IScope {


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
- Documentation: https://mgcrea.github.io/angular-strap/#/tootltip (note: the documentation is not complete)
- scope: https://github.com/mgcrea/angular-strap/blob/master/src/tooltip/tooltip.js#L48
- show: https://github.com/mgcrea/angular-strap/blob/master/src/tooltip/tooltip.js#L21
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.