### PR TITLE
[@types/ioredis] Support all Redis.Cluster node types

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -4,6 +4,7 @@
 //                 Christopher Eck <https://github.com/chrisleck>
 //                 Yoga Aliarham <https://github.com/aliarham11>
 //                 Ebrahim <https://github.com/br8h>
+//                 Shahar Mor <https://github.com/shaharmor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -744,8 +745,15 @@ declare namespace IORedis {
         pfcount(...keys: string[]): Pipeline;
     }
 
+    interface NodeConfiguration {
+        host?: string;
+        port?: number;
+    }
+
+    type ClusterNode = string | number | NodeConfiguration;
+
     interface Cluster extends NodeJS.EventEmitter, Commander {
-        new(nodes: Array<{ host: string; port: number; }>, options?: ClusterOptions): Redis;
+        new(nodes: ClusterNode[], options?: ClusterOptions): Redis;
         connect(callback: () => void): Promise<any>;
         disconnect(): void;
         nodes(role: string): Redis[];

--- a/types/ioredis/ioredis-tests.ts
+++ b/types/ioredis/ioredis-tests.ts
@@ -107,3 +107,24 @@ redis.multi([
 
 const keys = [ 'foo', 'bar' ];
 redis.mget(...keys);
+
+new Redis.Cluster([
+    'localhost'
+]);
+
+new Redis.Cluster([
+    6379
+]);
+
+new Redis.Cluster([{
+    host: 'localhost'
+}]);
+
+new Redis.Cluster([{
+    port: 6379
+}]);
+
+new Redis.Cluster([{
+    host: 'localhost',
+    port: 6379
+}]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/luin/ioredis/blob/master/lib/cluster/connection_pool.js#L95-L105
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
