### PR TITLE
add export to `text-encoding-utf-8` types

### DIFF
--- a/types/text-encoding-utf-8/index.d.ts
+++ b/types/text-encoding-utf-8/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Paul Taylor <https://github.com/trxcllnt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare namespace TextEncoding {
+export namespace TextEncoding {
     interface TextDecoderOptions {
         fatal?: boolean;
         ignoreBOM?: boolean;
@@ -49,8 +49,8 @@ declare namespace TextEncoding {
     }
 }
 
-declare var TextDecoder: TextEncoding.TextDecoderStatic;
+export const TextDecoder: TextEncoding.TextDecoderStatic;
 
-declare var TextEncoder: TextEncoding.TextEncoderStatic;
+export const TextEncoder: TextEncoding.TextEncoderStatic;
 
-declare var TextEncoding: TextEncoding.TextEncodingStatic;
+export const TextEncoding: TextEncoding.TextEncodingStatic;

--- a/types/text-encoding-utf-8/index.d.ts
+++ b/types/text-encoding-utf-8/index.d.ts
@@ -54,3 +54,5 @@ export const TextDecoder: TextEncoding.TextDecoderStatic;
 export const TextEncoder: TextEncoding.TextEncoderStatic;
 
 export const TextEncoding: TextEncoding.TextEncodingStatic;
+
+export as namespace TextEncoding;

--- a/types/text-encoding-utf-8/text-encoding-utf-8-tests.ts
+++ b/types/text-encoding-utf-8/text-encoding-utf-8-tests.ts
@@ -1,3 +1,5 @@
+import { TextDecoder, TextEncoder } from "text-encoding-utf-8";
+
 function test_encoder() {
     const text = "plain text";
     let uint8array: Uint8Array;


### PR DESCRIPTION
small fix to export the `TextEncoding` namespace declarations
  