### PR TITLE
Add type definitions for fs-readfile-promise.

### DIFF
--- a/types/fs-readfile-promise/fs-readfile-promise-tests.ts
+++ b/types/fs-readfile-promise/fs-readfile-promise-tests.ts
@@ -1,0 +1,32 @@
+import * as readFile from "fs-readfile-promise";
+
+declare const path: string;
+declare const encoding: string;
+declare const nullable: null;
+declare const options: { encoding: string, flag: string };
+
+async function testPathOnly() {
+    return readFile(path);
+}
+async function testPathEncoding() {
+    return readFile(path, encoding);
+}
+async function testPathNull() {
+    return readFile(path, nullable);
+}
+async function testPathOption() {
+    return readFile(path, options);
+}
+
+testPathOnly()
+    .then(console.log)
+    .catch(console.log);
+testPathEncoding()
+    .then(console.log)
+    .catch(console.log);
+testPathNull()
+    .then(console.log)
+    .catch(console.log);
+testPathOption()
+    .then(console.log)
+    .catch(console.log);

--- a/types/fs-readfile-promise/index.d.ts
+++ b/types/fs-readfile-promise/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for fs-readfile-promise 3.0
+// Project: https://github.com/shinnn/fs-readfile-promise
+// Definitions by: Motosugi Murata <https://github.com/mtsg>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import { PathLike } from "fs";
+type PathType = PathLike | number;
+type OptionsType = { encoding: string; flag?: string; } | string;
+
+export = fsReadFilePromise;
+
+/**
+ * Asynchronously reads the entire contents of a file.
+ * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+ * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+ * @param options Either the encoding for the result, or an object that contains the encoding and an optional flag.
+ * If a flag is not provided, it defaults to `'r'`.
+ */
+declare function fsReadFilePromise(path: PathType, options: OptionsType): Promise<string>;
+
+/**
+ * Asynchronously reads the entire contents of a file.
+ * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+ * If a file descriptor is provided, the underlying file will _not_ be closed automatically.
+ */
+declare function fsReadFilePromise(path: PathType, options?: null): Promise<Buffer>;
+
+declare namespace fsReadFilePromise { }

--- a/types/fs-readfile-promise/tsconfig.json
+++ b/types/fs-readfile-promise/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "fs-readfile-promise-tests.ts"
+    ]
+}

--- a/types/fs-readfile-promise/tslint.json
+++ b/types/fs-readfile-promise/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
