### PR TITLE
Fix Node's path.format() requiring all options

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -18,7 +18,6 @@
 //                 Hannes Magnusson <https://github.com/Hannes-Magnusson-CK>
 //                 Alberto Schiabel <https://github.com/jkomyno>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 /************************************************
 *                                               *
@@ -4574,6 +4573,28 @@ declare module "path" {
          */
         name: string;
     }
+    export interface FormatInputPathObject {
+        /**
+         * The root of the path such as '/' or 'c:\'
+         */
+        root?: string;
+        /**
+         * The full directory path such as '/home/user/dir' or 'c:\path\dir'
+         */
+        dir?: string;
+        /**
+         * The file name including extension (if any) such as 'index.html'
+         */
+        base?: string;
+        /**
+         * The file extension (if any) such as '.html'
+         */
+        ext?: string;
+        /**
+         * The file name without extension (if any) such as 'index'
+         */
+        name?: string;
+    }
 
     /**
      * Normalize a string path, reducing '..' and '.' parts.
@@ -4650,7 +4671,7 @@ declare module "path" {
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: Partial<ParsedPath>): string;
+    export function format(pathObject: FormatInputPathObject): string;
 
     export module posix {
         export function normalize(p: string): string;
@@ -4664,7 +4685,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: Partial<ParsedPath>): string;
+        export function format(pP: FormatInputPathObject): string;
     }
 
     export module win32 {
@@ -4679,7 +4700,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: Partial<ParsedPath>): string;
+        export function format(pP: FormatInputPathObject): string;
     }
 }
 

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -18,6 +18,7 @@
 //                 Hannes Magnusson <https://github.com/Hannes-Magnusson-CK>
 //                 Alberto Schiabel <https://github.com/jkomyno>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /************************************************
 *                                               *
@@ -4574,29 +4575,6 @@ declare module "path" {
         name: string;
     }
 
-    export interface FormatInputPathObject {
-        /**
-         * The root of the path such as '/' or 'c:\'
-         */
-        root?: string;
-        /**
-         * The full directory path such as '/home/user/dir' or 'c:\path\dir'
-         */
-        dir?: string;
-        /**
-         * The file name including extension (if any) such as 'index.html'
-         */
-        base?: string;
-        /**
-         * The file extension (if any) such as '.html'
-         */
-        ext?: string;
-        /**
-         * The file name without extension (if any) such as 'index'
-         */
-        name?: string;
-    }
-
     /**
      * Normalize a string path, reducing '..' and '.' parts.
      * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used.
@@ -4672,7 +4650,7 @@ declare module "path" {
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: FormatInputPathObject): string;
+    export function format(pathObject: Partial<ParsedPath>): string;
 
     export module posix {
         export function normalize(p: string): string;
@@ -4686,7 +4664,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: ParsedPath): string;
+        export function format(pP: Partial<ParsedPath>): string;
     }
 
     export module win32 {
@@ -4701,7 +4679,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: ParsedPath): string;
+        export function format(pP: Partial<ParsedPath>): string;
     }
 }
 

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1746,6 +1746,46 @@ namespace path_tests {
     });
     // returns
     //    '/home/user/dir/file.txt'
+
+    path.format({
+        dir: "/home/user/dir",
+        base: "file.txt"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.posix.format({
+        root: "/",
+        dir: "/home/user/dir",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.posix.format({
+        dir: "/home/user/dir",
+        base: "file.txt"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.win32.format({
+        root: "C:\\",
+        dir: "C:\\home\\user\\dir",
+        ext: ".txt",
+        name: "file"
+    });
+    // returns
+    //    'C:\home\user\dir\file.txt'
+
+    path.win32.format({
+        dir: "C:\\home\\user\\dir",
+        base: "file.txt"
+    });
+    // returns
+    //    'C:\home\user\dir\file.txt'
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -4,7 +4,6 @@
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 /************************************************
 *                                               *
@@ -1994,6 +1993,28 @@ declare module "path" {
          */
         name: string;
     }
+    export interface FormatInputPathObject {
+        /**
+         * The root of the path such as '/' or 'c:\'
+         */
+        root?: string;
+        /**
+         * The full directory path such as '/home/user/dir' or 'c:\path\dir'
+         */
+        dir?: string;
+        /**
+         * The file name including extension (if any) such as 'index.html'
+         */
+        base?: string;
+        /**
+         * The file extension (if any) such as '.html'
+         */
+        ext?: string;
+        /**
+         * The file name without extension (if any) such as 'index'
+         */
+        name?: string;
+    }
 
     /**
      * Normalize a string path, reducing '..' and '.' parts.
@@ -2077,7 +2098,7 @@ declare module "path" {
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: Partial<ParsedPath>): string;
+    export function format(pathObject: FormatInputPathObject): string;
 
     export module posix {
       export function normalize(p: string): string;
@@ -2091,7 +2112,7 @@ declare module "path" {
       export var sep: string;
       export var delimiter: string;
       export function parse(p: string): ParsedPath;
-      export function format(pP: Partial<ParsedPath>): string;
+      export function format(pP: FormatInputPathObject): string;
     }
 
     export module win32 {
@@ -2106,7 +2127,7 @@ declare module "path" {
       export var sep: string;
       export var delimiter: string;
       export function parse(p: string): ParsedPath;
-      export function format(pP: Partial<ParsedPath>): string;
+      export function format(pP: FormatInputPathObject): string;
     }
 }
 

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -4,6 +4,7 @@
 //                 DefinitelyTyped <https://github.com/DefinitelyTyped/DefinitelyTyped>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /************************************************
 *                                               *
@@ -2076,7 +2077,7 @@ declare module "path" {
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: ParsedPath): string;
+    export function format(pathObject: Partial<ParsedPath>): string;
 
     export module posix {
       export function normalize(p: string): string;
@@ -2090,7 +2091,7 @@ declare module "path" {
       export var sep: string;
       export var delimiter: string;
       export function parse(p: string): ParsedPath;
-      export function format(pP: ParsedPath): string;
+      export function format(pP: Partial<ParsedPath>): string;
     }
 
     export module win32 {
@@ -2105,7 +2106,7 @@ declare module "path" {
       export var sep: string;
       export var delimiter: string;
       export function parse(p: string): ParsedPath;
-      export function format(pP: ParsedPath): string;
+      export function format(pP: Partial<ParsedPath>): string;
     }
 }
 

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -772,6 +772,46 @@ namespace path_tests {
     });
     // returns
     //    '/home/user/dir/file.txt'
+
+    path.format({
+        dir: "/home/user/dir",
+        base: "file.txt"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.posix.format({
+        root: "/",
+        dir: "/home/user/dir",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.posix.format({
+        dir: "/home/user/dir",
+        base: "file.txt"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.win32.format({
+        root: "C:\\",
+        dir: "C:\\home\\user\\dir",
+        ext: ".txt",
+        name: "file"
+    });
+    // returns
+    //    'C:\home\user\dir\file.txt'
+
+    path.win32.format({
+        dir: "C:\\home\\user\\dir",
+        base: "file.txt"
+    });
+    // returns
+    //    'C:\home\user\dir\file.txt'
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -6,6 +6,7 @@
 //                 Thomas Bouldin <https://github.com/inlined>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /************************************************
 *                                               *
@@ -2951,7 +2952,7 @@ declare module "path" {
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: ParsedPath): string;
+    export function format(pathObject: Partial<ParsedPath>): string;
 
     export module posix {
         export function normalize(p: string): string;
@@ -2965,7 +2966,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: ParsedPath): string;
+        export function format(pP: Partial<ParsedPath>): string;
     }
 
     export module win32 {
@@ -2980,7 +2981,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: ParsedPath): string;
+        export function format(pP: Partial<ParsedPath>): string;
     }
 }
 

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -6,7 +6,6 @@
 //                 Thomas Bouldin <https://github.com/inlined>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 /************************************************
 *                                               *
@@ -2876,6 +2875,28 @@ declare module "path" {
          */
         name: string;
     }
+    export interface FormatInputPathObject {
+        /**
+         * The root of the path such as '/' or 'c:\'
+         */
+        root?: string;
+        /**
+         * The full directory path such as '/home/user/dir' or 'c:\path\dir'
+         */
+        dir?: string;
+        /**
+         * The file name including extension (if any) such as 'index.html'
+         */
+        base?: string;
+        /**
+         * The file extension (if any) such as '.html'
+         */
+        ext?: string;
+        /**
+         * The file name without extension (if any) such as 'index'
+         */
+        name?: string;
+    }
 
     /**
      * Normalize a string path, reducing '..' and '.' parts.
@@ -2952,7 +2973,7 @@ declare module "path" {
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: Partial<ParsedPath>): string;
+    export function format(pathObject: FormatInputPathObject): string;
 
     export module posix {
         export function normalize(p: string): string;
@@ -2966,7 +2987,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: Partial<ParsedPath>): string;
+        export function format(pP: FormatInputPathObject): string;
     }
 
     export module win32 {
@@ -2981,7 +3002,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: Partial<ParsedPath>): string;
+        export function format(pP: FormatInputPathObject): string;
     }
 }
 

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -1282,6 +1282,47 @@ namespace path_tests {
     });
     // returns
     //    '/home/user/dir/file.txt'
+
+
+    path.format({
+        dir: "/home/user/dir",
+        base: "file.txt"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.posix.format({
+        root: "/",
+        dir: "/home/user/dir",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.posix.format({
+        dir: "/home/user/dir",
+        base: "file.txt"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.win32.format({
+        root: "C:\\",
+        dir: "C:\\home\\user\\dir",
+        ext: ".txt",
+        name: "file"
+    });
+    // returns
+    //    'C:\home\user\dir\file.txt'
+
+    path.win32.format({
+        dir: "C:\\home\\user\\dir",
+        base: "file.txt"
+    });
+    // returns
+    //    'C:\home\user\dir\file.txt'
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -7,6 +7,7 @@
 //                 Wilco Bakker <https://github.com/WilcoBakker>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 /************************************************
 *                                               *
@@ -3081,7 +3082,7 @@ declare module "path" {
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: ParsedPath): string;
+    export function format(pathObject: Partial<ParsedPath>): string;
 
     export module posix {
         export function normalize(p: string): string;
@@ -3095,7 +3096,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: ParsedPath): string;
+        export function format(pP: Partial<ParsedPath>): string;
     }
 
     export module win32 {
@@ -3110,7 +3111,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: ParsedPath): string;
+        export function format(pP: Partial<ParsedPath>): string;
     }
 }
 

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -7,7 +7,6 @@
 //                 Wilco Bakker <https://github.com/WilcoBakker>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
 
 /************************************************
 *                                               *
@@ -3006,6 +3005,28 @@ declare module "path" {
          */
         name: string;
     }
+    export interface FormatInputPathObject {
+        /**
+         * The root of the path such as '/' or 'c:\'
+         */
+        root?: string;
+        /**
+         * The full directory path such as '/home/user/dir' or 'c:\path\dir'
+         */
+        dir?: string;
+        /**
+         * The file name including extension (if any) such as 'index.html'
+         */
+        base?: string;
+        /**
+         * The file extension (if any) such as '.html'
+         */
+        ext?: string;
+        /**
+         * The file name without extension (if any) such as 'index'
+         */
+        name?: string;
+    }
 
     /**
      * Normalize a string path, reducing '..' and '.' parts.
@@ -3082,7 +3103,7 @@ declare module "path" {
      *
      * @param pathString path to evaluate.
      */
-    export function format(pathObject: Partial<ParsedPath>): string;
+    export function format(pathObject: FormatInputPathObject): string;
 
     export module posix {
         export function normalize(p: string): string;
@@ -3096,7 +3117,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: Partial<ParsedPath>): string;
+        export function format(pP: FormatInputPathObject): string;
     }
 
     export module win32 {
@@ -3111,7 +3132,7 @@ declare module "path" {
         export var sep: string;
         export var delimiter: string;
         export function parse(p: string): ParsedPath;
-        export function format(pP: Partial<ParsedPath>): string;
+        export function format(pP: FormatInputPathObject): string;
     }
 }
 

--- a/types/node/v7/node-tests.ts
+++ b/types/node/v7/node-tests.ts
@@ -1379,6 +1379,46 @@ namespace path_tests {
     });
     // returns
     //    '/home/user/dir/file.txt'
+
+    path.format({
+        dir: "/home/user/dir",
+        base: "file.txt"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.posix.format({
+        root: "/",
+        dir: "/home/user/dir",
+        base: "file.txt",
+        ext: ".txt",
+        name: "file"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.posix.format({
+        dir: "/home/user/dir",
+        base: "file.txt"
+    });
+    // returns
+    //    '/home/user/dir/file.txt'
+
+    path.win32.format({
+        root: "C:\\",
+        dir: "C:\\home\\user\\dir",
+        ext: ".txt",
+        name: "file"
+    });
+    // returns
+    //    'C:\home\user\dir\file.txt'
+
+    path.win32.format({
+        dir: "C:\\home\\user\\dir",
+        base: "file.txt"
+    });
+    // returns
+    //    'C:\home\user\dir\file.txt'
 }
 
 ////////////////////////////////////////////////////


### PR DESCRIPTION
The bug manifested during use of path.win32 and path.posix submodules.
Both functions required all of the options to exist which is not
the case as some override others.
Further research indicated that previous Node versions were also
susceptible, up to v4.

I've used the Typescript's Partial<> type which makes all properties
optional, allowing for easier maintenance and readabillity at the cost
of now requiring Typescript 2.1, which I believe is a good trade-off.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/path.html#path_path_format_pathobject
- [x] Increase the version number in the header if appropriate. **Not applicable**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **Not applicable**