### PR TITLE
[velocity-animate] Export a module so it can be used with "import".

### DIFF
--- a/types/velocity-animate/index.d.ts
+++ b/types/velocity-animate/index.d.ts
@@ -6,6 +6,12 @@
 
 /// <reference types="jquery" />
 
+declare const Velocity: jquery.velocity.VelocityStatic;
+
+declare module "velocity-animate" {
+  export = Velocity;
+}
+
 interface JQuery {
 	velocity(name: string, options: jquery.velocity.RegisteredEffectOptions): JQuery;
 	velocity(options: {properties: jquery.velocity.Properties; options: jquery.velocity.Options}): JQuery;


### PR DESCRIPTION
The following code snippet would work nicely with the fix:

  import * as Velocity from 'velocity-animate';

  Velocity.animate(...);

Otherwise, TypeScript throws the following error:

  TS2307: Cannot find module 'velocity-animate'.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.