### PR TITLE
[hexo-fs] fix dtslint error

### DIFF
--- a/types/hexo-fs/hexo-fs-tests.ts
+++ b/types/hexo-fs/hexo-fs-tests.ts
@@ -594,8 +594,7 @@ it('emptyDir() - callback', callback => {
                 join('folder', 'h.txt'),
                 join('folder', 'i.js')
             ]);
-
-            Promise.map([
+            const elements: Array<[string, boolean]> = [
                 [join(target, '.hidden', 'a.txt'), true],
                 [join(target, '.hidden', 'b.js'), true],
                 [join(target, '.hidden', 'c', 'd'), true],
@@ -605,7 +604,8 @@ it('emptyDir() - callback', callback => {
                 [join(target, 'folder', 'h.txt'), false],
                 [join(target, 'folder', 'i.js'), false],
                 [join(target, 'folder', '.j'), true]
-            ] as Array<[string, boolean]>, data => {
+            ];
+            Promise.map(elements, data => {
                 return fs.exists(data[0]).then(exist => {
                     exist.should.eql(data[1]);
                 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: no API change
- x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

No functional change, just fix a lint error seen in an unrelated PR:
```
ERROR: 598:25  no-unnecessary-type-assertion  This assertion is unnecessary since it does not change the type of the expression.
```