### PR TITLE
[boom] isBoom is a type-guard

### DIFF
--- a/types/boom/boom-tests.ts
+++ b/types/boom/boom-tests.ts
@@ -144,6 +144,12 @@ const isBoomError = new Boom.Boom('test')
 
 Boom.isBoom(isBoomError);
 
+const maybeBoom = <any>new Boom.Boom('test');
+if(Boom.isBoom(maybeBoom)) {
+    // isBoom is a type guard that allows accessing these properties:
+    maybeBoom.output.headers;
+}
+
 // constructor
 
 const constructorError: Boom.Boom = new Boom.Boom('test');

--- a/types/boom/index.d.ts
+++ b/types/boom/index.d.ts
@@ -86,7 +86,7 @@ declare namespace Boom {
      * Identifies whether an error is a Boom object. Same as calling instanceof Boom.
      * @param error the error object to identify.
      */
-    export function isBoom(error: Error): boolean
+    export function isBoom(error: Error): error is Boom
 
     // 4xx
     /**


### PR DESCRIPTION
Instead of just returning boolean, the `isBoom` function can and should be a type-guard, which enables the obvious benefits.

--

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
(I could only run the linter after changing the TypeScript Version to 2.3... But this is another issue in my opinion)

