### PR TITLE
Add typings for logform

### DIFF
--- a/types/logform/index.d.ts
+++ b/types/logform/index.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for logform 1.2
+// Project: https://github.com/winstonjs/logform
+// Definitions by: DABH <https://github.com/DABH>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export interface TransformableInfo {
+    level: string;
+    message: string;
+    [key: string]: any;
+}
+
+export type TransformFunction = (info: TransformableInfo, opts?: any) => TransformableInfo | boolean;
+export type Colors = { [key: string]: string | string[] }; // tslint:disable-line interface-over-type-literal
+export type FormatWrap = (opts?: any) => Format;
+
+export class Format {
+    constructor(opts?: object);
+
+    options?: object;
+    transform: TransformFunction;
+}
+
+export class Colorizer extends Format {
+    constructor(opts?: object);
+
+    createColorize: (opts?: object) => Colorizer;
+    addColors: (colors: Colors) => Colors;
+    colorize: (level: string, message: string) => string;
+}
+
+export function format(transform: TransformFunction): FormatWrap;
+
+export function levels(config: object): object;
+
+export namespace format {
+    function align(opts?: object): Format;
+    function cli(opts?: object): Format;
+    function colorize(opts?: object): Colorizer;
+    function combine(...formats: Format[]): Format;
+    function json(opts?: object): Format;
+    function label(opts?: object): Format;
+    function logstash(opts?: object): Format;
+    function padLevels(opts?: object): Format;
+    function prettyPrint(opts?: object): Format;
+    function printf(templateFunction: (info: TransformableInfo) => string): Format;
+    function simple(opts?: object): Format;
+    function splat(opts?: object): Format;
+    function timestamp(opts?: object): Format;
+    function uncolorize(opts?: object): Format;
+}

--- a/types/logform/logform-tests.ts
+++ b/types/logform/logform-tests.ts
@@ -1,0 +1,58 @@
+import * as logform from 'logform';
+const format = logform.format;
+const { combine, timestamp, label } = format;
+
+const labelTimestamp = combine(
+  label({ label: 'right meow!' }),
+  timestamp()
+);
+
+const info = labelTimestamp.transform({
+  level: 'info',
+  message: 'What time is the testing at?'
+});
+
+const ignorePrivate = format((info, opts) => {
+  if (info.private) { return false; }
+  return info;
+})();
+
+ignorePrivate.transform({
+  level: 'error',
+  message: 'Public error to share'
+});
+
+ignorePrivate.transform({
+  level: 'error',
+  private: true,
+  message: 'This is super secret - hide it.'
+});
+
+const willNeverThrow = format.combine(
+  format(info => false)(), // Ignores everything
+  format(info => { throw new Error('Never reached'); })()
+);
+
+const volume = format((info, opts) => {
+  if (opts && opts.yell) {
+    info.message = info.message.toUpperCase();
+  } else if (opts && opts.whisper) {
+    info.message = info.message.toLowerCase();
+  }
+
+  return info;
+});
+
+// `volume` is now a function that returns instances of the format.
+const scream = volume({ yell: true });
+scream.transform({
+  level: 'info',
+  message: `sorry for making you YELL in your head!`
+}, scream.options);
+
+// `volume` can be used multiple times to create different formats.
+const whisper = volume({ whisper: true });
+whisper.transform({
+  level: 'info',
+  message: `WHY ARE THEY MAKING US YELL SO MUCH!`
+}, whisper.options);

--- a/types/logform/tsconfig.json
+++ b/types/logform/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "logform-tests.ts"
+    ]
+}

--- a/types/logform/tslint.json
+++ b/types/logform/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

The popular winston library has been split into a hierarchy of smaller libraries as of the 3.x series.  Accordingly, typings are needed for these new libraries that support winston.  This is the first of at least 2 new typings; once they are merged in, updated typings for winston@3.x can be provided.  See also Issue #20418 , which is what prompted this.