### PR TITLE
atom: support version 1.23

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -277,6 +277,12 @@ function testCommandRegistry() {
         "test-function": (event) => event.currentTarget.getModel(),
         "test-function2": (event) => event.currentTarget.getComponent(),
     });
+    atom.commands.add("atom-workspace", {
+        "test-command": {
+            didDispatch: (event) => {},
+            hiddenInCommandPalette: true
+        }
+    });
 
     const commands = atom.commands.findCommands({ target: element });
     atom.commands.dispatch(element, "test:function");
@@ -515,6 +521,8 @@ function testDecoration() {
     // Decoration Details
     num = decoration.getId();
     displayMarker = decoration.getMarker();
+    bool = decoration.isType("line-number");
+    bool = decoration.isType(["line-number", "line"]);
 
     // Properties
     const decorationProps = decoration.getProperties();
@@ -1077,6 +1085,7 @@ function testGrammarRegistry() {
     // Event Subscription
     subscription = registry.onDidAddGrammar(grammar => grammar.name);
     subscription = registry.onDidUpdateGrammar(grammar => grammar.name);
+    subscription = registry.onDidRemoveGrammar(grammar => grammar.name);
 
     // Managing Grammars
     grammars = registry.getGrammars();
@@ -1896,7 +1905,7 @@ function testSelection() {
     selection.insertText("Replacement", { undo: "skip" });
     selection.insertText("Replacement", { select: true, autoIndent: true,
         autoIndentNewline: true, autoDecreaseIndent: true, normalizeLineEndings: true,
-        undo: "skip" });
+        undo: "skip", preserveTrailingLineIndentation: false });
 
     selection.backspace();
     selection.deleteToPreviousWordBoundary();
@@ -1998,7 +2007,14 @@ function testTextBuffer() {
 
     // Event Subscription
     subscription = buffer.onWillChange(() => void {});
-    subscription = buffer.onDidChange(() => void {});
+
+    subscription = buffer.onDidChange((event): void => {
+        range = event.newRange;
+        for (const change of event.changes) {
+            range = change.newRange;
+        }
+    });
+
     subscription = buffer.onDidChangeText(() => void {});
 
     subscription = buffer.onDidStopChanging((event): void => {
@@ -2389,7 +2405,8 @@ function testTextEditor() {
     editor.insertText("Test", { select: true });
     editor.insertText("Test", { undo: "skip" });
     editor.insertText("Text", { autoDecreaseIndent: false, autoIndent: false,
-        autoIndentNewline: false, normalizeLineEndings: false, select: false, undo: "skip" });
+        autoIndentNewline: false, normalizeLineEndings: false, select: false,
+        undo: "skip", preserveTrailingLineIndentation: true });
 
     editor.insertNewline();
     editor.delete();

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -6291,12 +6291,33 @@ export interface SpawnProcessOptions {
 }
 
 export interface TextInsertionOptions {
+    /** If true, selects the newly added text. */
     select?: boolean;
+
+    /** If true, indents all inserted text appropriately. */
     autoIndent?: boolean;
+
+    /** If true, indent newline appropriately. */
     autoIndentNewline?: boolean;
+
+    /**
+     *  If true, decreases indent level appropriately (for example, when a closing
+     *  bracket is inserted).
+     */
     autoDecreaseIndent?: boolean;
+
+    /**
+     *  By default, when pasting multiple lines, Atom attempts to preserve the relative
+     *  indent level between the first line and trailing lines, even if the indent
+     *  level of the first line has changed from the copied text. If this option is
+     *  true, this behavior is suppressed.
+     */
     preserveTrailingLineIndentation?: boolean;
+
+    /** If true, all line endings will be normalized to match the editor's current mode. */
     normalizeLineEndings?: boolean;
+
+    /** If skip, skips the undo stack for this operation. */
     undo?: "skip";
 }
 


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[Atom v1.23 Blog Post](http://blog.atom.io/2017/12/12/atom-1-23.html)
[Atom v1.23 Release Page](https://github.com/atom/atom/releases/tag/v1.23.0)
[GrammarRegistry.onDidRemoveGrammar()](https://atom.io/docs/api/v1.23.1/GrammarRegistry#instance-onDidRemoveGrammar)
[TextEditor.insertText()](https://atom.io/docs/api/v1.23.1/TextEditor#instance-insertText)
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I believe these are all of the changes necessary to fully support Atom v1.23, which was another small update. The URI handling isn't handled via an API, so no additions are necessary on that front.