### PR TITLE
[restify] Fix build by removing wrong headers property from Response

### DIFF
--- a/types/restify/index.d.ts
+++ b/types/restify/index.d.ts
@@ -731,9 +731,6 @@ export interface Response extends http.ServerResponse {
     /** short hand for the header content-type. */
     contentType: string;
 
-    /** response headers. */
-    headers: any;
-
     /** A unique request id (x-request-id). */
     id: string;
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/restify/node-restify/blob/master/lib/response.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Got following error in #22171. Took a look into source code and it seems the `headers: any` property is wrong and therefore I removed it.

```
Error in restify
Command failed: node /home/travis/build/DefinitelyTyped/DefinitelyTyped/node_modules/dtslint/bin/index.js --onlyTestTsNext
Error: /home/travis/build/DefinitelyTyped/DefinitelyTyped/types/restify/index.d.ts
ERROR: 735:5  expect  TypeScript@next compile error: 
Subsequent property declarations must have the same type.  Property 'headers' must be of type '() => any', but here has type 'any'.
```

@blittle, @stevehipwell