### PR TITLE
Minor fixes on roslib typings.

### DIFF
--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -418,6 +418,14 @@ declare namespace ROSLIB {
 		});
 
 		/**
+		 * Connect callback functions to goal based events
+		 * 
+		 * @param eventName Name of event ('timeout', 'status', 'feedback', 'result')
+		 * @param callback Callback function executed on connected event
+		 */
+		on(eventName:string, callback:(event:any) => void):void;
+		
+		/**
 		 * Send the goal to the action server.
 		 *
 		 * @param timeout (optional) - a timeout length for the goal's result

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for roslib.js 0.18.1
+// Type definitions for roslib.js 0.18.2
 // Project: http://wiki.ros.org/roslibjs
 // Definitions by: Stefan Profanter <https://github.com/Pro>, Cooper Benson <https://github.com/skycoop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for roslib.js 0.18.0
+// Type definitions for roslib.js 0.18.1
 // Project: http://wiki.ros.org/roslibjs
 // Definitions by: Stefan Profanter <https://github.com/Pro>, Cooper Benson <https://github.com/skycoop>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/roslib/index.d.ts
+++ b/types/roslib/index.d.ts
@@ -58,7 +58,7 @@ declare namespace ROSLIB {
 		 * @param level - User level as a string given by the client.
 		 * @param end - End time of the client's session.
 		 */
-		authenticate(mac:string, client:string, dest:string, rand:string, t:number, level:string, end:string):void;
+		authenticate(mac:string, client:string, dest:string, rand:string, t:number, level:string, end:number):void;
 
 
 		/**


### PR DESCRIPTION
1. Changed data type of authenticate function parameter from 'string' to 'number'. The end time should be also transmitted as a number in seconds like time t.
2. Added missing function definition to roslib action goal. The 'on' function is necessary to connect callback functions to events from ROS action goal 'status', 'feedback', 'result'.

Changes in roslib types done by Lars-Pf <https://github.com/lars-pf>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
1. Function parameter 'end' is supposed to be a number: https://github.com/RobotWebTools/roslibjs/blob/a0f5b04c9ebec839133ad5a3e5a62f3bb7a0526d/src/core/Ros.js#L96-L98
2. Action Goal is missing the 'on' function definition (from event emitter) to connect goal feedback functions.
* ActionClient events:
https://github.com/RobotWebTools/roslibjs/blob/a0f5b04c9ebec839133ad5a3e5a62f3bb7a0526d/src/actionlib/ActionClient.js#L13-L17
* Emitter for action goals in goal object:
https://github.com/RobotWebTools/roslibjs/blob/a0f5b04c9ebec839133ad5a3e5a62f3bb7a0526d/src/actionlib/ActionClient.js#L83
https://github.com/RobotWebTools/roslibjs/blob/a0f5b04c9ebec839133ad5a3e5a62f3bb7a0526d/src/actionlib/ActionClient.js#L94-L95
https://github.com/RobotWebTools/roslibjs/blob/a0f5b04c9ebec839133ad5a3e5a62f3bb7a0526d/src/actionlib/ActionClient.js#L106-L107
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. => only minor changes
