### PR TITLE
kafka-node: fix message value to be string or Buffer

### DIFF
--- a/types/kafka-node/index.d.ts
+++ b/types/kafka-node/index.d.ts
@@ -3,6 +3,8 @@
 // Definitions by: Daniel Imrie-Situnayake <https://github.com/dansitu>, Bill <https://github.com/bkim54>, Michael Haan <https://github.com/sfrooster>, Amiram Korach <https://github.com/amiram>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 // # Classes
 export class Client {
     constructor(connectionString: string, clientId?: string, options?: ZKOptions, noBatchOptions?: AckBatchOptions, sslOptions?: any);
@@ -88,24 +90,24 @@ export class Offset {
 }
 
 export class KeyedMessage {
-    constructor(key: string, message: string);
+    constructor(key: string, value: string | Buffer);
 }
 
 // # Interfaces
 
 export interface Message {
-  topic: string;
-  value: string;
-  offset?: number;
-  partition?: number;
-  highWaterOffset?: number;
-  key?: string;
-}
+    topic: string;
+    value: string | Buffer;
+    offset?: number;
+    partition?: number;
+    highWaterOffset?: number;
+    key?: string;
+  }
 
 export interface ProducerOptions {
-  requireAcks?: number;
-  ackTimeoutMs?: number;
-  partitionerType?: number;
+    requireAcks?: number;
+    ackTimeoutMs?: number;
+    partitionerType?: number;
 }
 
 export interface KafkaClientOptions {


### PR DESCRIPTION
Unfortunately, I think this is a breaking change (existing users may assume that message value is a string). According to semver, we should upgrade the major version number of `@types/kafka-node` to 3, but this would make it different from the major version number of kafka-node`, which is 2.

Unfortunately, the design of this particular `kafka-node` interface makes type inference difficult.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:

- Evidence that it can be a string or Buffer: https://github.com/quiiver/kafka-node/blob/master/lib/protocol/protocol.js#L351 (producer side) and https://github.com/SOHU-Co/kafka-node#consumer (consumer side: comment on `encoding` option: "If set to 'buffer', values will be returned as raw buffer objects.")
- Renaming the second argument of KeyedMessage constructor: https://github.com/SOHU-Co/kafka-node/blob/master/lib/protocol/protocol_struct.js#L98
