### PR TITLE
@types/react-navigation: Add missing exported NavigationActions consts

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -613,6 +613,13 @@ export const TabBarBottom: React.ComponentClass<any>;
  * NavigationActions
  */
 export namespace NavigationActions {
+  const BACK: 'Navigation/BACK';
+  const INIT: 'Navigation/INIT';
+  const NAVIGATE: 'Navigation/NAVIGATE';
+  const RESET: 'Navigation/RESET';
+  const SET_PARAMS: 'Navigation/SET_PARAMS';
+  const URI: 'Navigation/URI';
+
   function init(options?: NavigationInitActionPayload): NavigationInitAction;
   function navigate(options: NavigationNavigateActionPayload): NavigationNavigateAction;
   function reset(options: NavigationResetActionPayload): NavigationResetAction;


### PR DESCRIPTION
Add missing exported consts for NavigationActions (https://github.com/react-navigation/react-navigation/blob/abbd88601f9c8b0aa0e596317a8728a05d34c9e8/src/NavigationActions.js#L160)

- [/] Use a meaningful title for the pull request. Include the name of the package modified.
- [/] Test the change in your own code. (Compile and run.)
- [/] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [/] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [/] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [/] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-navigation/react-navigation/blob/abbd88601f9c8b0aa0e596317a8728a05d34c9e8/src/NavigationActions.js#L160
