### PR TITLE
react-jsonschema-form: Fixed typo in ArrayFieldTemplateProps definition

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -122,7 +122,7 @@ declare module "react-jsonschema-form" {
     export type ArrayFieldTemplateProps = {
         DescriptionField: object;
         TitleField: object;
-        candAdd: boolean;
+        canAdd: boolean;
         className: string;
         disabled: boolean;
         idSchema: IdSchema;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mozilla-services/react-jsonschema-form#array-field-template
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.