### PR TITLE
[koa-webpack] Fix build by adapting test to changes in webpack-dev-mddleware

### DIFF
--- a/types/koa-webpack/koa-webpack-tests.ts
+++ b/types/koa-webpack/koa-webpack-tests.ts
@@ -12,8 +12,6 @@ const middleware = koaWebpack({
     compiler,
     config,
     dev: {
-        noInfo: false,
-        quiet: false,
         lazy: true,
         watchOptions: {
             aggregateTimeout: 300,


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack/webpack-dev-middleware/blob/master/breaking-changes.md
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I got following build error:
```
Error in koa-webpack
Command failed: node /home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js --onlyTestTsNext
Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/koa-webpack/koa-webpack-tests.ts
ERROR: 15:9  expect  TypeScript@next compile error: 
Argument of type '{ compiler: Compiler; config: Configuration; dev: { noInfo: boolean; quiet: boolean; lazy: boolea...' is not assignable to parameter of type 'Options | undefined'.
  Type '{ compiler: Compiler; config: Configuration; dev: { noInfo: boolean; quiet: boolean; lazy: boolea...' is not assignable to type 'Options'.
    Types of property 'dev' are incompatible.
      Type '{ noInfo: boolean; quiet: boolean; lazy: boolean; watchOptions: { aggregateTimeout: number; poll:...' is not assignable to type 'Options | undefined'.
        Object literal may only specify known properties, and 'noInfo' does not exist in type 'Options | undefined'.
```

Seems to be caused by #22267.
koa-webpack is still using webpack-dev-middleware in version 1.x but there are not 1.x typings for webpack-dev-middleware.
To fix this I removed the optional properties in test no longer present in webpack-dev-middleware as they were anyway optional.
