### PR TITLE
amqplib: add missing authentication method definitions PLAIN, EXTERNAL

### DIFF
--- a/types/amqplib/callback_api.d.ts
+++ b/types/amqplib/callback_api.d.ts
@@ -54,6 +54,19 @@ export interface ConfirmChannel extends Channel {
     waitForConfirms(callback?: (err: any) => void): void;
 }
 
+export const credentials: {
+    external(): {
+      mechanism: string;
+      response(): Buffer;
+    };
+    plain(username: string, password: string): {
+      mechanism: string;
+      response(): Buffer;
+      username: string;
+      password: string;
+    };
+};
+
 export function connect(callback: (err: any, connection: Connection) => void): void;
 export function connect(url: string, callback: (err: any, connection: Connection) => void): void;
 export function connect(url: string, socketOptions: any, callback: (err: any, connection: Connection) => void): void;

--- a/types/amqplib/index.d.ts
+++ b/types/amqplib/index.d.ts
@@ -63,4 +63,17 @@ export interface ConfirmChannel extends Channel {
     waitForConfirms(): Promise<void>;
 }
 
+export const credentials: {
+    external(): {
+      mechanism: string;
+      response(): Buffer;
+    };
+    plain(username: string, password: string): {
+      mechanism: string;
+      response(): Buffer;
+      username: string;
+      password: string;
+    };
+};
+
 export function connect(url: string | Options.Connect, socketOptions?: any): Promise<Connection>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

The code for which the definitions were missing: https://github.com/squaremo/amqp.node/blob/master/lib/credentials.js
The functionality had been added in [#105](https://github.com/squaremo/amqp.node/issues/105) but the types had not been updated. This PR adds the definitions for both promise based and callback based API of the library. The definitions allow users to use EXTERNAL authentication method of rabbitmq.

Tested using the code below

Call back based:
```javascript
// Callback based
import * as amqp from 'amqplib/callback_api';
import * as fs from 'fs';

var opts = {
  cert: fs.readFileSync('./self-crt.pem'),
  key: fs.readFileSync('./self-key.pem'),
  ca: [fs.readFileSync('./ca-crt.pem')],
  credentials: amqp.credentials.external() // PR allows to write this line
};

var open = amqp.connect('amqps://username@192.168.64.12:32591', opts, (err, connection) => {
  if(err) {
    console.error(err)
  } else {
    console.log('Connected')
  }
});
```

Promise based:
```javascript
// promise based
import * as amqp from 'amqplib';
import * as fs from 'fs';

var opts = {
  cert: fs.readFileSync('./self-crt.pem'),
  key: fs.readFileSync('./self-key.pem'),
  ca: [fs.readFileSync('./ca-crt.pem')],
  credentials: amqp.credentials.external()  // PR allows to write this line
};

var open = amqp.connect('amqps://username@192.168.64.12:32591', opts);

open.then(function(conn) {
  console.log('Connected')
}).catch(function(err) {
  console.error(err)
});
```

users can also do `credentials: amqp.credentials.plain('username', 'password')`