### PR TITLE
@types/iron -> downgrade TS from 2.6 to 2.4

### DIFF
--- a/types/iron/index.d.ts
+++ b/types/iron/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Simon Schick <https://github.com/simonschick>
 //                 Rafael Souza Fijalkowski <https://github.com/rafaelsouzaf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.4
 
 /// <reference types="node" />
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


This definition was made some days ago to work with the new hapi v17 ([PR here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22462)). But the hapi v17 is using TS 2.4, not 2.6 like that definition.

@SimonSchick Please I will appreciate if you can review this new pull request. Thank you!

