### PR TITLE
Howler: Add stereo method overload

### DIFF
--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for howler.js v2.0.5
+// Type definitions for howler.js v2.0.7
 // Project: https://github.com/goldfire/howler.js
 // Definitions by: Pedro Casaubon <https://github.com/xperiments>, Todd Dukart <https://github.com/tdukart>, Alexander Leon <https://github.com/alien35>, Nicholas Higgins <https://github.com/nicholashza> 
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/howler/index.d.ts
+++ b/types/howler/index.d.ts
@@ -110,6 +110,7 @@ interface Howl {
     state(): 'unloaded' | 'loading' | 'loaded';
     load(): void;
     unload(): void;
+    stereo(): number | null;
     stereo(pan: number, id?: number): this | void;
     pos(x: number, y: number, z: number, id?: number): this | void;
     orientation(x: number, y: number, z: number, xUp: number, yUp: number, zUp: number): this | void;


### PR DESCRIPTION
Update stereo overload to allow getting of stereo panning value (calling stereo() with no arguments)
https://github.com/goldfire/howler.js#stereopan-id
Howler documentation erroneously shows that pan value is mandatory

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/goldfire/howler.js#stereopan-id
- [x] Increase the version number in the header if appropriate. **Updated, but no API changes triggered this**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
