### PR TITLE
jszip: ReadStream -> ReadableStream

### DIFF
--- a/types/jszip/index.d.ts
+++ b/types/jszip/index.d.ts
@@ -219,7 +219,7 @@ interface JSZip {
      * @param onUpdate The optional function called on each internal update with the metadata.
      * @return A Node.js `ReadableStream`
      */
-    generateNodeStream(options?: JSZip.JSZipGeneratorOptions<'nodebuffer'>, onUpdate?: OnUpdateCallback): NodeJS.ReadStream;
+    generateNodeStream(options?: JSZip.JSZipGeneratorOptions<'nodebuffer'>, onUpdate?: OnUpdateCallback): NodeJS.ReadableStream;
 
     /**
      * Deserialize zip file asynchronously


### PR DESCRIPTION
NodeJS.ReadStream doesn't exist; it's ReadableStream instead