### PR TITLE
documentdb: update _ts property type

### DIFF
--- a/types/documentdb/index.d.ts
+++ b/types/documentdb/index.d.ts
@@ -133,7 +133,7 @@ export interface AbstractMeta extends UniqueId {
     _self: string;
 
     /** The time the object was created. */
-    _ts: string | number;
+    _ts: number;
 
     _rid?: string;
     _etag?: string;

--- a/types/documentdb/index.d.ts
+++ b/types/documentdb/index.d.ts
@@ -133,7 +133,7 @@ export interface AbstractMeta extends UniqueId {
     _self: string;
 
     /** The time the object was created. */
-    _ts: string;
+    _ts: string | number;
 
     _rid?: string;
     _etag?: string;


### PR DESCRIPTION
_ts (retrieved from documentdb documents) is a number (not a string).
 to be conservative I've used a union.

```
{
...
    "_rid": "...",
    "_self": "...",
    "_etag": "...",
    "_attachments": "attachments/",
    "_ts": 1513446828
}

```

@NoelAbrahams
@brettferdosi
@ctstone
@yifanwu
