### PR TITLE
[@types/caseless] Add type definition for caseless version 0.12

### DIFF
--- a/types/caseless/caseless-tests.ts
+++ b/types/caseless/caseless-tests.ts
@@ -1,0 +1,35 @@
+import caseless, { httpify } from "caseless";
+
+caseless(); // $ExpectType Caseless
+caseless({}); // $ExpectType Caseless
+caseless(null); // $ExpectError
+caseless(1); // $ExpectError
+caseless("2"); // $ExpectError
+
+const c = caseless();
+
+c.set({}); // $ExpectType void
+c.set('foo', 'bar'); // $ExpectType string | false
+c.set('foo', 'bar', false); // $ExpectType string | false
+c.set('foo', new Date()); // $ExpectType string | false
+c.set(10, 'bar'); // $ExpectError
+
+c.get('foo'); // $ExpectType any
+c.get(10); // $ExpectError
+
+c.has('foo'); // $ExpectType string | false
+c.has(10); // $ExpectError
+
+c.swap('foo'); // $ExpectType void
+c.swap(10); // $ExpectError
+
+c.del('foo'); // $ExpectType boolean
+
+httpify(null, {}); // $ExpectError
+httpify(1, {}); // $ExpectError
+httpify("2", {}); // $ExpectError
+httpify({}, null); // $ExpectError
+httpify({}, 1); // $ExpectError
+httpify({}, "2"); // $ExpectError
+
+httpify({}, {}); // $ExpectType Caseless

--- a/types/caseless/caseless-tests.ts
+++ b/types/caseless/caseless-tests.ts
@@ -1,4 +1,9 @@
-import caseless, { httpify } from "caseless";
+import caseless, { Caseless, httpify } from "caseless";
+
+new Caseless(); // $ExpectError
+
+// tslint:disable-next-line: prefer-const
+let c1: Caseless;
 
 caseless(); // $ExpectType Caseless
 caseless({}); // $ExpectType Caseless
@@ -6,24 +11,24 @@ caseless(null); // $ExpectError
 caseless(1); // $ExpectError
 caseless("2"); // $ExpectError
 
-const c = caseless();
+const c2 = caseless();
 
-c.set({}); // $ExpectType void
-c.set('foo', 'bar'); // $ExpectType string | false
-c.set('foo', 'bar', false); // $ExpectType string | false
-c.set('foo', new Date()); // $ExpectType string | false
-c.set(10, 'bar'); // $ExpectError
+c2.set({}); // $ExpectType void
+c2.set('foo', 'bar'); // $ExpectType string | false
+c2.set('foo', 'bar', false); // $ExpectType string | false
+c2.set('foo', new Date()); // $ExpectType string | false
+c2.set(10, 'bar'); // $ExpectError
 
-c.get('foo'); // $ExpectType any
-c.get(10); // $ExpectError
+c2.get('foo'); // $ExpectType any
+c2.get(10); // $ExpectError
 
-c.has('foo'); // $ExpectType string | false
-c.has(10); // $ExpectError
+c2.has('foo'); // $ExpectType string | false
+c2.has(10); // $ExpectError
 
-c.swap('foo'); // $ExpectType void
-c.swap(10); // $ExpectError
+c2.swap('foo'); // $ExpectType void
+c2.swap(10); // $ExpectError
 
-c.del('foo'); // $ExpectType boolean
+c2.del('foo'); // $ExpectType boolean
 
 httpify(null, {}); // $ExpectError
 httpify(1, {}); // $ExpectError

--- a/types/caseless/index.d.ts
+++ b/types/caseless/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for caseless 0.12
+// Project: https://github.com/mikeal/caseless
+// Definitions by: downace <https://github.com/downace>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+type KeyType = string;
+type ValueType = any;
+type RawDict = object;
+
+declare class Caseless {
+    constructor(dict?: RawDict);
+    set(name: KeyType, value: ValueType, clobber?: boolean): KeyType | false;
+    set(dict: RawDict): void;
+    has(name: KeyType): KeyType | false;
+    get(name: KeyType): ValueType | undefined;
+    swap(name: KeyType): void;
+    del(name: KeyType): boolean;
+}
+
+export function httpify(resp: object, headers: RawDict): Caseless;
+
+declare function caseless(dict?: RawDict): Caseless;
+
+export default caseless;

--- a/types/caseless/index.d.ts
+++ b/types/caseless/index.d.ts
@@ -8,8 +8,7 @@ type KeyType = string;
 type ValueType = any;
 type RawDict = object;
 
-declare class Caseless {
-    constructor(dict?: RawDict);
+export interface Caseless {
     set(name: KeyType, value: ValueType, clobber?: boolean): KeyType | false;
     set(dict: RawDict): void;
     has(name: KeyType): KeyType | false;

--- a/types/caseless/tsconfig.json
+++ b/types/caseless/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "caseless-tests.ts"
+    ]
+}

--- a/types/caseless/tslint.json
+++ b/types/caseless/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
