### PR TITLE
add hash argument in the constructor

### DIFF
--- a/types/navigo/index.d.ts
+++ b/types/navigo/index.d.ts
@@ -15,7 +15,7 @@ declare class Navigo {
      * @param root The main URL of your application.
      * @param useHash If useHash set to true then the router uses an old routing approach with hash in the URL. Navigo anyways falls back to this mode if there is no History API supported.
      */
-    constructor(root?: string | null, useHash?: boolean);
+    constructor(root?: string | null, useHash?: boolean, hash?: string);
 
     on(location: string, handler: RouteHandler, hooks?: NavigoHooks): Navigo;
     on(location: RegExp, handler: (...parameters: string[]) => void, hooks?: NavigoHooks): Navigo;


### PR DESCRIPTION
The argument hash was missed in the constructor (see more in https://github.com/krasimir/navigo)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
