### PR TITLE
which: Updates declarations for 1.3.0

### DIFF
--- a/types/which/index.d.ts
+++ b/types/which/index.d.ts
@@ -1,12 +1,66 @@
-// Type definitions for which 1.0.8
+// Type definitions for which 1.3.0
 // Project: https://github.com/isaacs/node-which
-// Definitions by: vvakame <https://github.com/vvakame>
+// Definitions by: vvakame <https://github.com/vvakame>, cspotcoxe <https://github.com/cspotcode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 
-declare function when(cmd: string, cb: (err: Error, path: string) => void): void;
-declare namespace when {
+/** Finds all instances of a specified executable in the PATH environment variable */
+declare function which(cmd: string, options: which.AsyncOptions & which.OptionsAll, cb: (err: Error | null, paths: Array<string> | undefined) => void): void;
+/** Finds the first instance of a specified executable in the PATH environment variable */
+declare function which(cmd: string, options: which.AsyncOptions & which.OptionsFirst, cb: (err: Error | null, path: string | undefined) => void): void;
+/** Finds the first instance of a specified executable in the PATH environment variable */
+declare function which(cmd: string, options: which.AsyncOptions, cb: (err: Error | null, path: string | Array<string> | undefined) => void): void;
+/** Finds the first instance of a specified executable in the PATH environment variable */
+declare function which(cmd: string, cb: (err: Error | null, path: string | undefined) => void): void;
+declare namespace which {
+    /** Finds all instances of a specified executable in the PATH environment variable */
+    function sync(cmd: string, options: which.Options & which.OptionsAll & which.OptionsNoThrow): Array<string> | null;
+    /** Finds the first instance of a specified executable in the PATH environment variable */
+    function sync(cmd: string, options: which.Options & which.OptionsFirst & which.OptionsNoThrow): string | null;
+    /** Finds all instances of a specified executable in the PATH environment variable */
+    function sync(cmd: string, options: which.Options & which.OptionsAll & which.OptionsThrow): Array<string>;
+    /** Finds the first instance of a specified executable in the PATH environment variable */
+    function sync(cmd: string, options: which.Options & which.OptionsFirst & which.OptionsThrow): string;
+    /** Finds the first instance of a specified executable in the PATH environment variable */
+    function sync(cmd: string, options: which.Options): string | Array<string> | null;
+    /** Finds the first instance of a specified executable in the PATH environment variable */
     function sync(cmd: string): string;
+
+    /** Options that ask for all matches. */
+    interface OptionsAll extends AsyncOptions {
+        all: true;
+    }
+
+    /** Options that ask for the first match (the default behavior) */
+    interface OptionsFirst extends AsyncOptions {
+        all?: false | undefined;
+    }
+
+    /** Options that ask to receive null instead of a thrown error */
+    interface OptionsNoThrow extends Options {
+        nothrow: true;
+    }
+
+    /** Options that ask for a thrown error if executable is not found (the default behavior) */
+    interface OptionsThrow extends Options {
+        nothrow?: false | undefined;
+    }
+
+    /** Options for which() async API */
+    interface AsyncOptions {
+        /** If true, return all matches, instead of just the first one. Note that this means the function returns an array of strings instead of a single string. */
+        all?: boolean;
+        /** Use instead of the PATH environment variable. */
+        path?: string;
+        /** Use instead of the PATHEXT environment variable. */
+        pathExt?: string;
+    }
+    
+    /** Options for which() sync and async APIs */
+    interface Options extends AsyncOptions {
+        /** If true, returns null when not found */
+        nothrow?: boolean;
+    }
 }
 
-export = when;
+export = which;

--- a/types/which/tsconfig.json
+++ b/types/which/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/which/which-tests.ts
+++ b/types/which/which-tests.ts
@@ -7,3 +7,29 @@ which("cat", (err, path) => {
 
 var path = which.sync("cat");
 console.log(path);
+
+which("cat", {all: true}, (err, paths) => {
+  if(err) return;
+  if(paths) {
+    for(let path of paths) {
+      console.log(path);
+    }
+  }
+});
+
+var paths = which.sync("cat", {all: true});
+for(let path of paths) {
+  console.log(path);
+}
+
+var paths2 = which.sync("cat", {all: true, nothrow: true});
+if(paths2 !== null) {
+  for(let path of paths2) {
+    console.log(path);
+  }
+}
+
+var path2 = which.sync("cat", {path: 'replacement path', pathExt: 'replacement pathext'});
+which("cat", {path: 'replacement path', pathExt: 'replacement pathext'}, (err, path) => {
+  const a: string = path!;
+});


### PR DESCRIPTION
- Enables strictNullChecks
- Adds options: `nothrow`, `all`, `path`, and `pathExt`
- Uses function overloading to pick most specific return types based on `all` and `nothrow` options

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/npm/node-which
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.