### PR TITLE
seamlessImmutable: Return the proper combined type for the .merge method

### DIFF
--- a/types/seamless-immutable/index.d.ts
+++ b/types/seamless-immutable/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: alex3165 <https://github.com/alex3165>
 //                 Stepan Burguchev <https://github.com/xsburg>
 //                 Geir Sagberg <https://github.com/geirsagberg>
+//                 Dustin Horne <https://github.com/dustinhorne>
+//                 garyyeap <https://github.com/garyyeap>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -55,8 +57,7 @@ declare namespace SeamlessImmutable {
 
         asMutable(opts?: AsMutableOptions): T;
 
-        merge(part: DeepPartial<T>, config?: MergeConfig): ImmutableObject<T>;
-
+        merge<U>(part: DeepPartial<U>, config?: MergeConfig): ImmutableObject<T> & U;
         update<K extends keyof T>(property: K, updaterFunction: (value: T[K], ...additionalParameters: any[]) => any, ...additionalArguments: any[]): ImmutableObject<T>;
         update<TValue>(property: string, updaterFunction: (value: TValue, ...additionalParameters: any[]) => any, ...additionalArguments: any[]): ImmutableObject<T>;
 

--- a/types/seamless-immutable/seamless-immutable-tests.ts
+++ b/types/seamless-immutable/seamless-immutable-tests.ts
@@ -3,8 +3,8 @@ import * as Immutable from 'seamless-immutable';
 // Test types
 
 interface User {
-    firstName: string;
-    lastName: string;
+    firstName?: string | null;
+    lastName?: string | null;
 }
 
 interface Address {
@@ -21,8 +21,8 @@ interface ExtendedUser extends User {
 
 {
     interface User {
-        firstName: string;
-        lastName: string;
+        firstName?: string | null;
+        lastName?: string | null;
     }
 
     const arrayOfNumbers1: Immutable.ImmutableArray<number> = Immutable.from([0, 2]);
@@ -76,7 +76,7 @@ interface ExtendedUser extends User {
     });
     const immutableUserEx: Immutable.ImmutableObject<ExtendedUser> = Immutable.from({
         firstName: 'Hairy',
-        lastName: 'Dog',
+        lastName: null,
         address: {
             line1: 'Big house'
         }
@@ -101,10 +101,10 @@ interface ExtendedUser extends User {
     const mutableUser22: User = immutableUser.asMutable({ deep: true });
 
     // merge: merged part is strongly checked as a deeply partial object
-    const mergedUser: Immutable.ImmutableObject<User> = immutableUserEx.merge({ address: { line1: 'Small house' }, firstName: 'Jack' });
+    const mergedUser: Immutable.ImmutableObject<ExtendedUser> = immutableUserEx.merge({ address: { line1: 'Small house' }, firstName: 'Jack' });
 
     // update: property name is strongly checked
-    const updatedUser41: Immutable.ImmutableObject<User> = immutableUser.update('firstName', x => x.toLowerCase() + ' Whirlwind');
+    const updatedUser41: Immutable.ImmutableObject<User> = immutableUser.update('firstName', x => x && x.toLowerCase() + ' Whirlwind');
     // the type of the updated value must be explicity specified in case of fallback
     const updatedUser42: Immutable.ImmutableObject<User> = immutableUser.update<string>(data.propertyId, x => x.toLowerCase() + ' Whirlwind');
 


### PR DESCRIPTION
This PR should be merged along with authorization from @dustinhorne as the idea was came from #20591 

Fix #20591 

- [v ] Use a meaningful title for the pull request. Include the name of the package modified.
- [v] Test the change in your own code. (Compile and run.)
- [v ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ v] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [v ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [v] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20591
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
