### PR TITLE
[react-bootstrap] Added Panel typings for Version 0.32.0

### DIFF
--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-bootstrap 0.31
+// Type definitions for react-bootstrap 0.32
 // Project: https://github.com/react-bootstrap/react-bootstrap
 // Definitions by: Walker Burgin <https://github.com/walkerburgin>,
 //                 Vincent Siao <https://github.com/vsiao>,

--- a/types/react-bootstrap/lib/Panel.d.ts
+++ b/types/react-bootstrap/lib/Panel.d.ts
@@ -16,18 +16,18 @@ declare namespace Panel {
         onSelect?: SelectCallback;
     }
 
-    export interface HeadingProps {
+    export interface HeadingProps extends React.HTMLProps<Panel.Heading> {
         componentClass?: JSX.Element;
         bsClass?: string;
     }
 
-    export interface TitleProps {
+    export interface TitleProps extends React.HTMLProps<Panel.Title> {
         componentClass?: JSX.Element;
         bsClass?: string;
         toggle?: boolean;
     }
 
-    export interface BodyProps {
+    export interface BodyProps extends React.HTMLProps<Panel.Body> {
         bsClass?: string;
         /**
          * Documentation marked it as required, but its default is false
@@ -36,16 +36,15 @@ declare namespace Panel {
         collapsible?: boolean;
     }
 
-    export interface ToggleProps {
+    export interface ToggleProps extends React.HTMLProps<Panel.Toggle> {
         componentClass?: JSX.Element;
-        onClick?: React.SyntheticEvent<Panel>;
     }
 
-    export interface FooterProps {
+    export interface FooterProps extends React.HTMLProps<Panel.Footer> {
         bsClass?: string;
     }
 
-    export class Heading extends React.Component<Panel.PanelProps> {
+    export class Heading extends React.Component<Panel.HeadingProps> {
 
     }
 
@@ -53,7 +52,7 @@ declare namespace Panel {
 
     }
 
-    export class Toggle extends React.Component<ToggleProps> {
+    export class Toggle extends React.Component<Panel.ToggleProps> {
 
     }
 

--- a/types/react-bootstrap/lib/Panel.d.ts
+++ b/types/react-bootstrap/lib/Panel.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TransitionCallbacks, Sizes, SelectCallback } from 'react-bootstrap';
+import { Collapse as RBCollapse, SelectCallback, Sizes, TransitionCallbacks } from 'react-bootstrap';
 
 declare namespace Panel {
     export interface PanelProps extends TransitionCallbacks, React.HTMLProps<Panel> {
@@ -12,7 +12,7 @@ declare namespace Panel {
         expanded?: boolean;
         footer?: React.ReactNode;
         header?: React.ReactNode;
-        onToggle?: () => void;
+        onToggle?: (expanded: boolean, event: React.SyntheticEvent<Panel>) => void;
         onSelect?: SelectCallback;
     }
 
@@ -21,16 +21,54 @@ declare namespace Panel {
         bsClass?: string;
     }
 
+    export interface TitleProps {
+        componentClass?: JSX.Element;
+        bsClass?: string;
+        toggle?: boolean;
+    }
+
     export interface BodyProps {
         bsClass?: string;
+        /**
+         * Documentation marked it as required, but its default is false
+         * @default false
+         */
         collapsible?: boolean;
     }
 
+    export interface ToggleProps {
+        componentClass?: JSX.Element;
+        onClick?: React.SyntheticEvent<Panel>;
+    }
+
+    export interface FooterProps {
+        bsClass?: string;
+    }
+
     export class Heading extends React.Component<Panel.PanelProps> {
+
+    }
+
+    export class Title extends React.Component<Panel.TitleProps> {
+
+    }
+
+    export class Toggle extends React.Component<ToggleProps> {
+
+    }
+
+    export class Collapse extends RBCollapse {
+
     }
 
     export class Body extends React.Component<Panel.BodyProps> {
+
     }
+
+    export class Footer extends React.Component<Panel.FooterProps> {
+
+    }
+
 }
 
 declare class Panel extends React.Component<Panel.PanelProps> {

--- a/types/react-bootstrap/lib/Panel.d.ts
+++ b/types/react-bootstrap/lib/Panel.d.ts
@@ -6,14 +6,34 @@ declare namespace Panel {
         bsClass?: string;
         bsSize?: Sizes;
         bsStyle?: string;
-        collapsible?: boolean;
+        collapsible?: string | boolean;
         defaultExpanded?: boolean;
         eventKey?: any;
         expanded?: boolean;
         footer?: React.ReactNode;
         header?: React.ReactNode;
+        onToggle?: () => void;
         onSelect?: SelectCallback;
     }
+
+    export interface HeadingProps {
+        componentClass?: JSX.Element;
+        bsClass?: string;
+    }
+
+    export interface BodyProps {
+        bsClass?: string;
+        collapsible?: boolean;
+    }
+
+    export class Heading extends React.Component<Panel.PanelProps> {
+    }
+
+    export class Body extends React.Component<Panel.BodyProps> {
+    }
 }
-declare class Panel extends React.Component<Panel.PanelProps> { }
+
+declare class Panel extends React.Component<Panel.PanelProps> {
+}
+
 export = Panel;


### PR DESCRIPTION
Provided Panel typings for react Bootstrap Version 0.32.0. 
While still being backward compatible with the additional string type on the collapsiable Property for the Panel.
As defined in the updated specification of: 
[https://react-bootstrap.github.io/components/panel/](https://react-bootstrap.github.io/components/panel/)

Needs some more rework, since not all types are provided within this PR. 
Provided typings for the use case for [https://react-bootstrap.github.io/components/panel/#panels-collapsible](Collapsible Panels)

- [x] Test the change in your own code. (Compile and run.)
- [x] The package does not provide its own types, and you can not add them.