### PR TITLE
[react] Use HTMLDialogElement for the dialog node

### DIFF
--- a/types/alt/index.d.ts
+++ b/types/alt/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/goatslacker/alt
 // Definitions by: Michael Shearer <https://github.com/Shearerbeard>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///<reference types="react"/>
 

--- a/types/aphrodite/index.d.ts
+++ b/types/aphrodite/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Khan/aphrodite
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/assert-equal-jsx/index.d.ts
+++ b/types/assert-equal-jsx/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/thejameskyle/assert-equal-jsx
 // Definitions by: Josh Toft <https://github.com/seryl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/braft-editor/index.d.ts
+++ b/types/braft-editor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/margox/braft#readme
 // Definitions by: My Self <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import { RawDraftContentState } from 'draft-js';

--- a/types/catalog/index.d.ts
+++ b/types/catalog/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/interactivethings/catalog/
 // Definitions by: Peter Gassner <https://github.com/grossbart>, Tomas Carnecky <https://github.com/wereHamster>
 // Definitions: https://github.com/interactivethings/catalog/
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/chai-enzyme/index.d.ts
+++ b/types/chai-enzyme/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/producthunt/chai-enzyme
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 
 /// <reference types="enzyme" />

--- a/types/cleave.js/index.d.ts
+++ b/types/cleave.js/index.d.ts
@@ -4,7 +4,7 @@
 //                 J Giancono <https://github.com/jasongi-at-sportsbet>,
 //                 Alex Shakun <https://github.com/sashashakun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { CleaveOptions } from './options';
 

--- a/types/create-react-class/index.d.ts
+++ b/types/create-react-class/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://facebook.github.io/react/
 // Definitions by: John Gozde <https://github.com/jgoz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentSpec, ClassicComponentClass } from "react";
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -8,7 +8,7 @@
 //                 Willis Plummer <https://github.com/willisplummer>
 //                 Santiago Vilar <https://github.com/smvilar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import * as Immutable from 'immutable';

--- a/types/emoji-mart/index.d.ts
+++ b/types/emoji-mart/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/missive/emoji-mart
 // Definitions by: Diogo Franco <https://github.com/Kovensky>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 // These definitions should work with 2.3, but the tests doesn't pass on 2.3.
 

--- a/types/enzyme-adapter-react-15.4/index.d.ts
+++ b/types/enzyme-adapter-react-15.4/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://airbnb.io/enzyme/
 // Definitions by: Nabeelah Ali <https://github.com/nali>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { EnzymeAdapter } from 'enzyme';
 

--- a/types/enzyme-adapter-react-15/index.d.ts
+++ b/types/enzyme-adapter-react-15/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/airbnb/enzyme
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { EnzymeAdapter } from 'enzyme';
 

--- a/types/enzyme-adapter-react-16/index.d.ts
+++ b/types/enzyme-adapter-react-16/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/airbnb/enzyme
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { EnzymeAdapter } from 'enzyme';
 

--- a/types/enzyme-to-json/index.d.ts
+++ b/types/enzyme-to-json/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/adriantoine/enzyme-to-json#readme
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ReactWrapper, ShallowWrapper } from 'enzyme';
 

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -8,7 +8,7 @@
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Torgeir Hovden <https://github.com/thovden>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="cheerio" />
 import { ReactElement, Component, AllHTMLAttributes as ReactHTMLAttributes, SVGAttributes as ReactSVGAttributes } from "react";

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -4,7 +4,7 @@
 //                 Martynas Kadiša <https://github.com/martynaskadisa>
 //                 Sergio Sánchez <https://github.com/ssanchezmarc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { EventSubscription } from 'fbemitter';
 import { Component, ComponentClass, Ref } from 'react';

--- a/types/expo/v23/index.d.ts
+++ b/types/expo/v23/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expo/expo-sdk
 // Definitions by: Konstantin Kai <https://github.com/KonstantinKai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { EventSubscription } from 'fbemitter';
 import { Component, Ref } from 'react';

--- a/types/expo__vector-icons/index.d.ts
+++ b/types/expo__vector-icons/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expo/vector-icons
 // Definitions by: Hyeonsu Lee <https://github.com/incleaf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { TextProperties } from 'react-native';

--- a/types/fixed-data-table-2/index.d.ts
+++ b/types/fixed-data-table-2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/schrodinger/fixed-data-table-2
 // Definitions by: Ilya Petukhov <https://github.com/ilivit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/fixed-data-table/index.d.ts
+++ b/types/fixed-data-table/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/facebook/fixed-data-table
 // Definitions by: Petar Paar <https://github.com/pepaar>, Stephen Jelfs <https://github.com/stephenjelfs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react"/>
 

--- a/types/flux/index.d.ts
+++ b/types/flux/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Steve Baker <https://github.com/stkb>
 //                 Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import Dispatcher = require("./lib/Dispatcher");
 

--- a/types/fluxxor/index.d.ts
+++ b/types/fluxxor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/BinaryMuse/fluxxor
 // Definitions by: Yuichi Murata <https://github.com/mrk21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as EventEmitter3 from 'eventemitter3';
 import * as React from "react";

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/istarkov/google-map-react
 // Definitions by: Honza Brecka <https://github.com/honzabrecka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/grid-styled/index.d.ts
+++ b/types/grid-styled/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jxnblk/grid-styled
 // Definitions by: Anton Vasin <https://github.com/antonvasin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
     { [P in U]: never } & { [x: string]: never })[T];

--- a/types/halogen/index.d.ts
+++ b/types/halogen/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/yuanyan/halogen
 // Definitions by: Vincent Rouffiat <https://github.com/steller>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as react from "react";
 

--- a/types/hedron/index.d.ts
+++ b/types/hedron/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/JSBros/hedron
 // Definitions by: Dmytro Borysov <https://github.com/dborysov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/jasmine-enzyme/index.d.ts
+++ b/types/jasmine-enzyme/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/blainekasten/enzyme-matchers/blob/master/packages/jasmine-enzyme/README.md
 // Definitions by: Umar Bolatov <https://github.com/bolatovumar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 /// <reference types="jasmine" />
 /// <reference types="react" />

--- a/types/jsnox/index.d.ts
+++ b/types/jsnox/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Steve Baker <https://github.com/stkb>
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/material-ui-datatables/index.d.ts
+++ b/types/material-ui-datatables/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/hyojin/material-ui-datatables#readme
 // Definitions by: Ravi L. <https://github.com/coding2012>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/material-ui-pagination/index.d.ts
+++ b/types/material-ui-pagination/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/lo-tp/material-ui-pagination
 // Definitions by: m0a <https://m0a.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 import * as React from 'react';
 export interface PaginationProps {
 	total: number;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -12,7 +12,7 @@
 //                 Dan Jones <https://github.com/dan-j>
 //                 Daisuke Mino <https://github.com/minodisk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 /// <reference types="react-addons-linked-state-mixin" />

--- a/types/mirrorx/index.d.ts
+++ b/types/mirrorx/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mirrorjs/mirror
 // Definitions by: Aaronphy <https://github.com/aaronphy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as H from 'history';
 

--- a/types/navigation-react/index.d.ts
+++ b/types/navigation-react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { StateNavigator } from 'navigation';
 import { Component, HTMLProps } from 'react';

--- a/types/next-redux-wrapper/index.d.ts
+++ b/types/next-redux-wrapper/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kirill-konshin/next-redux-wrapper
 // Definitions by: Steve <https://github.com/stevegeek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 /// <reference types="node" />
 /*~ Note that ES6 modules cannot directly export callable functions.

--- a/types/next/index.d.ts
+++ b/types/next/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Drew Hays <https://github.com/dru89>
 //                 Brice BERNARD <https://github.com/brikou>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="node" />
 

--- a/types/ngreact/index.d.ts
+++ b/types/ngreact/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ngReact/ngReact
 // Definitions by: Vicky Lai <https://github.com/velveret>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="angular"/>
 /// <reference types="react"/>

--- a/types/qrcode.react/index.d.ts
+++ b/types/qrcode.react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zpao/qrcode.react
 // Definitions by: Mleko <https://github.com/mleko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/radium/index.d.ts
+++ b/types/radium/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/formidablelabs/radium
 // Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev>, Philipp Holzer <https://github.com/nupplaphil>, Alexey Svetliakov <https://github.com/asvetliakov>, Mikael Hermansson <https://github.com/mihe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/rc-select/index.d.ts
+++ b/types/rc-select/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-component/select
 // Definitions by: Denis Tirilis <https://github.com/DenisTirilis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -5,7 +5,7 @@
 //                 Austin Turner <https://github.com/paustint>
 //                 Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: rhysd <https://rhysd.github.io>
 //                 ahstro <http://ahst.ro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/rc-tree/index.d.ts
+++ b/types/rc-tree/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-component/tree
 // Definitions by: John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import {
     Component,

--- a/types/react-addons-create-fragment/index.d.ts
+++ b/types/react-addons-create-fragment/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-addons-css-transition-group/index.d.ts
+++ b/types/react-addons-css-transition-group/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import 'react-addons-transition-group';
 import { ComponentClass, CSSTransitionGroupProps } from 'react';

--- a/types/react-addons-linked-state-mixin/index.d.ts
+++ b/types/react-addons-linked-state-mixin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Mixin } from 'react';
 

--- a/types/react-addons-pure-render-mixin/index.d.ts
+++ b/types/react-addons-pure-render-mixin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Mixin } from 'react';
 

--- a/types/react-addons-shallow-compare/index.d.ts
+++ b/types/react-addons-shallow-compare/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from 'react';
 

--- a/types/react-addons-test-utils/index.d.ts
+++ b/types/react-addons-test-utils/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { AbstractView, Component, ComponentClass,
     ReactElement, ReactInstance, ClassType,

--- a/types/react-addons-transition-group/index.d.ts
+++ b/types/react-addons-transition-group/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentClass, TransitionGroupProps } from 'react';
 

--- a/types/react-addons-update/index.d.ts
+++ b/types/react-addons-update/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-alert/index.d.ts
+++ b/types/react-alert/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/schiehll/react-alert
 // Definitions by: Steve Syrell <https://github.com/ssyrell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-alice-carousel/index.d.ts
+++ b/types/react-alice-carousel/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/maxmarinich/react-alice-carousel
 // Definitions by: endigo <https://github.com/endigo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-app/index.d.ts
+++ b/types/react-app/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kriasoft/react-app#readme
 // Definitions by: Prakarsh Pandey <https://github.com/prakarshpandey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Muhammad Fawwaz Orabi <https://github.com/forabi>
 //                 Chris Rohlfs <https://github.com/crohlfs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -7,7 +7,7 @@
 //                 Christopher Deutsch <https://github.com/cdeutsch>
 //                 Kevin Ross <https://github.com/rosskevin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: varHarrie <https://github.com/varHarrie>
 //                 Bradley Ayers <https://github.com/bradleyayers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Piotr Witek <http://piotrwitek.github.io>
 //                 Austin Turner <https://github.com/paustint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 declare module 'react-big-calendar' {
     import * as React from 'react';

--- a/types/react-body-classname/index.d.ts
+++ b/types/react-body-classname/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/PactCoffee/react-body-classname
 // Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-bootstrap-date-picker/index.d.ts
+++ b/types/react-bootstrap-date-picker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pushtell/react-bootstrap-date-picker#readme
 // Definitions by: Karol Janyst <https://github.com/LKay>, Antal Bodnar <https://github.com/ssi-hu-antal-bodnar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentClass, StatelessComponent, ReactNode, FocusEventHandler, HTMLAttributes } from "react";
 

--- a/types/react-bootstrap-daterangepicker/index.d.ts
+++ b/types/react-bootstrap-daterangepicker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/skratchdot/react-bootstrap-daterangepicker
 // Definitions by: Ian Ker-Seymer <https://github.com/ianks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 /// <reference types="daterangepicker" />

--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -6,7 +6,7 @@
 //                 Janeene Beeforth <https://github.com/dawnmist>
 //                 Oscar Andersson <https://github.com/Ogglas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 // documentation taken from http://allenfang.github.io/react-bootstrap-table/docs.html
 

--- a/types/react-bootstrap-table/v2/index.d.ts
+++ b/types/react-bootstrap-table/v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/AllenFang/react-bootstrap-table
 // Definitions by: Frank Laub <https://github.com/flaub>, Aleksander Lode <https://github.com/alelode>, Josué Us <https://github.com/UJosue10>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="node" />
 

--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ericgio/react-bootstrap-typeahead
 // Definitions by: Guymestef <https://github.com/Guymestef>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -12,7 +12,7 @@
 //                 Karol Janyst <https://github.com/LKay>
 //                 Aaron Beall <https://github.com/aaronbeall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-breadcrumbs-dynamic/index.d.ts
+++ b/types/react-breadcrumbs-dynamic/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oklas/react-breadcrumbs-dynamic
 // Definitions by: mitsuruog <https://github.com/mitsuruog>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-breadcrumbs/index.d.ts
+++ b/types/react-breadcrumbs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/svenanders/react-breadcrumbs
 // Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import * as ReactRouter from "react-router";

--- a/types/react-burger-menu/index.d.ts
+++ b/types/react-burger-menu/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/negomi/react-burger-menu
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-bytesize-icons/index.d.ts
+++ b/types/react-bytesize-icons/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/abdelhai/react-bytesize-icons
 // Definitions by: rhysd <https://rhysd.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-calendar-heatmap/index.d.ts
+++ b/types/react-calendar-heatmap/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/patientslikeme/react-calendar-heatmap
 // Definitions by: Keisuke Kan <https://github.com/9renpoto>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-calendar-timeline/index.d.ts
+++ b/types/react-calendar-timeline/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/namespace-ee/react-calendar-timeline
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react"/>
 

--- a/types/react-click-outside/index.d.ts
+++ b/types/react-click-outside/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kentor/react-click-outside
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 import * as React from "react";
 
 declare function enhanceWithClickOutside<P = {}>(wrappedComponent: React.ComponentClass<P>): React.ComponentClass<P>;

--- a/types/react-codemirror/index.d.ts
+++ b/types/react-codemirror/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Vicky Lai <https://github.com/velveret>
 //                 Rudi Chen <https://github.com/rudi-c>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 /// <reference types="react"/>
 /// <reference types="codemirror"/>

--- a/types/react-collapse/index.d.ts
+++ b/types/react-collapse/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nkbt/react-collapse
 // Definitions by: Adam Binford <https://github.com/Kimahriman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 import * as React from 'react';
 
 export interface CollapseProps extends React.HTMLProps<Collapse> {

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/casesandberg/react-color/
 // Definitions by: Karol Janyst <https://github.com/LKay>, Marks Polakovs <https://github.com/markspolakovs>, Matthieu Montaudouin <https://github.com/mntdn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentClass, ClassAttributes, StatelessComponent, ReactNode } from "react";
 

--- a/types/react-confirm/index.d.ts
+++ b/types/react-confirm/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/haradakunihiko/react-confirm
 // Definitions by: santiagodoldan <https://github.com/santiagodoldan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-content-loader/index.d.ts
+++ b/types/react-content-loader/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/danilowoz/react-content-loader
 // Definitions by: Alaa Masoud <https://github.com/alaatm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Meno Abels <https://github.com/mabels>
 //                 Bernabe <https://github.com/BernabeFelix>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-cropper/index.d.ts
+++ b/types/react-cropper/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/roadmanfong/react-cropper
 // Definitions by: Stepan Mikhaylyuk <https://github.com/stepancar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as cropperjs from 'cropperjs';
 import * as React from 'react';

--- a/types/react-css-modules/index.d.ts
+++ b/types/react-css-modules/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gajus/react-css-modules
 // Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>, Tadas Dailyda <https://github.com/skirsdeda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 interface TypeOptions {
     allowMultiple?: boolean;

--- a/types/react-css-transition-replace/index.d.ts
+++ b/types/react-css-transition-replace/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://marnusw.github.io/react-css-transition-replace/
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import * as CSSTransitionGroup from "react-addons-css-transition-group";

--- a/types/react-custom-scrollbars/index.d.ts
+++ b/types/react-custom-scrollbars/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by:  David-LeBlanc-git <https://github.com/David-LeBlanc-git>
 //                  kittimiyo <https://github.com/kittimiyo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-custom-scrollbars/v3/index.d.ts
+++ b/types/react-custom-scrollbars/v3/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/malte-wessel/react-custom-scrollbars
 // Definitions by: David-LeBlanc-git <https://github.com/David-LeBlanc-git>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-data-grid/index.d.ts
+++ b/types/react-data-grid/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/adazzle/react-data-grid.git
 // Definitions by: Simon Gellis <https://github.com/SupernaviX>, Kieran Peat <https://github.com/KieranPeat>, Martin Novak <https://github.com/martinnov92>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-data-grid/v1/index.d.ts
+++ b/types/react-data-grid/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/adazzle/react-data-grid.git
 // Definitions by: Simon Gellis <https://github.com/SupernaviX>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-datagrid/index.d.ts
+++ b/types/react-datagrid/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zippyui/react-datagrid.git
 // Definitions by: Stephen Jelfs <https://github.com/stephenjelfs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react"/>
 

--- a/types/react-date-range/index.d.ts
+++ b/types/react-date-range/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Adphorus/react-date-range/
 // Definitions by: Junbong Lee <https://github.com/Junbong>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import * as moment from "moment-timezone";

--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -7,7 +7,7 @@
 //                 Roy Xue <https://github.com/royxue>
 // 				   Koala Human <https://github.com/KoalaHuman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import * as moment from "moment";

--- a/types/react-daterange-picker/index.d.ts
+++ b/types/react-daterange-picker/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: UNCOVER TRUTH Inc. <https://github.com/uncovertruth>
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import * as moment from "moment";

--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/airbnb/react-dates
 // Definitions by: Artur Ampilogov <https://github.com/Artur-A>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import * as moment from "moment";

--- a/types/react-daum-postcode/index.d.ts
+++ b/types/react-daum-postcode/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kimminsik-bernard/react-daum-postcode
 // Definitions by: Sa-ryong Kang <https://github.com/Sa-ryong>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from 'react';
 

--- a/types/react-dnd-html5-backend/index.d.ts
+++ b/types/react-dnd-html5-backend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-dnd
 // Definitions by: Pedro Pereira <https://github.com/oizie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as ReactDnd from "react-dnd";
 

--- a/types/react-dnd-multi-backend/index.d.ts
+++ b/types/react-dnd-multi-backend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LouisBrunner/react-dnd-multi-backend
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { CSSProperties, PureComponent } from "react";
 import { Backend } from "react-dnd";

--- a/types/react-dnd-touch-backend/index.d.ts
+++ b/types/react-dnd-touch-backend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/yahoo/react-dnd-touch-backend#readme
 // Definitions by: Daniel Król <https://github.com/mleko>, Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as ReactDnd from "react-dnd";
 

--- a/types/react-dnd/index.d.ts
+++ b/types/react-dnd/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-dnd
 // Definitions by: Asana <https://asana.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///<reference types="react" />
 

--- a/types/react-document-title/index.d.ts
+++ b/types/react-document-title/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-document-title
 // Definitions by: Cleve Littlefield <https://github.com/cleverguy25>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-dom-factories/index.d.ts
+++ b/types/react-dom-factories/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://facebook.github.io/react/
 // Definitions by: John Gozde <https://github.com/jgoz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export as namespace ReactDOMFactories;
 export = ReactDOMFactories;

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -6,7 +6,7 @@
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Josh Rutherford <https://github.com/theruther4d>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export as namespace ReactDOM;
 

--- a/types/react-dom/v15/index.d.ts
+++ b/types/react-dom/v15/index.d.ts
@@ -5,7 +5,7 @@
 //                 Microsoft <https://microsoft.com>
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export as namespace ReactDOM;
 

--- a/types/react-dropzone/v2/index.d.ts
+++ b/types/react-dropzone/v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/okonet/react-dropzone
 // Definitions by: Mathieu Larouche Dube <https://github.com/matdube>, Ivo Jesus <https://github.com/LynxEyes>, Luís Rodrigues <https://github.com/goblindegook>, Ben Bayard <https://github.com/benbayard>
 // Definitions: https://github.com/Vooban/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react"/>
 

--- a/types/react-dropzone/v3/index.d.ts
+++ b/types/react-dropzone/v3/index.d.ts
@@ -6,7 +6,7 @@
 //                 Ben Bayard <https://github.com/benbayard>,
 //                 Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { CSSProperties, Component, DragEvent, InputHTMLAttributes } from "react";
 

--- a/types/react-easy-chart/index.d.ts
+++ b/types/react-easy-chart/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rma-consulting/react-easy-chart
 // Definitions by: Dave Leaver <https://github.com/danzel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-event-listener/index.d.ts
+++ b/types/react-event-listener/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oliviertassinari/react-event-listener
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-fa/index.d.ts
+++ b/types/react-fa/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/andreypopp/react-fa
 // Definitions by: Frank Laub <https://github.com/flaub>, Pat Sissons <https://github.com/patsissons>, Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component, ComponentClass, HTMLProps, StatelessComponent, ReactElement } from "react";
 

--- a/types/react-facebook-login/index.d.ts
+++ b/types/react-facebook-login/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/keppelen/react-facebook-login
 // Definitions by: Alexandre Paré <https://github.com/apare>, Jan Karres <https://github.com/jankarres>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-faux-dom/index.d.ts
+++ b/types/react-faux-dom/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ali Taheri Moghaddar <https://github.com/alitaheri>
 //                 Cleve Littlefield <https://github.com/cleverguy25>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-file-input/index.d.ts
+++ b/types/react-file-input/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/react-file-input
 // Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///<reference types="react" />
 

--- a/types/react-file-reader-input/index.d.ts
+++ b/types/react-file-reader-input/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/react-file-reader-input
 // Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>, Ali Taheri <https://github.com/alitaheri>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-flags-select/index.d.ts
+++ b/types/react-flags-select/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ekwonye-richard/react-flags-select#readme
 // Definitions by: Artur Sianiuk <https://github.com/senukartur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from 'react';
 

--- a/types/react-flatpickr/index.d.ts
+++ b/types/react-flatpickr/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/coderhaoxin/react-flatpickr
 // Definitions by: begincalendar <https://github.com/begincalendar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from 'react';
 import { Options } from 'flatpickr';

--- a/types/react-flex/index.d.ts
+++ b/types/react-flex/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zippyui/react-flex
 // Definitions by: Jeffery Grajkowski <https://github.com/pushplay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-flexr/index.d.ts
+++ b/types/react-flexr/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kodyl/react-flexr
 // Definitions by: Jeffery Grajkowski <https://github.com/pushplay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-fontawesome/index.d.ts
+++ b/types/react-fontawesome/index.d.ts
@@ -5,7 +5,7 @@
 //                 Vincas Stonys <https://github.com/vincaslt>
 //                 Gavin Gregory <https://github.com/gavingregory>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-form/index.d.ts
+++ b/types/react-form/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tannerlinsley/react-form#readme
 // Definitions by: Cameron McAteer <https://github.com/cameron-mcateer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-form/v1/index.d.ts
+++ b/types/react-form/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tannerlinsley/react-form#readme
 // Definitions by: Cameron McAteer <https://github.com/cameron-mcateer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-foundation/index.d.ts
+++ b/types/react-foundation/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/digiaonline/react-foundation
 // Definitions by: Daniel Earwicker <https://github.com/danielearwicker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export { Accordion, AccordionItem, AccordionTitle, AccordionContent } from './components/accordion';
 export { Badge } from './components/badge';

--- a/types/react-geosuggest/index.d.ts
+++ b/types/react-geosuggest/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ubilabs/react-geosuggest
 // Definitions by: Brad Menchl <https://github.com/brmenchl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 /// <reference types="googlemaps" />
 

--- a/types/react-google-recaptcha/index.d.ts
+++ b/types/react-google-recaptcha/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/dozoisch/react-google-recaptcha
 // Definitions by: Koala Human <https://github.com/KoalaHuman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-gravatar/index.d.ts
+++ b/types/react-gravatar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://kyleamathews.github.io/react-gravatar/
 // Definitions by: invliD <https://github.com/invliD>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-grid-layout/index.d.ts
+++ b/types/react-grid-layout/index.d.ts
@@ -5,7 +5,7 @@
 //                 Zheyang Song <https://github.com/ZheyangSong>,
 //                 Andrew Hathaway <https://github.com/andrewhathaway>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-hamburger-menu/index.d.ts
+++ b/types/react-hamburger-menu/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/cameronbourke/react-hamburger-menu
 // Definitions by: Grzegorz Kielak <https://github.com/grzesie2k>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nfl/react-helmet
 // Definitions by: Evan Bremer <https://github.com/evanbb>, Isman Usoh <https://github.com/isman-usoh>, François Nguyen <https://github.com/lith-light-g>, Kok Sam <https://github.com/sammkj>, Yui T. <https://github.com/yuit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-helmet/v4/index.d.ts
+++ b/types/react-helmet/v4/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nfl/react-helmet
 // Definitions by: Evan Bremer <https://github.com/evanbb>, Isman Usoh <https://github.com/isman-usoh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-highlight-words/index.d.ts
+++ b/types/react-highlight-words/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bvaughn/react-highlight-words#readme
 // Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-highlighter/index.d.ts
+++ b/types/react-highlighter/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/helior/react-highlighter
 // Definitions by: Pedro Pereira <https://github.com/oizie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-holder/index.d.ts
+++ b/types/react-holder/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Moeriki/react-holder
 // Definitions by: Isman Usoh <https://github.com/isman-usoh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///<reference types="react"/>
 

--- a/types/react-hot-loader/index.d.ts
+++ b/types/react-hot-loader/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-hot-loader
 // Definitions by: Jacek Jagiello <https://github.com/jacekjagiello>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react"
 

--- a/types/react-hyperscript/index.d.ts
+++ b/types/react-hyperscript/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mlmorg/react-hyperscript
 // Definitions by: tock203 <https://github.com/tock203>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentClass, StatelessComponent, ReactElement } from 'react';
 

--- a/types/react-i18next/index.d.ts
+++ b/types/react-i18next/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Simon Baumann <https://github.com/chnoch>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { TranslationFunction } from "i18next";
 

--- a/types/react-i18next/v1/index.d.ts
+++ b/types/react-i18next/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/i18next/react-i18next
 // Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as I18next from "i18next";
 import * as React from "react";

--- a/types/react-i18next/v4/index.d.ts
+++ b/types/react-i18next/v4/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/i18next/react-i18next
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { TranslationFunction } from "i18next";
 

--- a/types/react-icon-base/index.d.ts
+++ b/types/react-icon-base/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gorangajic/react-icon-base#readme
 // Definitions by: Alexandre Paré <https://github.com/apare>, Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-icons/index.d.ts
+++ b/types/react-icons/index.d.ts
@@ -4,4 +4,4 @@
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6

--- a/types/react-image-gallery/index.d.ts
+++ b/types/react-image-gallery/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/xiaolin/react-image-gallery
 // Definitions by: Adam Webb <https://github.com/adamwpc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-imageloader/index.d.ts
+++ b/types/react-imageloader/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/hzdg/react-imageloader
 // Definitions by: Stephen Jelfs <https://github.com/stephenjelfs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-infinite-scroller/index.d.ts
+++ b/types/react-infinite-scroller/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Lauri Lavanti <https://github.com/Lapanti>,
 //                 Piotr Srebniak <https://github.com/psrebniak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-infinite/index.d.ts
+++ b/types/react-infinite/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/seatgeek/react-infinite
 // Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///<reference types="react" />
 

--- a/types/react-input-calendar/index.d.ts
+++ b/types/react-input-calendar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Rudeg/react-input-calendar
 // Definitions by: Stepan Mikhaylyuk <https://github.com/stepancar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react"/>
 

--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/sanniassin/react-input-mask
 // Definitions by: Alexandre Paré <https://github.com/apare>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-intl-redux/index.d.ts
+++ b/types/react-intl-redux/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ratson/react-intl-redux
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { Action } from "redux"
 import { Provider as ReduxProvider } from "react-redux"

--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -9,7 +9,7 @@
 //                 Krister Kari <https://github.com/kristerkari>
 //                 Martin Raedlinger <https://github.com/formatlos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 declare namespace ReactIntl {
     type DateSource = Date | string | number;

--- a/types/react-intl/v1/index.d.ts
+++ b/types/react-intl/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://formatjs.io/react/
 // Definitions by: Bruno Grieder <https://github.com/bgrieder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///<reference types="react" />
 

--- a/types/react-is-deprecated/index.d.ts
+++ b/types/react-is-deprecated/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Aweary/react-is-deprecated
 // Definitions by: Sean Kelley <https://github.com/seansfkelley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 declare module 'react-is-deprecated' {
   import { Validator, Requireable, ValidationMap, ReactPropTypes } from 'react';

--- a/types/react-joyride/index.d.ts
+++ b/types/react-joyride/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gilbarbara/react-joyride
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>, Ben Dixon <https://github.com/bendxn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-json-pretty/index.d.ts
+++ b/types/react-json-pretty/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chenckang/react-json-pretty
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentClass, HTMLProps } from "react";
 

--- a/types/react-json-tree/index.d.ts
+++ b/types/react-json-tree/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/alexkuz/react-json-tree/
 // Definitions by: Grant Nestor <https://github.com/gnestor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import {
     Component,

--- a/types/react-json/index.d.ts
+++ b/types/react-json/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/arqex/react-json
 // Definitions by: Christoph Spielmann <https://github.com/spielc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -5,7 +5,7 @@
 //                 Ivan Jiang <https://github.com/iplus26>
 //                 Kurt Preston <https://github.com/KurtPreston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 declare module "react-jsonschema-form" {
     import * as React from "react";

--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jasonslyvia/react-lazyload
 // Definitions by: m0a <https://github.com/m0a>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from 'react';
 

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/PaulLeCam/react-leaflet
 // Definitions by: Dave Leaver <https://github.com/danzel>, David Schneider <https://github.com/davschne>, Yui T. <https://github.com/yuit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as Leaflet from 'leaflet';
 import * as React from 'react';

--- a/types/react-list/index.d.ts
+++ b/types/react-list/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/orgsync/react-list
 // Definitions by: Yifei Yan <https://github.com/buptyyf>, Tom Shen <https://github.com/tomshen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import {
     Component,

--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -5,7 +5,7 @@
 //                 Ian Ker-Seymer <https://github.com/ianks>
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-loader/index.d.ts
+++ b/types/react-loader/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/quickleft/react-loader
 // Definitions by: Sudarsan Balaji <https://github.com/artfuldev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from 'react';
 

--- a/types/react-maskedinput/index.d.ts
+++ b/types/react-maskedinput/index.d.ts
@@ -4,7 +4,7 @@
 //                 Adam Lavin <https://github.com/lavoaster>
 //                 Carlos Bonetti <https://github.com/CarlosBonetti>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-mce/index.d.ts
+++ b/types/react-mce/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/janstuemmel/react-mce
 // Definitions by: Gavin Heise <https://github.com/morphologue>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import * as ActualTinyMCE from 'tinymce';

--- a/types/react-mdl/index.d.ts
+++ b/types/react-mdl/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tleunen/react-mdl
 // Definitions by: Brad Zacher <https://github.com/bradzacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-measure/index.d.ts
+++ b/types/react-measure/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/souporserious/react-measure
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Marc Fallows <https://github.com/marcfallows>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-mixin/index.d.ts
+++ b/types/react-mixin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/brigand/react-mixin
 // Definitions by: Qubo <https://github.com/tkqubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -7,7 +7,7 @@
 //                 Uwe Wiemer <https://github.com/hallowatcher>,
 //                 Peter Blazejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-monaco-editor/index.d.ts
+++ b/types/react-monaco-editor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/superRaytin/react-monaco-editor
 // Definitions by: Joshua Netterfield <https://github.com/jnetterf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="monaco-editor" />
 

--- a/types/react-motion-slider/index.d.ts
+++ b/types/react-motion-slider/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/souporserious/react-motion-slider
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 declare module "react-motion-slider" {
     import * as React from "react";

--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -4,7 +4,7 @@
 //                 Alexey Svetliakov <https://github.com/asvetliakov>
 //                 Dimitar Nestorov <https://github.com/dimitarnestorov>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component, ReactElement } from 'react';
 

--- a/types/react-native-collapsible/index.d.ts
+++ b/types/react-native-collapsible/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oblador/react-native-collapsible
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-native-datepicker/index.d.ts
+++ b/types/react-native-datepicker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/xgfe/react-native-datepicker
 // Definitions by: Jacob Baskin <https://github.com/jacobbaskin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ImageURISource } from 'react-native';

--- a/types/react-native-doc-viewer/index.d.ts
+++ b/types/react-native-doc-viewer/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/philipphecht/react-native-doc-viewer/blob/master/README.md
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 export function openDoc(
     files: Array<{ url: string; fileName?: string }>,

--- a/types/react-native-drawer-layout/index.d.ts
+++ b/types/react-native-drawer-layout/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-native-community/react-native-drawer-layout
 // Definitions by: Justin Firth <https://github.com/jmfirth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ViewProperties } from 'react-native';

--- a/types/react-native-drawer/index.d.ts
+++ b/types/react-native-drawer/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/root-two/react-native-drawer
 // Definitions by: jnbt <https://github.com/jnbt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ViewStyle, ScaledSize } from 'react-native';

--- a/types/react-native-fbsdk/index.d.ts
+++ b/types/react-native-fbsdk/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/facebook/react-native-fbsdk
 // Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentClass, Component } from 'react';
 import { ViewStyle } from 'react-native';

--- a/types/react-native-fs/index.d.ts
+++ b/types/react-native-fs/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Paulo Cesar <https://github.com/pocesar>
 //                 Joseph Roque <https://github.com/josephroque>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react-native" />
 

--- a/types/react-native-google-signin/index.d.ts
+++ b/types/react-native-google-signin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/devfd/react-native-google-signin
 // Definitions by: Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ViewProperties } from 'react-native';

--- a/types/react-native-keep-awake/index.d.ts
+++ b/types/react-native-keep-awake/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/corbt/react-native-keep-awake
 // Definitions by: huhuanming <https://github.com/huhuanming>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 declare class KeepAwake extends React.Component<{ children?: JSX.Element }> {

--- a/types/react-native-linear-gradient/index.d.ts
+++ b/types/react-native-linear-gradient/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/brentvatne/react-native-linear-gradient#readme
 // Definitions by: Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ViewProperties } from 'react-native';

--- a/types/react-native-material-design-searchbar/index.d.ts
+++ b/types/react-native-material-design-searchbar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ananddayalan/react-native-material-design-searchbar
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import {

--- a/types/react-native-material-kit/index.d.ts
+++ b/types/react-native-material-kit/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 //                 Tim Wang <https://github.com/timwangdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import {

--- a/types/react-native-material-ui/index.d.ts
+++ b/types/react-native-material-ui/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/xotahal/react-native-material-ui
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from 'react';
 import { ViewStyle, TextStyle, Image } from 'react-native';

--- a/types/react-native-modalbox/index.d.ts
+++ b/types/react-native-modalbox/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/maxs15/react-native-modalbox#readme
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ViewProperties } from 'react-native';

--- a/types/react-native-navigation/index.d.ts
+++ b/types/react-native-navigation/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wix/react-native-navigation
 // Definitions by: Egor Shulga <https://github.com/egorshulga>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-native-popup-dialog/index.d.ts
+++ b/types/react-native-popup-dialog/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Paito Anderson <https://github.com/PaitoAnderson>
 //                 connectdotz <https://github.com/connectdotz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { GestureResponderEvent, StyleProp, ViewStyle, TextStyle } from 'react-native';

--- a/types/react-native-qrcode/index.d.ts
+++ b/types/react-native-qrcode/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/cssivision/react-native-qrcode
 // Definitions by: York Yao <https://github.com/plantain-00>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-native-safari-view/index.d.ts
+++ b/types/react-native-safari-view/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/naoufal/react-native-safari-view
 // Definitions by: Michael Randolph <https://github.com/mrand01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { EmitterSubscription } from 'react-native';
 

--- a/types/react-native-scrollable-tab-view/index.d.ts
+++ b/types/react-native-scrollable-tab-view/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/brentvatne/react-native-scrollable-tab-view#readme
 // Definitions by: CaiHuan <https://github.com/CaiHuan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import {

--- a/types/react-native-sensor-manager/index.d.ts
+++ b/types/react-native-sensor-manager/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kprimice/react-native-sensor-manager
 // Definitions by: Sahin Vardar <https://github.com/SahinVardar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react-native" />
 

--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: jnbt <https://github.com/jnbt>
 //                 Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import {

--- a/types/react-native-sortable-grid/index.d.ts
+++ b/types/react-native-sortable-grid/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ollija/react-native-sortable-grid#readme
 // Definitions by: Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { StyleProp, ViewStyle, Animated } from 'react-native';

--- a/types/react-native-sortable-list/index.d.ts
+++ b/types/react-native-sortable-list/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gitim/react-native-sortable-list
 // Definitions by: Michael Sivolobov <https://github.com/sivolobov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ViewStyle } from 'react-native';

--- a/types/react-native-svg-uri/index.d.ts
+++ b/types/react-native-svg-uri/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/matiascba/react-native-svg-uri#readme
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ImageURISource } from 'react-native';

--- a/types/react-native-swiper/index.d.ts
+++ b/types/react-native-swiper/index.d.ts
@@ -4,7 +4,7 @@
 //                 HuHuanming <https://github.com/huhuanming>
 //                 mhcgrq <https://github.com/mhcgrq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import {

--- a/types/react-native-tab-navigator/index.d.ts
+++ b/types/react-native-tab-navigator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/exponentjs/react-native-tab-navigator#readme
 // Definitions by: My Self <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ViewStyle, TextStyle } from 'react-native';

--- a/types/react-native-tab-view/index.d.ts
+++ b/types/react-native-tab-view/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-native-community/react-native-tab-view
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { PureComponent, ReactNode, ComponentType } from 'react'
 import {

--- a/types/react-native-vector-icons/index.d.ts
+++ b/types/react-native-vector-icons/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 //                 Tim Wang <https://github.com/timwangdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { Icon } from './Icon';

--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: HuHuanming <https://github.com/huhuanming>
 //                 abrahambotros <https://github.com/abrahambotros>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7,7 +7,7 @@
 //                 Kamal Mahyuddin <https://github.com/kamal>
 //                 Naoufal El Yousfi <https://github.com/nelyousfi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -12,7 +12,7 @@
 //                 Qibang Sun <https://github.com/bang88>
 //                 Sergei Butko: <https://github.com/svbutko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /**
  * BEGIN FLOW TYPEDEFINITION.JS PORT

--- a/types/react-notification-system-redux/index.d.ts
+++ b/types/react-notification-system-redux/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gor181/react-notification-system-redux
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from "react";
 import { Action } from "redux";

--- a/types/react-notification-system/index.d.ts
+++ b/types/react-notification-system/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/react-notification-system
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>, Deividas Bakanas <https://github.com/DeividasBakanas>, Karol Janyst <https://github.com/LKay>, Bartosz Szewczyk <https://github.com/sztobar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-numeric-input/index.d.ts
+++ b/types/react-numeric-input/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/vlad-ignatov/react-numeric-input#readme
 // Definitions by: Heather Booker <https://github.com/heatherbooker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Pomax/react-onclickoutside
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-onclickoutside/v5/index.d.ts
+++ b/types/react-onclickoutside/v5/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Pomax/react-onclickoutside
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-onsenui/index.d.ts
+++ b/types/react-onsenui/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://onsen.io/v2/docs/guide/react/
 // Definitions by: Ozytis <https://ozytis.fr>, Salim <https://github.com/salim7>, Jemmyw <https://github.com/jemmyw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import Component = React.Component;

--- a/types/react-overlays/index.d.ts
+++ b/types/react-overlays/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Aaron Beall <https://github.com/aaronbeall>
 //                 Vito Samson <https://github.com/vitosamson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-paginate/index.d.ts
+++ b/types/react-paginate/index.d.ts
@@ -5,7 +5,7 @@
 //                 pegel03 <https://github.com/pegel03>
 //                 Simon Archer <https://github.com/archy-bold>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-pointable/index.d.ts
+++ b/types/react-pointable/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Stefan Fochler <https://github.com/istefo>
 //                 Dibyo Majumdar <https://github.com/mdibyo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-portal/index.d.ts
+++ b/types/react-portal/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tajo/react-portal#readme
 // Definitions by: Shun Takahashi <https://github.com/shuntksh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-props-decorators/index.d.ts
+++ b/types/react-props-decorators/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/popkirby/react-props-decorators
 // Definitions by: Qubo <https://github.com/tkqubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-recaptcha/index.d.ts
+++ b/types/react-recaptcha/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
 //                 Zach <https://github.com/zzanol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from "react";
 

--- a/types/react-redux-i18n/index.d.ts
+++ b/types/react-redux-i18n/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zoover/react-redux-i18n
 // Definitions by: Clément Devos <https://github.com/clementdevos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 declare module 'react-redux-i18n' {
   import * as react from "react"

--- a/types/react-redux-toastr/index.d.ts
+++ b/types/react-redux-toastr/index.d.ts
@@ -4,7 +4,7 @@
 //                 Artyom Stukans <https://github.com/artyomsv>
 //                 Mika Kuitunen <https://github.com/kulmajaba>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { Component } from 'react';
 import { Action, ActionCreator, Reducer } from 'redux';

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -9,7 +9,7 @@
 //                 Dibyo Majumdar <https://github.com/mdibyo>
 //                 Prashant Deva <https://github.com/pdeva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
     
 // Known Issue:
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes 

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -5,7 +5,7 @@
 //                 Eloy Durán <https://github.com/alloy>
 //                 Nicolas Pirotte <https://github.com/npirotte>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 export {
     commitLocalUpdate,

--- a/types/react-resolver/index.d.ts
+++ b/types/react-resolver/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ericclemmons/react-resolver
 // Definitions by: forabi <https://github.com/forabi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentType, StatelessComponent, Factory } from 'react';
 

--- a/types/react-responsive/index.d.ts
+++ b/types/react-responsive/index.d.ts
@@ -4,7 +4,7 @@
 //                 Alec Hill <https://github.com/alechill>
 //                 Javier Gonzalez <https://github.com/xaviergonz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-responsive/v1/index.d.ts
+++ b/types/react-responsive/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/contra/react-responsive
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-router-bootstrap/index.d.ts
+++ b/types/react-router-bootstrap/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-bootstrap/react-router-bootstrap
 // Definitions by: Vincent Lesierse <https://github.com/vlesierse>, Karol Janyst <https://github.com/LKay>, Olmo del Corral <https://github.com/olmobrutall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 export { default as LinkContainer } from "react-router-bootstrap/lib/LinkContainer"
 export { default as IndexLinkContainer } from "react-router-bootstrap/lib/IndexLinkContainer"

--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import { RouteComponentProps, match } from "react-router";

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Huy Nguyen <https://github.com/huy-nguyen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { match } from "react-router";
 import * as React from 'react';

--- a/types/react-router-native/index.d.ts
+++ b/types/react-router-native/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ReactTraining/react-router-native
 // Definitions by: Eduard Zintz <https://github.com/ezintz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 export {
   match,

--- a/types/react-router-navigation-core/index.d.ts
+++ b/types/react-router-navigation-core/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LeoLeBras/react-router-navigation#readme
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 // High-level wrappers
 import { PureComponent, ReactNode, ComponentClass, ReactElement } from "react";

--- a/types/react-router-navigation/index.d.ts
+++ b/types/react-router-navigation/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LeoLeBras/react-router-navigation#readme
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { Component, ReactNode, ReactElement, ComponentClass } from "react";
 import { StyleProp, ViewProperties, ViewStyle, TextStyle } from "react-native";

--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
 //                 Shoya Tanaka <https://github.com/8398a7>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import {
     Store,

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -16,7 +16,7 @@
 //                 Egor Shulga <https://github.com/egorshulga>
 //                 Youen Toupin <https://github.com/neuoy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import * as H from 'history';

--- a/types/react-router/v2/index.d.ts
+++ b/types/react-router/v2/index.d.ts
@@ -7,7 +7,7 @@
 //                 Alex Wendland <https://github.com/awendland>
 //                 Kostya Esmukov <https://github.com/KostyaEsmukov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export as namespace ReactRouter;
 

--- a/types/react-router/v3/index.d.ts
+++ b/types/react-router/v3/index.d.ts
@@ -11,7 +11,7 @@
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 //                 Ross Allen <https://github.com/ssorallen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export {
     ChangeHook,

--- a/types/react-s-alert/index.d.ts
+++ b/types/react-s-alert/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/juliancwirko/react-s-alert
 // Definitions by: mitsuruog <https://github.com/mitsuruog>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-scroll/index.d.ts
+++ b/types/react-scroll/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ioannis Kokkinidis <https://github.com/sudoplz>
 //                 Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as ReactScroll from "./modules/index";
 export = ReactScroll;

--- a/types/react-scrollbar/index.d.ts
+++ b/types/react-scrollbar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/souhe/reactScrollbar
 // Definitions by: Stephen Jelfs <https://github.com/stephenjelfs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -12,7 +12,7 @@
 //                 Anton Novik <https://github.com/tehbi4>
 //                 David Schkalee <https://github.com/misantronic>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-side-effect/index.d.ts
+++ b/types/react-side-effect/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-side-effect
 // Definitions by: Remo H. Jansen <https://github.com/remojansen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-sidebar/index.d.ts
+++ b/types/react-sidebar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/balloob/react-sidebar#readme
 // Definitions by: Jeroen Vervaeke <https://github.com/jeroenvervaeke>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component } from "react";
 

--- a/types/react-sketchapp/index.d.ts
+++ b/types/react-sketchapp/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Rico Kahler <https://github.com/ricokahler>
 //                 DomiR <https://github.com/DomiR>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-slick/index.d.ts
+++ b/types/react-slick/index.d.ts
@@ -4,7 +4,7 @@
 //                 Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Andrew Makarov <https://github.com/r3nya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-smooth-scrollbar/index.d.ts
+++ b/types/react-smooth-scrollbar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/idiotWu/react-smooth-scrollbar
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import SmoothScrollbar from "smooth-scrollbar";

--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/clauderic/react-sortable-hoc
 // Definitions by: Ivo Stratev <https://github.com/NoHomey>, Charles Rey <https://github.com/charlesrey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-sortable-pane/index.d.ts
+++ b/types/react-sortable-pane/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bokuweb/react-sortable-pane
 // Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Wouter Hardeman <https://github.com/wouterhardeman>
 //                 Jovica Zoric <https://github.com/jzoric>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { ListProps, Index } from 'react-virtualized';

--- a/types/react-spinkit/index.d.ts
+++ b/types/react-spinkit/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/KyleAMathews/react-spinkit
 // Definitions by: Qubo <https://github.com/tkqubo>, Mleko <https://github.com/mleko>, Tom Crockett <https://github.com/pelotom>, zzanol <https://github.com/zzanol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-spinkit/v1/index.d.ts
+++ b/types/react-spinkit/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/KyleAMathews/react-spinkit
 // Definitions by: Qubo <https://github.com/tkqubo>, Mleko <https://github.com/mleko>, Tom Crockett <https://github.com/pelotom>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/react-sticky/index.d.ts
+++ b/types/react-sticky/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/captivationsoftware/react-sticky
 // Definitions by: Matej Lednicky <http://www.thinkcreatix.com/>, Curtis Warren <https://github.com/curtisw0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -4,7 +4,7 @@
 //                 Santiago Doldan <https://github.com/santiagodoldan>
 //                 sonnysangha <https://github.com/sonnysangha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="stripe-v3" />
 import * as React from 'react';

--- a/types/react-svg-pan-zoom/index.d.ts
+++ b/types/react-svg-pan-zoom/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chrvadala/react-svg-pan-zoom#readme
 // Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-swf/index.d.ts
+++ b/types/react-swf/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/syranide/react-swf
 // Definitions by: Stepan Mikhaylyuk <https://github.com/stepancar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 export as namespace ReactSWF;

--- a/types/react-swipe/index.d.ts
+++ b/types/react-swipe/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/voronianski/react-swipe
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="swipe" />
 

--- a/types/react-swipeable-views/index.d.ts
+++ b/types/react-swipeable-views/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Michael Ledin <https://github.com/mxl>
 //                 Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-swipeable/index.d.ts
+++ b/types/react-swipeable/index.d.ts
@@ -4,7 +4,7 @@
 //                 Konstantin Vasilev <https://github.com/mctep>
 //                 Hiroki Horiuchi <https://github.com/horiuchi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/conorhastings/react-syntax-highlighter
 // Definitions by: Ivo Stratev <https://github.com/NoHomey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 declare module 'react-syntax-highlighter' {
     import SyntaxHighlighter from 'react-syntax-highlighter/dist/light';

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-tools/react-table
 // Definitions by: Roy Xue <https://github.com/royxue>, Pavel Sakalo <https://github.com/psakalo>, Krzysztof Porębski <https://github.com/Havret>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 import * as React from 'react';
 
 export type ReactTableFunction = () => void;

--- a/types/react-tabs/index.d.ts
+++ b/types/react-tabs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/reactjs/react-tabs/
 // Definitions by: Yuu Igarashi <https://github.com/yu-i9/>, Daniel Tschinder <https://github.com/danez>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-tag-input/index.d.ts
+++ b/types/react-tag-input/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ogglas <https://github.com/Ogglas>
 //                  Jan Karres <https://github.com/jankarres>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-tagcloud/index.d.ts
+++ b/types/react-tagcloud/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/madox2/react-tagcloud
 // Definitions by: wassname <https://github.com/wassname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///<reference types="react"/>
 

--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/olahol/react-tagsinput
 // Definitions by: Michael Macnair <https://github.com/mykter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -5,7 +5,7 @@
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 John Gozde <https://github.com/jgoz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ReactElement, ReactType } from "react";
 

--- a/types/react-test-renderer/v15/index.d.ts
+++ b/types/react-test-renderer/v15/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://facebook.github.io/react/
 // Definitions by: Arvitaly <https://github.com/arvitaly>, Lochbrunner <https://github.com/lochbrunner>, Lochbrunner <https://github.com/lochbrunner>, John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ReactElement } from "react";
 

--- a/types/react-tether/index.d.ts
+++ b/types/react-tether/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/souporserious/react-tether
 // Definitions by: Ryan Price <https://github.com/ryprice>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export default TetherComponent;
 export as namespace ReactTether;

--- a/types/react-textarea-autosize/index.d.ts
+++ b/types/react-textarea-autosize/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/andreypopp/react-textarea-autosize
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Jerry Zou <https://github.com/zry656565>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 declare module "react-textarea-autosize" {
     import * as React from "react";

--- a/types/react-toastr/index.d.ts
+++ b/types/react-toastr/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tomchentw/react-toastr
 // Definitions by: Josh Holmer <https://github.com/shssoichiro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component, ReactHTML } from 'react';
 

--- a/types/react-toggle/index.d.ts
+++ b/types/react-toggle/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/aaronshaf/react-toggle
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component, InputHTMLAttributes, ReactNode } from "react";
 

--- a/types/react-toggle/v2/index.d.ts
+++ b/types/react-toggle/v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/aaronshaf/react-toggle
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component, HTMLAttributes, ReactNode } from "react";
 

--- a/types/react-tooltip/index.d.ts
+++ b/types/react-tooltip/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wwayne/react-tooltip
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-touch/index.d.ts
+++ b/types/react-touch/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/leonaves/react-touch
 // Definitions by: Grzegorz Kielak <https://github.com/grzesie2k>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/NYTimes/react-tracking
 // Definitions by: Eloy Durán <https://github.com/alloy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 

--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import CSSTransition = require("./CSSTransition");
 import Transition from "./Transition";

--- a/types/react-transition-group/v1/index.d.ts
+++ b/types/react-transition-group/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { HTMLAttributes, ReactElement, ReactType } from "react";
 

--- a/types/react-treeview/index.d.ts
+++ b/types/react-treeview/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chenglou/react-treeview
 // Definitions by: Jay Anslow <https://github.com/janslow>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component, HTMLAttributes } from 'react';
 

--- a/types/react-truncate/index.d.ts
+++ b/types/react-truncate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/One-com/react-truncate
 // Definitions by: Matt Perry <https://github.com/mattvperry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-user-tour/index.d.ts
+++ b/types/react-user-tour/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/socialtables/react-user-tour
 // Definitions by: Carlo Cancellieri <https://github.com/ccancellieri>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types='react' />
 

--- a/types/react-virtual-keyboard/index.d.ts
+++ b/types/react-virtual-keyboard/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/react-virtual-keyboard
 // Definitions by: Bogdan Surai <https://github.com/bsurai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { Component } from "react";
 import { KeyboardOptions, NavigateOptions } from "virtual-keyboard";

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bvaughn/react-virtualized-select
 // Definitions by: Sean Kelley <https://github.com/seansfkelley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import { ReactSelectProps } from "react-select";

--- a/types/react-virtualized/index.d.ts
+++ b/types/react-virtualized/index.d.ts
@@ -6,7 +6,7 @@
 //                 Szőke Szabolcs <https://github.com/szabolcsx>
 //                 Kræn Hansen <https://github.com/kraenhansen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export {
     ArrowKeyStepper,

--- a/types/react-widgets/index.d.ts
+++ b/types/react-widgets/index.d.ts
@@ -5,7 +5,7 @@
 //                 Frode Hansen <https://github.com/frodehansen2>
 //                 Andrew Makarov <https://github.com/r3nya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/react-youtube/index.d.ts
+++ b/types/react-youtube/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/troybetz/react-youtube
 // Definitions by: kgtkr <https://github.com/kgtkr>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react";
 export default class YouTube extends React.Component<{

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3500,7 +3500,7 @@ declare namespace React {
         del: DetailedHTMLFactory<DelHTMLAttributes<HTMLElement>, HTMLElement>;
         details: DetailedHTMLFactory<DetailsHTMLAttributes<HTMLElement>, HTMLElement>;
         dfn: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
-        dialog: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        dialog: DetailedHTMLFactory<HTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
         div: DetailedHTMLFactory<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
         dl: DetailedHTMLFactory<HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
         dt: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2863,6 +2863,10 @@ declare namespace React {
         dateTime?: string;
     }
 
+    interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
+        open?: boolean;
+    }
+
     interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
         height?: number | string;
         src?: string;
@@ -3500,7 +3504,7 @@ declare namespace React {
         del: DetailedHTMLFactory<DelHTMLAttributes<HTMLElement>, HTMLElement>;
         details: DetailedHTMLFactory<DetailsHTMLAttributes<HTMLElement>, HTMLElement>;
         dfn: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
-        dialog: DetailedHTMLFactory<HTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
+        dialog: DetailedHTMLFactory<DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
         div: DetailedHTMLFactory<HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
         dl: DetailedHTMLFactory<HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
         dt: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
@@ -3774,7 +3778,7 @@ declare global {
             del: React.DetailedHTMLProps<React.DelHTMLAttributes<HTMLElement>, HTMLElement>;
             details: React.DetailedHTMLProps<React.DetailsHTMLAttributes<HTMLElement>, HTMLElement>;
             dfn: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-            dialog: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            dialog: React.DetailedHTMLProps<React.DialogHTMLAttributes<HTMLDialogElement>, HTMLDialogElement>;
             div: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
             dl: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDListElement>, HTMLDListElement>;
             dt: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -15,7 +15,7 @@
 //                 Rich Seviora <https://github.com/richseviora>
 //                 Josh Rutherford <https://github.com/theruther4d>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /*
 Known Problems & Workarounds

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -13,7 +13,7 @@
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 //                 Stéphane Goetz <https://github.com/onigoetz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /*
 Known Problems & Workarounds

--- a/types/reactable/index.d.ts
+++ b/types/reactable/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/glittershark/reactable
 // Definitions by: Christoph Spielmann <https://github.com/spielc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/reactcss/index.d.ts
+++ b/types/reactcss/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://reactcss.com/
 // Definitions by: Chris Gervang <https://github.com/chrisgervang>, Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from "react"
 

--- a/types/reactstrap/index.d.ts
+++ b/types/reactstrap/index.d.ts
@@ -9,7 +9,7 @@
 //                 Kræn Hansen <https://github.com/kraenhansen>
 //                 Tim Chen <https://github.com/timc13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export interface CSSModule {
   [className: string]: string;

--- a/types/reactstrap/v4/index.d.ts
+++ b/types/reactstrap/v4/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/reactstrap/reactstrap#readme
 // Definitions by: Ali Hammad Baig <https://github.com/alihammad>, Marco Falkenberg <https://github.com/mfal>, Danilo Barros <https://github.com/danilobjr>, Fábio Paiva <https://github.com/fabiopaiva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export interface CSSModule {
   [className: string]: string;

--- a/types/reapop/index.d.ts
+++ b/types/reapop/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LouisBarranqueiro/reapop#readme
 // Definitions by: Barrokgl <https://github.com/Barrokgl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { Dispatch } from 'redux';

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jxnblk/rebass
 // Definitions by: rhysd <https://rhysd.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 ///<reference types="react" />
 

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -6,7 +6,7 @@
 //                 Zheyang Song <https://github.com/ZheyangSong>
 //                 Rich Baird <https://github.com/richbai90>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { CurveFactory } from 'd3-shape';

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -4,7 +4,7 @@
 //                 Samuel DeSota <https://github.com/mrapogee>
 //                 Curtis Layne <https://github.com/clayne11>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 ///<reference types="react" />
 

--- a/types/redux-auth-wrapper/index.d.ts
+++ b/types/redux-auth-wrapper/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mjrussell/redux-auth-wrapper
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import { ComponentClass, StatelessComponent, ComponentType, ReactType } from "react";
 

--- a/types/redux-auth-wrapper/v1/index.d.ts
+++ b/types/redux-auth-wrapper/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mjrussell/redux-auth-wrapper
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { ComponentClass, StatelessComponent, ReactType } from "react";
 import { Action } from "redux";

--- a/types/redux-devtools-dock-monitor/index.d.ts
+++ b/types/redux-devtools-dock-monitor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/redux-devtools-dock-monitor
 // Definitions by: Petryshyn Sergii <https://github.com/mc-petry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 

--- a/types/redux-devtools-log-monitor/index.d.ts
+++ b/types/redux-devtools-log-monitor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/redux-devtools-log-monitor
 // Definitions by: Petryshyn Sergii <https://github.com/mc-petry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react'
 import { ColorScheme } from 'base16'

--- a/types/redux-devtools/index.d.ts
+++ b/types/redux-devtools/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/redux-devtools
 // Definitions by: Petryshyn Sergii <https://github.com/mc-petry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { GenericStoreEnhancer } from 'redux';

--- a/types/redux-first-router-link/index.d.ts
+++ b/types/redux-first-router-link/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/faceyspacey/redux-first-router-link#readme
 // Definitions by: janb87 <https://github.com/janb87>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import { Location } from 'redux-first-router';

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -7,7 +7,7 @@
 //                 Alex Young <https://github.com/alsiola>
 //                 Anton Novik <https://github.com/tehbi4>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import {
   ComponentClass,

--- a/types/redux-form/v4/index.d.ts
+++ b/types/redux-form/v4/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/erikras/redux-form
 // Definitions by: Daniel Lytkin <https://github.com/aikoven>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { Dispatch, ActionCreator, Reducer } from 'redux';

--- a/types/redux-form/v6/index.d.ts
+++ b/types/redux-form/v6/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/erikras/redux-form
 // Definitions by: Carson Full <https://github.com/carsonf>, Daniel Lytkin <https://github.com/aikoven>, Karol Janyst <https://github.com/LKay>, Luka Zakrajsek <https://github.com/bancek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import {
   ComponentClass,

--- a/types/redux-infinite-scroll/index.d.ts
+++ b/types/redux-infinite-scroll/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/RealScout/redux-infinite-scroll
 // Definitions by: Tony Nikolov <https://github.com/silkyfray>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import { Component, HTMLProps } from "react";
 

--- a/types/redux-little-router/index.d.ts
+++ b/types/redux-little-router/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/FormidableLabs/redux-little-router
 // Definitions by: priecint <https://github.com/priecint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import { Reducer, Middleware, StoreEnhancer } from "redux";

--- a/types/redux-router/index.d.ts
+++ b/types/redux-router/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rackt/redux-router
 // Definitions by: Stepan Mikhaylyuk <https://github.com/stepancar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import * as ReactRouter from 'react-router';

--- a/types/redux-ui/index.d.ts
+++ b/types/redux-ui/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tonyhb/redux-ui
 // Definitions by: Andy Shu Xin <https://github.com/andyshuxin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 import * as Redux from 'redux';

--- a/types/rheostat/index.d.ts
+++ b/types/rheostat/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/airbnb/rheostat
 // Definitions by: Sasha Bayan <https://github.com/SashaBayan>, Wil Lee <https://github.com/kourge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/rrc/index.d.ts
+++ b/types/rrc/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pshrmn/rrc#readme
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from "react";
 import * as H from "history";

--- a/types/spectacle/index.d.ts
+++ b/types/spectacle/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/FormidableLabs/victory
 // Definitions by: Zachary Maybury <https://github.com/zmaybury>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react"/>
 

--- a/types/storybook__addon-actions/index.d.ts
+++ b/types/storybook__addon-actions/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 export type HandlerFunction = (...args: any[]) => undefined;
 export type DecoratorFunction = (args: any[]) => any[];

--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Mark Kornblum <https://github.com/mkornblum>
 //                 Mattias Wikstrom <https://github.com/fyrkant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { RenderFunction } from '@storybook/react';

--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Martynas Kadisa <https://github.com/martynaskadisa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { RenderFunction } from '@storybook/react';

--- a/types/storybook__addon-links/index.d.ts
+++ b/types/storybook__addon-links/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 

--- a/types/storybook__addon-notes/index.d.ts
+++ b/types/storybook__addon-notes/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { RenderFunction } from '@storybook/react';

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Anton Izmailov <https://github.com/wapgear>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="webpack-env" />
 

--- a/types/styled-jsx/index.d.ts
+++ b/types/styled-jsx/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zeit/styled-jsx
 // Definitions by: R1ZZU <https://github.com/R1ZZU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import "react";
 

--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -4,7 +4,7 @@
 //                 snerks <https://github.com/snerks>
 //                 Krzysztof Cebula <https://github.com/Havret>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react"/>
 

--- a/types/why-did-you-update/index.d.ts
+++ b/types/why-did-you-update/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/garbles/why-did-you-update
 // Definitions by: rhysd <https://rhysd.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 /// <reference types="react" />
 


### PR DESCRIPTION
The [HTMLDialogElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement) accepts an `open` property, but I can't add it because the react typings think dialogs are just like all other HTML elements.