### PR TITLE
Improve typings for Enumerable

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1174,7 +1174,7 @@ declare module 'ember' {
              * can pass an optional second argument with the target value. Otherwise
              * this will match any property that evaluates to `true`.
              */
-            findBy(key: string, value: string): T | undefined;
+            findBy(key: string, value: any): T | undefined;
             /**
              * Returns `true` if the passed function returns true for every item in the
              * enumeration. This corresponds with the `every()` method in JavaScript 1.6.

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1142,24 +1142,24 @@ declare module 'ember' {
                 callbackfn: (value: T, index: number, array: T[]) => value is S,
                 thisArg?: any
             ): S[];
-            filter(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): Enumerable<T>;
+            filter(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): NativeArray<T>;
             /**
              * Returns an array with all of the items in the enumeration where the passed
              * function returns false. This method is the inverse of filter().
              */
-            reject(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): Enumerable<T>;
+            reject(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): NativeArray<T>;
             /**
              * Returns an array with just the items with the matched property. You
              * can pass an optional second argument with the target value. Otherwise
              * this will match any property that evaluates to `true`.
              */
-            filterBy(key: string, value?: any): Enumerable<T>;
+            filterBy(key: string, value?: any): NativeArray<T>;
             /**
              * Returns an array with the items that do not have truthy values for
              * key.  You can pass an optional second argument with the target value.  Otherwise
              * this will match any property that evaluates to false.
              */
-            rejectBy(key: string, value?: string): Enumerable<T>;
+            rejectBy(key: string, value?: string): NativeArray<T>;
             /**
              * Returns the first item in the array for which the callback returns true.
              * This method works similar to the `filter()` method defined in JavaScript 1.6
@@ -1174,7 +1174,7 @@ declare module 'ember' {
              * can pass an optional second argument with the target value. Otherwise
              * this will match any property that evaluates to `true`.
              */
-            findBy(key: string, value: any): T | undefined;
+            findBy(key: string, value?: any): T | undefined;
             /**
              * Returns `true` if the passed function returns true for every item in the
              * enumeration. This corresponds with the `every()` method in JavaScript 1.6.
@@ -1221,28 +1221,28 @@ declare module 'ember' {
             /**
              * Returns a copy of the array with all `null` and `undefined` elements removed.
              */
-            compact(): Enumerable<T>;
+            compact(): NativeArray<T>;
             /**
              * Returns a new enumerable that excludes the passed value. The default
              * implementation returns an array regardless of the receiver type.
              * If the receiver does not contain the value it returns the original enumerable.
              */
-            without(value: T): Enumerable<T>;
+            without(value: T): NativeArray<T>;
             /**
              * Returns a new enumerable that contains only unique values. The default
              * implementation returns an array regardless of the receiver type.
              */
-            uniq(): Enumerable<T>;
+            uniq(): NativeArray<T>;
             /**
              * Converts the enumerable into an array and sorts by the keys
              * specified in the argument.
              */
-            sortBy(property: string): Enumerable<T>;
+            sortBy(property: string): NativeArray<T>;
             /**
              * Returns a new enumerable that contains only items containing a unique property value.
              * The default implementation returns an array regardless of the receiver type.
              */
-            uniqBy(): Enumerable<T>;
+            uniqBy(): NativeArray<T>;
             /**
              * Returns `true` if the passed object can be found in the enumerable.
              */

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -5,6 +5,7 @@
 //                 Derek Wickern <https://github.com/dwickern>
 //                 Chris Krycho <https://github.com/chriskrycho>
 //                 Theron Cross <https://github.com/theroncross>
+//                 Martin Feckie <https://github.com/mfeckie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -1141,24 +1142,24 @@ declare module 'ember' {
                 callbackfn: (value: T, index: number, array: T[]) => value is S,
                 thisArg?: any
             ): S[];
-            filter(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): T[];
+            filter(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): Enumerable<T>;
             /**
              * Returns an array with all of the items in the enumeration where the passed
              * function returns false. This method is the inverse of filter().
              */
-            reject(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): T[];
+            reject(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): Enumerable<T>;
             /**
              * Returns an array with just the items with the matched property. You
              * can pass an optional second argument with the target value. Otherwise
              * this will match any property that evaluates to `true`.
              */
-            filterBy(key: string, value?: any): any[];
+            filterBy(key: string, value?: any): Enumerable<T>;
             /**
              * Returns an array with the items that do not have truthy values for
              * key.  You can pass an optional second argument with the target value.  Otherwise
              * this will match any property that evaluates to false.
              */
-            rejectBy(key: string, value?: string): any[];
+            rejectBy(key: string, value?: string): Enumerable<T>;
             /**
              * Returns the first item in the array for which the callback returns true.
              * This method works similar to the `filter()` method defined in JavaScript 1.6
@@ -1617,6 +1618,11 @@ declare module 'ember' {
              */
             reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
             reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+            filter<S extends T>(
+                callbackfn: (value: T, index: number, array: T[]) => value is S,
+                thisArg?: any
+            ): S[];
+            filter(callbackfn: (value: T, index: number, array: T[]) => any, thisArg?: any): Enumerable<T>;
         }
         const NativeArray: Mixin<NativeArray<any>>;
         /**

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1492,7 +1492,7 @@ declare module 'ember' {
          * It builds upon the Array mixin and adds methods to modify the array.
          * One concrete implementations of this class include ArrayProxy.
          */
-        interface MutableArray<T> extends Array<T>, MutableEnumberable<T> {
+        interface MutableArray<T> extends Array<T>, MutableEnumerable<T> {
             /**
              * __Required.__ You must implement this method to apply this mixin.
              */
@@ -1559,7 +1559,7 @@ declare module 'ember' {
          * can be applied to an object regardless of whether it is ordered or
          * unordered.
          */
-        interface MutableEnumberable<T> extends Enumerable<T> {
+        interface MutableEnumerable<T> extends Enumerable<T> {
             /**
              * __Required.__ You must implement this method to apply this mixin.
              */
@@ -1577,7 +1577,7 @@ declare module 'ember' {
              */
             removeObjects(objects: Enumerable<T>): this;
         }
-        const MutableEnumerable: Mixin<MutableEnumberable<any>>;
+        const MutableEnumerable: Mixin<MutableEnumerable<any>>;
         /**
          * A Namespace is an object usually used to contain other objects or methods
          * such as an application or framework. Create a namespace anytime you want

--- a/types/ember/test/array.ts
+++ b/types/ember/test/array.ts
@@ -16,7 +16,9 @@ assertType<number>(people.get('length'));
 assertType<Person>(people.get('lastObject'));
 assertType<boolean>(people.isAny('isHappy'));
 assertType<boolean>(people.isAny('isHappy', false));
-assertType<Person[]>(people.filterBy('isHappy'));
+assertType<Ember.Enumerable<Person>>(people.filterBy('isHappy'));
+assertType<Ember.Enumerable<Person>>(people.rejectBy('isHappy'));
+assertType<Ember.Enumerable<Person>>(people.filter((person) => person.get('name') === 'Yehuda'));
 assertType<typeof people>(people.get('[]'));
 assertType<Person>(people.get('[]').get('firstObject'));
 

--- a/types/ember/v1/index.d.ts
+++ b/types/ember/v1/index.d.ts
@@ -727,9 +727,9 @@ declare namespace Ember {
         lastObject: any;
         length: number;
         addObject(object: any): any;
-        addObjects(objects: Enumerable): MutableEnumberable;
+        addObjects(objects: Enumerable): MutableEnumerable;
         removeObject(object: any): any;
-        removeObjects(objects: Enumerable): MutableEnumberable;
+        removeObjects(objects: Enumerable): MutableEnumerable;
     }
     var BOOTED: boolean;
     /**
@@ -1425,7 +1425,7 @@ declare namespace Ember {
         detect(obj: any): boolean;
         reopen<T extends Mixin>(args?: {}): T;
     }
-    class MutableArray implements Array, MutableEnumberable {
+    class MutableArray implements Array, MutableEnumerable {
         addArrayObserver(target: any, opts?: EnumerableConfigurationOptions): any[];
         addEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): Enumerable;
         any(callback: Function, target?: any): boolean;
@@ -1495,14 +1495,14 @@ declare namespace Ember {
         lastObject: any;
         length: number;
         addObject(object: any): any;
-        addObjects(objects: Enumerable): MutableEnumberable;
+        addObjects(objects: Enumerable): MutableEnumerable;
         removeObject(object: any): any;
-        removeObjects(objects: Enumerable): MutableEnumberable;
+        removeObjects(objects: Enumerable): MutableEnumerable;
     }
-    class MutableEnumberable implements Enumerable {
+    class MutableEnumerable implements Enumerable {
         addEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): Enumerable;
         addObject(object: any): any;
-        addObjects(objects: Enumerable): MutableEnumberable;
+        addObjects(objects: Enumerable): MutableEnumerable;
         any(callback: Function, target?: any): boolean;
         anyBy(key: string, value?: string): boolean;
         someProperty(key: string, value?: string): boolean;
@@ -1538,7 +1538,7 @@ declare namespace Ember {
         rejectBy(key: string, value?: string): any[];
         removeEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): Enumerable;
         removeObject(object: any): any;
-        removeObjects(objects: Enumerable): MutableEnumberable;
+        removeObjects(objects: Enumerable): MutableEnumerable;
         setEach(key: string, value?: any): any;
         some(callback: Function, target?: any): boolean;
         toArray(): any[];
@@ -1638,9 +1638,9 @@ declare namespace Ember {
         lastObject: any;
         length: number;
         addObject(object: any): any;
-        addObjects(objects: Enumerable): MutableEnumberable;
+        addObjects(objects: Enumerable): MutableEnumerable;
         removeObject(object: any): any;
-        removeObjects(objects: Enumerable): MutableEnumberable;
+        removeObjects(objects: Enumerable): MutableEnumerable;
         addObserver: ModifyObserver;
         beginPropertyChanges(): Observable;
         cacheFor(keyName: string): any;
@@ -2457,7 +2457,7 @@ declare namespace Ember {
         static isClass: boolean;
         static isMethod: boolean;
     }
-    class Set extends CoreObject implements MutableEnumberable, Copyable, Freezable {
+    class Set extends CoreObject implements MutableEnumerable, Copyable, Freezable {
         addEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): Set;
         addObject(object: any): any;
         addObjects(objects: Enumerable): Set;
@@ -2522,10 +2522,10 @@ declare namespace Ember {
         unshift(obj: any): Set;
         length: number;
     }
-    class SortableMixin implements MutableEnumberable {
+    class SortableMixin implements MutableEnumerable {
         addEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): Enumerable;
         addObject(object: any): any;
-        addObjects(objects: Enumerable): MutableEnumberable;
+        addObjects(objects: Enumerable): MutableEnumerable;
         any(callback: Function, target?: any): boolean;
         anyBy(key: string, value?: string): boolean;
         someProperty(key: string, value?: string): boolean;
@@ -2561,7 +2561,7 @@ declare namespace Ember {
         rejectBy(key: string, value?: string): any[];
         removeEnumerableObserver(target: any, opts: EnumerableConfigurationOptions): Enumerable;
         removeObject(object: any): any;
-        removeObjects(objects: Enumerable): MutableEnumberable;
+        removeObjects(objects: Enumerable): MutableEnumerable;
         setEach(key: string, value?: any): any;
         some(callback: Function, target?: any): boolean;
         toArray(): any[];
@@ -3086,7 +3086,7 @@ declare namespace Em {
     class MapWithDefault extends Ember.MapWithDefault { }
     class Mixin extends Ember.Mixin { }
     class MutableArray extends Ember.MutableArray { }
-    class MutableEnumerable extends Ember.MutableEnumberable { }
+    class MutableEnumerable extends Ember.MutableEnumerable { }
     var NAME_KEY: typeof Ember.NAME_KEY;
     class Namespace extends Ember.Namespace { }
     class NativeArray extends Ember.NativeArray { }
@@ -3330,7 +3330,7 @@ declare module "Ember" {
     class MapWithDefault extends Ember.MapWithDefault { }
     class Mixin extends Ember.Mixin { }
     class MutableArray extends Ember.MutableArray { }
-    class MutableEnumerable extends Ember.MutableEnumberable { }
+    class MutableEnumerable extends Ember.MutableEnumerable { }
     var NAME_KEY: typeof Ember.NAME_KEY;
     class Namespace extends Ember.Namespace { }
     class NativeArray extends Ember.NativeArray { }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- Fixes typo where `Enumerable` was `Enumberable`
- Converts return type from `T[]` to `Enumerable<T>` where appropriate to allow for chaining multiple enumerable transforms
- Updates findBy to all `any` type for comparison value

