### PR TITLE
Add definition for owasp-password-strength-test

### DIFF
--- a/types/owasp-password-strength-test/index.d.ts
+++ b/types/owasp-password-strength-test/index.d.ts
@@ -1,0 +1,73 @@
+// Type definitions for owasp-password-strength-test 1.3
+// Project: https://github.com/nowsecure/owasp-password-strength-test
+// Definitions by: Stephan Troyer <https://github.com/stephtr>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export as namespace owaspPasswordStrengthTest;
+
+export interface PasswordTestResult {
+    /** error messages associated with the failed tests */
+    errors: string[];
+    /** enumerates which tests have failed, beginning from 0 with the first required test */
+    failedTests: number[];
+    /** enumerates which tests have succeeded, beginning from 0 with the first required test */
+    passedTests: number[];
+    /** error messages of required tests that have failed */
+    requiredTestErrors: string[];
+    /** error messages of optional tests that have failed */
+    optionalTestErrors: string[];
+    /** indicates whether or not the password was considered to be a passphrase */
+    isPassphrase: boolean;
+    /** indicates whether or not the user's password satisfied the strength requirements */
+    strong: boolean;
+    /**
+     * indicates how many of the optional tests were passed;
+     * In order for the password to be considered "strong", it (by default) must either be a passphrase,
+     * or must pass a number of optional tests that is equal to or greater than configs.minOptionalTestsToPass
+     */
+    optionalTestsPassed: number;
+}
+export interface PasswordTestConfiguration {
+    /**
+     * toggles the "passphrase" mechanism on and off;
+     * If set to false, the strength-checker will abandon the notion of "passphrases",
+     * and will subject all passwords to the same complexity requirements.
+     */
+    allowPassphrases?: boolean;
+    /** constraint on a password's maximum length */
+    maxLength?: number;
+    /** constraint on a password's minimum length */
+    minLength?: number;
+    /**
+     * minimum length a password needs to achieve in order to be considered a "passphrase"
+     * (and thus exempted from the optional complexity tests by default)
+     */
+    minPhraseLength?: number;
+    /**
+     * minimum number of optional tests that a password must pass in order to be considered "strong";
+     * By default (per the OWASP guidelines), four optional complexity tests are made,
+     * and a password must pass at least three of them in order to be considered "strong"
+     */
+    minOptionalTestsToPass?: number;
+
+    // // to add support for https://github.com/nowsecure/owasp-password-strength-test/pull/5
+    // /**
+    //  * toggles the i18n error keys in place of english error messages.
+    //  * This can be useful when translating the errors using a 3rd party i18n library.
+    //  * When true the following keys can be returned:
+    //  * `failedMinLength`, `failedMaxLength`, `failedThreeRepeatedChars`, `optionalLowercaseRequired`, `optionalUppercaseRequired`, `optionalNumberRequired` and `optionalSpecialCharRequired`.
+    //  */
+    // i18nErrorKeys?: boolean;
+}
+
+export type PasswordTest = (password: string) => string | undefined;
+
+export function test(password: string): PasswordTestResult;
+export function config(configuration: PasswordTestConfiguration): void;
+
+export let tests: {
+    required: PasswordTest[];
+    optional: PasswordTest[];
+};
+export const configs: Readonly<PasswordTestConfiguration>;

--- a/types/owasp-password-strength-test/index.d.ts
+++ b/types/owasp-password-strength-test/index.d.ts
@@ -6,7 +6,7 @@
 
 export as namespace owaspPasswordStrengthTest;
 
-export interface PasswordTestResult {
+export interface TestResult {
     /** error messages associated with the failed tests */
     errors: string[];
     /** enumerates which tests have failed, beginning from 0 with the first required test */
@@ -28,28 +28,28 @@ export interface PasswordTestResult {
      */
     optionalTestsPassed: number;
 }
-export interface PasswordTestConfiguration {
+export interface TestConfig {
     /**
      * toggles the "passphrase" mechanism on and off;
      * If set to false, the strength-checker will abandon the notion of "passphrases",
      * and will subject all passwords to the same complexity requirements.
      */
-    allowPassphrases?: boolean;
+    allowPassphrases: boolean;
     /** constraint on a password's maximum length */
-    maxLength?: number;
+    maxLength: number;
     /** constraint on a password's minimum length */
-    minLength?: number;
+    minLength: number;
     /**
      * minimum length a password needs to achieve in order to be considered a "passphrase"
      * (and thus exempted from the optional complexity tests by default)
      */
-    minPhraseLength?: number;
+    minPhraseLength: number;
     /**
      * minimum number of optional tests that a password must pass in order to be considered "strong";
      * By default (per the OWASP guidelines), four optional complexity tests are made,
      * and a password must pass at least three of them in order to be considered "strong"
      */
-    minOptionalTestsToPass?: number;
+    minOptionalTestsToPass: number;
 
     // // to add support for https://github.com/nowsecure/owasp-password-strength-test/pull/5
     // /**
@@ -63,11 +63,11 @@ export interface PasswordTestConfiguration {
 
 export type PasswordTest = (password: string) => string | undefined;
 
-export function test(password: string): PasswordTestResult;
-export function config(configuration: PasswordTestConfiguration): void;
+export function test(password: string): TestResult;
+export function config(configuration: Partial<TestConfig>): void;
 
 export let tests: {
     required: PasswordTest[];
     optional: PasswordTest[];
 };
-export const configs: Readonly<PasswordTestConfiguration>;
+export const configs: Readonly<TestConfig>;

--- a/types/owasp-password-strength-test/owasp-password-strength-test-tests.ts
+++ b/types/owasp-password-strength-test/owasp-password-strength-test-tests.ts
@@ -1,0 +1,18 @@
+import * as owasp from 'owasp-password-strength-test';
+
+owasp.config({
+    allowPassphrases: true,
+    maxLength: 128,
+    minLength: 10,
+    minPhraseLength: 20,
+    minOptionalTestsToPass: 4,
+});
+
+owasp.tests.required.push(password => {
+    if (password === 'one two three four five') {
+        return "That's the kind of thing an idiot would have on his luggage!";
+    }
+});
+
+const result = owasp.test('correct horse battery staple');
+result.errors.length;

--- a/types/owasp-password-strength-test/tsconfig.json
+++ b/types/owasp-password-strength-test/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "owasp-password-strength-test-tests.ts"
+    ]
+}

--- a/types/owasp-password-strength-test/tslint.json
+++ b/types/owasp-password-strength-test/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
