### PR TITLE
Add isFlat definition to Leaflet LineUtil + fix linter errors

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -18,20 +18,14 @@ export class Class {
 
 export class Transformation {
     constructor(a: number, b: number, c: number, d: number);
-
     transform(point: Point, scale?: number): Point;
-
     untransform(point: Point, scale?: number): Point;
-    
 }
 
 export namespace LineUtil {
     function simplify(points: Point[], tolerance: number): Point[];
-
     function pointToSegmentDistance(p: Point, p1: Point, p2: Point): number;
-
     function closestPointOnSegment(p: Point, p1: Point, p2: Point): Point;
-    
     function isFlat(latlngs: LatLngExpression[]): boolean;
 }
 

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -22,6 +22,7 @@ export class Transformation {
     transform(point: Point, scale?: number): Point;
 
     untransform(point: Point, scale?: number): Point;
+    
 }
 
 export namespace LineUtil {
@@ -30,6 +31,8 @@ export namespace LineUtil {
     function pointToSegmentDistance(p: Point, p1: Point, p2: Point): number;
 
     function closestPointOnSegment(p: Point, p1: Point, p2: Point): Point;
+    
+    function isFlat(latlngs: LatLngExpression[]): boolean;
 }
 
 export namespace PolyUtil {

--- a/types/proj4leaflet/index.d.ts
+++ b/types/proj4leaflet/index.d.ts
@@ -42,7 +42,7 @@ declare module 'leaflet' {
 
     class GeoJSON extends L.GeoJSON {}
 
-    const geoJson: (geojson?: geojson.GeoJsonObject, options?: GeoJSONOptions) => GeoJSON;
+    const geoJson: (geojson?: Proj4GeoJSONFeature, options?: GeoJSONOptions) => GeoJSON;
 
     class ImageOverlay extends L.ImageOverlay {}
 
@@ -57,3 +57,6 @@ declare module 'leaflet' {
     }
   }
 }
+export type Proj4GeoJSONFeature = geojson.Feature<geojson.GeometryObject> & {
+  crs?: { type: string; properties: { name: string } }
+};

--- a/types/proj4leaflet/proj4leaflet-tests.ts
+++ b/types/proj4leaflet/proj4leaflet-tests.ts
@@ -1,6 +1,5 @@
 import * as L from 'leaflet';
-import 'proj4leaflet';
-
+import * as proj4leaflet from "proj4leaflet";
 import * as proj4 from 'proj4';
 
 import LatLngBoundsExpression = L.LatLngBoundsExpression;
@@ -43,12 +42,13 @@ const crs3 = new L.Proj.CRS('EPSG:3006',
 // geoJson
 proj4.defs("urn:ogc:def:crs:EPSG::26915", "+proj=utm +zone=15 +ellps=GRS80 +datum=NAD83 +units=m +no_defs");
 
-const geojson = {
+const geojson: proj4leaflet.Proj4GeoJSONFeature = {
   type: "Feature",
   geometry: {
     type: "Point",
     coordinates: [481650, 4980105]
   },
+  properties: {},
   crs: {
     type: "name",
     properties: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://leafletjs.com/reference-1.2.0.html#lineutil-isflat
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.