### PR TITLE
[react-grid-layout] Add null to compactType

### DIFF
--- a/types/react-grid-layout/index.d.ts
+++ b/types/react-grid-layout/index.d.ts
@@ -140,7 +140,7 @@ declare namespace ReactGridLayout {
         /**
          * Compaction type.
          */
-        compactType?: "vertical" | "horizontal";
+        compactType?: "vertical" | "horizontal" | null;
 
         /**
          * This allows setting the initial width on the server side.


### PR DESCRIPTION
When using undefined on the compactType the Component uses the compactType "vertical" instead of null. By excplicitely using null the grid works fine.

See Deprecated Warning:
`verticalCompact` on <ReactGridLayout> is deprecated and will be removed soon. Use `compactType`: "horizontal" | "vertical" | null.

Also see: 
[https://github.com/STRML/react-grid-layout#grid-layout-props](url)
