### PR TITLE
[q] Allow thenReject to return a promise for a different type

### DIFF
--- a/types/q/index.d.ts
+++ b/types/q/index.d.ts
@@ -145,7 +145,7 @@ declare namespace Q {
 		/**
 		 * A sugar method, equivalent to promise.then(function () { throw reason; }).
 		 */
-		thenReject(reason?: any): Promise<T>;
+		thenReject<U = T>(reason?: any): Promise<U>;
 
 		/**
 		 * Attaches a handler that will observe the value of the promise when it becomes fulfilled, returning a promise for that same value, perhaps deferred but not replaced by the promise returned

--- a/types/q/q-tests.ts
+++ b/types/q/q-tests.ts
@@ -234,3 +234,37 @@ Q.try(() => {
 	return true;
 })
 	.catch((error) => console.error("Couldn't sync to the cloud", error));
+
+// thenReject, returning a Promise of the same type as the Promise it is called on
+function thenRejectSameType(arg: any): Q.Promise<number> {
+	if (!arg) {
+		return returnsNumPromise('')
+			.thenReject(new Error('failed'));
+	}
+	return Q.resolve(2);
+}
+
+// thenReject, returning a Promise of a different type to the Promise it is called on.
+// The generic type argument is specified.
+function thenRejectSpecificOtherType(arg: any): Q.Promise<string> {
+	if (!arg) {
+		return returnsNumPromise('')
+			.thenReject<string>(new Error('failed'));
+	}
+	return Q.resolve('');
+}
+
+// thenReject, returning a Promise of a different type to the Promise it is called on.
+// The generic type argument is inferred.
+// This relies on 'Return types as inference targets', new in TS 2.4.
+// Commented out as we support TS 2.3.
+// This should be uncommented if the minimum version is changed.
+/*
+function thenRejectInferredOtherType(arg: any): Q.Promise<string> {
+	if (!arg) {
+		return returnsNumPromise('')
+			.thenReject(new Error('failed'));
+	}
+	return Q.resolve('');
+}
+*/


### PR DESCRIPTION
* Change the Promise.thenReject signature to allow matching of a different type.

Type-checking rejections is problematic as it's equivalent to `throw`: you don't get a value of type T in your success callback. You get an `Error` (or other thrown type) in an error callback. We can't remove the generic parameter, as suggested in Common Mistakes, because we have to provide some type as the type argument for the returned `Promise`.

Checklist:
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Promise.thenReject](https://github.com/kriskowal/q/wiki/API-Reference#promisethenrejectreason)
- [ ] Increase the version number in the header if appropriate. **Remains compatible with TS 2.3.**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **tslint.json already present.**