### PR TITLE
Update storybook__addon-notes

### DIFF
--- a/types/storybook__addon-notes/index.d.ts
+++ b/types/storybook__addon-notes/index.d.ts
@@ -1,10 +1,13 @@
-// Type definitions for @storybook/addon-notes 3.0
+// Type definitions for @storybook/addon-notes 3.3.3
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
 import * as React from 'react';
+import { RenderFunction } from '@storybook/react';
+
+export function withNotes(textOrOptions: string | object): (getStory: RenderFunction) => RenderFunction;
 
 export interface WithNotesProps extends React.HTMLProps<HTMLDivElement> {
     notes?: string;

--- a/types/storybook__addon-notes/storybook__addon-notes-tests.tsx
+++ b/types/storybook__addon-notes/storybook__addon-notes-tests.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react';
 
 import { storiesOf } from '@storybook/react';
-import { WithNotes } from '@storybook/addon-notes';
+import { withNotes, WithNotes } from '@storybook/addon-notes';
 
 storiesOf('Component', module)
   .add('with some emoji', () => (
     <WithNotes notes={'A very simple component'}>
       my component
     </WithNotes>
-  ));
+  ))
+  .add('with withNotes',
+    withNotes('A very simple component')(
+      () => (<div>my component</div>)
+    )
+  );


### PR DESCRIPTION
This implementation is deprecated in version 3.3.3

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/storybooks/storybook/blob/master/addons/notes/src/index.js>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.