### PR TITLE
atom: fix type of Task.send()'s message parameter

### DIFF
--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -4810,7 +4810,6 @@ export class Task {
      *  Throws an error if this task has already been terminated or if sending a
      *  message to the child process fails.
      */
-    // tslint:disable-next-line:no-any
     send(message: string | number | boolean | object | null |
       Array<string | number | boolean | object | null>): void;
 

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -4811,7 +4811,8 @@ export class Task {
      *  message to the child process fails.
      */
     // tslint:disable-next-line:no-any
-    send(message: any): void;
+    send(message: string | number | boolean | object | null |
+      Array<string | number | boolean | object | null>): void;
 
     /** Call a function when an event is emitted by the child process. */
     // tslint:disable-next-line:no-any

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -4810,7 +4810,8 @@ export class Task {
      *  Throws an error if this task has already been terminated or if sending a
      *  message to the child process fails.
      */
-    send(message: string): void;
+    // tslint:disable-next-line:no-any
+    send(message: any): void;
 
     /** Call a function when an event is emitted by the child process. */
     // tslint:disable-next-line:no-any

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -4810,8 +4810,8 @@ export class Task {
      *  Throws an error if this task has already been terminated or if sending a
      *  message to the child process fails.
      */
-    send(message: string | number | boolean | object | null |
-      Array<string | number | boolean | object | null>): void;
+    // tslint:disable-next-line:no-any
+    send(message: string | number | boolean | object | null | any[]): void;
 
     /** Call a function when an event is emitted by the child process. */
     // tslint:disable-next-line:no-any


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/atom/atom/blob/v1.0.2/src/task.coffee#L131
https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L2023
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The Atom API docs are not very specific on what constitutes a "message," but if you look at the source code, the value of the `message` parameter is passed directly to `ChildProcess.send()`, which [is capable of performing serialization and parsing](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) on non-string messages. This patch changes the declared type of the `message` parameter to `any` (to match the signature of `ChildProcess.send()` declared in `@types/node`) since Atom doesn't actually access or modify the provided message at all, and simply passes it along to the child process wrapped by the Task object.

/cc @GlenCFL @lierdakil 