### PR TITLE
Added type definitions for react-flags-select

### DIFF
--- a/types/react-flags-select/index.d.ts
+++ b/types/react-flags-select/index.d.ts
@@ -1,17 +1,15 @@
-// Type definitions for react-flags-select 1.1.2
+// Type definitions for react-flags-select 1.1
 // Project: https://github.com/ekwonye-richard/react-flags-select#readme
 // Definitions by: Artur Sianiuk <https://github.com/senukartur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
-import { Component } React from 'react';
-
-export = ReactFlagSelect;
+import { Component } from 'react';
 
 interface Props {
     countries?: string[];
     blackList?: boolean;
-    customLabels?: string[];
+    customLabels?: {[propName: string]: string};
     selectedSize?: number;
     optionsSize?: number;
     defaultCountry?: string;
@@ -27,3 +25,5 @@ interface Props {
 declare class ReactFlagsSelect extends Component<Props> {
     updateSelected(countryCode: string): void;
 }
+
+export default ReactFlagsSelect;

--- a/types/react-flags-select/index.d.ts
+++ b/types/react-flags-select/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for react-flags-select 1.1.2
+// Project: https://github.com/ekwonye-richard/react-flags-select#readme
+// Definitions by: Artur Sianiuk <https://github.com/senukartur>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Component } React from 'react';
+
+export = ReactFlagSelect;
+
+interface Props {
+    countries?: string[];
+    blackList?: boolean;
+    customLabels?: string[];
+    selectedSize?: number;
+    optionsSize?: number;
+    defaultCountry?: string;
+    placeholder?: string;
+    className?: string;
+    showSelectedLabel?: boolean;
+    showOptionLabel?: boolean;
+    alignOptions?: string;
+    onSelect?: (countryCode: string) => void;
+    disabled?: boolean;
+    searchable?: boolean;
+}
+declare class ReactFlagsSelect extends Component<Props> {
+    updateSelected(countryCode: string): void;
+}

--- a/types/react-flags-select/react-flags-select-tests.tsx
+++ b/types/react-flags-select/react-flags-select-tests.tsx
@@ -2,7 +2,72 @@ import * as React from 'react';
 import ReactFlagsSelect from 'react-flags-select';
 
 export class ReactFlagsSelectTest extends React.Component {
+    countries = ['US', 'GB', 'FR', 'DE', 'IT'];
+    customLabels = {US: 'EN-US', GB: 'EN-GB', FR: 'FR', DE: 'DE', IT: 'IT'};
+    onSelectFlag(countryCode: string) { }
     render() {
-        <ReactFlagsSelect />
+        return (
+            <div>
+                <ReactFlagsSelect />
+                <ReactFlagsSelect defaultCountry='US' />
+                <ReactFlagsSelect searchable={true} />
+                <ReactFlagsSelect countries={this.countries} />
+                <ReactFlagsSelect countries={this.countries} blackList={true} />
+                <ReactFlagsSelect className='menu-flags' />
+                <ReactFlagsSelect alignOptions='left' />
+                <ReactFlagsSelect
+                    countries={this.countries}
+                    customLabels={this.customLabels}
+                />
+                <ReactFlagsSelect
+                    countries={this.countries}
+                    customLabels={this.customLabels}
+                    placeholder='Select Language'
+                />
+                <ReactFlagsSelect
+                    countries={this.countries}
+                    customLabels={this.customLabels}
+                    placeholder='Select Language'
+                    showSelectedLabel={false}
+                />
+                <ReactFlagsSelect
+                    countries={this.countries}
+                    customLabels={this.customLabels}
+                    placeholder='Select Language'
+                    showSelectedLabel={false}
+                    showOptionLabel={false}
+                />
+                <ReactFlagsSelect
+                    countries={this.countries}
+                    customLabels={this.customLabels}
+                    placeholder='Select Language'
+                    showSelectedLabel={false}
+                    showOptionLabel={false}
+                    selectedSize={14}
+                />
+                <ReactFlagsSelect
+                    countries={this.countries}
+                    customLabels={this.customLabels}
+                    placeholder='Select Language'
+                    showSelectedLabel={false}
+                    showOptionLabel={false}
+                    selectedSize={18}
+                    optionsSize={14}
+                />
+                <ReactFlagsSelect
+                    defaultCountry='US'
+                    showSelectedLabel={false}
+                    disabled={true}
+                />
+                <ReactFlagsSelect
+                    defaultCountry='GB'
+                    onSelect={this.onSelectFlag}
+                />
+                <ReactFlagsSelect
+                    ref='userFlag'
+                    defaultCountry='FR'
+                />
+            </div>
+        );
     }
 }

--- a/types/react-flags-select/react-flags-select-tests.tsx
+++ b/types/react-flags-select/react-flags-select-tests.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import ReactFlagsSelect from 'react-flags-select';
+
+export class ReactFlagsSelectTest extends React.Component {
+    render() {
+        <ReactFlagsSelect />
+    }
+}

--- a/types/react-flags-select/tsconfig.json
+++ b/types/react-flags-select/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-flags-select-tests.tsx"
+    ]
+}

--- a/types/react-flags-select/tslint.json
+++ b/types/react-flags-select/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
