### PR TITLE
[aws-lambda] AttributeValue "N" should be string

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -120,7 +120,7 @@ var dynamoDBStreamEvent: AWSLambda.DynamoDBStreamEvent = {
             dynamodb: {
                 Keys: {
                     Id: {
-                        N: 101
+                        N: '101'
                     }
                 },
                 NewImage: {
@@ -128,7 +128,7 @@ var dynamoDBStreamEvent: AWSLambda.DynamoDBStreamEvent = {
                         S: 'New item!'
                     },
                     Id: {
-                        N: 101
+                        N: '101'
                     }
                 },
                 StreamViewType: 'NEW_AND_OLD_IMAGES',
@@ -150,13 +150,13 @@ var dynamoDBStreamEvent: AWSLambda.DynamoDBStreamEvent = {
                         S: 'New item!'
                     },
                     Id: {
-                        N: 101
+                        N: '101'
                     }
                 },
                 SequenceNumber: '222',
                 Keys: {
                     Id: {
-                        N: 101
+                        N: '101'
                     }
                 },
                 SizeBytes: 59,
@@ -165,7 +165,7 @@ var dynamoDBStreamEvent: AWSLambda.DynamoDBStreamEvent = {
                         S: 'This item has changed'
                     },
                     Id: {
-                        N: 101
+                        N: '101'
                     }
                 },
                 StreamViewType: 'NEW_AND_OLD_IMAGES'
@@ -182,7 +182,7 @@ var dynamoDBStreamEvent: AWSLambda.DynamoDBStreamEvent = {
             dynamodb: {
                 Keys: {
                     Id: {
-                        N: 101
+                        N: '101'
                     }
                 },
                 SizeBytes: 38,
@@ -192,7 +192,7 @@ var dynamoDBStreamEvent: AWSLambda.DynamoDBStreamEvent = {
                         S: 'This item has changed'
                     },
                     Id: {
-                        N: 101
+                        N: '101'
                     }
                 },
                 StreamViewType: 'NEW_AND_OLD_IMAGES'

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -74,7 +74,7 @@ interface AttributeValue {
     BOOL?: boolean;
     L?: Array<AttributeValue>;
     M?: { [id: string]: AttributeValue };
-    N?: number;
+    N?: string;
     NS?: Array<string>;
     NULL?: boolean;
     S?: string;


### PR DESCRIPTION
AttributeValue's "N" is a string, not a number: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_AttributeValue.html

This causes an incompatibility between this AttributeValue and the one in the AWS SDK types, which makes it impossible to use something like AWS.DynamoDB.Converter.unmarshall() for items in records on a DynamoDBStreamEvent.