### PR TITLE
Underscore: Chain#mapObject is for objects, not arrays

### DIFF
--- a/types/underscore/index.d.ts
+++ b/types/underscore/index.d.ts
@@ -5696,6 +5696,12 @@ declare module _ {
 
         /**
         * Wrapped type `object`.
+        * @see _.mapObject
+        **/
+        mapObject(fn: _.ListIterator<T, any>): _Chain<T>;
+
+        /**
+        * Wrapped type `object`.
         * @see _.pairs
         **/
         pairs(): _Chain<T[]>;
@@ -6096,6 +6102,5 @@ declare module _ {
     }
     interface _ChainOfArrays<T> extends _Chain<T[]> {
         flatten(shallow?: boolean): _Chain<T>;
-        mapObject(fn: _.ListIterator<T, any>): _ChainOfArrays<T>;
     }
 }


### PR DESCRIPTION
`mapObject` is intended for use on objects, not specifically on arrays. That is clear in [the example given in the documentation](http://underscorejs.org/#mapObject):
```js
_.mapObject({start: 5, end: 12}, function(val, key) {
  return val + 5;
});
=> {start: 10, end: 17}
```

So, this PR moves the definition from `ChainOfArrays` up to its superinterface, `Chain`.

---

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://underscorejs.org/#mapObject
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
