### PR TITLE
Add types for hbs npm package

### DIFF
--- a/types/hbs/hbs-tests.ts
+++ b/types/hbs/hbs-tests.ts
@@ -3,6 +3,7 @@ import * as express from 'express';
 const app = express();
 
 app.set('view engine', 'html');
+// tslint:disable-next-line no-var-requires
 app.engine('html', require('hbs').__express);
 
 import hbs = require('hbs');

--- a/types/hbs/hbs-tests.ts
+++ b/types/hbs/hbs-tests.ts
@@ -13,3 +13,13 @@ hbs.registerPartial('partial_name', 'partial value');
 hbs.registerPartials(__dirname + '/views/partials');
 
 hbs.registerPartials(__dirname + '/views/partials', () => {});
+
+hbs.localsAsTemplateData(app);
+
+const safeString = new hbs.handlebars.SafeString("string");
+
+const instance1 = hbs.create();
+const instance2 = hbs.create();
+
+app.engine('html', instance1.__express);
+app.engine('hbs', instance2.__express);

--- a/types/hbs/hbs-tests.ts
+++ b/types/hbs/hbs-tests.ts
@@ -3,10 +3,13 @@ import * as express from 'express';
 const app = express();
 
 app.set('view engine', 'html');
-// tslint:disable-next-line no-var-requires
-app.engine('html', require('hbs').__express);
 
 import hbs = require('hbs');
+
+// The idiom for this is
+//   app.engine('html', require('hbs').__express);
+// However this undermines the test since the return type of require() is any
+app.engine('html', hbs.__express);
 
 hbs.registerHelper('helper_name', (testParm: number) => testParm++);
 hbs.registerPartial('partial_name', 'partial value');

--- a/types/hbs/hbs-tests.ts
+++ b/types/hbs/hbs-tests.ts
@@ -1,0 +1,15 @@
+import * as express from 'express';
+
+const app = express();
+
+app.set('view engine', 'html');
+app.engine('html', require('hbs').__express);
+
+import hbs = require('hbs');
+
+hbs.registerHelper('helper_name', (testParm: number) => testParm++);
+hbs.registerPartial('partial_name', 'partial value');
+
+hbs.registerPartials(__dirname + '/views/partials');
+
+hbs.registerPartials(__dirname + '/views/partials', () => {});

--- a/types/hbs/index.d.ts
+++ b/types/hbs/index.d.ts
@@ -11,10 +11,10 @@ type handlebarsModule = typeof handlebars;
 interface hbsModule {
     readonly handlebars: handlebarsModule;
     localsAsTemplateData(app: any): void;
-    registerHelper(helperName: string, helperFunction: Function): void;
+    registerHelper(helperName: string, helperFunction: (...args: any[]) => any): void;
     registerPartial(partialName: string, partialValue: string): void;
     registerPartials(directoryName: string, callback?: () => void): void;
-    __express(filename: string, options: any, cb: Function): any;
+    __express(filename: string, options: any, cb: (...args: any[]) => any): any;
 }
 
 interface hbsModuleWithCreate extends hbsModule {

--- a/types/hbs/index.d.ts
+++ b/types/hbs/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for hbs 4.0
+// Project: https://github.com/pillarjs/hbs
+// Definitions by: David Muller <https://github.com/davidm77>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import handlebars = require('handlebars');
+
+type handlebarsModule = typeof handlebars;
+
+interface hbsModule {
+    readonly handlebars: handlebarsModule;
+    localsAsTemplateData(app: any): void;
+    registerHelper(helperName: string, helperFunction: Function): void;
+    registerPartial(partialName: string, partialValue: string): void;
+    registerPartials(directoryName: string, callback?: () => void): void;
+    __express(filename: string, options: any, cb: Function): any;
+}
+
+interface hbsModuleWithCreate extends hbsModule {
+    create(handlebars?: handlebarsModule): hbsModule;
+}
+
+declare var baseModule: hbsModuleWithCreate;
+
+export = baseModule;

--- a/types/hbs/tsconfig.json
+++ b/types/hbs/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "files": [
+        "index.d.ts",
+        "hbs-tests.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": false,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/hbs/tsconfig.json
+++ b/types/hbs/tsconfig.json
@@ -1,16 +1,12 @@
 {
-    "files": [
-        "index.d.ts",
-        "hbs-tests.ts"
-    ],
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
             "es6"
         ],
         "noImplicitAny": true,
-        "noImplicitThis": false,
-        "strictNullChecks": false,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
@@ -19,5 +15,9 @@
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
-    }
+    },
+    "files": [
+        "index.d.ts",
+        "hbs-tests.ts"
+    ]
 }

--- a/types/hbs/tslint.json
+++ b/types/hbs/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "ban-types": false,
+        "no-var-requires": false
+    }
+}

--- a/types/hbs/tslint.json
+++ b/types/hbs/tslint.json
@@ -1,7 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "ban-types": false,
-        "no-var-requires": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [X] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Notes: Function type is used, but this is inline with the existing Handlebars and Express types.  Since hbs is an integration between Handlebars and Express I feel this is justified.