### PR TITLE
remove export in types Keys, State, Params

### DIFF
--- a/types/navigo/index.d.ts
+++ b/types/navigo/index.d.ts
@@ -3,9 +3,9 @@
 // Definitions by: Adrian Ehrsam <https://github.com/aersamkull>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export type Keys = string
-export type State = {[k in Keys]: any}
-export type Params = State;
+type Keys = string
+type State = {[k in Keys]: any}
+type Params = State;
 
 interface NavigoHooks {
     before?(done: (suppress?: boolean) => void, params?: Params): void;


### PR DESCRIPTION
I remove this export to avoid the error  error TS2309: An export assignment cannot be used in a module with other exported elements.
Sorry @Mohamed Hegazy that I have to change it again, I didn't get this error before when I tested.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.