### PR TITLE
enzyme: Improve signature of ShallowWrapper.filter and ReactWrapper.filter

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -17,8 +17,17 @@ interface MyComponentProps {
     numberProp?: number;
 }
 
+interface AnotherComponentProps {
+    anotherStringProp?: string;
+    anotherNumberProp?: number;
+}
+
 interface StatelessProps {
     stateless: string;
+}
+
+interface AnotherStatelessProps {
+    anotherStateless: string;
 }
 
 interface MyComponentState {
@@ -31,7 +40,15 @@ class MyComponent extends Component<MyComponentProps, MyComponentState> {
     }
 }
 
+class AnotherComponent extends Component<AnotherComponentProps> {
+    setState(...args: any[]) {
+        console.log(args);
+    }
+}
+
 const MyStatelessComponent = (props: StatelessProps) => <span />;
+
+const AnotherStatelessComponent = (props: AnotherStatelessProps) => <span />;
 
 // Enzyme.configure
 function configureTest() {
@@ -57,7 +74,8 @@ function ShallowWrapperTest() {
     let stringVal: string;
     let numOrStringVal: number | string;
     let elementWrapper: ShallowWrapper<HTMLAttributes<{}>>;
-    let statelessWrapper: ShallowWrapper<StatelessProps, never>;
+    let anotherStatelessWrapper: ShallowWrapper<AnotherStatelessProps, never>;
+    let anotherComponentWrapper: ShallowWrapper<AnotherComponentProps, any>;
 
     function test_props_state_inferring() {
         let wrapper: ShallowWrapper<MyComponentProps, MyComponentState>;
@@ -77,8 +95,8 @@ function ShallowWrapperTest() {
     }
 
     function test_find() {
-        shallowWrapper = shallowWrapper.find(MyComponent);
-        statelessWrapper = shallowWrapper.find(MyStatelessComponent);
+        anotherComponentWrapper = shallowWrapper.find(AnotherComponent);
+        anotherStatelessWrapper = shallowWrapper.find(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.find({ prop: 'value' });
         elementWrapper = shallowWrapper.find('.selector');
     }
@@ -89,10 +107,10 @@ function ShallowWrapperTest() {
     }
 
     function test_filter() {
-        shallowWrapper = shallowWrapper.filter(MyComponent);
-        statelessWrapper = statelessWrapper.filter(MyStatelessComponent);
+        anotherComponentWrapper = shallowWrapper.filter(AnotherComponent);
+        anotherStatelessWrapper = shallowWrapper.filter(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.filter({ numberProp: 12 });
-        shallowWrapper = shallowWrapper.filter('.selector');
+        elementWrapper = shallowWrapper.filter('.selector');
     }
 
     function test_filterWhere() {
@@ -165,8 +183,8 @@ function ShallowWrapperTest() {
 
     function test_children() {
         shallowWrapper = shallowWrapper.children();
-        shallowWrapper = shallowWrapper.children(MyComponent);
-        statelessWrapper = shallowWrapper.children(MyStatelessComponent);
+        anotherComponentWrapper = shallowWrapper.children(AnotherComponent);
+        anotherStatelessWrapper = shallowWrapper.children(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.children({ prop: 'value' });
         elementWrapper = shallowWrapper.children('.selector');
     }
@@ -187,8 +205,8 @@ function ShallowWrapperTest() {
 
     function test_parents() {
         shallowWrapper = shallowWrapper.parents();
-        shallowWrapper = shallowWrapper.parents(MyComponent);
-        statelessWrapper = shallowWrapper.parents(MyStatelessComponent);
+        anotherComponentWrapper = shallowWrapper.parents(AnotherComponent);
+        anotherStatelessWrapper = shallowWrapper.parents(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.parents({ prop: 'myprop' });
         elementWrapper = shallowWrapper.parents('.selector');
     }
@@ -198,8 +216,8 @@ function ShallowWrapperTest() {
     }
 
     function test_closest() {
-        shallowWrapper = shallowWrapper.closest(MyComponent);
-        statelessWrapper = shallowWrapper.closest(MyStatelessComponent);
+        anotherComponentWrapper = shallowWrapper.closest(AnotherComponent);
+        anotherStatelessWrapper = shallowWrapper.closest(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.closest({ prop: 'myprop' });
         elementWrapper = shallowWrapper.closest('.selector');
     }
@@ -280,8 +298,8 @@ function ShallowWrapperTest() {
 
     function test_props() {
         const props: MyComponentProps = shallowWrapper.props();
-        const props2: MyComponentProps = shallowWrapper.find(MyComponent).props();
-        const props3: StatelessProps = shallowWrapper.find(MyStatelessComponent).props();
+        const props2: AnotherComponentProps = shallowWrapper.find(AnotherComponent).props();
+        const props3: AnotherStatelessProps = shallowWrapper.find(AnotherStatelessComponent).props();
         const props4: HTMLAttributes<any> = shallowWrapper.find('.selector').props();
     }
 
@@ -357,8 +375,8 @@ function ShallowWrapperTest() {
     }
 
     function test_some() {
-        boolVal = shallowWrapper.some(MyComponent);
-        boolVal = shallowWrapper.some(MyStatelessComponent);
+        boolVal = shallowWrapper.some(AnotherComponent);
+        boolVal = shallowWrapper.some(AnotherStatelessComponent);
         boolVal = shallowWrapper.some({ prop: 'myprop' });
         boolVal = shallowWrapper.some('.selector');
     }
@@ -368,8 +386,8 @@ function ShallowWrapperTest() {
     }
 
     function test_every() {
-        boolVal = shallowWrapper.every(MyComponent);
-        boolVal = shallowWrapper.every(MyStatelessComponent);
+        boolVal = shallowWrapper.every(AnotherComponent);
+        boolVal = shallowWrapper.every(AnotherStatelessComponent);
         boolVal = shallowWrapper.every({ prop: 'myprop' });
         boolVal = shallowWrapper.every('.selector');
     }
@@ -409,7 +427,8 @@ function ReactWrapperTest() {
     let boolVal: boolean;
     let stringVal: string;
     let elementWrapper: ReactWrapper<HTMLAttributes<{}>>;
-    let statelessWrapper: ReactWrapper<StatelessProps, never>;
+    let anotherStatelessWrapper: ReactWrapper<AnotherStatelessProps, never>;
+    let anotherComponentWrapper: ReactWrapper<AnotherComponentProps, any>;
 
     function test_prop_state_inferring() {
         let wrapper: ReactWrapper<MyComponentProps, MyComponentState>;
@@ -457,8 +476,8 @@ function ReactWrapperTest() {
 
     function test_find() {
         elementWrapper = reactWrapper.find('.selector');
-        reactWrapper = reactWrapper.find(MyComponent);
-        statelessWrapper = reactWrapper.find(MyStatelessComponent);
+        anotherComponentWrapper = reactWrapper.find(AnotherComponent);
+        anotherStatelessWrapper = reactWrapper.find(AnotherStatelessComponent);
         reactWrapper = reactWrapper.find({ prop: 'myprop' });
     }
 
@@ -468,10 +487,10 @@ function ReactWrapperTest() {
     }
 
     function test_filter() {
-        reactWrapper = reactWrapper.filter(MyComponent);
-        statelessWrapper = statelessWrapper.filter(MyStatelessComponent);
+        elementWrapper = reactWrapper.filter('.selector');
+        anotherComponentWrapper = reactWrapper.filter(AnotherComponent);
+        anotherStatelessWrapper = reactWrapper.filter(AnotherStatelessComponent);
         reactWrapper = reactWrapper.filter({ numberProp: 12 });
-        reactWrapper = reactWrapper.filter('.selector');
     }
 
     function test_filterWhere() {
@@ -524,8 +543,8 @@ function ReactWrapperTest() {
 
     function test_children() {
         reactWrapper = reactWrapper.children();
-        reactWrapper = reactWrapper.children(MyComponent);
-        statelessWrapper = reactWrapper.children(MyStatelessComponent);
+        anotherComponentWrapper = reactWrapper.children(AnotherComponent);
+        anotherStatelessWrapper = reactWrapper.children(AnotherStatelessComponent);
         reactWrapper = reactWrapper.children({ prop: 'myprop' });
         elementWrapper = reactWrapper.children('.selector');
     }
@@ -546,8 +565,8 @@ function ReactWrapperTest() {
 
     function test_parents() {
         reactWrapper = reactWrapper.parents();
-        reactWrapper = reactWrapper.parents(MyComponent);
-        statelessWrapper = reactWrapper.parents(MyStatelessComponent);
+        anotherComponentWrapper = reactWrapper.parents(AnotherComponent);
+        anotherStatelessWrapper = reactWrapper.parents(AnotherStatelessComponent);
         reactWrapper = reactWrapper.parents({ prop: 'myprop' });
         elementWrapper = reactWrapper.parents('.selector');
     }
@@ -557,8 +576,8 @@ function ReactWrapperTest() {
     }
 
     function test_closest() {
-        reactWrapper = reactWrapper.closest(MyComponent);
-        statelessWrapper = reactWrapper.closest(MyStatelessComponent);
+        anotherComponentWrapper = reactWrapper.closest(AnotherComponent);
+        anotherStatelessWrapper = reactWrapper.closest(AnotherStatelessComponent);
         reactWrapper = reactWrapper.closest({ prop: 'myprop' });
         elementWrapper = reactWrapper.closest('.selector');
     }
@@ -631,8 +650,8 @@ function ReactWrapperTest() {
 
     function test_props() {
         const props: MyComponentProps = reactWrapper.props();
-        const props2: MyComponentProps = reactWrapper.find(MyComponent).props();
-        const props3: StatelessProps = reactWrapper.find(MyStatelessComponent).props();
+        const props2: AnotherComponentProps = reactWrapper.find(AnotherComponent).props();
+        const props3: AnotherStatelessProps = reactWrapper.find(AnotherStatelessComponent).props();
         const props4: HTMLAttributes<any> = reactWrapper.find('.selector').props();
     }
 
@@ -708,8 +727,8 @@ function ReactWrapperTest() {
     }
 
     function test_some() {
-        boolVal = reactWrapper.some(MyComponent);
-        boolVal = reactWrapper.some(MyStatelessComponent);
+        boolVal = reactWrapper.some(AnotherComponent);
+        boolVal = reactWrapper.some(AnotherStatelessComponent);
         boolVal = reactWrapper.some({ prop: 'myprop' });
         boolVal = reactWrapper.some('.selector');
     }
@@ -719,8 +738,8 @@ function ReactWrapperTest() {
     }
 
     function test_every() {
-        boolVal = reactWrapper.every(MyComponent);
-        boolVal = reactWrapper.every(MyStatelessComponent);
+        boolVal = reactWrapper.every(AnotherComponent);
+        boolVal = reactWrapper.every(AnotherStatelessComponent);
         boolVal = reactWrapper.every({ prop: 'myprop' });
         boolVal = reactWrapper.every('.selector');
     }

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -373,7 +373,8 @@ export class ShallowWrapper<P = {}, S = {}> {
      * Removes nodes in the current wrapper that do not match the provided selector.
      * @param selector The selector to match.
      */
-    filter<P2>(component: ComponentClass<P2> | StatelessComponent<P2>): this;
+    filter<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
+    filter<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
     filter(selector: Partial<P> | string): this;
 
     /**
@@ -492,7 +493,8 @@ export class ReactWrapper<P = {}, S = {}> {
      * Removes nodes in the current wrapper that do not match the provided selector.
      * @param selector The selector to match.
      */
-    filter<P2>(component: ComponentClass<P2> | StatelessComponent<P2>): this;
+    filter<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
+    filter<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
     filter(props: Partial<P> | string): this;
 
     /**

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -375,7 +375,8 @@ export class ShallowWrapper<P = {}, S = {}> {
      */
     filter<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;
     filter<P2>(statelessComponent: StatelessComponent<P2>): ShallowWrapper<P2, never>;
-    filter(selector: Partial<P> | string): this;
+    filter(props: EnzymePropSelector): this;
+    filter(selector: string): ShallowWrapper<HTMLAttributes, any>;
 
     /**
      * Finds every node in the render tree that returns true for the provided predicate function.
@@ -495,7 +496,8 @@ export class ReactWrapper<P = {}, S = {}> {
      */
     filter<P2>(component: ComponentClass<P2>): ReactWrapper<P2, any>;
     filter<P2>(statelessComponent: StatelessComponent<P2>): ReactWrapper<P2, never>;
-    filter(props: Partial<P> | string): this;
+    filter(props: EnzymePropSelector): this;
+    filter(selector: string): ReactWrapper<HTMLAttributes, any>;
 
     /**
      * Returns a new wrapper with all of the children of the node(s) in the current wrapper. Optionally, a selector


### PR DESCRIPTION
@types/enzyme
Improve signature of ShallowWrapper.filter and ReactWrapper.filter to return appropriate specific types when the param is a ComponentClass or StatelessComponent.

This is needed, for example, to easily call the `.props()` method of the appropriate type of wrapper returned by `.filter()` without requiring any type casting.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: (shouldn't be necessary because it's very simple)
- [ ] Increase the version number in the header if appropriate. (there's no clarification of when it is "appropriate"; should I do this?)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (I'm guessing that my changes are not "substantial")
