### PR TITLE
Add mathjs createUnit()

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -30,7 +30,7 @@ declare namespace mathjs {
 
 		uninitialized: any;
 		version: string;
-		
+
 		config(options: any): void;
 
                 expression: MathNode;
@@ -554,6 +554,13 @@ declare namespace mathjs {
 		 */
 		unit(unit: string): Unit;
 		unit(value: number, unit: string): Unit;
+
+		/**
+                 * Create a user-defined unit and register it with the Unit type.
+		 */
+		createUnit(name: string): Unit;
+		createUnit(name: string, definition: string|UnitDefinition, options?: CreateUnitOptions): Unit;
+		createUnit(units: {[name: string]: string|UnitDefinition}, options?: CreateUnitOptions): Unit;
 
 		/**
 		 * Parse and compile an expression. Returns a an object with a function eval([scope]) to evaluate the compiled expression.
@@ -1344,6 +1351,17 @@ declare namespace mathjs {
 		toNumber(unit: string): number;
 	}
 
+	export interface CreateUnitOptions {
+		override?: boolean;
+	}
+
+	export interface UnitDefinition {
+		definition?: string|Unit;
+		prefixes?: string;
+		offset?: number;
+		aliases?: string[];
+	}
+
 	export interface Index {
 
 	}
@@ -1396,7 +1414,7 @@ declare namespace mathjs {
                  * @return {[type]}                 [description]
                  */
                 forEach(callback: (node: MathNode, path: string, parent: MathNode)=>any): MathNode[];
-		
+
 
                 /**
                 * `traverse(callback)`
@@ -1427,10 +1445,10 @@ declare namespace mathjs {
                 traverse(callback: (node: MathNode, path: string, parent: MathNode)=> void): any;
 //addEventListener(ev: 'change', callback: (ev: EditorChangeEvent) => any);
                 /**
-                 * Recursively transform an expression tree via a transform function. Similar to Array.map, 
-                 * but recursively executed on all nodes in the expression tree. The callback function is a 
-                 * mapping function accepting a node, and returning a replacement for the node or the original node. 
-                 * Function callback is called as callback(node: Node, path: string, parent: Node) for every node in 
+                 * Recursively transform an expression tree via a transform function. Similar to Array.map,
+                 * but recursively executed on all nodes in the expression tree. The callback function is a
+                 * mapping function accepting a node, and returning a replacement for the node or the original node.
+                 * Function callback is called as callback(node: Node, path: string, parent: Node) for every node in
                  * the tree, and must return a Node. Parameter path is a string containing a relative JSON Path.
                  *
                  * For example, to replace all nodes of type SymbolNode having name ‘x’ with a ConstantNode with value 3:
@@ -1449,9 +1467,9 @@ declare namespace mathjs {
                  */
                 transform(callback: (node: MathNode, path: string, parent: MathNode)=>MathNode): MathNode;
                 /**
-                 * Transform a node. Creates a new Node having it’s childs be the results of calling the provided 
-                 * callback function for each of the childs of the original node. The callback function is called 
-                 * as `callback(child: Node, path: string, parent: Node)` and must return a Node. 
+                 * Transform a node. Creates a new Node having it’s childs be the results of calling the provided
+                 * callback function for each of the childs of the original node. The callback function is called
+                 * as `callback(child: Node, path: string, parent: Node)` and must return a Node.
                  * Parameter path is a string containing a relative JSON Path.
                  *
                  *
@@ -2281,4 +2299,3 @@ declare namespace mathjs {
 declare module 'mathjs'{
 	export = math;
 }
-

--- a/types/mathjs/mathjs-tests.ts
+++ b/types/mathjs/mathjs-tests.ts
@@ -496,6 +496,35 @@ Units examples
 	var b = math.unit('0.1m'); // 100 mm
 	console.log();
 
+	// creating units
+	math.createUnit('foo');
+	math.createUnit('furlong', '220 yards');
+	math.createUnit('furlong', '220 yards', {override: true});
+	math.createUnit('fahrenheit', {definition: '0.555556 kelvin', offset: 459.67});
+	math.createUnit('fahrenheit', {definition: '0.555556 kelvin', offset: 459.67}, {override: true});
+	math.createUnit('knot', {definition: '0.514444 m/s', aliases: ['knots', 'kt', 'kts']});
+	math.createUnit('knot', {definition: '0.514444 m/s', aliases: ['knots', 'kt', 'kts']}, {override: true});
+	math.createUnit('knot', {
+		definition: '0.514444 m/s',
+		aliases: ['knots', 'kt', 'kts'],
+		prefixes: 'long'
+	}, {override: true});
+	math.createUnit( {
+		foo: {
+			prefixes: 'long'
+		},
+		bar: '40 foo',
+		baz: {
+			definition: '1 bar/hour',
+			prefixes: 'long'
+		}
+	}, {
+		override: true
+	});
+	// use Unit as definition
+	math.createUnit('c', {definition: b});
+	math.createUnit('c', {definition: b}, {override: true});
+
 	// units can be added, subtracted, and multiplied or divided by numbers and by other units
 	console.log('perform operations');
 	math.add(a, b);                                  // 0.55 m


### PR DESCRIPTION
### createUnit



- [y] Use a meaningful title for the pull request. Include the name of the package modified.
- [y] Test the change in your own code. (Compile and run.)
- [y] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [y] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


Changing an existing definition:
- [y] Provide a URL to documentation or source code which provides context for the suggested changes: http://mathjs.org/docs/datatypes/units.html#userdefined-units
http://mathjs.org/docs/reference/functions/createUnit.html
https://github.com/josdejong/mathjs/blob/master/lib/type/unit/function/createUnit.js#L47
https://github.com/josdejong/mathjs/blob/master/lib/type/unit/Unit.js#L3159
Note: the createUnit doc page shows `prefixes` as `object`, but it's listed as a string on the other page (first link), and in the code it's handled as a string with toUpperCase (last link).

- [n] Increase the version number in the header if appropriate.
- [n] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
