### PR TITLE
Knex.join: table can be a subquery

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -183,12 +183,12 @@ declare namespace Knex {
 
     interface Join {
         (raw: Raw): QueryBuilder;
-        (tableName: TableName, clause: (this: JoinClause, join: JoinClause) => void): QueryBuilder;
-        (tableName: TableName, columns: { [key: string]: string | number | Raw }): QueryBuilder;
-        (tableName: TableName, raw: Raw): QueryBuilder;
-        (tableName: TableName, column1: string, column2: string): QueryBuilder;
-        (tableName: TableName, column1: string, raw: Raw): QueryBuilder;
-        (tableName: TableName, column1: string, operator: string, column2: string): QueryBuilder;
+        (tableName: TableName | QueryCallback, clause: (this: JoinClause, join: JoinClause) => void): QueryBuilder;
+        (tableName: TableName | QueryCallback, columns: { [key: string]: string | number | Raw }): QueryBuilder;
+        (tableName: TableName | QueryCallback, raw: Raw): QueryBuilder;
+        (tableName: TableName | QueryCallback, column1: string, column2: string): QueryBuilder;
+        (tableName: TableName | QueryCallback, column1: string, raw: Raw): QueryBuilder;
+        (tableName: TableName | QueryCallback, column1: string, operator: string, column2: string): QueryBuilder;
     }
 
     interface JoinClause {

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -459,6 +459,44 @@ knex.select('*').from('accounts').joinRaw('natural full join table1').where('id'
 
 knex.select('*').from('accounts').join(knex.raw('natural full join table1')).where('id', 1);
 
+knex.select('*').from('accounts')
+  .join(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+knex.select('*').from('accounts')
+  .leftJoin(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+knex.select('*').from('accounts')
+  .leftOuterJoin(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+knex.select('*').from('accounts')
+  .rightJoin(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+knex.select('*').from('accounts')
+  .rightOuterJoin(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+knex.select('*').from('accounts')
+  .innerJoin(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+knex.select('*').from('accounts')
+  .crossJoin(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+knex.select('*').from('accounts')
+  .fullOuterJoin(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+knex.select('*').from('accounts')
+  .outerJoin(function() {
+    this.select('*').from('accounts').as('special_accounts');
+  }, 'special_accounts.a', '=', 'accounts.b');
+
+
 knex('customers')
   .distinct('first_name', 'last_name')
   .select();


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

---

- [X] Provide a URL to documentation or source code which provides context for the suggested changes

The documentation is very unclear about this. https://github.com/knex/knex/issues/5838

Still figuring out where to find where the code does this. A start:

* The definition of `join`: https://github.com/tgriesser/knex/blob/master/src/query/builder.js#L151
 
Here's a usage example:

```
> knex.select('*').from('users').join(function() { this.select('*').from('accounts') }, 'a', '=', 'b').toSQL().sql
'select * from `users` inner join (select * from `accounts`) on `a` = `b`'
```

- N/A Increase the version number in the header if appropriate.
- N/A If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
