### PR TITLE
[graphql] Reformat all files using prettier.

### DIFF
--- a/types/graphql/error/GraphQLError.d.ts
+++ b/types/graphql/error/GraphQLError.d.ts
@@ -9,60 +9,60 @@ import { Source } from '../language/source';
  * GraphQL document and/or execution result that correspond to the Error.
  */
 export class GraphQLError extends Error {
-    /**
-     * A message describing the Error for debugging purposes.
-     *
-     * Enumerable, and appears in the result of JSON.stringify().
-     */
-    message: string;
+  /**
+   * A message describing the Error for debugging purposes.
+   *
+   * Enumerable, and appears in the result of JSON.stringify().
+   */
+  message: string;
 
-    /**
-     * An array of { line, column } locations within the source GraphQL document
-     * which correspond to this error.
-     *
-     * Errors during validation often contain multiple locations, for example to
-     * point out two things with the same name. Errors during execution include a
-     * single location, the field which produced the error.
-     *
-     * Enumerable, and appears in the result of JSON.stringify().
-     */
-    locations?: Array<{ line: number, column: number }> | undefined;
+  /**
+   * An array of { line, column } locations within the source GraphQL document
+   * which correspond to this error.
+   *
+   * Errors during validation often contain multiple locations, for example to
+   * point out two things with the same name. Errors during execution include a
+   * single location, the field which produced the error.
+   *
+   * Enumerable, and appears in the result of JSON.stringify().
+   */
+  locations?: Array<{ line: number; column: number }> | undefined;
 
-    /**
-     * An array describing the JSON-path into the execution response which
-     * corresponds to this error. Only included for errors during execution.
-     *
-     * Enumerable, and appears in the result of JSON.stringify().
-     */
-    path?: Array<string | number> | undefined;
+  /**
+   * An array describing the JSON-path into the execution response which
+   * corresponds to this error. Only included for errors during execution.
+   *
+   * Enumerable, and appears in the result of JSON.stringify().
+   */
+  path?: Array<string | number> | undefined;
 
-    /**
-     * An array of GraphQL AST Nodes corresponding to this error.
-     */
-    nodes?: ASTNode[] | undefined;
+  /**
+   * An array of GraphQL AST Nodes corresponding to this error.
+   */
+  nodes?: ASTNode[] | undefined;
 
-    /**
-     * The source GraphQL document corresponding to this error.
-     */
-    source?: Source | undefined;
+  /**
+   * The source GraphQL document corresponding to this error.
+   */
+  source?: Source | undefined;
 
-    /**
-     * An array of character offsets within the source GraphQL document
-     * which correspond to this error.
-     */
-    positions?: number[] | undefined;
+  /**
+   * An array of character offsets within the source GraphQL document
+   * which correspond to this error.
+   */
+  positions?: number[] | undefined;
 
-    /**
-     * The original error thrown from a field resolver during execution.
-     */
-    originalError?: Error;
+  /**
+   * The original error thrown from a field resolver during execution.
+   */
+  originalError?: Error;
 
-    constructor(
-        message: string,
-        nodes?: any[],
-        source?: Source,
-        positions?: number[],
-        path?: Array<string | number>,
-        originalError?: Error,
-    );
+  constructor(
+    message: string,
+    nodes?: any[],
+    source?: Source,
+    positions?: number[],
+    path?: Array<string | number>,
+    originalError?: Error,
+  );
 }

--- a/types/graphql/error/formatError.d.ts
+++ b/types/graphql/error/formatError.d.ts
@@ -7,12 +7,12 @@ import { GraphQLError } from './GraphQLError';
 export function formatError(error: GraphQLError): GraphQLFormattedError;
 
 export interface GraphQLFormattedError {
-    message: string;
-    locations?: GraphQLErrorLocation[];
-    path?: Array<string | number>;
+  message: string;
+  locations?: GraphQLErrorLocation[];
+  path?: Array<string | number>;
 }
 
 export interface GraphQLErrorLocation {
-    line: number;
-    column: number;
+  line: number;
+  column: number;
 }

--- a/types/graphql/error/index.d.ts
+++ b/types/graphql/error/index.d.ts
@@ -1,4 +1,8 @@
 export { GraphQLError } from './GraphQLError';
 export { syntaxError } from './syntaxError';
 export { locatedError } from './locatedError';
-export { formatError, GraphQLFormattedError, GraphQLErrorLocation } from './formatError';
+export {
+  formatError,
+  GraphQLFormattedError,
+  GraphQLErrorLocation,
+} from './formatError';

--- a/types/graphql/error/locatedError.d.ts
+++ b/types/graphql/error/locatedError.d.ts
@@ -6,7 +6,7 @@ import { GraphQLError } from './GraphQLError';
  * document responsible for the original Error.
  */
 export function locatedError<T>(
-    originalError: Error,
-    nodes: T[],
-    path: Array<string | number>
+  originalError: Error,
+  nodes: T[],
+  path: Array<string | number>,
 ): GraphQLError;

--- a/types/graphql/error/syntaxError.d.ts
+++ b/types/graphql/error/syntaxError.d.ts
@@ -6,7 +6,7 @@ import { GraphQLError } from './GraphQLError';
  * descriptive information about the syntax error's position in the source.
  */
 export function syntaxError(
-    source: Source,
-    position: number,
-    description: string
+  source: Source,
+  position: number,
+  description: string,
 ): GraphQLError;

--- a/types/graphql/execution/execute.d.ts
+++ b/types/graphql/execution/execute.d.ts
@@ -1,14 +1,18 @@
 import { GraphQLError, locatedError } from '../error';
 import { GraphQLSchema } from '../type/schema';
-import { GraphQLField, GraphQLFieldResolver, ResponsePath } from '../type/definition';
 import {
-    DirectiveNode,
-    DocumentNode,
-    OperationDefinitionNode,
-    SelectionSetNode,
-    FieldNode,
-    InlineFragmentNode,
-    FragmentDefinitionNode,
+  GraphQLField,
+  GraphQLFieldResolver,
+  ResponsePath,
+} from '../type/definition';
+import {
+  DirectiveNode,
+  DocumentNode,
+  OperationDefinitionNode,
+  SelectionSetNode,
+  FieldNode,
+  InlineFragmentNode,
+  FragmentDefinitionNode,
 } from '../language/ast';
 /**
  * Data that must be available at all points during query execution.
@@ -17,13 +21,13 @@ import {
  * and the fragments defined in the query document
  */
 export interface ExecutionContext {
-    schema: GraphQLSchema;
-    fragments: { [key: string]: FragmentDefinitionNode };
-    rootValue: any;
-    operation: OperationDefinitionNode;
-    variableValues: { [key: string]: any };
-    fieldResolver: GraphQLFieldResolver<any, any>;
-    errors: GraphQLError[];
+  schema: GraphQLSchema;
+  fragments: { [key: string]: FragmentDefinitionNode };
+  rootValue: any;
+  operation: OperationDefinitionNode;
+  variableValues: { [key: string]: any };
+  fieldResolver: GraphQLFieldResolver<any, any>;
+  errors: GraphQLError[];
 }
 
 /**
@@ -33,19 +37,19 @@ export interface ExecutionContext {
  * non-empty array if an error occurred.
  */
 export interface ExecutionResult {
-    data?: { [key: string]: any };
-    extensions?: { [key: string]: any };
-    errors?: GraphQLError[];
+  data?: { [key: string]: any };
+  extensions?: { [key: string]: any };
+  errors?: GraphQLError[];
 }
 
 export type ExecutionArgs = {
-  schema: GraphQLSchema,
-  document: DocumentNode,
-  rootValue?: any,
-  contextValue?: any,
-  variableValues?: {[key: string]: any},
-  operationName?: string,
-  fieldResolver?: GraphQLFieldResolver<any, any>
+  schema: GraphQLSchema;
+  document: DocumentNode;
+  rootValue?: any;
+  contextValue?: any;
+  variableValues?: { [key: string]: any };
+  operationName?: string;
+  fieldResolver?: GraphQLFieldResolver<any, any>;
 };
 
 /**
@@ -60,24 +64,22 @@ export type ExecutionArgs = {
  */
 export function execute(args: ExecutionArgs): Promise<ExecutionResult>;
 export function execute(
-    schema: GraphQLSchema,
-    document: DocumentNode,
-    rootValue?: any,
-    contextValue?: any,
-    variableValues?: {
-        [key: string]: any
-    },
-    operationName?: string,
-    fieldResolver?: GraphQLFieldResolver<any, any>,
+  schema: GraphQLSchema,
+  document: DocumentNode,
+  rootValue?: any,
+  contextValue?: any,
+  variableValues?: {
+    [key: string]: any;
+  },
+  operationName?: string,
+  fieldResolver?: GraphQLFieldResolver<any, any>,
 ): Promise<ExecutionResult>;
 
 /**
  * Given a ResponsePath (found in the `path` entry in the information provided
  * as the last argument to a field resolver), return an Array of the path keys.
  */
-export function responsePathAsArray(
-    path: ResponsePath
-): Array<string | number>;
+export function responsePathAsArray(path: ResponsePath): Array<string | number>;
 
 export function addPath(prev: ResponsePath, key: string | number): any;
 

--- a/types/graphql/execution/index.d.ts
+++ b/types/graphql/execution/index.d.ts
@@ -1,9 +1,9 @@
 export {
-    execute,
-    defaultFieldResolver,
-    responsePathAsArray,
-    ExecutionArgs,
-    ExecutionResult
+  execute,
+  defaultFieldResolver,
+  responsePathAsArray,
+  ExecutionArgs,
+  ExecutionResult,
 } from './execute';
 
 export { getDirectiveValues } from './values';

--- a/types/graphql/execution/values.d.ts
+++ b/types/graphql/execution/values.d.ts
@@ -1,7 +1,15 @@
-import { GraphQLInputType, GraphQLField, GraphQLArgument } from '../type/definition';
+import {
+  GraphQLInputType,
+  GraphQLField,
+  GraphQLArgument,
+} from '../type/definition';
 import { GraphQLDirective } from '../type/directives';
 import { GraphQLSchema } from '../type/schema';
-import { FieldNode, DirectiveNode, VariableDefinitionNode } from '../language/ast';
+import {
+  FieldNode,
+  DirectiveNode,
+  VariableDefinitionNode,
+} from '../language/ast';
 
 /**
  * Prepares an object map of variableValues of the correct type based on the
@@ -9,9 +17,9 @@ import { FieldNode, DirectiveNode, VariableDefinitionNode } from '../language/as
  * parsed to match the variable definitions, a GraphQLError will be thrown.
  */
 export function getVariableValues(
-    schema: GraphQLSchema,
-    varDefNodes: VariableDefinitionNode[],
-    inputs: { [key: string]: any }
+  schema: GraphQLSchema,
+  varDefNodes: VariableDefinitionNode[],
+  inputs: { [key: string]: any },
 ): { [key: string]: any };
 
 /**
@@ -19,9 +27,9 @@ export function getVariableValues(
  * definitions and list of argument AST nodes.
  */
 export function getArgumentValues(
-    def: GraphQLField<any, any> | GraphQLDirective,
-    node: FieldNode | DirectiveNode,
-    variableValues?: { [key: string]: any }
+  def: GraphQLField<any, any> | GraphQLDirective,
+  node: FieldNode | DirectiveNode,
+  variableValues?: { [key: string]: any },
 ): { [key: string]: any };
 
 /**
@@ -32,7 +40,7 @@ export function getArgumentValues(
  * If the directive does not exist on the node, returns undefined.
  */
 export function getDirectiveValues(
-    directiveDef: GraphQLDirective,
-    node: { directives?: Array<DirectiveNode> },
-    variableValues?: { [key: string]: any }
+  directiveDef: GraphQLDirective,
+  node: { directives?: Array<DirectiveNode> },
+  variableValues?: { [key: string]: any },
 ): void | { [key: string]: any };

--- a/types/graphql/language/ast.d.ts
+++ b/types/graphql/language/ast.d.ts
@@ -5,30 +5,30 @@ import { Source } from './source';
  * identify the region of the source from which the AST derived.
  */
 export interface Location {
-    /**
-     * The character offset at which this Node begins.
-     */
-    start: number;
+  /**
+   * The character offset at which this Node begins.
+   */
+  start: number;
 
-    /**
-     * The character offset at which this Node ends.
-     */
-    end: number;
+  /**
+   * The character offset at which this Node ends.
+   */
+  end: number;
 
-    /**
-     * The Token at which this Node begins.
-     */
-    startToken: Token;
+  /**
+   * The Token at which this Node begins.
+   */
+  startToken: Token;
 
-    /**
-     * The Token at which this Node ends.
-     */
-    endToken: Token;
+  /**
+   * The Token at which this Node ends.
+   */
+  endToken: Token;
 
-    /**
-     * The Source document the AST represents.
-     */
-    source: Source;
+  /**
+   * The Source document the AST represents.
+   */
+  source: Source;
 }
 
 /**
@@ -37,181 +37,181 @@ export interface Location {
  * *only*.
  */
 type TokenKind =
-    | '<SOF>'
-    | '<EOF>'
-    | '!'
-    | '$'
-    | '('
-    | ')'
-    | '...'
-    | ':'
-    | '='
-    | '@'
-    | '['
-    | ']'
-    | '{'
-    | '|'
-    | '}'
-    | 'Name'
-    | 'Int'
-    | 'Float'
-    | 'String'
-    | 'BlockString'
-    | 'Comment';
+  | '<SOF>'
+  | '<EOF>'
+  | '!'
+  | '$'
+  | '('
+  | ')'
+  | '...'
+  | ':'
+  | '='
+  | '@'
+  | '['
+  | ']'
+  | '{'
+  | '|'
+  | '}'
+  | 'Name'
+  | 'Int'
+  | 'Float'
+  | 'String'
+  | 'BlockString'
+  | 'Comment';
 
 /**
  * Represents a range of characters represented by a lexical token
  * within a Source.
  */
 export interface Token {
-    /**
-     * The kind of Token.
-     */
-    kind: TokenKind;
+  /**
+   * The kind of Token.
+   */
+  kind: TokenKind;
 
-    /**
-     * The character offset at which this Node begins.
-     */
-    start: number;
+  /**
+   * The character offset at which this Node begins.
+   */
+  start: number;
 
-    /**
-     * The character offset at which this Node ends.
-     */
-    end: number;
+  /**
+   * The character offset at which this Node ends.
+   */
+  end: number;
 
-    /**
-     * The 1-indexed line number on which this Token appears.
-     */
-    line: number;
+  /**
+   * The 1-indexed line number on which this Token appears.
+   */
+  line: number;
 
-    /**
-     * The 1-indexed column number at which this Token begins.
-     */
-    column: number;
+  /**
+   * The 1-indexed column number at which this Token begins.
+   */
+  column: number;
 
-    /**
-     * For non-punctuation tokens, represents the interpreted value of the token.
-     */
-    value: string | undefined;
+  /**
+   * For non-punctuation tokens, represents the interpreted value of the token.
+   */
+  value: string | undefined;
 
-    /**
-     * Tokens exist as nodes in a double-linked-list amongst all tokens
-     * including ignored tokens. <SOF> is always the first node and <EOF>
-     * the last.
-     */
-    prev?: Token;
-    next?: Token;
+  /**
+   * Tokens exist as nodes in a double-linked-list amongst all tokens
+   * including ignored tokens. <SOF> is always the first node and <EOF>
+   * the last.
+   */
+  prev?: Token;
+  next?: Token;
 }
 
 /**
  * The list of all possible AST node types.
  */
 export type ASTNode =
-    | NameNode
-    | DocumentNode
-    | OperationDefinitionNode
-    | VariableDefinitionNode
-    | VariableNode
-    | SelectionSetNode
-    | FieldNode
-    | ArgumentNode
-    | FragmentSpreadNode
-    | InlineFragmentNode
-    | FragmentDefinitionNode
-    | IntValueNode
-    | FloatValueNode
-    | StringValueNode
-    | BooleanValueNode
-    | NullValueNode
-    | EnumValueNode
-    | ListValueNode
-    | ObjectValueNode
-    | ObjectFieldNode
-    | DirectiveNode
-    | NamedTypeNode
-    | ListTypeNode
-    | NonNullTypeNode
-    | SchemaDefinitionNode
-    | OperationTypeDefinitionNode
-    | ScalarTypeDefinitionNode
-    | ObjectTypeDefinitionNode
-    | FieldDefinitionNode
-    | InputValueDefinitionNode
-    | InterfaceTypeDefinitionNode
-    | UnionTypeDefinitionNode
-    | EnumTypeDefinitionNode
-    | EnumValueDefinitionNode
-    | InputObjectTypeDefinitionNode
-    | ScalarTypeExtensionNode
-    | ObjectTypeExtensionNode
-    | InterfaceTypeExtensionNode
-    | UnionTypeExtensionNode
-    | EnumTypeExtensionNode
-    | InputObjectTypeExtensionNode
-    | DirectiveDefinitionNode;
+  | NameNode
+  | DocumentNode
+  | OperationDefinitionNode
+  | VariableDefinitionNode
+  | VariableNode
+  | SelectionSetNode
+  | FieldNode
+  | ArgumentNode
+  | FragmentSpreadNode
+  | InlineFragmentNode
+  | FragmentDefinitionNode
+  | IntValueNode
+  | FloatValueNode
+  | StringValueNode
+  | BooleanValueNode
+  | NullValueNode
+  | EnumValueNode
+  | ListValueNode
+  | ObjectValueNode
+  | ObjectFieldNode
+  | DirectiveNode
+  | NamedTypeNode
+  | ListTypeNode
+  | NonNullTypeNode
+  | SchemaDefinitionNode
+  | OperationTypeDefinitionNode
+  | ScalarTypeDefinitionNode
+  | ObjectTypeDefinitionNode
+  | FieldDefinitionNode
+  | InputValueDefinitionNode
+  | InterfaceTypeDefinitionNode
+  | UnionTypeDefinitionNode
+  | EnumTypeDefinitionNode
+  | EnumValueDefinitionNode
+  | InputObjectTypeDefinitionNode
+  | ScalarTypeExtensionNode
+  | ObjectTypeExtensionNode
+  | InterfaceTypeExtensionNode
+  | UnionTypeExtensionNode
+  | EnumTypeExtensionNode
+  | InputObjectTypeExtensionNode
+  | DirectiveDefinitionNode;
 
 /**
  * Utility type listing all nodes indexed by their kind.
  */
 export interface ASTKindToNode {
-    Name: NameNode;
-    Document: DocumentNode;
-    OperationDefinition: OperationDefinitionNode;
-    VariableDefinition: VariableDefinitionNode;
-    Variable: VariableNode;
-    SelectionSet: SelectionSetNode;
-    Field: FieldNode;
-    Argument: ArgumentNode;
-    FragmentSpread: FragmentSpreadNode;
-    InlineFragment: InlineFragmentNode;
-    FragmentDefinition: FragmentDefinitionNode;
-    IntValue: IntValueNode;
-    FloatValue: FloatValueNode;
-    StringValue: StringValueNode;
-    BooleanValue: BooleanValueNode;
-    NullValue: NullValueNode;
-    EnumValue: EnumValueNode;
-    ListValue: ListValueNode;
-    ObjectValue: ObjectValueNode;
-    ObjectField: ObjectFieldNode;
-    Directive: DirectiveNode;
-    NamedType: NamedTypeNode;
-    ListType: ListTypeNode;
-    NonNullType: NonNullTypeNode;
-    SchemaDefinition: SchemaDefinitionNode;
-    OperationTypeDefinition: OperationTypeDefinitionNode;
-    ScalarTypeDefinition: ScalarTypeDefinitionNode;
-    ObjectTypeDefinition: ObjectTypeDefinitionNode;
-    FieldDefinition: FieldDefinitionNode;
-    InputValueDefinition: InputValueDefinitionNode;
-    InterfaceTypeDefinition: InterfaceTypeDefinitionNode;
-    UnionTypeDefinition: UnionTypeDefinitionNode;
-    EnumTypeDefinition: EnumTypeDefinitionNode;
-    EnumValueDefinition: EnumValueDefinitionNode;
-    InputObjectTypeDefinition: InputObjectTypeDefinitionNode;
-    ScalarTypeExtension: ScalarTypeExtensionNode;
-    ObjectTypeExtension: ObjectTypeExtensionNode;
-    InterfaceTypeExtension: InterfaceTypeExtensionNode;
-    UnionTypeExtension: UnionTypeExtensionNode;
-    EnumTypeExtension: EnumTypeExtensionNode;
-    InputObjectTypeExtension: InputObjectTypeExtensionNode;
-    DirectiveDefinition: DirectiveDefinitionNode;
+  Name: NameNode;
+  Document: DocumentNode;
+  OperationDefinition: OperationDefinitionNode;
+  VariableDefinition: VariableDefinitionNode;
+  Variable: VariableNode;
+  SelectionSet: SelectionSetNode;
+  Field: FieldNode;
+  Argument: ArgumentNode;
+  FragmentSpread: FragmentSpreadNode;
+  InlineFragment: InlineFragmentNode;
+  FragmentDefinition: FragmentDefinitionNode;
+  IntValue: IntValueNode;
+  FloatValue: FloatValueNode;
+  StringValue: StringValueNode;
+  BooleanValue: BooleanValueNode;
+  NullValue: NullValueNode;
+  EnumValue: EnumValueNode;
+  ListValue: ListValueNode;
+  ObjectValue: ObjectValueNode;
+  ObjectField: ObjectFieldNode;
+  Directive: DirectiveNode;
+  NamedType: NamedTypeNode;
+  ListType: ListTypeNode;
+  NonNullType: NonNullTypeNode;
+  SchemaDefinition: SchemaDefinitionNode;
+  OperationTypeDefinition: OperationTypeDefinitionNode;
+  ScalarTypeDefinition: ScalarTypeDefinitionNode;
+  ObjectTypeDefinition: ObjectTypeDefinitionNode;
+  FieldDefinition: FieldDefinitionNode;
+  InputValueDefinition: InputValueDefinitionNode;
+  InterfaceTypeDefinition: InterfaceTypeDefinitionNode;
+  UnionTypeDefinition: UnionTypeDefinitionNode;
+  EnumTypeDefinition: EnumTypeDefinitionNode;
+  EnumValueDefinition: EnumValueDefinitionNode;
+  InputObjectTypeDefinition: InputObjectTypeDefinitionNode;
+  ScalarTypeExtension: ScalarTypeExtensionNode;
+  ObjectTypeExtension: ObjectTypeExtensionNode;
+  InterfaceTypeExtension: InterfaceTypeExtensionNode;
+  UnionTypeExtension: UnionTypeExtensionNode;
+  EnumTypeExtension: EnumTypeExtensionNode;
+  InputObjectTypeExtension: InputObjectTypeExtensionNode;
+  DirectiveDefinition: DirectiveDefinitionNode;
 }
 
 // Name
 
 export interface NameNode {
-    kind: 'Name';
-    loc?: Location;
-    value: string;
+  kind: 'Name';
+  loc?: Location;
+  value: string;
 }
 
 // Document
 
 export interface DocumentNode {
-    kind: 'Document';
-    loc?: Location;
-    definitions: DefinitionNode[];
+  kind: 'Document';
+  loc?: Location;
+  definitions: DefinitionNode[];
 }
 
 export type DefinitionNode =
@@ -223,300 +223,294 @@ export type ExecutableDefinitionNode =
   | FragmentDefinitionNode;
 
 export interface OperationDefinitionNode {
-    kind: 'OperationDefinition';
-    loc?: Location;
-    operation: OperationTypeNode;
-    name?: NameNode;
-    variableDefinitions?: VariableDefinitionNode[];
-    directives?: DirectiveNode[];
-    selectionSet: SelectionSetNode;
+  kind: 'OperationDefinition';
+  loc?: Location;
+  operation: OperationTypeNode;
+  name?: NameNode;
+  variableDefinitions?: VariableDefinitionNode[];
+  directives?: DirectiveNode[];
+  selectionSet: SelectionSetNode;
 }
 
 // Note: subscription is an experimental non-spec addition.
 export type OperationTypeNode = 'query' | 'mutation' | 'subscription';
 
 export interface VariableDefinitionNode {
-    kind: 'VariableDefinition';
-    loc?: Location;
-    variable: VariableNode;
-    type: TypeNode;
-    defaultValue?: ValueNode;
+  kind: 'VariableDefinition';
+  loc?: Location;
+  variable: VariableNode;
+  type: TypeNode;
+  defaultValue?: ValueNode;
 }
 
 export interface VariableNode {
-    kind: 'Variable';
-    loc?: Location;
-    name: NameNode;
+  kind: 'Variable';
+  loc?: Location;
+  name: NameNode;
 }
 
 export interface SelectionSetNode {
-    kind: 'SelectionSet';
-    loc?: Location;
-    selections: SelectionNode[];
+  kind: 'SelectionSet';
+  loc?: Location;
+  selections: SelectionNode[];
 }
 
-export type SelectionNode =
-  | FieldNode
-  | FragmentSpreadNode
-  | InlineFragmentNode;
+export type SelectionNode = FieldNode | FragmentSpreadNode | InlineFragmentNode;
 
 export interface FieldNode {
-    kind: 'Field';
-    loc?: Location;
-    alias?: NameNode;
-    name: NameNode;
-    arguments?: ArgumentNode[];
-    directives?: DirectiveNode[];
-    selectionSet?: SelectionSetNode;
+  kind: 'Field';
+  loc?: Location;
+  alias?: NameNode;
+  name: NameNode;
+  arguments?: ArgumentNode[];
+  directives?: DirectiveNode[];
+  selectionSet?: SelectionSetNode;
 }
 
 export interface ArgumentNode {
-    kind: 'Argument';
-    loc?: Location;
-    name: NameNode;
-    value: ValueNode;
+  kind: 'Argument';
+  loc?: Location;
+  name: NameNode;
+  value: ValueNode;
 }
 
 // Fragments
 
 export interface FragmentSpreadNode {
-    kind: 'FragmentSpread';
-    loc?: Location;
-    name: NameNode;
-    directives?: DirectiveNode[];
+  kind: 'FragmentSpread';
+  loc?: Location;
+  name: NameNode;
+  directives?: DirectiveNode[];
 }
 
 export interface InlineFragmentNode {
-    kind: 'InlineFragment';
-    loc?: Location;
-    typeCondition?: NamedTypeNode;
-    directives?: DirectiveNode[];
-    selectionSet: SelectionSetNode;
+  kind: 'InlineFragment';
+  loc?: Location;
+  typeCondition?: NamedTypeNode;
+  directives?: DirectiveNode[];
+  selectionSet: SelectionSetNode;
 }
 
 export interface FragmentDefinitionNode {
-    kind: 'FragmentDefinition';
-    loc?: Location;
-    name: NameNode;
-    // Note: fragment variable definitions are experimental and may be changed
-    // or removed in the future.
-    variableDefinitions?: VariableDefinitionNode[];
-    typeCondition: NamedTypeNode;
-    directives?: DirectiveNode[];
-    selectionSet: SelectionSetNode;
+  kind: 'FragmentDefinition';
+  loc?: Location;
+  name: NameNode;
+  // Note: fragment variable definitions are experimental and may be changed
+  // or removed in the future.
+  variableDefinitions?: VariableDefinitionNode[];
+  typeCondition: NamedTypeNode;
+  directives?: DirectiveNode[];
+  selectionSet: SelectionSetNode;
 }
 
 // Values
 
 export type ValueNode =
-    | VariableNode
-    | IntValueNode
-    | FloatValueNode
-    | StringValueNode
-    | BooleanValueNode
-    | NullValueNode
-    | EnumValueNode
-    | ListValueNode
-    | ObjectValueNode;
+  | VariableNode
+  | IntValueNode
+  | FloatValueNode
+  | StringValueNode
+  | BooleanValueNode
+  | NullValueNode
+  | EnumValueNode
+  | ListValueNode
+  | ObjectValueNode;
 
 export interface IntValueNode {
-    kind: 'IntValue';
-    loc?: Location;
-    value: string;
+  kind: 'IntValue';
+  loc?: Location;
+  value: string;
 }
 
 export interface FloatValueNode {
-    kind: 'FloatValue';
-    loc?: Location;
-    value: string;
+  kind: 'FloatValue';
+  loc?: Location;
+  value: string;
 }
 
 export interface StringValueNode {
-    kind: 'StringValue';
-    loc?: Location;
-    value: string;
+  kind: 'StringValue';
+  loc?: Location;
+  value: string;
 }
 
 export interface BooleanValueNode {
-    kind: 'BooleanValue';
-    loc?: Location;
-    value: boolean;
+  kind: 'BooleanValue';
+  loc?: Location;
+  value: boolean;
 }
 
 export interface NullValueNode {
-    kind: 'NullValue';
-    loc?: Location;
+  kind: 'NullValue';
+  loc?: Location;
 }
 
 export interface EnumValueNode {
-    kind: 'EnumValue';
-    loc?: Location;
-    value: string;
+  kind: 'EnumValue';
+  loc?: Location;
+  value: string;
 }
 
 export interface ListValueNode {
-    kind: 'ListValue';
-    loc?: Location;
-    values: ValueNode[];
+  kind: 'ListValue';
+  loc?: Location;
+  values: ValueNode[];
 }
 
 export interface ObjectValueNode {
-    kind: 'ObjectValue';
-    loc?: Location;
-    fields: ObjectFieldNode[];
+  kind: 'ObjectValue';
+  loc?: Location;
+  fields: ObjectFieldNode[];
 }
 
 export interface ObjectFieldNode {
-    kind: 'ObjectField';
-    loc?: Location;
-    name: NameNode;
-    value: ValueNode;
+  kind: 'ObjectField';
+  loc?: Location;
+  name: NameNode;
+  value: ValueNode;
 }
 
 // Directives
 
 export interface DirectiveNode {
-    kind: 'Directive';
-    loc?: Location;
-    name: NameNode;
-    arguments?: ArgumentNode[];
+  kind: 'Directive';
+  loc?: Location;
+  name: NameNode;
+  arguments?: ArgumentNode[];
 }
 
 // Type Reference
 
-export type TypeNode =
-  | NamedTypeNode
-  | ListTypeNode
-  | NonNullTypeNode;
+export type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
 
 export interface NamedTypeNode {
-    kind: 'NamedType';
-    loc?: Location;
-    name: NameNode;
+  kind: 'NamedType';
+  loc?: Location;
+  name: NameNode;
 }
 
 export interface ListTypeNode {
-    kind: 'ListType';
-    loc?: Location;
-    type: TypeNode;
+  kind: 'ListType';
+  loc?: Location;
+  type: TypeNode;
 }
 
 export interface NonNullTypeNode {
-    kind: 'NonNullType';
-    loc?: Location;
-    type: NamedTypeNode | ListTypeNode;
+  kind: 'NonNullType';
+  loc?: Location;
+  type: NamedTypeNode | ListTypeNode;
 }
 
 // Type System Definition
 
 export type TypeSystemDefinitionNode =
-    | SchemaDefinitionNode
-    | TypeDefinitionNode
-    | TypeExtensionNode
-    | DirectiveDefinitionNode;
+  | SchemaDefinitionNode
+  | TypeDefinitionNode
+  | TypeExtensionNode
+  | DirectiveDefinitionNode;
 
 export interface SchemaDefinitionNode {
-    kind: 'SchemaDefinition';
-    loc?: Location;
-    directives: DirectiveNode[];
-    operationTypes: OperationTypeDefinitionNode[];
+  kind: 'SchemaDefinition';
+  loc?: Location;
+  directives: DirectiveNode[];
+  operationTypes: OperationTypeDefinitionNode[];
 }
 
 export interface OperationTypeDefinitionNode {
-    kind: 'OperationTypeDefinition';
-    loc?: Location;
-    operation: OperationTypeNode;
-    type: NamedTypeNode;
+  kind: 'OperationTypeDefinition';
+  loc?: Location;
+  operation: OperationTypeNode;
+  type: NamedTypeNode;
 }
 
 export type TypeDefinitionNode =
-    | ScalarTypeDefinitionNode
-    | ObjectTypeDefinitionNode
-    | InterfaceTypeDefinitionNode
-    | UnionTypeDefinitionNode
-    | EnumTypeDefinitionNode
-    | InputObjectTypeDefinitionNode;
+  | ScalarTypeDefinitionNode
+  | ObjectTypeDefinitionNode
+  | InterfaceTypeDefinitionNode
+  | UnionTypeDefinitionNode
+  | EnumTypeDefinitionNode
+  | InputObjectTypeDefinitionNode;
 
 export interface ScalarTypeDefinitionNode {
-    kind: 'ScalarTypeDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    directives?: DirectiveNode[];
+  kind: 'ScalarTypeDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  directives?: DirectiveNode[];
 }
 
 export interface ObjectTypeDefinitionNode {
-    kind: 'ObjectTypeDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    interfaces?: NamedTypeNode[];
-    directives?: DirectiveNode[];
-    fields: FieldDefinitionNode[];
+  kind: 'ObjectTypeDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  interfaces?: NamedTypeNode[];
+  directives?: DirectiveNode[];
+  fields: FieldDefinitionNode[];
 }
 
 export interface FieldDefinitionNode {
-    kind: 'FieldDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    arguments: InputValueDefinitionNode[];
-    type: TypeNode;
-    directives?: DirectiveNode[];
+  kind: 'FieldDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  arguments: InputValueDefinitionNode[];
+  type: TypeNode;
+  directives?: DirectiveNode[];
 }
 
 export interface InputValueDefinitionNode {
-    kind: 'InputValueDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    type: TypeNode;
-    defaultValue?: ValueNode;
-    directives?: DirectiveNode[];
+  kind: 'InputValueDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  type: TypeNode;
+  defaultValue?: ValueNode;
+  directives?: DirectiveNode[];
 }
 
 export interface InterfaceTypeDefinitionNode {
-    kind: 'InterfaceTypeDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    directives?: DirectiveNode[];
-    fields: FieldDefinitionNode[];
+  kind: 'InterfaceTypeDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  directives?: DirectiveNode[];
+  fields: FieldDefinitionNode[];
 }
 
 export interface UnionTypeDefinitionNode {
-    kind: 'UnionTypeDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    directives?: DirectiveNode[];
-    types: NamedTypeNode[];
+  kind: 'UnionTypeDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  directives?: DirectiveNode[];
+  types: NamedTypeNode[];
 }
 
 export interface EnumTypeDefinitionNode {
-    kind: 'EnumTypeDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    directives?: DirectiveNode[];
-    values: EnumValueDefinitionNode[];
+  kind: 'EnumTypeDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  directives?: DirectiveNode[];
+  values: EnumValueDefinitionNode[];
 }
 
 export interface EnumValueDefinitionNode {
-    kind: 'EnumValueDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    directives?: DirectiveNode[];
+  kind: 'EnumValueDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  directives?: DirectiveNode[];
 }
 
 export interface InputObjectTypeDefinitionNode {
-    kind: 'InputObjectTypeDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    directives?: DirectiveNode[];
-    fields: InputValueDefinitionNode[];
+  kind: 'InputObjectTypeDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  directives?: DirectiveNode[];
+  fields: InputValueDefinitionNode[];
 }
 
 export type TypeExtensionNode =
@@ -528,60 +522,60 @@ export type TypeExtensionNode =
   | InputObjectTypeExtensionNode;
 
 export type ScalarTypeExtensionNode = {
-    kind: 'ScalarTypeExtension',
-    loc?: Location,
-    name: NameNode,
-    directives?: DirectiveNode[],
+  kind: 'ScalarTypeExtension';
+  loc?: Location;
+  name: NameNode;
+  directives?: DirectiveNode[];
 };
 
 export type ObjectTypeExtensionNode = {
-  kind: 'ObjectTypeExtension',
-  loc?: Location,
-  name: NameNode,
-  interfaces?: NamedTypeNode[],
-  directives?: DirectiveNode[],
-  fields?: FieldDefinitionNode[],
+  kind: 'ObjectTypeExtension';
+  loc?: Location;
+  name: NameNode;
+  interfaces?: NamedTypeNode[];
+  directives?: DirectiveNode[];
+  fields?: FieldDefinitionNode[];
 };
 
 export type InterfaceTypeExtensionNode = {
-  kind: 'InterfaceTypeExtension',
-  loc?: Location,
-  name: NameNode,
-  directives?: DirectiveNode[],
-  fields?: FieldDefinitionNode[],
+  kind: 'InterfaceTypeExtension';
+  loc?: Location;
+  name: NameNode;
+  directives?: DirectiveNode[];
+  fields?: FieldDefinitionNode[];
 };
 
 export type UnionTypeExtensionNode = {
-  kind: 'UnionTypeExtension',
-  loc?: Location,
-  name: NameNode,
-  directives?: DirectiveNode[],
-  types?: NamedTypeNode[],
+  kind: 'UnionTypeExtension';
+  loc?: Location;
+  name: NameNode;
+  directives?: DirectiveNode[];
+  types?: NamedTypeNode[];
 };
 
 export type EnumTypeExtensionNode = {
-  kind: 'EnumTypeExtension',
-  loc?: Location,
-  name: NameNode,
-  directives?: DirectiveNode[],
-  values?: EnumValueDefinitionNode[],
+  kind: 'EnumTypeExtension';
+  loc?: Location;
+  name: NameNode;
+  directives?: DirectiveNode[];
+  values?: EnumValueDefinitionNode[];
 };
 
 export type InputObjectTypeExtensionNode = {
-  kind: 'InputObjectTypeExtension',
-  loc?: Location,
-  name: NameNode,
-  directives?: DirectiveNode[],
-  fields?: InputValueDefinitionNode[],
+  kind: 'InputObjectTypeExtension';
+  loc?: Location;
+  name: NameNode;
+  directives?: DirectiveNode[];
+  fields?: InputValueDefinitionNode[];
 };
 
 // Directive Definitions
 
 export interface DirectiveDefinitionNode {
-    kind: 'DirectiveDefinition';
-    loc?: Location;
-    description?: StringValueNode;
-    name: NameNode;
-    arguments?: InputValueDefinitionNode[];
-    locations: NameNode[];
+  kind: 'DirectiveDefinition';
+  loc?: Location;
+  description?: StringValueNode;
+  name: NameNode;
+  arguments?: InputValueDefinitionNode[];
+  locations: NameNode[];
 }

--- a/types/graphql/language/index.d.ts
+++ b/types/graphql/language/index.d.ts
@@ -7,9 +7,9 @@ export { parse, parseValue, parseType, ParseOptions } from './parser';
 export { print } from './printer';
 export { Source } from './source';
 export {
-    visit,
-    visitInParallel,
-    visitWithTypeInfo,
-    getVisitFn,
-    BREAK
+  visit,
+  visitInParallel,
+  visitWithTypeInfo,
+  getVisitFn,
+  BREAK,
 } from './visitor';

--- a/types/graphql/language/lexer.d.ts
+++ b/types/graphql/language/lexer.d.ts
@@ -11,41 +11,41 @@ import { syntaxError } from '../error';
  * whenever called.
  */
 export function createLexer<TOptions>(
-    source: Source,
-    options: TOptions
+  source: Source,
+  options: TOptions,
 ): Lexer<TOptions>;
 
 /**
  * The return type of createLexer.
  */
 export interface Lexer<TOptions> {
-    source: Source;
-    options: TOptions;
+  source: Source;
+  options: TOptions;
 
-    /**
-     * The previously focused non-ignored token.
-     */
-    lastToken: Token;
+  /**
+   * The previously focused non-ignored token.
+   */
+  lastToken: Token;
 
-    /**
-     * The currently focused non-ignored token.
-     */
-    token: Token;
+  /**
+   * The currently focused non-ignored token.
+   */
+  token: Token;
 
-    /**
-     * The (1-indexed) line containing the current token.
-     */
-    line: number;
+  /**
+   * The (1-indexed) line containing the current token.
+   */
+  line: number;
 
-    /**
-     * The character offset at which the current line begins.
-     */
-    lineStart: number;
+  /**
+   * The character offset at which the current line begins.
+   */
+  lineStart: number;
 
-    /**
-     * Advances the token stream to the next non-ignored token.
-     */
-    advance(): Token;
+  /**
+   * Advances the token stream to the next non-ignored token.
+   */
+  advance(): Token;
 }
 
 /**
@@ -53,26 +53,26 @@ export interface Lexer<TOptions> {
  * lexer emits.
  */
 export const TokenKind: {
-    SOF: '<SOF>'
-    EOF: '<EOF>'
-    BANG: '!'
-    DOLLAR: '$'
-    PAREN_L: '('
-    PAREN_R: ')'
-    SPREAD: '...'
-    COLON: ':'
-    EQUALS: '='
-    AT: '@'
-    BRACKET_L: '['
-    BRACKET_R: ']'
-    BRACE_L: '{'
-    PIPE: '|'
-    BRACE_R: '}'
-    NAME: 'Name'
-    INT: 'Int'
-    FLOAT: 'Float'
-    STRING: 'String'
-    COMMENT: 'Comment'
+  SOF: '<SOF>';
+  EOF: '<EOF>';
+  BANG: '!';
+  DOLLAR: '$';
+  PAREN_L: '(';
+  PAREN_R: ')';
+  SPREAD: '...';
+  COLON: ':';
+  EQUALS: '=';
+  AT: '@';
+  BRACKET_L: '[';
+  BRACKET_R: ']';
+  BRACE_L: '{';
+  PIPE: '|';
+  BRACE_R: '}';
+  NAME: 'Name';
+  INT: 'Int';
+  FLOAT: 'Float';
+  STRING: 'String';
+  COMMENT: 'Comment';
 };
 
 /**

--- a/types/graphql/language/location.d.ts
+++ b/types/graphql/language/location.d.ts
@@ -1,8 +1,8 @@
-import { Source } from "./source";
+import { Source } from './source';
 
 export interface SourceLocation {
-    line: number;
-    column: number;
+  line: number;
+  column: number;
 }
 
 export function getLocation(source: Source, position: number): SourceLocation;

--- a/types/graphql/language/parser.d.ts
+++ b/types/graphql/language/parser.d.ts
@@ -1,17 +1,17 @@
-import { NamedTypeNode, TypeNode, ValueNode, DocumentNode } from "./ast";
-import { Source } from "./source";
-import { Lexer } from "./lexer";
+import { NamedTypeNode, TypeNode, ValueNode, DocumentNode } from './ast';
+import { Source } from './source';
+import { Lexer } from './lexer';
 
 /**
  * Configuration options to control parser behavior
  */
 export interface ParseOptions {
-    /**
-     * By default, the parser creates AST nodes that know the location
-     * in the source that they correspond to. This configuration flag
-     * disables that behavior for performance or testing.
-     */
-    noLocation?: boolean;
+  /**
+   * By default, the parser creates AST nodes that know the location
+   * in the source that they correspond to. This configuration flag
+   * disables that behavior for performance or testing.
+   */
+  noLocation?: boolean;
 }
 
 /**
@@ -19,8 +19,8 @@ export interface ParseOptions {
  * Throws GraphQLError if a syntax error is encountered.
  */
 export function parse(
-    source: string | Source,
-    options?: ParseOptions
+  source: string | Source,
+  options?: ParseOptions,
 ): DocumentNode;
 
 /**
@@ -31,8 +31,8 @@ export function parse(
  * in isolation of complete GraphQL documents.
  */
 export function parseValue(
-    source: Source | string,
-    options?: ParseOptions
+  source: Source | string,
+  options?: ParseOptions,
 ): ValueNode;
 
 export function parseConstValue<TOptions>(lexer: Lexer<TOptions>): ValueNode;

--- a/types/graphql/language/source.d.ts
+++ b/types/graphql/language/source.d.ts
@@ -1,5 +1,5 @@
 export class Source {
-    body: string;
-    name: string;
-    constructor(body: string, name?: string);
+  body: string;
+  name: string;
+  constructor(body: string, name?: string);
 }

--- a/types/graphql/language/visitor.d.ts
+++ b/types/graphql/language/visitor.d.ts
@@ -1,43 +1,43 @@
 export const QueryDocumentKeys: {
-    Name: any[];
-    Document: string[];
-    OperationDefinition: string[];
-    VariableDefinition: string[];
-    Variable: string[];
-    SelectionSet: string[];
-    Field: string[];
-    Argument: string[];
+  Name: any[];
+  Document: string[];
+  OperationDefinition: string[];
+  VariableDefinition: string[];
+  Variable: string[];
+  SelectionSet: string[];
+  Field: string[];
+  Argument: string[];
 
-    FragmentSpread: string[];
-    InlineFragment: string[];
-    FragmentDefinition: string[];
+  FragmentSpread: string[];
+  InlineFragment: string[];
+  FragmentDefinition: string[];
 
-    IntValue: number[];
-    FloatValue: number[];
-    StringValue: string[];
-    BooleanValue: boolean[];
-    NullValue: null[],
-    EnumValue: any[];
-    ListValue: string[];
-    ObjectValue: string[];
-    ObjectField: string[];
+  IntValue: number[];
+  FloatValue: number[];
+  StringValue: string[];
+  BooleanValue: boolean[];
+  NullValue: null[];
+  EnumValue: any[];
+  ListValue: string[];
+  ObjectValue: string[];
+  ObjectField: string[];
 
-    Directive: string[];
+  Directive: string[];
 
-    NamedType: string[];
-    ListType: string[];
-    NonNullType: string[];
+  NamedType: string[];
+  ListType: string[];
+  NonNullType: string[];
 
-    ObjectTypeDefinition: string[];
-    FieldDefinition: string[];
-    InputValueDefinition: string[];
-    InterfaceTypeDefinition: string[];
-    UnionTypeDefinition: string[];
-    ScalarTypeDefinition: string[];
-    EnumTypeDefinition: string[];
-    EnumValueDefinition: string[];
-    InputObjectTypeDefinition: string[];
-    TypeExtensionDefinition: string[];
+  ObjectTypeDefinition: string[];
+  FieldDefinition: string[];
+  InputValueDefinition: string[];
+  InterfaceTypeDefinition: string[];
+  UnionTypeDefinition: string[];
+  ScalarTypeDefinition: string[];
+  EnumTypeDefinition: string[];
+  EnumValueDefinition: string[];
+  InputObjectTypeDefinition: string[];
+  TypeExtensionDefinition: string[];
 };
 
 export const BREAK: any;

--- a/types/graphql/subscription/subscribe.d.ts
+++ b/types/graphql/subscription/subscribe.d.ts
@@ -4,26 +4,26 @@ import { GraphQLFieldResolver } from '../type/definition';
 import { ExecutionResult } from '../execution/execute';
 
 export function subscribe(
-    schema: GraphQLSchema,
-    document: DocumentNode,
-    rootValue?: any,
-    contextValue?: any,
-    variableValues?: {
-        [key: string]: any;
-    },
-    operationName?: string,
-    fieldResolver?: GraphQLFieldResolver<any, any>,
-    subscribeFieldResolver?: GraphQLFieldResolver<any, any>
+  schema: GraphQLSchema,
+  document: DocumentNode,
+  rootValue?: any,
+  contextValue?: any,
+  variableValues?: {
+    [key: string]: any;
+  },
+  operationName?: string,
+  fieldResolver?: GraphQLFieldResolver<any, any>,
+  subscribeFieldResolver?: GraphQLFieldResolver<any, any>,
 ): Promise<AsyncIterator<ExecutionResult> | ExecutionResult>;
 
 export function createSourceEventStream(
-    schema: GraphQLSchema,
-    document: DocumentNode,
-    rootValue?: any,
-    contextValue?: any,
-    variableValues?: {
-        [key: string]: any;
-    },
-    operationName?: string,
-    fieldResolver?: GraphQLFieldResolver<any, any>
+  schema: GraphQLSchema,
+  document: DocumentNode,
+  rootValue?: any,
+  contextValue?: any,
+  variableValues?: {
+    [key: string]: any;
+  },
+  operationName?: string,
+  fieldResolver?: GraphQLFieldResolver<any, any>,
 ): Promise<AsyncIterable<any>>;

--- a/types/graphql/type/definition.d.ts
+++ b/types/graphql/type/definition.d.ts
@@ -1,18 +1,18 @@
 import {
-    ScalarTypeDefinitionNode,
-    ObjectTypeDefinitionNode,
-    FieldDefinitionNode,
-    InputValueDefinitionNode,
-    InterfaceTypeDefinitionNode,
-    UnionTypeDefinitionNode,
-    EnumTypeDefinitionNode,
-    EnumValueDefinitionNode,
-    InputObjectTypeDefinitionNode,
-    TypeExtensionNode,
-    OperationDefinitionNode,
-    FieldNode,
-    FragmentDefinitionNode,
-    ValueNode,
+  ScalarTypeDefinitionNode,
+  ObjectTypeDefinitionNode,
+  FieldDefinitionNode,
+  InputValueDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  UnionTypeDefinitionNode,
+  EnumTypeDefinitionNode,
+  EnumValueDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  TypeExtensionNode,
+  OperationDefinitionNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  ValueNode,
 } from '../language/ast';
 import { GraphQLSchema } from './schema';
 
@@ -20,14 +20,14 @@ import { GraphQLSchema } from './schema';
  * These are all of the possible kinds of types.
  */
 export type GraphQLType =
-    | GraphQLScalarType
-    | GraphQLObjectType
-    | GraphQLInterfaceType
-    | GraphQLUnionType
-    | GraphQLEnumType
-    | GraphQLInputObjectType
-    | GraphQLList<any>
-    | GraphQLNonNull<any>;
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType
+  | GraphQLInputObjectType
+  | GraphQLList<any>
+  | GraphQLNonNull<any>;
 
 export function isType(type: any): type is GraphQLType;
 
@@ -37,15 +37,16 @@ export function assertType(type: any): GraphQLType;
  * These types may be used as input types for arguments and directives.
  */
 export type GraphQLInputType =
-    | GraphQLScalarType
-    | GraphQLEnumType
-    | GraphQLInputObjectType
-    | GraphQLList<any>
-    | GraphQLNonNull<
-        | GraphQLScalarType
-        | GraphQLEnumType
-        | GraphQLInputObjectType
-        | GraphQLList<any>>;
+  | GraphQLScalarType
+  | GraphQLEnumType
+  | GraphQLInputObjectType
+  | GraphQLList<any>
+  | GraphQLNonNull<
+      | GraphQLScalarType
+      | GraphQLEnumType
+      | GraphQLInputObjectType
+      | GraphQLList<any>
+    >;
 
 export function isInputType(type: GraphQLType): type is GraphQLInputType;
 
@@ -55,19 +56,20 @@ export function assertInputType(type: GraphQLType): GraphQLInputType;
  * These types may be used as output types as the result of fields.
  */
 export type GraphQLOutputType =
-    | GraphQLScalarType
-    | GraphQLObjectType
-    | GraphQLInterfaceType
-    | GraphQLUnionType
-    | GraphQLEnumType
-    | GraphQLList<any>
-    | GraphQLNonNull<
-        | GraphQLScalarType
-        | GraphQLObjectType
-        | GraphQLInterfaceType
-        | GraphQLUnionType
-        | GraphQLEnumType
-        | GraphQLList<any>>;
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType
+  | GraphQLList<any>
+  | GraphQLNonNull<
+      | GraphQLScalarType
+      | GraphQLObjectType
+      | GraphQLInterfaceType
+      | GraphQLUnionType
+      | GraphQLEnumType
+      | GraphQLList<any>
+    >;
 
 export function isOutputType(type: GraphQLType): type is GraphQLOutputType;
 
@@ -76,9 +78,7 @@ export function assertOutputType(type: GraphQLType): GraphQLOutputType;
 /**
  * These types may describe types which may be leaf values.
  */
-export type GraphQLLeafType =
-    | GraphQLScalarType
-    | GraphQLEnumType;
+export type GraphQLLeafType = GraphQLScalarType | GraphQLEnumType;
 
 export function isLeafType(type: GraphQLType): type is GraphQLLeafType;
 
@@ -88,20 +88,20 @@ export function assertLeafType(type: GraphQLType): GraphQLLeafType;
  * These types may describe the parent context of a selection set.
  */
 export type GraphQLCompositeType =
-    | GraphQLObjectType
-    | GraphQLInterfaceType
-    | GraphQLUnionType;
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType;
 
-export function isCompositeType(type: GraphQLType): type is GraphQLCompositeType;
+export function isCompositeType(
+  type: GraphQLType,
+): type is GraphQLCompositeType;
 
 export function assertCompositeType(type: GraphQLType): GraphQLCompositeType;
 
 /**
  * These types may describe the parent context of a selection set.
  */
-export type GraphQLAbstractType =
-    | GraphQLInterfaceType
-    | GraphQLUnionType;
+export type GraphQLAbstractType = GraphQLInterfaceType | GraphQLUnionType;
 
 export function isAbstractType(type: GraphQLType): type is GraphQLAbstractType;
 
@@ -111,28 +111,28 @@ export function assertAbstractType(type: GraphQLType): GraphQLAbstractType;
  * These types can all accept null as a value.
  */
 export type GraphQLNullableType =
-    | GraphQLScalarType
-    | GraphQLObjectType
-    | GraphQLInterfaceType
-    | GraphQLUnionType
-    | GraphQLEnumType
-    | GraphQLInputObjectType
-    | GraphQLList<any>;
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType
+  | GraphQLInputObjectType
+  | GraphQLList<any>;
 
 export function getNullableType<T extends GraphQLType>(
-    type: T
-): (T & GraphQLNullableType);
+  type: T,
+): T & GraphQLNullableType;
 
 /**
  * These named types do not include modifiers like List or NonNull.
  */
 export type GraphQLNamedType =
-    | GraphQLScalarType
-    | GraphQLObjectType
-    | GraphQLInterfaceType
-    | GraphQLUnionType
-    | GraphQLEnumType
-    | GraphQLInputObjectType;
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType
+  | GraphQLInputObjectType;
 
 export function isNamedType(type: GraphQLType): boolean;
 
@@ -164,30 +164,30 @@ export type Thunk<T> = (() => T) | T;
  *
  */
 export class GraphQLScalarType {
-    name: string;
-    description: string;
-    astNode?: ScalarTypeDefinitionNode;
-    constructor(config: GraphQLScalarTypeConfig<any, any>);
+  name: string;
+  description: string;
+  astNode?: ScalarTypeDefinitionNode;
+  constructor(config: GraphQLScalarTypeConfig<any, any>);
 
-    // Serializes an internal value to include in a response.
-    serialize(value: any): any;
+  // Serializes an internal value to include in a response.
+  serialize(value: any): any;
 
-    // Parses an externally provided value to use as an input.
-    parseValue(value: any): any;
+  // Parses an externally provided value to use as an input.
+  parseValue(value: any): any;
 
-    // Parses an externally provided literal value to use as an input.
-    parseLiteral(valueNode: ValueNode): any;
+  // Parses an externally provided literal value to use as an input.
+  parseLiteral(valueNode: ValueNode): any;
 
-    toString(): string;
+  toString(): string;
 }
 
 export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
-    name: string;
-    description?: string;
-    astNode?: ScalarTypeDefinitionNode;
-    serialize(value: any): TExternal | null | undefined;
-    parseValue?(value: any): TInternal | null | undefined;
-    parseLiteral?(valueNode: ValueNode): TInternal | null | undefined;
+  name: string;
+  description?: string;
+  astNode?: ScalarTypeDefinitionNode;
+  serialize(value: any): TExternal | null | undefined;
+  parseValue?(value: any): TInternal | null | undefined;
+  parseLiteral?(valueNode: ValueNode): TInternal | null | undefined;
 }
 
 /**
@@ -228,109 +228,123 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
  *
  */
 export class GraphQLObjectType {
-    name: string;
-    description: string;
-    astNode?: ObjectTypeDefinitionNode;
-    extensionASTNodes: Array<TypeExtensionNode>;
-    isTypeOf: GraphQLIsTypeOfFn<any, any>;
+  name: string;
+  description: string;
+  astNode?: ObjectTypeDefinitionNode;
+  extensionASTNodes: Array<TypeExtensionNode>;
+  isTypeOf: GraphQLIsTypeOfFn<any, any>;
 
-    constructor(config: GraphQLObjectTypeConfig<any, any>);
-    getFields(): GraphQLFieldMap<any, any>;
-    getInterfaces(): GraphQLInterfaceType[];
-    toString(): string;
+  constructor(config: GraphQLObjectTypeConfig<any, any>);
+  getFields(): GraphQLFieldMap<any, any>;
+  getInterfaces(): GraphQLInterfaceType[];
+  toString(): string;
 }
 
 export interface GraphQLObjectTypeConfig<TSource, TContext> {
-    name: string;
-    interfaces?: Thunk<GraphQLInterfaceType[]>;
-    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
-    isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext>;
-    description?: string;
-    astNode?: ObjectTypeDefinitionNode;
-    extensionASTNodes?: Array<TypeExtensionNode>;
+  name: string;
+  interfaces?: Thunk<GraphQLInterfaceType[]>;
+  fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
+  isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext>;
+  description?: string;
+  astNode?: ObjectTypeDefinitionNode;
+  extensionASTNodes?: Array<TypeExtensionNode>;
 }
 
 export type GraphQLTypeResolver<TSource, TContext> = (
-    value: TSource,
-    context: TContext,
-    info: GraphQLResolveInfo
+  value: TSource,
+  context: TContext,
+  info: GraphQLResolveInfo,
 ) => GraphQLObjectType | string | Promise<GraphQLObjectType | string>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
-    source: TSource,
-    context: TContext,
-    info: GraphQLResolveInfo
+  source: TSource,
+  context: TContext,
+  info: GraphQLResolveInfo,
 ) => boolean | Promise<boolean>;
 
-export type GraphQLFieldResolver<TSource, TContext, TArgs = { [argName: string]: any }> = (
-    source: TSource,
-    args: TArgs,
-    context: TContext,
-    info: GraphQLResolveInfo
+export type GraphQLFieldResolver<
+  TSource,
+  TContext,
+  TArgs = { [argName: string]: any }
+> = (
+  source: TSource,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo,
 ) => any;
 
 export interface GraphQLResolveInfo {
-    fieldName: string;
-    fieldNodes: FieldNode[];
-    returnType: GraphQLOutputType;
-    parentType: GraphQLCompositeType;
-    path: ResponsePath;
-    schema: GraphQLSchema;
-    fragments: { [fragmentName: string]: FragmentDefinitionNode };
-    rootValue: any;
-    operation: OperationDefinitionNode;
-    variableValues: { [variableName: string]: any };
+  fieldName: string;
+  fieldNodes: FieldNode[];
+  returnType: GraphQLOutputType;
+  parentType: GraphQLCompositeType;
+  path: ResponsePath;
+  schema: GraphQLSchema;
+  fragments: { [fragmentName: string]: FragmentDefinitionNode };
+  rootValue: any;
+  operation: OperationDefinitionNode;
+  variableValues: { [variableName: string]: any };
 }
 
-export type ResponsePath = { prev: ResponsePath, key: string | number } | undefined;
+export type ResponsePath =
+  | { prev: ResponsePath; key: string | number }
+  | undefined;
 
-export interface GraphQLFieldConfig<TSource, TContext, TArgs = { [argName: string]: any }> {
-    type: GraphQLOutputType;
-    args?: GraphQLFieldConfigArgumentMap;
-    resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-    subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-    deprecationReason?: string;
-    description?: string;
-    astNode?: FieldDefinitionNode;
+export interface GraphQLFieldConfig<
+  TSource,
+  TContext,
+  TArgs = { [argName: string]: any }
+> {
+  type: GraphQLOutputType;
+  args?: GraphQLFieldConfigArgumentMap;
+  resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
+  subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
+  deprecationReason?: string;
+  description?: string;
+  astNode?: FieldDefinitionNode;
 }
 
 export interface GraphQLFieldConfigArgumentMap {
-    [argName: string]: GraphQLArgumentConfig;
+  [argName: string]: GraphQLArgumentConfig;
 }
 
 export interface GraphQLArgumentConfig {
-    type: GraphQLInputType;
-    defaultValue?: any;
-    description?: string;
-    astNode?: InputValueDefinitionNode;
+  type: GraphQLInputType;
+  defaultValue?: any;
+  description?: string;
+  astNode?: InputValueDefinitionNode;
 }
 
 export interface GraphQLFieldConfigMap<TSource, TContext> {
-    [fieldName: string]: GraphQLFieldConfig<TSource, TContext>;
+  [fieldName: string]: GraphQLFieldConfig<TSource, TContext>;
 }
 
-export interface GraphQLField<TSource, TContext, TArgs = { [argName: string]: any }> {
-    name: string;
-    description: string;
-    type: GraphQLOutputType;
-    args: GraphQLArgument[];
-    resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-    subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-    isDeprecated?: boolean;
-    deprecationReason?: string;
-    astNode?: FieldDefinitionNode;
+export interface GraphQLField<
+  TSource,
+  TContext,
+  TArgs = { [argName: string]: any }
+> {
+  name: string;
+  description: string;
+  type: GraphQLOutputType;
+  args: GraphQLArgument[];
+  resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
+  subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
+  isDeprecated?: boolean;
+  deprecationReason?: string;
+  astNode?: FieldDefinitionNode;
 }
 
 export interface GraphQLArgument {
-    name: string;
-    type: GraphQLInputType;
-    defaultValue?: any;
-    description?: string;
-    astNode?: InputValueDefinitionNode;
+  name: string;
+  type: GraphQLInputType;
+  defaultValue?: any;
+  description?: string;
+  astNode?: InputValueDefinitionNode;
 }
 
 export interface GraphQLFieldMap<TSource, TContext> {
-    [fieldName: string]: GraphQLField<TSource, TContext>;
+  [fieldName: string]: GraphQLField<TSource, TContext>;
 }
 
 /**
@@ -352,29 +366,29 @@ export interface GraphQLFieldMap<TSource, TContext> {
  *
  */
 export class GraphQLInterfaceType {
-    name: string;
-    description: string;
-    astNode?: InterfaceTypeDefinitionNode;
-    resolveType: GraphQLTypeResolver<any, any>;
+  name: string;
+  description: string;
+  astNode?: InterfaceTypeDefinitionNode;
+  resolveType: GraphQLTypeResolver<any, any>;
 
-    constructor(config: GraphQLInterfaceTypeConfig<any, any>);
+  constructor(config: GraphQLInterfaceTypeConfig<any, any>);
 
-    getFields(): GraphQLFieldMap<any, any>;
+  getFields(): GraphQLFieldMap<any, any>;
 
-    toString(): string;
+  toString(): string;
 }
 
 export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
-    name: string;
-    fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
-    /**
-     * Optionally provide a custom type resolver function. If one is not provided,
-     * the default implementation will call `isTypeOf` on each implementing
-     * Object type.
-     */
-    resolveType?: GraphQLTypeResolver<TSource, TContext>;
-    description?: string;
-    astNode?: InterfaceTypeDefinitionNode;
+  name: string;
+  fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
+  /**
+   * Optionally provide a custom type resolver function. If one is not provided,
+   * the default implementation will call `isTypeOf` on each implementing
+   * Object type.
+   */
+  resolveType?: GraphQLTypeResolver<TSource, TContext>;
+  description?: string;
+  astNode?: InterfaceTypeDefinitionNode;
 }
 
 /**
@@ -401,29 +415,29 @@ export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
  *
  */
 export class GraphQLUnionType {
-    name: string;
-    description: string;
-    astNode?: UnionTypeDefinitionNode;
-    resolveType: GraphQLTypeResolver<any, any>;
+  name: string;
+  description: string;
+  astNode?: UnionTypeDefinitionNode;
+  resolveType: GraphQLTypeResolver<any, any>;
 
-    constructor(config: GraphQLUnionTypeConfig<any, any>);
+  constructor(config: GraphQLUnionTypeConfig<any, any>);
 
-    getTypes(): GraphQLObjectType[];
+  getTypes(): GraphQLObjectType[];
 
-    toString(): string;
+  toString(): string;
 }
 
 export interface GraphQLUnionTypeConfig<TSource, TContext> {
-    name: string;
-    types: Thunk<GraphQLObjectType[]>;
-    /**
-     * Optionally provide a custom type resolver function. If one is not provided,
-     * the default implementation will call `isTypeOf` on each implementing
-     * Object type.
-     */
-    resolveType?: GraphQLTypeResolver<TSource, TContext>;
-    description?: string;
-    astNode?: UnionTypeDefinitionNode;
+  name: string;
+  types: Thunk<GraphQLObjectType[]>;
+  /**
+   * Optionally provide a custom type resolver function. If one is not provided,
+   * the default implementation will call `isTypeOf` on each implementing
+   * Object type.
+   */
+  resolveType?: GraphQLTypeResolver<TSource, TContext>;
+  description?: string;
+  astNode?: UnionTypeDefinitionNode;
 }
 
 /**
@@ -448,45 +462,45 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
  * will be used as its internal value.
  */
 export class GraphQLEnumType {
-    name: string;
-    description: string;
-    astNode?: EnumTypeDefinitionNode;
+  name: string;
+  description: string;
+  astNode?: EnumTypeDefinitionNode;
 
-    constructor(config: GraphQLEnumTypeConfig);
-    getValues(): GraphQLEnumValue[];
-    getValue(name: string): GraphQLEnumValue;
-    isValidValue(value: any): boolean;
-    serialize(value: any): string;
-    parseValue(value: any): any;
-    parseLiteral(valueNode: ValueNode): any;
-    toString(): string;
+  constructor(config: GraphQLEnumTypeConfig);
+  getValues(): GraphQLEnumValue[];
+  getValue(name: string): GraphQLEnumValue;
+  isValidValue(value: any): boolean;
+  serialize(value: any): string;
+  parseValue(value: any): any;
+  parseLiteral(valueNode: ValueNode): any;
+  toString(): string;
 }
 
 export interface GraphQLEnumTypeConfig {
-    name: string;
-    values: GraphQLEnumValueConfigMap;
-    description?: string;
-    astNode?: EnumTypeDefinitionNode;
+  name: string;
+  values: GraphQLEnumValueConfigMap;
+  description?: string;
+  astNode?: EnumTypeDefinitionNode;
 }
 
 export interface GraphQLEnumValueConfigMap {
-    [valueName: string]: GraphQLEnumValueConfig;
+  [valueName: string]: GraphQLEnumValueConfig;
 }
 
 export interface GraphQLEnumValueConfig {
-    value?: any;
-    deprecationReason?: string;
-    description?: string;
-    astNode?: EnumValueDefinitionNode;
+  value?: any;
+  deprecationReason?: string;
+  description?: string;
+  astNode?: EnumValueDefinitionNode;
 }
 
 export interface GraphQLEnumValue {
-    name: string;
-    description: string;
-    isDeprecated?: boolean;
-    deprecationReason: string;
-    astNode?: EnumValueDefinitionNode;
-    value: any;
+  name: string;
+  description: string;
+  isDeprecated?: boolean;
+  deprecationReason: string;
+  astNode?: EnumValueDefinitionNode;
+  value: any;
 }
 
 /**
@@ -510,42 +524,42 @@ export interface GraphQLEnumValue {
  *
  */
 export class GraphQLInputObjectType {
-    name: string;
-    description: string;
-    astNode?: InputObjectTypeDefinitionNode;
-    constructor(config: GraphQLInputObjectTypeConfig);
-    getFields(): GraphQLInputFieldMap;
-    toString(): string;
+  name: string;
+  description: string;
+  astNode?: InputObjectTypeDefinitionNode;
+  constructor(config: GraphQLInputObjectTypeConfig);
+  getFields(): GraphQLInputFieldMap;
+  toString(): string;
 }
 
 export interface GraphQLInputObjectTypeConfig {
-    name: string;
-    fields: Thunk<GraphQLInputFieldConfigMap>;
-    description?: string;
-    astNode?: InputObjectTypeDefinitionNode;
+  name: string;
+  fields: Thunk<GraphQLInputFieldConfigMap>;
+  description?: string;
+  astNode?: InputObjectTypeDefinitionNode;
 }
 
 export interface GraphQLInputFieldConfig {
-    type: GraphQLInputType;
-    defaultValue?: any;
-    description?: string;
-    astNode?: InputValueDefinitionNode;
+  type: GraphQLInputType;
+  defaultValue?: any;
+  description?: string;
+  astNode?: InputValueDefinitionNode;
 }
 
 export interface GraphQLInputFieldConfigMap {
-    [fieldName: string]: GraphQLInputFieldConfig;
+  [fieldName: string]: GraphQLInputFieldConfig;
 }
 
 export interface GraphQLInputField {
-    name: string;
-    type: GraphQLInputType;
-    defaultValue?: any;
-    description?: string;
-    astNode?: InputValueDefinitionNode;
+  name: string;
+  type: GraphQLInputType;
+  defaultValue?: any;
+  description?: string;
+  astNode?: InputValueDefinitionNode;
 }
 
 export interface GraphQLInputFieldMap {
-    [fieldName: string]: GraphQLInputField;
+  [fieldName: string]: GraphQLInputField;
 }
 
 /**
@@ -567,9 +581,9 @@ export interface GraphQLInputFieldMap {
  *
  */
 export class GraphQLList<T extends GraphQLType> {
-    ofType: T;
-    constructor(type: T);
-    toString(): string;
+  ofType: T;
+  constructor(type: T);
+  toString(): string;
 }
 
 /**
@@ -593,9 +607,9 @@ export class GraphQLList<T extends GraphQLType> {
  * Note: the enforcement of non-nullability occurs within the executor.
  */
 export class GraphQLNonNull<T extends GraphQLNullableType> {
-    ofType: T;
+  ofType: T;
 
-    constructor(type: T);
+  constructor(type: T);
 
-    toString(): string;
+  toString(): string;
 }

--- a/types/graphql/type/directives.d.ts
+++ b/types/graphql/type/directives.d.ts
@@ -1,30 +1,27 @@
-import {
-    GraphQLFieldConfigArgumentMap,
-    GraphQLArgument
-} from './definition';
+import { GraphQLFieldConfigArgumentMap, GraphQLArgument } from './definition';
 import { DirectiveDefinitionNode } from '../language/ast';
 
 export const DirectiveLocation: {
-    // Operations
-    QUERY: 'QUERY',
-    MUTATION: 'MUTATION',
-    SUBSCRIPTION: 'SUBSCRIPTION',
-    FIELD: 'FIELD',
-    FRAGMENT_DEFINITION: 'FRAGMENT_DEFINITION',
-    FRAGMENT_SPREAD: 'FRAGMENT_SPREAD',
-    INLINE_FRAGMENT: 'INLINE_FRAGMENT',
-    // Schema Definitions
-    SCHEMA: 'SCHEMA',
-    SCALAR: 'SCALAR',
-    OBJECT: 'OBJECT',
-    FIELD_DEFINITION: 'FIELD_DEFINITION',
-    ARGUMENT_DEFINITION: 'ARGUMENT_DEFINITION',
-    INTERFACE: 'INTERFACE',
-    UNION: 'UNION',
-    ENUM: 'ENUM',
-    ENUM_VALUE: 'ENUM_VALUE',
-    INPUT_OBJECT: 'INPUT_OBJECT',
-    INPUT_FIELD_DEFINITION: 'INPUT_FIELD_DEFINITION',
+  // Operations
+  QUERY: 'QUERY';
+  MUTATION: 'MUTATION';
+  SUBSCRIPTION: 'SUBSCRIPTION';
+  FIELD: 'FIELD';
+  FRAGMENT_DEFINITION: 'FRAGMENT_DEFINITION';
+  FRAGMENT_SPREAD: 'FRAGMENT_SPREAD';
+  INLINE_FRAGMENT: 'INLINE_FRAGMENT';
+  // Schema Definitions
+  SCHEMA: 'SCHEMA';
+  SCALAR: 'SCALAR';
+  OBJECT: 'OBJECT';
+  FIELD_DEFINITION: 'FIELD_DEFINITION';
+  ARGUMENT_DEFINITION: 'ARGUMENT_DEFINITION';
+  INTERFACE: 'INTERFACE';
+  UNION: 'UNION';
+  ENUM: 'ENUM';
+  ENUM_VALUE: 'ENUM_VALUE';
+  INPUT_OBJECT: 'INPUT_OBJECT';
+  INPUT_FIELD_DEFINITION: 'INPUT_FIELD_DEFINITION';
 };
 
 export type DirectiveLocationEnum = keyof typeof DirectiveLocation;
@@ -34,21 +31,21 @@ export type DirectiveLocationEnum = keyof typeof DirectiveLocation;
  * behavior. Type system creators will usually not create these directly.
  */
 export class GraphQLDirective {
-    name: string;
-    description?: string;
-    locations: DirectiveLocationEnum[];
-    args: GraphQLArgument[];
-    astNode?: DirectiveDefinitionNode;
+  name: string;
+  description?: string;
+  locations: DirectiveLocationEnum[];
+  args: GraphQLArgument[];
+  astNode?: DirectiveDefinitionNode;
 
-    constructor(config: GraphQLDirectiveConfig);
+  constructor(config: GraphQLDirectiveConfig);
 }
 
 export interface GraphQLDirectiveConfig {
-    name: string;
-    description?: string;
-    locations: DirectiveLocationEnum[];
-    args?: GraphQLFieldConfigArgumentMap;
-    astNode?: DirectiveDefinitionNode;
+  name: string;
+  description?: string;
+  locations: DirectiveLocationEnum[];
+  args?: GraphQLFieldConfigArgumentMap;
+  astNode?: DirectiveDefinitionNode;
 }
 
 /**

--- a/types/graphql/type/index.d.ts
+++ b/types/graphql/type/index.d.ts
@@ -4,49 +4,44 @@ export { GraphQLSchema } from './schema';
 export * from './definition';
 
 export {
-    // "Enum" of Directive Locations
-    DirectiveLocation,
-
-    // Directives Definition
-    GraphQLDirective,
-
-    // Built-in Directives defined by the Spec
-    specifiedDirectives,
-    GraphQLIncludeDirective,
-    GraphQLSkipDirective,
-    GraphQLDeprecatedDirective,
-
-    // Constant Deprecation Reason
-    DEFAULT_DEPRECATION_REASON,
+  // "Enum" of Directive Locations
+  DirectiveLocation,
+  // Directives Definition
+  GraphQLDirective,
+  // Built-in Directives defined by the Spec
+  specifiedDirectives,
+  GraphQLIncludeDirective,
+  GraphQLSkipDirective,
+  GraphQLDeprecatedDirective,
+  // Constant Deprecation Reason
+  DEFAULT_DEPRECATION_REASON,
 } from './directives';
 
 // Common built-in scalar instances.
 export {
-    GraphQLInt,
-    GraphQLFloat,
-    GraphQLString,
-    GraphQLBoolean,
-    GraphQLID,
+  GraphQLInt,
+  GraphQLFloat,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLID,
 } from './scalars';
 
 export {
-    // "Enum" of Type Kinds
-    TypeKind,
-
-    // GraphQL Types for introspection.
-    __Schema,
-    __Directive,
-    __DirectiveLocation,
-    __Type,
-    __Field,
-    __InputValue,
-    __EnumValue,
-    __TypeKind,
-
-    // Meta-field definitions.
-    SchemaMetaFieldDef,
-    TypeMetaFieldDef,
-    TypeNameMetaFieldDef,
+  // "Enum" of Type Kinds
+  TypeKind,
+  // GraphQL Types for introspection.
+  __Schema,
+  __Directive,
+  __DirectiveLocation,
+  __Type,
+  __Field,
+  __InputValue,
+  __EnumValue,
+  __TypeKind,
+  // Meta-field definitions.
+  SchemaMetaFieldDef,
+  TypeMetaFieldDef,
+  TypeNameMetaFieldDef,
 } from './introspection';
 
 export { DirectiveLocationEnum } from './directives';

--- a/types/graphql/type/introspection.d.ts
+++ b/types/graphql/type/introspection.d.ts
@@ -1,12 +1,12 @@
 import {
-    GraphQLScalarType,
-    GraphQLObjectType,
-    GraphQLInterfaceType,
-    GraphQLUnionType,
-    GraphQLEnumType,
-    GraphQLInputObjectType,
-    GraphQLList,
-    GraphQLNonNull,
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
 } from './definition';
 import { GraphQLField } from './definition';
 
@@ -19,14 +19,14 @@ export const __InputValue: GraphQLObjectType;
 export const __EnumValue: GraphQLObjectType;
 
 export const TypeKind: {
-    SCALAR: 'SCALAR',
-    OBJECT: 'OBJECT',
-    INTERFACE: 'INTERFACE',
-    UNION: 'UNION',
-    ENUM: 'ENUM',
-    INPUT_OBJECT: 'INPUT_OBJECT',
-    LIST: 'LIST',
-    NON_NULL: 'NON_NULL',
+  SCALAR: 'SCALAR';
+  OBJECT: 'OBJECT';
+  INTERFACE: 'INTERFACE';
+  UNION: 'UNION';
+  ENUM: 'ENUM';
+  INPUT_OBJECT: 'INPUT_OBJECT';
+  LIST: 'LIST';
+  NON_NULL: 'NON_NULL';
 };
 
 export const __TypeKind: GraphQLEnumType;

--- a/types/graphql/type/schema.d.ts
+++ b/types/graphql/type/schema.d.ts
@@ -1,17 +1,11 @@
+import { GraphQLObjectType } from './definition';
 import {
-    GraphQLObjectType,
+  GraphQLType,
+  GraphQLNamedType,
+  GraphQLAbstractType,
 } from './definition';
-import {
-    GraphQLType,
-    GraphQLNamedType,
-    GraphQLAbstractType
-} from './definition';
-import {
-  SchemaDefinitionNode
-} from '../language/ast';
-import {
-    GraphQLDirective,
-} from './directives';
+import { SchemaDefinitionNode } from '../language/ast';
+import { GraphQLDirective } from './directives';
 
 /**
  * Schema Definition
@@ -40,38 +34,38 @@ import {
  *
  */
 export class GraphQLSchema {
-    astNode?: SchemaDefinitionNode;
-    // private _queryType: GraphQLObjectType;
-    // private _mutationType: GraphQLObjectType;
-    // private _subscriptionType: GraphQLObjectType;
-    // private _directives: Array<GraphQLDirective>;
-    // private _typeMap: TypeMap;
-    // private _implementations: { [interfaceName: string]: Array<GraphQLObjectType> };
-    // private _possibleTypeMap: { [abstractName: string]: { [possibleName: string]: boolean } };
+  astNode?: SchemaDefinitionNode;
+  // private _queryType: GraphQLObjectType;
+  // private _mutationType: GraphQLObjectType;
+  // private _subscriptionType: GraphQLObjectType;
+  // private _directives: Array<GraphQLDirective>;
+  // private _typeMap: TypeMap;
+  // private _implementations: { [interfaceName: string]: Array<GraphQLObjectType> };
+  // private _possibleTypeMap: { [abstractName: string]: { [possibleName: string]: boolean } };
 
-    constructor(config: GraphQLSchemaConfig)
+  constructor(config: GraphQLSchemaConfig);
 
-    getQueryType(): GraphQLObjectType;
-    getMutationType(): GraphQLObjectType|null|undefined;
-    getSubscriptionType(): GraphQLObjectType|null|undefined;
-    getTypeMap(): { [typeName: string]: GraphQLNamedType };
-    getType(name: string): GraphQLNamedType;
-    getPossibleTypes(abstractType: GraphQLAbstractType): GraphQLObjectType[];
+  getQueryType(): GraphQLObjectType;
+  getMutationType(): GraphQLObjectType | null | undefined;
+  getSubscriptionType(): GraphQLObjectType | null | undefined;
+  getTypeMap(): { [typeName: string]: GraphQLNamedType };
+  getType(name: string): GraphQLNamedType;
+  getPossibleTypes(abstractType: GraphQLAbstractType): GraphQLObjectType[];
 
-    isPossibleType(
-        abstractType: GraphQLAbstractType,
-        possibleType: GraphQLObjectType
-    ): boolean;
+  isPossibleType(
+    abstractType: GraphQLAbstractType,
+    possibleType: GraphQLObjectType,
+  ): boolean;
 
-    getDirectives(): GraphQLDirective[];
-    getDirective(name: string): GraphQLDirective;
+  getDirectives(): GraphQLDirective[];
+  getDirective(name: string): GraphQLDirective;
 }
 
 export interface GraphQLSchemaConfig {
-    query: GraphQLObjectType;
-    mutation?: GraphQLObjectType;
-    subscription?: GraphQLObjectType;
-    types?: GraphQLNamedType[];
-    directives?: GraphQLDirective[];
-    astNode?: SchemaDefinitionNode;
+  query: GraphQLObjectType;
+  mutation?: GraphQLObjectType;
+  subscription?: GraphQLObjectType;
+  types?: GraphQLNamedType[];
+  directives?: GraphQLDirective[];
+  astNode?: SchemaDefinitionNode;
 }

--- a/types/graphql/utilities/TypeInfo.d.ts
+++ b/types/graphql/utilities/TypeInfo.d.ts
@@ -1,12 +1,12 @@
 import { GraphQLSchema } from '../type/schema';
 import {
-    GraphQLOutputType,
-    GraphQLCompositeType,
-    GraphQLInputType,
-    GraphQLField,
-    GraphQLArgument,
-    GraphQLEnumValue,
-    GraphQLType,
+  GraphQLOutputType,
+  GraphQLCompositeType,
+  GraphQLInputType,
+  GraphQLField,
+  GraphQLArgument,
+  GraphQLEnumValue,
+  GraphQLType,
 } from '../type/definition';
 import { GraphQLDirective } from '../type/directives';
 import { ASTNode, FieldNode } from '../language/ast';
@@ -17,27 +17,27 @@ import { ASTNode, FieldNode } from '../language/ast';
  * AST during a recursive descent by calling `enter(node)` and `leave(node)`.
  */
 export class TypeInfo {
-    constructor(
-        schema: GraphQLSchema,
-        // NOTE: this experimental optional second parameter is only needed in order
-        // to support non-spec-compliant codebases. You should never need to use it.
-        // It may disappear in the future.
-        getFieldDefFn?: getFieldDef
-    );
+  constructor(
+    schema: GraphQLSchema,
+    // NOTE: this experimental optional second parameter is only needed in order
+    // to support non-spec-compliant codebases. You should never need to use it.
+    // It may disappear in the future.
+    getFieldDefFn?: getFieldDef,
+  );
 
-    getType(): GraphQLOutputType;
-    getParentType(): GraphQLCompositeType;
-    getInputType(): GraphQLInputType;
-    getFieldDef(): GraphQLField<any, any>;
-    getDirective(): GraphQLDirective;
-    getArgument(): GraphQLArgument;
-    getEnumValue(): GraphQLEnumValue;
-    enter(node: ASTNode): any;
-    leave(node: ASTNode): any;
+  getType(): GraphQLOutputType;
+  getParentType(): GraphQLCompositeType;
+  getInputType(): GraphQLInputType;
+  getFieldDef(): GraphQLField<any, any>;
+  getDirective(): GraphQLDirective;
+  getArgument(): GraphQLArgument;
+  getEnumValue(): GraphQLEnumValue;
+  enter(node: ASTNode): any;
+  leave(node: ASTNode): any;
 }
 
 export type getFieldDef = (
-    schema: GraphQLSchema,
-    parentType: GraphQLType,
-    fieldNode: FieldNode,
+  schema: GraphQLSchema,
+  parentType: GraphQLType,
+  fieldNode: FieldNode,
 ) => GraphQLField<any, any>;

--- a/types/graphql/utilities/astFromValue.d.ts
+++ b/types/graphql/utilities/astFromValue.d.ts
@@ -1,6 +1,6 @@
 import {
-    ValueNode,
-    /*
+  ValueNode,
+  /*
     TODO:
     IntValueNode,
     FloatValueNode,
@@ -30,7 +30,4 @@ import { GraphQLInputType } from '../type/definition';
  *
  */
 // TODO: this should set overloads according to above the table
-export function astFromValue(
-    value: any,
-    type: GraphQLInputType
-): ValueNode; // Warning: there is a code in bottom: throw new TypeError
+export function astFromValue(value: any, type: GraphQLInputType): ValueNode; // Warning: there is a code in bottom: throw new TypeError

--- a/types/graphql/utilities/buildClientSchema.d.ts
+++ b/types/graphql/utilities/buildClientSchema.d.ts
@@ -11,5 +11,5 @@ import { GraphQLSchema } from '../type/schema';
  * server-internal mechanisms.
  */
 export function buildClientSchema(
-    introspection: IntrospectionQuery
+  introspection: IntrospectionQuery,
 ): GraphQLSchema;

--- a/types/graphql/utilities/extendSchema.d.ts
+++ b/types/graphql/utilities/extendSchema.d.ts
@@ -14,6 +14,6 @@ import { GraphQLSchema } from '../type/schema';
  * producing the copy. The original schema remains unaltered.
  */
 export function extendSchema(
-    schema: GraphQLSchema,
-    documentAST: DocumentNode
+  schema: GraphQLSchema,
+  documentAST: DocumentNode,
 ): GraphQLSchema;

--- a/types/graphql/utilities/findBreakingChanges.d.ts
+++ b/types/graphql/utilities/findBreakingChanges.d.ts
@@ -1,35 +1,35 @@
 import {
-    getNamedType,
-    GraphQLScalarType,
-    GraphQLEnumType,
-    GraphQLInputObjectType,
-    GraphQLInterfaceType,
-    GraphQLObjectType,
-    GraphQLUnionType,
-    GraphQLNamedType,
+  getNamedType,
+  GraphQLScalarType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNamedType,
 } from '../type/definition';
 import { GraphQLSchema } from '../type/schema';
 
 export const BreakingChangeType: {
-    FIELD_CHANGED_KIND: 'FIELD_CHANGED_KIND',
-    FIELD_REMOVED: 'FIELD_REMOVED',
-    TYPE_CHANGED_KIND: 'TYPE_CHANGED_KIND',
-    TYPE_REMOVED: 'TYPE_REMOVED',
-    TYPE_REMOVED_FROM_UNION: 'TYPE_REMOVED_FROM_UNION',
-    VALUE_REMOVED_FROM_ENUM: 'VALUE_REMOVED_FROM_ENUM',
+  FIELD_CHANGED_KIND: 'FIELD_CHANGED_KIND';
+  FIELD_REMOVED: 'FIELD_REMOVED';
+  TYPE_CHANGED_KIND: 'TYPE_CHANGED_KIND';
+  TYPE_REMOVED: 'TYPE_REMOVED';
+  TYPE_REMOVED_FROM_UNION: 'TYPE_REMOVED_FROM_UNION';
+  VALUE_REMOVED_FROM_ENUM: 'VALUE_REMOVED_FROM_ENUM';
 };
 
 export type BreakingChangeKey =
-    | 'FIELD_CHANGED_KIND'
-    | 'FIELD_REMOVED'
-    | 'TYPE_CHANGED_KIND'
-    | 'TYPE_REMOVED'
-    | 'TYPE_REMOVED_FROM_UNION'
-    | 'VALUE_REMOVED_FROM_ENUM';
+  | 'FIELD_CHANGED_KIND'
+  | 'FIELD_REMOVED'
+  | 'TYPE_CHANGED_KIND'
+  | 'TYPE_REMOVED'
+  | 'TYPE_REMOVED_FROM_UNION'
+  | 'VALUE_REMOVED_FROM_ENUM';
 
 export interface BreakingChange {
-    type: BreakingChangeKey;
-    description: string;
+  type: BreakingChangeKey;
+  description: string;
 }
 
 /**
@@ -37,8 +37,8 @@ export interface BreakingChange {
  * of breaking changes covered by the other functions down below.
  */
 export function findBreakingChanges(
-    oldSchema: GraphQLSchema,
-    newSchema: GraphQLSchema
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
 ): BreakingChange[];
 
 /**
@@ -46,8 +46,8 @@ export function findBreakingChanges(
  * changes in the newSchema related to removing an entire type.
  */
 export function findRemovedTypes(
-    oldSchema: GraphQLSchema,
-    newSchema: GraphQLSchema
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
 ): BreakingChange[];
 
 /**
@@ -55,8 +55,8 @@ export function findRemovedTypes(
  * changes in the newSchema related to changing the type of a type.
  */
 export function findTypesThatChangedKind(
-    oldSchema: GraphQLSchema,
-    newSchema: GraphQLSchema
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
 ): BreakingChange[];
 
 /**
@@ -65,8 +65,8 @@ export function findTypesThatChangedKind(
  * a field has been removed from a type or if a field has changed type.
  */
 export function findFieldsThatChangedType(
-    oldSchema: GraphQLSchema,
-    newSchema: GraphQLSchema
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
 ): BreakingChange[];
 
 /**
@@ -74,8 +74,8 @@ export function findFieldsThatChangedType(
  * changes in the newSchema related to removing types from a union type.
  */
 export function findTypesRemovedFromUnions(
-    oldSchema: GraphQLSchema,
-    newSchema: GraphQLSchema
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
 ): BreakingChange[];
 
 /**
@@ -83,6 +83,6 @@ export function findTypesRemovedFromUnions(
  * changes in the newSchema related to removing values from an enum type.
  */
 export function findValuesRemovedFromEnums(
-    oldSchema: GraphQLSchema,
-    newSchema: GraphQLSchema
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
 ): BreakingChange[];

--- a/types/graphql/utilities/findDeprecatedUsages.d.ts
+++ b/types/graphql/utilities/findDeprecatedUsages.d.ts
@@ -8,6 +8,6 @@ import { GraphQLError } from '../error/GraphQLError';
  * Returns a list of GraphQLError instances describing each deprecated use.
  */
 export function findDeprecatedUsages(
-    schema: GraphQLSchema,
-    ast: DocumentNode
+  schema: GraphQLSchema,
+  ast: DocumentNode,
 ): GraphQLError[];

--- a/types/graphql/utilities/getOperationAST.d.ts
+++ b/types/graphql/utilities/getOperationAST.d.ts
@@ -6,6 +6,6 @@ import { DocumentNode, OperationDefinitionNode } from '../language/ast';
  * provided in the document.
  */
 export function getOperationAST(
-    documentAST: DocumentNode,
-    operationName?: string
+  documentAST: DocumentNode,
+  operationName?: string,
 ): OperationDefinitionNode;

--- a/types/graphql/utilities/index.d.ts
+++ b/types/graphql/utilities/index.d.ts
@@ -1,23 +1,23 @@
 // The GraphQL query recommended for a full schema introspection.
 export { introspectionQuery } from './introspectionQuery';
 export {
-    IntrospectionQuery,
-    IntrospectionSchema,
-    IntrospectionType,
-    IntrospectionScalarType,
-    IntrospectionObjectType,
-    IntrospectionInterfaceType,
-    IntrospectionUnionType,
-    IntrospectionEnumType,
-    IntrospectionInputObjectType,
-    IntrospectionTypeRef,
-    IntrospectionNamedTypeRef,
-    IntrospectionListTypeRef,
-    IntrospectionNonNullTypeRef,
-    IntrospectionField,
-    IntrospectionInputValue,
-    IntrospectionEnumValue,
-    IntrospectionDirective,
+  IntrospectionQuery,
+  IntrospectionSchema,
+  IntrospectionType,
+  IntrospectionScalarType,
+  IntrospectionObjectType,
+  IntrospectionInterfaceType,
+  IntrospectionUnionType,
+  IntrospectionEnumType,
+  IntrospectionInputObjectType,
+  IntrospectionTypeRef,
+  IntrospectionNamedTypeRef,
+  IntrospectionListTypeRef,
+  IntrospectionNonNullTypeRef,
+  IntrospectionField,
+  IntrospectionInputValue,
+  IntrospectionEnumValue,
+  IntrospectionDirective,
 } from './introspectionQuery';
 
 // Gets the target Operation from a Document
@@ -33,7 +33,11 @@ export { buildASTSchema, buildSchema } from './buildASTSchema';
 export { extendSchema } from './extendSchema';
 
 // Print a GraphQLSchema to GraphQL Schema language.
-export { printSchema, printType, printIntrospectionSchema } from './schemaPrinter';
+export {
+  printSchema,
+  printType,
+  printIntrospectionSchema,
+} from './schemaPrinter';
 
 // Create a GraphQLType from a GraphQL language AST.
 export { typeFromAST } from './typeFromAST';
@@ -62,9 +66,9 @@ export { separateOperations } from './separateOperations';
 
 // Comparators for types
 export {
-    isEqualType,
-    isTypeSubTypeOf,
-    doTypesOverlap
+  isEqualType,
+  isTypeSubTypeOf,
+  doTypesOverlap,
 } from './typeComparators';
 
 // Asserts that a string is a valid GraphQL name

--- a/types/graphql/utilities/introspectionQuery.d.ts
+++ b/types/graphql/utilities/introspectionQuery.d.ts
@@ -96,114 +96,114 @@ fragment TypeRef on __Type {
 export const introspectionQuery: string;
 
 export interface IntrospectionQuery {
-    __schema: IntrospectionSchema;
+  __schema: IntrospectionSchema;
 }
 
 export interface IntrospectionSchema {
-    queryType: IntrospectionNamedTypeRef;
-    mutationType?: IntrospectionNamedTypeRef;
-    subscriptionType?: IntrospectionNamedTypeRef;
-    types: IntrospectionType[];
-    directives: IntrospectionDirective[];
+  queryType: IntrospectionNamedTypeRef;
+  mutationType?: IntrospectionNamedTypeRef;
+  subscriptionType?: IntrospectionNamedTypeRef;
+  types: IntrospectionType[];
+  directives: IntrospectionDirective[];
 }
 
 export type IntrospectionType =
-    | IntrospectionScalarType
-    | IntrospectionObjectType
-    | IntrospectionInterfaceType
-    | IntrospectionUnionType
-    | IntrospectionEnumType
-    | IntrospectionInputObjectType;
+  | IntrospectionScalarType
+  | IntrospectionObjectType
+  | IntrospectionInterfaceType
+  | IntrospectionUnionType
+  | IntrospectionEnumType
+  | IntrospectionInputObjectType;
 
 export interface IntrospectionScalarType {
-    kind: 'SCALAR';
-    name: string;
-    description?: string;
+  kind: 'SCALAR';
+  name: string;
+  description?: string;
 }
 
 export interface IntrospectionObjectType {
-    kind: 'OBJECT';
-    name: string;
-    description?: string;
-    fields: IntrospectionField[];
-    interfaces: IntrospectionNamedTypeRef[];
+  kind: 'OBJECT';
+  name: string;
+  description?: string;
+  fields: IntrospectionField[];
+  interfaces: IntrospectionNamedTypeRef[];
 }
 
 export interface IntrospectionInterfaceType {
-    kind: 'INTERFACE';
-    name: string;
-    description?: string;
-    fields: IntrospectionField[];
-    possibleTypes: IntrospectionNamedTypeRef[];
+  kind: 'INTERFACE';
+  name: string;
+  description?: string;
+  fields: IntrospectionField[];
+  possibleTypes: IntrospectionNamedTypeRef[];
 }
 
 export interface IntrospectionUnionType {
-    kind: 'UNION';
-    name: string;
-    description?: string;
-    possibleTypes: IntrospectionNamedTypeRef[];
+  kind: 'UNION';
+  name: string;
+  description?: string;
+  possibleTypes: IntrospectionNamedTypeRef[];
 }
 
 export interface IntrospectionEnumType {
-    kind: 'ENUM';
-    name: string;
-    description?: string;
-    enumValues: IntrospectionEnumValue[];
+  kind: 'ENUM';
+  name: string;
+  description?: string;
+  enumValues: IntrospectionEnumValue[];
 }
 
 export interface IntrospectionInputObjectType {
-    kind: 'INPUT_OBJECT';
-    name: string;
-    description?: string;
-    inputFields: IntrospectionInputValue[];
+  kind: 'INPUT_OBJECT';
+  name: string;
+  description?: string;
+  inputFields: IntrospectionInputValue[];
 }
 
 export type IntrospectionTypeRef =
-    | IntrospectionNamedTypeRef
-    | IntrospectionListTypeRef
-    | IntrospectionNonNullTypeRef;
+  | IntrospectionNamedTypeRef
+  | IntrospectionListTypeRef
+  | IntrospectionNonNullTypeRef;
 
 export interface IntrospectionNamedTypeRef {
-    kind: string;
-    name: string;
+  kind: string;
+  name: string;
 }
 
 export interface IntrospectionListTypeRef {
-    kind: 'LIST';
-    ofType?: IntrospectionTypeRef;
+  kind: 'LIST';
+  ofType?: IntrospectionTypeRef;
 }
 
 export interface IntrospectionNonNullTypeRef {
-    kind: 'NON_NULL';
-    ofType?: IntrospectionTypeRef;
+  kind: 'NON_NULL';
+  ofType?: IntrospectionTypeRef;
 }
 
 export interface IntrospectionField {
-    name: string;
-    description?: string;
-    args: IntrospectionInputValue[];
-    type: IntrospectionTypeRef;
-    isDeprecated: boolean;
-    deprecationReason?: string;
+  name: string;
+  description?: string;
+  args: IntrospectionInputValue[];
+  type: IntrospectionTypeRef;
+  isDeprecated: boolean;
+  deprecationReason?: string;
 }
 
 export interface IntrospectionInputValue {
-    name: string;
-    description?: string;
-    type: IntrospectionTypeRef;
-    defaultValue?: string;
+  name: string;
+  description?: string;
+  type: IntrospectionTypeRef;
+  defaultValue?: string;
 }
 
 export interface IntrospectionEnumValue {
-    name: string;
-    description?: string;
-    isDeprecated: boolean;
-    deprecationReason?: string;
+  name: string;
+  description?: string;
+  isDeprecated: boolean;
+  deprecationReason?: string;
 }
 
 export interface IntrospectionDirective {
-    name: string;
-    description?: string;
-    locations: DirectiveLocationEnum[];
-    args: IntrospectionInputValue[];
+  name: string;
+  description?: string;
+  locations: DirectiveLocationEnum[];
+  args: IntrospectionInputValue[];
 }

--- a/types/graphql/utilities/isValidJSValue.d.ts
+++ b/types/graphql/utilities/isValidJSValue.d.ts
@@ -5,7 +5,4 @@ import { GraphQLInputType } from '../type/definition';
  * accepted for that type. This is primarily useful for validating the
  * runtime values of query variables.
  */
-export function isValidJSValue(
-    value: any,
-    type: GraphQLInputType
-): string[];
+export function isValidJSValue(value: any, type: GraphQLInputType): string[];

--- a/types/graphql/utilities/isValidLiteralValue.d.ts
+++ b/types/graphql/utilities/isValidLiteralValue.d.ts
@@ -9,6 +9,6 @@ import { GraphQLInputType } from '../type/definition';
  * provide values of the correct type.
  */
 export function isValidLiteralValue(
-    type: GraphQLInputType,
-    valueNode: ValueNode
+  type: GraphQLInputType,
+  valueNode: ValueNode,
 ): string[];

--- a/types/graphql/utilities/separateOperations.d.ts
+++ b/types/graphql/utilities/separateOperations.d.ts
@@ -1,8 +1,5 @@
-import {
-    DocumentNode,
-    OperationDefinitionNode,
-} from '../language/ast';
+import { DocumentNode, OperationDefinitionNode } from '../language/ast';
 
 export function separateOperations(
-    documentAST: DocumentNode
+  documentAST: DocumentNode,
 ): { [operationName: string]: DocumentNode };

--- a/types/graphql/utilities/typeComparators.d.ts
+++ b/types/graphql/utilities/typeComparators.d.ts
@@ -1,11 +1,9 @@
 import {
-    GraphQLType,
-    GraphQLCompositeType,
-    GraphQLAbstractType
+  GraphQLType,
+  GraphQLCompositeType,
+  GraphQLAbstractType,
 } from '../type/definition';
-import {
-    GraphQLSchema
-} from '../type/schema';
+import { GraphQLSchema } from '../type/schema';
 
 /**
  * Provided two types, return true if the types are equal (invariant).
@@ -17,9 +15,9 @@ export function isEqualType(typeA: GraphQLType, typeB: GraphQLType): boolean;
  * equal or a subset of the second super type (covariant).
  */
 export function isTypeSubTypeOf(
-    schema: GraphQLSchema,
-    maybeSubType: GraphQLType,
-    superType: GraphQLType
+  schema: GraphQLSchema,
+  maybeSubType: GraphQLType,
+  superType: GraphQLType,
 ): boolean;
 
 /**
@@ -32,7 +30,7 @@ export function isTypeSubTypeOf(
  * This function is commutative.
  */
 export function doTypesOverlap(
-    schema: GraphQLSchema,
-    typeA: GraphQLCompositeType,
-    typeB: GraphQLCompositeType
+  schema: GraphQLSchema,
+  typeA: GraphQLCompositeType,
+  typeB: GraphQLCompositeType,
 ): boolean;

--- a/types/graphql/utilities/typeFromAST.d.ts
+++ b/types/graphql/utilities/typeFromAST.d.ts
@@ -3,6 +3,6 @@ import { GraphQLType, GraphQLNullableType } from '../type/definition';
 import { GraphQLSchema } from '../type/schema';
 
 export function typeFromAST(
-    schema: GraphQLSchema,
-    typeNode: TypeNode
+  schema: GraphQLSchema,
+  typeNode: TypeNode,
 ): GraphQLType;

--- a/types/graphql/utilities/valueFromAST.d.ts
+++ b/types/graphql/utilities/valueFromAST.d.ts
@@ -1,15 +1,15 @@
 import { GraphQLInputType } from '../type/definition';
 import {
-    ValueNode,
-    VariableNode,
-    ListValueNode,
-    ObjectValueNode
+  ValueNode,
+  VariableNode,
+  ListValueNode,
+  ObjectValueNode,
 } from '../language/ast';
 
 export function valueFromAST(
-    valueNode: ValueNode,
-    type: GraphQLInputType,
-    variables?: {
-        [key: string]: any
-    }
+  valueNode: ValueNode,
+  type: GraphQLInputType,
+  variables?: {
+    [key: string]: any;
+  },
 ): any;

--- a/types/graphql/validation/index.d.ts
+++ b/types/graphql/validation/index.d.ts
@@ -3,130 +3,126 @@ export { specifiedRules } from './specifiedRules';
 
 // Spec Section: "Argument Values Type Correctness"
 export {
-    ArgumentsOfCorrectType as ArgumentsOfCorrectTypeRule
+  ArgumentsOfCorrectType as ArgumentsOfCorrectTypeRule,
 } from './rules/ArgumentsOfCorrectType';
 
 // Spec Section: "Variable Default Values Are Correctly Typed"
 export {
-    DefaultValuesOfCorrectType as DefaultValuesOfCorrectTypeRule
+  DefaultValuesOfCorrectType as DefaultValuesOfCorrectTypeRule,
 } from './rules/DefaultValuesOfCorrectType';
 
 // Spec Section: "Field Selections on Objects, Interfaces, and Unions Types"
 export {
-    FieldsOnCorrectType as FieldsOnCorrectTypeRule
+  FieldsOnCorrectType as FieldsOnCorrectTypeRule,
 } from './rules/FieldsOnCorrectType';
 
 // Spec Section: "Fragments on Composite Types"
 export {
-    FragmentsOnCompositeTypes as FragmentsOnCompositeTypesRule
+  FragmentsOnCompositeTypes as FragmentsOnCompositeTypesRule,
 } from './rules/FragmentsOnCompositeTypes';
 
 // Spec Section: "Argument Names"
 export {
-    KnownArgumentNames as KnownArgumentNamesRule
+  KnownArgumentNames as KnownArgumentNamesRule,
 } from './rules/KnownArgumentNames';
 
 // Spec Section: "Directives Are Defined"
 export {
-    KnownDirectives as KnownDirectivesRule
+  KnownDirectives as KnownDirectivesRule,
 } from './rules/KnownDirectives';
 
 // Spec Section: "Fragment spread target defined"
 export {
-    KnownFragmentNames as KnownFragmentNamesRule
+  KnownFragmentNames as KnownFragmentNamesRule,
 } from './rules/KnownFragmentNames';
 
 // Spec Section: "Fragment Spread Type Existence"
-export {
-    KnownTypeNames as KnownTypeNamesRule
-} from './rules/KnownTypeNames';
+export { KnownTypeNames as KnownTypeNamesRule } from './rules/KnownTypeNames';
 
 // Spec Section: "Lone Anonymous Operation"
 export {
-    LoneAnonymousOperation as LoneAnonymousOperationRule
+  LoneAnonymousOperation as LoneAnonymousOperationRule,
 } from './rules/LoneAnonymousOperation';
 
 // Spec Section: "Fragments must not form cycles"
 export {
-    NoFragmentCycles as NoFragmentCyclesRule
+  NoFragmentCycles as NoFragmentCyclesRule,
 } from './rules/NoFragmentCycles';
 
 // Spec Section: "All Variable Used Defined"
 export {
-    NoUndefinedVariables as NoUndefinedVariablesRule
+  NoUndefinedVariables as NoUndefinedVariablesRule,
 } from './rules/NoUndefinedVariables';
 
 // Spec Section: "Fragments must be used"
 export {
-    NoUnusedFragments as NoUnusedFragmentsRule
+  NoUnusedFragments as NoUnusedFragmentsRule,
 } from './rules/NoUnusedFragments';
 
 // Spec Section: "All Variables Used"
 export {
-    NoUnusedVariables as NoUnusedVariablesRule
+  NoUnusedVariables as NoUnusedVariablesRule,
 } from './rules/NoUnusedVariables';
 
 // Spec Section: "Field Selection Merging"
 export {
-    OverlappingFieldsCanBeMerged as OverlappingFieldsCanBeMergedRule
+  OverlappingFieldsCanBeMerged as OverlappingFieldsCanBeMergedRule,
 } from './rules/OverlappingFieldsCanBeMerged';
 
 // Spec Section: "Fragment spread is possible"
 export {
-    PossibleFragmentSpreads as PossibleFragmentSpreadsRule
+  PossibleFragmentSpreads as PossibleFragmentSpreadsRule,
 } from './rules/PossibleFragmentSpreads';
 
 // Spec Section: "Argument Optionality"
 export {
-    ProvidedNonNullArguments as ProvidedNonNullArgumentsRule
+  ProvidedNonNullArguments as ProvidedNonNullArgumentsRule,
 } from './rules/ProvidedNonNullArguments';
 
 // Spec Section: "Leaf Field Selections"
-export {
-    ScalarLeafs as ScalarLeafsRule
-} from './rules/ScalarLeafs';
+export { ScalarLeafs as ScalarLeafsRule } from './rules/ScalarLeafs';
 
 // Spec Section: "Subscriptions with Single Root Field"
 export {
-    SingleFieldSubscriptions as SingleFieldSubscriptionsRule
+  SingleFieldSubscriptions as SingleFieldSubscriptionsRule,
 } from './rules/SingleFieldSubscriptions';
 
 // Spec Section: "Argument Uniqueness"
 export {
-    UniqueArgumentNames as UniqueArgumentNamesRule
+  UniqueArgumentNames as UniqueArgumentNamesRule,
 } from './rules/UniqueArgumentNames';
 
 // Spec Section: "Directives Are Unique Per Location"
 export {
-    UniqueDirectivesPerLocation as UniqueDirectivesPerLocationRule
+  UniqueDirectivesPerLocation as UniqueDirectivesPerLocationRule,
 } from './rules/UniqueDirectivesPerLocation';
 
 // Spec Section: "Fragment Name Uniqueness"
 export {
-    UniqueFragmentNames as UniqueFragmentNamesRule
+  UniqueFragmentNames as UniqueFragmentNamesRule,
 } from './rules/UniqueFragmentNames';
 
 // Spec Section: "Input Object Field Uniqueness"
 export {
-    UniqueInputFieldNames as UniqueInputFieldNamesRule
+  UniqueInputFieldNames as UniqueInputFieldNamesRule,
 } from './rules/UniqueInputFieldNames';
 
 // Spec Section: "Operation Name Uniqueness"
 export {
-    UniqueOperationNames as UniqueOperationNamesRule
+  UniqueOperationNames as UniqueOperationNamesRule,
 } from './rules/UniqueOperationNames';
 
 // Spec Section: "Variable Uniqueness"
 export {
-    UniqueVariableNames as UniqueVariableNamesRule
+  UniqueVariableNames as UniqueVariableNamesRule,
 } from './rules/UniqueVariableNames';
 
 // Spec Section: "Variables are Input Types"
 export {
-    VariablesAreInputTypes as VariablesAreInputTypesRule
+  VariablesAreInputTypes as VariablesAreInputTypesRule,
 } from './rules/VariablesAreInputTypes';
 
 // Spec Section: "All Variable Usages Are Allowed"
 export {
-    VariablesInAllowedPosition as VariablesInAllowedPositionRule
+  VariablesInAllowedPosition as VariablesInAllowedPositionRule,
 } from './rules/VariablesInAllowedPosition';

--- a/types/graphql/validation/validate.d.ts
+++ b/types/graphql/validation/validate.d.ts
@@ -1,19 +1,19 @@
 import { GraphQLError } from '../error';
 import {
-    DocumentNode,
-    OperationDefinitionNode,
-    VariableNode,
-    SelectionSetNode,
-    FragmentSpreadNode,
-    FragmentDefinitionNode,
+  DocumentNode,
+  OperationDefinitionNode,
+  VariableNode,
+  SelectionSetNode,
+  FragmentSpreadNode,
+  FragmentDefinitionNode,
 } from '../language/ast';
 import { GraphQLSchema } from '../type/schema';
 import {
-    GraphQLInputType,
-    GraphQLOutputType,
-    GraphQLCompositeType,
-    GraphQLField,
-    GraphQLArgument
+  GraphQLInputType,
+  GraphQLOutputType,
+  GraphQLCompositeType,
+  GraphQLField,
+  GraphQLArgument,
 } from '../type/definition';
 import { GraphQLDirective } from '../type/directives';
 import { TypeInfo } from '../utilities/TypeInfo';
@@ -33,9 +33,9 @@ import { specifiedRules } from './specifiedRules';
  * GraphQLErrors, or Arrays of GraphQLErrors when invalid.
  */
 export function validate(
-    schema: GraphQLSchema,
-    ast: DocumentNode,
-    rules?: any[]
+  schema: GraphQLSchema,
+  ast: DocumentNode,
+  rules?: any[],
 ): GraphQLError[];
 
 /**
@@ -45,16 +45,18 @@ export function validate(
  * @internal
  */
 export function visitUsingRules(
-    schema: GraphQLSchema,
-    typeInfo: TypeInfo,
-    documentAST: DocumentNode,
-    rules: any[]
+  schema: GraphQLSchema,
+  typeInfo: TypeInfo,
+  documentAST: DocumentNode,
+  rules: any[],
 ): GraphQLError[];
 
-export type NodeWithSelectionSet = OperationDefinitionNode | FragmentDefinitionNode;
+export type NodeWithSelectionSet =
+  | OperationDefinitionNode
+  | FragmentDefinitionNode;
 export interface VariableUsage {
-    node: VariableNode;
-    type: GraphQLInputType;
+  node: VariableNode;
+  type: GraphQLInputType;
 }
 
 /**
@@ -63,38 +65,38 @@ export interface VariableUsage {
  * validation rule.
  */
 export class ValidationContext {
-    constructor(schema: GraphQLSchema, ast: DocumentNode, typeInfo: TypeInfo);
-    reportError(error: GraphQLError): void;
+  constructor(schema: GraphQLSchema, ast: DocumentNode, typeInfo: TypeInfo);
+  reportError(error: GraphQLError): void;
 
-    getErrors(): GraphQLError[];
+  getErrors(): GraphQLError[];
 
-    getSchema(): GraphQLSchema;
+  getSchema(): GraphQLSchema;
 
-    getDocument(): DocumentNode;
+  getDocument(): DocumentNode;
 
-    getFragment(name: string): FragmentDefinitionNode;
+  getFragment(name: string): FragmentDefinitionNode;
 
-    getFragmentSpreads(node: SelectionSetNode): FragmentSpreadNode[];
+  getFragmentSpreads(node: SelectionSetNode): FragmentSpreadNode[];
 
-    getRecursivelyReferencedFragments(
-        operation: OperationDefinitionNode
-    ): FragmentDefinitionNode[];
+  getRecursivelyReferencedFragments(
+    operation: OperationDefinitionNode,
+  ): FragmentDefinitionNode[];
 
-    getVariableUsages(node: NodeWithSelectionSet): VariableUsage[];
+  getVariableUsages(node: NodeWithSelectionSet): VariableUsage[];
 
-    getRecursiveVariableUsages(
-        operation: OperationDefinitionNode
-    ): VariableUsage[];
+  getRecursiveVariableUsages(
+    operation: OperationDefinitionNode,
+  ): VariableUsage[];
 
-    getType(): GraphQLOutputType;
+  getType(): GraphQLOutputType;
 
-    getParentType(): GraphQLCompositeType;
+  getParentType(): GraphQLCompositeType;
 
-    getInputType(): GraphQLInputType;
+  getInputType(): GraphQLInputType;
 
-    getFieldDef(): GraphQLField<any, any>;
+  getFieldDef(): GraphQLField<any, any>;
 
-    getDirective(): GraphQLDirective;
+  getDirective(): GraphQLDirective;
 
-    getArgument(): GraphQLArgument;
+  getArgument(): GraphQLArgument;
 }


### PR DESCRIPTION
See https://github.com/graphql/graphql-js/pull/1112

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/graphql/graphql-js/pull/1112
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

----------

It's hard to keep typings in sync with `graphql-js` since copying code requires a lot of reformating because `graphql-js` use 2 space indentation.

Moreover, it leads to inconsistent code formatting, e.g.: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22980/files#r162014636

Reformatted all `*.d.ts` files using the .prettierrc from graphql-js:
https://github.com/graphql/graphql-js/blob/master/.prettierrc