### PR TITLE
@types/react-native-push-notification Fix "date" casing on PushNotificationScheduleObject

### DIFF
--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -62,7 +62,7 @@ export class PushNotificationObject {
 }
 
 export class PushNotificationScheduleObject extends PushNotificationObject {
-    Date: Date;
+    date: Date;
 }
 
 export interface PushNotification {


### PR DESCRIPTION
Fix "date" casing on PushNotificationScheduleObject according to this: https://github.com/zo0r/react-native-push-notification#scheduled-notifications

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zo0r/react-native-push-notification#scheduled-notifications
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.