### PR TITLE
python-shell to extend EventEmitter

### DIFF
--- a/types/python-shell/index.d.ts
+++ b/types/python-shell/index.d.ts
@@ -1,10 +1,11 @@
 // Type definitions for python-shell 0.4
 // Project: https://github.com/extrabacon/python-shell
-// Definitions by: Dolan Miu <https://github.com/dolanmiu>
+// Definitions by: Dolan Miu <https://github.com/dolanmiu>, Colin Richardson <https://github.com/WORMSS>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export class PythonShell {
-    on(message: string, callback: (message: string) => void): void;
+import { EventEmitter } from "events";
+
+export class PythonShell extends EventEmitter {
     end(callback: (message: string) => void): void;
     send(message: any | string): void;
 


### PR DESCRIPTION
Change to python-shell to extends EventEmitter and removed on function
since it is specified in EventEmitter

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/extrabacon/python-shell/blob/master/index.js#L119
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
