### PR TITLE
[react-native-tab-view] SceneMap should support all React.ComponentType's

### DIFF
--- a/types/react-native-tab-view/index.d.ts
+++ b/types/react-native-tab-view/index.d.ts
@@ -4,7 +4,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-import { PureComponent, ReactNode } from 'react'
+import { PureComponent, ReactNode, ComponentType } from 'react'
 import {
   Animated,
   StyleProp,
@@ -233,5 +233,5 @@ export class TabBar<T extends Route = Route> extends PureComponent<
 > {}
 
 export function SceneMap(scenes: {
-  [key: string]: (props: any) => ReactNode
+  [key: string]: ComponentType<any>
 }): (props: { route: Route }) => ReactNode

--- a/types/react-native-tab-view/react-native-tab-view-tests.tsx
+++ b/types/react-native-tab-view/react-native-tab-view-tests.tsx
@@ -1,4 +1,4 @@
-import { PureComponent } from 'react'
+import { PureComponent, Component } from 'react'
 import { View, StyleSheet } from 'react-native'
 import {
   TabViewAnimated,
@@ -11,9 +11,14 @@ import {
 const FirstRoute = () => (
   <View style={[styles.container, { backgroundColor: '#ff4081' }]} />
 )
-const SecondRoute = () => (
-  <View style={[styles.container, { backgroundColor: '#673ab7' }]} />
-)
+
+class SecondRoute extends Component {
+  render() {
+    return (
+      <View style={[styles.container, { backgroundColor: '#673ab7' }]} />
+    );
+  }
+}
 
 class TabViewExample extends PureComponent {
   state: { index: number; routes: Array<RouteBase & { title: string }> } = {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/react-native-community/react-native-tab-view#scenemap>.
