### PR TITLE
[@types/request] Lint fix.

### DIFF
--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -60,8 +60,7 @@ declare namespace request {
         delete(options: TUriUrlOptions & TOptions, callback?: RequestCallback): TRequest;
 
         initParams(uri: string, options?: TOptions, callback?: RequestCallback): RequiredUriUrl & TOptions;
-        initParams(uri: string, callback?: RequestCallback): RequiredUriUrl & TOptions;
-        initParams(options: RequiredUriUrl & TOptions, callback?: RequestCallback): RequiredUriUrl & TOptions;
+        initParams(uriOrOpts: string | RequiredUriUrl & TOptions, callback?: RequestCallback): RequiredUriUrl & TOptions;
 
         forever(agentOptions: any, optionsArg: any): TRequest;
         jar(store?: any): CookieJar;
@@ -249,7 +248,7 @@ declare namespace request {
         multipart(multipart: RequestPart[]): Request;
         json(val: any): Request;
         aws(opts: AWSOptions, now?: boolean): Request;
-        auth(username: string, password: string, sendInmediately?: boolean, bearer?: string): Request;
+        auth(username: string, password: string, sendImmediately?: boolean, bearer?: string): Request;
         oauth(oauth: OAuthOptions): Request;
         jar(jar: CookieJar): Request;
 

--- a/types/request/request-tests.ts
+++ b/types/request/request-tests.ts
@@ -7,7 +7,7 @@ import request = require('request');
 import stream = require('stream');
 import urlModule = require('url');
 
-let value: any;
+const value: any = 'value';
 let str: string;
 let strOrUndef: string | undefined;
 let strOrTrueOrUndef: string | true | undefined;


### PR DESCRIPTION
I had two PRs merge close together that caused the build to fail.
- #22809 fixed a bug
- #22821 removed all the overrides from `tslint.json`

Unfortunately, the former ended up with a couple lint issues.
```
./types/request/index.d.ts
ERROR: 64:20  unified-signatures  This overload and the one on line 63 can be combined into one signature taking `string | RequiredUriUrl & TOptions`.

./types/request/request-tests.ts
ERROR: 10:5   prefer-const        Identifier 'value' is never reassigned; use 'const' instead of 'let'.
```

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).