### PR TITLE
@types/express-enforces-ssl: added namespace on declaration

### DIFF
--- a/types/express-enforces-ssl/express-enforces-ssl-tests.ts
+++ b/types/express-enforces-ssl/express-enforces-ssl-tests.ts
@@ -1,6 +1,6 @@
-import express = require('express');
-import expressEnforcesSsl = require('express-enforces-ssl');
+import * as express from 'express';
+import { enforceHTTPS } from 'express-enforces-ssl';
 
 const app: express.Express = express();
 
-app.use(expressEnforcesSsl());
+app.use(enforceHTTPS());

--- a/types/express-enforces-ssl/index.d.ts
+++ b/types/express-enforces-ssl/index.d.ts
@@ -9,6 +9,8 @@ import { Request, Response, NextFunction } from 'express';
 /**
  * Enforces HTTPS connections on any incoming requests.
  */
-declare function enforceHTTPS(): (req: Request, res: Response, next: NextFunction) => void;
+declare namespace enforceHTTPS {
+  function enforceHTTPS(): (req: Request, res: Response, next: NextFunction) => void;
+}
 
 export = enforceHTTPS;


### PR DESCRIPTION
Allowing to use:

`import { enforceHTTPS } from 'express-enforces-ssl';`

instead of:

`require('express-enforces-ssl');`

Author: @kevinstubbs 
