### PR TITLE
snapsvg: Added missing parameter format

### DIFF
--- a/types/snapsvg/index.d.ts
+++ b/types/snapsvg/index.d.ts
@@ -279,6 +279,7 @@ declare namespace Snap {
         image(src:string,x:number,y:number,width:number,height:number):Snap.Element;
         line(x1:number,y1:number,x2:number,y2:number):Snap.Element;
         path(pathString?:string):Snap.Element;
+        path(pathSpec:(string | number)[][]):Snap.Element;
         polygon(varargs:any[]):Snap.Element;
         polyline(varargs:any[]):Snap.Element;
         rect(x:number,y:number,width:number,height:number,rx?:number,ry?:number):Snap.Element;


### PR DESCRIPTION
Paper.path also accepts an array of commands instead of a path string. 

Example: 
paper.path([
            ["M", 5, 10],
            ["l", 15,  2],
            ["h", 30],
            ["Z"]
]);

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X ] Test the change in your own code. (Compile and run.)
- [X ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ C] Provide a URL to documentation or source code which provides context for the suggested changes: 
See code of proto.path (~line 5009 of snap.svg.js) where (if an object or array was provided a special handling of the given parameter "d" is done. This dives into the function Snap.parsePathString (roughly line 1819 in actual node version (0.5.0)) where a stringified path definition is converted to an array of arrays. If an array of arrays is given, this step is skipped and the next function is called with a cloned version.


- [Already there ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
