### PR TITLE
charset: adds new declarations

### DIFF
--- a/types/charset/charset-tests.ts
+++ b/types/charset/charset-tests.ts
@@ -1,0 +1,11 @@
+import charset = require('charset');
+import http = require('http');
+
+http.get('http://nodejs.org', (res) => {
+  res.on('data', (chunk: Buffer) => {
+    console.log(charset(res.headers, chunk));
+    console.log(charset(res, chunk));
+    console.log(charset('content-type header, for example charset=utf8', chunk));
+    res.destroy();
+  });
+});

--- a/types/charset/index.d.ts
+++ b/types/charset/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for charset 1.0
+// Project: https://github.com/node-modules/charset
+// Definitions by: Andrew Bradley <https://github.com/cspotcode>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+import { ClientResponse, IncomingHttpHeaders } from 'http';
+
+/**
+ * guess data charset from req.headers, xml, html content-type meta tag
+ *
+ * headers:
+ *
+ *    'content-type': 'text/html;charset=gbk'
+ *
+ * meta tag:
+ *
+ *    <meta http-equiv="Content-Type" content="text/html; charset=xxxx"/>
+ *
+ * xml file:
+ *
+ *    <?xml version="1.0" encoding="UTF-8"?>
+ *
+ * @param obj `Content-Type` String, or `res.headers`, or `res` Object
+ * @param data content buffer
+ * @param peekSize max content peek size, default is 512
+ * @return charset, lower case, e.g.: utf8, gbk, gb2312, .... If can\'t guess, return null
+ */
+// tslint:disable-next-line strict-export-declare-modifiers
+declare function charset(obj: string | IncomingHttpHeaders | ClientResponse, data?: Buffer, peekSize?: number): string | null;
+
+// tslint:disable-next-line strict-export-declare-modifiers
+export = charset;

--- a/types/charset/tsconfig.json
+++ b/types/charset/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "charset-tests.ts"
+    ]
+}

--- a/types/charset/tslint.json
+++ b/types/charset/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-redundant-jsdoc-2": false
+    }
+}


### PR DESCRIPTION
**Note:** I disabled dtslint's "no-redundant-jsdoc-2" rule because it was rejecting my `@param` and `@return` JSDoc annotations.  However, I don't think the annotations are redundant since they provide descriptions, not duplicated type annotations.  If I'm supposed to be formatting them differently to please the linter, please let me know.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
