### PR TITLE
[react-onclickoutside] enable/disableOnClickOutside returned to optional

### DIFF
--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -11,8 +11,8 @@ export interface HandleClickOutside<T> {
 }
 
 export interface InjectedOnClickOutProps {
-    disableOnClickOutside(): void;
-    enableOnClickOutside(): void;
+    disableOnClickOutside()?: void;
+    enableOnClickOutside()?: void;
 }
 
 export interface OnClickOutProps {

--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -11,8 +11,8 @@ export interface HandleClickOutside<T> {
 }
 
 export interface InjectedOnClickOutProps {
-    disableOnClickOutside()?: void;
-    enableOnClickOutside()?: void;
+    disableOnClickOutside?(): void;
+    enableOnClickOutside?(): void;
 }
 
 export interface OnClickOutProps {

--- a/types/react-onclickoutside/react-onclickoutside-tests.tsx
+++ b/types/react-onclickoutside/react-onclickoutside-tests.tsx
@@ -23,14 +23,14 @@ render(
     document.getElementById("main")
 );
 
-class TestComponent extends React.Component<{ disableOnClickOutside(): void; enableOnClickOutside(): void; }> {
+class TestComponent extends React.Component<{ disableOnClickOutside?(): void; enableOnClickOutside?(): void; }> {
     handleClickOutside = () => {
         console.log('this.handleClickOutside');
     }
 
     render() {
-        this.props.disableOnClickOutside();
-        this.props.enableOnClickOutside();
+        if (this.props.disableOnClickOutside) this.props.disableOnClickOutside();
+        if (this.props.enableOnClickOutside) this.props.enableOnClickOutside();
         return (
             <div onClick={this.props.disableOnClickOutside}>TestComponent</div>
         );


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

https://github.com/Pomax/react-onclickoutside/issues/171 and https://github.com/DefinitelyTyped/DefinitelyTyped/commit/0d96c339bccb58d2f37181411438ddb403c08f70

__tl;dr:__ changing the types of these methods from optional to required caused breakage for me and many other people, this merely reverts that change.

*(I don't think the the following two are applicable for this PR - please correct me if I'm wrong)*
- [ ] Increase the version number in the header if appropriate. 
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I've tested by editing `node_modules/@types/react-onclickoutside/index.d.ts` in a local app as well to get this back to expected functionality, and it works.
