### PR TITLE
add types of react-native-document-picker

### DIFF
--- a/types/react-native-document-picker/index.d.ts
+++ b/types/react-native-document-picker/index.d.ts
@@ -1,0 +1,28 @@
+// Type definitions for react-native-document-picker 2.0
+// Project: https://github.com/Elyx0/react-native-document-picker
+// Definitions by: Jacob Baskin <https://github.com/plantain-00>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export const DocumentPicker: {
+    show(options: Options, callback: (error: Error, result: Result) => void): void;
+};
+
+export const DocumentPickerUtil: {
+    allFiles(): string;
+    pdf(): string;
+    audio(): string;
+    plainText(): string;
+};
+
+export interface Options {
+    top?: number;
+    left?: number;
+    filetype: string[];
+}
+
+export interface Result {
+    uri: string;
+    type: string;
+    fileName: string;
+    fileSize: number;
+}

--- a/types/react-native-document-picker/react-native-document-picker-tests.tsx
+++ b/types/react-native-document-picker/react-native-document-picker-tests.tsx
@@ -1,0 +1,7 @@
+import { DocumentPicker, DocumentPickerUtil } from "react-native-document-picker";
+
+DocumentPicker.show({
+    filetype: [DocumentPickerUtil.allFiles()],
+}, (error, res) => {
+    // do nothing
+});

--- a/types/react-native-document-picker/tsconfig.json
+++ b/types/react-native-document-picker/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "jsx": "react"
+    },
+    "files": [
+        "index.d.ts",
+        "react-native-document-picker-tests.tsx"
+    ]
+}

--- a/types/react-native-document-picker/tslint.json
+++ b/types/react-native-document-picker/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.(when I tried to generate it, there is error of `SyntaxError: Unexpected token import` for `dts-gen -m react-native-document-picker`)
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
