### PR TITLE
add mozilla/readability types

### DIFF
--- a/types/mozilla-readability/index.d.ts
+++ b/types/mozilla-readability/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for mozilla-readability 0.1
+// Project: https://github.com/mozilla/readability
+// Definitions by: Charles Vandevoorde <https://github.com/charlesvdv>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export = Readability;
+
+declare class Readability {
+    constructor(uri: Readability.Uri, doc: Document, options?: Readability.Options);
+
+    parse(): Readability.ParseResult;
+    isProbablyReaderable(helperIsVisible?: (node: any) => boolean): boolean;
+}
+
+declare namespace Readability {
+    interface Uri {
+        spec: string;
+        host: string;
+        prePath: string;
+        scheme: string;
+        pathBase: string;
+    }
+
+    interface Options {
+        debug?: boolean;
+        maxElemsToParse?: number;
+        nbTopCandidates?: number;
+        wordThreshold?: number;
+        classesToPreserve?: string[];
+    }
+
+    interface ParseResult {
+        uri: Uri;
+        title: string;
+        byline: string;
+        dir: string;
+        content: string;
+        textContent: string;
+        length: number;
+        excerpt: string;
+    }
+}

--- a/types/mozilla-readability/mozilla-readability-tests.ts
+++ b/types/mozilla-readability/mozilla-readability-tests.ts
@@ -1,0 +1,46 @@
+import * as Readability from 'mozilla-readability';
+import { JSDOM } from 'jsdom';
+
+// Compiling requires `--noImplicitUseStrict`
+// because issue https://github.com/mozilla/readability/issues/346
+// requires global variable `Node` when using nodejs.
+
+const fakeUri: Readability.Uri = {
+    spec: "http://fakehost/test/page.html",
+    host: "fakehost",
+    prePath: "http://fakehost",
+    scheme: "http",
+    pathBase: "http://fakehost/test/"
+};
+
+function test_basic_usage() {
+    const dom = new JSDOM(`<p>Hello</p><p><strong>Hi!</strong>`);
+    // Required until https://github.com/mozilla/readability/issues/346
+    // is fixed.
+    Node = dom.window.Node;
+
+    const reader = new Readability(fakeUri, dom.window.document);
+    const article = reader.parse();
+}
+
+function test_readability_with_options() {
+    const dom = new JSDOM(`<p>Hello</p><p><strong>Hi!</strong>`);
+    // Required until https://github.com/mozilla/readability/issues/346
+    // is fixed.
+    Node = dom.window.Node;
+
+    const options: Readability.Options = {
+        debug: true,
+        maxElemsToParse: 100,
+    };
+    const article = new Readability(fakeUri, dom.window.document, options).parse();
+}
+
+function test_is_probably_readerable() {
+    const dom = new JSDOM(`<p>Hello</p><p><strong>Hi!</strong>`);
+    // Required until https://github.com/mozilla/readability/issues/346
+    // is fixed.
+    Node = dom.window.Node;
+
+    const isReadable = new Readability(fakeUri, dom.window.document).isProbablyReaderable();
+}

--- a/types/mozilla-readability/tsconfig.json
+++ b/types/mozilla-readability/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": false,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mozilla-readability-tests.ts"
+    ]
+}

--- a/types/mozilla-readability/tslint.json
+++ b/types/mozilla-readability/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

This pull request is adding type for https://github.com/mozilla/readability.
