### PR TITLE
Fix Leaflet.Draw.DrawEvents.Created.layer type

### DIFF
--- a/types/leaflet-draw/index.d.ts
+++ b/types/leaflet-draw/index.d.ts
@@ -387,7 +387,7 @@ declare module 'leaflet' {
 			/**
 			 * Layer that was just created.
 			 */
-			layer: Layer;
+			layer: Circle | CircleMarker | Marker | Polygon | Polyline | Rectangle;
 
 			/**
 			 * The type of layer this is. One of: polyline, polygon, rectangle, circle, marker.

--- a/types/leaflet-draw/leaflet-draw-tests.ts
+++ b/types/leaflet-draw/leaflet-draw-tests.ts
@@ -41,6 +41,7 @@ map.addControl(drawControl);
 map.on(L.Draw.Event.CREATED, (e: L.DrawEvents.Created) => {
     const type = e.layerType;
     const layer = e.layer;
+    const geojson = e.layer.toGeoJSON();
 
     drawnItems.addLayer(layer);
 });


### PR DESCRIPTION
Editing an existing type definition to fix a type.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://leaflet.github.io/Leaflet.draw/docs/leaflet-draw-latest.html#l-draw-event-draw:created

The `DrawEvents.Created` layer variable is not of type `Layer`. [As noted by the in-code documentation, the `Leaflet.Draw.DrawEvents.Created.layer` variable is one of Leaflet's vector shapes or a markers.](https://github.com/Leaflet/Leaflet.draw/blob/c6af99b761c5d9900bf5a3e2e1d8827bbde29542/src/Leaflet.Draw.Event.js#L31)

[The `L.Draw.Event.CREATED` event is only fired by `Draw.Feature` in the `_fireCreatedEvent` method.](https://github.com/Leaflet/Leaflet.draw/blob/develop/src/draw/handler/Draw.Feature.js#L94)

Draw.Feature bequeaths _fireCreatedEvent to it's subclasses Draw.Marker, Draw.Polyline, and `Draw.SimpleShape`, which in turn bequeath the method to  `Draw.Circle`, `Draw.Rectangle` (both from `Draw.SimpleShape`), `Draw.CircleMarker` (from `Draw.Marker`), and `Draw.Polygon` (from `Draw.Polyline`).

[`Draw.Circle`](https://github.com/Leaflet/Leaflet.draw/blob/develop/src/draw/handler/Draw.Circle.js#L56), [`Draw.CircleMarker`](https://github.com/Leaflet/Leaflet.draw/blob/develop/src/draw/handler/Draw.CircleMarker.js#L36), [`Draw.Marker`](https://github.com/Leaflet/Leaflet.draw/blob/develop/src/draw/handler/Draw.Marker.js#L125), [`Draw.Rectangle`](https://github.com/Leaflet/Leaflet.draw/blob/develop/src/draw/handler/Draw.Rectangle.js#L71) and [`Draw.Polyline`](https://github.com/Leaflet/Leaflet.draw/blob/develop/src/draw/handler/Draw.Polyline.js#L590) override the `_fireCreatedEvent` to pass instances of their respective vector classes to `_fireCreatedEvent`, meaning that the layer variable is not of type `Layer`, but instead one of the vector or marker classes. For example, `Draw.Circle` passes `L.Circle` to `L.Draw.Feature.prototype._fireCreatedEvent` as the argument to the `layer` parameter.

`Draw.Polygon` inherits `Draw.Polyline's` behavior without changes, but changes the vector class via the [Poly class variable](https://github.com/Leaflet/Leaflet.draw/blob/develop/src/draw/handler/Draw.Polygon.js#L11).

Note that some of the documentation indicates that the `layer` variable may also be a `string`, whereas other parts of the documentation omit this type. I have not seen evidence of this in the code, so I have omitted the `string` type from the new list. Apologies to future users if I missed it.