### PR TITLE
resolve: fix type of readFileSync

### DIFF
--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for resolve
 // Project: https://github.com/substack/node-resolve
 // Definitions by: Mario Nebl <https://github.com/marionebl>
+//                 Klaus Meinhardt <https://github.com/ajafff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -88,7 +89,7 @@ declare namespace resolve {
 
   export interface SyncOpts extends Opts {
     // how to read files synchronously (defaults to fs.readFileSync)
-    readFileSync?: (file: string) => Buffer;
+    readFileSync?: (file: string, charset: string) => string | Buffer;
     // function to synchronously test whether a file exists
     isFile?: (file: string) => boolean;
   }

--- a/types/resolve/resolve-tests.ts
+++ b/types/resolve/resolve-tests.ts
@@ -73,6 +73,11 @@ function test_options_sync() {
     }
   });
   console.log(resolved);
+  resolved = resolve.sync('typescript', {
+      readFileSync(file, charset) {
+          return fs.readFileSync(file, charset);
+      }
+  });
 }
 
 function test_is_core() {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/browserify/resolve/blob/master/lib/sync.js#L61
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
