### PR TITLE
fix(aws-lambda): AuthResponseContext children may be objects

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -457,7 +457,7 @@ export interface Statement {
  * http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output
  */
 export interface AuthResponseContext {
-    [name: string]: string | number | boolean;
+    [name: string]: any;
 }
 
 /**


### PR DESCRIPTION
If used with a custom authorizer, there will be a claims object
with the parsed JSON web token.
See https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html