### PR TITLE
[reactstrap] Don't declare "popper.js" module, prevent TypeScript conflict error

### DIFF
--- a/types/reactstrap/lib/Popover.d.ts
+++ b/types/reactstrap/lib/Popover.d.ts
@@ -1,7 +1,7 @@
 /// <reference types='react' />
-/// <reference path="./Popper.d.ts" />
 
 import { CSSModule } from '../index';
+import Popper from './Popper';
 
 export interface PopoverProps extends React.HTMLAttributes<HTMLElement> {
   isOpen?: boolean;

--- a/types/reactstrap/lib/Popover.d.ts
+++ b/types/reactstrap/lib/Popover.d.ts
@@ -1,7 +1,7 @@
 /// <reference types='react' />
 
 import { CSSModule } from '../index';
-import Popper from './Popper';
+import {Popper} from './Popper';
 
 export interface PopoverProps extends React.HTMLAttributes<HTMLElement> {
   isOpen?: boolean;

--- a/types/reactstrap/lib/Popper.d.ts
+++ b/types/reactstrap/lib/Popper.d.ts
@@ -6,114 +6,114 @@
 // It should not define internal pieces such as utils or modifier details.
 // It has been copied from: https://raw.githubusercontent.com/FezVrasta/popper.js/master/packages/popper/index.d.ts
 
-declare namespace Popper {
-    export type Position = "top" | "right" | "bottom" | "left";
+export as namespace Popper;
 
-    export type Placement =
-        | "auto-start"
-        | "auto"
-        | "auto-end"
-        | "top-start"
-        | "top"
-        | "top-end"
-        | "right-start"
-        | "right"
-        | "right-end"
-        | "bottom-end"
-        | "bottom"
-        | "bottom-start"
-        | "left-end"
-        | "left"
-        | "left-start";
+export type Position = "top" | "right" | "bottom" | "left";
 
-    export type Boundary = "scrollParent" | "viewport" | "window";
+export type Placement =
+    | "auto-start"
+    | "auto"
+    | "auto-end"
+    | "top-start"
+    | "top"
+    | "top-end"
+    | "right-start"
+    | "right"
+    | "right-end"
+    | "bottom-end"
+    | "bottom"
+    | "bottom-start"
+    | "left-end"
+    | "left"
+    | "left-start";
 
-    export type ModifierFn = (data: Data, options: Object) => Data;
+export type Boundary = "scrollParent" | "viewport" | "window";
 
-    export interface BaseModifier {
-        order?: number;
-        enabled?: boolean;
-        fn?: ModifierFn;
-    }
+export type ModifierFn = (data: Data, options: Object) => Data;
 
-    export interface Modifiers {
-        shift?: BaseModifier;
-        offset?: BaseModifier & {
-            offset?: number | string;
-        };
-        preventOverflow?: BaseModifier & {
-            priority?: Position[];
-            padding?: number;
-            boundariesElement?: Boundary | Element;
-            escapeWithReference?: boolean;
-        };
-        keepTogether?: BaseModifier;
-        arrow?: BaseModifier & {
-            element?: string | Element;
-        };
-        flip?: BaseModifier & {
-            behavior?: "flip" | "clockwise" | "counterclockwise" | Position[];
-            padding?: number;
-            boundariesElement?: Boundary | Element;
-        };
-        inner?: BaseModifier;
-        hide?: BaseModifier;
-        applyStyle?: BaseModifier & {
-            onLoad?: Function;
-            gpuAcceleration?: boolean;
-        };
-        computeStyle?: BaseModifier & {
-            gpuAcceleration?: boolean;
-            x?: "bottom" | "top";
-            y?: "left" | "right";
-        };
-        [name: string]: (BaseModifier & Record<string, any>) | undefined;
-    }
-
-    export interface Offset {
-        top: number;
-        left: number;
-        width: number;
-        height: number;
-    }
-
-    export interface Data {
-        instance: Popper;
-        placement: Placement;
-        originalPlacement: Placement;
-        flipped: boolean;
-        hide: boolean;
-        arrowElement: Element;
-        styles: CSSStyleDeclaration;
-        boundaries: Object;
-        offsets: {
-            popper: Offset;
-            reference: Offset;
-            arrow: {
-                top: number;
-                left: number;
-            };
-        };
-    }
-
-    export interface PopperOptions {
-        placement?: Placement;
-        positionFixed: boolean;
-        eventsEnabled?: boolean;
-        modifiers?: Modifiers;
-        removeOnDestroy?: boolean;
-        onCreate?(data: Data): void;
-        onUpdate?(data: Data): void;
-    }
-
-    export interface ReferenceObject {
-        clientHeight: number;
-        clientWidth: number;
-        getBoundingClientRect(): ClientRect;
-    }
+export interface BaseModifier {
+    order?: number;
+    enabled?: boolean;
+    fn?: ModifierFn;
 }
 
-declare class Popper {
+export interface Modifiers {
+    shift?: BaseModifier;
+    offset?: BaseModifier & {
+        offset?: number | string;
+    };
+    preventOverflow?: BaseModifier & {
+        priority?: Position[];
+        padding?: number;
+        boundariesElement?: Boundary | Element;
+        escapeWithReference?: boolean;
+    };
+    keepTogether?: BaseModifier;
+    arrow?: BaseModifier & {
+        element?: string | Element;
+    };
+    flip?: BaseModifier & {
+        behavior?: "flip" | "clockwise" | "counterclockwise" | Position[];
+        padding?: number;
+        boundariesElement?: Boundary | Element;
+    };
+    inner?: BaseModifier;
+    hide?: BaseModifier;
+    applyStyle?: BaseModifier & {
+        onLoad?: Function;
+        gpuAcceleration?: boolean;
+    };
+    computeStyle?: BaseModifier & {
+        gpuAcceleration?: boolean;
+        x?: "bottom" | "top";
+        y?: "left" | "right";
+    };
+    [name: string]: (BaseModifier & Record<string, any>) | undefined;
+}
+
+export interface Offset {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+}
+
+export interface Data {
+    instance: Popper;
+    placement: Placement;
+    originalPlacement: Placement;
+    flipped: boolean;
+    hide: boolean;
+    arrowElement: Element;
+    styles: CSSStyleDeclaration;
+    boundaries: Object;
+    offsets: {
+        popper: Offset;
+        reference: Offset;
+        arrow: {
+            top: number;
+            left: number;
+        };
+    };
+}
+
+export interface PopperOptions {
+    placement?: Placement;
+    positionFixed: boolean;
+    eventsEnabled?: boolean;
+    modifiers?: Modifiers;
+    removeOnDestroy?: boolean;
+    onCreate?(data: Data): void;
+    onUpdate?(data: Data): void;
+}
+
+export interface ReferenceObject {
+    clientHeight: number;
+    clientWidth: number;
+    getBoundingClientRect(): ClientRect;
+}
+
+export class Popper {
     static modifiers: (Popper.BaseModifier & { name: string })[];
     static placements: Popper.Placement[];
     static Defaults: Popper.PopperOptions;
@@ -132,5 +132,3 @@ declare class Popper {
     enableEventListeners(): void;
     disableEventListeners(): void;
 }
-
-export default Popper;

--- a/types/reactstrap/lib/Popper.d.ts
+++ b/types/reactstrap/lib/Popper.d.ts
@@ -7,127 +7,130 @@
 // It has been copied from: https://raw.githubusercontent.com/FezVrasta/popper.js/master/packages/popper/index.d.ts
 
 declare namespace Popper {
-    export type Position = 'top' | 'right' | 'bottom' | 'left';
+    export type Position = "top" | "right" | "bottom" | "left";
 
-    export type Placement = 'auto-start'
-      | 'auto'
-      | 'auto-end'
-      | 'top-start'
-      | 'top'
-      | 'top-end'
-      | 'right-start'
-      | 'right'
-      | 'right-end'
-      | 'bottom-end'
-      | 'bottom'
-      | 'bottom-start'
-      | 'left-end'
-      | 'left'
-      | 'left-start';
+    export type Placement =
+        | "auto-start"
+        | "auto"
+        | "auto-end"
+        | "top-start"
+        | "top"
+        | "top-end"
+        | "right-start"
+        | "right"
+        | "right-end"
+        | "bottom-end"
+        | "bottom"
+        | "bottom-start"
+        | "left-end"
+        | "left"
+        | "left-start";
 
-    export type Boundary = 'scrollParent' | 'viewport' | 'window';
+    export type Boundary = "scrollParent" | "viewport" | "window";
 
     export type ModifierFn = (data: Data, options: Object) => Data;
 
     export interface BaseModifier {
-      order?: number;
-      enabled?: boolean;
-      fn?: ModifierFn;
+        order?: number;
+        enabled?: boolean;
+        fn?: ModifierFn;
     }
 
     export interface Modifiers {
-      shift?: BaseModifier;
-      offset?: BaseModifier & {
-        offset?: number | string,
-      };
-      preventOverflow?: BaseModifier & {
-        priority?: Position[],
-        padding?: number,
-        boundariesElement?: Boundary | Element,
-        escapeWithReference?: boolean
-      };
-      keepTogether?: BaseModifier;
-      arrow?: BaseModifier & {
-        element?: string | Element,
-      };
-      flip?: BaseModifier & {
-        behavior?: 'flip' | 'clockwise' | 'counterclockwise' | Position[],
-        padding?: number,
-        boundariesElement?: Boundary | Element,
-      };
-      inner?: BaseModifier;
-      hide?: BaseModifier;
-      applyStyle?: BaseModifier & {
-        onLoad?: Function,
-        gpuAcceleration?: boolean,
-      };
-      computeStyle?: BaseModifier & {
-          gpuAcceleration?: boolean;
-          x?: 'bottom' | 'top',
-          y?: 'left' | 'right'
-      };
-      [name: string]: (BaseModifier & Record<string, any>) | undefined;
+        shift?: BaseModifier;
+        offset?: BaseModifier & {
+            offset?: number | string;
+        };
+        preventOverflow?: BaseModifier & {
+            priority?: Position[];
+            padding?: number;
+            boundariesElement?: Boundary | Element;
+            escapeWithReference?: boolean;
+        };
+        keepTogether?: BaseModifier;
+        arrow?: BaseModifier & {
+            element?: string | Element;
+        };
+        flip?: BaseModifier & {
+            behavior?: "flip" | "clockwise" | "counterclockwise" | Position[];
+            padding?: number;
+            boundariesElement?: Boundary | Element;
+        };
+        inner?: BaseModifier;
+        hide?: BaseModifier;
+        applyStyle?: BaseModifier & {
+            onLoad?: Function;
+            gpuAcceleration?: boolean;
+        };
+        computeStyle?: BaseModifier & {
+            gpuAcceleration?: boolean;
+            x?: "bottom" | "top";
+            y?: "left" | "right";
+        };
+        [name: string]: (BaseModifier & Record<string, any>) | undefined;
     }
 
     export interface Offset {
-      top: number;
-      left: number;
-      width: number;
-      height: number;
+        top: number;
+        left: number;
+        width: number;
+        height: number;
     }
 
     export interface Data {
-      instance: Popper;
-      placement: Placement;
-      originalPlacement: Placement;
-      flipped: boolean;
-      hide: boolean;
-      arrowElement: Element;
-      styles: CSSStyleDeclaration;
-      boundaries: Object;
-      offsets: {
-        popper: Offset,
-        reference: Offset,
-        arrow: {
-          top: number,
-          left: number,
-        },
-      };
+        instance: Popper;
+        placement: Placement;
+        originalPlacement: Placement;
+        flipped: boolean;
+        hide: boolean;
+        arrowElement: Element;
+        styles: CSSStyleDeclaration;
+        boundaries: Object;
+        offsets: {
+            popper: Offset;
+            reference: Offset;
+            arrow: {
+                top: number;
+                left: number;
+            };
+        };
     }
 
     export interface PopperOptions {
-      placement?: Placement;
-      positionFixed: boolean;
-      eventsEnabled?: boolean;
-      modifiers?: Modifiers;
-      removeOnDestroy?: boolean;
-      onCreate?(data: Data): void;
-      onUpdate?(data: Data): void;
+        placement?: Placement;
+        positionFixed: boolean;
+        eventsEnabled?: boolean;
+        modifiers?: Modifiers;
+        removeOnDestroy?: boolean;
+        onCreate?(data: Data): void;
+        onUpdate?(data: Data): void;
     }
 
     export interface ReferenceObject {
-      clientHeight: number;
-      clientWidth: number;
-      getBoundingClientRect(): ClientRect;
+        clientHeight: number;
+        clientWidth: number;
+        getBoundingClientRect(): ClientRect;
     }
-  }
+}
 
-  declare class Popper {
+declare class Popper {
     static modifiers: (Popper.BaseModifier & { name: string })[];
     static placements: Popper.Placement[];
     static Defaults: Popper.PopperOptions;
 
     options: Popper.PopperOptions;
 
-    constructor(reference: Element | Popper.ReferenceObject, popper: Element, options?: Popper.PopperOptions);
+    constructor(
+        reference: Element | Popper.ReferenceObject,
+        popper: Element,
+        options?: Popper.PopperOptions
+    );
 
     destroy(): void;
     update(): void;
     scheduleUpdate(): void;
     enableEventListeners(): void;
     disableEventListeners(): void;
-  }
+}
 
-  declare module 'popper.js' {
-    export default Popper;
-  }
+export default Popper;

--- a/types/reactstrap/lib/Tooltip.d.ts
+++ b/types/reactstrap/lib/Tooltip.d.ts
@@ -1,7 +1,7 @@
 /// <reference types='react' />
 
 import { CSSModule } from '../index';
-import Popper from './Popper';
+import {Popper} from './Popper';
 
 export interface UncontrolledProps extends React.HTMLAttributes<HTMLElement> {
   target: string | HTMLElement;

--- a/types/reactstrap/lib/Tooltip.d.ts
+++ b/types/reactstrap/lib/Tooltip.d.ts
@@ -1,7 +1,7 @@
 /// <reference types='react' />
-/// <reference path="./Popper.d.ts" />
 
 import { CSSModule } from '../index';
+import Popper from './Popper';
 
 export interface UncontrolledProps extends React.HTMLAttributes<HTMLElement> {
   target: string | HTMLElement;


### PR DESCRIPTION
I recently submitted pull request #22512, which was merged.  However, upon updating my definitions, I realized that if a user has the `popper.js` node module installed, Typescript complains about conflicting type definitions.

This pull request removes the line re-declaring the popper.js module, and uses `import`s instead of `reference`s, keeping the definition internal.

I have copied this folder into my project's `node_modules/types/reactstrap` path, and it seems to work.  Please let me know if there is a better way to test it.

Also, apologies for pushing out an errant definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: **n/a — no external API changes, but rather fixing conflicting definition error**
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
