### PR TITLE
Add `getRenderTarget`; deprecate `getCurrentRenderTarget()`

### DIFF
--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -1,6 +1,6 @@
-// Type definitions for three.js 0.84
-// Project: http://mrdoob.github.com/three.js/
-// Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>, HouChunlei <https://github.com/omni360>, Ivo <https://github.com/ivoisbelongtous>, David Asmuth <https://github.com/piranha771>, Brandon Roberge, Qinsi ZHU <https://github.com/qszhusightp>, Toshiya Nakakura <https://github.com/nakakura>, Poul Kjeldager Sørensen <https://github.com/s093294>, Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>, Roelof Jooste <https://github.com/PsychoSTS>
+// Type definitions for three.js 0.89
+// Project: https://threejs.org
+// Definitions by: Kon <http://phyzkit.net/>, Satoru Kimura <https://github.com/gyohk>, Florent Poujol <https://github.com/florentpoujol>, SereznoKot <https://github.com/SereznoKot>, HouChunlei <https://github.com/omni360>, Ivo <https://github.com/ivoisbelongtous>, David Asmuth <https://github.com/piranha771>, Brandon Roberge, Qinsi ZHU <https://github.com/qszhusightp>, Toshiya Nakakura <https://github.com/nakakura>, Poul Kjeldager Sørensen <https://github.com/s093294>, Stefan Profanter <https://github.com/Pro>, Edmund Fokschaner <https://github.com/efokschaner>, Roelof Jooste <https://github.com/PsychoSTS>, Daniel Hritzkiv <https://github.com/dhritzkiv>
 // Definitions: https://github.com//DefinitelyTyped
 
 export * from "./three-core";

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5216,6 +5216,10 @@ export class WebGLRenderer implements Renderer {
     setTexture(texture: Texture, slot: number): void;
     setTexture2D(texture: Texture, slot: number): void;
     setTextureCube(texture: Texture, slot: number): void;
+    getRenderTarget(): RenderTarget;
+	/**
+     * @deprecated Use getRenderTarget instead.
+     */
     getCurrentRenderTarget(): RenderTarget;
     setRenderTarget(renderTarget: RenderTarget): void;
     readRenderTargetPixels( renderTarget: RenderTarget, x: number, y: number, width: number, height: number, buffer: any ): void;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - [new method](https://github.com/mrdoob/three.js/blob/da2936540a48774b043a1e617bddbdce5102e417/src/renderers/WebGLRenderer.js#L2422-L2426)
    - [deprecated](https://github.com/mrdoob/three.js/blob/fd1419c0e18c75009b9c6568096242a513a04a2b/src/Three.Legacy.js#L1235-L1240)
- [x] Increase the version number in the header if appropriate.