### PR TITLE
[redis] hgetall cb to be optional

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -472,8 +472,8 @@ export interface Commands<R> {
     /**
      * Get all fields and values in a hash.
      */
-    hgetall(key: string, cb: Callback<{ [key: string]: string }>): R;
-    HGETALL(key: string, cb: Callback<{ [key: string]: string }>): R;
+    hgetall(key: string, cb?: Callback<{ [key: string]: string }>): R;
+    HGETALL(key: string, cb?: Callback<{ [key: string]: string }>): R;
 
     /**
      * Increment the integer value of a hash field by the given number.


### PR DESCRIPTION
I noticed that all other definitions callbacks were optional and the callback for hgetall was not marked optional.  This is what I fixed.

Please fill in this template.

- [y] Use a meaningful title for the pull request. Include the name of the package modified.
- [y ] Test the change in your own code. (Compile and run.)
- [y ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [y ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [y ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ y] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [na ] Increase the version number in the header if appropriate.
- [ y] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


