### PR TITLE
Add readOnly property to editable.

### DIFF
--- a/types/react-bootstrap-table/v2/index.d.ts
+++ b/types/react-bootstrap-table/v2/index.d.ts
@@ -680,6 +680,9 @@ export interface TableHeaderColumnProps extends Props<TableHeaderColumn> {
 }
 export interface Editable {
 	type?: string; // edit type, avaiable value is textarea, select, checkbox
+	
+	readOnly?: boolean // Default is false, true will make it so cell can't be edited but still can be insert.
+	
 	/**
 	 * Function for validation and taking only one "cell value" as argument. This function should return Bool.
 	 */


### PR DESCRIPTION
According to the document there is a 'readOnly' property for 'editable' 
http://allenfang.github.io/react-bootstrap-table/docs.html#editable

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I