### PR TITLE
inline-style-prefixer missing CSSStyleDeclaration

### DIFF
--- a/types/inline-style-prefixer/index.d.ts
+++ b/types/inline-style-prefixer/index.d.ts
@@ -4,6 +4,8 @@
 //                 dpetrezselyova <https://github.com/dpetrezselyova>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+declare type CSSStyleDeclaration = any;
+
 declare namespace InlineStylePrefixer {
     interface Configuration {
         userAgent?: string;

--- a/types/inline-style-prefixer/index.d.ts
+++ b/types/inline-style-prefixer/index.d.ts
@@ -4,7 +4,7 @@
 //                 dpetrezselyova <https://github.com/dpetrezselyova>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare type CSSStyleDeclaration = any;
+type CSSStyleDeclaration = any;
 
 declare namespace InlineStylePrefixer {
     interface Configuration {


### PR DESCRIPTION
If changing an existing definition:

inline-style-prefixer missing CSSStyleDeclaration
