### PR TITLE
[redux-first-router-link] Proper html attribute props

### DIFF
--- a/types/redux-first-router-link/index.d.ts
+++ b/types/redux-first-router-link/index.d.ts
@@ -9,8 +9,6 @@ import { Location } from 'redux-first-router';
 
 export type To = string | string[] | object;
 
-export type OnClick = false | ((e: React.MouseEvent<HTMLElement>) => void);
-
 export interface Match<P> {
     params: P;
     isExact: boolean;
@@ -18,14 +16,12 @@ export interface Match<P> {
     url: string;
 }
 
-export interface LinkProps {
+// Unfortunately we can't pass `HTMLAnchorElement` since the `tagName` attribute allows you to use other tags than anchor.
+export interface LinkProps extends React.HTMLAttributes<HTMLElement> {
     to: To;
     redirect?: boolean;
     replace?: boolean;
     tagName?: string;
-    children?: React.ReactNode;
-    onPress?: OnClick;
-    onClick?: OnClick;
     down?: boolean;
     shouldDispatch?: boolean;
     target?: string;
@@ -33,18 +29,7 @@ export interface LinkProps {
 
 export default class Link extends React.Component<LinkProps> {}
 
-export interface NavLinkProps {
-    to: To;
-    redirect?: boolean;
-    replace?: boolean;
-    children?: React.ReactNode;
-    onPress?: OnClick;
-    onClick?: OnClick;
-    down?: boolean;
-    shouldDispatch?: boolean;
-    target?: string;
-    className?: string;
-    style?: React.CSSProperties;
+export interface NavLinkProps extends LinkProps {
     activeClassName?: string;
     activeStyle?: React.CSSProperties;
     ariaCurrent?: string;

--- a/types/redux-first-router-link/redux-first-router-link-tests.tsx
+++ b/types/redux-first-router-link/redux-first-router-link-tests.tsx
@@ -17,6 +17,16 @@ export default () => {
             { /* as an action object (RECOMMENDED APPROACH SO YOU CAN CHANGE ALL URLs FROM YOUR ROUTESMAP): */ }
             <Link to={{type: 'LIST', payload: { category: 'fp' }}}>FP</Link>
 
+            <Link
+                to='/'
+                key='1'
+                className='home-link'
+                style={{
+                    color: 'hotpink',
+                }}
+                id='the-home-link'
+            >Home</Link>
+
             <NavLink
                 to={{ type: 'LIST', payload: { category: 'redux-first-router' } }}
                 activeClassName='active'
@@ -26,6 +36,11 @@ export default () => {
                 isActive={(match, location) => (location.payload as Payload).category === 'redux-first-router'} >
                 Redux First Router
             </NavLink>
+
+            <NavLink
+                to='/'
+                className='nav-link'
+            >Nav link with class</NavLink>
         </div>
     );
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/faceyspacey/redux-first-router-link/blob/16784368064a2704d4623df5981a9f17d838ad88/src/Link.js
https://github.com/faceyspacey/redux-first-router-link/blob/16784368064a2704d4623df5981a9f17d838ad88/README.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

`<Link>` cannot take `className` or `style` props as is. This is fixed by letting the props extending the general HTML Attribute props.

Also made `NavLinkProps` extend `LinkProps` since the implementation of `NavLink` extends `Link`