### PR TITLE
[atom] Remove undefined from return-type of atom.config.get

### DIFF
--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -396,7 +396,7 @@ export interface Config {
     /** Retrieves the setting for the given key. */
     get<T extends keyof ConfigValues>(keyPath: T, options?: { sources?: string[],
         excludeSources?: string[], scope?: string[]|ScopeDescriptor }):
-        ConfigValues[T]|undefined;
+        ConfigValues[T];
 
     /**
      *  Sets the value for a configuration setting.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://atom.io/docs/api/v1.23.1/Config#instance-get
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

So, I thought about it for a good while, and figured that it's *really* hard to get `atom.config.get` to return `undefined`. I might be wrong, so please correct me if so, but I can't invent a more-or-less feasible situation where it would. Of course, if package is not activated, it could. Or if a default value is not specified in the config schema. But former can only happen if something has horribly gone wrong, so it's arguable whether it should be handled (or even if it could be handled at all). And latter is basically user's own fault, and can be directly specified in `ConfigValues` if needed.

It's even more strange, considering that by default, return type of `atom.config.get` is `any|undefined`, which is just `any`.

I would argue that we could as well just assume that result is always `ConfigValues[T]` there.

For reference, current definition:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8c51dc56effadda2721c487acc34bb081f2fc77d/types/atom/index.d.ts#L397-L399

Proposed definition:
```ts
 get<T extends keyof ConfigValues>(keyPath: T, options?: { sources?: string[], 
     excludeSources?: string[], scope?: string[]|ScopeDescriptor }): 
     ConfigValues[T]; 
```

/cc @smhxx, @GlenCFL

This requires discussion, but I went ahead and created a PR anyway. We can always close it after all.