### PR TITLE
@types/dockerode Add df definition (docker system df)

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -945,6 +945,9 @@ declare class Dockerode {
   info(callback: Callback<any>): void;
   info(): Promise<any>;
 
+  df(callback: Callback<any>): void;
+  df(): Promise<any>;
+
   version(callback: Callback<any>): void;
   version(): Promise<any>;
 


### PR DESCRIPTION
missing definition in class Dockerode.

https://github.com/apocas/dockerode/blob/master/lib/docker.js#L1265
