### PR TITLE
Update googlemaps fitbounds method to include padding

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -31,7 +31,7 @@ declare namespace google.maps {
     /***** Map *****/
     export class Map extends MVCObject {
         constructor(mapDiv: Element|null, opts?: MapOptions);
-        fitBounds(bounds: LatLngBounds|LatLngBoundsLiteral): void;
+        fitBounds(bounds: LatLngBounds|LatLngBoundsLiteral, padding?: number): void;
         getBounds(): LatLngBounds|null|undefined;
         getCenter(): LatLng;
         getDiv(): Element;


### PR DESCRIPTION
`fitbounds()` has an optional second argument: padding.

reference: https://developers.google.com/maps/documentation/javascript/reference (see Methods section, first method).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/maps/documentation/javascript/reference
- [x] Increase the version number in the header if appropriate.