### PR TITLE
Add additional events emitted by kafka-node's Client

### DIFF
--- a/types/kafka-node/index.d.ts
+++ b/types/kafka-node/index.d.ts
@@ -10,13 +10,13 @@ export class Client {
     topicExists(topics: string[], cb: (error?: TopicsNotExistError | any) => any): void;
     refreshMetadata(topics: string[], cb?: (error?: any) => any): void;
     sendOffsetCommitV2Request(group: string, generationId: number, memberId: string, commits: OffsetCommitRequest[], cb: (error: any, data: any) => any): void;
+    // Note: socket_error is currently KafkaClient only, and zkReconnect is currently Client only.
+    on(eventName: "brokersChanged" | "close" | "connect" | "ready" | "reconnect" | "zkReconnect", cb: () => any): this;
+    on(eventName: "error" | "socket_error", cb: (error: any) => any): this;
 }
 
 export class KafkaClient extends Client {
     constructor(options?: KafkaClientOptions);
-    on(eventName: "ready", cb: () => any): this;
-    on(eventName: "reconnect", cb: () => void): this;
-    on(eventName: "error", cb: (error: any) => any): this;
     connect(): void;
 }
 


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18614Previously, only KafkaClient (subclass) had signatures for `on()`.
However, Client and KafkaClient emit many of the same events.
- See https://github.com/SOHU-Co/kafka-node/blob/master/lib/client.js
  and https://github.com/SOHU-Co/kafka-node/blob/master/lib/kafkaClient.js
  (Search for the string `emit(`)

zkReconnect is exclusive to Client, and socket_connect is exclusive to
KafkaClient. TypeScript's type checker warns if I put on() declarations
in KafkaClient. (Haven't tried duplicating.)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/SOHU-Co/kafka-node/blob/master/lib/client.js and  https://github.com/SOHU-Co/kafka-node/blob/master/lib/kafkaClient.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  