### PR TITLE
[@types/react-redux] react-redux update for redux 4.0.0

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -10,14 +10,14 @@
 //                 Prashant Deva <https://github.com/pdeva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
-    
+
 // Known Issue:
-// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes 
+// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @connect() decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use connect() as a function call on
 // a separate line instead of as a decorator. Discussed in this github issue:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20796
-    
+
 import * as React from 'react';
 import * as Redux from 'redux';
 
@@ -25,7 +25,8 @@ type ComponentClass<P> = React.ComponentClass<P>;
 type StatelessComponent<P> = React.StatelessComponent<P>;
 type Component<P> = React.ComponentType<P>;
 type ReactNode = React.ReactNode;
-type Store<S> = Redux.Store<S>;
+type Action<T = any> = Redux.Action<T>;
+type Store<S, A extends Action, N> = Redux.Store<S, A, N>;
 type Dispatch<S> = Redux.Dispatch<S>;
 type ActionCreator<A> = Redux.ActionCreator<A>;
 
@@ -34,7 +35,7 @@ type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: n
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
 export interface DispatchProp<S> {
-  dispatch?: Dispatch<S>;
+    dispatch?: Dispatch<S>;
 }
 
 interface AdvancedComponentDecorator<TProps, TOwnProps> {
@@ -288,18 +289,18 @@ export interface ConnectOptions {
     withRef?: boolean
 }
 
-export interface ProviderProps {
+export interface ProviderProps<S, A extends Action, N> {
     /**
      * The single Redux store in your application.
      */
-    store?: Store<any>;
+    store?: Store<S, A, N>;
     children?: ReactNode;
 }
 
 /**
  * Makes the Redux store available to the connect() calls in the component hierarchy below.
  */
-export class Provider extends React.Component<ProviderProps, {}> { }
+export class Provider<S = any, A extends Action = Action, N = never> extends React.Component<ProviderProps<S, A, N>, {}> { }
 
 /**
  * Creates a new <Provider> which will set the Redux Store on the passed key of the context. You probably only need this

--- a/types/react-redux/package.json
+++ b/types/react-redux/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.6.0"
+        "redux": "^4.0.0-beta.1"
     }
 }

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1,7 +1,7 @@
 import { Component, ReactElement } from 'react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Store, Dispatch, ActionCreator, createStore, bindActionCreators, ActionCreatorsMapObject } from 'redux';
+import { Store, Dispatch, Action, ActionCreator, createStore, bindActionCreators, ActionCreatorsMapObject } from 'redux';
 import { Connect, connect, createProvider, Provider, DispatchProp, MapStateToProps, Options } from 'react-redux';
 import objectAssign = require('object-assign');
 
@@ -877,8 +877,8 @@ namespace TestCreateProvider {
     };
 
     interface State { a: number };
-    const store = createStore<State>(() => ({ a: 1 }));
-    const myStore = createStore<State>(() => ({ a: 2 }));
+    const store = createStore<State, Action, never>(() => ({ a: 1 }));
+    const myStore = createStore<State, Action, never>(() => ({ a: 2 }));
 
     interface AProps { a: number };
     const A = (props: AProps) => (<h1>A is {props.a}</h1>);
@@ -898,4 +898,26 @@ namespace TestCreateProvider {
     // <h1>A is 1</h1>
     // <h1>A is 2</h1>
     ReactDOM.render(<Combined />, document.body);
+}
+
+namespace TestRenderProviderWithEnhancedAction {
+    interface State {
+        prop: string;
+    }
+    interface MyAction extends Action {
+        extra: any;
+    }
+    interface NonAction {
+        (): any;
+    }
+    declare const store: Store<State, MyAction, NonAction>;
+
+    const targetEl = document.getElementById('root');
+
+    class SpecifiedProvider extends Provider<State, MyAction, NonAction> {}
+    ReactDOM.render((
+        <SpecifiedProvider store={store}>
+            {null}
+        </SpecifiedProvider>
+    ), targetEl);
 }


### PR DESCRIPTION
I'm not sure when the packages should update the dependency version and if they should do it all together or one by one, but as I got stuck on that ts-breaking change of redux, I decided to make a PR.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [redux/index.d.ts](https://github.com/reactjs/redux/blob/master/index.d.ts)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

In case the PR is untimely, the workaround example for case of `Store` with second and third generic arguments that differ from default ones is simple:
```
import {Action} from 'redux';

interface MyAction extends Action {
    extra: any;
}
interface NonAction {...}

type MyStore = Store<State, MyAction, NonAction>;
function getStore(): MyStore {
    return store;
}

type SimplifiedStore = Store<State, Action, NonAction>;

function render(): React.ReactNode {
    return (
        <Provider store={getStore() as SimplifiedStore}>{...}</Provider>
    );
}
```

UPD: Apparently, you can't keep different versions of redux in different packages, so the CI fails.