### PR TITLE
koa-session: Allow generic for stronger typing of Context.session

### DIFF
--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -69,7 +69,8 @@ declare namespace session {
          */
         beforeSave?(ctx: Koa.Context, session: sessionProps): void;
     }
-    interface sessionProps {
+
+    type sessionProps<SessionProps = {[propName: string]: any}> = SessionProps & {
         /**
          * Returns true if the session is new
          */
@@ -84,8 +85,7 @@ declare namespace session {
          * Save this session no matter whether it is populated
          */
         save(): void;
-        [propName: string]: any;
-    }
+    };
 
     interface stores {
         /**
@@ -110,8 +110,8 @@ declare function session(CONFIG: session.sessionConfig, app: Koa): Koa.Middlewar
 declare function session(app: Koa): Koa.Middleware;
 
 declare module 'koa' {
-    interface Context {
-        session: session.sessionProps | null;
+    interface Context<SessionProps = {[propName: string]: any}> {
+        session: session.sessionProps<SessionProps> | null;
     }
 }
 

--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for koa-session 3.0
 // Project: https://github.com/koajs/session
 // Definitions by: Yu Hsin Lu <https://github.com/kerol2r20>
+//                 Sebastian Ferreyra <https://github.com/saabi>
+//                 Nick Small <https://github.com/nickjs>
 // Definitions: https://github.com/kerol2r20/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
koa-session adds a `session` object to `Context` that allows you to get and set any keys on it and it will save those keys and values to the actual session. This PR allows you to provide a generic T for the interface that your particular session object conforms to, so that you can have strong typing whenever you use `context.session.foo`. Thanks!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Any use case that uses the session object should make it apparent why it's useful having stronger typing than just an index definition. See the example: https://github.com/koajs/session#example
- [ ] Increase the version number in the header if appropriate. N/A. NB: The current typings for koa-session are marked as using version 3.0, but the actual koa-session module is on 5.8.1. A more substantial PR would probably be required to bring the typings up to date with all the latest in the module.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. N/A, already exists.
