### PR TITLE
Allow settings when opening page in phantom

### DIFF
--- a/types/phantom/index.d.ts
+++ b/types/phantom/index.d.ts
@@ -12,6 +12,7 @@ export interface PhantomJS {
 
 export interface WebPage {
     open(url: string): Promise<string>;
+    open(url: string, settings: IOpenWebPageSettings): Promise<string>;
     close(): Promise<void>;
 
     evaluate<R>(callback: () => R): Promise<R>;
@@ -57,4 +58,11 @@ export interface IPaperSizeOptions {
     format?: string;
     orientation?: string;
     margin?: any; // string | { top?: string; left?: string; bottom?: string; right?: string;  }
+}
+
+export interface IOpenWebPageSettings {
+    operation?: string;
+    encoding?: string;
+    headers?: { [s: string]: string };
+    data?: string;
 }

--- a/types/phantom/phantom-tests.ts
+++ b/types/phantom/phantom-tests.ts
@@ -2,7 +2,9 @@ import phantom = require("phantom");
 
 phantom.create().then((ph: phantom.PhantomJS): void => {
     ph.createPage().then((page): void => {
-        page.open("http://www.google.com").then((status: string) => {
+        page.open("http://www.google.com", {
+          operation: "GET"
+        }).then((status: string) => {
             console.log("opened google? ", status);
             return page.evaluate((): string => {
                 return document.title;


### PR DESCRIPTION
PhantomJS allows passing settings object to configure how page should be opened.
Ref: http://phantomjs.org/api/webpage/method/open.html

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://phantomjs.org/api/webpage/method/open.html
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
