### PR TITLE
throng: relax constraints

### DIFF
--- a/types/throng/index.d.ts
+++ b/types/throng/index.d.ts
@@ -1,18 +1,21 @@
 // Type definitions for throng 4.0
 // Project: https://github.com/hunterloftis/throng
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
+//                 Tate Thurston <https://github.com/tatethurston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare function throng(options: throng.WorkerCallback | throng.Options | number, startFunction?: throng.WorkerCallback): void;
+declare function throng(startOrOptions: throng.ProcessCallback | throng.Options): void;
+declare function throng(workers: throng.WorkerCount, start: throng.ProcessCallback): void;
 declare namespace throng {
-    type WorkerCallback = (id: number) => void;
+    type WorkerCount = number | string;
+    type ProcessCallback = (id: number) => any;
 
     interface Options {
         grace?: number;
         lifetime?: number;
-        master(): void;
-        start: WorkerCallback;
-        workers: number;
+        master?: ProcessCallback;
+        start: ProcessCallback;
+        workers?: WorkerCount;
     }
 }
 


### PR DESCRIPTION
- Relax workers value to be a string or number. The library handles
both, and this value is frequently supplied as an ENV.
- Relax master in config object to be optional
- Relax master and start functions signature to return any. This allows async functions to be supplied, which currently fail because of the void constraint.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hunterloftis/throng
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
