### PR TITLE
dockerode: Fix ContainerInspectInfo according to Docker REST API documentation.

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -400,10 +400,10 @@ declare namespace Dockerode {
       LinkLocalIPv6Address: string;
       LinkLocalIPv6PrefixLen: number;
       Ports: {
-        [portAndProtocol: string]: {
+        [portAndProtocol: string]: Array<{
           HostIp: string;
           HostPort: string;
-        }
+        }>;
       };
       SandboxKey: string;
       SecondaryIPAddresses?: any;


### PR DESCRIPTION
The Ports field is a map of string to _array_ of Ip/Port objects, as you
can see in the docs: https://docs.docker.com/engine/api/v1.32/#operation/ContainerInspect

As a result of this error type checks are not being run. e.g. Doing
`container.inspect().NetworkSettings.Ports['test'][0].BadField` will
compile without error, despite `BadField` to existing in the interface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.docker.com/engine/api/v1.32/#operation/ContainerInspect
