### PR TITLE
[@types/twit] Add optional `include_email` to Param

### DIFF
--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -258,6 +258,7 @@ declare module 'twit' {
       lat?: number,
       long?: number,
       follow?: boolean,
+      include_email?: boolean,
     }
     export interface PromiseResponse {
       data: Response,


### PR DESCRIPTION
Twitter's [verify_credentials](https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials) also accepts the `include_email` which is missing in definitions here.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
