### PR TITLE
[react-redux-toastr] Add JSX.Element to component in BasicToastrOptions

### DIFF
--- a/types/react-redux-toastr/index.d.ts
+++ b/types/react-redux-toastr/index.d.ts
@@ -18,7 +18,7 @@ export type transitionOutType = 'bounceOut' | 'bounceOutUp' | 'fadeOut';
 interface BasicToastrOptions {
     attention?: boolean;
     className?: string;
-    component?: Component;
+    component?: Component | JSX.Element;
     icon?: JSX.Element;
     onCloseButtonClick?: () => void;
     onHideComplete?: () => void;


### PR DESCRIPTION
We are getting error when trying to add component for Toastr.info, success, error and warning since "component" property is of type Component and not JSX.Element like the LightToastrOptions has. Hence it would be great if we can add it to the BasicToastrOptions as well.

Thanks

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).