### PR TITLE
Generic param default for MockStoreCreator in redux-mock-store

### DIFF
--- a/types/redux-mock-store/index.d.ts
+++ b/types/redux-mock-store/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for Redux Mock Store 0.0
+// Type definitions for Redux Mock Store 0.0.1
 // Project: https://github.com/arnaudbenard/redux-mock-store
 // Definitions by: Marian Palkus <https://github.com/MarianPalkus>, Cap3 <http://www.cap3.de>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
+// TypeScript Version: 2.3
 
 import * as Redux from 'redux';
 
@@ -10,7 +11,7 @@ export interface MockStore<T> extends Redux.Store<T> {
     clearActions(): void;
 }
 
-export type MockStoreCreator<T> = (state?: T) => MockStore<T>;
+export type MockStoreCreator<T = {}> = (state?: T) => MockStore<T>;
 
 declare function createMockStore<T>(middlewares?: Redux.Middleware[]): MockStoreCreator<T>;
 


### PR DESCRIPTION
As of TypeScript 2.3, there is now [support for Generic parameter defaults](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html). By setting a reasonable default type on `MockStoreCreator`, we can eliminate unneeded verbosity.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (Not applicable)