### PR TITLE
Fix auth0-js Auth0UserProfile

### DIFF
--- a/types/auth0-js/index.d.ts
+++ b/types/auth0-js/index.d.ts
@@ -590,7 +590,7 @@ export interface Auth0UserProfile {
     given_name?: string;
     family_name?: string;
     email?: string;
-    email_verified?: string;
+    email_verified?: boolean;
     clientID: string;
     gender?: string;
     locale?: string;


### PR DESCRIPTION
Update type definitions for email_verified property to boolean as described [here](https://auth0.com/docs/api/management/v2#!/Users/get_users)
