### PR TITLE
[lodash] genericize isEqual

### DIFF
--- a/types/lodash/index.d.ts
+++ b/types/lodash/index.d.ts
@@ -9859,9 +9859,9 @@ declare namespace _ {
          * object === other;
          * // => false
          */
-        isEqual(
-            value: any,
-            other: any
+        isEqual<T1, T2>(
+            value: T1,
+            other: T2
         ): boolean;
     }
 
@@ -9869,8 +9869,8 @@ declare namespace _ {
         /**
          * @see _.isEqual
          */
-        isEqual(
-            other: any
+        isEqual<T>(
+            other: T
         ): boolean;
     }
 
@@ -9878,13 +9878,13 @@ declare namespace _ {
         /**
          * @see _.isEqual
          */
-        isEqual(
-            other: any
+        isEqual<T>(
+            other: T
         ): LoDashExplicitWrapper<boolean>;
     }
 
     // _.isEqualWith
-    type IsEqualCustomizer = (value: any, other: any, indexOrKey: PropertyName | undefined, parent: any, otherParent: any, stack: any) => boolean|undefined;
+    type IsEqualCustomizer<T1, T2> = (value: T1, other: T2, indexOrKey: PropertyName | undefined, parent: any, otherParent: any, stack: any) => boolean|undefined;
 
     interface LoDashStatic {
         /**
@@ -9916,10 +9916,10 @@ declare namespace _ {
          * _.isEqualWith(array, other, customizer);
          * // => true
          */
-        isEqualWith(
-            value: any,
-            other: any,
-            customizer?: IsEqualCustomizer
+        isEqualWith<T1, T2>(
+            value: T1,
+            other: T2,
+            customizer?: IsEqualCustomizer<T1, T2>
         ): boolean;
     }
 
@@ -9927,9 +9927,9 @@ declare namespace _ {
         /**
          * @see _.isEqualWith
          */
-        isEqualWith(
-            other: any,
-            customizer?: IsEqualCustomizer
+        isEqualWith<T>(
+            other: T,
+            customizer?: IsEqualCustomizer<TValue, T>
         ): boolean;
     }
 
@@ -9937,9 +9937,9 @@ declare namespace _ {
         /**
          * @see _.isEqualWith
          */
-        isEqualWith(
-            other: any,
-            customizer?: IsEqualCustomizer
+        isEqualWith<T>(
+            other: T,
+            customizer?: IsEqualCustomizer<TValue, T>
         ): LoDashExplicitWrapper<boolean>;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ReactiveX/rxjs/blob/5.5.5/src/operator/distinctUntilChanged.ts#L6
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

More context: When chaining observable sequences and using `_.isEqual` as an argument to `distinctUntilChanged`, the type `any` is inferred instead of the correct type of the Observable that was used as an input to `distinctUntilChanged`:

```typescript
// https://github.com/ReactiveX/rxjs/blob/5.5.5/src/operator/distinctUntilChanged.ts#L6
export function distinctUntilChanged<T>(this: Observable<T>, compare?: (x: T, y: T) => boolean): Observable<T>;
```
Example:

```typescript
import { isEqual } from 'lodash';

Observable.of(1).distinctUntilChanged(isEqual).subscribe((value) => {
  // the inferred type of `value` is `any` due to `isEqual` arguments being typed as `any`, so no compilation errors
  value.foo();
});
```

This PR genericizes the inputs to isEqual, allowing types to be inferred from calls to `isEqual`.