### PR TITLE
Rollup: transform/transformBundle can return a promise

### DIFF
--- a/types/rollup/index.d.ts
+++ b/types/rollup/index.d.ts
@@ -138,9 +138,9 @@ export interface Plugin {
 	 */
 	resolveId?(importee: string, importer: string | undefined): string | null | undefined | false | 0 | ''
 	/** A module transformer function */
-	transform?(this: TransformContext, source: string, id: string): string | null | undefined | { code: string, map: SourceMap }
+	transform?(this: TransformContext, source: string, id: string): TransformResult | Promise<TransformResult>
 	/** A bundle transformer function */
-	transformBundle?(source: string, options: { format: Format }): string | null | undefined | { code: string, map: SourceMap }
+	transformBundle?(source: string, options: { format: Format }): TransformResult | Promise<TransformResult>
 	/** Function hook called when bundle.generate() is being executed. */
 	ongenerate?(options: GenerateOptions, bundle: Bundle): void
 	/** Function hook called when bundle.write() is being executed, after the file has been written to disk. */
@@ -162,6 +162,8 @@ export interface TransformContext {
 	/** Emit an error, which will abort the bundling process */
 	error(message: string | { message: string }, pos?: number | { line: number, column: number }): void
 }
+
+export type TransformResult = string | null | undefined | { code: string, map: SourceMap }
 
 /** Returns a Promise that resolves with a bundle */
 export function rollup(options: Options): Promise<Bundle>

--- a/types/rollup/rollup-tests.ts
+++ b/types/rollup/rollup-tests.ts
@@ -21,6 +21,9 @@ const plugin: Plugin = {
             this.warn(`Prefer ' over " for strings`, indexOfQuote)
             return undefined
         }
+        if (id === 'foo') {
+            return Promise.resolve(source)
+        }
         return source
     },
     transformBundle(source, options) {
@@ -29,7 +32,9 @@ const plugin: Plugin = {
         } else if (options.format === 'cjs') {
             return null
         }
-
+        if (options.format !== 'es') {
+            return Promise.resolve(source)
+        }
         return undefined
     }
 }


### PR DESCRIPTION
I didn't find that in documentation, but this is obvious it's possible to return a promise from transform/transformBundle.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [transform](https://github.com/rollup/rollup/blob/1ef720f551d97f72b2aecea2bfaed3c7a1fb2605/src/utils/transform.ts#L82), [transformBundle](https://github.com/rollup/rollup/blob/1ef720f551d97f72b2aecea2bfaed3c7a1fb2605/src/utils/transformBundle.ts#L18)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
