### PR TITLE
[jquery] Support projects without ES2015.Iterable.

### DIFF
--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -5370,6 +5370,9 @@ interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement>
     [n: number]: TElement;
 }
 
+// ES5 compatibility
+interface Iterable<T> { }
+
 declare namespace JQuery {
     type TypeOrArray<T> = T | T[];
     type Node = Element | Text | Comment;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~
- ~~Increase the version number in the header if appropriate.~~
- ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

This allows `@types/jquery` to be used in projects without `ES2015.Iterable`. Previously, users would see `error TS2304: Cannot find name 'Iterable'.`. TypeScript will still block attempts to use `for...of` in those projects.