### PR TITLE
Use 'export =' for type-detect

### DIFF
--- a/types/type-detect/index.d.ts
+++ b/types/type-detect/index.d.ts
@@ -3,4 +3,5 @@
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export default function typeDetect(obj: any): string;
+declare function typeDetect(obj: any): string;
+export = typeDetect;

--- a/types/type-detect/type-detect-tests.ts
+++ b/types/type-detect/type-detect-tests.ts
@@ -1,4 +1,4 @@
-import type from 'type-detect';
+import type = require('type-detect');
 
 // $ExpectType string
 type(123);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chaijs/type-detect/blob/master/rollup.conf.js#L17 (`umd` is specified, so it becomes a CJS default export)

I changed these recently (#22881) and thought I tested it properly, but somehow my build didn't fail then even though this needed `export =` instead of `export default`.