### PR TITLE
@types/quixote -  make attributes in ElementDescriptor optional

### DIFF
--- a/types/quixote/index.d.ts
+++ b/types/quixote/index.d.ts
@@ -74,28 +74,28 @@ interface QElementList {
 // Element positions and sizes are available on all QElement instances.
 interface ElementDescriptor {
     // The top edge of the element
-    top: PositionDescriptor;
+    top?: PositionDescriptor;
     
     // The right edge of the element
-    right: PositionDescriptor;
+    right?: PositionDescriptor;
     
     // The bottom edge of the element
-    bottom: PositionDescriptor;
+    bottom?: PositionDescriptor;
     
     // The left edge of the element
-    left: PositionDescriptor;
+    left?: PositionDescriptor;
     
     // Horizontal center: midway between the right and left edges.
-    center: PositionDescriptor;
+    center?: PositionDescriptor;
     
     // Vertical middle: midway between the top and bottom edges.
-    middle: PositionDescriptor;
+    middle?: PositionDescriptor;
     
     // Width of the element.
-    width: SizeDescriptor;
+    width?: SizeDescriptor;
     
     // Height of the element.
-    height: SizeDescriptor;
+    height?: SizeDescriptor;
 }
 
 // Viewport positions and sizes are available on QFrame.viewport()


### PR DESCRIPTION
When do assertion, you need not provide all options
somethings like 
```
        button.assert({
            width: container.width
        } );
```
is also ok from official doc.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/jamesshore/quixote/blob/release/docs/QElement.md#elementassert >>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

