### PR TITLE
resolve: fix signatures of callback types

### DIFF
--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -6,13 +6,19 @@
 
 /// <reference types="node" />
 
+interface PackageMeta {
+  name: string;
+  version: string;
+  [key: string]: any;
+}
+
 /**
  * Callback invoked when resolving asynchronously
  *
  * @param error
  * @param resolved Absolute path to resolved identifier
  */
-type resolveCallback = (err: Error, resolved?: string) => void;
+type resolveCallback = (err: Error | null, resolved?: string, pkg?: PackageMeta) => void;
 
 /**
  * Callback invoked when checking if a file exists
@@ -20,7 +26,7 @@ type resolveCallback = (err: Error, resolved?: string) => void;
  * @param error
  * @param isFile If the given file exists
  */
-type isFileCallback = (err: Error, isFile?: boolean) => void;
+type isFileCallback = (err: Error | null, isFile?: boolean) => void;
 
 /**
  * Callback invoked when reading a file
@@ -28,7 +34,7 @@ type isFileCallback = (err: Error, isFile?: boolean) => void;
  * @param error
  * @param isFile If the given file exists
  */
-type readFileCallback = (err: Error, file?: Buffer) => void;
+type readFileCallback = (err: Error | null, file?: Buffer) => void;
 
 /**
  * Asynchronously resolve the module path string id into cb(err, res [, pkg]), where pkg (if defined) is the data from package.json

--- a/types/resolve/resolve-tests.ts
+++ b/types/resolve/resolve-tests.ts
@@ -2,12 +2,13 @@ import * as fs from 'fs';
 import * as resolve from 'resolve';
 
 function test_basic_async() {
-  resolve('typescript', function(error, resolved) {
+  resolve('typescript', function(error, resolved, pkg) {
     if (error) {
       console.error(error.message);
       return;
     }
     console.log(resolved);
+    console.log(pkg.version);
   });
 }
 
@@ -41,12 +42,13 @@ function test_options_async() {
         }
       });
     }
-  }, function(error, resolved) {
+  }, function(error, resolved, pkg) {
     if (error) {
       console.error(error.message);
       return;
     }
     console.log(resolved);
+    console.log(pkg.version);
   });
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/browserify/resolve#resolveid-opts-cb
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The callback accepted by the asynchronous `resolve()` method can be passed up to three parameters:

* an `Error` (if any is encountered)
* the absolute path of the resolved module, and
* the parsed contents of the module's package.json file, if applicable.

The current definitions incorrectly omit this third parameter, causing a compiler error when a three-parameter callback is provided. Since it is legal for callbacks to disregard a parameter (but not to *consume* a parameter that doesn't exist on the expected function signature,) this change is backwards-compatible and won't affect any existing code.

In addition, the `err` parameter is incorrectly declared with the type `Error`, implying that there will *always* be an error passed to the callback. Upon reviewing the [source code](https://github.com/browserify/resolve/blob/master/lib/async.js#L45), it appears that the correct type for this parameter is `Error | null`.