### PR TITLE
knex cb selectors: `this` is a `QueryBuilder`

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -116,7 +116,7 @@ declare namespace Knex {
 
         // Union
         union: Union;
-        unionAll(callback: Function): QueryBuilder;
+        unionAll(callback: QueryCallback): QueryBuilder;
 
         // Having
         having: Having;
@@ -193,19 +193,19 @@ declare namespace Knex {
 
     interface JoinClause {
         on(raw: Raw): JoinClause;
-        on(callback: Function): JoinClause;
+        on(callback: QueryCallback): JoinClause;
         on(columns: { [key: string]: string | Raw }): JoinClause;
         on(column1: string, column2: string): JoinClause;
         on(column1: string, raw: Raw): JoinClause;
         on(column1: string, operator: string, column2: string | Raw): JoinClause;
         andOn(raw: Raw): JoinClause;
-        andOn(callback: Function): JoinClause;
+        andOn(callback: QueryCallback): JoinClause;
         andOn(columns: { [key: string]: string | Raw }): JoinClause;
         andOn(column1: string, column2: string): JoinClause;
         andOn(column1: string, raw: Raw): JoinClause;
         andOn(column1: string, operator: string, column2: string | Raw): JoinClause;
         orOn(raw: Raw): JoinClause;
-        orOn(callback: Function): JoinClause;
+        orOn(callback: QueryCallback): JoinClause;
         orOn(columns: { [key: string]: string | Raw }): JoinClause;
         orOn(column1: string, column2: string): JoinClause;
         orOn(column1: string, raw: Raw): JoinClause;
@@ -222,12 +222,12 @@ declare namespace Knex {
         onNotNull(column1: string): JoinClause;
         andOnNotNull(column1: string): JoinClause;
         orOnNotNull(column1: string): JoinClause;
-        onExists(callback: () => void): JoinClause;
-        andOnExists(callback: () => void): JoinClause;
-        orOnExists(callback: () => void): JoinClause;
-        onNotExists(callback: () => void): JoinClause;
-        andOnNotExists(callback: () => void): JoinClause;
-        orOnNotExists(callback: () => void): JoinClause;
+        onExists(callback: QueryCallback): JoinClause;
+        andOnExists(callback: QueryCallback): JoinClause;
+        orOnExists(callback: QueryCallback): JoinClause;
+        onNotExists(callback: QueryCallback): JoinClause;
+        andOnNotExists(callback: QueryCallback): JoinClause;
+        orOnNotExists(callback: QueryCallback): JoinClause;
         onBetween(column1: string, range: [any, any]): JoinClause;
         andOnBetween(column1: string, range: [any, any]): JoinClause;
         orOnBetween(column1: string, range: [any, any]): JoinClause;
@@ -260,7 +260,7 @@ declare namespace Knex {
 
     interface Where extends WhereRaw, WhereWrapped, WhereNull {
         (raw: Raw): QueryBuilder;
-        (callback: (queryBuilder: QueryBuilder) => any): QueryBuilder;
+        (callback: QueryCallback): QueryBuilder;
         (object: Object): QueryBuilder;
         (columnName: string, value: Value): QueryBuilder;
         (columnName: string, operator: string, value: Value): QueryBuilder;
@@ -272,7 +272,7 @@ declare namespace Knex {
     }
 
     interface WhereWrapped {
-        (callback: Function): QueryBuilder;
+        (callback: QueryCallback): QueryBuilder;
     }
 
     interface WhereNull {
@@ -281,7 +281,7 @@ declare namespace Knex {
 
     interface WhereIn {
         (columnName: string, values: Value[]): QueryBuilder;
-        (columnName: string, callback: Function): QueryBuilder;
+        (columnName: string, callback: QueryCallback): QueryBuilder;
         (columnName: string, query: QueryBuilder): QueryBuilder;
     }
 
@@ -290,7 +290,7 @@ declare namespace Knex {
     }
 
     interface WhereExists {
-        (callback: Function): QueryBuilder;
+        (callback: QueryCallback): QueryBuilder;
         (query: QueryBuilder): QueryBuilder;
     }
 
@@ -310,10 +310,10 @@ declare namespace Knex {
     }
 
     interface Union {
-        (callback: Function, wrap?: boolean): QueryBuilder;
-        (callbacks: Function[], wrap?: boolean): QueryBuilder;
-        (...callbacks: Function[]): QueryBuilder;
-        // (...callbacks: Function[], wrap?: boolean): QueryInterface;
+        (callback: QueryCallback, wrap?: boolean): QueryBuilder;
+        (callbacks: QueryCallback[], wrap?: boolean): QueryBuilder;
+        (...callbacks: QueryCallback[]): QueryBuilder;
+        // (...callbacks: QueryCallback[], wrap?: boolean): QueryInterface;
     }
 
     interface Having extends RawQueryBuilder, WhereWrapped {
@@ -350,6 +350,7 @@ declare namespace Knex {
     // QueryBuilder
     //
 
+    type QueryCallback = (this: QueryBuilder, builder: QueryBuilder) => void;
     interface QueryBuilder extends QueryInterface, ChainableInterface {
         or: QueryBuilder;
         and: QueryBuilder;

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -904,6 +904,72 @@ knex.select('*')
   knex.select('*').from('users').where(knex.raw('id = ?', [1])).toSQL();
 
 //
+// Callback functions
+//
+knex('users')
+  .select('*')
+  .join('contacts', function(builder) {
+    this.on(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    }).andOn(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    }).orOn(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    }).onExists(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    }).orOnExists(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    }).andOnExists(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    }).onNotExists(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    }).andOnNotExists(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    }).orOnNotExists(function(builder) {
+      let self: Knex.QueryBuilder = this;
+      self = builder;
+    });
+  }).where(function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).orWhere(function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).andWhere(function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).whereIn('column', function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).orWhereIn('column', function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).whereNotIn('column', function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).orWhereNotIn('column', function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).whereWrapped(function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).union(function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  }).unionAll(function(builder) {
+    let self: Knex.QueryBuilder = this;
+    self = builder;
+  });
+
+//
 // Migrations
 //
 var config = {


### PR DESCRIPTION
In pretty much all the examples, the value of `this` is a `QueryBuilder` interface, so this just makes it so that gets applied in general, so that I don't have to explicitly in my own code say that this in fact is a `QueryBuilder`. Makes code completion work automatically.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: pretty much all of the documentation lol. But [this should be the relevant implementing code](https://github.com/tgriesser/knex/blob/50557f757121798cf2e1328afe085e80b6cdb4d1/src/formatter.js#L126).
- **N/A**: Increase the version number in the header if appropriate.
- **Nah.** If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
