### PR TITLE
[adone] fix builderror because of incompatible definition of duplex.end()

### DIFF
--- a/types/adone/glosses/collections.d.ts
+++ b/types/adone/glosses/collections.d.ts
@@ -1651,7 +1651,8 @@ declare namespace adone {
             /**
              * Ends the stream
              */
-            end(chunk?: () => void | Buffer): void;
+            end(chunk?: Buffer): void;
+            end(chunk?: () => void): void;
 
             /**
              * Returns the byte at the specified index

--- a/types/adone/glosses/collections.d.ts
+++ b/types/adone/glosses/collections.d.ts
@@ -1651,7 +1651,7 @@ declare namespace adone {
             /**
              * Ends the stream
              */
-            end(chunk?: Buffer | Function): void;
+            end(chunk?: () => void | Buffer): void;
 
             /**
              * Returns the byte at the specified index

--- a/types/adone/glosses/collections.d.ts
+++ b/types/adone/glosses/collections.d.ts
@@ -1651,7 +1651,7 @@ declare namespace adone {
             /**
              * Ends the stream
              */
-            end(chunk?: Buffer): void;
+            end(chunk?: Buffer | Function): void;
 
             /**
              * Returns the byte at the specified index


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/dist/latest-v9.x/docs/api/stream.html#stream_writable_end_chunk_encoding_callback
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I got a build error in another PR because end() defined in adone doesn't match to `end()` defined in nodejs duplex stream which is used as base class:
```
Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/adone/glosses/collections.d.ts
ERROR: 1630:15  expect  TypeScript@next compile error: 
Class 'BufferList' incorrectly extends base class 'Duplex'.
  Types of property 'end' are incompatible.
    Type '(chunk?: Buffer | undefined) => void' is not assignable to type '{ (cb?: Function | undefined): void; (chunk: any, cb?: Function | undefined): void; (chunk: any, ...'.
      Types of parameters 'chunk' and 'cb' are incompatible.
        Type 'Function | undefined' is not assignable to type 'Buffer | undefined'.
          Type 'Function' is not assignable to type 'Buffer | undefined'.
            Type 'Function' is not assignable to type 'Buffer'.
              Property 'write' is missing in type 'Function'.
```
Most likely caused by #22077.
