### PR TITLE
[cucumber] Update the HookScenarioResult to match the v3 api

### DIFF
--- a/types/cucumber/cucumber-tests.ts
+++ b/types/cucumber/cucumber-tests.ts
@@ -24,17 +24,17 @@ function StepSample() {
         });
 
         Before((scenarioResult: HookScenarioResult, callback: Callback) => {
-            console.log(scenarioResult.status === Status.FAILED);
+            console.log(scenarioResult.result.status === Status.FAILED);
             callback();
         });
 
         Before({ timeout: 1000 }, (scenarioResult: HookScenarioResult, callback: Callback) => {
-            console.log(scenarioResult.status === Status.FAILED);
+            console.log(scenarioResult.result.status === Status.FAILED);
             callback();
         });
 
         Before('@tag', (scenarioResult: HookScenarioResult, callback: Callback) => {
-            console.log(scenarioResult.status === Status.FAILED);
+            console.log(scenarioResult.result.status === Status.FAILED);
             callback();
         });
 
@@ -54,7 +54,7 @@ function StepSample() {
         });
 
         Around((scenarioResult: HookScenarioResult, runScenario: (error: string | null, callback?: () => void) => void) => {
-            if (scenarioResult.status === Status.FAILED) {
+            if (scenarioResult.result.status === Status.FAILED) {
                 runScenario(null, () => {
                     console.log('finish tasks');
                 });

--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -50,11 +50,49 @@ export interface StepDefinitions {
 }
 
 export interface HookScenarioResult {
+    sourceLocation: SourceLocation;
+    result: ScenarioResult;
+    pickle: pickle.Pickle;
+}
+
+export interface SourceLocation {
+    line: number;
+    url: string;
+}
+
+export interface ScenarioResult {
     duration: number;
-    failureException: Error;
-    scenario: Scenario;
     status: Status;
-    stepsResults: any;
+}
+
+export namespace pickle {
+    interface Pickle {
+        language: string;
+        locations: Location[];
+        name: string;
+        steps: Step[];
+        tags: string[];
+    }
+
+    interface Location {
+        column: number;
+        line: number;
+    }
+
+    interface Step {
+        arguments: Argument[];
+        locations: Location[];
+        text: string;
+    }
+
+    interface Argument {
+        rows: Cell[];
+    }
+
+    interface Cell {
+        location: Location;
+        value: string;
+    }
 }
 
 export type HookCode = (this: World, scenario: HookScenarioResult, callback?: CallbackStepDefinition) => void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md#afteroptions-fn
  - https://raw.githubusercontent.com/cucumber/cucumber/gherkin-v4.1.3/gherkin/testdata/good/datatables.feature.pickles.ndjson
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

----

I noticed the `HookScenarioResult` was still aligned the [v2 api](https://github.com/cucumber/cucumber-js/blob/2.x/docs/support_files/api_reference.md#afteroptions-fn).  This PR updates it to match the [v3 api](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md#afteroptions-fn).

I added the `pickle` namespace to contain the types needed for the `Pickle` object graph, and used to the [sample pickle](https://raw.githubusercontent.com/cucumber/cucumber/gherkin-v4.1.3/gherkin/testdata/good/datatables.feature.pickles.ndjson) to infer the types for this graph.
