### PR TITLE
[knex-postgis] fix CI build error

### DIFF
--- a/types/knex-postgis/knex-postgis-tests.ts
+++ b/types/knex-postgis/knex-postgis-tests.ts
@@ -7,13 +7,7 @@ const st: KPG.KnexPostgis = KPG(knex);
 
 const point: GeoJSON.Point = {
   type: 'Point',
-  coordinates: [23.773206, 61.506005],
-  crs: {
-    type: 'name',
-    properties: {
-      name: 'EPSG:4326'
-    }
-  }
+  coordinates: [23.773206, 61.506005]
 };
 
 const wktPoint = 'POINT(23.773206 61.506005)';


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: no API change
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

No functional change, just fix a compile error seen in an unrelated PR:
```
Testing knex-postgis
	Running: node /home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js --onlyTestTsNext
	Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/knex-postgis/knex-postgis-tests.ts
ERROR: 11:3  expect  TypeScript@next compile error: 
Type '{ type: "Point"; coordinates: number[]; crs: { type: string; properties: { name: string; }; }; }' is not assignable to type 'Point'.
  Object literal may only specify known properties, and 'crs' does not exist in type 'Point'.
    at /home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js:74:19
    at Generator.next (<anonymous>)
    at fulfilled (/home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js:5:58)
    at <anonymous>
```