### PR TITLE
ember: allow get/set with dynamic key

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -3055,10 +3055,12 @@ declare module 'ember' {
             obj: ComputedProperties<T>,
             list: K[]
         ): Pick<T, K>;
+        function getProperties<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K>; // for dynamic K
         function getProperties<T, K extends keyof T>(
             obj: ComputedProperties<T>,
             ...list: K[]
         ): Pick<T, K>;
+        function getProperties<T, K extends keyof T>(obj: T, ...list: K[]): Pick<T, K>; // for dynamic K
         /**
          * A value is blank if it is empty or a whitespace string.
          */
@@ -3143,6 +3145,7 @@ declare module 'ember' {
          * object implements the `unknownProperty` method then that will be invoked.
          */
         function get<T, K extends keyof T>(obj: ComputedProperties<T>, key: K): T[K];
+        function get<T, K extends keyof T>(obj: T, key: K): T[K]; // for dynamic K
         /**
          * Retrieves the value of a property from an Object, or a default value in the
          * case that the property returns `undefined`.
@@ -3152,6 +3155,7 @@ declare module 'ember' {
             key: K,
             defaultValue: T[K]
         ): T[K];
+        function getWithDefault<T, K extends keyof T>(obj: T, key: K, defaultValue: T[K]): T[K]; // for dynamic K
         /**
          * Sets the value of a property on an object, respecting computed properties
          * and notifying observers and other listeners of the change. If the
@@ -3163,6 +3167,7 @@ declare module 'ember' {
             key: K,
             value: V
         ): V;
+        function set<T, K extends keyof T, V extends T[K]>(obj: T, key: K, value: V): V; // for dynamic K
         /**
          * Error-tolerant form of `Ember.set`. Will not blow up if any part of the
          * chain is `undefined`, `null`, or destroyed.
@@ -3177,6 +3182,7 @@ declare module 'ember' {
             obj: ComputedProperties<T>,
             hash: Pick<T, K>
         ): Pick<T, K>;
+        function setProperties<T, K extends keyof T>(obj: T, hash: Pick<T, K>): Pick<T, K>; // for dynamic K
         /**
          * Detects when a specific package of Ember (e.g. 'Ember.Application')
          * has fully loaded and is available for extension.

--- a/types/ember/test/observable.ts
+++ b/types/ember/test/observable.ts
@@ -86,3 +86,21 @@ function testSetProperties() {
     assertType<{ name: string, capitalized: string }>(person.setProperties({ name: 'Joe', capitalized: 'JOE' }));
     assertType<{ name: string, age: number }>(Ember.setProperties(pojo, { name: 'Joe', age: 35 }));
 }
+
+function testDynamic() {
+    const obj: any = {};
+    const dynamicKey: string = 'dummy'; // tslint:disable-line:no-inferrable-types
+
+    assertType<any>(Ember.get(obj, 'dummy'));
+    assertType<any>(Ember.get(obj, dynamicKey));
+    assertType<string>(Ember.getWithDefault(obj, 'dummy', 'default'));
+    assertType<string>(Ember.getWithDefault(obj, dynamicKey, 'default'));
+    assertType<{ dummy: any }>(Ember.getProperties(obj, 'dummy'));
+    assertType<{ dummy: any }>(Ember.getProperties(obj, [ 'dummy' ]));
+    assertType<object>(Ember.getProperties(obj, dynamicKey));
+    assertType<object>(Ember.getProperties(obj, [ dynamicKey ]));
+    assertType<string>(Ember.set(obj, 'dummy', 'value'));
+    assertType<string>(Ember.set(obj, dynamicKey, 'value'));
+    assertType<{ dummy: string }>(Ember.setProperties(obj, { dummy: 'value '}));
+    assertType<object>(Ember.setProperties(obj, { [dynamicKey]: 'value' }));
+}

--- a/types/ember/tslint.json
+++ b/types/ember/tslint.json
@@ -23,7 +23,10 @@
         "no-void-expression": false,
         "only-arrow-functions": false,
         "no-submodule-imports": false,
-        
-        "no-unnecessary-class": false
+
+        "no-unnecessary-class": false,
+
+        // false positives
+        "unified-signatures": false
     }
 }


### PR DESCRIPTION
Allow get/set with any key if the object is type `any`, e.g. `Ember.get(obj as any, someString)`. It can be useful if the key is not known at compile time. This brings the ember APIs more in line with regular typescript.