### PR TITLE
mocha: reporter() method takes optional second parameter

### DIFF
--- a/types/mocha/index.d.ts
+++ b/types/mocha/index.d.ts
@@ -86,9 +86,9 @@ declare class Mocha {
     bail(value?: boolean): Mocha;
     addFile(file: string): Mocha;
     /** Sets reporter by name, defaults to "spec". */
-    reporter(name: string): Mocha;
+    reporter(name: string, reporterOptions?: any): Mocha;
     /** Sets reporter constructor, defaults to mocha.reporters.Spec. */
-    reporter(reporter: ReporterConstructor): Mocha;
+    reporter(reporter: ReporterConstructor, reporterOptions?: any): Mocha;
     ui(value: string): Mocha;
     grep(value: string): Mocha;
     grep(value: RegExp): Mocha;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mochajs/mocha/blob/master/lib/mocha.js#L131
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR adds the missing second parameter, `reporterOptions`, to the `Mocha.reporter()` method. Although the API suggests that `reporterOptions` should be an "Object," searching through the source code shows that the current implementation doesn't actually care what its type is, and simply passes it to the reporter constructor without modifying or accessing it in any way. As such - and to mimic the other reference to `reporterOptions` in the current definitions which already describes it as being an `any` - I've used `any` for this new parameter rather than the stricter `object`.

Since any custom reporter can "expect" and potentially deal with whatever types of options it wants to, it seems that `any` better captures the potential forms that this parameter can take. Given the other occurrence of `reporterOptions?: any` that already exists in the current definitions, this seems to be an opinion shared by the original author, although `object` would likely be an acceptable substitute.