### PR TITLE
redux-form: Add export default for SubmissionError from lib.

### DIFF
--- a/types/redux-form/lib/SubmissionError.d.ts
+++ b/types/redux-form/lib/SubmissionError.d.ts
@@ -5,3 +5,5 @@ export interface SubmissionErrorConstructor<T> {
 }
 
 export const SubmissionError: SubmissionErrorConstructor<any>;
+
+export default SubmissionError;

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -22,7 +22,8 @@ import {
     reducer,
     FormAction,
     actionTypes,
-    submit
+    submit,
+    SubmissionError
 } from "redux-form";
 import {
     Field as ImmutableField,
@@ -37,6 +38,7 @@ import LibFormSection from "redux-form/lib/FormSection";
 import libFormValueSelector from "redux-form/lib/formValueSelector";
 import libReduxForm from "redux-form/lib/reduxForm";
 import libActions from "redux-form/lib/actions";
+import LibSubmissionError from "redux-form/lib/SubmissionError";
 
 /* Decorated components */
 interface TestFormData {
@@ -334,6 +336,14 @@ reducer.plugin({
     }
 });
 
+try {
+    throw new SubmissionError({_error: "Submission failed."});
+} catch (error) {
+    if (!(error instanceof SubmissionError)) {
+        throw new Error("SubmissionError not imported correctly");
+    }
+}
+
 /* Test using versions imported directly/as defaults from lib */
 const DefaultField = (
     <LibField
@@ -358,3 +368,11 @@ const TestLibForm = libReduxForm<TestFormData, TestFormComponentProps>({ form : 
 
 const testSubmit = submit("test");
 const testLibSubmit = libActions.submit("test");
+
+try {
+    throw new LibSubmissionError({_error: "Submission failed."});
+} catch (error) {
+    if (!(error instanceof LibSubmissionError)) {
+        throw new Error("SubmissionError from lib not imported correctly");
+    }
+}


### PR DESCRIPTION
- `SubmissionError` is exported as default from `lib/SubmissionError` in the source and the types should match: https://github.com/erikras/redux-form/blob/v7.2.0/src/SubmissionError.js#L11

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/erikras/redux-form/blob/v7.2.0/src/SubmissionError.js#L11

  