### PR TITLE
[cucumber] deprecate 'typeName' for 'name'

### DIFF
--- a/types/cucumber/cucumber-tests.ts
+++ b/types/cucumber/cucumber-tests.ts
@@ -144,7 +144,13 @@ function StepSample() {
         defineParameterType({
             regexp: /particular/,
             transformer: s => s.toUpperCase(),
-            typeName: 'param'
+            typeName: 'param'  // deprecated but still supported
+        });
+
+        defineParameterType({
+            regexp: /particularly/,
+            transformer: s => s.toUpperCase(),
+            name: 'param'
         });
 
         Given('a {param} step', param => {

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cucumber-js 3.1
+// Type definitions for cucumber-js 3.2
 // Project: https://github.com/cucumber/cucumber-js
 // Definitions by: Abraão Alves <https://github.com/abraaoalves>
 //                 Jan Molak <https://github.com/jan-molak>
@@ -56,7 +56,8 @@ export type AroundCode = (scenario: HookScenarioResult, runScenario?: (error: st
 export interface Transform {
     regexp: RegExp;
     transformer(arg: string): any;
-    typeName: string;
+    name?: string;
+    typeName?: string; // deprecated
 }
 
 export interface HookOptions {


### PR DESCRIPTION
See <https://github.com/cucumber/cucumber-js/pull/904>

Old and new name marked optional to preserve backward-compatibility,
though specifying neither one will produce an error.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
