### PR TITLE
Add types for @material group at tag v0.26.0

### DIFF
--- a/types/material-components-web/index.d.ts
+++ b/types/material-components-web/index.d.ts
@@ -1,0 +1,64 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import autoInit from 'material__auto-init';
+import * as base from 'material__base';
+import * as checkbox from 'material__checkbox';
+import * as dialog from 'material__dialog';
+import * as drawer from 'material__drawer';
+import * as formField from 'material__form-field';
+import * as gridList from 'material__grid-list';
+import * as iconToggle from 'material__icon-toggle';
+import * as linearProgress from 'material__linear-progress';
+import * as menu from 'material__menu';
+import * as radio from 'material__radio';
+import * as ripple from 'material__ripple';
+import * as select from 'material__select';
+import * as selectionControl from 'material__selection-control';
+import * as slider from 'material__slider';
+import * as snackbar from 'material__snackbar';
+import * as tabs from 'material__tabs';
+import * as textField from 'material__textfield';
+import * as toolbar from 'material__toolbar';
+
+// Export all components.
+export {
+    autoInit,
+    base,
+    checkbox,
+    dialog,
+    drawer,
+    formField,
+    gridList,
+    iconToggle,
+    linearProgress,
+    menu,
+    radio,
+    ripple,
+    select,
+    selectionControl,
+    slider,
+    snackbar,
+    tabs,
+    textField,
+    toolbar,
+};

--- a/types/material-components-web/tsconfig.json
+++ b/types/material-components-web/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "files": [
+        "index.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material-components-web/tslint.json
+++ b/types/material-components-web/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__animation/index.d.ts
+++ b/types/material__animation/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const transformStyleProperties: string[];
+
+export function getCorrectEventName(windowObj: Window, eventType: string): string;
+
+export function getCorrectPropertyName(windowObj: Window, eventType: string): string;

--- a/types/material__animation/tsconfig.json
+++ b/types/material__animation/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "files": [
+        "index.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__animation/tslint.json
+++ b/types/material__animation/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__auto-init/index.d.ts
+++ b/types/material__auto-init/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type MDCLogger = (message?: any, ...optionalParams: any[]) => void;
+
+export interface MDCAutoInit {
+    (root?: Document, warn?: MDCLogger): MDCAutoInit;
+    register(componentName: string, Ctor: (...args: any[]) => any, warn?: MDCLogger): void;
+    deregister(componentName: string): void;
+    deregisterAll(): void;
+}
+
+/**
+ * Auto-initializes all mdc components on a page.
+ */
+declare const mdcAutoInit: MDCAutoInit;
+
+export default mdcAutoInit;

--- a/types/material__auto-init/tsconfig.json
+++ b/types/material__auto-init/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "files": [
+        "index.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__auto-init/tslint.json
+++ b/types/material__auto-init/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__base/component.d.ts
+++ b/types/material__base/component.d.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from './foundation';
+
+export class MDCComponent<A, F extends MDCFoundation<A>> {
+    static attachTo(root: Element): MDCComponent<any, MDCFoundation<any>>;
+
+    constructor(root: Element, foundation?: F, ...args: any[]);
+
+    // Subclasses can override this to do any additional setup work that would be considered part of a
+    // "constructor". Essentially, it is a hook into the parent constructor before the foundation is
+    // initialized. Any additional arguments besides root and foundation will be passed in here.
+    initialize(...args: any[]): void;
+
+    // Subclasses must override this method to return a properly configured foundation class for the
+    // component.
+    getDefaultFoundation(): F;
+
+    // Subclasses should override this method if they need to perform work to synchronize with a host DOM
+    // object. An example of this would be a form control wrapper that needs to synchronize its internal state
+    // to some property or attribute of the host DOM. Please note: this is *not* the place to perform DOM
+    // reads/writes that would cause layout / paint, as this is called synchronously from within the constructor.
+    initialSyncWithDOM(): void;
+
+    // Subclasses may implement this method to release any resources / deregister any listeners they have
+    // attached. An example of this might be deregistering a resize event from the window object.
+    destroy(): void;
+
+    /**
+     * Wrapper method to add an event listener to the component's root element. This is most useful when
+     * listening for custom events.
+     */
+    listen(evtType: string, handler: EventListenerOrEventListenerObject): void;
+
+    /**
+     * Wrapper method to remove an event listener to the component's root element. This is most useful when
+     * unlistening for custom events.
+     */
+    unlisten(evtType: string, handler: EventListenerOrEventListenerObject): void;
+
+    /**
+     * Fires a cross-browser-compatible custom event from the component root of the given type,
+     * with the given data.
+     */
+    emit(evtType: string, evtData: any, shouldBubble?: boolean): void;
+}
+
+export default MDCComponent;

--- a/types/material__base/foundation.d.ts
+++ b/types/material__base/foundation.d.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCStrings {
+    [key: string]: string;
+}
+
+export interface MDCNumbers {
+    [key: string]: number;
+}
+
+export class MDCFoundation<A> {
+    static readonly cssClasses: MDCStrings;
+
+    static readonly strings: MDCStrings;
+
+    static readonly numbers: MDCNumbers;
+
+    static readonly defaultAdapter: any;
+
+    constructor(adapter: A);
+
+    // Subclasses should override this method to perform initialization routines (registering events, etc.)
+    init(): void;
+
+    // Subclasses should override this method to perform de-initialization routines (de-registering events, etc.)
+    destroy(): void;
+}
+
+export default MDCFoundation;

--- a/types/material__base/index.d.ts
+++ b/types/material__base/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCNumbers, MDCStrings, MDCFoundation } from './foundation';
+import MDCComponent from './component';
+
+export {MDCNumbers, MDCStrings, MDCFoundation, MDCComponent};

--- a/types/material__base/tsconfig.json
+++ b/types/material__base/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "files": [
+        "component.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__base/tslint.json
+++ b/types/material__base/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__checkbox/adapter.d.ts
+++ b/types/material__checkbox/adapter.d.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCSelectionControlState } from 'material__selection-control';
+
+/**
+ * Adapter for MDC Checkbox. Provides an interface for managing
+ * - classes
+ * - dom
+ * - event handlers
+ *
+ * Additionally, provides type information for the adapter to the Closure
+ * compiler.
+ *
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/architecture.md
+ */
+export class MDCCheckboxAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    registerAnimationEndHandler(handler: EventListener): void;
+
+    deregisterAnimationEndHandler(handler: EventListener): void;
+
+    registerChangeHandler(handler: EventListener): void;
+
+    deregisterChangeHandler(handler: EventListener): void;
+
+    getNativeControl(): MDCSelectionControlState;
+
+    forceLayout(): void;
+
+    isAttachedToDOM(): boolean;
+}
+
+export default MDCCheckboxAdapter;

--- a/types/material__checkbox/constants.d.ts
+++ b/types/material__checkbox/constants.d.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ import { MDCStrings, MDCNumbers } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    UPGRADED: 'mdc-checkbox--upgraded';
+    CHECKED: 'mdc-checkbox--checked';
+    INDETERMINATE: 'mdc-checkbox--indeterminate';
+    DISABLED: 'mdc-checkbox--disabled';
+    ANIM_UNCHECKED_CHECKED: 'mdc-checkbox--anim-unchecked-checked';
+    ANIM_UNCHECKED_INDETERMINATE: 'mdc-checkbox--anim-unchecked-indeterminate';
+    ANIM_CHECKED_UNCHECKED: 'mdc-checkbox--anim-checked-unchecked';
+    ANIM_CHECKED_INDETERMINATE: 'mdc-checkbox--anim-checked-indeterminate';
+    ANIM_INDETERMINATE_CHECKED: 'mdc-checkbox--anim-indeterminate-checked';
+    ANIM_INDETERMINATE_UNCHECKED: 'mdc-checkbox--anim-indeterminate-unchecked';
+}
+
+export interface strings extends MDCStrings {
+    NATIVE_CONTROL_SELECTOR: '.mdc-checkbox__native-control';
+    TRANSITION_STATE_INIT: 'init';
+    TRANSITION_STATE_CHECKED: 'checked';
+    TRANSITION_STATE_UNCHECKED: 'unchecked';
+    TRANSITION_STATE_INDETERMINATE: 'indeterminate';
+}
+
+export interface numbers extends MDCNumbers {
+    ANIM_END_LATCH_MS: 100;
+}

--- a/types/material__checkbox/foundation.d.ts
+++ b/types/material__checkbox/foundation.d.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import MDCCheckboxAdapter from './adapter';
+import { cssClasses, strings, numbers } from './constants';
+
+export class MDCCheckboxFoundation extends MDCFoundation<MDCCheckboxAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly numbers: numbers;
+
+    static readonly defaultAdapter: MDCCheckboxAdapter;
+
+    isChecked(): boolean;
+
+    setChecked(checked: boolean): boolean;
+
+    isIndeterminate(): boolean;
+
+    setIndeterminate(indeterminate: boolean): void;
+
+    isDisabled(): boolean;
+
+    setDisabled(disabled: boolean): void;
+
+    getValue(): string;
+
+    setValue(value: string): void;
+}
+
+export default MDCCheckboxFoundation;

--- a/types/material__checkbox/index.d.ts
+++ b/types/material__checkbox/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+import MDCCheckboxAdapter from './adapter';
+import { MDCSelectionControl } from 'material__selection-control';
+import MDCCheckboxFoundation from './foundation';
+import { MDCRipple } from 'material__ripple';
+
+export {MDCCheckboxAdapter, MDCCheckboxFoundation};
+
+export class MDCCheckbox extends MDCComponent<MDCCheckboxAdapter, MDCCheckboxFoundation> implements MDCSelectionControl {
+    static attachTo(root: Element): MDCCheckbox;
+
+    getDefaultFoundation(): MDCCheckboxFoundation;
+
+    readonly ripple: MDCRipple;
+
+    checked: boolean;
+
+    indeterminate: boolean;
+
+    disabled: boolean;
+
+    value: string;
+
+    destroy(): void;
+}

--- a/types/material__checkbox/tsconfig.json
+++ b/types/material__checkbox/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__checkbox/tslint.json
+++ b/types/material__checkbox/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__dialog/adapter.d.ts
+++ b/types/material__dialog/adapter.d.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MSDDialogAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    addBodyClass(className: string): void;
+
+    removeBodyClass(className: string): void;
+
+    eventTargetHasClass(target: EventTarget, className: string): boolean;
+
+    registerInteractionHandler(evt: string, handler: EventListener): void;
+
+    deregisterInteractionHandler(evt: string, handler: EventListener): void;
+
+    registerSurfaceInteractionHandler(evt: string, handler: EventListener): void;
+
+    deregisterSurfaceInteractionHandler(evt: string, handler: EventListener): void;
+
+    registerDocumentKeydownHandler(handler: EventListener): void;
+
+    deregisterDocumentKeydownHandler(handler: EventListener): void;
+
+    registerTransitionEndHandler(handler: EventListener): void;
+
+    deregisterTransitionEndHandler(handler: EventListener): void;
+
+    notifyAccept(): void;
+
+    notifyCancel(): void;
+
+    trapFocusOnSurface(): void;
+
+    untrapFocusOnSurface(): void;
+
+    isDialog(el: Element): boolean;
+
+    layoutFooterRipples(): void;
+}

--- a/types/material__dialog/constants.d.ts
+++ b/types/material__dialog/constants.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-dialog';
+    OPEN: 'mdc-dialog--open';
+    ANIMATING: 'mdc-dialog--animating';
+    BACKDROP: 'mdc-dialog__backdrop';
+    SCROLL_LOCK: 'mdc-dialog-scroll-lock';
+    ACCEPT_BTN: 'mdc-dialog__footer__button--accept';
+    CANCEL_BTN: 'mdc-dialog__footer__button--cancel';
+}
+
+export interface strings extends MDCStrings {
+    OPEN_DIALOG_SELECTOR: '.mdc-dialog--open';
+    DIALOG_SURFACE_SELECTOR: '.mdc-dialog__surface';
+    ACCEPT_SELECTOR: '.mdc-dialog__footer__button--accept';
+    ACCEPT_EVENT: 'MDCDialog:accept';
+    CANCEL_EVENT: 'MDCDialog:cancel';
+}

--- a/types/material__dialog/foundation.d.ts
+++ b/types/material__dialog/foundation.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCFoundation } from 'material__base';
+import { cssClasses, strings } from './constants';
+import { MSDDialogAdapter } from './adapter';
+
+export class MDCDialogFoundation extends MDCFoundation<MSDDialogAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MSDDialogAdapter;
+
+    open(): void;
+
+    close(): void;
+
+    isOpen(): boolean;
+
+    accept(shouldNotify: boolean): void;
+
+    cancel(shouldNotify: boolean): void;
+}
+
+export default MDCDialogFoundation;

--- a/types/material__dialog/index.d.ts
+++ b/types/material__dialog/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCComponent } from 'material__base';
+import { MDCRipple } from 'material__ripple';
+
+import MDCDialogFoundation from './foundation';
+import { MSDDialogAdapter } from './adapter';
+import * as util from './util';
+
+export {MSDDialogAdapter, MDCDialogFoundation, util};
+
+export class MDCDialog extends MDCComponent<MSDDialogAdapter, MDCDialogFoundation> {
+    static attachTo(root: Element): MDCDialog;
+
+    readonly open: boolean;
+
+    initialize(): void;
+
+    destroy(): void;
+
+    show(): void;
+
+    close(): void;
+
+    getDefaultFoundation(): MDCDialogFoundation;
+}

--- a/types/material__dialog/tsconfig.json
+++ b/types/material__dialog/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "util.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__dialog/tslint.json
+++ b/types/material__dialog/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__dialog/util.d.ts
+++ b/types/material__dialog/util.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type MDCFocusTrapFactory = (a: Element, b: {initialFocus: Element, clickOutsideDeactivates: boolean}) => any;
+
+export function createFocusTrapInstance(surfaceEl: Element, acceptButtonEl: Element, focusTrapFactory?: MDCFocusTrapFactory): any;

--- a/types/material__drawer/index.d.ts
+++ b/types/material__drawer/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as util from './util';
+export {MDCSlidableDrawerAdapter} from './slidable';
+export {MDCTemporaryDrawer, MDCTemporaryDrawerFoundation} from './temporary';
+export {MDCPersistentDrawer, MDCPersistentDrawerFoundation} from './persistent';
+export {util};

--- a/types/material__drawer/persistent/constants.d.ts
+++ b/types/material__drawer/persistent/constants.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-persistent-drawer';
+    OPEN: 'mdc-persistent-drawer--open';
+    ANIMATING: 'mdc-persistent-drawer--animating';
+}
+
+export interface strings extends MDCStrings {
+    DRAWER_SELECTOR: '.mdc-persistent-drawer__drawer';
+    FOCUSABLE_ELEMENTS: 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex], [contenteditable]';
+    OPEN_EVENT: 'MDCPersistentDrawer:open';
+    CLOSE_EVENT: 'MDCPersistentDrawer:close';
+}

--- a/types/material__drawer/persistent/foundation.d.ts
+++ b/types/material__drawer/persistent/foundation.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCSlidableDrawerAdapter, MDCSlidableDrawerFoundation } from '../slidable';
+import { cssClasses, strings } from './constants';
+
+export class MDCPersistentDrawerFoundation extends MDCSlidableDrawerFoundation {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCSlidableDrawerAdapter;
+}
+
+export default MDCPersistentDrawerFoundation;

--- a/types/material__drawer/persistent/index.d.ts
+++ b/types/material__drawer/persistent/index.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCComponent } from 'material__base';
+import { MDCPersistentDrawerFoundation } from './foundation';
+import { MDCSlidableDrawerAdapter } from '../slidable';
+import * as util from '../util';
+
+export {MDCSlidableDrawerAdapter, MDCPersistentDrawerFoundation, util};
+
+export class MDCPersistentDrawer extends MDCComponent<MDCSlidableDrawerAdapter, MDCPersistentDrawerFoundation> {
+    static attachTo(root: Element): MDCPersistentDrawer;
+
+    open: boolean;
+
+    // Return the drawer element inside the component.
+    readonly drawer: Element | null;
+
+    getDefaultFoundation(): MDCPersistentDrawerFoundation;
+}

--- a/types/material__drawer/slidable/adapter.d.ts
+++ b/types/material__drawer/slidable/adapter.d.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCSlidableDrawerAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    hasClass(className: string): void;
+
+    hasNecessaryDom(): boolean;
+
+    registerInteractionHandler(evt: string, handler: EventListener): void;
+
+    deregisterInteractionHandler(evt: string, handler: EventListener): void;
+
+    registerDrawerInteractionHandler(evt: string, handler: EventListener): void;
+
+    deregisterDrawerInteractionHandler(evt: string, handler: EventListener): void;
+
+    registerTransitionEndHandler(handler: EventListener): void;
+
+    deregisterTransitionEndHandler(handler: EventListener): void;
+
+    registerDocumentKeydownHandler(handler: EventListener): void;
+
+    deregisterDocumentKeydownHandler(handler: EventListener): void;
+
+    setTranslateX(value: number | null): void;
+
+    getFocusableElements(): NodeList;
+
+    saveElementTabState(el: Element): void;
+
+    restoreElementTabState(el: Element): void;
+
+    makeElementUntabbable(el: Element): void;
+
+    notifyOpen(): void;
+
+    notifyClose(): void;
+
+    isRtl(): boolean;
+
+    getDrawerWidth(): number;
+}

--- a/types/material__drawer/slidable/constants.d.ts
+++ b/types/material__drawer/slidable/constants.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const FOCUSABLE_ELEMENTS: string;

--- a/types/material__drawer/slidable/foundation.d.ts
+++ b/types/material__drawer/slidable/foundation.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCFoundation } from 'material__base';
+import { MDCSlidableDrawerAdapter } from './adapter';
+
+export class MDCSlidableDrawerFoundation extends MDCFoundation<MDCSlidableDrawerAdapter> {
+    static readonly defaultAdapter: MDCSlidableDrawerAdapter;
+
+    constructor(adapter: MDCSlidableDrawerAdapter, rootCssClass: string, animatingCssClass: string, openCssClass: string);
+
+    open(): void;
+
+    close(): void;
+
+    isOpen(): boolean;
+}

--- a/types/material__drawer/slidable/index.d.ts
+++ b/types/material__drawer/slidable/index.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {FOCUSABLE_ELEMENTS} from './constants';
+export {MDCSlidableDrawerFoundation} from './foundation';
+export {MDCSlidableDrawerAdapter} from './adapter';

--- a/types/material__drawer/temporary/constants.d.ts
+++ b/types/material__drawer/temporary/constants.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-temporary-drawer';
+    OPEN: 'mdc-temporary-drawer--open';
+    ANIMATING: 'mdc-temporary-drawer--animating';
+    SCROLL_LOCK: 'mdc-drawer-scroll-lock';
+}
+
+export interface strings extends MDCStrings {
+    DRAWER_SELECTOR: '.mdc-temporary-drawer__drawer';
+    OPACITY_VAR_NAME: '--mdc-temporary-drawer-opacity';
+    FOCUSABLE_ELEMENTS: 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex], [contenteditable]';
+    OPEN_EVENT: 'MDCTemporaryDrawer:open';
+    CLOSE_EVENT: 'MDCTemporaryDrawer:close';
+}

--- a/types/material__drawer/temporary/foundation.d.ts
+++ b/types/material__drawer/temporary/foundation.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCSlidableDrawerFoundation, MDCSlidableDrawerAdapter } from '../slidable';
+import { cssClasses, strings } from './constants';
+
+export class MDCTemporaryDrawerFoundation extends MDCSlidableDrawerFoundation {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCSlidableDrawerAdapter;
+
+    open(): void;
+
+    close(): void;
+}
+
+export default MDCTemporaryDrawerFoundation;

--- a/types/material__drawer/temporary/index.d.ts
+++ b/types/material__drawer/temporary/index.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCComponent } from 'material__base';
+import MDCTemporaryDrawerFoundation from './foundation';
+import { MDCSlidableDrawerAdapter } from '../slidable';
+import * as util from '../util';
+
+export {MDCSlidableDrawerAdapter, MDCTemporaryDrawerFoundation, util};
+
+export class MDCTemporaryDrawer extends MDCComponent<MDCSlidableDrawerAdapter, MDCTemporaryDrawerFoundation> {
+    static attachTo(root: Element): MDCTemporaryDrawer;
+
+    open: boolean;
+
+    /* Return the drawer element inside the component. */
+    readonly drawer: Element | null;
+
+    getDefaultFoundation(): MDCTemporaryDrawerFoundation;
+}

--- a/types/material__drawer/tsconfig.json
+++ b/types/material__drawer/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "files": [
+        "persistent/constants.d.ts",
+        "persistent/index.d.ts",
+        "persistent/foundation.d.ts",
+        "slidable/constants.d.ts",
+        "slidable/adapter.d.ts",
+        "slidable/index.d.ts",
+        "slidable/foundation.d.ts",
+        "temporary/constants.d.ts",
+        "temporary/index.d.ts",
+        "temporary/foundation.d.ts",
+        "util.d.ts",
+        "index.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__drawer/tslint.json
+++ b/types/material__drawer/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__drawer/util.d.ts
+++ b/types/material__drawer/util.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Remap touch events to pointer events, if the browser doesn't support touch events.
+export function remapEvent(eventName: string, globalObj?: Window): string;
+
+// Choose the correct transform property to use on the current browser.
+export function getTransformPropertyName(globalObj?: Window, forceRefresh?: boolean): string;
+
+// Determine whether the current browser supports CSS properties.
+export function supportsCssCustomProperties(globalObj?: Window): boolean;
+
+// Determine whether the current browser supports passive event listeners, and if so, use them.
+export function applyPassive(globalObj?: Window, forceRefresh?: boolean): boolean;
+
+// Save the tab state for an element.
+export function saveElementTabState(el: Element): void;
+
+// Restore the tab state for an element, if it was saved.
+export function restoreElementTabState(el: Element): void;

--- a/types/material__form-field/adapter.d.ts
+++ b/types/material__form-field/adapter.d.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adapter for MDC Form Field. Provides an interface for managing
+ * - event handlers
+ * - ripple activation
+ *
+ * Additionally, provides type information for the adapter to the Closure
+ * compiler.
+ *
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/architecture.md
+ *
+ * @record
+ */
+export class MDCFormFieldAdapter {
+    registerInteractionHandler(type: string, handler: EventListener): void;
+
+    deregisterInteractionHandler(type: string, handler: EventListener): void;
+
+    activateInputRipple(): void;
+
+    deactivateInputRipple(): void;
+}
+
+export default MDCFormFieldAdapter;

--- a/types/material__form-field/constants.d.ts
+++ b/types/material__form-field/constants.d.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-form-field';
+}
+
+export interface strings extends MDCStrings {
+    LABEL_SELECTOR: '.mdc-form-field > label';
+}

--- a/types/material__form-field/foundation.d.ts
+++ b/types/material__form-field/foundation.d.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import MDCFormFieldAdapter from './adapter';
+import { cssClasses, strings } from './constants';
+
+export class MDCFormFieldFoundation extends MDCFoundation<MDCFormFieldAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCFormFieldAdapter;
+}
+
+export default MDCFormFieldFoundation;

--- a/types/material__form-field/index.d.ts
+++ b/types/material__form-field/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+import MDCFormFieldFoundation from './foundation';
+import MDCFormFieldAdapter from './adapter';
+import { MDCSelectionControl } from 'material__selection-control';
+
+export {MDCFormFieldAdapter, MDCFormFieldFoundation};
+
+export class MDCFormField extends MDCComponent<MDCFormFieldAdapter, MDCFormFieldFoundation> {
+    static attachTo(root: Element): MDCFormField;
+
+    input: MDCSelectionControl;
+
+    getDefaultFoundation(): MDCFormFieldFoundation;
+}

--- a/types/material__form-field/tsconfig.json
+++ b/types/material__form-field/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__form-field/tslint.json
+++ b/types/material__form-field/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__grid-list/adapter.d.ts
+++ b/types/material__grid-list/adapter.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCGridListAdapter {
+    getOffsetWidth(): number;
+
+    getNumberOfTiles(): number;
+
+    getOffsetWidthForTileAtIndex(index: number): number;
+
+    setStyleForTilesElement(property: string, value: string): void;
+
+    registerResizeHandler(handler: EventListener): void;
+
+    deregisterResizeHandler(handler: EventListener): void;
+}

--- a/types/material__grid-list/constants.d.ts
+++ b/types/material__grid-list/constants.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface strings extends MDCStrings {
+    TILES_SELECTOR: '.mdc-grid-list__tiles';
+    TILE_SELECTOR: '.mdc-grid-tile';
+}

--- a/types/material__grid-list/foundation.d.ts
+++ b/types/material__grid-list/foundation.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCFoundation } from 'material__base';
+import { strings } from './constants';
+import { MDCGridListAdapter } from './adapter';
+
+export class MDCGridListFoundation extends MDCFoundation<MDCGridListAdapter> {
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCGridListAdapter;
+
+    alignCenter(): void;
+}
+
+export default MDCGridListFoundation;

--- a/types/material__grid-list/index.d.ts
+++ b/types/material__grid-list/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCComponent } from 'material__base';
+import { MDCGridListAdapter } from './adapter';
+import MDCGridListFoundation from './foundation';
+
+export {MDCGridListAdapter, MDCGridListFoundation};
+
+export class MDCGridList extends MDCComponent<MDCGridListAdapter, MDCGridListFoundation> {
+  static attachTo(root: Element): MDCGridList;
+
+  getDefaultFoundation(): MDCGridListFoundation;
+}

--- a/types/material__grid-list/tsconfig.json
+++ b/types/material__grid-list/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__grid-list/tslint.json
+++ b/types/material__grid-list/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__icon-toggle/adapter.d.ts
+++ b/types/material__icon-toggle/adapter.d.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adapter for MDC Icon Toggle. Provides an interface for managing
+ * - classes
+ * - dom
+ * - inner text
+ * - event handlers
+ * - event dispatch
+ *
+ * Additionally, provides type information for the adapter to the Closure
+ * compiler.
+ *
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/architecture.md
+ *
+ * @record
+ */
+
+export class MDCIconToggleAdapter {
+  addClass(className: string): void;
+
+  removeClass(className: string): void;
+
+  registerInteractionHandler(type: string, handler: EventListener): void;
+
+  deregisterInteractionHandler(type: string, handler: EventListener): void;
+
+  setText(text: string): void;
+
+  getTabIndex(): number;
+
+  setTabIndex(tabIndex: number): void;
+
+  getAttr(name: string): string;
+
+  setAttr(name: string, value: string): void;
+
+  rmAttr(name: string): void;
+
+  notifyChange(evtData: IconToggleEvent): void;
+}
+
+export interface IconToggleEvent {
+    isOn: boolean;
+}

--- a/types/material__icon-toggle/constants.d.ts
+++ b/types/material__icon-toggle/constants.d.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-icon-toggle';
+    DISABLED: 'mdc-icon-toggle--disabled';
+}
+
+export interface strings extends MDCStrings {
+    DATA_TOGGLE_ON: 'data-toggle-on';
+    DATA_TOGGLE_OFF: 'data-toggle-off';
+    ARIA_PRESSED: 'aria-pressed';
+    ARIA_DISABLED: 'aria-disabled';
+    ARIA_LABEL: 'aria-label';
+    CHANGE_EVENT: 'MDCIconToggle:change';
+}

--- a/types/material__icon-toggle/foundation.d.ts
+++ b/types/material__icon-toggle/foundation.d.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import { MDCIconToggleAdapter, IconToggleEvent } from './adapter';
+import { cssClasses, strings } from './constants';
+
+export class MDCIconToggleFoundation extends MDCFoundation<MDCIconToggleAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCIconToggleAdapter;
+
+    refreshToggleData(): void;
+
+    isOn(): boolean;
+
+    toggle(isOn?: boolean): void;
+
+    isDisabled(): boolean;
+
+    setDisabled(isDisabled: boolean): void;
+
+    isKeyboardActivated(): boolean;
+}
+
+export interface KeyboardKey {
+    key: string;
+    keyCode: number;
+}
+
+export function isSpace(keyboardKey: KeyboardKey): boolean;
+
+export class IconToggleState {
+    /**
+     * The aria-label value of the icon toggle, or undefined if there is no aria-label.
+     */
+    label: string|undefined;
+    /**
+     * The text for the icon toggle, or undefined if there is no text.
+     */
+    content: string|undefined;
+    /**
+     * The CSS class to add to the icon toggle, or undefined if there is no CSS class.
+     */
+    cssClass: string|undefined;
+}
+
+export default MDCIconToggleFoundation;

--- a/types/material__icon-toggle/index.d.ts
+++ b/types/material__icon-toggle/index.d.ts
@@ -1,0 +1,47 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+import MDCIconToggleFoundation from './foundation';
+import { MDCIconToggleAdapter } from './adapter';
+import { MDCRipple, MDCRippleFoundation } from 'material__ripple';
+
+export {MDCIconToggleAdapter, MDCIconToggleFoundation};
+
+export class MDCIconToggle extends MDCComponent<MDCIconToggleAdapter, MDCIconToggleFoundation> {
+    static attachTo(root: Element): MDCIconToggle;
+
+    destroy(): void;
+
+    getDefaultFoundation(): MDCIconToggleFoundation;
+
+    initialSyncWithDOM(): void;
+
+    readonly ripple: MDCRipple;
+
+    on: boolean;
+
+    disabled: boolean;
+
+    refreshToggleData(): void;
+}

--- a/types/material__icon-toggle/tsconfig.json
+++ b/types/material__icon-toggle/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__icon-toggle/tslint.json
+++ b/types/material__icon-toggle/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__linear-progress/adapter.d.ts
+++ b/types/material__linear-progress/adapter.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCLinearProgressAdapter {
+    addClass(className: string): void;
+
+    getPrimaryBar(): Element;
+
+    getBuffer(): Element;
+
+    hasClass(className: string): boolean;
+
+    removeClass(className: string): void;
+
+    setStyle(el: Element, styleProperty: string, value: number): void;
+}

--- a/types/material__linear-progress/constants.d.ts
+++ b/types/material__linear-progress/constants.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    CLOSED_CLASS: 'mdc-linear-progress--closed';
+    INDETERMINATE_CLASS: 'mdc-linear-progress--indeterminate';
+    REVERSED_CLASS: 'mdc-linear-progress--reversed';
+}
+
+export interface strings extends MDCStrings {
+    PRIMARY_BAR_SELECTOR: '.mdc-linear-progress__primary-bar';
+    BUFFER_SELECTOR: '.mdc-linear-progress__buffer';
+}

--- a/types/material__linear-progress/foundation.d.ts
+++ b/types/material__linear-progress/foundation.d.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCFoundation } from 'material__base';
+import { transformStyleProperties } from 'material__animation';
+import { MDCLinearProgressAdapter } from './adapter';
+import { cssClasses, strings } from './constants';
+
+export class MDCLinearProgressFoundation extends MDCFoundation<MDCLinearProgressAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCLinearProgressAdapter;
+
+    setDeterminate(isDeterminate: boolean): void;
+
+    setProgress(value: number): void;
+
+    setBuffer(value: number): void;
+
+    setReverse(isReversed: boolean): void;
+
+    open(): void;
+
+    close(): void;
+}

--- a/types/material__linear-progress/index.d.ts
+++ b/types/material__linear-progress/index.d.ts
@@ -1,0 +1,45 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCComponent } from 'material__base';
+import { MDCLinearProgressAdapter } from './adapter';
+import { MDCLinearProgressFoundation } from './foundation';
+
+export {MDCLinearProgressAdapter, MDCLinearProgressFoundation};
+
+export class MDCLinearProgress extends MDCComponent<MDCLinearProgressAdapter, MDCLinearProgressFoundation> {
+    static attachTo(root: Element): MDCLinearProgress;
+
+    determinate: boolean;
+
+    progress: number;
+
+    buffer: number;
+
+    reverse: boolean;
+
+    open(): void;
+
+    close(): void;
+
+    getDefaultFoundation(): MDCLinearProgressFoundation;
+}

--- a/types/material__linear-progress/tsconfig.json
+++ b/types/material__linear-progress/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__linear-progress/tslint.json
+++ b/types/material__linear-progress/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__menu/index.d.ts
+++ b/types/material__menu/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as util from './util';
+import { MDCSimpleMenu, MDCSimpleMenuAdapter, MDCSimpleMenuFoundation } from './simple/index';
+export { MDCSimpleMenu, MDCSimpleMenuAdapter, MDCSimpleMenuFoundation, util };

--- a/types/material__menu/simple/adapter.d.ts
+++ b/types/material__menu/simple/adapter.d.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adapter for MDC Simple Menu. Provides an interface for managing
+ * - classes
+ * - dom
+ * - focus
+ * - position
+ * - dimensions
+ * - event handlers
+ *
+ * Additionally, provides type information for the adapter to the Closure
+ * compiler.
+ *
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/architecture.md
+ *
+ * @record
+ */
+export default class MDCSimpleMenuAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    hasClass(className: string): boolean;
+
+    hasNecessaryDom(): boolean;
+
+    getAttributeForEventTarget(target: EventTarget, attributeName: string): string;
+
+    getInnerDimensions(): {width: number, height: number};
+
+    hasAnchor(): boolean;
+
+    getAnchorDimensions(): {width: number, height: number, top: number, right: number, bottom: number, left: number};
+
+    getWindowDimensions(): {width: number, height: number};
+
+    setScale(x: number, y: number): void;
+
+    setInnerScale(x: number, y: number): void;
+
+    getNumberOfItems(): number;
+
+    registerInteractionHandler(type: string, handler: EventListener): void;
+
+    deregisterInteractionHandler(type: string, handler: EventListener): void;
+
+    registerBodyClickHandler(handler: EventListener): void;
+
+    deregisterBodyClickHandler(handler: EventListener): void;
+
+    getYParamsForItemAtIndex(index: number): {top: number, height: number};
+
+    setTransitionDelayForItemAtIndex(index: number, value: string|null): void;
+
+    getIndexForEventTarget(target: EventTarget): number;
+
+    notifySelected(evtData: {index: number}): void;
+
+    notifyCancel(): void;
+
+    saveFocus(): void;
+
+    restoreFocus(): void;
+
+    isFocused(): boolean;
+
+    focus(): void;
+
+    getFocusedItemIndex(): number;
+
+    focusItemAtIndex(index: number): void;
+
+    isRtl(): boolean;
+
+    setTransformOrigin(origin: string): void;
+
+    setPosition(position: {
+        top: string|undefined,
+        right: string|undefined,
+        bottom: string|undefined,
+        left: string|undefined
+    }): void;
+
+    getAccurateTime(): number;
+}

--- a/types/material__menu/simple/constants.d.ts
+++ b/types/material__menu/simple/constants.d.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings, MDCNumbers } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-simple-menu';
+    OPEN: 'mdc-simple-menu--open';
+    ANIMATING: 'mdc-simple-menu--animating';
+    TOP_RIGHT: 'mdc-simple-menu--open-from-top-right';
+    BOTTOM_LEFT: 'mdc-simple-menu--open-from-bottom-left';
+    BOTTOM_RIGHT: 'mdc-simple-menu--open-from-bottom-right';
+}
+
+export interface strings extends MDCStrings {
+    ITEMS_SELECTOR: '.mdc-simple-menu__items';
+    SELECTED_EVENT: 'MDCSimpleMenu:selected';
+    CANCEL_EVENT: 'MDCSimpleMenu:cancel';
+    ARIA_DISABLED_ATTR: 'aria-disabled';
+}
+
+export interface numbers extends MDCNumbers {
+  // Amount of time to wait before triggering a selected event on the menu. Note that this time
+  // will most likely be bumped up once interactive lists are supported to allow for the ripple to
+  // animate before closing the menu
+  SELECTED_TRIGGER_DELAY: 50;
+  // Total duration of the menu animation.
+  TRANSITION_DURATION_MS: 300;
+  // The menu starts its open animation with the X axis at this time value (0 - 1).
+  TRANSITION_SCALE_ADJUSTMENT_X: 0.5;
+  // The time value the menu waits until the animation starts on the Y axis (0 - 1).
+  TRANSITION_SCALE_ADJUSTMENT_Y: 0.2;
+  // The cubic bezier control points for the animation (cubic-bezier(0, 0, 0.2, 1)).
+  TRANSITION_X1: 0;
+  TRANSITION_Y1: 0;
+  TRANSITION_X2: 0.2;
+  TRANSITION_Y2: 1;
+}

--- a/types/material__menu/simple/foundation.d.ts
+++ b/types/material__menu/simple/foundation.d.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import MDCSimpleMenuAdapter from './adapter';
+import { cssClasses, strings, numbers } from './constants';
+import { clamp, bezierProgress } from '../util';
+
+export default class MDCSimpleMenuFoundation extends MDCFoundation<MDCSimpleMenuAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly numbers: numbers;
+
+    static readonly defaultAdapter: MDCSimpleMenuAdapter;
+
+    /**
+     * Open the menu.
+     */
+    open(options?: {focusIndex?: number}): void;
+
+    /**
+     * Closes the menu.
+     */
+    close(evt?: Event): void;
+
+    isOpen(): boolean;
+}

--- a/types/material__menu/simple/index.d.ts
+++ b/types/material__menu/simple/index.d.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+import MDCSimpleMenuFoundation from './foundation';
+import MDCSimpleMenuAdapter from './adapter';
+import { getTransformPropertyName } from '../util';
+
+export {MDCSimpleMenuAdapter, MDCSimpleMenuFoundation};
+
+export class MDCSimpleMenu extends MDCComponent<MDCSimpleMenuAdapter, MDCSimpleMenuFoundation> {
+  static attachTo(root: Element): MDCSimpleMenu;
+
+  open: boolean;
+
+  show(options?: {focusIndex?: number}): void;
+
+  hide(): void;
+
+  /**
+   * Return the items within the menu. Note that this only contains the set of elements within
+   * the items container that are proper list items, and not supplemental / presentational DOM
+   * elements.
+   */
+  readonly items: Element[];
+
+  getDefaultFoundation(): MDCSimpleMenuFoundation;
+}

--- a/types/material__menu/tsconfig.json
+++ b/types/material__menu/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "files": [
+        "simple/constants.d.ts",
+        "simple/adapter.d.ts",
+        "simple/index.d.ts",
+        "simple/foundation.d.ts",
+        "util.d.ts",
+        "index.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__menu/tslint.json
+++ b/types/material__menu/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__menu/util.d.ts
+++ b/types/material__menu/util.d.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns the name of the correct transform property to use on the current browser.
+ */
+export function getTransformPropertyName(globalObj: Window, forceRefresh?: boolean): string|undefined;
+
+/**
+ * Clamps a value between the minimum and the maximum, returning the clamped value.
+ */
+export function clamp(value: number, min?: number, max?: number): number;
+
+/**
+ * Returns the easing value to apply at time t, for a given cubic bezier curve.
+ * Control points P0 and P3 are assumed to be (0,0) and (1,1), respectively.
+ * Parameters are as follows:
+ * - time: The current time in the animation, scaled between 0 and 1.
+ * - x1: The x value of control point P1.
+ * - y1: The y value of control point P1.
+ * - x2: The x value of control point P2.
+ * - y2: The y value of control point P2.
+ */
+export function bezierProgress(time: number, x1: number, y1: number, x2: number, y2: number): number;

--- a/types/material__radio/adapter.d.ts
+++ b/types/material__radio/adapter.d.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCSelectionControlState } from 'material__selection-control';
+
+/**
+ * Adapter for MDC Radio. Provides an interface for managing
+ * - classes
+ * - dom
+ *
+ * Additionally, provides type information for the adapter to the Closure
+ * compiler.
+ *
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/architecture.md
+ */
+export class MDCRadioAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    getNativeControl(): MDCSelectionControlState;
+}
+
+export default MDCRadioAdapter;

--- a/types/material__radio/constants.d.ts
+++ b/types/material__radio/constants.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface strings extends MDCStrings {
+    NATIVE_CONTROL_SELECTOR: '.mdc-radio__native-control';
+}
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-radio';
+    DISABLED: 'mdc-radio--disabled';
+}

--- a/types/material__radio/foundation.d.ts
+++ b/types/material__radio/foundation.d.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import { MDCSelectionControlState } from 'material__selection-control';
+import MDCRadioAdapter from './adapter';
+import { cssClasses, strings } from './constants';
+
+export class MDCRadioFoundation extends MDCFoundation<MDCRadioAdapter> {
+  static readonly cssClasses: cssClasses;
+
+  static readonly strings: strings;
+
+  static readonly defaultAdapter: MDCRadioAdapter;
+
+  isChecked(): boolean;
+
+  setChecked(checked: boolean): void;
+
+  isDisabled(): boolean;
+
+  setDisabled(disabled: boolean): void;
+
+  getValue(): string;
+
+  setValue(value?: string): void;
+}
+
+export default MDCRadioFoundation;

--- a/types/material__radio/index.d.ts
+++ b/types/material__radio/index.d.ts
@@ -1,0 +1,46 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+import { MDCSelectionControl } from 'material__selection-control';
+import MDCRadioAdapter from './adapter';
+import MDCRadioFoundation from './foundation';
+import { MDCRipple, MDCRippleFoundation } from 'material__ripple';
+
+export {MDCRadioAdapter, MDCRadioFoundation};
+
+export class MDCRadio extends MDCComponent<MDCRadioAdapter, MDCRadioFoundation> implements MDCSelectionControl {
+    static attachTo(root: Element): MDCRadio;
+
+    checked: boolean;
+
+    disabled: boolean;
+
+    value: string;
+
+    readonly ripple: MDCRipple;
+
+    destroy(): void;
+
+    getDefaultFoundation(): MDCRadioFoundation;
+}

--- a/types/material__radio/tsconfig.json
+++ b/types/material__radio/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__radio/tslint.json
+++ b/types/material__radio/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__ripple/adapter.d.ts
+++ b/types/material__ripple/adapter.d.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adapter for MDC Ripple. Provides an interface for managing
+ * - classes
+ * - dom
+ * - CSS variables
+ * - position
+ * - dimensions
+ * - scroll position
+ * - event handlers
+ * - unbounded, active and disabled states
+ *
+ * Additionally, provides type information for the adapter to the Closure
+ * compiler.
+ *
+ * Implement this adapter for your framework of choice to delegate updates to
+ * the component in your framework of choice. See architecture documentation
+ * for more details.
+ * https://github.com/material-components/material-components-web/blob/master/docs/architecture.md
+ *
+ * @record
+ */
+export default class MDCRippleAdapter {
+    browserSupportsCssVars(): boolean;
+
+    isUnbounded(): boolean;
+
+    isSurfaceActive(): boolean;
+
+    isSurfaceDisabled(): boolean;
+
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    registerInteractionHandler(evtType: string, handler: EventListener): void;
+
+    deregisterInteractionHandler(evtType: string, handler: EventListener): void;
+
+    registerResizeHandler(handler: EventListener): void;
+
+    deregisterResizeHandler(handler: EventListener): void;
+
+    updateCssVariable(varName: string, value: number|string): void;
+
+    computeBoundingRect(): ClientRect;
+
+    getWindowPageOffset(): {x: number, y: number};
+}

--- a/types/material__ripple/constants.d.ts
+++ b/types/material__ripple/constants.d.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings, MDCNumbers } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    // Ripple is a special case where the "root" component is really a "mixin" of sorts,
+    // given that it's an 'upgrade' to an existing component. That being said it is the root
+    // CSS class that all other CSS classes derive from.
+    ROOT: 'mdc-ripple-upgraded';
+    UNBOUNDED: 'mdc-ripple-upgraded--unbounded';
+    BG_FOCUSED: 'mdc-ripple-upgraded--background-focused';
+    BG_ACTIVE_FILL: 'mdc-ripple-upgraded--background-active-fill';
+    FG_ACTIVATION: 'mdc-ripple-upgraded--foreground-activation';
+    FG_DEACTIVATION: 'mdc-ripple-upgraded--foreground-deactivation';
+}
+
+export interface strings extends MDCStrings {
+    VAR_FG_SIZE: '--mdc-ripple-fg-size';
+    VAR_LEFT: '--mdc-ripple-left';
+    VAR_TOP: '--mdc-ripple-top';
+    VAR_FG_SCALE: '--mdc-ripple-fg-scale';
+    VAR_FG_TRANSLATE_START: '--mdc-ripple-fg-translate-start';
+    VAR_FG_TRANSLATE_END: '--mdc-ripple-fg-translate-end';
+}
+
+export interface numbers extends MDCNumbers {
+    PADDING: 10;
+    INITIAL_ORIGIN_SCALE: 0.6;
+    DEACTIVATION_TIMEOUT_MS: 300;
+    FG_DEACTIVATION_MS: 83;
+}

--- a/types/material__ripple/foundation.d.ts
+++ b/types/material__ripple/foundation.d.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import MDCRippleAdapter from './adapter';
+import { cssClasses, strings, numbers } from './constants';
+import { getNormalizedEventCoords } from './util';
+
+export interface ActivationStateType {
+    isActivated: boolean|undefined;
+    hasDeactivationUXRun: boolean|undefined;
+    wasActivatedByPointer: boolean|undefined;
+    wasElementMadeActive: boolean|undefined;
+    activationStartTime: number|undefined;
+    activationEvent: Event;
+    isProgrammatic: boolean|undefined;
+}
+
+export interface ListenerInfoType {
+    activate: string|undefined;
+    deactivate: string|undefined;
+    focus: string|undefined;
+    blur: string|undefined;
+}
+
+export interface ListenersType {
+    activate(e: Event): void;
+
+    deactivate(e: Event): void;
+
+    focus(): void;
+
+    blur(): void;
+}
+
+export interface PointType {
+    x: number;
+    y: number;
+}
+
+export default class MDCRippleFoundation extends MDCFoundation<MDCRippleAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly numbers: numbers;
+
+    static readonly defaultAdapter: MDCRippleAdapter;
+
+    activate(event?: Event): void;
+
+    deactivate(event?: Event): void;
+
+    layout(): void;
+}

--- a/types/material__ripple/index.d.ts
+++ b/types/material__ripple/index.d.ts
@@ -1,0 +1,66 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+import MDCRippleAdapter from './adapter';
+import MDCRippleFoundation from './foundation';
+import * as util from './util';
+
+export {MDCRippleAdapter, MDCRippleFoundation, util};
+
+export class MDCRipple extends MDCComponent<MDCRippleAdapter, MDCRippleFoundation> {
+  static attachTo(root: Element, bound?: {isUnbounded: boolean|undefined}): MDCRipple;
+
+  static createAdapter(instance: RippleCapableSurface): MDCRippleAdapter;
+
+  unbounded: boolean;
+
+  activate(): void;
+
+  deactivate(): void;
+
+  layout(): void;
+
+  getDefaultFoundation(): MDCRippleFoundation;
+
+  initialSyncWithDOM(): void;
+}
+
+/**
+ * See Material Design spec for more details on when to use ripples.
+ * https://material.io/guidelines/motion/choreography.html#choreography-creation
+ * @record
+ */
+export class RippleCapableSurface {
+    protected root_: Element;
+
+    /**
+     * Whether or not the ripple bleeds out of the bounds of the element.
+     */
+    unbounded: boolean|undefined;
+
+    /**
+     * Whether or not the ripple is attached to a disabled component.
+     */
+    disabled: boolean|undefined;
+}

--- a/types/material__ripple/tsconfig.json
+++ b/types/material__ripple/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "util.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__ripple/tslint.json
+++ b/types/material__ripple/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__ripple/util.d.ts
+++ b/types/material__ripple/util.d.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function supportsCssVariables(windowObj: Window, forceRefresh?: boolean): boolean|undefined;
+
+/**
+ * Determine whether the current browser supports passive event listeners, and if so, use them.
+ */
+export function applyPassive(globalObj?: Window, forceRefresh?: boolean): boolean|{passive: boolean};
+
+export function getMatchesProperty(HTMLElementPrototype: object): string[];
+
+export function getNormalizedEventCoords(ev: Event, pageOffset: {x: number, y: number}, clientRect: ClientRect): {x: number, y: number};

--- a/types/material__select/adapter.d.ts
+++ b/types/material__select/adapter.d.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCSelectAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    addBodyClass(className: string): void;
+
+    removeBodyClass(className: string): void;
+
+    setAttr(attr: string, value: string): void;
+
+    rmAttr(attr: string): void;
+
+    computeBoundingRect(): {left: number, top: number};
+
+    registerInteractionHandler(type: string, handler: EventListener): void;
+
+    deregisterInteractionHandler(type: string, handler: EventListener): void;
+
+    focus(): void;
+
+    makeTabbable(): void;
+
+    makeUntabbable(): void;
+
+    getComputedStyleValue(propertyName: string): string;
+
+    setStyle(propertyName: string, value: string): void;
+
+    create2dRenderingContext(): {font: string, measureText: (val: string) => {width: number}};
+
+    setMenuElStyle(propertyName: string, value: string): void;
+
+    setMenuElAttr(attr: string, value: string): void;
+
+    rmMenuElAttr(attr: string): void;
+
+    getMenuElOffsetHeight(): number;
+
+    openMenu(focusIndex: number): void;
+
+    isMenuOpen(): boolean;
+
+    setSelectedTextContent(textContent: string): void;
+
+    getNumberOfOptions(): number;
+
+    getTextForOptionAtIndex(index: number): string;
+
+    getValueForOptionAtIndex(index: number): string;
+
+    setAttrForOptionAtIndex(index: number, attr: string, value: string): void;
+
+    rmAttrForOptionAtIndex(index: number, attr: string): void;
+
+    getOffsetTopForOptionAtIndex(index: number): number;
+
+    registerMenuInteractionHandler(type: string, handler: EventListener): void;
+
+    deregisterMenuInteractionHandler(type: string, handler: EventListener): void;
+
+    notifyChange(): void;
+
+    getWindowInnerHeight(): number;
+}

--- a/types/material__select/constants.d.ts
+++ b/types/material__select/constants.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-select';
+    OPEN: 'mdc-select--open';
+    DISABLED: 'mdc-select--disabled';
+    SCROLL_LOCK: 'mdc-select-scroll-lock';
+}
+
+export interface strings extends MDCStrings {
+    CHANGE_EVENT: 'MDCSelect:change';
+}

--- a/types/material__select/foundation.d.ts
+++ b/types/material__select/foundation.d.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCFoundation } from 'material__base';
+import { cssClasses, strings } from './constants';
+import { MDCSimpleMenuFoundation } from 'material__menu';
+import { MDCSelectAdapter } from './adapter';
+
+export default class MDCSelectFoundation extends MDCFoundation<MDCSelectAdapter> {
+  static readonly cssClasses: cssClasses;
+
+  static readonly strings: strings;
+
+  static readonly defaultAdapter: MDCSelectAdapter;
+
+  getValue(): string;
+
+  getSelectedIndex(): number;
+
+  setSelectedIndex(index: number): void;
+
+  isDisabled(): boolean;
+
+  setDisabled(disabled: boolean): void;
+
+  resize(): void;
+}

--- a/types/material__select/index.d.ts
+++ b/types/material__select/index.d.ts
@@ -1,0 +1,53 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCComponent } from 'material__base';
+import { MDCSimpleMenu } from 'material__menu';
+
+import { MDCSelectAdapter } from './adapter';
+import MDCSelectFoundation from './foundation';
+
+export {MDCSelectAdapter, MDCSelectFoundation};
+
+export class MDCSelect extends MDCComponent<MDCSelectAdapter, MDCSelectFoundation> {
+    static attachTo(root: Element): MDCSelect;
+
+    readonly value: string;
+
+    readonly options: Element[];
+
+    readonly selectedOptions: NodeListOf<Element>;
+
+    selectedIndex: number;
+
+    disabled: boolean;
+
+    item(index: number): Element|null;
+
+    nameditem(key: string): Element|null;
+
+    initialize(menuFactory?: (el: Element) => MDCSimpleMenu): void;
+
+    getDefaultFoundation(): MDCSelectFoundation;
+
+    initialSyncWithDOM(): void;
+}

--- a/types/material__select/tsconfig.json
+++ b/types/material__select/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__select/tslint.json
+++ b/types/material__select/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__selection-control/index.d.ts
+++ b/types/material__selection-control/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCRipple } from 'material__ripple';
+
+export interface MDCSelectionControlState {
+    checked: boolean;
+    indeterminate: boolean;
+    disabled: boolean;
+    value?: string;
+}
+
+export class MDCSelectionControl {
+    readonly ripple: MDCRipple;
+}

--- a/types/material__selection-control/tsconfig.json
+++ b/types/material__selection-control/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "files": [
+        "index.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__selection-control/tslint.json
+++ b/types/material__selection-control/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__slider/adapter.d.ts
+++ b/types/material__slider/adapter.d.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCSliderAdapter {
+    hasClass(className: string): boolean;
+
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    getAttribute(name: string): string|null;
+
+    setAttribute(name: string, value: string): void;
+
+    removeAttribute(name: string): void;
+
+    computeBoundingRect(): ClientRect;
+
+    getTabIndex(): number;
+
+    registerInteractionHandler(type: string, handler: EventListener): void;
+
+    deregisterInteractionHandler(type: string, handler: EventListener): void;
+
+    registerThumbContainerInteractionHandler(type: string, handler: EventListener): void;
+
+    deregisterThumbContainerInteractionHandler(type: string, handler: EventListener): void;
+
+    registerBodyInteractionHandler(type: string, handler: EventListener): void;
+
+    deregisterBodyInteractionHandler(type: string, handler: EventListener): void;
+
+    registerResizeHandler(handler: EventListener): void;
+
+    deregisterResizeHandler(handler: EventListener): void;
+
+    notifyInput(): void;
+
+    notifyChange(): void;
+
+    setThumbContainerStyleProperty(propertyName: string, value: string): void;
+
+    setTrackStyleProperty(propertyName: string, value: string): void;
+
+    setMarkerValue(value: number): void;
+
+    appendTrackMarkers(numMarkers: number): void;
+
+    removeTrackMarkers(): void;
+
+    setLastTrackMarkersStyleProperty(propertyName: string, value: string): void;
+
+    isRTL(): boolean;
+}

--- a/types/material__slider/constants.d.ts
+++ b/types/material__slider/constants.d.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings, MDCNumbers } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ACTIVE: 'mdc-slider--active';
+    DISABLED: 'mdc-slider--disabled';
+    DISCRETE: 'mdc-slider--discrete';
+    FOCUS: 'mdc-slider--focus';
+    IN_TRANSIT: 'mdc-slider--in-transit';
+    IS_DISCRETE: 'mdc-slider--discrete';
+    HAS_TRACK_MARKER: 'mdc-slider--display-markers';
+}
+
+export interface strings extends MDCStrings {
+    TRACK_SELECTOR: '.mdc-slider__track';
+    TRACK_MARKER_CONTAINER_SELECTOR: '.mdc-slider__track-marker-container';
+    LAST_TRACK_MARKER_SELECTOR: '.mdc-slider__track-marker:last-child';
+    THUMB_CONTAINER_SELECTOR: '.mdc-slider__thumb-container';
+    PIN_VALUE_MARKER_SELECTOR: '.mdc-slider__pin-value-marker';
+    ARIA_VALUEMIN: 'aria-valuemin';
+    ARIA_VALUEMAX: 'aria-valuemax';
+    ARIA_VALUENOW: 'aria-valuenow';
+    ARIA_DISABLED: 'aria-disabled';
+    STEP_DATA_ATTR: 'data-step';
+    CHANGE_EVENT: 'MDCSlider:change';
+    INPUT_EVENT: 'MDCSlider:input';
+}
+
+export interface numbers extends MDCNumbers {
+    PAGE_FACTOR: 4;
+}

--- a/types/material__slider/foundation.d.ts
+++ b/types/material__slider/foundation.d.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cssClasses, strings, numbers } from './constants';
+
+import { getCorrectEventName, getCorrectPropertyName } from 'material__animation';
+import MDCFoundation from 'material__base/foundation';
+import { MDCSliderAdapter } from './adapter';
+
+export default class MDCSliderFoundation extends MDCFoundation<MDCSliderAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly numbers: numbers;
+
+    static readonly defaultAdapter: MDCSliderAdapter;
+
+    setupTrackMarker(): void;
+
+    layout(): void;
+
+    getValue(): number;
+
+    setValue(value: number): void;
+
+    getMax(): number;
+
+    setMax(max: number): void;
+
+    getMin(): number;
+
+    setMin(min: number): void;
+
+    getStep(): number;
+
+    setStep(step: number): void;
+
+    isDisabled(): boolean;
+
+    setDisabled(disabled: boolean): void;
+}

--- a/types/material__slider/index.d.ts
+++ b/types/material__slider/index.d.ts
@@ -1,0 +1,54 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+
+import MDCSliderFoundation from './foundation';
+import { MDCSliderAdapter } from './adapter';
+
+export {MDCSliderAdapter, MDCSliderFoundation};
+
+export class MDCSlider extends MDCComponent<MDCSliderAdapter, MDCSliderFoundation> {
+  static attachTo(root: Element): MDCSlider;
+
+  value: number;
+
+  min: number;
+
+  max: number;
+
+  step: number;
+
+  disabled: boolean;
+
+  initialize(): void;
+
+  getDefaultFoundation(): MDCSliderFoundation;
+
+  initialSyncWithDOM(): void;
+
+  layout(): void;
+
+  stepUp(amount?: number): void;
+
+  stepDown(amount?: number): void;
+}

--- a/types/material__slider/tsconfig.json
+++ b/types/material__slider/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__slider/tslint.json
+++ b/types/material__slider/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__snackbar/adapter.d.ts
+++ b/types/material__snackbar/adapter.d.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCSnackbarAdapter {
+    addClass(className: string): void;
+    removeClass(className: string): void;
+    setAriaHidden(): void;
+    unsetAriaHidden(): void;
+    setActionAriaHidden(): void;
+    unsetActionAriaHidden(): void;
+    setActionText(actionText: string): void;
+    setMessageText(message: string): void;
+    setFocus(): void;
+    visibilityIsHidden(): boolean;
+    registerCapturedBlurHandler(handler: EventListener): void;
+    deregisterCapturedBlurHandler(handler: EventListener): void;
+    registerVisibilityChangeHandler(handler: EventListener): void;
+    deregisterVisibilityChangeHandler(handler: EventListener): void;
+    registerCapturedInteractionHandler(evtType: string, handler: EventListener): void;
+    deregisterCapturedInteractionHandler(evtType: string, handler: EventListener): void;
+    registerActionClickHandler(handler: EventListener): void;
+    deregisterActionClickHandler(handler: EventListener): void;
+    registerTransitionEndHandler(handler: EventListener): void;
+    deregisterTransitionEndHandler(handler: EventListener): void;
+}

--- a/types/material__snackbar/constants.d.ts
+++ b/types/material__snackbar/constants.d.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings, MDCNumbers } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-snackbar';
+    TEXT: 'mdc-snackbar__text';
+    ACTION_WRAPPER: 'mdc-snackbar__action-wrapper';
+    ACTION_BUTTON: 'mdc-snackbar__action-button';
+    ACTIVE: 'mdc-snackbar--active';
+    MULTILINE: 'mdc-snackbar--multiline';
+    ACTION_ON_BOTTOM: 'mdc-snackbar--action-on-bottom';
+}
+
+export interface strings extends MDCStrings {
+    TEXT_SELECTOR: '.mdc-snackbar__text';
+    ACTION_WRAPPER_SELECTOR: '.mdc-snackbar__action-wrapper';
+    ACTION_BUTTON_SELECTOR: '.mdc-snackbar__action-button';
+}
+
+export interface numbers extends MDCNumbers {
+    MESSAGE_TIMEOUT: 2750;
+}

--- a/types/material__snackbar/foundation.d.ts
+++ b/types/material__snackbar/foundation.d.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCFoundation } from 'material__base';
+import { cssClasses, strings, numbers } from './constants';
+import { MDCSnackbarAdapter } from './adapter';
+
+export interface MDCSnackbarData {
+    message: string;
+    actionHandler: EventListener;
+    actionText: string;
+    multiline?: boolean;
+    actionOnBottom?: boolean;
+    timeout?: number;
+}
+
+export class MDCSnackbarFoundation extends MDCFoundation<MDCSnackbarAdapter> {
+  static readonly cssClasses: cssClasses;
+
+  static readonly strings: strings;
+
+  static readonly defaultAdapter: MDCSnackbarAdapter;
+
+  readonly active: boolean;
+
+  dismissesOnAction(): boolean;
+
+  setDismissOnAction(dismissOnAction: boolean): void;
+
+  show(data: MDCSnackbarData): void;
+}

--- a/types/material__snackbar/index.d.ts
+++ b/types/material__snackbar/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCComponent } from 'material__base';
+import { MDCSnackbarAdapter } from './adapter';
+import { MDCSnackbarFoundation, MDCSnackbarData } from './foundation';
+import { getCorrectEventName } from 'material__animation';
+
+export {MDCSnackbarAdapter, MDCSnackbarFoundation};
+
+export class MDCSnackbar extends MDCComponent<MDCSnackbarAdapter, MDCSnackbarFoundation> {
+  static attachTo(root: Element): MDCSnackbar;
+
+  show(data: MDCSnackbarData): void;
+
+  getDefaultFoundation(): MDCSnackbarFoundation;
+
+  dismissesOnAction: boolean;
+}

--- a/types/material__snackbar/tsconfig.json
+++ b/types/material__snackbar/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__snackbar/tslint.json
+++ b/types/material__snackbar/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__tabs/index.d.ts
+++ b/types/material__tabs/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {MDCTabFoundation, MDCTab} from './tab/index';
+export {MDCTabBarAdapter, MDCTabBarFoundation, MDCTabBar} from './tab-bar/index';
+export {MDCTabBarScrollerAdapter, MDCTabBarScrollerFoundation, MDCTabBarScroller} from './tab-bar-scroller/index';

--- a/types/material__tabs/tab-bar-scroller/adapter.d.ts
+++ b/types/material__tabs/tab-bar-scroller/adapter.d.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCTabBarScrollerAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    eventTargetHasClass(target: EventTarget, className: string): boolean;
+
+    addClassToForwardIndicator(className: string): void;
+
+    removeClassFromForwardIndicator(className: string): void;
+
+    addClassToBackIndicator(className: string): void;
+
+    removeClassFromBackIndicator(className: string): void;
+
+    isRTL(): boolean;
+
+    registerBackIndicatorClickHandler(handler: EventListener): void;
+
+    deregisterBackIndicatorClickHandler(handler: EventListener): void;
+
+    registerForwardIndicatorClickHandler(handler: EventListener): void;
+
+    deregisterForwardIndicatorClickHandler(handler: EventListener): void;
+
+    registerCapturedInteractionHandler(evt: string, handler: EventListener): void;
+
+    deregisterCapturedInteractionHandler(evt: string, handler: EventListener): void;
+
+    registerWindowResizeHandler(handler: EventListener): void;
+
+    deregisterWindowResizeHandler(handler: EventListener): void;
+
+    getNumberOfTabs(): number;
+
+    getComputedWidthForTabAtIndex(): number;
+
+    getComputedLeftForTabAtIndex(): number;
+
+    getOffsetWidthForScrollFrame(): number;
+
+    getScrollLeftForScrollFrame(): number;
+
+    setScrollLeftForScrollFrame(scrollLeftAmount: number): void;
+
+    getOffsetWidthForTabBar(): number;
+
+    setTransformStyleForTabBar(value: string): void;
+
+    getOffsetLeftForEventTarget(target: EventTarget): number;
+
+    getOffsetWidthForEventTarget(target: EventTarget): number;
+}

--- a/types/material__tabs/tab-bar-scroller/constants.d.ts
+++ b/types/material__tabs/tab-bar-scroller/constants.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    INDICATOR_FORWARD: 'mdc-tab-bar-scroller__indicator--forward';
+    INDICATOR_BACK: 'mdc-tab-bar-scroller__indicator--back';
+    INDICATOR_ENABLED: 'mdc-tab-bar-scroller__indicator--enabled';
+    TAB: 'mdc-tab';
+}
+
+export interface strings extends MDCStrings {
+    FRAME_SELECTOR: '.mdc-tab-bar-scroller__scroll-frame';
+    TABS_SELECTOR: '.mdc-tab-bar-scroller__scroll-frame__tabs';
+    TAB_SELECTOR: '.mdc-tab';
+    INDICATOR_FORWARD_SELECTOR: '.mdc-tab-bar-scroller__indicator--forward';
+    INDICATOR_BACK_SELECTOR: '.mdc-tab-bar-scroller__indicator--back';
+}

--- a/types/material__tabs/tab-bar-scroller/foundation.d.ts
+++ b/types/material__tabs/tab-bar-scroller/foundation.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+
+import { cssClasses, strings } from './constants';
+import { MDCTabBarScrollerAdapter } from './adapter';
+
+export default class MDCTabBarScrollerFoundation extends MDCFoundation<MDCTabBarScrollerAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCTabBarScrollerAdapter;
+
+    scrollBack(evt?: Event): void;
+
+    scrollForward(evt?: Event): void;
+
+    layout(): void;
+
+    scrollToTabAtIndex(index: number): void;
+}

--- a/types/material__tabs/tab-bar-scroller/index.d.ts
+++ b/types/material__tabs/tab-bar-scroller/index.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getCorrectPropertyName } from 'material__animation';
+import MDCComponent from 'material__base/component';
+
+import { MDCTabBar } from '../tab-bar/index';
+import MDCTabBarScrollerFoundation from './foundation';
+import { MDCTabBarScrollerAdapter } from './adapter';
+
+export {MDCTabBarScrollerAdapter, MDCTabBarScrollerFoundation};
+
+export class MDCTabBarScroller extends MDCComponent<MDCTabBarScrollerAdapter, MDCTabBarScrollerFoundation> {
+  static attachTo(root: Element): MDCTabBarScroller;
+
+  readonly tabBar: MDCTabBar;
+
+  initialize(tabBarFactory?: (el: Element) => MDCTabBar): void;
+
+  getDefaultFoundation(): MDCTabBarScrollerFoundation;
+
+  layout(): void;
+}

--- a/types/material__tabs/tab-bar/adapter.d.ts
+++ b/types/material__tabs/tab-bar/adapter.d.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCTabBarAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    bindOnMDCTabSelectedEvent(): void;
+
+    unbindOnMDCTabSelectedEvent(): void;
+
+    registerResizeHandler(handler: EventListener): void;
+
+    deregisterResizeHandler(handler: EventListener): void;
+
+    getOffsetWidth(): number;
+
+    setStyleForIndicator(propertyName: string, value: string): void;
+
+    getOffsetWidthForIndicator(): number;
+
+    notifyChange(evtData: {activeTabIndex: number}): void;
+
+    getNumberOfTabs(): number;
+
+    isTabActiveAtIndex(index: number): boolean;
+
+    setTabActiveAtIndex(index: number, isActive: true): void;
+
+    isDefaultPreventedOnClickForTabAtIndex(index: number): boolean;
+
+    setPreventDefaultOnClickForTabAtIndex(index: number, preventDefaultOnClick: boolean): void;
+
+    measureTabAtIndex(index: number): void;
+
+    getComputedWidthForTabAtIndex(index: number): number;
+
+    getComputedLeftForTabAtIndex(index: number): number;
+}

--- a/types/material__tabs/tab-bar/constants.d.ts
+++ b/types/material__tabs/tab-bar/constants.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    UPGRADED: 'mdc-tab-bar-upgraded';
+}
+
+export interface strings extends MDCStrings {
+    TAB_SELECTOR: '.mdc-tab';
+    INDICATOR_SELECTOR: '.mdc-tab-bar__indicator';
+    CHANGE_EVENT: 'MDCTabBar:change';
+}

--- a/types/material__tabs/tab-bar/foundation.d.ts
+++ b/types/material__tabs/tab-bar/foundation.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import { getCorrectPropertyName } from 'material__animation';
+
+import { cssClasses, strings } from './constants';
+import { MDCTabBarAdapter } from './adapter';
+
+export default class MDCTabBarFoundation extends MDCFoundation<MDCTabBarAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCTabBarAdapter;
+
+    layout(): void;
+
+    switchToTabAtIndex(index: number, shouldNotify: boolean): void;
+
+    getActiveTabIndex(): number;
+}

--- a/types/material__tabs/tab-bar/index.d.ts
+++ b/types/material__tabs/tab-bar/index.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+
+import { MDCTab, MDCTabFoundation } from '../tab/index';
+import MDCTabBarFoundation from './foundation';
+import { MDCTabBarAdapter } from './adapter';
+
+export {MDCTabBarAdapter, MDCTabBarFoundation};
+
+export class MDCTabBar extends MDCComponent<MDCTabBarAdapter, MDCTabBarFoundation> {
+    static attachTo(root: Element): MDCTabBar;
+
+    readonly tabs: MDCTab[];
+
+    activeTab: MDCTab;
+
+    activeTabIndex: number;
+
+    initialize(tabFactory?: (el: Element) => MDCTab): void;
+
+    getDefaultFoundation(): MDCTabBarFoundation;
+
+    layout(): void;
+}

--- a/types/material__tabs/tab/adapter.d.ts
+++ b/types/material__tabs/tab/adapter.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCTabAdapter {
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    registerInteractionHandler(type: string, handler: EventListener): void;
+
+    deregisterInteractionHandler(type: string, handler: EventListener): void;
+
+    getOffsetWidth(): number;
+
+    getOffsetLeft(): number;
+
+    notifySelected(): void;
+}

--- a/types/material__tabs/tab/constants.d.ts
+++ b/types/material__tabs/tab/constants.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    ACTIVE: 'mdc-tab--active';
+}
+
+export interface strings extends MDCStrings {
+    SELECTED_EVENT: 'MDCTab:selected';
+}

--- a/types/material__tabs/tab/foundation.d.ts
+++ b/types/material__tabs/tab/foundation.d.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import { cssClasses, strings } from './constants';
+import { MDCTabAdapter } from './adapter';
+
+export class MDCTabFoundation extends MDCFoundation<MDCTabAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCTabAdapter;
+
+    getComputedWidth(): number;
+
+    getComputedLeft(): number;
+
+    isActive(): boolean;
+
+    setActive(isActive: boolean): void;
+
+    preventsDefaultOnClick(): boolean;
+
+    setPreventDefaultOnClick(preventDefaultOnClick: boolean): void;
+
+    measureSelf(): void;
+}

--- a/types/material__tabs/tab/index.d.ts
+++ b/types/material__tabs/tab/index.d.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+import { MDCRipple } from 'material__ripple';
+
+import { MDCTabAdapter } from './adapter';
+import { cssClasses } from './constants';
+import { MDCTabFoundation } from './foundation';
+
+export {MDCTabAdapter, MDCTabFoundation};
+
+export class MDCTab extends MDCComponent<MDCTabAdapter, MDCTabFoundation> {
+    static attachTo(root: Element): MDCTab;
+
+    readonly computedWidth: number;
+
+    readonly computedLeft: number;
+
+    isActive: boolean;
+
+    preventDefaultOnClick: boolean;
+
+    destroy(): void;
+
+    getDefaultFoundation(): MDCTabFoundation;
+
+    initialSyncWithDOM(): void;
+
+    measureSelf(): void;
+}

--- a/types/material__tabs/tsconfig.json
+++ b/types/material__tabs/tsconfig.json
@@ -1,0 +1,36 @@
+{
+    "files": [
+        "tab-bar/constants.d.ts",
+        "tab-bar/adapter.d.ts",
+        "tab-bar/index.d.ts",
+        "tab-bar/foundation.d.ts",
+        "tab/constants.d.ts",
+        "tab/adapter.d.ts",
+        "tab/index.d.ts",
+        "tab/foundation.d.ts",
+        "index.d.ts",
+        "tab-bar-scroller/constants.d.ts",
+        "tab-bar-scroller/adapter.d.ts",
+        "tab-bar-scroller/index.d.ts",
+        "tab-bar-scroller/foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__tabs/tslint.json
+++ b/types/material__tabs/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__textfield/adapter.d.ts
+++ b/types/material__textfield/adapter.d.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCTextFieldBottomLineFoundation from './bottom-line/foundation';
+import MDCTextFieldHelperTextFoundation from './helper-text/foundation';
+
+export interface NativeInputType {
+    value: string;
+    disabled: boolean;
+    badInput: boolean;
+    checkValidity(): boolean;
+}
+
+/**
+ * Adapter for MDC Text Field.
+ *
+ * Defines the shape of the adapter expected by the foundation. Implement this
+ * adapter to integrate the Text Field into your framework. See
+ * https://github.com/material-components/material-components-web/blob/master/docs/authoring-components.md
+ * for more information.
+ *
+ * @record
+ */
+export class MDCTextFieldAdapter {
+    /**
+     * Adds a class to the root Element.
+     */
+    addClass(className: string): void;
+
+    /**
+     * Removes a class from the root Element.
+     */
+    removeClass(className: string): void;
+
+    /**
+     * Adds a class to the label Element. We recommend you add a conditional
+     * check here, and in removeClassFromLabel for whether or not the label is
+     * present so that the JS component could be used with text fields that don't
+     * require a label, such as the full-width text field.
+     */
+    addClassToLabel(className: string): void;
+
+    /**
+     * Removes a class from the label Element.
+     */
+    removeClassFromLabel(className: string): void;
+
+    /**
+     * Sets an attribute on the icon Element.
+     */
+    setIconAttr(name: string, value: string): void;
+
+    /**
+     * Returns true if classname exists for a given target element.
+     */
+    eventTargetHasClass(target: EventTarget, className: string): boolean;
+
+    /**
+     * Registers an event handler on the root element for a given event.
+     */
+    registerTextFieldInteractionHandler(type: string, handler: EventListener): void;
+
+    /**
+     * Deregisters an event handler on the root element for a given event.
+     */
+    deregisterTextFieldInteractionHandler(type: string, handler: EventListener): void;
+
+    /**
+     * Emits a custom event "MDCTextField:icon" denoting a user has clicked the icon.
+     */
+    notifyIconAction(): void;
+
+    /**
+     * Adds a class to the helper text element. Note that in our code we check for
+     * whether or not we have a helper text element and if we don't, we simply
+     * return.
+     */
+    addClassToHelperText(className: string): void;
+
+    /**
+     * Removes a class from the helper text element.
+     */
+    removeClassFromHelperText(className: string): void;
+
+    /**
+     * Returns whether or not the helper text element contains the given class.
+     */
+    helperTextHasClass(className: string): boolean;
+
+    /**
+     * Registers an event listener on the native input element for a given event.
+     */
+    registerInputInteractionHandler(evtType: string, handler: EventListener): void;
+
+    /**
+     * Deregisters an event listener on the native input element for a given event.
+     */
+    deregisterInputInteractionHandler(evtType: string, handler: EventListener): void;
+
+    /**
+     * Registers an event listener on the bottom line element for a given event.
+     */
+    registerBottomLineEventHandler(evtType: string, handler: EventListener): void;
+
+    /**
+     * Deregisters an event listener on the bottom line element for a given event.
+     */
+    deregisterBottomLineEventHandler(evtType: string, handler: EventListener): void;
+
+    /**
+     * Sets an attribute with a given value on the helper text element.
+     */
+    setHelperTextAttr(name: string, value: string): void;
+
+    /**
+     * Removes an attribute from the helper text element.
+     */
+    removeHelperTextAttr(name: string): void;
+
+    /**
+     * Sets the text content for the help text element
+     */
+    setHelperTextContent(content: string): void;
+
+    /**
+     * Returns an object representing the native text input element, with a
+     * similar API shape. The object returned should include the value, disabled
+     * and badInput properties, as well as the checkValidity() function. We never
+     * alter the value within our code, however we do update the disabled
+     * property, so if you choose to duck-type the return value for this method
+     * in your implementation it's important to keep this in mind. Also note that
+     * this method can return null, which the foundation will handle gracefully.
+     */
+    getNativeInput(): Element|NativeInputType;
+
+    /**
+     * Returns the foundation for the bottom line element. Returns undefined if
+     * there is no bottom line element.
+     */
+    getBottomLineFoundation(): MDCTextFieldBottomLineFoundation;
+
+    /**
+     * Returns the foundation for the helper text element. Returns undefined if
+     * there is no helper text element.
+     */
+    getHelperTextFoundation(): MDCTextFieldHelperTextFoundation;
+}

--- a/types/material__textfield/bottom-line/adapter.d.ts
+++ b/types/material__textfield/bottom-line/adapter.d.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adapter for MDC TextField Bottom Line.
+ *
+ * Defines the shape of the adapter expected by the foundation. Implement this
+ * adapter to integrate the TextField bottom line into your framework. See
+ * https://github.com/material-components/material-components-web/blob/master/docs/authoring-components.md
+ * for more information.
+ *
+ * @record
+ */
+export default class MDCTextFieldBottomLineAdapter {
+    /**
+     * Adds a class to the bottom line element.
+     */
+    addClass(className: string): void;
+
+    /**
+     * Removes a class from the bottom line element.
+     */
+    removeClass(className: string): void;
+
+    /**
+     * Sets an attribute with a given value on the bottom line element.
+     */
+    setAttr(attr: string, value: string): void;
+
+    /**
+     * Registers an event listener on the bottom line element for a given event.
+     */
+    registerEventHandler(evtType: string, handler: EventListener): void;
+
+    /**
+     * Deregisters an event listener on the bottom line element for a given event.
+     */
+    deregisterEventHandler(evtType: string, handler: EventListener): void;
+
+    /**
+     * Emits a custom event "MDCTextFieldBottomLine:animation-end" denoting the
+     * bottom line has finished its animation; either the activate or
+     * deactivate animation
+     */
+    notifyAnimationEnd(): void;
+}

--- a/types/material__textfield/bottom-line/constants.d.ts
+++ b/types/material__textfield/bottom-line/constants.d.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface strings extends MDCStrings {
+    ANIMATION_END_EVENT: 'MDCTextFieldBottomLine:animation-end';
+}
+
+export interface cssClasses extends MDCStrings {
+    BOTTOM_LINE_ACTIVE: 'mdc-text-field__bottom-line--active';
+}

--- a/types/material__textfield/bottom-line/foundation.d.ts
+++ b/types/material__textfield/bottom-line/foundation.d.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import MDCTextFieldBottomLineAdapter from './adapter';
+import { cssClasses, strings } from './constants';
+
+export default class MDCTextFieldBottomLineFoundation extends MDCFoundation<MDCTextFieldBottomLineAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCTextFieldBottomLineAdapter;
+
+    /**
+     * Activates the bottom line
+     */
+    activate(): void;
+
+    /**
+     * Sets the transform origin given a user's click location.
+     */
+    setTransformOrigin(evt: Event): void;
+
+    /**
+     * Deactivates the bottom line
+     */
+    deactivate(): void;
+
+    /**
+     * Handles a transition end event
+     */
+    handleTransitionEnd(evt: Event): void;
+}

--- a/types/material__textfield/bottom-line/index.d.ts
+++ b/types/material__textfield/bottom-line/index.d.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+
+import MDCTextFieldBottomLineAdapter from './adapter';
+import MDCTextFieldBottomLineFoundation from './foundation';
+
+export {MDCTextFieldBottomLineAdapter, MDCTextFieldBottomLineFoundation};
+
+export class MDCTextFieldBottomLine extends MDCComponent<MDCTextFieldBottomLineAdapter, MDCTextFieldBottomLineFoundation> {
+    static attachTo(root: Element): MDCTextFieldBottomLine;
+
+    readonly foundation: MDCTextFieldBottomLineFoundation;
+
+    getDefaultFoundation(): MDCTextFieldBottomLineFoundation;
+}

--- a/types/material__textfield/constants.d.ts
+++ b/types/material__textfield/constants.d.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface strings extends MDCStrings {
+    ARIA_CONTROLS: 'aria-controls';
+    INPUT_SELECTOR: '.mdc-text-field__input';
+    LABEL_SELECTOR: '.mdc-text-field__label';
+    ICON_SELECTOR: '.mdc-text-field__icon';
+    ICON_EVENT: 'MDCTextField:icon';
+    BOTTOM_LINE_SELECTOR: '.mdc-text-field__bottom-line';
+}
+
+export interface cssClasses extends MDCStrings {
+    ROOT: 'mdc-text-field';
+    UPGRADED: 'mdc-text-field--upgraded';
+    DISABLED: 'mdc-text-field--disabled';
+    FOCUSED: 'mdc-text-field--focused';
+    INVALID: 'mdc-text-field--invalid';
+    LABEL_FLOAT_ABOVE: 'mdc-text-field__label--float-above';
+    LABEL_SHAKE: 'mdc-text-field__label--shake';
+    BOX: 'mdc-text-field--box';
+    TEXT_FIELD_ICON: 'mdc-text-field__icon';
+    TEXTAREA: 'mdc-text-field--textarea';
+}

--- a/types/material__textfield/foundation.d.ts
+++ b/types/material__textfield/foundation.d.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import { MDCTextFieldAdapter, NativeInputType } from './adapter';
+import MDCTextFieldBottomLineFoundation from './bottom-line/foundation';
+import { cssClasses, strings } from './constants';
+
+export default class MDCTextFieldFoundation extends MDCFoundation<MDCTextFieldAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCTextFieldAdapter;
+
+    handleTextFieldInteraction(evt: Event): void;
+
+    /**
+     * Activates the text field focus state.
+     */
+    activateFocus(): void;
+
+    /**
+     * Sets the bottom line's transform origin, so that the bottom line activate
+     * animation will animate out from the user's click location.
+     */
+    setBottomLineTransformOrigin(evt: Event): void;
+
+    /**
+     * Activates the Text Field's focus state in cases when the input value
+     * changes without user input (e.g. programatically).
+     */
+    autoCompleteFocus(): void;
+
+    /**
+     * Handles when bottom line animation ends, performing actions that must wait
+     * for animations to finish.
+     */
+    handleBottomLineAnimationEnd(): void;
+
+    /**
+     * Deactives the Text Field's focus state.
+     */
+    deactivateFocus(): void;
+
+    /**
+     * True if the Text Field is disabled.
+     */
+    isDisabled(): boolean;
+
+    /**
+     * Sets the text-field disabled or enabled.
+     */
+    setDisabled(disabled: boolean): void;
+
+    /**
+     * Sets the content of the helper text.
+     */
+    setHelperTextContent(content: string): void;
+
+    /**
+     * Sets the validity state of the Text Field.
+     */
+    setValid(isValid: boolean): void;
+}

--- a/types/material__textfield/helper-text/adapter.d.ts
+++ b/types/material__textfield/helper-text/adapter.d.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Adapter for MDC Text Field Helper Text.
+ *
+ * Defines the shape of the adapter expected by the foundation. Implement this
+ * adapter to integrate the TextField helper text into your framework. See
+ * https://github.com/material-components/material-components-web/blob/master/docs/authoring-components.md
+ * for more information.
+ *
+ * @record
+ */
+export default class MDCTextFieldHelperTextAdapter {
+    /**
+     * Adds a class to the helper text element.
+     */
+    addClass(className: string): void;
+
+    /**
+     * Removes a class from the helper text element.
+     */
+    removeClass(className: string): void;
+
+    /**
+     * Returns whether or not the helper text element contains the given class.
+     */
+    hasClass(className: string): boolean;
+
+    /**
+     * Sets an attribute with a given value on the helper text element.
+     */
+    setAttr(attr: string, value: string): void;
+
+    /**
+     * Removes an attribute from the helper text element.
+     */
+    removeAttr(attr: string): void;
+
+    /**
+     * Sets the text content for the helper text element.
+     */
+    setContent(content: string): void;
+}

--- a/types/material__textfield/helper-text/constants.d.ts
+++ b/types/material__textfield/helper-text/constants.d.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings } from 'material__base';
+
+export interface strings extends MDCStrings {
+    ARIA_HIDDEN: 'aria-hidden';
+    ROLE: 'role';
+}
+
+export interface cssClasses extends MDCStrings {
+    HELPER_TEXT_PERSISTENT: 'mdc-text-field-helper-text--persistent';
+    HELPER_TEXT_VALIDATION_MSG: 'mdc-text-field-helper-text--validation-msg';
+}

--- a/types/material__textfield/helper-text/foundation.d.ts
+++ b/types/material__textfield/helper-text/foundation.d.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCFoundation from 'material__base/foundation';
+import MDCTextFieldHelperTextAdapter from './adapter';
+import { cssClasses, strings } from './constants';
+
+export default class MDCTextFieldHelperTextFoundation extends MDCFoundation<MDCTextFieldHelperTextAdapter> {
+    static readonly cssClasses: cssClasses;
+
+    static readonly strings: strings;
+
+    static readonly defaultAdapter: MDCTextFieldHelperTextAdapter;
+
+    /**
+     * Sets the content of the helper text field.
+     */
+    setContent(content: string): void;
+
+    /** Makes the helper text visible to the screen reader. */
+    showToScreenReader(): void;
+
+    /**
+     * Sets the validity of the helper text based on the input validity.
+     */
+    setValidity(inputIsValid: boolean): void;
+}

--- a/types/material__textfield/helper-text/index.d.ts
+++ b/types/material__textfield/helper-text/index.d.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+
+import MDCTextFieldHelperTextAdapter from './adapter';
+import MDCTextFieldHelperTextFoundation from './foundation';
+
+export {MDCTextFieldHelperTextAdapter, MDCTextFieldHelperTextFoundation};
+
+export class MDCTextFieldHelperText extends MDCComponent<MDCTextFieldHelperTextAdapter, MDCTextFieldHelperTextFoundation> {
+    static attachTo(root: Element): MDCTextFieldHelperText;
+
+    readonly foundation: MDCTextFieldHelperTextFoundation;
+
+    getDefaultFoundation(): MDCTextFieldHelperTextFoundation;
+}

--- a/types/material__textfield/index.d.ts
+++ b/types/material__textfield/index.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import MDCComponent from 'material__base/component';
+import { MDCRipple } from 'material__ripple';
+
+import { cssClasses, strings } from './constants';
+import { MDCTextFieldAdapter } from './adapter';
+import MDCTextFieldFoundation from './foundation';
+import { MDCTextFieldBottomLine } from './bottom-line/index';
+import { MDCTextFieldHelperText } from './helper-text/index';
+
+export {MDCTextFieldAdapter, MDCTextFieldFoundation};
+
+export class MDCTextField extends MDCComponent<MDCTextFieldAdapter, MDCTextFieldFoundation> {
+    static attachTo(root: Element): MDCTextField;
+
+    initialize(
+      rippleFactory?: (el: Element) => MDCRipple,
+      bottomLineFactory?: (el: Element) => MDCTextFieldBottomLine
+    ): void;
+
+    destroy(): void;
+
+    /**
+     * Initiliazes the Text Field's internal state based on the environment's
+     * state.
+     */
+    initialSyncWithDom(): void;
+
+    disabled: boolean;
+
+    valid: boolean;
+
+    /**
+     * Sets the helper text element content.
+     */
+    helperTextContent: string;
+
+    getDefaultFoundation(): MDCTextFieldFoundation;
+}

--- a/types/material__textfield/tsconfig.json
+++ b/types/material__textfield/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "helper-text/constants.d.ts",
+        "helper-text/adapter.d.ts",
+        "helper-text/index.d.ts",
+        "helper-text/foundation.d.ts",
+        "bottom-line/constants.d.ts",
+        "bottom-line/adapter.d.ts",
+        "bottom-line/index.d.ts",
+        "bottom-line/foundation.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__textfield/tslint.json
+++ b/types/material__textfield/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__toolbar/adapter.d.ts
+++ b/types/material__toolbar/adapter.d.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MDCToolbarAdapter {
+    hasClass(className: string): boolean;
+
+    addClass(className: string): void;
+
+    removeClass(className: string): void;
+
+    registerScrollHandler(handler: EventListener): void;
+
+    deregisterScrollHandler(handler: EventListener): void;
+
+    registerResizeHandler(handler: EventListener): void;
+
+    deregisterResizeHandler(handler: EventListener): void;
+
+    getViewportWidth(): number;
+
+    getViewportScrollY(): number;
+
+    getOffsetHeight(): number;
+
+    getFirstRowElementOffsetHeight(): number;
+
+    notifyChange(evtData: {flexibleExpansionRatio: number}): void;
+
+    setStyle(property: string, value: string): void;
+
+    setStyleForTitleElement(property: string, value: string): void;
+
+    setStyleForFlexibleRowElement(property: string, value: string): void;
+
+    setStyleForFixedAdjustElement(property: string, value: string): void;
+}

--- a/types/material__toolbar/constants.d.ts
+++ b/types/material__toolbar/constants.d.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCStrings, MDCNumbers } from 'material__base';
+
+export interface cssClasses extends MDCStrings {
+    FIXED: 'mdc-toolbar--fixed';
+    FIXED_LASTROW: 'mdc-toolbar--fixed-lastrow-only';
+    FIXED_AT_LAST_ROW: 'mdc-toolbar--fixed-at-last-row';
+    TOOLBAR_ROW_FLEXIBLE: 'mdc-toolbar--flexible';
+    FLEXIBLE_DEFAULT_BEHAVIOR: 'mdc-toolbar--flexible-default-behavior';
+    FLEXIBLE_MAX: 'mdc-toolbar--flexible-space-maximized';
+    FLEXIBLE_MIN: 'mdc-toolbar--flexible-space-minimized';
+}
+
+export interface strings extends MDCStrings {
+    TITLE_SELECTOR: '.mdc-toolbar__title';
+    FIRST_ROW_SELECTOR: '.mdc-toolbar__row:first-child';
+    CHANGE_EVENT: 'MDCToolbar:change';
+}
+
+export interface numbers extends MDCNumbers {
+    MAX_TITLE_SIZE: 2.125;
+    MIN_TITLE_SIZE: 1.25;
+    TOOLBAR_ROW_HEIGHT: 64;
+    TOOLBAR_ROW_MOBILE_HEIGHT: 56;
+    TOOLBAR_MOBILE_BREAKPOINT: 600;
+}

--- a/types/material__toolbar/foundation.d.ts
+++ b/types/material__toolbar/foundation.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import MDCFoundation from 'material__base/foundation';
+import { cssClasses, strings, numbers } from './constants';
+import { MDCToolbarAdapter } from './adapter';
+
+export default class MDCToolbarFoundation extends MDCFoundation<MDCToolbarAdapter> {
+  static readonly cssClasses: cssClasses;
+
+  static readonly strings: strings;
+
+  static readonly numbers: numbers;
+
+  static readonly defaultAdapter: MDCToolbarAdapter;
+
+  updateAdjustElementStyles(): void;
+}

--- a/types/material__toolbar/index.d.ts
+++ b/types/material__toolbar/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for Material Components Web 0.26
+// Project: https://material.io/components/
+// Definitions by: Brent Douglas <https://github.com/BrentDouglas>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MDCComponent } from 'material__base';
+
+import MDCToolbarFoundation from './foundation';
+import { MDCToolbarAdapter } from './adapter';
+import * as util from './util';
+
+export {MDCToolbarAdapter, MDCToolbarFoundation, util};
+
+export class MDCToolbar extends MDCComponent<MDCToolbarAdapter, MDCToolbarFoundation> {
+  static attachTo(root: HTMLElement): MDCToolbar;
+
+  fixedAdjustElement: HTMLElement;
+
+  getDefaultFoundation(): MDCToolbarFoundation;
+}

--- a/types/material__toolbar/tsconfig.json
+++ b/types/material__toolbar/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "files": [
+        "constants.d.ts",
+        "adapter.d.ts",
+        "util.d.ts",
+        "index.d.ts",
+        "foundation.d.ts"
+    ],
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    }
+}

--- a/types/material__toolbar/tslint.json
+++ b/types/material__toolbar/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/material__toolbar/util.d.ts
+++ b/types/material__toolbar/util.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Determine whether the current browser supports passive event listeners, and if so, use them.
+export function applyPassive(globalObj?: Window, forceRefresh?: boolean): boolean;


### PR DESCRIPTION
These types were handrolled by combining the original js files headers with their closure type annotations a few weeks ago, before I realised how much of a hurdle it would be to use them locally. I would appreciate some input into what I need to to with this submission to get it up to scratch. My main open questions are:

a) Will these manually edited closure types be acceptable or to you only take types from dts-gen?
b) Most of the other types in here don't have a package.json file, should they be included? The linter was complaining about parts of it so I get the impression I can have it here to describe the inter-package deps, right? If it is ok, it didn't want me to include the version so I'm not sure how I'm meant to point the packages to each other.
c) I'm not really sure how the enums in the constants files should be represented. (In js they are  `const val = {FOO: 'bar'}`. At work we export enums as `module val { const FOO: 'bar'; };` but that doesn't play well with IDE's auto imports)


And the template

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
   - See above, I haven't added the config files for it yet

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
   - The maintainers use closure-compliers type annotations and are not willing to add TS definitions to their repo. (https://github.com/material-components/material-components-web/issues/1840)
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
   - This was created my manually from the closure type annotations 
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.