### PR TITLE
read-pkg-up: fix return value

### DIFF
--- a/types/read-pkg-up/index.d.ts
+++ b/types/read-pkg-up/index.d.ts
@@ -7,8 +7,8 @@
 import normalize = require('normalize-package-data');
 
 declare namespace ReadPkgUp {
-    function sync(options: Options & {normalize: false}): {[k: string]: any};
-    function sync(options?: Options): normalize.Package;
+    function sync(options: Options & {normalize: false}): {path: string, pkg: {[k: string]: any}};
+    function sync(options?: Options): {path: string, pkg: Package};
 
     interface Options {
         /**
@@ -28,7 +28,7 @@ declare namespace ReadPkgUp {
     type Package = normalize.Package;
 }
 
-declare function ReadPkgUp(options: ReadPkgUp.Options & {normalize: false}): Promise<{[k: string]: any}>;
-declare function ReadPkgUp(options?: ReadPkgUp.Options): Promise<normalize.Package>;
+declare function ReadPkgUp(options: ReadPkgUp.Options & {normalize: false}): Promise<{path: string, pkg: {[k: string]: any}}>;
+declare function ReadPkgUp(options?: ReadPkgUp.Options): Promise<{path: string, pkg: normalize.Package}>;
 
 export = ReadPkgUp;

--- a/types/read-pkg-up/read-pkg-up-tests.ts
+++ b/types/read-pkg-up/read-pkg-up-tests.ts
@@ -1,8 +1,8 @@
 import ReadPkgUp = require('read-pkg-up');
 
-ReadPkgUp().then(pkg => pkg.name); // $ExpectType Promise<string>
-ReadPkgUp({cwd: '.', normalize: true}).then(pkg => pkg.name); // $ExpectType Promise<string>
-ReadPkgUp({cwd: '.', normalize: false}).then(pkg => pkg['name']); // $ExpectType Promise<any>
-ReadPkgUp.sync().name; // $ExpectType string
-ReadPkgUp.sync({cwd: '.', normalize: true}).name; // $ExpectType string
-ReadPkgUp.sync({cwd: '.', normalize: false})['name']; // $ExpectType any
+ReadPkgUp().then(pkg => pkg.pkg.name); // $ExpectType Promise<string>
+ReadPkgUp({cwd: '.', normalize: true}).then(pkg => pkg.pkg.name); // $ExpectType Promise<string>
+ReadPkgUp({cwd: '.', normalize: false}).then(pkg => pkg.pkg['name']); // $ExpectType Promise<any>
+ReadPkgUp.sync().pkg.name; // $ExpectType string
+ReadPkgUp.sync({cwd: '.', normalize: true}).pkg.name; // $ExpectType string
+ReadPkgUp.sync({cwd: '.', normalize: false}).pkg['name']; // $ExpectType any


### PR DESCRIPTION
The original types were wrong here when I added in the normalized package data.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/sindresorhus/read-pkg-up>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.