### PR TITLE
luxon: fix two typos, and make constants readonly

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -61,26 +61,26 @@ declare module 'luxon' {
         };
 
         class DateTime {
-            static DATETIME_FULL: DateTimeFormatOptions;
-            static DATETIME_FULL_WITH_SECONDS: DateTimeFormatOptions;
-            static DATEIME_HUGE: DateTimeFormatOptions;
-            static DATEIME_HUGE_WITH_SECONDS: DateTimeFormatOptions;
-            static DATETIME_MED: DateTimeFormatOptions;
-            static DATETIME_MED_WITH_SECONDS: DateTimeFormatOptions;
-            static DATETIME_SHORT: DateTimeFormatOptions;
-            static DATETIME_SHORT_WITH_SECONDS: DateTimeFormatOptions;
-            static DATE_FULL: DateTimeFormatOptions;
-            static DATE_HUGE: DateTimeFormatOptions;
-            static DATE_MED: DateTimeFormatOptions;
-            static DATE_SHORT: DateTimeFormatOptions;
-            static TIME_24_SIMPLE: DateTimeFormatOptions;
-            static TIME_24_WITH_LONG_OFFSET: DateTimeFormatOptions;
-            static TIME_24_WITH_SECONDS: DateTimeFormatOptions;
-            static TIME_24_WITH_SHORT_OFFSET: DateTimeFormatOptions;
-            static TIME_SIMPLE: DateTimeFormatOptions;
-            static TIME_WITH_LONG_OFFSET: DateTimeFormatOptions;
-            static TIME_WITH_SECONDS: DateTimeFormatOptions;
-            static TIME_WITH_SHORT_OFFSET: DateTimeFormatOptions;
+            static readonly DATETIME_FULL: DateTimeFormatOptions;
+            static readonly DATETIME_FULL_WITH_SECONDS: DateTimeFormatOptions;
+            static readonly DATETIME_HUGE: DateTimeFormatOptions;
+            static readonly DATETIME_HUGE_WITH_SECONDS: DateTimeFormatOptions;
+            static readonly DATETIME_MED: DateTimeFormatOptions;
+            static readonly DATETIME_MED_WITH_SECONDS: DateTimeFormatOptions;
+            static readonly DATETIME_SHORT: DateTimeFormatOptions;
+            static readonly DATETIME_SHORT_WITH_SECONDS: DateTimeFormatOptions;
+            static readonly DATE_FULL: DateTimeFormatOptions;
+            static readonly DATE_HUGE: DateTimeFormatOptions;
+            static readonly DATE_MED: DateTimeFormatOptions;
+            static readonly DATE_SHORT: DateTimeFormatOptions;
+            static readonly TIME_24_SIMPLE: DateTimeFormatOptions;
+            static readonly TIME_24_WITH_LONG_OFFSET: DateTimeFormatOptions;
+            static readonly TIME_24_WITH_SECONDS: DateTimeFormatOptions;
+            static readonly TIME_24_WITH_SHORT_OFFSET: DateTimeFormatOptions;
+            static readonly TIME_SIMPLE: DateTimeFormatOptions;
+            static readonly TIME_WITH_LONG_OFFSET: DateTimeFormatOptions;
+            static readonly TIME_WITH_SECONDS: DateTimeFormatOptions;
+            static readonly TIME_WITH_SHORT_OFFSET: DateTimeFormatOptions;
             static fromHTTP(text: string, options?: DateTimeOptions): DateTime;
             static fromISO(text: string, options?: DateTimeOptions): DateTime;
             static fromJSDate(


### PR DESCRIPTION
the constants should be readonly, since the original source code has getters, but no setters for these constants (see https://github.com/moment/luxon/blob/master/src/datetime.js#L1715-L1850)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/blob/master/src/datetime.js#L1715-L1850
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

