### PR TITLE
Update index.d.ts for Kendo-UI GridColumn definition

### DIFF
--- a/types/kendo-ui/index.d.ts
+++ b/types/kendo-ui/index.d.ts
@@ -3810,7 +3810,7 @@ declare namespace kendo.ui {
         aggregates?: any;
         attributes?: any;
         columns?: any;
-        command?: GridColumnCommandItem[];
+        command?: string|(string|GridColumnCommandItem)[];
         editable?: Function;
         encoded?: boolean;
         field?: string;


### PR DESCRIPTION
Since the command property of a GridColumn can be an array of strings or string, for example:

{ command: ["edit", "destroy"], title: "kendo", width: "250px" }
{ command: "destroy", title: "kendo", width: "250px" }

The current definition is
command?: GridColumnCommandItem[];

but it should be
string|(string|GridColumnCommandItem)[];

Following documentation at https://docs.telerik.com/kendo-ui/api/jsp/grid/column-commanditem
