### PR TITLE
@types/express-busboy: New typing for version 6.0

### DIFF
--- a/types/express-busboy/express-busboy-tests.ts
+++ b/types/express-busboy/express-busboy-tests.ts
@@ -1,0 +1,7 @@
+import * as expressBusboy from 'express-busboy';
+
+import * as express from 'express';
+
+const app: express.Application = express();
+const options: expressBusboy.ExpressBusboyOptions = {};
+const result: express.Application = expressBusboy.extend(app, options);

--- a/types/express-busboy/index.d.ts
+++ b/types/express-busboy/index.d.ts
@@ -1,0 +1,18 @@
+// Type definitions for express-busboy 6.0
+// Project: https://github.com/yahoo/express-busboy
+// Definitions by: Pinguet62 <https://github.com/pinguet62>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import * as connectBusboy from 'connect-busboy';
+import * as express from 'express';
+
+export interface ExpressBusboyOptions extends connectBusboy.ConnectBusboyOptions {
+    upload?: number;
+    path?: string;
+    allowedPath?: string | RegExp | ((url: string) => boolean);
+    restrictMultiple?: boolean;
+    mimeTypeLimit?: string | string[];
+}
+
+export function extend(app: express.Application, options?: ExpressBusboyOptions): express.Application;

--- a/types/express-busboy/tsconfig.json
+++ b/types/express-busboy/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-busboy-tests.ts"
+    ]
+}

--- a/types/express-busboy/tslint.json
+++ b/types/express-busboy/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.