### PR TITLE
[swagger-tools] Supporting optional parameters and typed requests

### DIFF
--- a/types/swagger-tools/index.d.ts
+++ b/types/swagger-tools/index.d.ts
@@ -28,7 +28,7 @@ export interface SwaggerRequestParameter<T> {
 }
 
 export interface SwaggerRequestParameters {
-    [paramName: string]: SwaggerRequestParameter<any>;
+    [paramName: string]: SwaggerRequestParameter<any> | undefined;
 }
 
 export interface Swagger12Request extends IncomingMessage {
@@ -82,14 +82,14 @@ export interface Swagger20Operation {
     tags?: string[];
 }
 
-export interface Swagger20Request extends IncomingMessage {
+export interface Swagger20Request<P extends SwaggerRequestParameters> extends IncomingMessage {
     swagger: {
         apiPath: string;
         operation?: Swagger20Operation;
         operationPath?: string[];
         operationParameters?: OperationParameter[];
         path: any;
-        params: SwaggerRequestParameters;
+        params: P;
         security: any[];
         swaggerObject: any;
         swaggerVersion: string;
@@ -97,7 +97,7 @@ export interface Swagger20Request extends IncomingMessage {
     };
 }
 
-export type SwaggerRouter20HandlerFunction = (req: Swagger20Request, res: ServerResponse, next: (arg?: any) => void) => void;
+export type SwaggerRouter20HandlerFunction = (req: Swagger20Request<any>, res: ServerResponse, next: (arg?: any) => void) => void;
 
 export interface SwaggerRouter20OptionsControllers {
     [handlerName: string]: SwaggerRouter20HandlerFunction;

--- a/types/swagger-tools/swagger-tools-tests.ts
+++ b/types/swagger-tools/swagger-tools-tests.ts
@@ -46,8 +46,8 @@ swaggerTools.initializeMiddleware(swaggerDoc20, middleware => {
                 req.swagger.operation = {
                     security: [
                         {
-                            oauth2: ["read"]
-                        }
+                        oauth2: ["read"]
+                    }
                     ],
                     tags: [ "Pet Operations" ],
                     operationId: "getPetById",
@@ -59,52 +59,52 @@ swaggerTools.initializeMiddleware(swaggerDoc20, middleware => {
                                 $ref: "#/definitions/Pet"
                             }
                         },
-                        default: {
-                            description: "Unexpected error",
-                            schema: {
-                                $ref: "#/definitions/Error"
-                            }
+                    default: {
+                        description: "Unexpected error",
+                        schema: {
+                            $ref: "#/definitions/Error"
                         }
+                    }
                     },
                     parameters: [
                         {
-                            in: 'query',
-                            name: 'mock',
-                            description: 'Mock mode',
-                            required: false,
-                            type: 'boolean'
-                        }
+                        in: 'query',
+                        name: 'mock',
+                        description: 'Mock mode',
+                        required: false,
+                        type: 'boolean'
+                    }
                     ]
                 };
 
                 req.swagger.operationParameters = [
                     {
-                        path: ['paths', '/pets/{id}', 'get', 'parameters', '0'],
-                        schema: {
-                            in: 'query',
-                            name: 'mock',
-                            description: 'Mock mode',
-                            required: false,
-                            type: 'boolean'
-                        },
+                    path: ['paths', '/pets/{id}', 'get', 'parameters', '0'],
+                    schema: {
+                        in: 'query',
+                        name: 'mock',
+                        description: 'Mock mode',
+                        required: false,
+                        type: 'boolean'
                     },
+                },
                     {
-                        path: ['paths', '/pets/{id}', 'parameters', '0'],
-                        schema: {
-                            name: "id",
-                            in: "path",
-                            description: "ID of pet",
-                            required: true,
-                            type: "integer",
-                            format: "int64"
-                        }
+                    path: ['paths', '/pets/{id}', 'parameters', '0'],
+                    schema: {
+                        name: "id",
+                        in: "path",
+                        description: "ID of pet",
+                        required: true,
+                        type: "integer",
+                        format: "int64"
                     }
+                }
                 ];
                 req.swagger.operationPath = ['paths', '/pets/{id}', 'get'];
                 req.swagger.security = [
                     {
-                        oauth2: [ 'read' ]
-                    }
+                    oauth2: [ 'read' ]
+                }
                 ];
                 req.swagger.params = {
                     id: {
@@ -324,4 +324,21 @@ swaggerTools.initializeMiddleware(apiDoc12, apiDeclarations, middleware => {
     createServer(app).listen(serverPort, () => {
         console.log('Your server is listening on port %d (http://localhost:%d)', serverPort, serverPort);
     });
+});
+
+// Testing that handler functions can type the incoming request
+type TypedRequest = swaggerTools.Swagger20Request<{
+    foo: swaggerTools.SwaggerRequestParameter<number>;
+    bar?: swaggerTools.SwaggerRequestParameter<string>;
+}>;
+
+swaggerTools.initializeMiddleware(swaggerDoc20, middleware => {
+    app.use(middleware.swaggerRouter({
+        controllers: {
+            foo_bar: (req: TypedRequest, res, next) => {
+                req.swagger.params.foo.value + 2;
+                req.swagger.params.bar && req.swagger.params.bar.value.replace('a', 'b');
+            },
+        }
+    }));
 });


### PR DESCRIPTION
Two changes:

1) We are now allowing the parameters of a request to be typed. This
adds more type safety to consumers.

2) We support optional parameters in the request.

For (2), the root cause is this issue in how Typescript handles
--strictNullChecking:
https://github.com/Microsoft/TypeScript/issues/9235

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).