### PR TITLE
[atom] atom.workspace.isTextEditor is a type assertion and should be marked as such

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -3102,7 +3102,9 @@ function testWorkspace() {
 
     obj = atom.workspace.createItemForURI("https://test");
 
-    bool = atom.workspace.isTextEditor(obj);
+    if (atom.workspace.isTextEditor(obj)) {
+      const textEditor: Atom.TextEditor = obj;
+    }
 
     async function workspaceReopen() {
         const result = await atom.workspace.reopenItem();

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -2697,7 +2697,7 @@ export interface Workspace {
     createItemForURI(uri: string): Promise<object|TextEditor>;
 
     /** Returns a boolean that is true if object is a TextEditor. */
-    isTextEditor(object: object): boolean;
+    isTextEditor(object: object): object is TextEditor;
 
     /**
      *  Asynchronously reopens the last-closed item's URI if it hasn't already


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://atom.io/docs/api/v1.23.1/Workspace#instance-isTextEditor
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Pretty much what the subject says, if `atom.workspace.isTextEditor(obj)` returns `true`, we're pretty sure that `obj` is a `TextEditor`, might as well reflect that in the return type.