### PR TITLE
@types/yargs wrap should accept null parameter

### DIFF
--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -214,7 +214,7 @@ declare namespace yargs {
         version(optionKey: string, version: string): Argv;
         version(optionKey: string, description: string, version: string): Argv;
 
-        wrap(columns: number): Argv;
+        wrap(columns: number | null): Argv;
     }
 
     interface Arguments {

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yargs 10.0
+// Type definitions for yargs 10.0.1
 // Project: https://github.com/chevex/yargs
 // Definitions by: Martin Poelstra <https://github.com/poelstra>
 //                 Mizunashi Mana <https://github.com/mizunashi-mana>

--- a/types/yargs/index.d.ts
+++ b/types/yargs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for yargs 10.0.1
+// Type definitions for yargs 10.0
 // Project: https://github.com/chevex/yargs
 // Definitions by: Martin Poelstra <https://github.com/poelstra>
 //                 Mizunashi Mana <https://github.com/mizunashi-mana>


### PR DESCRIPTION
According to the yargs documentation, `.wrap()` accepts null to mean "no wrapping"

See: https://github.com/yargs/yargs/blob/master/docs/api.md#wrapcolumns

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/yargs/yargs/blob/master/docs/api.md#wrapcolumns
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
