### PR TITLE
[multistream] The last parameter in FactoryStream can take null

### DIFF
--- a/types/multistream/index.d.ts
+++ b/types/multistream/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for multistream 2.1
 // Project: https://github.com/feross/multistream
-// Definitions by: mrmlnc <https://github.com/mrmlnc>
+// Definitions by: mrmlnc <https://github.com/mrmlnc>, Kenzie Togami <https://github.com/kenzierocks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -9,9 +9,14 @@ import { Stream } from 'stream';
 
 declare function multistream(streams: multistream.Streams): NodeJS.ReadableStream;
 
+interface FactoryStreamCallback {
+    (err: Error | null, stream: null): any;
+    (err: null, stream: NodeJS.ReadableStream): any;
+}
+
 declare namespace multistream {
     type LazyStream = () => Stream;
-    type FactoryStream = (cb: (err: Error | null, stream: NodeJS.ReadableStream) => any) => void;
+    type FactoryStream = (cb: FactoryStreamCallback) => void;
     type Streams = Array<LazyStream | NodeJS.ReadableStream> | FactoryStream;
 
     function obj(streams: Streams): NodeJS.ReadableStream;

--- a/types/multistream/multistream-tests.ts
+++ b/types/multistream/multistream-tests.ts
@@ -26,6 +26,11 @@ const factory: multistream.FactoryStream = (cb) => {
     if (1 === 1) return cb(null, fs.createReadStream('.filepath'));
 
     cb(null, fs.createReadStream('.filepath'));
+    cb(null, null);
+    cb(new Error('some error'), null);
+
+    // $ExpectError
+    cb(new Error('some error'), fs.createReadStream('.filepath'));
 };
 
 // $ExpectType ReadableStream


### PR DESCRIPTION
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Third example in https://github.com/feross/multistream#user-content-usage
- [x] Increase the version number in the header if appropriate.