### PR TITLE
cucumber: add status enum

### DIFF
--- a/types/cucumber/cucumber-tests.ts
+++ b/types/cucumber/cucumber-tests.ts
@@ -12,6 +12,7 @@ function StepSample() {
     type Callback = cucumber.CallbackStepDefinition;
     type Table = cucumber.TableDefinition;
     type HookScenarioResult = cucumber.HookScenarioResult;
+    const Status = cucumber.Status;
 
     cucumber.defineSupportCode(({setWorldConstructor, defineParameterType, After, AfterAll, Around, Before, BeforeAll, registerHandler, Given, When, Then}) => {
         setWorldConstructor(function({attach, parameters}) {
@@ -23,17 +24,17 @@ function StepSample() {
         });
 
         Before((scenarioResult: HookScenarioResult, callback: Callback) => {
-            console.log(scenarioResult.status === "failed");
+            console.log(scenarioResult.status === Status.FAILED);
             callback();
         });
 
         Before({ timeout: 1000 }, (scenarioResult: HookScenarioResult, callback: Callback) => {
-            console.log(scenarioResult.status === "failed");
+            console.log(scenarioResult.status === Status.FAILED);
             callback();
         });
 
         Before('@tag', (scenarioResult: HookScenarioResult, callback: Callback) => {
-            console.log(scenarioResult.status === "failed");
+            console.log(scenarioResult.status === Status.FAILED);
             callback();
         });
 
@@ -53,7 +54,7 @@ function StepSample() {
         });
 
         Around((scenarioResult: HookScenarioResult, runScenario: (error: string | null, callback?: () => void) => void) => {
-            if (scenarioResult.status === "failed") {
+            if (scenarioResult.status === Status.FAILED) {
                 runScenario(null, () => {
                     console.log('finish tasks');
                 });

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -4,8 +4,18 @@
 //                 Jan Molak <https://github.com/jan-molak>
 //                 Isaiah Soung <https://github.com/isoung>
 //                 BendingBender <https://github.com/BendingBender>
+//                 ErikSchierboom <https://github.com/ErikSchierboom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.4
+
+export enum Status {
+    AMBIGUOUS = "ambiguous",
+    FAILED = "failed",
+    PASSED = "passed",
+    PENDING = "pending",
+    SKIPPED = "skipped",
+    UNDEFINED = "undefined"
+}
 
 export interface World {
     [key: string]: any;
@@ -43,7 +53,7 @@ export interface HookScenarioResult {
     duration: number;
     failureException: Error;
     scenario: Scenario;
-    status: string;
+    status: Status;
     stepsResults: any;
 }
 
@@ -142,7 +152,7 @@ export namespace events {
         duration: any;
         failureException: Error;
         scenario: Scenario;
-        status: string;
+        status: Status;
         stepResults: any[];
     }
 
@@ -164,7 +174,7 @@ export namespace events {
         failureException: Error;
         step: Step;
         stepDefinition: StepDefinition;
-        status: string;
+        status: Status;
     }
 }
 


### PR DESCRIPTION
This PR adds an enumeration to represent the status enumeration defined here: https://github.com/cucumber/cucumber-js/blob/master/src/status.js#L3