### PR TITLE
chai: fix signature of match()/matches() methods

### DIFF
--- a/types/chai-dom/chai-dom-tests.ts
+++ b/types/chai-dom/chai-dom-tests.ts
@@ -18,7 +18,7 @@ function test() {
     expect(testElement).to.be.empty;
     expect(testElement).to.have.length(2);
     expect(testElement).to.exist;
-    expect(testElement).to.match('foo');
+    expect(testElement).to.match(/foo/);
     expect(testElement).to.contain('foo');
     expect(testElement).to.contain(document.body);
 

--- a/types/chai-jquery/chai-jquery-tests.ts
+++ b/types/chai-jquery/chai-jquery-tests.ts
@@ -78,7 +78,7 @@ function test_exist() {
 }
 
 function test_match_selector() {
-    $('input').should.match('#foo');
+    $('input').should.match(/#foo/);
 }
 
 function test_contain() {

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -226,7 +226,7 @@ declare namespace Chai {
     }
 
     interface Match {
-        (regexp: RegExp|string, message?: string): Assertion;
+        (regexp: RegExp, message?: string): Assertion;
     }
 
     interface Keys {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://chaijs.com/api/bdd/#method_match
https://github.com/chaijs/chai/blob/c808e11ffc931be6923250857f033dea40c7d5c3/lib/chai/core/assertions.js#L2087
![chai-error](https://user-images.githubusercontent.com/839240/35182186-6c5a191c-fd95-11e7-8693-5f6d8dcc064d.PNG)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This is a simple fix that adjusts the type of the first parameter to the `match()` and `matches()` methods, which currently states that the parameter can be a `string`. (As seen in the API docs linked above, and the error message shown, this is incorrect as the parameter *must* be a `RegExp`.)