### PR TITLE
Added border radii properties into ImageProperties for react-native

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3302,6 +3302,12 @@ export interface ImageProperties extends ImagePropertiesIOS, ImagePropertiesAndr
     onLoadStart?: () => void;
 
     progressiveRenderingEnabled?: boolean;
+    
+    borderRadius?: number;
+    borderTopLeftRadius?: number;
+    borderTopRightRadius?: number;
+    borderBottomLeftRadius?: number;
+    borderBottomRightRadius?: number;
 
     /**
      * Determines how to resize the image when the frame doesn't match the raw

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -3304,11 +3304,15 @@ export interface ImageProperties extends ImagePropertiesIOS, ImagePropertiesAndr
     progressiveRenderingEnabled?: boolean;
     
     borderRadius?: number;
+    
     borderTopLeftRadius?: number;
+    
     borderTopRightRadius?: number;
+    
     borderBottomLeftRadius?: number;
+    
     borderBottomRightRadius?: number;
-
+    
     /**
      * Determines how to resize the image when the frame doesn't match the raw
      * image dimensions.


### PR DESCRIPTION
There are still no links on the react-native page about it but it's been possible to pass border radii props for a long time and it works on both platforms.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
