### PR TITLE
atom: add PackageManager.deactivatePackage() method

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -1459,6 +1459,14 @@ function testPackageManager() {
 
     bool = atom.packages.isPackageDisabled("Test");
 
+    // Activating and deactivating packages
+    atom.packages.activatePackage("Test").then((activePack) => {
+        pack = activePack;
+    });
+    atom.packages.deactivatePackage("Test", true).then(() => {
+        // package is deactivated
+    });
+
     // Accessing active packages
     packs = atom.packages.getActivePackages();
 

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -4111,6 +4111,9 @@ export interface PackageManager {
     /** Activate a single package by name or path. */
     activatePackage(nameOrPath: string): Promise<Package>;
 
+    /** Deactivate a single package by name or path. */
+    deactivatePackage(nameOrPath: string, suppressSerialization?: boolean): Promise<void>;
+
     /** Triggers the given package activation hook. */
     triggerActivationHook(hook: string): void;
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/atom/atom/blob/d6a3a604695df62a7b813bd229316042a501aee5/src/package-manager.js#L760
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This patch adds the `deactivatePackage()` method to the `PackageManager` class. Like `activatePackage()`, this method is actually undocumented, but is very useful for testing. Since `activatePackage()` is already included in the current definitions, it would be good to add `deactivatePackage()` for the sake of parity.