### PR TITLE
@types/croppie: change import/export style

### DIFF
--- a/types/croppie/croppie-tests.ts
+++ b/types/croppie/croppie-tests.ts
@@ -1,4 +1,4 @@
-import Croppie from 'croppie';
+import Croppie = require('croppie');
 
 const c = new Croppie(document.getElementById('item'), {
     boundary: { width: 300, height: 300 },

--- a/types/croppie/index.d.ts
+++ b/types/croppie/index.d.ts
@@ -4,7 +4,7 @@
 //                 dklmuc <https://github.com/dklmuc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default class Croppie {
+declare class Croppie {
     constructor(container: HTMLElement, options?: CroppieOptions);
 
     bind(options: {
@@ -28,13 +28,13 @@ export default class Croppie {
     destroy(): void;
 }
 
-export type CropType = 'square' | 'circle';
+type CropType = 'square' | 'circle';
 
-export type Format = 'jpeg' | 'png' | 'webp';
+type Format = 'jpeg' | 'png' | 'webp';
 
-export type Type = 'canvas' | 'base64' | 'html' | 'blob' | 'rawcanvas';
+type Type = 'canvas' | 'base64' | 'html' | 'blob' | 'rawcanvas';
 
-export interface ResultOptions {
+interface ResultOptions {
     type?: Type;
     size?: 'viewport' | 'original' | { width: number, height: number };
     format?: Format;
@@ -42,7 +42,7 @@ export interface ResultOptions {
     circle?: boolean;
 }
 
-export interface CroppieOptions {
+interface CroppieOptions {
     boundary?: { width: number, height: number };
     customClass?: string;
     enableExif?: boolean;
@@ -53,3 +53,5 @@ export interface CroppieOptions {
     showZoomer?: boolean;
     viewport?: { width: number, height: number, type?: CropType };
 }
+
+export = Croppie;


### PR DESCRIPTION
From now on, users should import Croppie in TypeScript like this:

```javascript
import Croppie = require('croppie');
```

This style of import is documented [here](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.