### PR TITLE
Add id to mongodb gridfs upload streams

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -31,7 +31,7 @@ export class MongoClient extends EventEmitter {
     static connect(uri: string, callback: MongoCallback<MongoClient>): void;
     static connect(uri: string, options?: MongoClientOptions): Promise<MongoClient>;
     static connect(uri: string, options: MongoClientOptions, callback: MongoCallback<MongoClient>): void;
-    /** 
+    /**
      * @deprecated
      * http://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#connect
      */
@@ -830,7 +830,7 @@ export interface CollectionAggregationOptions {
     collation?: Object;
     comment?: string
     session?: ClientSession;
-                                  
+
 }
 
 /** http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#insertMany */
@@ -1353,7 +1353,7 @@ export class GridFSBucket {
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/GridFSBucket.html#openUploadStream */
     openUploadStream(filename: string, options?: GridFSBucketOpenUploadStreamOptions): GridFSBucketWriteStream;
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/GridFSBucket.html#openUploadStreamWithId */
-    openUploadStreamWithId(id: string | number | Object, filename: string, options?: GridFSBucketOpenUploadStreamOptions): GridFSBucketWriteStream;
+    openUploadStreamWithId(id: GridFSBucketWriteStreamId, filename: string, options?: GridFSBucketOpenUploadStreamOptions): GridFSBucketWriteStream;
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/GridFSBucket.html#rename */
     rename(id: ObjectID, filename: string, callback?: GridFSBucketErrorCallback): void;
 }
@@ -1391,6 +1391,7 @@ export interface GridFSBucketOpenUploadStreamOptions {
 
 /** https://mongodb.github.io/node-mongodb-native/3.0/api/GridFSBucketReadStream.html */
 export class GridFSBucketReadStream extends Readable {
+    id: ObjectID;
     constructor(chunks: Collection<any>, files: Collection<any>, readPreference: Object, filter: Object, options?: GridFSBucketReadStreamOptions);
 }
 
@@ -1404,14 +1405,17 @@ export interface GridFSBucketReadStreamOptions {
 
 /** https://mongodb.github.io/node-mongodb-native/3.0/api/GridFSBucketWriteStream.html */
 export class GridFSBucketWriteStream extends Writable {
+    id: GridFSBucketWriteStreamId;
     constructor(bucket: GridFSBucket, filename: string, options?: GridFSBucketWriteStreamOptions);
 }
 
 /** https://mongodb.github.io/node-mongodb-native/3.0/api/GridFSBucketWriteStream.html */
 export interface GridFSBucketWriteStreamOptions {
-    id?: string | number | Object,
+    id?: GridFSBucketWriteStreamId,
     chunkSizeBytes?: number,
     w?: number,
     wtimeout?: number,
     j?: number
 }
+
+type GridFSBucketWriteStreamId = string | number | Object | ObjectID;

--- a/types/mongodb/v2/index.d.ts
+++ b/types/mongodb/v2/index.d.ts
@@ -1371,7 +1371,7 @@ export class GridFSBucket {
     // http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#openUploadStream
     openUploadStream(filename: string, options?: GridFSBucketOpenUploadStreamOptions): GridFSBucketWriteStream;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#openUploadStreamWithId
-    openUploadStreamWithId(id: string | number | Object, filename: string, options?: GridFSBucketOpenUploadStreamOptions): GridFSBucketWriteStream;
+    openUploadStreamWithId(id: GridFSBucketWriteStreamId, filename: string, options?: GridFSBucketOpenUploadStreamOptions): GridFSBucketWriteStream;
     // http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#rename
     rename(id: ObjectID, filename: string, callback?: GridFSBucketErrorCallback): void;
 }
@@ -1409,6 +1409,7 @@ export interface GridFSBucketOpenUploadStreamOptions {
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketReadStream.html
 export class GridFSBucketReadStream extends Readable {
+    id: ObjectID;
     constructor(chunks: Collection<any>, files: Collection<any>, readPreference: Object, filter: Object, options?: GridFSBucketReadStreamOptions);
 }
 
@@ -1422,14 +1423,17 @@ export interface GridFSBucketReadStreamOptions {
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketWriteStream.html
 export class GridFSBucketWriteStream extends Writable {
+    id: GridFSBucketWriteStreamId;
     constructor(bucket: GridFSBucket, filename: string, options?: GridFSBucketWriteStreamOptions);
 }
 
 // https://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketWriteStream.html
 export interface GridFSBucketWriteStreamOptions {
-    id?: string | number | Object,
+    id?: GridFSBucketWriteStreamId,
     chunkSizeBytes?: number,
     w?: number,
     wtimeout?: number,
     j?: number
 }
+
+type GridFSBucketWriteStreamId = string | number | Object | ObjectID;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#openUploadStream
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


As seen in http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#openUploadStream:

```js
    var uploadStream = bucket.openUploadStream('test.dat');

    var license = fs.readFileSync('./LICENSE');
    var id = uploadStream.id;
```

The resulting stream from `openUploadStream` *has* an id, which is currently absent in the `@types/mongo` package.

