### PR TITLE
Adds type definitions for raspi-gpio, raspi-i2c, raspi-led, raspi-onewire, raspi-pwm, raspi-serial, raspi-soft-pwm

### DIFF
--- a/types/raspi-gpio/index.d.ts
+++ b/types/raspi-gpio/index.d.ts
@@ -1,0 +1,31 @@
+// Type definitions for raspi-gpio 5.0
+// Project: https://github.com/nebrius/raspi-gpio
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+import { Peripheral } from 'raspi-peripheral';
+export interface Config {
+    pin: number | string;
+    pullResistor?: number;
+}
+export const LOW = 0;
+export const HIGH = 1;
+export const PULL_NONE: number;
+export const PULL_DOWN: number;
+export const PULL_UP: number;
+export class DigitalOutput extends Peripheral {
+    private _output;
+    private _currentValue;
+    readonly value: number;
+    constructor(config: number | string | Config);
+    write(value: number): void;
+}
+export class DigitalInput extends Peripheral {
+    private _input;
+    private _currentValue;
+    readonly value: number;
+    constructor(config: number | string | Config);
+    destroy(): void;
+    read(): number;
+}

--- a/types/raspi-gpio/raspi-gpio-tests.ts
+++ b/types/raspi-gpio/raspi-gpio-tests.ts
@@ -1,0 +1,24 @@
+import { DigitalInput, DigitalOutput, Config, LOW, HIGH, PULL_UP, PULL_DOWN, PULL_NONE } from 'raspi-gpio';
+
+const inputConfig: Config = {
+  pin: 'P1-3',
+  pullResistor: PULL_UP
+};
+const input = new DigitalInput(inputConfig);
+input.read();
+input.value;
+
+new DigitalInput({
+  pin: 'P1-3',
+  pullResistor: PULL_DOWN
+});
+
+new DigitalInput({
+  pin: 'P1-3',
+  pullResistor: PULL_NONE
+});
+
+const output = new DigitalOutput('P1-5');
+output.write(LOW);
+output.write(HIGH);
+output.value;

--- a/types/raspi-gpio/tsconfig.json
+++ b/types/raspi-gpio/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-gpio-tests.ts"
+    ]
+}

--- a/types/raspi-gpio/tslint.json
+++ b/types/raspi-gpio/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/raspi-i2c/index.d.ts
+++ b/types/raspi-i2c/index.d.ts
@@ -6,30 +6,30 @@
 
 /// <reference types="node" />
 import { Peripheral } from 'raspi-peripheral';
-export type IReadCallback = (err: null | Error | string, data: null | Buffer | number) => void;
-export type IWriteCallback = (err: null | Error | string) => void;
+export type ReadCallback = (err: null | Error | string, data: null | Buffer | number) => void;
+export type WriteCallback = (err: null | Error | string) => void;
 export class I2C extends Peripheral {
     private _devices;
     constructor();
     destroy(): void;
     private _getDevice(address);
-    read(address: number, length: number, cb: IReadCallback): void;
-    read(address: number, register: number, length: number, cb: IReadCallback): void;
+    read(address: number, length: number, cb: ReadCallback): void;
+    read(address: number, register: number, length: number, cb: ReadCallback): void;
     readSync(address: number, registerOrLength: number | undefined, length?: number): Buffer;
-    readByte(address: number, cb: IReadCallback): void;
-    readByte(address: number, register: number, cb: IReadCallback): void;
+    readByte(address: number, cb: ReadCallback): void;
+    readByte(address: number, register: number, cb: ReadCallback): void;
     readByteSync(address: number, register?: number): number;
-    readWord(address: number, cb: IReadCallback): void;
-    readWord(address: number, register: number, cb: IReadCallback): void;
+    readWord(address: number, cb: ReadCallback): void;
+    readWord(address: number, register: number, cb: ReadCallback): void;
     readWordSync(address: number, register?: number): number;
-    write(address: number, buffer: Buffer, cb?: IWriteCallback): void;
-    write(address: number, register: number, buffer: Buffer, cb?: IWriteCallback): void;
+    write(address: number, buffer: Buffer, cb?: WriteCallback): void;
+    write(address: number, register: number, buffer: Buffer, cb?: WriteCallback): void;
     writeSync(address: number, buffer: Buffer): void;
     writeSync(address: number, register: number, buffer: Buffer): void;
-    writeByte(address: number, byte: number, cb?: IWriteCallback): void;
-    writeByte(address: number, register: number, byte: number, cb?: IWriteCallback): void;
+    writeByte(address: number, byte: number, cb?: WriteCallback): void;
+    writeByte(address: number, register: number, byte: number, cb?: WriteCallback): void;
     writeByteSync(address: number, registerOrByte: number, byte?: number): void;
-    writeWord(address: number, word: number, cb?: IWriteCallback): void;
-    writeWord(address: number, register: number, word: number, cb?: IWriteCallback): void;
+    writeWord(address: number, word: number, cb?: WriteCallback): void;
+    writeWord(address: number, register: number, word: number, cb?: WriteCallback): void;
     writeWordSync(address: number, registerOrWord: number, word?: number): void;
 }

--- a/types/raspi-i2c/index.d.ts
+++ b/types/raspi-i2c/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for raspi-i2c 6.1
+// Project: https://github.com/nebrius/raspi-i2c
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+import { Peripheral } from 'raspi-peripheral';
+export type IReadCallback = (err: null | Error | string, data: null | Buffer | number) => void;
+export type IWriteCallback = (err: null | Error | string) => void;
+export class I2C extends Peripheral {
+    private _devices;
+    constructor();
+    destroy(): void;
+    private _getDevice(address);
+    read(address: number, length: number, cb: IReadCallback): void;
+    read(address: number, register: number, length: number, cb: IReadCallback): void;
+    readSync(address: number, registerOrLength: number | undefined, length?: number): Buffer;
+    readByte(address: number, cb: IReadCallback): void;
+    readByte(address: number, register: number, cb: IReadCallback): void;
+    readByteSync(address: number, register?: number): number;
+    readWord(address: number, cb: IReadCallback): void;
+    readWord(address: number, register: number, cb: IReadCallback): void;
+    readWordSync(address: number, register?: number): number;
+    write(address: number, buffer: Buffer, cb?: IWriteCallback): void;
+    write(address: number, register: number, buffer: Buffer, cb?: IWriteCallback): void;
+    writeSync(address: number, buffer: Buffer): void;
+    writeSync(address: number, register: number, buffer: Buffer): void;
+    writeByte(address: number, byte: number, cb?: IWriteCallback): void;
+    writeByte(address: number, register: number, byte: number, cb?: IWriteCallback): void;
+    writeByteSync(address: number, registerOrByte: number, byte?: number): void;
+    writeWord(address: number, word: number, cb?: IWriteCallback): void;
+    writeWord(address: number, register: number, word: number, cb?: IWriteCallback): void;
+    writeWordSync(address: number, registerOrWord: number, word?: number): void;
+}

--- a/types/raspi-i2c/raspi-i2c-tests.ts
+++ b/types/raspi-i2c/raspi-i2c-tests.ts
@@ -1,0 +1,38 @@
+import { I2C } from 'raspi-i2c';
+
+const i2c = new I2C();
+
+i2c.read(1, 1, (err, data) => {});
+i2c.read(1, 1, 1, (err, data) => {});
+
+i2c.readSync(1, 1);
+i2c.readSync(1, 1, 1);
+
+i2c.readByte(1, (err, data) => {});
+i2c.readByte(1, 1, (err, data) => {});
+
+i2c.readByteSync(1);
+i2c.readByteSync(1, 1);
+
+i2c.readWord(1, (err, data) => {});
+i2c.readWord(1, 1, (err, data) => {});
+
+const buf = Buffer.alloc(1);
+
+i2c.write(1, buf, (err) => {});
+i2c.write(1, 1, buf, (err) => {});
+
+i2c.writeSync(1, buf);
+i2c.writeSync(1, 1, buf);
+
+i2c.writeByte(1, 1, (err) => {});
+i2c.writeByte(1, 1, 1, (err) => {});
+
+i2c.writeByteSync(1, 1);
+i2c.writeByteSync(1, 1, 1);
+
+i2c.writeWord(1, 1, (err) => {});
+i2c.writeWord(1, 1, 1, (err) => {});
+
+i2c.writeWordSync(1, 1);
+i2c.writeWordSync(1, 1, 1);

--- a/types/raspi-i2c/tsconfig.json
+++ b/types/raspi-i2c/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-i2c-tests.ts"
+    ]
+}

--- a/types/raspi-i2c/tslint.json
+++ b/types/raspi-i2c/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/raspi-led/index.d.ts
+++ b/types/raspi-led/index.d.ts
@@ -1,0 +1,15 @@
+// Type definitions for raspi-led 2.0
+// Project: https://github.com/nebrius/raspi-led
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+import { Peripheral } from 'raspi-peripheral';
+export const OFF = 0;
+export const ON = 1;
+export class LED extends Peripheral {
+    constructor();
+    hasLed(): boolean;
+    read(): 0 | 1;
+    write(value: 0 | 1): void;
+}

--- a/types/raspi-led/raspi-led-tests.ts
+++ b/types/raspi-led/raspi-led-tests.ts
@@ -1,0 +1,7 @@
+import { OFF, ON, LED } from 'raspi-led';
+
+const led = new LED();
+led.hasLed();
+led.read();
+led.write(OFF);
+led.write(ON);

--- a/types/raspi-led/tsconfig.json
+++ b/types/raspi-led/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-led-tests.ts"
+    ]
+}

--- a/types/raspi-led/tslint.json
+++ b/types/raspi-led/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/raspi-onewire/index.d.ts
+++ b/types/raspi-onewire/index.d.ts
@@ -1,0 +1,17 @@
+// Type definitions for raspi-onewire 1.0
+// Project: https://github.com/nebrius/raspi-onewire
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+import { Peripheral } from 'raspi-peripheral';
+export class OneWire extends Peripheral {
+    private _deviceIdMapping;
+    constructor();
+    private _convertIDToMappingKey(deviceID);
+    private _getNameFromID(deviceID);
+    searchForDevices(cb: (readErr: string | Error | undefined, devices: number[][] | undefined) => void): void;
+    read(deviceID: number[], numBytesToRead: number, cb: (err: string | Error | undefined, data: Buffer | undefined) => void): void;
+    readAllAvailable(deviceID: number[], cb: (err: string | Error | undefined, data: Buffer | undefined) => void): void;
+}

--- a/types/raspi-onewire/raspi-onewire-tests.ts
+++ b/types/raspi-onewire/raspi-onewire-tests.ts
@@ -1,0 +1,7 @@
+import { OneWire } from 'raspi-onewire';
+
+const oneWire = new OneWire();
+
+oneWire.searchForDevices((err, devices) => {});
+oneWire.read([ 1, 2 ], 1, (err, data) => {});
+oneWire.readAllAvailable([ 1, 2 ], (err, data) => {});

--- a/types/raspi-onewire/tsconfig.json
+++ b/types/raspi-onewire/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-onewire-tests.ts"
+    ]
+}

--- a/types/raspi-onewire/tslint.json
+++ b/types/raspi-onewire/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/raspi-pwm/index.d.ts
+++ b/types/raspi-pwm/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for raspi-pwm 5.0
+// Project: https://github.com/nebrius/raspi-pwm
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+import { Peripheral } from 'raspi-peripheral';
+export interface Config {
+    pin?: number | string;
+    frequency?: number;
+}
+export class PWM extends Peripheral {
+    private _frequencyValue;
+    private _dutyCycleValue;
+    private _pwmPort;
+    private _pwm;
+    readonly frequency: number;
+    readonly dutyCycle: number;
+    constructor(config?: number | string | Config);
+    destroy(): void;
+    write(dutyCycle: number): void;
+}

--- a/types/raspi-pwm/raspi-pwm-tests.ts
+++ b/types/raspi-pwm/raspi-pwm-tests.ts
@@ -1,0 +1,15 @@
+import { Config, PWM } from 'raspi-pwm';
+
+const config: Config = {
+  pin: 'P1-3',
+  frequency: 1
+};
+
+new PWM();
+new PWM(1);
+new PWM('P1-3');
+const pwm = new PWM(config);
+
+pwm.write(1);
+pwm.frequency;
+pwm.dutyCycle;

--- a/types/raspi-pwm/tsconfig.json
+++ b/types/raspi-pwm/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-pwm-tests.ts"
+    ]
+}

--- a/types/raspi-pwm/tslint.json
+++ b/types/raspi-pwm/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/raspi-serial/index.d.ts
+++ b/types/raspi-serial/index.d.ts
@@ -1,0 +1,40 @@
+// Type definitions for raspi-serial 4.0
+// Project: https://github.com/nebrius/raspi-serial
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+/// <reference types="node" />
+import { Peripheral } from 'raspi-peripheral';
+export const PARITY_NONE = "none";
+export const PARITY_EVEN = "even";
+export const PARITY_ODD = "odd";
+export const PARITY_MARK = "mark";
+export const PARITY_SPACE = "space";
+export const DEFAULT_PORT = "/dev/ttyAMA0";
+export interface Options {
+    portId?: string;
+    baudRate?: 115200 | 57600 | 38400 | 19200 | 9600 | 4800 | 2400 | 1800 | 1200 | 600 | 300 | 200 | 150 | 134 | 110 | 75 | 50 | number;
+    dataBits?: 8 | 7 | 6 | 5;
+    stopBits?: 1 | 2;
+    parity?: 'none' | 'even' | 'mark' | 'odd' | 'space';
+}
+export type ICallback = () => void;
+export type IErrorCallback = (err: Error | string) => void;
+export class Serial extends Peripheral {
+    private _portId;
+    private _options;
+    private _portInstance;
+    private _isOpen;
+    constructor({ portId, baudRate, dataBits, stopBits, parity }?: Options);
+    readonly port: string;
+    readonly baudRate: number;
+    readonly dataBits: number;
+    readonly stopBits: number;
+    readonly parity: string;
+    destroy(): void;
+    open(cb?: ICallback): void;
+    close(cb?: IErrorCallback): void;
+    write(data: Buffer | string, cb?: ICallback): void;
+    flush(cb?: IErrorCallback): void;
+}

--- a/types/raspi-serial/index.d.ts
+++ b/types/raspi-serial/index.d.ts
@@ -19,8 +19,8 @@ export interface Options {
     stopBits?: 1 | 2;
     parity?: 'none' | 'even' | 'mark' | 'odd' | 'space';
 }
-export type ICallback = () => void;
-export type IErrorCallback = (err: Error | string) => void;
+export type Callback = () => void;
+export type ErrorCallback = (err: Error | string) => void;
 export class Serial extends Peripheral {
     private _portId;
     private _options;
@@ -33,8 +33,8 @@ export class Serial extends Peripheral {
     readonly stopBits: number;
     readonly parity: string;
     destroy(): void;
-    open(cb?: ICallback): void;
-    close(cb?: IErrorCallback): void;
-    write(data: Buffer | string, cb?: ICallback): void;
-    flush(cb?: IErrorCallback): void;
+    open(cb?: Callback): void;
+    close(cb?: ErrorCallback): void;
+    write(data: Buffer | string, cb?: Callback): void;
+    flush(cb?: ErrorCallback): void;
 }

--- a/types/raspi-serial/raspi-serial-tests.ts
+++ b/types/raspi-serial/raspi-serial-tests.ts
@@ -1,0 +1,34 @@
+import {
+  PARITY_NONE,
+  PARITY_EVEN,
+  PARITY_ODD,
+  PARITY_MARK,
+  PARITY_SPACE,
+  DEFAULT_PORT,
+  Options,
+  Serial
+} from 'raspi-serial';
+
+let options: Options = {};
+options = {
+  parity: PARITY_EVEN
+};
+options = {
+  parity: PARITY_ODD
+};
+options = {
+  parity: PARITY_MARK
+};
+options = {
+  parity: PARITY_SPACE
+};
+options = {
+  portId: DEFAULT_PORT,
+  baudRate: 9600,
+  dataBits: 8,
+  stopBits: 1,
+  parity: PARITY_NONE
+};
+
+new Serial();
+const serial = new Serial(options);

--- a/types/raspi-serial/tsconfig.json
+++ b/types/raspi-serial/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-serial-tests.ts"
+    ]
+}

--- a/types/raspi-serial/tslint.json
+++ b/types/raspi-serial/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/raspi-soft-pwm/index.d.ts
+++ b/types/raspi-soft-pwm/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for raspi-soft-pwm 4.0
+// Project: https://github.com/nebrius/raspi-soft-pwm
+// Definitions by: Bryan Hughes <https://github.com/nebrius>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+import { Peripheral } from 'raspi-peripheral';
+export interface Config {
+    pin: number | string;
+    frequency?: number;
+    range?: number;
+}
+export class SoftPWM extends Peripheral {
+    private _pwm;
+    private _frequency;
+    private _range;
+    private _dutyCycle;
+    readonly frequency: number;
+    readonly range: number;
+    readonly dutyCycle: number;
+    constructor(config: number | string | Config);
+    write(dutyCycle: number): void;
+}

--- a/types/raspi-soft-pwm/raspi-soft-pwm-tests.ts
+++ b/types/raspi-soft-pwm/raspi-soft-pwm-tests.ts
@@ -1,0 +1,16 @@
+import { Config, SoftPWM } from 'raspi-soft-pwm';
+
+const config: Config = {
+  pin: 'P1-3',
+  frequency: 1,
+  range: 1
+};
+
+new SoftPWM(1);
+new SoftPWM('P1-3');
+const pwm = new SoftPWM(config);
+
+pwm.write(1);
+pwm.frequency;
+pwm.dutyCycle;
+pwm.range;

--- a/types/raspi-soft-pwm/tsconfig.json
+++ b/types/raspi-soft-pwm/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "raspi-soft-pwm-tests.ts"
+    ]
+}

--- a/types/raspi-soft-pwm/tslint.json
+++ b/types/raspi-soft-pwm/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

**Justification for not checking the first option above:** As discussed in depth at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21618, this suite of packages cannot be installed on anything other than a Raspberry Pi due to install scripts that are Raspberry Pi specific. Without these DefinitelyTyped definitions, the only way to develop using this module on a laptop is to manually copy the definition files into the project and use a custom typings folder, which tends to be kludgy and error-prone IME.

@andy-ms can you add these to the list of excludes once finished, as we discussed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22321?

Thanks everyone!