### PR TITLE
@types/sequelize Added generic types for various option classes

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -141,7 +141,7 @@ declare namespace sequelize {
          */
         (
             values?: TAttributes,
-            options?: BelongsToCreateAssociationMixinOptions | CreateOptions | BelongsToSetAssociationMixinOptions
+            options?: BelongsToCreateAssociationMixinOptions | CreateOptions<TAttributes> | BelongsToSetAssociationMixinOptions
         ): Promise<void>;
     }
 
@@ -255,7 +255,7 @@ declare namespace sequelize {
          */
         (
             values?: TAttributes,
-            options?: HasOneCreateAssociationMixinOptions | HasOneSetAssociationMixinOptions | CreateOptions
+            options?: HasOneCreateAssociationMixinOptions | HasOneSetAssociationMixinOptions | CreateOptions<TAttributes>
         ): Promise<void>;
     }
 
@@ -496,7 +496,7 @@ declare namespace sequelize {
          */
         (
             values?: TAttributes,
-            options?: HasManyCreateAssociationMixinOptions | CreateOptions
+            options?: HasManyCreateAssociationMixinOptions | CreateOptions<TAttributes>
         ): Promise<TInstance>;
     }
 
@@ -959,7 +959,7 @@ declare namespace sequelize {
          */
         (
             values?: TAttributes,
-            options?: BelongsToManyCreateAssociationMixinOptions | CreateOptions | { through: TJoinTableAttributes }
+            options?: BelongsToManyCreateAssociationMixinOptions | CreateOptions<TAttributes> | { through: TJoinTableAttributes }
         ): Promise<TInstance>;
     }
 
@@ -1332,8 +1332,8 @@ declare namespace sequelize {
          */
         keyType?: DataTypeAbstract;
         /**
-         * A string to represent the name of the field to use as the key for an 1 to many association in the source table. 
-         * 
+         * A string to represent the name of the field to use as the key for an 1 to many association in the source table.
+         *
          * @see http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-hasMany
          * @see https://github.com/sequelize/sequelize/blob/b4fd46426db9cdbb97074bea121203d565e4195d/lib/associations/has-many.js#L81
          */
@@ -3187,7 +3187,7 @@ declare namespace sequelize {
     /**
      * Complex include options
      */
-    interface IncludeOptions {
+    interface IncludeOptions<TAttributes = any> {
 
         /**
          * The model you want to eagerly load
@@ -3214,7 +3214,7 @@ declare namespace sequelize {
         /**
          * A list of attributes to select from the child model
          */
-        attributes?: FindOptionsAttributesArray | { include?: FindOptionsAttributesArray, exclude?: Array<string> };
+        attributes?: FindOptionsAttributesArray<TAttributes> | { include?: FindOptionsAttributesArray<TAttributes>, exclude?: keyof TAttributes };
 
         /**
          * If true, converts to an inner join, which means that the parent model will only be loaded if it has any
@@ -3230,7 +3230,7 @@ declare namespace sequelize {
         /**
          * Load further nested related models
          */
-        include?: Array<Model<any, any> | IncludeOptions>;
+        include?: Array<Model<any, any> | IncludeOptions<TAttributes>>;
 
         /**
          * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will
@@ -3244,14 +3244,14 @@ declare namespace sequelize {
     /**
      * Shortcut for types used in FindOptions.attributes
      */
-    type FindOptionsAttributesArray = Array<string | literal | [string, string] | fn | [fn, string] | cast | [cast, string] | [literal, string]>;
+    type FindOptionsAttributesArray<TAttributes> = Array<keyof TAttributes | literal | [keyof TAttributes, string] | fn | [fn, string] | cast | [cast, string] | [literal, string]>;
 
     /**
      * Options that are passed to any model creating a SELECT query
      *
      * A hash of options to describe the scope of the search
      */
-    interface FindOptions<T> extends LoggingOptions, SearchPathOptions {
+    interface FindOptions<T = any> extends LoggingOptions, SearchPathOptions {
 
         /**
          * A hash of attributes to describe your search. See above for examples.
@@ -3264,7 +3264,7 @@ declare namespace sequelize {
          * `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to
          * have in the returned instance
          */
-        attributes?: FindOptionsAttributesArray | { include?: FindOptionsAttributesArray, exclude?: Array<string> };
+        attributes?: FindOptionsAttributesArray<T> | { include?: FindOptionsAttributesArray<T>, exclude?: Array<keyof T> };
 
         /**
          * If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will
@@ -3278,7 +3278,7 @@ declare namespace sequelize {
          * If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in
          * the as attribute when eager loading Y).
          */
-        include?: Array<Model<any, any> | IncludeOptions>;
+        include?: Array<Model<any, any> | IncludeOptions<T>>;
 
         /**
          * Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide
@@ -3319,7 +3319,7 @@ declare namespace sequelize {
          * Group by. It is not mentioned in sequelize's JSDoc, but mentioned in docs.
          * https://github.com/sequelize/sequelize/blob/master/docs/docs/models-usage.md#user-content-manipulating-the-dataset-with-limit-offset-order-and-group
          */
-        group?: string | string[] | Object;
+        group?: keyof T | keyof T[] | Object;
 
 
         /**
@@ -3338,12 +3338,12 @@ declare namespace sequelize {
         rejectOnEmpty?: boolean;
     }
 
-    type AnyFindOptions = FindOptions<any>;
+    type AnyFindOptions = FindOptions;
 
     /**
      * Options for Model.count method
      */
-    interface CountOptions extends LoggingOptions, SearchPathOptions {
+    interface CountOptions<T = any> extends LoggingOptions, SearchPathOptions {
 
         /**
          * A hash of search attributes.
@@ -3353,7 +3353,7 @@ declare namespace sequelize {
         /**
          * Include options. See `find` for details
          */
-        include?: Array<Model<any, any> | IncludeOptions>;
+        include?: Array<Model<any, any> | IncludeOptions<T>>;
 
         /**
          * Apply COUNT(DISTINCT(col))
@@ -3376,7 +3376,7 @@ declare namespace sequelize {
     /**
      * Options for Model.build method
      */
-    interface BuildOptions extends ReturningOptions {
+    interface BuildOptions<T = any> extends ReturningOptions {
 
         /**
          * If set to true, values will ignore field and virtual setters.
@@ -3393,13 +3393,13 @@ declare namespace sequelize {
          *
          * TODO: See set
          */
-        include?: Array<Model<any, any> | IncludeOptions>;
+        include?: Array<Model<any, any> | IncludeOptions<T>>;
     }
 
     /**
      * Options for Model.create method
      */
-    interface CreateOptions extends BuildOptions, InstanceSaveOptions {
+    interface CreateOptions<T = any> extends BuildOptions<T>, InstanceSaveOptions {
 
         /**
          * On Duplicate
@@ -3867,7 +3867,7 @@ declare namespace sequelize {
          *
          * If you provide an `include` option, the number of matching associations will be counted instead.
          */
-        count(options?: CountOptions): Promise<number>;
+        count(options?: CountOptions<TAttributes>): Promise<number>;
 
         /**
          * Find all the rows matching your query, within a specified offset / limit, and get the total number of
@@ -3925,17 +3925,17 @@ declare namespace sequelize {
         /**
          * Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
          */
-        build(record?: TAttributes, options?: BuildOptions): TInstance;
+        build(record?: TAttributes, options?: BuildOptions<TAttributes>): TInstance;
 
         /**
          * Undocumented bulkBuild
          */
-        bulkBuild(records: TAttributes[], options?: BuildOptions): TInstance[];
+        bulkBuild(records: TAttributes[], options?: BuildOptions<TAttributes>): TInstance[];
 
         /**
          * Builds a new model instance and calls save on it.
          */
-        create(values?: TAttributes, options?: CreateOptions): Promise<TInstance>;
+        create(values?: TAttributes, options?: CreateOptions<TAttributes>): Promise<TInstance>;
 
         /**
          * Find a row that matches the query, or build (but don't save) the row if none is found.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Incoming PR for [RobinBuschmann/sequelize-typescript](/RobinBuschmann/sequelize-typescript)

The following PR adds additional, stronger typings used for [RobinBuschmann/sequelize-typescript](/RobinBuschmann/sequelize-typescript), that will notably be used to type its [@Scope decorators](/RobinBuschmann/sequelize-typescript#scopes)

There is still a lot of improvements to make here, so any help would be greatly appreciated!