### PR TITLE
Update Firmata options and constructor (@types/firmata)

### DIFF
--- a/types/firmata/index.d.ts
+++ b/types/firmata/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for firmata.js 0.15
+// Type definitions for firmata.js 0.19
 // Project: https://github.com/firmata/firmata.js
 // Definitions by: Troy W. <https://github.com/troywweber7>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -16,7 +16,7 @@ export = Board;
  * guarantee that it cannot be improved.
  */
 declare class Board extends NodeJS.EventEmitter {
-	constructor(serialPort: string, optionsOrCallback?: Board.Options|((error: any) => void), callback?: (error: any) => void)
+	constructor(serialPort: any, optionsOrCallback?: Board.Options|((error: any) => void), callback?: (error: any) => void)
 	MODES: Board.PinModes;
 	STEPPER: Board.StepperConstants;
 	I2C_MODES: Board.I2cModes;
@@ -153,9 +153,12 @@ declare class Board extends NodeJS.EventEmitter {
 declare namespace Board {
 	// https://github.com/firmata/firmata.js/blob/master/lib/firmata.js#L429-L451
 	interface Options {
+		skipCapabilities?: boolean;
 		reportVersionTimeout?: number;
 		samplingInterval?: number;
 		serialport?: SerialPort.Options;
+		pins?: Pins[];
+		analogPins?: number[];
 	}
 
 	interface PinModes {


### PR DESCRIPTION
Common checks performed:
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/firmata/firmata.js>>
- [X] Increase the version number in the header if appropriate.

Rationale: 
- Firmata.js allows Board object to be constructed via serial port path or serial/ether port implementation. Custom (currently non-typed) transport can be implemented as well, therefore the only possible constructor argument type to cover for all the cases is any.
- Firmata.js specifies additional Board constructor options (skipCapabilities, pins, analogPins, ...)