### PR TITLE
[react-loadable] ability to import types which were unavailable

### DIFF
--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -185,7 +185,7 @@ declare namespace LoadableExport {
     }
 }
 
-declare const LoadableExport: Loadable.Loadable;
+declare const LoadableExport: LoadableExport.Loadable;
 
 /* tslint:disable-next-line */
 declare module "react-loadable" {

--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for react-loadable 5.3
 // Project: https://github.com/thejameskyle/react-loadable#readme
-// Definitions by: Diogo Franco <https://github.com/Kovensky>, Oden S. <https://github.com/odensc>, Ian Ker-Seymer <https://github.com/ianks>
+// Definitions by: Diogo Franco <https://github.com/Kovensky>
+//                 Oden S. <https://github.com/odensc>
+//                 Ian Ker-Seymer <https://github.com/ianks>
+//                 Tomek Łaziuk <https://github.com/tlaziuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/react-loadable/index.d.ts
+++ b/types/react-loadable/index.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="react" />
 
-declare namespace Loadable {
+declare namespace LoadableExport {
     interface LoadingComponentProps {
         isLoading: boolean;
         pastDelay: boolean;

--- a/types/react-loadable/test/index.tsx
+++ b/types/react-loadable/test/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Loadable = require('react-loadable');
+import * as Loadable from 'react-loadable';
 
 class LoadingComponent extends React.Component<Loadable.LoadingComponentProps> {
   render() {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] ~~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~~
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I'm making this PR because this package confused me a little as it exports only the `Loadable` interface, other interfaces/types are available only by using `require`.

This PR intruduces an ability do to following thing without any error:
``` typescript
import { Component } from "react";
import { LoadingComponentProps } from "react-loadable";

class LoadingComponent extends Component<LoadingComponentProps> { ... }
```

The previous way should be working as it was, without any changes:
``` typescript
import { Component } from "react";
const Loadable = require("react-loadable");

class LoadingComponent extends Component<Loadable.LoadingComponentProps> { ... }
```