### PR TITLE
[@types/kendo-ui] Adding missing properties to DropTargetEvent

### DIFF
--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -1373,6 +1373,8 @@ declare namespace kendo.ui {
 
     interface DropTargetEvent {
         sender?: DropTarget;
+        dropTarget?: JQuery;
+        target?: Element;
     }
 
     interface DropTargetDragenterEvent extends DropTargetEvent {


### PR DESCRIPTION
As per: https://docs.telerik.com/kendo-ui/api/javascript/ui/droptarget#events dropTarget and target were missing.