### PR TITLE
bootbox: BootboxDialogOptions message type extended according to jquery

### DIFF
--- a/types/bootbox/index.d.ts
+++ b/types/bootbox/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Bootbox 4.4.0
 // Project: https://github.com/makeusabrew/bootbox
-// Definitions by: Vincent Bortone <https://github.com/vbortone>, Kon Pik <https://github.com/konpikwastaken>, Anup Kattel <https://github.com/kanup>, Dominik Schroeter <https://github.com/icereed>, Troy McKinnon <https://github.com/trodi>, Stanny Nuytkens <https://github.com/stannynuytkens>
+// Definitions by: Vincent Bortone <https://github.com/vbortone>, Kon Pik <https://github.com/konpikwastaken>, Anup Kattel <https://github.com/kanup>, Dominik Schroeter <https://github.com/icereed>, Troy McKinnon <https://github.com/trodi>, Stanny Nuytkens <https://github.com/stannynuytkens>, Soner Köksal <https://github.com/renjfk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -23,7 +23,7 @@ interface BootboxBaseOptions<T = any> {
 
 /** Bootbox options available for custom modals */
 interface BootboxDialogOptions<T = any> extends BootboxBaseOptions<T> {
-	message: string | Element;
+	message: JQuery|any[]|Element|DocumentFragment|Text|string|((index: number, html: string) => string|Element|JQuery);
 }
 
 /** Bootbox options available for alert modals */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

- according to [bootbox sources](https://github.com/makeusabrew/bootbox/blob/master/bootbox.js#L607) dialog message gets processed via jquery html function.
- jquery [html function](https://github.com/jquery/jquery/blob/1.12-stable/src/manipulation.js#L534) ends up with append function whether input is a string or not therefore message type is updated according to [acceptable parameter types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/v1/index.d.ts#L3137).