### PR TITLE
ember-feature-flags: Add types

### DIFF
--- a/types/ember-feature-flags/ember-feature-flags-tests.ts
+++ b/types/ember-feature-flags/ember-feature-flags-tests.ts
@@ -1,0 +1,14 @@
+import Features from 'ember-feature-flags';
+import 'ember-feature-flags/tests/helpers/with-feature';
+
+// https://www.npmjs.com/package/ember-feature-flags#withfeature
+declare var features: Features;
+features.isEnabled('new-billing-plans'); // $ExpectType boolean
+features.enable('newHomepage'); // $ExpectType void
+features.disable('newHomepage'); // $ExpectType void
+const setup = {
+  "new-billing-plans": true,
+  "new-homepage": false
+};
+features.setup(setup); // $ExpectType void
+withFeature('new-homepage'); // $ExpectType void

--- a/types/ember-feature-flags/index.d.ts
+++ b/types/ember-feature-flags/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for ember-feature-flags 3.0
+// Project: https://github.com/kategengler/ember-feature-flags#readme
+// Definitions by: Frank Tan <https://github.com/tansongyang>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+import Ember from 'ember';
+
+// https://github.com/kategengler/ember-feature-flags/blob/v3.0.0/addon/services/features.js#L5
+export default class Features extends Ember.Service {
+    setup(features: { [key: string]: boolean }): void;
+    enable(feature: string): void;
+    disable(feature: string): void;
+    isEnabled(feature: string): boolean;
+}

--- a/types/ember-feature-flags/tests/helpers/with-feature.d.ts
+++ b/types/ember-feature-flags/tests/helpers/with-feature.d.ts
@@ -1,0 +1,3 @@
+// https://www.npmjs.com/package/ember-feature-flags#withfeature
+// https://github.com/kategengler/ember-feature-flags/blob/v3.0.0/test-support/helpers/with-feature.js#L3
+declare function withFeature(name: string): void;

--- a/types/ember-feature-flags/tsconfig.json
+++ b/types/ember-feature-flags/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "tests/helpers/with-feature.d.ts",
+        "ember-feature-flags-tests.ts"
+    ]
+}

--- a/types/ember-feature-flags/tslint.json
+++ b/types/ember-feature-flags/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`. _We cannot set `strictFunctionTypes` because these types depend on `ember` types, which fail to compile with `tsc` when `strictFunctionTypes` is on._