### PR TITLE
Updated mapbox-gl to include correct FitBoundsOptions

### DIFF
--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -161,7 +161,7 @@ declare namespace mapboxgl {
 
         setPitch(pitch: number, eventData?: EventData): this;
 
-        fitBounds(bounds: LngLatBoundsLike, options?: { linear?: boolean, easing?: Function, padding?: number | mapboxgl.PaddingOptions, offset?: PointLike, maxZoom?: number }, eventData?: mapboxgl.EventData): this;
+        fitBounds(bounds: LngLatBoundsLike, options?: mapboxgl.FitBoundsOptions, eventData?: mapboxgl.EventData): this;
 
         jumpTo(options: mapboxgl.CameraOptions, eventData?: mapboxgl.EventData): this;
 
@@ -402,10 +402,6 @@ declare namespace mapboxgl {
         enableHighAccuracy?: boolean;
         timeout?: number;
         maximumAge?: number;
-    }
-
-    export class FitBoundsOptions {
-        maxZoom?: number;
     }
 
     /**
@@ -870,6 +866,15 @@ declare namespace mapboxgl {
         speed?: number;
         screenSpeed?: number;
         easing?: Function;
+    }
+
+    export interface FitBoundsOptions extends mapboxgl.FlyToOptions {
+        linear?: boolean;
+        easing?: Function;
+        padding?: number | mapboxgl.PaddingOptions;
+        offset?: mapboxgl.PointLike;
+        maxZoom?: number;
+        maxDuration?: number;
     }
 
     /**


### PR DESCRIPTION
As can be seen in the `mapbox-gl-js` [source code](https://github.com/mapbox/mapbox-gl-js/blob/master/src/ui/camera.js#L370), the `fitBounds()` function receives `AnimationOptions & CameraOptions`.

It then calls the `flyTo` or `easeTo` functions according to the options it received.

The `FitBoundsOptions` interface extends `FlyToOptions` as that already extends `AnimationOptions & Camera Options`.

* The `maxDuration` option is listed in the jsdoc comment above the `flyTo` method and is referenced in this [issue](https://github.com/mapbox/mapbox-gl-js/pull/5349)

### Filled Template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

#### changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [url](https://github.com/mapbox/mapbox-gl-js/blob/master/src/ui/camera.js#L370)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
