### PR TITLE
[p-limit] fix generics

### DIFF
--- a/types/p-limit/index.d.ts
+++ b/types/p-limit/index.d.ts
@@ -7,4 +7,4 @@ declare namespace pLimit {}
 
 export = pLimit;
 
-declare function pLimit<T>(concurrency: number): (fn: () => PromiseLike<T>) => Promise<T>;
+declare function pLimit(concurrency: number): <T>(fn: () => PromiseLike<T>) => Promise<T>;

--- a/types/p-limit/p-limit-tests.ts
+++ b/types/p-limit/p-limit-tests.ts
@@ -1,6 +1,6 @@
 import pLimit = require('p-limit');
 
-const limit = pLimit<string | undefined>(1);
+const limit = pLimit(1);
 
 const input = [
     limit(() => Promise.resolve('foo')),


### PR DESCRIPTION
Generated limit functions don't care about types, but preserve the return type of the function that they are passed.

The existing tests cover this behaviour, but no longer require an explicit type argument.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: _(see tests)_
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.