### PR TITLE
@types/react-native-push-notification: Add missing 'finish' function to PushNotification object, fix typing for popInitialNotification

### DIFF
--- a/types/react-native-push-notification/index.d.ts
+++ b/types/react-native-push-notification/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-native-push-notification 3.0
 // Project: https://github.com/zo0r/react-native-push-notification#readme
 // Definitions by: Paito Anderson <https://github.com/PaitoAnderson>
+//                 Tom Sawkins <https://github.com/tomSawkins>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -18,6 +19,7 @@ export interface PushNotification {
     badge: number;
     alert: object;
     sound: string;
+    finish: (fetchResult: string) => void;
 }
 
 export class PushNotificationOptions {
@@ -77,7 +79,7 @@ export interface PushNotification {
     cancelAllLocalNotifications(): void;
     setApplicationIconBadgeNumber(badgeCount: number): void;
     getApplicationIconBadgeNumber(callback: (badgeCount: number) => void): void;
-    popInitialNotification(): Promise<PushNotification>;
+    popInitialNotification(callback: (notification: PushNotification | null) => void): void;
     abandonPermissions(): void;
     checkPermissions(callback: (permissions: PushNotificationPermissions) => void): void;
     registerNotificationActions(actions: string[]): void;

--- a/types/react-native-push-notification/react-native-push-notification-tests.ts
+++ b/types/react-native-push-notification/react-native-push-notification-tests.ts
@@ -1,7 +1,9 @@
 import PushNotification from 'react-native-push-notification';
 
 PushNotification.configure({
-    onNotification: (notification) => {},
+    onNotification: (notification) => {
+        notification.finish("UIBackgroundFetchResultNoData");
+    },
     onRegister: (token) => {},
     senderID: 'XXX',
     popInitialNotification: false,
@@ -18,7 +20,7 @@ PushNotification.cancelLocalNotifications = (details) => {};
 PushNotification.cancelAllLocalNotifications();
 PushNotification.setApplicationIconBadgeNumber(1);
 PushNotification.getApplicationIconBadgeNumber((badgeCount) => {});
-PushNotification.popInitialNotification();
+PushNotification.popInitialNotification((notification) => {});
 PushNotification.checkPermissions((checkPermissions) => {});
 PushNotification.abandonPermissions();
 PushNotification.registerNotificationActions(['Accept', 'Reject', 'Yes', 'No']);


### PR DESCRIPTION
- Add missing 'finish' function to PushNotification object that is received in onNotification https://github.com/zo0r/react-native-push-notification#usage
- fix typing for popInitialNotification, does not return promise and expects a handler function to be passed instead. https://github.com/zo0r/react-native-push-notification/blob/81744d6d732a679a356ffe9b891838f8eeca2618/index.js#L301

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zo0r/react-native-push-notification#usage
https://github.com/zo0r/react-native-push-notification/blob/81744d6d732a679a356ffe9b891838f8eeca2618/index.js#L301