### PR TITLE
[@types/react-dates] Add missing firstDayOfWeek optional prop to DayPickerRangeController component

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -237,6 +237,7 @@ declare namespace ReactDates {
         onOutsideClick?: (e: any) => void,
         keepOpenOnDateSelect?: boolean,
         noBorder?: boolean,
+        firstDayOfWeek? : 0 | 1 | 2 | 3 | 4 | 5 | 6,
 
         // navigation related props
         navPrev?: string | JSX.Element,


### PR DESCRIPTION
[@types/react-dates] Add missing firstDayOfWeek optional prop to DayPickerRangeController component

The firstDayOfWeek is an optional property that exists in the DayPickerRangeController component but is missing from the types definition.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/airbnb/react-dates/blob/master/src/components/DayPickerRangeController.jsx
- [n/a] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

