### PR TITLE
bootstrap: add missed carousel definition variant

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -115,6 +115,7 @@ interface JQuery {
 
     carousel(options?: CarouselOptions): JQuery;
     carousel(command: string): JQuery;
+    carousel(index: number): JQuery;
 
     typeahead(options?: TypeaheadOptions): JQuery;
 


### PR DESCRIPTION
https://getbootstrap.com/docs/3.3/javascript/#carousel-number