### PR TITLE
[@types/twit] correct wrong field name in interface and wrong type

### DIFF
--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for twit 2.2
 // Project: https://github.com/ttezel/twit
 // Definitions by: Volox <https://github.com/Volox>
+//                 lostfictions <https://github.com/lostfictions>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -208,12 +209,22 @@ declare module 'twit' {
         query?: string,
         max_id_str?: string
       }
+
+      export interface Errors {
+        errors: {
+          code: number
+          message: string
+        }[]
+      }
+
+      export interface SearchResults {
+        statuses: Twitter.Status[],
+        search_metadata: Twitter.Metadata,
+      }
     }
 
-    export interface Response {
-      statuses: Twitter.Status[],
-      search_metadata: Twitter.Metadata,
-    }
+    export type Response = object
+
     interface MediaParam {
       file_path: string
     }
@@ -250,7 +261,7 @@ declare module 'twit' {
     }
     export interface PromiseResponse {
       data: Response,
-      responde: IncomingMessage,
+      resp: IncomingMessage,
     }
     export interface Callback {
       (err: Error, result: Response, response: IncomingMessage): void

--- a/types/twit/twit-tests.ts
+++ b/types/twit/twit-tests.ts
@@ -5,3 +5,9 @@ const t = new Twit( {
   consumer_secret: '',
   app_only_auth: true,
 } );
+
+t.post('statuses/update', { status: 'hello!' }).then(res => {
+    const status = res.data as Twit.Twitter.Status
+    console.log(status.id_str)
+    console.log(res.resp.statusCode)
+})


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ttezel/twit/blame/master/README.md#L55-L63
- Increase the version number in the header if appropriate. (n/a)
- If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (already present.)

-----

This is a bit of a quick fix. The `PromiseResponse` interface has a straight-up incorrect field name that prevents it from being used, so I fixed that. Unfortunately, the type of the `Response` interface it wraps is also wrong -- it can be any response type returned by the Twitter API, so I've changed it to `object`.

A more thorough fix would be fill in the definitions with the different response types, and overload the `get()` and `post()` definitions to return the correct responses based on the endpoint that's passed in, ie.

```diff
- post(path: string, callback: Twit.Callback): void;
+ post(path: 'statuses/update', callback: Twit.Callback<StatusResponse>): void;
+ post(path: string, callback: Twit.Callback<any>): void;

- post(path: string, params: Twit.Params, callback: Twit.Callback): void;
+ post(path: 'statuses/update', params: Twit.Params<StatusParams>, callback: Twit.Callback<StatusResponse>): void;
+ post(path: string, params: Twit.Params<any>, callback: Twit.Callback<any>): void;

- post(path: string, params?: Twit.Params): Promise<Twit.PromiseResponse>;
+ post(path: 'statuses/update', params?: Twit.Params<StatusParams>): Promise<Twit.PromiseResponse<StatusResponse>>;
+ post(path: string, params?: Twit.Params<any>): Promise<Twit.PromiseResponse<any>>;
```

Unfortunately, that's a bit more time than I'm able to spare on this. Maybe some other brave soul will take it up!