### PR TITLE
[@types/masonry-layout] add new horizontalOrder option

### DIFF
--- a/types/masonry-layout/index.d.ts
+++ b/types/masonry-layout/index.d.ts
@@ -50,6 +50,7 @@ declare namespace Masonry {
         fitWidth?: boolean;
         originLeft?: boolean;
         originTop?: boolean;
+        horizontalOrder?: boolean;
 
         // setup
         containerStyle?: {};

--- a/types/masonry-layout/index.d.ts
+++ b/types/masonry-layout/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Masonry 4.0
+// Type definitions for Masonry 4.2
 // Project: https://github.com/desandro/masonry
 // Definitions by: Mark Wilson <https://github.com/m-a-wilson>, Travis Brown <https://github.com/warriorrocker>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped

--- a/types/masonry-layout/masonry-layout-tests.ts
+++ b/types/masonry-layout/masonry-layout-tests.ts
@@ -42,6 +42,7 @@ function testExtendedOptions() {
         },
         transitionDuration: '0.4s',
         resize: true,
-        initLayout: true
+        initLayout: true,
+        horizontalOrder: true
     });
 }


### PR DESCRIPTION
Introduced with masonry v4.2.0 ([release history](https://github.com/desandro/masonry/releases))

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [github issue](https://github.com/desandro/masonry/issues/873), [release](https://github.com/desandro/masonry/releases/tag/v4.2.0)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
