### PR TITLE
[@types/caseless] Add Httpified interface.

### DIFF
--- a/types/caseless/caseless-tests.ts
+++ b/types/caseless/caseless-tests.ts
@@ -1,4 +1,4 @@
-import caseless, { Caseless, httpify } from "caseless";
+import caseless, { Caseless, httpify, Httpified } from "caseless";
 
 new Caseless(); // $ExpectError
 
@@ -38,3 +38,20 @@ httpify({}, 1); // $ExpectError
 httpify({}, "2"); // $ExpectError
 
 httpify({}, {}); // $ExpectType Caseless
+
+const request: Httpified = {}; // $ExpectError
+
+request.setHeader({}); // $ExpectType void
+request.setHeader('foo', 'bar'); // $ExpectType string | false
+request.setHeader('foo', 'bar', false); // $ExpectType string | false
+request.setHeader('foo', new Date()); // $ExpectType string | false
+request.setHeader(10, 'bar'); // $ExpectError
+
+request.getHeader('foo'); // $ExpectType any
+request.getHeader(10); // $ExpectError
+
+request.hasHeader('foo'); // $ExpectType string | false
+request.hasHeader(10); // $ExpectError
+
+request.removeHeader('foo'); // $ExpectType boolean
+request.headers = {};

--- a/types/caseless/index.d.ts
+++ b/types/caseless/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for caseless 0.12
 // Project: https://github.com/mikeal/caseless
 // Definitions by: downace <https://github.com/downace>
+//                 Matt R. Wilson <https://github.com/mastermatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -15,6 +16,15 @@ export interface Caseless {
     get(name: KeyType): ValueType | undefined;
     swap(name: KeyType): void;
     del(name: KeyType): boolean;
+}
+
+export interface Httpified {
+  headers: RawDict;
+  setHeader(name: KeyType, value: ValueType, clobber?: boolean): KeyType | false;
+  setHeader(dict: RawDict): void;
+  hasHeader(name: KeyType): KeyType | false;
+  getHeader(name: KeyType): ValueType | undefined;
+  removeHeader(name: KeyType): boolean;
 }
 
 export function httpify(resp: object, headers: RawDict): Caseless;


### PR DESCRIPTION
To allow importing libs to extend the interface.
Objects passed into `caseless.httpify` are extended with these methods. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/request/caseless/blob/a3edd69b68c014a1599bd095ca19a944a355d013/index.js#L50-L67>>
