### PR TITLE
@storybook/addon-knobs: add framework-specific entry points

### DIFF
--- a/types/storybook__addon-knobs/angular.d.ts
+++ b/types/storybook__addon-knobs/angular.d.ts
@@ -1,0 +1,3 @@
+declare module '@storybook/addon-knobs/angular' {
+    export * from '@storybook/addon-knobs';
+}

--- a/types/storybook__addon-knobs/angular.d.ts
+++ b/types/storybook__addon-knobs/angular.d.ts
@@ -1,3 +1,1 @@
-declare module '@storybook/addon-knobs/angular' {
-    export * from '@storybook/addon-knobs';
-}
+export * from './index';

--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @storybook/addon-knobs 3.2
+// Type definitions for @storybook/addon-knobs 3.3
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Martynas Kadisa <https://github.com/martynaskadisa>
@@ -56,3 +56,7 @@ export interface WrapStoryProps {
 
 export function withKnobs(storyFn: RenderFunction, context: StoryContext): React.ReactElement<WrapStoryProps>;
 export function withKnobsOptions(options: { debounce: boolean, timestamps: boolean }): (storyFn: RenderFunction, context: StoryContext) => React.ReactElement<WrapStoryProps>;
+
+/// <reference path="./angular.d.ts" />
+/// <reference path="./react.d.ts" />
+/// <reference path="./vue.d.ts" />

--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -56,7 +56,3 @@ export interface WrapStoryProps {
 
 export function withKnobs(storyFn: RenderFunction, context: StoryContext): React.ReactElement<WrapStoryProps>;
 export function withKnobsOptions(options: { debounce: boolean, timestamps: boolean }): (storyFn: RenderFunction, context: StoryContext) => React.ReactElement<WrapStoryProps>;
-
-/// <reference path="./angular.d.ts" />
-/// <reference path="./react.d.ts" />
-/// <reference path="./vue.d.ts" />

--- a/types/storybook__addon-knobs/react.d.ts
+++ b/types/storybook__addon-knobs/react.d.ts
@@ -1,3 +1,1 @@
-declare module '@storybook/addon-knobs/react' {
-    export * from '@storybook/addon-knobs';
-}
+export * from './index';

--- a/types/storybook__addon-knobs/react.d.ts
+++ b/types/storybook__addon-knobs/react.d.ts
@@ -1,0 +1,3 @@
+declare module '@storybook/addon-knobs/react' {
+    export * from '@storybook/addon-knobs';
+}

--- a/types/storybook__addon-knobs/tsconfig.json
+++ b/types/storybook__addon-knobs/tsconfig.json
@@ -27,7 +27,10 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
+        "angular.d.ts",
         "index.d.ts",
-        "storybook__addon-knobs-tests.tsx"
+        "react.d.ts",
+        "storybook__addon-knobs-tests.tsx",
+        "bue.d.ts"
     ]
 }

--- a/types/storybook__addon-knobs/tsconfig.json
+++ b/types/storybook__addon-knobs/tsconfig.json
@@ -31,6 +31,6 @@
         "index.d.ts",
         "react.d.ts",
         "storybook__addon-knobs-tests.tsx",
-        "bue.d.ts"
+        "vue.d.ts"
     ]
 }

--- a/types/storybook__addon-knobs/vue.d.ts
+++ b/types/storybook__addon-knobs/vue.d.ts
@@ -1,0 +1,3 @@
+declare module '@storybook/addon-knobs/angular' {
+    export * from '@storybook/addon-knobs';
+}

--- a/types/storybook__addon-knobs/vue.d.ts
+++ b/types/storybook__addon-knobs/vue.d.ts
@@ -1,3 +1,1 @@
-declare module '@storybook/addon-knobs/angular' {
-    export * from '@storybook/addon-knobs';
-}
+export * from './index';

--- a/types/storybook__addon-knobs/vue.d.ts
+++ b/types/storybook__addon-knobs/vue.d.ts
@@ -1,3 +1,3 @@
-declare module '@storybook/addon-knobs/angular' {
+declare module '@storybook/addon-knobs/vue' {
     export * from '@storybook/addon-knobs';
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/storybooks/storybook/pull/1832 and https://github.com/storybooks/storybook/blob/master/MIGRATION.md#refactored-knobs
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The Storybook knobs add-on has changed its API due to the support of more frameworks. The old way of importing from `@storybook/addon-knobs` is still available but deprecated. The right way (without performance penalty of importing all frameworks) is to import the specific version, e.g.:

* In the case of React: `import { withKnobs, text, boolean, number } from '@storybook/addon-knobs/react';`
* In the case of Vue: `import { ... } from '@storybook/addon-knobs/vue';`
* In the case of Angular: `import { ... } from '@storybook/addon-knobs/angular';`

Locally, for TS this is currently broken due to the changes in knobs, I added a d.ts file locally:
```
declare module '@storybook/addon-knobs/react' {
  export * from '@storybook/addon-knobs';
}
```
which works there, but I am unsure about this approach within DefinitelyTyped, @martynaskadisa @andy-ms any ideas?