### PR TITLE
[atom] add type guarding to isFile() and isDirectory() methods

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -32,6 +32,7 @@ declare let editor: Atom.TextEditor;
 declare let editors: Atom.TextEditor[];
 declare let emitter: Atom.Emitter;
 declare let file: Atom.File;
+declare let fileOrDir: Atom.File | Atom.Directory;
 declare let grammar: Atom.Grammar;
 declare let grammars: Atom.Grammar[];
 declare let gutter: Atom.Gutter;
@@ -964,6 +965,16 @@ function testFile() {
 
     file.createWriteStream();
     file.writeSync("Test");
+}
+
+// File/Directory Type Guarding ===============================================
+function testFileDirectoryTypeGuarding() {
+    if (fileOrDir.isFile()) {
+      file = fileOrDir;
+    }
+    if (fileOrDir.isDirectory()) {
+      dir = fileOrDir;
+    }
 }
 
 // GitRepository ==============================================================

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -3279,10 +3279,10 @@ export class Directory {
 
     // Directory Metadata
     /** Returns a boolean, always false. */
-    isFile(): boolean;
+    isFile(): this is File;
 
     /** Returns a roolean, always true. */
-    isDirectory(): boolean;
+    isDirectory(): this is Directory;
 
     /** Returns a boolean indicating whether or not this is a symbolic link. */
     isSymbolicLink(): boolean;
@@ -3496,10 +3496,10 @@ export class File {
 
     // File Metadata
     /** Returns a boolean, always true. */
-    isFile(): boolean;
+    isFile(): this is File;
 
     /** Returns a boolean, always false. */
-    isDirectory(): boolean;
+    isDirectory(): this is Directory;
 
     /** Returns a boolean indicating whether or not this is a symbolic link. */
     isSymbolicLink(): boolean;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://atom.io/docs/api/v1.23.1/File
https://atom.io/docs/api/v1.23.1/Directory
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

While reviewing #22590, I realized that there were actually two more methods that should ideally be designated as user-defined type guards. These are the `isFile()` and `isDirectory()` methods of the `File` and `Directory` classes. It's a bit strange, since the two classes don't share a (public) superclass, but the signatures of many of their methods actually *are* shared. Anyway, the point is that a very small number of API methods have a return value of type `File|Directory` and these methods are the provided way of determining which type the value belongs to. As such, they should really be declared as type guards so that tooling (compilers, linters, etc.) will be able to understand those use cases. 👍