### PR TITLE
google-libphonenumber PhoneNumber is class and not interface

### DIFF
--- a/types/google-libphonenumber/index.d.ts
+++ b/types/google-libphonenumber/index.d.ts
@@ -35,7 +35,7 @@ declare namespace libphonenumber {
         }
     }
 
-    export interface PhoneNumber {
+    export class PhoneNumber {
         getCountryCode(): number | undefined;
         getCountryCodeOrDefault(): number;
         setCountryCode(value: number): void;


### PR DESCRIPTION
`PhoneNumber` was declared as an interface but it's a class, so it was failing to do things like `something instanceof PhoneNumber`, I've just changed `interface` keyword into `class`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/ruimarinho/google-libphonenumber/blob/master/src/phonenumberutil.js#L4343
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
