### PR TITLE
Make dsn parameter in Raven.config() optional

### DIFF
--- a/types/raven/index.d.ts
+++ b/types/raven/index.d.ts
@@ -10,7 +10,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { EventEmitter } from 'events';
 
 export const version: string;
-export function config(dsn: string | false, options?: ConstructorOptions): Client;
+export function config(dsn?: string | false, options?: ConstructorOptions): Client;
 export function wrap<T>(func: () => T): () => T;
 export function wrap<T>(options: any, func: () => T): () => T;
 export function interceptErr(ctx: any): Client;


### PR DESCRIPTION
dsn parameter in Raven.config() is actually optional. When it's omitted, dsn is taken from SENTRY_DSN environment variable (see https://github.com/getsentry/raven-node/blob/master/lib/client.js#L39).

false is also a valid option, but has different semantics (it disables reporting).

CC @scttcper, @1999

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/getsentry/raven-node/blob/master/lib/client.js#L39
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
