### PR TITLE
Create correct major version for webpack-dev-middleware (fixes bugs from #22267)

### DIFF
--- a/types/webpack-dev-middleware/v1/index.d.ts
+++ b/types/webpack-dev-middleware/v1/index.d.ts
@@ -1,13 +1,12 @@
-// Type definitions for webpack-dev-middleware 2.0
+// Type definitions for webpack-dev-middleware 1.12
 // Project: https://github.com/webpack/webpack-dev-middleware
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
 //                 reduckted <https://github.com/reduckted>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import * as webpack from 'webpack';
-import * as loglevel from 'loglevel';
 import { NextHandleFunction } from 'connect';
+import * as webpack from 'webpack';
 import MemoryFileSystem = require('memory-fs');
 
 export = WebpackDevMiddleware;
@@ -19,7 +18,8 @@ declare function WebpackDevMiddleware(
 
 declare namespace WebpackDevMiddleware {
 	interface Options {
-		logLevel?: string;
+		noInfo?: boolean;
+		quiet?: boolean;
 		lazy?: boolean;
 		watchOptions?: webpack.Options.WatchOptions;
 		publicPath: string;
@@ -30,18 +30,22 @@ declare namespace WebpackDevMiddleware {
 		stats?: webpack.Options.Stats;
 		reporter?: Reporter | null;
 		serverSideRender?: boolean;
-		logger?: Logger;
+
+		log?: Logger;
+		warn?: Logger;
+		error?: Logger;
 		filename?: string;
 	}
 
 	interface ReporterOptions {
 		state: boolean;
-		stats?: webpack.Stats;
-		log: Logger;
+		stats: webpack.Stats;
+		options: Options;
 	}
 
-	type Logger = loglevel.Logger;
-	type Reporter = (middlewareOptions: Options, reporterOptions: ReporterOptions) => void;
+	type Reporter = (reporterOptions: ReporterOptions) => void;
+
+	type Logger = (message?: any, ...optionalParams: any[]) => void;
 
 	interface WebpackDevMiddleware {
 		close(callback?: () => void): void;

--- a/types/webpack-dev-middleware/v1/tsconfig.json
+++ b/types/webpack-dev-middleware/v1/tsconfig.json
@@ -12,6 +12,11 @@
         "typeRoots": [
             "../../"
         ],
+        "paths": {
+            "webpack-dev-middleware": [
+                "webpack-dev-middleware/v1"
+            ]
+        },
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true

--- a/types/webpack-dev-middleware/v1/tsconfig.json
+++ b/types/webpack-dev-middleware/v1/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../../",
+        "typeRoots": [
+            "../../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "webpack-dev-middleware-tests.ts"
+    ]
+}

--- a/types/webpack-dev-middleware/v1/tslint.json
+++ b/types/webpack-dev-middleware/v1/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/webpack-dev-middleware/v1/webpack-dev-middleware-tests.ts
+++ b/types/webpack-dev-middleware/v1/webpack-dev-middleware-tests.ts
@@ -1,0 +1,50 @@
+import * as express from 'express';
+import * as webpack from 'webpack';
+import * as webpackDevMiddleware from 'webpack-dev-middleware';
+
+const compiler = webpack({});
+
+let webpackDevMiddlewareInstance = webpackDevMiddleware(compiler);
+
+webpackDevMiddlewareInstance = webpackDevMiddleware(compiler, {
+	noInfo: false,
+	quiet: false,
+	lazy: true,
+	watchOptions: {
+		aggregateTimeout: 300,
+		poll: true,
+	},
+	publicPath: '/assets/',
+	index: 'index.html',
+	headers: {
+		'X-Custom-Header': 'yes'
+	},
+	stats: {
+		colors: true,
+	},
+	reporter: null,
+	serverSideRender: false,
+});
+
+const app = express();
+app.use([webpackDevMiddlewareInstance]);
+
+webpackDevMiddlewareInstance.close(() => {
+	console.log('closed');
+});
+
+webpackDevMiddlewareInstance.invalidate((stats) => {
+	console.log(stats.toJson());
+});
+
+webpackDevMiddlewareInstance.waitUntilValid((stats) => {
+	console.log('Package is in a valid state:' + stats.toJson());
+});
+
+const fs = webpackDevMiddlewareInstance.fileSystem;
+fs.mkdirpSync('foo');
+
+let filename = webpackDevMiddlewareInstance.getFilenameFromUrl('url');
+if (filename !== false) {
+	filename = filename.substr(0);
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22267
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

Sadly there was a bug in the CI (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22267#issuecomment-354517093) which didn't catch the errors of my incorrect pull request to include webpack-dev-middleware v2 changes (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22267). This PR tries to fix my older PR.
  
(Note: First time I created a new major version for lib here. Hope I checked everything.)