### PR TITLE
[@types/request-promise] Stop extending Promise.

### DIFF
--- a/types/request-promise-native/index.d.ts
+++ b/types/request-promise-native/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for request-promise-native 1.0
 // Project: https://github.com/request/request-promise-native
 // Definitions by: Gustavo Henke <https://github.com/gustavohenke>
+//                 Matt R. Wilson <https://github.com/mastermatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -8,7 +9,9 @@ import request = require('request');
 import http = require('http');
 
 declare namespace requestPromise {
-    interface RequestPromise extends request.Request, Promise<any> {
+    interface RequestPromise extends request.Request {
+        then: Promise<any>["then"];
+        catch: Promise<any>["catch"];
         promise(): Promise<any>;
     }
 

--- a/types/request-promise-native/request-promise-native-tests.ts
+++ b/types/request-promise-native/request-promise-native-tests.ts
@@ -25,6 +25,7 @@ rpn('http://google.com').then(() => { });
 rpn('http://google.com').then(console.dir);
 rpn('http://google.com').catch(console.error);
 rpn('http://google.com').then(console.dir, console.error);
+rpn('http://google.com').promise().then(console.dir);
 
 rpn({ uri: 'http://google.com', resolveWithFullResponse: true }).then((response) => { });
 rpn({ uri: 'http://google.com', simple: false }).catch((reason) => { });

--- a/types/request-promise/index.d.ts
+++ b/types/request-promise/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for request-promise 4.1
 // Project: https://github.com/request/request-promise
-// Definitions by: Christopher Glantschnig <https://github.com/cglantschnig>, Joe Skeen <https://github.com/joeskeen>, Aya Morisawa <https://github.com/AyaMorisawa>
+// Definitions by: Christopher Glantschnig <https://github.com/cglantschnig>
+//                 Joe Skeen <https://github.com/joeskeen>
+//                 Aya Morisawa <https://github.com/AyaMorisawa>
+//                 Matt R. Wilson <https://github.com/mastermatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -10,7 +13,11 @@ import errors = require('./errors');
 import Promise = require('bluebird');
 
 declare namespace requestPromise {
-    interface RequestPromise extends request.Request, Promise<any> {
+    interface RequestPromise extends request.Request {
+        then: Promise<any>["then"];
+        catch: Promise<any>["catch"];
+        finally: Promise<any>["finally"];
+        cancel: Promise<any>["cancel"];
         promise(): Promise<any>;
     }
 

--- a/types/request-promise/request-promise-tests.ts
+++ b/types/request-promise/request-promise-tests.ts
@@ -23,6 +23,8 @@ rp('http://google.com').finally(() => {});
 rp('http://google.com').then(console.dir);
 rp('http://google.com').catch(console.error);
 rp('http://google.com').then(console.dir, console.error);
+rp('http://google.com').cancel();
+rp('http://google.com').promise().then(console.dir);
 
 // This works as well since additional methods are only used AFTER the FIRST call in the chain:
 


### PR DESCRIPTION
Both `@types/request-promise` and `@types/request-promise-native` were
extending their particular `Promise` implementations, however, the
actual libs don't extend these objects. All they do is add logic to the
`Request.prototype.init` function and "expose" a few defined methods
from their `Promise` implementations.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [`promise-core` exposing `Promise` methods.](https://github.com/request/promise-core/blob/master/configure/request2.js)
  - [`request-promise` options.](https://github.com/request/request-promise/blob/18c838a1ba2e201cdb263a3ec41e0e66453c9c9c/lib/rp.js#L28-L45)
  - [`request-promise-native` options.](https://github.com/request/request-promise-native/blob/1874877850a59152915c9e9cbacbdc577486cca5/lib/rp.js#L15-L23)


This will unblock the issue on #23004.