### PR TITLE
@types/redux-first-router: Improve StateGetter and RouteThunk by including State

### DIFF
--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -232,7 +232,7 @@ export function connectRoutes<TKeys = {}, TState = any>(
 ): {
         reducer: Reducer<LocationState<TKeys, TState>>;
         middleware: Middleware;
-        thunk<ThunkState = TState>(store: Store<ThunkState>): Promise<Nullable<RouteThunk<ThunkState>>>;
+        thunk(store: Store<TState>): Promise<Nullable<RouteThunk<TState>>>;
         enhancer: StoreEnhancer<TState>;
         initialDispatch?(): void;
     };

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -23,7 +23,7 @@ export type StateGetter<TState = any> = () => TState;
 export type RouteString = string;
 
 export type RouteThunk<TState = any> = (
-    dispatch: Dispatch<TState>,
+    dispatch: Dispatch<any>,
     getState: StateGetter<TState>,
 ) => any | Promise<any>;
 
@@ -195,9 +195,9 @@ export interface Options<TKeys = {}, TState = any> {
     location?: string | SelectLocationState<TKeys, TState>;
     notFoundPath?: string;
     scrollTop?: boolean;
-    onBeforeChange?(dispatch: Dispatch<TState>, getState: StateGetter<TState>): void;
-    onAfterChange?(dispatch: Dispatch<TState>, getState: StateGetter<TState>): void;
-    onBackNext?(dispatch: Dispatch<TState>, getState: StateGetter<TState>): void;
+    onBeforeChange?(dispatch: Dispatch<any>, getState: StateGetter<TState>): void;
+    onAfterChange?(dispatch: Dispatch<any>, getState: StateGetter<TState>): void;
+    onBackNext?(dispatch: Dispatch<any>, getState: StateGetter<TState>): void;
     restoreScroll?(history: History): ScrollBehavior;
     initialDispatch?: boolean;
     querySerializer?: QuerySerializer;

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -12,7 +12,7 @@ import {
     Store,
     Reducer,
     Middleware,
-    StoreEnhancer
+    GenericStoreEnhancer
 } from 'redux';
 import { History } from 'history';
 
@@ -233,7 +233,7 @@ export function connectRoutes<TKeys = {}, TState = any>(
         reducer: Reducer<LocationState<TKeys, TState>>;
         middleware: Middleware;
         thunk(store: Store<TState>): Promise<Nullable<RouteThunk<TState>>>;
-        enhancer: StoreEnhancer<TState>;
+        enhancer: GenericStoreEnhancer;
         initialDispatch?(): void;
     };
 

--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -45,7 +45,7 @@ const routesMap: RoutesMap<Keys, State> = {
         path: '/status',
         role: 'user',
         thunk: (dispatch, getState) => {
-            dispatch; // $ExpectType Dispatch<State>
+            dispatch; // $ExpectType Dispatch<any>
             getState; // $ExpectType StateGetter<State>
         }
     }
@@ -60,7 +60,7 @@ const {
 } = connectRoutes(history, routesMap, {
         initialDispatch: false,
         onBeforeChange: (dispatch, getState) => {
-            dispatch; // $ExpectType Dispatch<State>
+            dispatch; // $ExpectType Dispatch<any>
             getState; // $ExpectType StateGetter<State>
         },
         location: state => {

--- a/types/redux-first-router/redux-first-router-tests.ts
+++ b/types/redux-first-router/redux-first-router-tests.ts
@@ -18,21 +18,36 @@ import {
     compose,
     Action,
     GenericStoreEnhancer,
-    StoreEnhancerStoreCreator
+    StoreEnhancerStoreCreator,
+    combineReducers
 } from 'redux';
 import { History } from 'history';
 
 declare var console: any;
 declare var history: History;
 
-type State = LocationState;
+interface Keys {
+    role: string;
+}
+interface State {
+    location: LocationState<Keys, State>;
+    stale: boolean;
+}
 type StoreCreator = StoreEnhancerStoreCreator<State>;
 
-const routesMap: RoutesMap<{ role: string }> = {
+const routesMap: RoutesMap<Keys, State> = {
     HOME: '/',
     ADMIN: {
         path: '/admin',
         role: 'admin'
+    },
+    STATUS: {
+        path: '/status',
+        role: 'user',
+        thunk: (dispatch, getState) => {
+            dispatch; // $ExpectType Dispatch<State>
+            getState; // $ExpectType StateGetter<State>
+        }
     }
 };
 
@@ -40,10 +55,23 @@ const {
     reducer,
     middleware,
     enhancer,
-    initialDispatch
+    initialDispatch,
+    thunk,
 } = connectRoutes(history, routesMap, {
-    initialDispatch: false
-});
+        initialDispatch: false,
+        onBeforeChange: (dispatch, getState) => {
+            dispatch; // $ExpectType Dispatch<State>
+            getState; // $ExpectType StateGetter<State>
+        },
+        location: state => {
+            const locationState = state.location; // $ExpectType LocationState<Keys, State>
+            return locationState;
+        },
+        title: state => {
+            const title = state.location.pathname; // $ExpectType string
+            return title;
+        }
+    });
 
 const dumbMiddleware: Middleware = store => next => action => next(action);
 
@@ -54,7 +82,15 @@ const storeEnhancer = compose<StoreCreator, StoreCreator, StoreCreator>(
     composedMiddleware
 );
 
-const store = createStore(reducer, storeEnhancer);
+const combined = combineReducers<State>({ location: reducer });
+
+const store = createStore(combined, storeEnhancer);
+
+// Test that `thunk()` has correct state types now that `store` is defined
+thunk(store)
+    .then((t) => {
+        t = t!; // $ExpectType RouteThunk<State>
+    });
 
 const receivedAction: ReceivedAction = {
     type: 'HOME',
@@ -73,5 +109,7 @@ const action: ReduxFirstRouterAction = {
 };
 redirect(action); // $ExpectType Action
 
-// $ExpectType Store<LocationState>
+// $ExpectType Store<State>
 store;
+
+store.getState().location.routesMap; // $ExpectType RoutesMap<Keys, State>


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/faceyspacey/redux-first-router/tree/master/src

The case i ran into was 

```typescript
const routesMap: RoutesMap = {
    HOME: {
        path: '/',
        thunk: async (dispatch, getState) => {
            const state = getState(); // will be typed as `object`
            if (state.loading) { // Property 'loading' does not exist on type 'object'
                 //
            }
        },
    },
};
```

Which leaves us with a state that only have `object` type. Since it is `object` instead of `any` also means that trying to access any property on `state` will fail. Current work around is to define it in every thunk;

```typescript
const routesMap: RoutesMap = {
    HOME: {
        path: '/',
        thunk: async (dispatch, getState: () => State) => {
            const state = getState(); // will be typed as `State`
            if (state.loading) {
                //
            }
        },
    },
};
```

I suggest allowing us to provide the shape of our state to allow for better typed thunks:

```typescript
const routesMap: RoutesMap<{}, State> = {
    HOME: {
        path: '/',
        thunk: async (dispatch, getState) => {
            const state = getState(); // will be typed as `State`
            if (state.loading) {
                //
            }
            dispatch; // will be typed as `Dispatch<State>`
        },
    },
};
```

I also default the statetype to `any` so that if you do not provide a stateType, you can still access the state properties.

I applied the same logic across the entire typing, always allowing typing of state.