### PR TITLE
[graphql] rename TypeExtensionDefinitionNode to TypeExtensionNode

### DIFF
--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -11,6 +11,7 @@
 //                 Ricardo Portugal <https://github.com/rportugal>
 //                 Tim Griesser <https://github.com/tgriesser>
 //                 Dylan Stewart <https://github.com/dyst5422>
+//                 Alessio Dionisi <https://github.com/adnsio>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -8,7 +8,7 @@ import {
     EnumTypeDefinitionNode,
     EnumValueDefinitionNode,
     InputObjectTypeDefinitionNode,
-    TypeExtensionDefinitionNode,
+    TypeExtensionNode,
     OperationDefinitionNode,
     FieldNode,
     FragmentDefinitionNode,
@@ -231,7 +231,7 @@ export class GraphQLObjectType {
     name: string;
     description: string;
     astNode?: ObjectTypeDefinitionNode;
-    extensionASTNodes: Array<TypeExtensionDefinitionNode>;
+    extensionASTNodes: Array<TypeExtensionNode>;
     isTypeOf: GraphQLIsTypeOfFn<any, any>;
 
     constructor(config: GraphQLObjectTypeConfig<any, any>);
@@ -247,7 +247,7 @@ export interface GraphQLObjectTypeConfig<TSource, TContext> {
     isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext>;
     description?: string;
     astNode?: ObjectTypeDefinitionNode;
-    extensionASTNodes?: Array<TypeExtensionDefinitionNode>;
+    extensionASTNodes?: Array<TypeExtensionNode>;
 }
 
 export type GraphQLTypeResolver<TSource, TContext> = (


### PR DESCRIPTION
@dyst5422 Fix compilation error.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).