### PR TITLE
chai, chai-dom, chai-jquery: fix signature of match()/matches() methods

### DIFF
--- a/types/chai-dom/index.d.ts
+++ b/types/chai-dom/index.d.ts
@@ -23,6 +23,18 @@ declare namespace Chai {
 
         value(text: string): Assertion;
 
+        empty: Assertion;
+
+        // exist, length, and contain are already defined in @types/chai and have the
+        // same type or a more general type, so don't need to be re-declared even though
+        // the implementation is different
+
+        descendant(element: string|HTMLElement): Assertion;
+
+        descendants(selector: string): Assertion;
+
+        displayed: Assertion;
+
     }
 
     interface Include {
@@ -30,6 +42,12 @@ declare namespace Chai {
         text(text: string|string[]): Assertion;
 
         html(text: string|string[]): Assertion;
+
+    }
+
+    interface Match {
+
+        (selector: string): Assertion;
 
     }
 

--- a/types/chai-jquery/index.d.ts
+++ b/types/chai-jquery/index.d.ts
@@ -27,6 +27,10 @@ declare namespace Chai {
         disabled(): Assertion;
         (selector: string): Assertion;
     }
+
+    interface Match {
+        (selector: string): Assertion;
+    }
 }
 
 /**

--- a/types/chai/index.d.ts
+++ b/types/chai/index.d.ts
@@ -226,7 +226,7 @@ declare namespace Chai {
     }
 
     interface Match {
-        (regexp: RegExp|string, message?: string): Assertion;
+        (regexp: RegExp, message?: string): Assertion;
     }
 
     interface Keys {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

**chai:** [API](http://chaijs.com/api/bdd/#method_match) | [Source](https://github.com/chaijs/chai/blob/9a6610eb1e6b6da1645e9aee26ba452c227aa1dc/chai.js#L2422)
**chai-dom:** [API](https://github.com/nathanboktae/chai-dom#matchselector) | [Source](https://github.com/nathanboktae/chai-dom/blob/master/chai-dom.js#L232)
**chai-jquery:** [API](https://github.com/chaijs/chai-jquery#matchselector) | [Source](https://github.com/chaijs/chai-jquery/blob/master/chai-jquery.js#L194)

- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR was previously submitted as #23073 but I rebased after adding new commits (after I closed it,) so GitHub won't allow me to re-open. Anyway, here's the recap, because it took me a while to iron out the kinks in the interactions between the various `@types/chai-xxx` definitions.

The original reason I opened the first PR was that I noticed `match()` and `matches()` (in the BDD-style expect/should interface) are declared as taking either a `RegExp` or a `string` as their parameter; in reality, the parameter *must* be a `RegExp` and a runtime error will be thrown if a string is given. See below:

![Error message](https://user-images.githubusercontent.com/839240/35182186-6c5a191c-fd95-11e7-8693-5f6d8dcc064d.PNG)

That fix is simple enough. There are also two other patches included in this PR which affect the `chai-dom` and `chai-jquery` definitions. Both of these packages provide their own implementations of `match()` which *do* accept strings, but were previously not declared separately because they didn't need to be. Changing the signature of `match()` to *not* accept strings, as is the case with normal, un-extended chai, breaks these two packages' tests, so they have been modified to merge their own overloads of the method into the `Match` interface.