### PR TITLE
[aws-serverless-express] createServer should expect a method that returns void

### DIFF
--- a/types/aws-serverless-express/index.d.ts
+++ b/types/aws-serverless-express/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for aws-serverless-express 2.1
 // Project: https://github.com/awslabs/aws-serverless-express
-// Definitions by: Ben Speakman <https://github.com/threesquared>, Josh Caffey <https://github.com/jcaffey>, Matthias Meyer <https://github.com/mattmeye>
+// Definitions by: Ben Speakman <https://github.com/threesquared>, Josh Caffey <https://github.com/jcaffey>, Matthias Meyer <https://github.com/mattmeye>, Alberto Vasquez <https://github.com/albertovasquez>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/aws-serverless-express/index.d.ts
+++ b/types/aws-serverless-express/index.d.ts
@@ -9,7 +9,7 @@ import * as http from 'http';
 import * as lambda from 'aws-lambda';
 
 export function createServer(
-    requestListener: (request: http.IncomingMessage, response: http.ServerResponse) => http.Server,
+    requestListener: (request: http.IncomingMessage, response: http.ServerResponse) => void,
     serverListenCallback?: () => any,
     binaryMimeTypes?: string[]
 ): http.Server;

--- a/types/aws-serverless-express/index.d.ts
+++ b/types/aws-serverless-express/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for aws-serverless-express 2.1
+// Type definitions for aws-serverless-express 3.0.2
 // Project: https://github.com/awslabs/aws-serverless-express
 // Definitions by: Ben Speakman <https://github.com/threesquared>, Josh Caffey <https://github.com/jcaffey>, Matthias Meyer <https://github.com/mattmeye>, Alberto Vasquez <https://github.com/albertovasquez>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped


### PR DESCRIPTION
aws-serverless-express's createServer uses http.createServer
`const server = http.createServer(requestListener)`

Which defines the requestListener in node's index.d.ts as
`export function createServer(requestListener?: (request: IncomingMessage, response: ServerResponse) =>void ): Server;`

Which is defined as returning a `void` not `server`
  
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the readme.
- [x] Avoid common mistakes.
- [x] Run npm run lint package-name (or tsc if no tslint.json is present).
Select one of these and delete the others:

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/awslabs/aws-serverless-express/blob/master/index.jsx
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a tslint.json containing { "extends": "dtslint/dt.json" }.