### PR TITLE
[react-native] Replacing ScrollViewProperties with VirtualizedListProperties for SectionList

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3662,7 +3662,7 @@ export interface SectionListData<ItemT> extends SectionBase<ItemT> {
     [key: string]: any;
 }
 
-export interface SectionListProperties<ItemT> extends ScrollViewProperties {
+export interface SectionListProperties<ItemT> extends VirtualizedListProperties<ItemT> {
     /**
      * Rendered in between adjacent Items within each section.
      */
@@ -3736,7 +3736,7 @@ export interface SectionListProperties<ItemT> extends ScrollViewProperties {
     /**
      * Default renderer for every item in every section. Can be over-ridden on a per-section basis.
      */
-    renderItem?: ListRenderItem<ItemT>;
+    renderItem: ListRenderItem<ItemT>;
 
     /**
      * Rendered at the top of each section. Sticky headers are not yet supported.


### PR DESCRIPTION
This commit is replacing ScrollViewProperties with VirtualizedListProperties to conform the specification in the documentation.

SectionList documentation for React Native v0.51 (https://facebook.github.io/react-native/docs/0.51/sectionlist.html) states that SectionList inherits VirtualizedList's props. In contrary to documentation SectionListProperties have been extending ScrollViewProperties.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/0.51/sectionlist.html
