### PR TITLE
html-minifier - Change customAttrCollapse to RegExp

### DIFF
--- a/types/html-minifier/index.d.ts
+++ b/types/html-minifier/index.d.ts
@@ -33,7 +33,7 @@ export interface Options {
     customAttrAssign?: RegExp[];
 
     // Regex that specifies custom attribute to strip newlines from (e.g. /ng-class/)
-    customAttrCollapse?: RegExp[];
+    customAttrCollapse?: RegExp;
 
     // Arrays of regex'es that allow to support custom attribute surround expressions (e.g. <input {{#if value}}checked="checked"{{/if}}>)
     customAttrSurround?: RegExp[];


### PR DESCRIPTION
The `customAttrCollapse` is supposed to be a Regular Expression, not an array of Regular Expressions.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [https://github.com/kangax/html-minifier#options-quick-reference]
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.