### PR TITLE
Fix Expo AuthSession returnUrl to be optional as per documentation

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -73,6 +73,10 @@ AuthSession.startAsync({
             break;
     }
 });
+AuthSession.startAsync({
+    authUrl: 'url1',
+    returnUrl: undefined
+});
 
 Audio.setAudioModeAsync({
     shouldDuckAndroid: false,

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -90,7 +90,7 @@ export class Asset {
  * AuthSession
  */
 export namespace AuthSession {
-    function startAsync(options: { authUrl: string; returnUrl: string; }): Promise<{
+    function startAsync(options: { authUrl: string; returnUrl?: string; }): Promise<{
         type: 'cancel';
     } | {
         type: 'dismissed';


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/latest/sdk/auth-session.html#options-object-
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
