### PR TITLE
clipboard: isSupported() is a static method

### DIFF
--- a/types/clipboard/clipboard-tests.ts
+++ b/types/clipboard/clipboard-tests.ts
@@ -1,28 +1,28 @@
-import * as Clipboard from 'clipboard';
+import * as Clipboard from "clipboard";
 
-const cb1 = new Clipboard('.btn');
-const cb2 = new Clipboard(document.getElementById('id'), {
-    action: elem => 'copy'
+const cb1 = new Clipboard(".btn");
+const cb2 = new Clipboard(document.getElementById("id"), {
+    action: elem => "copy"
 });
-const cb3 = new Clipboard(document.querySelectorAll('query'), {
+const cb3 = new Clipboard(document.querySelectorAll("query"), {
     text: elem => null
 });
-const cb4 = new Clipboard('.btn', {
+const cb4 = new Clipboard(".btn", {
     target: elem => null
 });
-const cb5 = new Clipboard('.btn', {
-    action: elem => 'copy',
+const cb5 = new Clipboard(".btn", {
+    action: elem => "copy",
     target: elem => null
 });
 
 cb1.destroy();
-cb1.isSupported();
+Clipboard.isSupported();
 
-cb2.on('success', e => {
-    console.info('Action:', e.action);
-    console.info('Text:', e.text);
-    console.info('Trigger:', e.trigger);
+cb2.on("success", e => {
+    console.info("Action:", e.action);
+    console.info("Text:", e.text);
+    console.info("Trigger:", e.trigger);
 
     e.clearSelection();
 });
-cb2.on('error', e => { });
+cb2.on("error", e => {});

--- a/types/clipboard/index.d.ts
+++ b/types/clipboard/index.d.ts
@@ -4,7 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare class Clipboard {
-    constructor(selector: (string | Element | NodeListOf<Element>), options?: Clipboard.Options);
+    constructor(
+        selector: string | Element | NodeListOf<Element>,
+        options?: Clipboard.Options
+    );
 
     /**
      * Subscribes to events that indicate the result of a copy/cut operation.
@@ -22,7 +25,7 @@ declare class Clipboard {
     /**
      * Checks if clipboard.js is supported
      */
-    isSupported(): boolean;
+    static isSupported(): boolean;
 }
 
 declare namespace Clipboard {


### PR DESCRIPTION
The `clipboard` definition is wrong: `isSupported()` is a static method (source: https://github.com/zenorocha/clipboard.js/blob/master/src/clipboard.js#L87)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zenorocha/clipboard.js/blob/master/src/clipboard.js#L87
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.