### PR TITLE
Fix trial_end type to allow special value 'now' 

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1330,7 +1330,7 @@ declare namespace Stripe {
              * override the default trial period of the plan the customer is being subscribed to. The special value now can be provided to
              * end the customer's trial immediately. Only applies when the plan parameter is also provided.
              */
-            trial_end?: number | string;
+            trial_end?: number | "now";
         }
 
         interface ICustomerUpdateOptions extends IDataOptionsWithMetadata {
@@ -4370,7 +4370,7 @@ declare namespace Stripe {
              * will override the default trial period of the plan the customer is being subscribed to. The special value now can be provided to end the
              * customer's trial immediately.
              */
-            trial_end?: number | string;
+            trial_end?: number | "now";
 
             /**
              * List of subscription items, each with an attached plan.
@@ -4446,7 +4446,7 @@ declare namespace Stripe {
              * will override the default trial period of the plan the customer is being subscribed to. The special value now can be provided to end the
              * customer's trial immediately.
              */
-            trial_end?: number | string;
+            trial_end?: number | "now";
 
             /**
              * Either "charge_automatically", or "send_invoice". When charging automatically, Stripe will attempt to pay this subscription at the end of the 

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1330,7 +1330,7 @@ declare namespace Stripe {
              * override the default trial period of the plan the customer is being subscribed to. The special value now can be provided to
              * end the customer's trial immediately. Only applies when the plan parameter is also provided.
              */
-            trial_end?: number;
+            trial_end?: number | string;
         }
 
         interface ICustomerUpdateOptions extends IDataOptionsWithMetadata {
@@ -4370,7 +4370,7 @@ declare namespace Stripe {
              * will override the default trial period of the plan the customer is being subscribed to. The special value now can be provided to end the
              * customer's trial immediately.
              */
-            trial_end?: number;
+            trial_end?: number | string;
 
             /**
              * List of subscription items, each with an attached plan.
@@ -4446,7 +4446,7 @@ declare namespace Stripe {
              * will override the default trial period of the plan the customer is being subscribed to. The special value now can be provided to end the
              * customer's trial immediately.
              */
-            trial_end?: number;
+            trial_end?: number | string;
 
             /**
              * Either "charge_automatically", or "send_invoice". When charging automatically, Stripe will attempt to pay this subscription at the end of the 

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -252,8 +252,12 @@ stripe.customers.create({
     customer.cards.del("card_17xMvXBoqMA9o2xkq6W5gamx").then(function (confirmation) {});
 
     customer.subscriptions.create({ plan: "gold" }).then(function (subscription) { });
+    customer.subscriptions.create({ plan: "gold", trial_end: "now" }).then(function (subscription) { });
+    customer.subscriptions.create({ plan: "gold", trial_end: 1516881177 }).then(function (subscription) { });
     customer.subscriptions.retrieve("sub_8Eluur5KoIKxuy").then(function (subscription) { });
     customer.subscriptions.update("sub_8Eluur5KoIKxuy", { plan: "silver" }).then(function (subscription) { });
+    customer.subscriptions.update("sub_8Eluur5KoIKxuy", { trial_end: "now" });
+    customer.subscriptions.update("sub_8Eluur5KoIKxuy", { trial_end: 1516881177 });
     customer.subscriptions.list().then(function (subscriptions) { });
     customer.subscriptions.del("sub_8Eluur5KoIKxuy").then(function (subscription) { });
     customer.subscriptions.deleteDiscount("sub_8Eluur5KoIKxuy").then(function (confirmation) { });
@@ -294,6 +298,22 @@ stripe.customers.create({
     source: "tok_15V2YhEe31JkLCeQy9iUgsJX" // obtained with Stripe.js
 }, { stripe_account: "" }).then(function (customer) {
 
+});
+
+// {"now"} for trial_end
+stripe.customers.create({
+    description: "Customer for test@example.com",
+    source: "tok_15V2YhEe31JkLCeQy9iUgsJX", // obtained with Stripe.js
+    plan: "platypi-dev",
+    trial_end: "now"
+});
+
+// {number} for trial_end
+stripe.customers.create({
+    description: "Customer for test@example.com",
+    source: "tok_15V2YhEe31JkLCeQy9iUgsJX", // obtained with Stripe.js
+    plan: "platypi-dev",
+    trial_end: 1516881177
 });
 
 stripe.customers.retrieve(


### PR DESCRIPTION
https://stripe.com/docs/api/node

The api allows the special value of 'now' to be passed for trial_end.