### PR TITLE
Support className prop for interface ReduxToastrProps in react-redux-toastr

### DIFF
--- a/types/react-redux-toastr/index.d.ts
+++ b/types/react-redux-toastr/index.d.ts
@@ -100,6 +100,7 @@ interface ReduxToastrProps {
     toastr?: ToastrState;
     transitionIn?: transitionInType;
     transitionOut?: transitionOutType;
+    className?: string;
 }
 
 interface ToastrEmitter {


### PR DESCRIPTION
Added optional className prop on `ReduxToastrProps` to support https://github.com/diegoddox/react-redux-toastr/issues/103 no change to version in header required.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/diegoddox/react-redux-toastr/issues/103
