### PR TITLE
Reactstrap: Renaming Input's size property to bsSize

### DIFF
--- a/types/reactstrap/index.d.ts
+++ b/types/reactstrap/index.d.ts
@@ -6,6 +6,7 @@
 //                 Fábio Paiva <https://github.com/fabiopaiva>
 //                 FaithForHumans <https://github.com/FaithForHumans>
 //                 Kurt Preston <https://github.com/KurtPreston>
+//                 Kræn Hansen <https://github.com/kraenhansen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/reactstrap/lib/Input.d.ts
+++ b/types/reactstrap/lib/Input.d.ts
@@ -27,15 +27,9 @@ type InputType =
   | 'time'
   | 'color';
 
-// Intermediate interface to "redefine" the type of size to string
-// size:number => size:any => size:string
-interface Intermediate extends React.InputHTMLAttributes<HTMLInputElement> {
-  size?: any;
-}
-
-export interface InputProps extends Intermediate {
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   type?: InputType;
-  size?: string;
+  bsSize?: 'lg' | 'sm';
   state?: string;
   valid?: boolean;
   tag?: React.ReactType;

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -1381,16 +1381,16 @@ class Example50 extends React.Component {
   render() {
     return (
       <Form>
-        <Input placeholder="lg" size="lg" />
+        <Input placeholder="lg" bsSize="lg" />
         <Input placeholder="default" />
-        <Input placeholder="sm" size="sm" />
-        <Input type="select" size="lg">
+        <Input placeholder="sm" bsSize="sm" />
+        <Input type="select" bsSize="lg">
           <option>Large Select</option>
         </Input>
         <Input type="select">
           <option>Default Select</option>
         </Input>
-        <Input type="select" size="sm">
+        <Input type="select" bsSize="sm">
           <option>Small Select</option>
         </Input>
       </Form>
@@ -3247,7 +3247,7 @@ function Example104() {
       </Label>
 
       <Col className="col-12" sm={9}>
-        <Input type="text" size="lg" {...props} />
+        <Input type="text" bsSize="lg" {...props} />
       </Col>
     </FormGroup>
   );


### PR DESCRIPTION
See https://github.com/reactstrap/reactstrap/commit/cc2bd1386fbcaf20ad18ab9437a84ced1879d25e fixing https://github.com/reactstrap/reactstrap/issues/660

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactstrap/reactstrap/commit/cc2bd1386fbcaf20ad18ab9437a84ced1879d25e
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
