### PR TITLE
react: allow null as props for React.createElement()

### DIFF
--- a/types/create-react-class/create-react-class-tests.ts
+++ b/types/create-react-class/create-react-class-tests.ts
@@ -73,6 +73,12 @@ const ClassicComponent: React.ClassicComponentClass<Props> = createReactClass<Pr
     }
 });
 
+const ClassicComponentNoProps: React.ClassicComponentClass = createReactClass({
+    render() {
+        return DOM.div();
+    }
+});
+
 // React.createFactory
 const classicFactory: React.ClassicFactory<Props> =
     React.createFactory(ClassicComponent);
@@ -81,6 +87,7 @@ const classicFactoryElement: React.ClassicElement<Props> =
 
 // React.createElement
 const classicElement: React.ClassicElement<Props> = React.createElement(ClassicComponent, props);
+const classicElementNullProps: React.ClassicElement<{}> = React.createElement(ClassicComponentNoProps, null);
 
 // React.cloneElement
 const clonedClassicElement: React.ClassicElement<Props> =

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -193,37 +193,37 @@ declare namespace React {
     // TODO: generalize this to everything in `keyof ReactHTML`, not just "input"
     function createElement(
         type: "input",
-        props?: InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement>,
+        props?: InputHTMLAttributes<HTMLInputElement> & ClassAttributes<HTMLInputElement> | null,
         ...children: ReactNode[]): DetailedReactHTMLElement<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
     function createElement<P extends HTMLAttributes<T>, T extends HTMLElement>(
         type: keyof ReactHTML,
-        props?: ClassAttributes<T> & P,
+        props?: ClassAttributes<T> & P | null,
         ...children: ReactNode[]): DetailedReactHTMLElement<P, T>;
     function createElement<P extends SVGAttributes<T>, T extends SVGElement>(
         type: keyof ReactSVG,
-        props?: ClassAttributes<T> & P,
+        props?: ClassAttributes<T> & P | null,
         ...children: ReactNode[]): ReactSVGElement;
     function createElement<P extends DOMAttributes<T>, T extends Element>(
         type: string,
-        props?: ClassAttributes<T> & P,
+        props?: ClassAttributes<T> & P | null,
         ...children: ReactNode[]): DOMElement<P, T>;
 
     // Custom components
     function createElement<P>(
         type: SFC<P>,
-        props?: Attributes & P,
+        props?: Attributes & P | null,
         ...children: ReactNode[]): SFCElement<P>;
     function createElement<P>(
         type: ClassType<P, ClassicComponent<P, ComponentState>, ClassicComponentClass<P>>,
-        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P,
+        props?: ClassAttributes<ClassicComponent<P, ComponentState>> & P | null,
         ...children: ReactNode[]): CElement<P, ClassicComponent<P, ComponentState>>;
     function createElement<P, T extends Component<P, ComponentState>, C extends ComponentClass<P>>(
         type: ClassType<P, T, C>,
-        props?: ClassAttributes<T> & P,
+        props?: ClassAttributes<T> & P | null,
         ...children: ReactNode[]): CElement<P, T>;
     function createElement<P>(
         type: SFC<P> | ComponentClass<P> | string,
-        props?: Attributes & P,
+        props?: Attributes & P | null,
         ...children: ReactNode[]): ReactElement<P>;
 
     // DOM Elements

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -141,6 +141,9 @@ const StatelessComponent3: React.SFC<SCProps> =
     // allows null return
     props => props.foo ? DOM.div(null, props.foo, props.children) : null;
 
+// allows null as props
+const StatelessComponent4: React.SFC = props => null;
+
 // React.createFactory
 const factory: React.CFactory<Props, ModernComponent> =
     React.createFactory(ModernComponent);
@@ -160,15 +163,22 @@ const domFactoryElement: React.DOMElement<React.DOMAttributes<{}>, Element> =
 // React.createElement
 const element: React.CElement<Props, ModernComponent> = React.createElement(ModernComponent, props);
 const elementNoState: React.CElement<Props, ModernComponentNoState> = React.createElement(ModernComponentNoState, props);
+const elementNullProps: React.CElement<{}, ModernComponentNoPropsAndState> = React.createElement(ModernComponentNoPropsAndState, null);
 const statelessElement: React.SFCElement<SCProps> = React.createElement(StatelessComponent, props);
+const statelessElementNullProps: React.SFCElement<SCProps> = React.createElement(StatelessComponent4, null);
 const domElement: React.DOMElement<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> = React.createElement("div");
+const domElementNullProps = React.createElement("div", null);
 const htmlElement = React.createElement("input", { type: "text" });
+const inputElementNullProps: React.DOMElement<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> = React.createElement("input", null);
 const svgElement = React.createElement("svg", { accentHeight: 12 });
+const svgElementNullProps = React.createElement("svg", null);
 const fragmentElement: React.ReactElement<{}> = React.createElement(React.Fragment, {}, [React.createElement("div"), React.createElement("div")]);
+const fragmentElementNullProps: React.ReactElement<{}> = React.createElement(React.Fragment, null, [React.createElement("div"), React.createElement("div")]);
 
 const customProps: React.HTMLProps<HTMLElement> = props;
 const customDomElement = "my-element";
 const nonLiteralElement = React.createElement(customDomElement, customProps);
+const customDomElementNullProps = React.createElement(customDomElement, null);
 
 // https://github.com/Microsoft/TypeScript/issues/15019
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/react-without-jsx.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The existing definitions allow passing `undefined` as the props, but `null` is also supported by React and used in documentation examples.