### PR TITLE
[react-copy-to-clipboard] Add missing parameter to onCopy

### DIFF
--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-copy-to-clipboard 4.2
 // Project: https://github.com/nkbt/react-copy-to-clipboard
 // Definitions by: Meno Abels <https://github.com/mabels>
+//                 Bernabe <https://github.com/BernabeFelix>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -18,7 +19,7 @@ declare namespace CopyToClipboard {
 
   interface Props {
     text: string;
-    onCopy?(a: string): void;
+    onCopy?(a: string, b: boolean): void;
     options?: Options;
   }
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>


Added `result` parameter to onCopy optional callback
https://github.com/nkbt/react-copy-to-clipboard/blob/master/src/Component.js#L37

which can be `false` if the text could not be copied:
https://github.com/sudodoki/copy-to-clipboard/blob/master/index.js#L45