### PR TITLE
kafka-node: Fix type of Message.key to be optional string

### DIFF
--- a/types/kafka-node/index.d.ts
+++ b/types/kafka-node/index.d.ts
@@ -99,7 +99,7 @@ export interface Message {
   offset?: number;
   partition?: number;
   highWaterOffset?: number;
-  key?: number;
+  key?: string;
 }
 
 export interface ProducerOptions {


### PR DESCRIPTION
key is not a number, it's a string. See KeyedMessage constructor, above.

(However, if `encoding` is specified as "buffer" in ConsumerOptions then `key` and `value` are actually `Buffer` rather than `string`. I'm not sure if it's possible to specify this better than `string|Buffer` since it may not be knowable at compile time.)


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.npmjs.com/package/kafka-node#sendpayloads-cb
- [ ] Increase the version number in the header if appropriate: *The header does not include the bugfix version number*
