### PR TITLE
fix type of @types/twit

### DIFF
--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/ttezel/twit
 // Definitions by: Volox <https://github.com/Volox>
 //                 lostfictions <https://github.com/lostfictions>
+//                 sapphiredev <https://github.com/sapphiredev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -31,7 +32,7 @@ declare module 'twit' {
        * @see https://dev.twitter.com/overview/api/entities
        */
       export interface HashtagEntity {
-        indices: number[],
+        indices: [number, number],
         text: string,
       }
       export interface Size {
@@ -48,7 +49,7 @@ declare module 'twit' {
       export interface MediaEntity {
         id: number,
         id_str: string,
-        indices: number[],
+        indices: [number, number],
         url: string,
         display_url: string,
         expanded_url: string,
@@ -63,12 +64,12 @@ declare module 'twit' {
         url: string,
         display_url: string,
         expanded_url: string,
-        indices: number[],
+        indices: [number, number],
       }
       export interface UserMentionEntity {
         id: number,
         id_str: string,
-        indices: number[],
+        indices: [number, number],
         name: string,
         screen_name: string,
       }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/29c6e0f81ab314cd1d1f17ab92f59bb87f6a5c3f/types/twitter-text/index.d.ts#L65
https://developer.twitter.com/en/docs/tweets/data-dictionary/overview/entities-object
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The type of `UrlEntity.indices: number[]` of `@types/twit` does not match with `UrlEntity.indices:
 [number, number]` of `@types/twitter-text`