### PR TITLE
update dom4 types for v2.0

### DIFF
--- a/types/dom4/dom4-tests.ts
+++ b/types/dom4/dom4-tests.ts
@@ -1,7 +1,7 @@
 function testDocument() {
-    document.query(".container-a").classList;
-    document.queryAll(".container-b")[0].className;
-    document.queryAll(".container-c").childElementCount;
+    document.querySelector(".container-a").classList;
+    document.querySelectorAll(".container-b")[0].className;
+    document.querySelector(".container-c").append("foo", document.createElement("button"));
 }
 
 function testElement(el: Element) {

--- a/types/dom4/index.d.ts
+++ b/types/dom4/index.d.ts
@@ -40,7 +40,7 @@ interface ChildNode {
     /**
      * Replaces this node with `nodes`, while replacing strings in nodes with equivalent Text nodes.
      */
-    replaceWith(...node: Array<Node | string>): void;
+    replaceWith(...nodes: Array<Node | string>): void;
 
     /**
      * Removes this node.

--- a/types/dom4/index.d.ts
+++ b/types/dom4/index.d.ts
@@ -1,8 +1,11 @@
-// Type definitions for dom4 v1.5
+// Type definitions for dom4 v2.0
 // Project: https://github.com/WebReflection/dom4
 // Definitions by: Adi Dahiya <https://github.com/adidahiya>, Gilad Gray <https://github.com/giladgray>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
+/**
+ * https://dom.spec.whatwg.org/#parentnode
+ */
 interface ParentNode {
     /**
      * Returns the child elements.
@@ -10,21 +13,46 @@ interface ParentNode {
     readonly children: HTMLCollection;
 
     /**
-     * Returns the first element that is a descendant of node that matches relativeSelectors.
+     * Inserts `nodes` after the last child of this node, while replacing strings with equivalent `Text` nodes.
      */
-    query(relativeSelectors: string): Element;
+    append(...nodes: Array<Node | string>): void;
 
     /**
-     * Returns all element descendants of node that match relativeSelectors.
+     * Inserts `nodes` before the first child of this node, while replacing strings with equivalent `Text` nodes.
      */
-    queryAll(relativeSelectors: string): Elements;
+    prepend(...nodes: Array<Node | string>): void;
+}
+
+/**
+ * https://dom.spec.whatwg.org/#childnode
+ */
+interface ChildNode {
+    /**
+     * Inserts `nodes` just after this node, while replacing strings with equivalent `Text` nodes.
+     */
+    after(...nodes: Array<Node | string>): void;
+
+    /**
+     * Inserts `nodes` just before this node, while replacing strings with equivalent `Text` nodes.
+     */
+    before(...nodes: Array<Node | string>): void;
+
+    /**
+     * Replaces this node with `nodes`, while replacing strings in nodes with equivalent Text nodes.
+     */
+    replaceWith(...node: Array<Node | string>): void;
+
+    /**
+     * Removes this node.
+     */
+    remove(): void;
 }
 
 interface Element extends ParentNode {
     /**
      * Returns the first (starting at element) inclusive ancestor that matches selectors, and null otherwise.
      */
-    closest(selectors: string): Element;
+    closest(selectors: string): Element | null;
 
     /**
      * Returns true if matching selectors against element’s root yields element, and false otherwise.


### PR DESCRIPTION
per https://github.com/WebReflection/dom4#new-v2: 
> ### New v2
>
> Both `query` and `queryAll` have been removed, while CSS `:scope` selector has been added.

I also added all the other polyfilled methods that were missing from the declaration files. 
Fixes #17664.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/WebReflection/dom4#new-v2
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

cc @adidahiya @WebReflection