### PR TITLE
@types/Knex added unnceccessay length param to table builder binary method according to knex docs.

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -427,7 +427,7 @@ declare namespace Knex {
         time(columnName: string): ColumnBuilder;
         timestamp(columnName: string): ColumnBuilder;
         timestamps(useTimestampType?: boolean, makeDefaultNow?: boolean): ColumnBuilder;
-        binary(columnName: string): ColumnBuilder;
+        binary(columnName: string, length?: number): ColumnBuilder;
         enum(columnName: string, values: Value[]): ColumnBuilder;
         enu(columnName: string, values: Value[]): ColumnBuilder;
         json(columnName: string): ColumnBuilder;

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -937,5 +937,5 @@ knex.schema
 
 //creating table in MySQL with binary primary key with known field length
 knex.schema.createTable('testTable', function (table) {
-    table.binary('binaryKey', 16).primary() //will make table with binaryKey type BINARY(16)
-})
+    table.binary('binaryKey', 16).primary(); //will make table with binaryKey type BINARY(16)
+});

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -933,3 +933,9 @@ knex.schema
   .createTable('A', table => {
     table.integer('C').unsigned().references('B.id').notNullable();
   });
+
+
+//creating table in MySQL with binary primary key with known field length
+knex.schema.createTable('testTable', function (table) {
+    table.binary('binaryKey', 16).primary() //will make table with binaryKey type BINARY(16)
+})


### PR DESCRIPTION
Binary() method of table builder takes additional length param for MySQL db that sets field size in db.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
   http://knexjs.org/#Schema-binary
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.