### PR TITLE
fix(@types/croppie): do not export Croppie as default export

### DIFF
--- a/types/croppie/croppie-tests.ts
+++ b/types/croppie/croppie-tests.ts
@@ -1,4 +1,4 @@
-import Croppie from 'croppie';
+import * as Croppie from 'croppie';
 
 const c = new Croppie(document.getElementById('item'), {
     boundary: { width: 300, height: 300 },

--- a/types/croppie/index.d.ts
+++ b/types/croppie/index.d.ts
@@ -5,8 +5,12 @@
 //                 Sarun Intaralawan <https://github.com/sarunint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default class Croppie {
-    constructor(container: HTMLElement, options?: CroppieOptions);
+export as namespace Croppie;
+
+export = Croppie;
+
+declare class Croppie {
+    constructor(container: HTMLElement, options?: Croppie.CroppieOptions);
 
     bind(options: {
         url: string,
@@ -16,11 +20,11 @@ export default class Croppie {
         useCanvas?: boolean,
     }): Promise<void>;
 
-    result(options: ResultOptions & { type: 'base64' | 'canvas' }): Promise<string>;
-    result(options: ResultOptions & { type: 'html' }): Promise<HTMLElement>;
-    result(options: ResultOptions & { type: 'blob' }): Promise<Blob>;
-    result(options: ResultOptions & { type: 'rawcanvas' }): Promise<HTMLCanvasElement>;
-    result(options?: ResultOptions): Promise<HTMLCanvasElement>;
+    result(options: Croppie.ResultOptions & { type: 'base64' | 'canvas' }): Promise<string>;
+    result(options: Croppie.ResultOptions & { type: 'html' }): Promise<HTMLElement>;
+    result(options: Croppie.ResultOptions & { type: 'blob' }): Promise<Blob>;
+    result(options: Croppie.ResultOptions & { type: 'rawcanvas' }): Promise<HTMLCanvasElement>;
+    result(options?: Croppie.ResultOptions): Promise<HTMLCanvasElement>;
 
     rotate(degrees: 90 | 180 | 270 | -90 | -180 | -270): void;
 
@@ -29,28 +33,30 @@ export default class Croppie {
     destroy(): void;
 }
 
-export type CropType = 'square' | 'circle';
+declare namespace Croppie {
+    type CropType = 'square' | 'circle';
 
-export type Format = 'jpeg' | 'png' | 'webp';
+    type Format = 'jpeg' | 'png' | 'webp';
 
-export type Type = 'canvas' | 'base64' | 'html' | 'blob' | 'rawcanvas';
+    type Type = 'canvas' | 'base64' | 'html' | 'blob' | 'rawcanvas';
 
-export interface ResultOptions {
-    type?: Type;
-    size?: 'viewport' | 'original' | { width: number, height: number };
-    format?: Format;
-    quality?: number;
-    circle?: boolean;
-}
+    interface ResultOptions {
+        type?: Type;
+        size?: 'viewport' | 'original' | { width: number, height: number };
+        format?: Format;
+        quality?: number;
+        circle?: boolean;
+    }
 
-export interface CroppieOptions {
-    boundary?: { width: number, height: number };
-    customClass?: string;
-    enableExif?: boolean;
-    enableOrientation?: boolean;
-    enableZoom?: boolean;
-    enforceBoundary?: boolean;
-    mouseWheelZoom?: boolean;
-    showZoomer?: boolean;
-    viewport?: { width: number, height: number, type?: CropType };
+    interface CroppieOptions {
+        boundary?: { width: number, height: number };
+        customClass?: string;
+        enableExif?: boolean;
+        enableOrientation?: boolean;
+        enableZoom?: boolean;
+        enforceBoundary?: boolean;
+        mouseWheelZoom?: boolean;
+        showZoomer?: boolean;
+        viewport?: { width: number, height: number, type?: CropType };
+    }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Note: from now on, users should import `Croppie` like this:

```typescript
import * as Croppie from 'croppie';
```

Fixes #21928 