### PR TITLE
@types/react-list: replace obsolete React.Props

### DIFF
--- a/types/react-list/index.d.ts
+++ b/types/react-list/index.d.ts
@@ -6,7 +6,8 @@
 
 import {
     Component,
-    Props
+    DetailedHTMLProps,
+    HTMLAttributes
 } from "react";
 
 type ItemRenderer = (index: number, key: number | string) => JSX.Element;
@@ -15,7 +16,7 @@ type ItemSizeEstimator = (index: number, cache: {}) => number;
 type ItemSizeGetter = (index: number) => number;
 type ScrollParentGetter = () => JSX.Element;
 
-interface ReactListProps extends Props<ReactList> {
+interface ReactListProps extends DetailedHTMLProps<HTMLAttributes<ReactList>, ReactList> {
     axis?: 'x' | 'y';
     initialIndex?: number;
     itemRenderer?: ItemRenderer;

--- a/types/react-list/react-list-tests.tsx
+++ b/types/react-list/react-list-tests.tsx
@@ -7,6 +7,7 @@ const renderItem = (index: number, key: number) =>
     </div>;
 
 <ReactList
+    className="react-list"
     itemRenderer={renderItem}
     type="uniform"
     length={1000}


### PR DESCRIPTION
Replaced React.Props with React.DetailedHTMLProps. This fixes a condition where className attribute couldn't be used with <ReactList/>