### PR TITLE
add types for form-urlencoded

### DIFF
--- a/types/form-urlencoded/form-urlencoded-tests.ts
+++ b/types/form-urlencoded/form-urlencoded-tests.ts
@@ -1,0 +1,10 @@
+import encode, { FormEncodedOptions } from "form-urlencoded";
+
+const opts: FormEncodedOptions = {
+    sorted: true,
+    skipIndex: false,
+    ignorenull: true
+};
+
+encode([1, 2, 3]);
+encode([1, 2, 3], opts);

--- a/types/form-urlencoded/index.d.ts
+++ b/types/form-urlencoded/index.d.ts
@@ -1,0 +1,12 @@
+// Type definitions for form-urlencoded 2.0
+// Project: https://github.com/iambumblehead/form-urlencoded#readme
+// Definitions by: Antoine Lépée <https://github.com/alepee>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface FormEncodedOptions {
+    sorted?: boolean;
+    skipIndex?: boolean;
+    ignorenull?: boolean;
+}
+
+export default function(data: any, opts?: FormEncodedOptions): string;

--- a/types/form-urlencoded/tsconfig.json
+++ b/types/form-urlencoded/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "form-urlencoded-tests.ts"
+    ]
+}

--- a/types/form-urlencoded/tslint.json
+++ b/types/form-urlencoded/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.