### PR TITLE
[bluebird] chore: reduce some boilerplate on catch filters

### DIFF
--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -192,34 +192,34 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    */
   tapCatch<U>(onReject: (error?: any) => U | PromiseLike<U>): Bluebird<R>;
 
-  tapCatch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error, E5 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | object,
-    filter5: (new (...args: any[]) => E5) | ((error: any) => boolean) | object,
+  tapCatch<U, E1, E2, E3, E4, E5>(
+    filter1: CatchFilter<E1>,
+    filter2: CatchFilter<E2>,
+    filter3: CatchFilter<E3>,
+    filter4: CatchFilter<E4>,
+    filter5: CatchFilter<E5>,
     onReject: (error: E1 | E2 | E3 | E4 | E5) => U | PromiseLike<U>,
   ): Bluebird<R>;
-  tapCatch<U, E1 extends Error, E2 extends Error, E3 extends Error, E4 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | object,
-    filter4: (new (...args: any[]) => E4) | ((error: any) => boolean) | object,
+  tapCatch<U, E1, E2, E3, E4>(
+    filter1: CatchFilter<E1>,
+    filter2: CatchFilter<E2>,
+    filter3: CatchFilter<E3>,
+    filter4: CatchFilter<E4>,
     onReject: (error: E1 | E2 | E3 | E4) => U | PromiseLike<U>,
   ): Bluebird<R>;
-  tapCatch<U, E1 extends Error, E2 extends Error, E3 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => E3) | ((error: any) => boolean) | object,
+  tapCatch<U, E1, E2, E3>(
+    filter1: CatchFilter<E1>,
+    filter2: CatchFilter<E2>,
+    filter3: CatchFilter<E3>,
     onReject: (error: E1 | E2 | E3) => U | PromiseLike<U>,
   ): Bluebird<R>;
-  tapCatch<U, E1 extends Error, E2 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => E2) | ((error: any) => boolean) | object,
+  tapCatch<U, E1, E2>(
+    filter1: CatchFilter<E1>,
+    filter2: CatchFilter<E2>,
     onReject: (error: E1 | E2) => U | PromiseLike<U>,
   ): Bluebird<R>;
-  tapCatch<U, E1 extends Error>(
-    filter1: (new (...args: any[]) => E1) | ((error: any) => boolean) | object,
+  tapCatch<U, E1>(
+    filter1: CatchFilter<E1>,
     onReject: (error: E1) => U | PromiseLike<U>,
   ): Bluebird<R>;
 
@@ -364,34 +364,35 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    */
   catchReturn<U>(value: U): Bluebird<R | U>;
 
+  // No need to be specific about Error types in these overrides, since there's no handler function
   catchReturn<U>(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter4: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter5: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
+    filter2: CatchFilter<Error>,
+    filter3: CatchFilter<Error>,
+    filter4: CatchFilter<Error>,
+    filter5: CatchFilter<Error>,
     value: U,
   ): Bluebird<R | U>;
   catchReturn<U>(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter4: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
+    filter2: CatchFilter<Error>,
+    filter3: CatchFilter<Error>,
+    filter4: CatchFilter<Error>,
     value: U,
   ): Bluebird<R | U>;
   catchReturn<U>(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
+    filter2: CatchFilter<Error>,
+    filter3: CatchFilter<Error>,
     value: U,
   ): Bluebird<R | U>;
   catchReturn<U>(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
+    filter2: CatchFilter<Error>,
     value: U,
   ): Bluebird<R | U>;
   catchReturn<U>(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
     value: U,
   ): Bluebird<R | U>;
 
@@ -407,34 +408,35 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    */
   catchThrow(reason: Error): Bluebird<R>;
 
+  // No need to be specific about Error types in these overrides, since there's no handler function
   catchThrow(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter4: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter5: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
+    filter2: CatchFilter<Error>,
+    filter3: CatchFilter<Error>,
+    filter4: CatchFilter<Error>,
+    filter5: CatchFilter<Error>,
     reason: Error,
   ): Bluebird<R>;
   catchThrow(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter4: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
+    filter2: CatchFilter<Error>,
+    filter3: CatchFilter<Error>,
+    filter4: CatchFilter<Error>,
     reason: Error,
   ): Bluebird<R>;
   catchThrow(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter3: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
+    filter2: CatchFilter<Error>,
+    filter3: CatchFilter<Error>,
     reason: Error,
   ): Bluebird<R>;
   catchThrow(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
-    filter2: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
+    filter2: CatchFilter<Error>,
     reason: Error,
   ): Bluebird<R>;
   catchThrow(
-    filter1: (new (...args: any[]) => Error) | ((error: any) => boolean) | object,
+    filter1: CatchFilter<Error>,
     reason: Error,
   ): Bluebird<R>;
 

--- a/types/bluebird/index.d.ts
+++ b/types/bluebird/index.d.ts
@@ -47,7 +47,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   /**
    * Promises/A+ `.then()`. Returns a new promise chained from this promise.
    *
-   * The new promise will be rejected or resolved dedefer on the passed `fulfilledHandler`, `rejectedHandler` and the state of this promise.
+   * The new promise will be rejected or resolved depending on the passed `fulfilledHandler`, `rejectedHandler` and the state of this promise.
    */
   // Based on PromiseLike.then, but returns a Bluebird instance.
   then<U>(onFulfill?: (value: R) => U | PromiseLike<U>, onReject?: (error: any) => U | PromiseLike<U>): Bluebird<U>; // For simpler signature help.
@@ -761,7 +761,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
   static race<R>(values: PromiseLike<Iterable<PromiseLike<R> | R>> | Iterable<PromiseLike<R> | R>): Bluebird<R>;
 
   /**
-   * Initiate a competetive race between multiple promises or values (values will become immediately fulfilled promises).
+   * Initiate a competitive race between multiple promises or values (values will become immediately fulfilled promises).
    * When `count` amount of promises have been fulfilled, the returned promise is fulfilled with an array that contains the fulfillment values of the winners in order of resolution.
    *
    * If too many promises are rejected so that the promise can never become fulfilled, it will be immediately rejected with an array of rejection reasons in the order they were thrown in.
@@ -835,7 +835,7 @@ declare class Bluebird<R> implements PromiseLike<R>, Bluebird.Inspection<R> {
    *
    * If the reducer function returns a promise or a thenable, the result for the promise is awaited for before continuing with next iteration.
    *
-   * *The original array is not modified. If no `intialValue` is given and the array doesn't contain at least 2 items, the callback will not be called and `undefined` is returned.
+   * *The original array is not modified. If no `initialValue` is given and the array doesn't contain at least 2 items, the callback will not be called and `undefined` is returned.
    * If `initialValue` is given and the array doesn't have at least 1 item, `initialValue` is returned.*
    */
   static reduce<R, U>(
@@ -1053,7 +1053,7 @@ declare namespace Bluebird {
      * Gives you a callback representation of the `PromiseResolver`. Note that this is not a method but a property.
      * The callback accepts error object in first argument and success values on the 2nd parameter and the rest, I.E. node js conventions.
      *
-     * If the the callback is called with multiple success values, the resolver fullfills its promise with an array of the values.
+     * If the the callback is called with multiple success values, the resolver fulfills its promise with an array of the values.
      */
     // TODO specify resolver callback
     callback(err: any, value: R, ...values: R[]): void;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

A bit of a follow-up to #22167, which added a CatchFilter type helper, this applies that helper to the other variants of `.catch`: `.catchThrow`, `.catchReturn`, and `.tapCatch`.  Mostly this just removes boilerplate in the typings, and ensures consistent behavior between the various catch methods.

---

Also, fixed the handful of spelling errors my spell-check plugin caught.