### PR TITLE
[@types/request] Fill out Request and Response.

### DIFF
--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -17,11 +17,11 @@ declare namespace requestPromise {
 
     interface RequestPromiseOptions extends request.CoreOptions {
         simple?: boolean;
-        transform?(body: any, response: http.IncomingMessage, resolveWithFullResponse?: boolean): any;
+        transform?(body: any, response: request.Response, resolveWithFullResponse?: boolean): any;
         resolveWithFullResponse?: boolean;
     }
 
-    type FullResponse = request.RequestResponse;
+    type FullResponse = request.Response;
     type OptionsWithUri = request.UriOptions & RequestPromiseOptions;
     type OptionsWithUrl = request.UrlOptions & RequestPromiseOptions;
     type Options = OptionsWithUri | OptionsWithUrl;

--- a/types/request-promise/index.d.ts
+++ b/types/request-promise/index.d.ts
@@ -23,7 +23,7 @@ declare namespace requestPromise {
 
     interface RequestPromiseOptions extends request.CoreOptions {
         simple?: boolean;
-        transform?(body: any, response: http.IncomingMessage, resolveWithFullResponse?: boolean): any;
+        transform?(body: any, response: request.Response, resolveWithFullResponse?: boolean): any;
         transform2xxOnly?: boolean;
         resolveWithFullResponse?: boolean;
     }

--- a/types/request/index.d.ts
+++ b/types/request/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for request 2.0
+// Type definitions for request 2.47
 // Project: https://github.com/request/request
 // Definitions by: Carlos Ballesteros Velasco <https://github.com/soywiz>,
 //                 bonnici <https://github.com/bonnici>,
@@ -14,11 +14,13 @@
 
 /// <reference types="node" />
 
+import caseless = require('caseless');
 import stream = require('stream');
 import http = require('http');
 import https = require('https');
 import fs = require('fs');
 import FormData = require('form-data');
+import net = require('net');
 import tough = require('tough-cookie');
 import { Url } from 'url';
 
@@ -113,7 +115,7 @@ declare namespace request {
 
     interface CoreOptions {
         baseUrl?: string;
-        callback?: (error: any, response: RequestResponse, body: any) => void;
+        callback?: RequestCallback;
         jar?: CookieJar | boolean;
         formData?: { [key: string]: any };
         form?: { [key: string]: any } | string;
@@ -177,32 +179,7 @@ declare namespace request {
     type OptionsWithUrl = UrlOptions & CoreOptions;
     type Options = OptionsWithUri | OptionsWithUrl;
 
-    type RequestCallback = (error: any, response: RequestResponse, body: any) => void;
-
-    type ResponseRequest = CoreOptions & {
-      uri: Url;
-    };
-
-	interface RequestResponse extends http.IncomingMessage {
-		request: ResponseRequest;
-		body: any;
-		timingStart?: number;
-		timings?: {
-			socket: number;
-			lookup: number;
-			connect: number;
-			response: number;
-			end: number;
-		};
-		timingPhases?: {
-			wait: number;
-			dns: number;
-			tcp: number;
-			firstByte: number;
-			download: number;
-			total: number;
-		};
-	}
+    type RequestCallback = (error: any, response: Response, body: any) => void;
 
     interface HttpArchiveRequest {
         url?: string;
@@ -232,32 +209,32 @@ declare namespace request {
         body: any;
     }
 
-    interface Request extends stream.Stream {
+    interface Request extends caseless.Httpified, stream.Stream {
         readable: boolean;
         writable: boolean;
+        explicitMethod?: true;
 
-        getAgent(): http.Agent;
-        // start(): void;
-        // abort(): void;
+        debug(...args: any[]): void;
         pipeDest(dest: any): void;
-        setHeader(name: string, value: string, clobber?: boolean): Request;
-        setHeaders(headers: Headers): Request;
         qs(q: object, clobber?: boolean): Request;
         form(): FormData;
         form(form: any): Request;
         multipart(multipart: RequestPart[]): Request;
         json(val: any): Request;
         aws(opts: AWSOptions, now?: boolean): Request;
+        hawk(opts: HawkOptions): void;
         auth(username: string, password: string, sendImmediately?: boolean, bearer?: string): Request;
         oauth(oauth: OAuthOptions): Request;
         jar(jar: CookieJar): Request;
 
         on(event: string, listener: (...args: any[]) => void): this;
         on(event: 'request', listener: (req: http.ClientRequest) => void): this;
-        on(event: 'response', listener: (resp: http.IncomingMessage) => void): this;
+        on(event: 'response', listener: (resp: Response) => void): this;
         on(event: 'data', listener: (data: Buffer | string) => void): this;
         on(event: 'error', listener: (e: Error) => void): this;
-        on(event: 'complete', listener: (resp: http.IncomingMessage, body?: string | Buffer) => void): this;
+        on(event: 'complete', listener: (resp: Response, body?: string | Buffer) => void): this;
+        on(event: 'pipe', listener: (src: stream.Readable) => void): this;
+        on(event: 'socket', listener: (src: net.Socket) => void): this;
 
         write(buffer: Buffer | string, cb?: (err?: Error) => void): boolean;
         write(str: string, encoding?: string, cb?: (err?: Error) => void): boolean;
@@ -269,8 +246,94 @@ declare namespace request {
         resume(): void;
         abort(): void;
         destroy(): void;
-        toJSON(): object;
+        toJSON(): RequestAsJSON;
+
+        // several of the CoreOptions are copied onto the request instance
+        host?: string;
+        port?: number;
+        followAllRedirects?: boolean;
+        followOriginalHttpMethod?: boolean;
+        maxRedirects?: number;
+        removeRefererHeader?: boolean;
+        encoding?: string | null;
+        timeout?: number;
+        localAddress?: string;
+        strictSSL?: boolean;
+        rejectUnauthorized?: boolean;
+        time?: boolean;
+        gzip?: boolean;
+        preambleCRLF?: boolean;
+        postambleCRLF?: boolean;
+        withCredentials?: boolean;
+        key?: Buffer;
+        cert?: Buffer;
+        passphrase?: string;
+        ca?: string | Buffer | string[] | Buffer[];
+        har?: HttpArchiveRequest;
+
+        // set in `Request.prototype.init`
+        headers: Headers;
+        method: string;
+        pool: false | { [key: string]: http.Agent | https.Agent };
+        dests: stream.Readable[];
+        callback?: RequestCallback;
+        uri: Url & { href: string, pathname: string };
+        proxy: null | string | Url;
+        tunnel: boolean;
+        setHost: boolean;
+        path: string;
+        agent: false | http.Agent | https.Agent;
+        body: Buffer | Buffer[] | string | string[] | stream.Readable;
+        timing?: boolean;
+        src?: stream.Readable;
+
+        // set in `Request.prototype.start`
+        href: string;
+        startTime?: number;
+        startTimeNow?: number;
+        timings?: {
+            socket: number;
+            lookup: number;
+            connect: number;
+            response: number;
+            end: number;
+        };
+
+        // set in `Request.prototype.onRequestResponse`
+        elapsedTime?: number;
+        response?: Response;
     }
+
+    interface Response extends http.IncomingMessage {
+        statusCode: number;
+        statusMessage: string;
+        request: Request;
+        body: any; // Buffer, string, stream.Readable, or a plain object if `json` was truthy
+        caseless: caseless.Caseless; // case-insensitive access to headers
+        toJSON(): ResponseAsJSON;
+
+        timingStart?: number;
+        elapsedTime?: number;
+        timings?: {
+            socket: number;
+            lookup: number;
+            connect: number;
+            response: number;
+            end: number;
+        };
+        timingPhases?: {
+            wait: number;
+            dns: number;
+            tcp: number;
+            firstByte: number;
+            download: number;
+            total: number;
+        };
+    }
+
+    // aliases for backwards compatibility
+    type ResponseRequest = Request;
+    type RequestResponse = Response;
 
     interface Headers {
         [key: string]: any;
@@ -303,6 +366,19 @@ declare namespace request {
     interface AWSOptions {
         secret: string;
         bucket?: string;
+    }
+
+    interface RequestAsJSON {
+        uri: Url;
+        method: string;
+        headers: Headers;
+    }
+
+    interface ResponseAsJSON {
+        statusCode: number;
+        body: any;
+        headers: Headers;
+        request: RequestAsJSON;
     }
 
     type Cookie = tough.Cookie;

--- a/types/request/request-tests.ts
+++ b/types/request/request-tests.ts
@@ -7,23 +7,23 @@ import request = require('request');
 import stream = require('stream');
 import urlModule = require('url');
 
-const value: any = 'value';
+let value: any;
 let str: string;
 let strOrUndef: string | undefined;
 let strOrTrueOrUndef: string | true | undefined;
 const buffer: NodeBuffer = new Buffer('foo');
-const num = 0;
+let num = 0;
 let bool: boolean;
 let date: Date;
 let obj: object;
 const dest = 'foo';
 
 const uri = 'foo-bar';
-const headers: request.Headers = {};
+let headers: request.Headers = {};
 
-let agent: http.Agent;
 let write: stream.Writable = new stream.Writable();
 let req: request.Request = request(uri, function callback() {});
+let res: request.Response;
 let form: FormData;
 
 const bodyArr: request.RequestPart[] = [{
@@ -126,14 +126,14 @@ const opt: request.OptionsWithUri = {
 opt.uri = str;
 
 // --- --- --- --- --- --- --- --- --- --- --- ---
+let strOrFalse: string | false;
+strOrFalse = req.setHeader(str, str);
+strOrFalse = req.setHeader(str, str, bool);
+req.setHeader({str});
+strOrFalse = req.hasHeader(str);
+strOrUndef = req.getHeader(str);
+bool = req.removeHeader(str);
 
-agent = req.getAgent();
-// req.start();
-// req.abort();
-req.pipeDest(dest);
-req = req.setHeader(str, str);
-req = req.setHeader(str, str, bool);
-req = req.setHeaders(headers);
 req = req.qs(obj);
 req = req.qs(obj, bool);
 req = req.form(obj);
@@ -147,6 +147,7 @@ req = req.jar(jar);
 write = req.pipe(write);
 write = req.pipe(write, value);
 req.pipe(req);
+req.pipeDest(dest);
 req.write(value);
 req.end(str);
 req.end(buffer);
@@ -155,6 +156,19 @@ req.resume();
 req.abort();
 req.destroy();
 
+strOrUndef = req.host;
+str = req.method;
+str = req.path;
+str = req.href;
+str = req.uri.href;
+str = req.uri.pathname;
+value = req.body;
+headers = req.headers;
+value = req.headers['foo'];
+
+if (req.response) {
+  res = req.response;
+}
 // --- --- --- --- --- --- --- --- --- --- --- ---
 
 req = request(uri);
@@ -227,8 +241,30 @@ r.post(options);
 
 request
 .get('http://example.com/example.png')
-.on('response', (response: any) => {
-	// check response
+.on('response', (response) => {
+  res = response;
+  num = response.statusCode;
+  str = response.statusMessage;
+  req = response.request;
+  value = response.body;
+  strOrUndef = response.caseless.get('foo');
+  strOrFalse = response.caseless.has('content-type');
+
+  if (response.timings) {
+    num = response.timings.socket;
+    num = response.timings.lookup;
+    num = response.timings.connect;
+    num = response.timings.response;
+    num = response.timings.end;
+  }
+  if (response.timingPhases) {
+    num = response.timingPhases.wait;
+    num = response.timingPhases.dns;
+    num = response.timingPhases.tcp;
+    num = response.timingPhases.firstByte;
+    num = response.timingPhases.download;
+    num = response.timingPhases.total;
+  }
 })
 .pipe(request.put('http://another.com/another.png'));
 
@@ -247,7 +283,7 @@ request.get('http://google.com/img.png').pipe(request.put('http://mysite.com/img
 
 request
   .get('http://google.com/img.png')
-  .on('response', (response: any) => {
+  .on('response', (response) => {
     console.log(response.statusCode); // 200
     console.log(response.headers['content-type']); // 'image/png'
   })


### PR DESCRIPTION
This holds much more true to the actual lib where a `Request` and
`Response` reference each other and the `Request` has most of the
provided options merged onto it, plus other stuff.

Makes use of the newly added `@types/caseless` to DRY up some of the
header work.

I have a project that uses `request-promise-native`, these changes work
in my testing and having the `Response` object typed allowed me to
remove all my declaration merging files from the `request` namespace.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/request/request/blob/master/request.js#L94>
- [x] Increase the version number in the header if appropriate.
Updated version reference from 2.0 to 2.47 to cover both the addition of
`caseless` ([which removed `setHeaders`](https://github.com/request/request/pull/1006)) and the [removal of `getAgent`](https://github.com/request/request/pull/1197) from the lib.
- [x] update tests.
