### PR TITLE
Fix react-bootstrap DropdownButton title prop

### DIFF
--- a/types/react-bootstrap/lib/DropdownButton.d.ts
+++ b/types/react-bootstrap/lib/DropdownButton.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Sizes } from 'react-bootstrap';
+import { Sizes, Omit } from 'react-bootstrap';
 import { DropdownBaseProps } from './Dropdown';
 
 declare namespace DropdownButton {
@@ -13,7 +13,7 @@ declare namespace DropdownButton {
         title: React.ReactNode;
     }
 
-    export type DropdownButtonProps = DropdownButtonBaseProps & React.HTMLProps<DropdownButton>;
+    export type DropdownButtonProps = DropdownButtonBaseProps & Omit<React.HTMLProps<DropdownButton>, 'title'>;
 
 }
 declare class DropdownButton extends React.Component<DropdownButton.DropdownButtonProps> { }


### PR DESCRIPTION
Don't narrow down DropdownButton title prop type with more restrictive title prop coming from React.HTMLProps.

Properly fix https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14191

As described in the linked closed PR, using a React.ReactNode title compilation still fails with:

```
Types of property 'title' are incompatible.
      Type 'Element' is not assignable to type 'string | (undefined & string) | (null & string) | (string & undefined) | (number & undefined) | (...'.
        Type 'Element' is not assignable to type 'ReactPortal & string'.
          Type 'Element' is not assignable to type 'ReactPortal'.
            Property 'children' is missing in type 'Element'.
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
