### PR TITLE
luxon: make Settings a namespace

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for luxon 0.2
+// Type definitions for luxon 0.3
 // Project: https://github.com/moment/luxon#readme
 // Definitions by: Colby DeHart <https://github.com/colbydehart>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -334,16 +334,16 @@ declare module 'luxon' {
             union(other: Interval): Interval;
         }
 
-        type Settings = {
-            defaultLocale: string;
-            defaultNumberingSystem: string;
-            defaultOutputCalendar: string;
-            defaultZone: Zone;
-            defaultZoneName: string;
-            now: Function;
-            throwOnInvalid: boolean;
-            resetCache(): void;
-        };
+        namespace Settings {
+            let defaultLocale: string;
+            let defaultNumberingSystem: string;
+            let defaultOutputCalendar: string;
+            const defaultZone: Zone;
+            let defaultZoneName: string;
+            let now: number;
+            let throwOnInvalid: boolean;
+            function resetCache(): void;
+        }
 
         type ZoneOffsetOptions = {
             format?: 'short' | 'long';

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -1,4 +1,4 @@
-import { DateTime, Duration, Interval } from 'luxon';
+import { DateTime, Duration, Interval, Settings } from 'luxon';
 
 const dt = DateTime.local(2017, 5, 15, 8, 30);
 
@@ -68,3 +68,6 @@ i.contains(DateTime.local(2019));
 
 i.toISO();
 i.toString();
+
+Settings.defaultLocale = 'fr';
+Settings.defaultZoneName = 'Europe/Paris';


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/blob/master/src/settings.js
- [x] Increase the version number in the header if appropriate.

Settings was defined as a type, making it impossible to modify the Settings: importing it and modifying it caused the following compilation error: "error TS2693: 'Settings' only refers to a type, but is being used as a value here.".

Note: I initially thought of defining it as a class, but the linter prevented me from doing so because all its members are static. That's why it's defined as a namespace.