### PR TITLE
which: Fixes typo in my username in author credits

### DIFF
--- a/types/which/index.d.ts
+++ b/types/which/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for which 1.3.0
 // Project: https://github.com/isaacs/node-which
-// Definitions by: vvakame <https://github.com/vvakame>, cspotcoxe <https://github.com/cspotcode>
+// Definitions by: vvakame <https://github.com/vvakame>
+//                 cspotcode <https://github.com/cspotcode>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 


### PR DESCRIPTION
Normal PR template doesn't apply because this merely fixes a typo in the comment headers.  No functional code changes.

Related to #22437