### PR TITLE
atom: fix return type of LinterProvider.lint()

### DIFF
--- a/types/atom/linter/index.d.ts
+++ b/types/atom/linter/index.d.ts
@@ -78,5 +78,5 @@ export interface LinterProvider {
     scope: "file"|"project";
     lintsOnChange: boolean;
     grammarScopes: string[];
-    lint(textEditor: TextEditor): Message[]|void|Promise<Message[]|undefined>;
+    lint(textEditor: TextEditor): Message[]|null|Promise<Message[]|null>;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/steelbrain/linter/blob/master/docs/types/standard-linter-v2.md
https://github.com/steelbrain/linter/blob/master/docs/guides/upgrading-to-standard-linter-v2.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

As of Standard Linter v2, the `lint()` method of linter providers *must* return either a `Message[]` or `null`, or a Promise that resolves to one of these types. Returning `undefined`, as was common practice with Standard Linter v1, [is now considered an error](https://github.com/steelbrain/linter/blob/master/docs/guides/upgrading-to-standard-linter-v2.md#other-changes). This patch changes the return type of the `lint()` method from

```typescript
Message[]|void|Promise<Message[]|undefined>
```

to

```typescript
Message[]|null|Promise<Message[]|null>
```

in order to reflect proper usage of the v2 API (which the rest of the `LinterProvider` interface seems to abide by.)

/cc @GlenCFL @lierdakil 