### PR TITLE
[karma-webpack] Fix build by adding type for Logger

### DIFF
--- a/types/karma-webpack/index.d.ts
+++ b/types/karma-webpack/index.d.ts
@@ -9,6 +9,8 @@ import webpack = require('webpack');
 import webpackDevMiddleware = require('webpack-dev-middleware');
 
 declare module 'karma' {
+    type Logger = (message?: any, ...optionalParams: any[]) => void;
+
     // Note: karma-webpack will set publicPath for us, so it is optional here.
     // Unfortuantely, Typescript doesn't let you overload properties, so
     // the entire definition is duplicated here.
@@ -26,9 +28,9 @@ declare module 'karma' {
         reporter?: webpackDevMiddleware.Reporter | null;
         serverSideRender?: boolean;
 
-        log?: webpackDevMiddleware.Logger;
-        warn?: webpackDevMiddleware.Logger;
-        error?: webpackDevMiddleware.Logger;
+        log?: Logger;
+        warn?: Logger;
+        error?: Logger;
         filename?: string;
     }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack-dev-middleware/blob/master/breaking-changes.md
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Got following build error:
```
Error in karma-webpack
Command failed: node /home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js --onlyTestTsNext
Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/karma-webpack/index.d.ts
ERROR: 29:36  expect  TypeScript@next compile error: 
Namespace 'WebpackDevMiddleware' has no exported member 'Logger'.
ERROR: 30:37  expect  TypeScript@next compile error: 
Namespace 'WebpackDevMiddleware' has no exported member 'Logger'.
ERROR: 31:38  expect  TypeScript@next compile error: 
Namespace 'WebpackDevMiddleware' has no exported member 'Logger'.
```
I think it's caused by #22267.

karma-webpack is still using 1.12.x of webpack-dev-middleware therefore I added only a local definition of `Logger` to fix this as there is no v1 typing for webpack-dev-middleware.
