### PR TITLE
[@types/nock] Fix nock.pendingMocks() return type.

### DIFF
--- a/types/nock/index.d.ts
+++ b/types/nock/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: bonnici <https://github.com/bonnici>
 //                 Horiuchi_H <https://github.com/horiuchi>
 //                 afharo <https://github.com/afharo>
+//                 Matt R. Wilson <https://github.com/mastermatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -17,7 +18,7 @@ declare namespace nock {
     export function activate(): void;
     export function isActive(): boolean;
     export function isDone(): boolean;
-    export function pendingMocks(): void;
+    export function pendingMocks(): string[];
     export function removeInterceptor(interceptor: Interceptor | RequestOptions): boolean;
     export function disableNetConnect(): void;
     export function enableNetConnect(matcher?: string | RegExp): void;

--- a/types/nock/nock-tests.ts
+++ b/types/nock/nock-tests.ts
@@ -125,8 +125,6 @@ scope.done();
 bool = scope.isDone();
 scope.restore();
 
-strings = scope.pendingMocks();
-
 nock.recorder.rec();
 nock.recorder.rec(true);
 nock.recorder.rec({
@@ -567,6 +565,8 @@ var scope = nock('http://persisssists.con')
   .reply(200, 'Persisting all the way');
 
 /// .pendingMocks()
+strings = scope.pendingMocks();
+strings = nock.pendingMocks();
 if (!scope.isDone()) {
   console.error('pending mocks: %j', scope.pendingMocks());
 }


### PR DESCRIPTION
[nock](https://github.com/node-nock/nock) Fix `nock.pendingMocks()` return type to `string[]`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [intercept level](https://github.com/node-nock/nock/blob/master/lib/intercept.js#L331-L335), [scope level](https://github.com/node-nock/nock/blob/master/lib/scope.js#L124-L139)
