### PR TITLE
react-virtualized: Added missing autoReload param to InfiniteLoader.resetLoadMoreRowsCache

### DIFF
--- a/types/react-virtualized/dist/es/InfiniteLoader.d.ts
+++ b/types/react-virtualized/dist/es/InfiniteLoader.d.ts
@@ -77,7 +77,7 @@ export class InfiniteLoader extends PureComponent<InfiniteLoaderProps> {
 
     constructor(props: InfiniteLoaderProps, context: any);
 
-    resetLoadMoreRowsCache(): void;
+    resetLoadMoreRowsCache(autoReload?: boolean): void;
 
     render(): JSX.Element;
 }


### PR DESCRIPTION
Fix for the following issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/22287

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/bvaughn/react-virtualized/blob/master/source/InfiniteLoader/InfiniteLoader.js#L72
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.