### PR TITLE
[Actions-on-google] add Coordinates interface for long latitude

### DIFF
--- a/types/actions-on-google/assistant-app.d.ts
+++ b/types/actions-on-google/assistant-app.d.ts
@@ -278,9 +278,9 @@ export interface DeviceLocation {
  */
 export interface Coordinates {
     /** Latitude coordinate. */
-    latitude: number,
+    latitude: number;
     /** Longitude coordinate. */
-    longitude: number
+    longitude: number;
 }
 
 /**

--- a/types/actions-on-google/assistant-app.d.ts
+++ b/types/actions-on-google/assistant-app.d.ts
@@ -263,14 +263,24 @@ export interface UserName {
  * User's permissioned device location.
  */
 export interface DeviceLocation {
-    /** {latitude, longitude}. Requested with SupportedPermissions.DEVICE_PRECISE_LOCATION. */
-    coordinates: object;
+    /** Coordinates: {latitude, longitude}. Requested with SupportedPermissions.DEVICE_PRECISE_LOCATION. */
+    coordinates: Coordinates;
     /** Full, formatted street address. Requested with SupportedPermissions.DEVICE_PRECISE_LOCATION. */
     address: string;
     /** Zip code. Requested with SupportedPermissions.DEVICE_COARSE_LOCATION. */
     zipCode: string;
     /** Device city. Requested with SupportedPermissions.DEVICE_COARSE_LOCATION. */
     city: string;
+}
+
+/**
+ * Coordinates containing latitude and longitude
+ */
+export interface Coordinates {
+    /** Latitude coordinate. */
+    latitude: number,
+    /** Longitude coordinate. */
+    longitude: number
 }
 
 /**


### PR DESCRIPTION
The coordinates property typed as object, which forced users to cast coordinates manually.
With the Coordinates interface that is not necessary anymore.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developers.google.com/actions/reference/nodejs/global#DeviceLocation
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
