### PR TITLE
Update electron-packager for 10.1

### DIFF
--- a/types/electron-packager/electron-packager-tests.ts
+++ b/types/electron-packager/electron-packager-tests.ts
@@ -1,8 +1,16 @@
 import * as packager from "electron-packager";
 
-function callback(err: Error, appPath: string) {
+function callback(err: Error, appPaths: string[]) {
 	const msg = err.message;
-	const	index = appPath.indexOf("test");
+	const	index = appPaths.indexOf("test");
+}
+
+function completeFunction(buildPath: string, electronVersion: string, platform: string, arch: string, callbackFn: () => void) {
+	callbackFn();
+}
+
+function ignoreFunction(path: string) {
+	return true;
 }
 
 packager({
@@ -10,20 +18,38 @@ packager({
 	name: "myapplication",
 	platform: "win32",
 	arch: "all",
-	electronVersion: "0.34.0"
+	electronVersion: "0.34.0",
+	win32metadata: {
+		CompanyName: "Acme CO",
+		FileDescription: "My application",
+		OriginalFilename: "myapp.exe",
+		ProductName: "Application",
+		InternalName: "roadrunner",
+		"requested-execution-level": "highestAvailable",
+		"application-manifest": "manifest.xml"
+	}
 }, callback);
 
 packager({
 	dir: ".",
 	name: "myapplication",
 	electronVersion: "0.34.0",
-	all: true
+	all: true,
+	win32metadata: {
+		CompanyName: "Acme CO",
+		FileDescription: "My application",
+		OriginalFilename: "myapp.exe",
+		ProductName: "Application",
+		InternalName: "roadrunner",
+		"requested-execution-level": "requireAdministrator",
+		"application-manifest": "manifest.xml"
+	}
 }, callback);
 
 packager({
 	dir: ".",
 	name: "myapplication",
-	platform: "win32",
+	platform: "all",
 	arch: "all",
 	electronVersion: "0.34.0"
 }, callback);
@@ -33,4 +59,137 @@ packager({
 	name: "myapplication",
 	electronVersion: "0.34.0",
 	all: true
+}, callback);
+
+packager({
+	dir: ".",
+	name: "myapplication",
+	electronVersion: "0.34.0",
+	arch: "arm64",
+	executableName: "myapp"
+}, callback);
+
+packager({
+	dir: ".",
+	afterCopy: [
+		completeFunction
+	],
+	afterExtract: [
+		completeFunction
+	],
+	afterPrune:  [
+		completeFunction
+	],
+	appCopyright: "Copyright",
+	appVersion: "1.0",
+	arch: "ia32",
+	asar: false,
+	buildVersion: "1.2.3",
+	derefSymlinks: true,
+	download: {
+		cache: "./zips",
+		mirror: "https://10.1.2.105/",
+		quiet: true,
+		strictSSL: true
+	},
+	extraResource: "foo.js",
+	icon: "foo.ico",
+	ignore: /ab+c/,
+	out: "out",
+	overwrite: true,
+	packageManager: false,
+	prune: true,
+	quiet: true,
+	tmpdir: "/tmp",
+	win32metadata: {
+		CompanyName: "Acme CO",
+		FileDescription: "My application",
+		OriginalFilename: "myapp.exe",
+		ProductName: "Application",
+		InternalName: "roadrunner",
+		"requested-execution-level": "asInvoker",
+		"application-manifest": "manifest.xml"
+	}
+}, callback);
+
+packager({
+	dir: ".",
+	arch: "x64",
+	asar: true,
+	derefSymlinks: false,
+	download: {
+		cache: "./zips",
+		mirror: "https://10.1.2.105/",
+		quiet: false,
+		strictSSL: true
+	},
+	extraResource: [
+		"foo.js",
+		"bar.js"
+	],
+	ignore: [
+		/ab+c/,
+		new RegExp('abc')
+	],
+	overwrite: false,
+	packageManager: "npm",
+	platform: "darwin",
+	prune: false,
+	quiet: false,
+	tmpdir: "false",
+	appBundleId: "123456",
+	appCategoryType: "public.app-category.developer-tools",
+	extendInfo: "plist.txt",
+	helperBundleId: "23223f",
+	osxSign: true
+}, callback);
+
+packager({
+	dir: ".",
+	arch: "armv7l",
+	asar: {
+		ordering: "order.txt",
+		unpack: "*.js",
+		unpackDir: "sub_dir"
+	},
+	download: {
+		cache: "./zips",
+		mirror: "https://10.1.2.105/",
+		quiet: false,
+		strictSSL: false
+	},
+	ignore: ignoreFunction,
+	packageManager: "cnpm",
+	platform: "linux"
+}, callback);
+
+packager({
+	dir: ".",
+	arch: [
+		"ia32",
+		"x64"
+	],
+	download: {
+		cache: "./zips",
+		mirror: "https://10.1.2.105/",
+		quiet: true,
+		strictSSL: false
+	},
+	packageManager: "yarn",
+	platform: "mas",
+	extendInfo: {
+		foo: "bar"
+	},
+	osxSign: {
+		identity: "myidentity",
+		entitlements: "path/to/my.entitlements",
+		"entitlements-inherit": "path/to/inherit.entitlements"
+	},
+	protocols: [{
+		name: "myappproto",
+		schemes: [
+			"myapp",
+			"myapp2"
+		]
+	}]
 }, callback);

--- a/types/electron-packager/index.d.ts
+++ b/types/electron-packager/index.d.ts
@@ -1,7 +1,8 @@
-// Type definitions for electron-packager 8.7
+// Type definitions for electron-packager 10.1
 // Project: https://github.com/electron-userland/electron-packager
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT>
 //                 Juan Jimenez-Anca <https://github.com/cortopy>
+//                 John Kleinschmidt <https://github.com/jkleinsc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -31,8 +32,8 @@ declare namespace electronPackager {
 
     type ignoreFunction = (path: string) => boolean;
     type onCompleteFn = (buildPath: string, electronVersion: string, platform: string, arch: string, callbackFn: () => void) => void;
-    type arch = "ia32" | "x64" | "armv7l" | "all";
-    type packageManager = "npm" | "cnpm" | "yarn";
+    type arch = "ia32" | "x64" | "armv7l" | "arm64" |"all";
+    type packageManager = "npm" | "cnpm" | "yarn" | false;
     type platform = "linux" | "win32" | "darwin" | "mas" | "all";
 
     interface AsarOptions {
@@ -94,7 +95,7 @@ declare namespace electronPackager {
          * Arbitrary combinations of individual architectures are also supported via a comma-delimited string or array of strings.
          * The non-all values correspond to the architecture names used by Electron releases. This value is not restricted to the official set if download.mirror is set.
          */
-        arch?: arch;
+        arch?: arch | arch[];
         /**
          * Whether to package the application's source code into an archive, using Electron's archive format
          */
@@ -120,6 +121,10 @@ declare namespace electronPackager {
          * One or more files to be copied directly into the app's Contents/Resources directory for OS X target platforms, and the resources directory for other target platforms.
          */
         extraResource?: string | string[];
+        /**
+         * The name of the executable file, sans file extension. Defaults to the value for the name parameter
+         */
+        executableName?: string;
         /**
          * The local path to the icon file, if the target platform supports setting embedding an icon.
          */


### PR DESCRIPTION
This PR updates electron-packager to 10.1
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/electron-userland/electron-packager/compare/v8.7.0...v10.1.0#diff-0f426376b964e609c5c4618eb8bed3b2 
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.