### PR TITLE
[react-native-snap-carousel] Update definitions to match v3.x changes

### DIFF
--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -21,11 +21,11 @@ import {
 
 export interface AdditionalParallaxProps {
     carouselRef?: React.Component<FlatListProperties<any>>;
-    itemHeight?: number | undefined;
-    itemWidth?: number | undefined;
+    itemHeight?: number;
+    itemWidth?: number;
     scrollPosition?: Animated.Value;
-    sliderHeight?: number | undefined;
-    sliderWidth?: number | undefined;
+    sliderHeight?: number;
+    sliderWidth?: number;
     vertical?: boolean;
 }
 

--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -61,7 +61,7 @@ export interface CarouselProps<T> extends React.Props<ScrollViewProperties> {
      * Duration of time while component is hidden after mounting. NOTE: May cause rendering
      * issues on Android. Defaults to 0
      */
-    apaparitionDelay?: number;
+    apparitionDelay?: number;
     /**
      * Defines a small margin for callbacks firing from scroll events.  Increase this value
      * if you experience missed callbacks. Defaults to 5

--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for react-native-snap-carousel 2.4
+// Type definitions for react-native-snap-carousel 3.5
 // Project: https://github.com/archriss/react-native-snap-carousel
 // Definitions by: jnbt <https://github.com/jnbt>
+//                 Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -13,12 +14,22 @@ import {
     StyleProp,
     ScrollViewProperties,
     ScrollViewStyle,
-    ViewStyle
+    ViewStyle,
+    ImageProperties
 } from 'react-native';
 
-export interface CarouselProps extends React.Props<ScrollViewProperties> {
+export interface CarouselProps<T> extends React.Props<ScrollViewProperties> {
     // Required
 
+    /**
+     * Array of items to loop over
+     */
+    data?: ReadonlyArray<T>;
+    /**
+     * Function that takes an item from the `data` array and returns a React
+     * Element. See `react-native`'s `FlatList`
+     */
+    renderItem?(item: { item: T; index: number }, index: number): React.ReactNode;
     /**
      * Width in pixels of your slides, must be the same for all of them
      * Note: Required with horizontal carousel
@@ -47,6 +58,16 @@ export interface CarouselProps extends React.Props<ScrollViewProperties> {
      */
     activeSlideOffset?: number;
     /**
+     * Duration of time while component is hidden after mounting. NOTE: May cause rendering
+     * issues on Android. Defaults to 0
+     */
+    apaparitionDelay?: number;
+    /**
+     * Defines a small margin for callbacks firing from scroll events.  Increase this value
+     * if you experience missed callbacks. Defaults to 5
+     */
+    callbackOffsetMargin?: number;
+    /**
      * Since 1.5.0, the snapping effect can now be based on momentum instead of when you're
      * releasing your finger. It means that the component will wait until the ScrollView
      * isn't moving anymore to snap
@@ -60,6 +81,16 @@ export interface CarouselProps extends React.Props<ScrollViewProperties> {
      * Index of the first item to display
      */
     firstItem?: number;
+    /**
+     * Flag to indicate whether the carousel contains `<ParallaxImage />`. Parallax data
+     * will not be passed to carousel items if this is false
+     */
+    hasParallaxImages?: boolean;
+    /**
+     * Prevent the user from interacting with the carousel while it is snapping. Ignored
+     * if `enableMomentum` is `true`
+     */
+    lockScrollWhileSnapping?: boolean;
     /**
      * When momentum is disabled, this prop defines the timeframe during which multiple
      * callback calls should be "grouped" into a single one. This debounce also helps
@@ -81,10 +112,28 @@ export interface CarouselProps extends React.Props<ScrollViewProperties> {
      * Delta x when swiping to trigger the snap
      */
     swipeThreshold?: number;
+    /**
+     * Determines whether to use `ScrollView` instead of `FlatList`. May cause
+     * rendering performance issues due to losing `FlatList`'s performance
+     * optimizations
+     */
+    useScrollView?: boolean;
     /*
      * Layout slides vertically instead of horizontally
      */
     vertical?: boolean;
+
+    // Loop
+
+    /**
+     * Enable infinite loop mode. Does not work if `enableSnap` is `false`
+     */
+    loop?: boolean;
+    /**
+     * Number of clones to render at the beginning and end of the list. Default
+     * is 3
+     */
+    loopClonesPerSide?: number;
 
     // Autoplay
 
@@ -104,13 +153,17 @@ export interface CarouselProps extends React.Props<ScrollViewProperties> {
     // Style and animation
 
     /**
+     * Determine active slide's alignment relative to the carousel
+     */
+    activeSlideAlignment?: 'start' | 'center' | 'end';
+    /**
      * Animated animation to use. Provide the name of the method
      */
     animationFunc?: 'decay' | 'timing' | 'spring';
     /**
      * Animation options to be merged with the default ones. Can be used w/ animationFunc
      */
-    animationOptions?: Animated.DecayAnimationConfig | Animated.TimingAnimationConfig | Animated.SpringAnimationConfig;
+    customAnimationOptions?: Animated.DecayAnimationConfig | Animated.TimingAnimationConfig | Animated.SpringAnimationConfig;
     /**
      * Override container's inner padding (needed for slides's centering).
      * Warning: be aware that overriding the default value can mess with carousel's behavior.
@@ -132,6 +185,11 @@ export interface CarouselProps extends React.Props<ScrollViewProperties> {
      * Value of the 'scale' transform applied to inactive slides
      */
     inactiveSlideScale?: number;
+    /**
+     * Value of the 'translate' transform applied to inactive slides. Not recommended with
+     * `customAnimationOptions`
+     */
+    inactiveSlideShift?: number;
     /**
      * Optional style for each item's container (the one whose scale and opacity are animated)
      */
@@ -162,7 +220,7 @@ export interface CarouselProps extends React.Props<ScrollViewProperties> {
     onSnapToItem?(slideIndex: number): void;
 }
 
-export interface CarouselStatic extends React.ComponentClass<CarouselProps> {
+export interface CarouselStatic<T> extends React.ComponentClass<CarouselProps<T>> {
     currentIndex: number;
     currentScrollPosition: number;
     startAutoplay(instantly?: boolean): void;
@@ -172,7 +230,38 @@ export interface CarouselStatic extends React.ComponentClass<CarouselProps> {
     snapToPrev(animated?: boolean): void;
 }
 
-export type CarouselProperties = ScrollViewProperties & CarouselProps & React.Props<CarouselStatic>;
+export type CarouselProperties<T> = ScrollViewProperties & CarouselProps<T> & React.Props<CarouselStatic<T>>;
+
+export interface ParallaxImageProps extends ImageProperties {
+    /**
+     * Optional style for image's container
+     */
+    containerStyle?: StyleProp<ViewStyle>;
+    /**
+     * On screen dimensions of the image
+     */
+    dimensions?: { width: number; height: number };
+    /**
+     * Duration of fade in when object is loaded. Default of 500
+     */
+    fadeDuration?: number;
+    /**
+     * Speed of parallax effect. A higher value appears more 'zoomed in'
+     */
+    parallaxFactor?: number;
+    /**
+     * Whether to display a loading spinner
+     */
+    showSpinner?: boolean;
+    /**
+     * Color of the loading spinner if displayed
+     */
+    spinnerColor?: string;
+}
+
+export type ParallaxImageStatic = React.ComponentClass<ParallaxImageProps>;
+
+export type ParallaxImageProperties = PaginationProps & React.Props<PaginationStatic>;
 
 export interface PaginationProps {
     /**
@@ -207,4 +296,4 @@ export type PaginationProperties = PaginationProps & React.Props<PaginationStati
 
 export class Pagination extends React.Component<PaginationProperties> { }
 
-export default class Carousel extends React.Component<CarouselProperties> { }
+export default class Carousel<T> extends React.Component<CarouselProperties<T>> { }

--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -19,7 +19,6 @@ import {
     FlatListProperties
 } from 'react-native';
 
-
 export interface AdditionalParallaxProps {
     carouselRef?: React.Component<FlatListProperties<any>>;
     itemHeight?: number | undefined;

--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -15,8 +15,20 @@ import {
     ScrollViewProperties,
     ScrollViewStyle,
     ViewStyle,
-    ImageProperties
+    ImageProperties,
+    FlatListProperties
 } from 'react-native';
+
+
+export interface AdditionalParallaxProps {
+    carouselRef?: React.Component<FlatListProperties<any>>;
+    itemHeight?: number | undefined;
+    itemWidth?: number | undefined;
+    scrollPosition?: Animated.Value;
+    sliderHeight?: number | undefined;
+    sliderWidth?: number | undefined;
+    vertical?: boolean;
+}
 
 export interface CarouselProps<T> extends React.Props<ScrollViewProperties> {
     // Required
@@ -24,12 +36,12 @@ export interface CarouselProps<T> extends React.Props<ScrollViewProperties> {
     /**
      * Array of items to loop over
      */
-    data?: ReadonlyArray<T>;
+    data: ReadonlyArray<T>;
     /**
      * Function that takes an item from the `data` array and returns a React
      * Element. See `react-native`'s `FlatList`
      */
-    renderItem?(item: { item: T; index: number }, index: number): React.ReactNode;
+    renderItem(item: { item: T; index: number }, parallaxProps?: AdditionalParallaxProps): React.ReactNode;
     /**
      * Width in pixels of your slides, must be the same for all of them
      * Note: Required with horizontal carousel
@@ -232,7 +244,7 @@ export interface CarouselStatic<T> extends React.ComponentClass<CarouselProps<T>
 
 export type CarouselProperties<T> = ScrollViewProperties & CarouselProps<T> & React.Props<CarouselStatic<T>>;
 
-export interface ParallaxImageProps extends ImageProperties {
+export interface ParallaxImageProps extends ImageProperties, AdditionalParallaxProps {
     /**
      * Optional style for image's container
      */
@@ -261,7 +273,9 @@ export interface ParallaxImageProps extends ImageProperties {
 
 export type ParallaxImageStatic = React.ComponentClass<ParallaxImageProps>;
 
-export type ParallaxImageProperties = PaginationProps & React.Props<PaginationStatic>;
+export type ParallaxImageProperties = ParallaxImageProps & React.Props<ParallaxImageStatic>;
+
+export class ParallaxImage extends React.Component<ParallaxImageProperties> { }
 
 export interface PaginationProps {
     /**

--- a/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
+++ b/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
@@ -23,18 +23,6 @@ class SnapCarouselTest extends React.Component {
         );
     }
 
-    renderParallaxItem({ item }: { item: string }, parallaxProps?: AdditionalParallaxProps): React.ReactNode {
-        return (
-            <ParallaxImage
-                source={{ uri: 'http://via.placeholder.com/350x150' }}
-                containerStyle={{ height: 350, width: 350 }}
-                parallaxFactor={0.5}
-                showSpinner={true}
-                {...parallaxProps}
-            />
-        );
-    }
-
     render(): React.ReactElement<any> {
         return (
             <View>
@@ -54,11 +42,10 @@ class SnapCarouselTest extends React.Component {
                 />
                 <StringCarousel
                     data={this.data}
-                    renderItem={item => this.renderParallaxItem(item)}
+                    renderItem={item => this.renderItem(item)}
                     itemHeight={75}
                     sliderHeight={300}
                     vertical={true}
-                    hasParallaxImages={true}
                 />
             </View>
         );
@@ -121,6 +108,36 @@ class SnapCarouselWithPaginationTest extends React.Component<{}, {activeSlide: n
     }
 }
 
+class SnapCarouselWithParallaxTest extends React.Component {
+    data = ['Item #1', 'Item #2', 'Item #3'];
+
+    renderParallaxItem({ item }: { item: string }, parallaxProps?: AdditionalParallaxProps): React.ReactNode {
+        return (
+            <ParallaxImage
+                source={{ uri: 'http://via.placeholder.com/350x150' }}
+                containerStyle={styles.parallaxItem}
+                parallaxFactor={0.5}
+                showSpinner={true}
+                {...parallaxProps}
+            />
+        );
+    }
+
+    render(): React.ReactElement<any> {
+        return (
+            <View>
+                <StringCarousel
+                    data={this.data}
+                    renderItem={(item, parallaxProps) => this.renderParallaxItem(item, parallaxProps)}
+                    itemWidth={75}
+                    sliderWidth={300}
+                    containerCustomStyle={styles.container}
+                />
+            </View>
+        );
+    }
+}
+
 const styles = StyleSheet.create({
     container: {
         flex: 1
@@ -128,4 +145,8 @@ const styles = StyleSheet.create({
     item: {
         width: 75
     } as ViewStyle,
+    parallaxItem: {
+        height: 350,
+        width: 350
+    }
 });

--- a/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
+++ b/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
@@ -6,10 +6,9 @@ import {
     StyleSheet,
     Text,
     View,
-    ViewStyle
+    ViewStyle,
 } from 'react-native';
-
-import Carousel, { Pagination } from 'react-native-snap-carousel';
+import Carousel, { Pagination, ParallaxImage, AdditionalParallaxProps, } from 'react-native-snap-carousel';
 
 class StringCarousel extends Carousel<string> {}
 
@@ -24,13 +23,21 @@ class SnapCarouselTest extends React.Component {
         );
     }
 
+    renderParallaxItem({ item }: { item: string }, parallaxProps?: AdditionalParallaxProps): React.ReactNode {
+        return (
+            <ParallaxImage
+                source={{ uri: 'http://via.placeholder.com/350x150' }}
+                containerStyle={{ height: 350, width: 350 }}
+                parallaxFactor={0.5}
+                showSpinner={true}
+                {...parallaxProps}
+            />
+        );
+    }
+
     render(): React.ReactElement<any> {
         return (
             <View>
-                <Carousel
-                    itemWidth={75}
-                    sliderWidth={300}
-                />
                 <StringCarousel
                     data={this.data}
                     renderItem={item => this.renderItem(item)}
@@ -45,10 +52,13 @@ class SnapCarouselTest extends React.Component {
                     scrollEndDragDebounceValue={100}
                     vertical={false}
                 />
-                <Carousel
+                <StringCarousel
+                    data={this.data}
+                    renderItem={item => this.renderParallaxItem(item)}
                     itemHeight={75}
                     sliderHeight={300}
                     vertical={true}
+                    hasParallaxImages={true}
                 />
             </View>
         );
@@ -73,22 +83,25 @@ class SnapCarouselWithPaginationTest extends React.Component<{}, {activeSlide: n
         this.state = { activeSlide: 0 };
     }
 
+    renderItem({ item }: { item: string }): React.ReactNode {
+        return (
+            <View style={styles.item}>
+                <Text>{item}</Text>
+            </View>
+        );
+    }
+
     render(): React.ReactElement<any> {
         return (
             <View>
-                <Carousel
+                <StringCarousel
+                    data={['Item #1', 'Item #2']}
+                    renderItem={item => this.renderItem(item)}
                     itemWidth={75}
                     sliderWidth={300}
                     keyboardDismissMode='interactive'
                     onSnapToItem={(index) => this.setState({ activeSlide: index })}
-                >
-                    <View>
-                        <Text>Item #1</Text>
-                    </View>
-                    <View>
-                        <Text>Item #2</Text>
-                    </View>
-                </Carousel>
+                />
                 <Pagination
                         dotsLength={2}
                         activeDotIndex={this.state.activeSlide}

--- a/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
+++ b/types/react-native-snap-carousel/react-native-snap-carousel-tests.tsx
@@ -11,7 +11,19 @@ import {
 
 import Carousel, { Pagination } from 'react-native-snap-carousel';
 
+class StringCarousel extends Carousel<string> {}
+
 class SnapCarouselTest extends React.Component {
+    data = ['Item #1', 'Item #2', 'Item #3'];
+
+    renderItem({ item }: { item: string }): React.ReactNode {
+        return (
+            <View style={styles.item}>
+                <Text>{item}</Text>
+            </View>
+        );
+    }
+
     render(): React.ReactElement<any> {
         return (
             <View>
@@ -19,7 +31,9 @@ class SnapCarouselTest extends React.Component {
                     itemWidth={75}
                     sliderWidth={300}
                 />
-                <Carousel
+                <StringCarousel
+                    data={this.data}
+                    renderItem={item => this.renderItem(item)}
                     itemWidth={75}
                     sliderWidth={300}
                     containerCustomStyle={styles.container}
@@ -30,13 +44,7 @@ class SnapCarouselTest extends React.Component {
                     onLayout={this.onLayout}
                     scrollEndDragDebounceValue={100}
                     vertical={false}
-                >
-                    <View
-                        style={styles.item}
-                    >
-                        <Text>Item #1</Text>
-                    </View>
-                </Carousel>
+                />
                 <Carousel
                     itemHeight={75}
                     sliderHeight={300}


### PR DESCRIPTION
`react-native-snap-carousel` v3.x includes several changes and additions to props (most significantly using `Flatlist` under the hood and so requiring a `data` and `renderItem` prop).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [README](https://github.com/archriss/react-native-snap-carousel)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
