### PR TITLE
jwplayer: Correct return type for getSafeRegion() function

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://developer.longtailvideo.com/trac/
 // Definitions by: Martin Duparc <https://github.com/martinduparc>
 //                 Tomer Kruvi <https://github.com/kutomer>
+//                 Philipp Gürtler <https://github.com/philippguertler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // JW Player is the leading HTML5 & Flash video player, optimized for mobile and the desktop. Easy enough for beginners, advanced enough for pros.
@@ -224,6 +225,13 @@ interface EventCallback<T extends CallbackParam> {
     (param: T): void;
 }
 
+interface Region {
+    x: 0; // x and y will always be 0 according to https://developer.jwplayer.com/jw-player/docs/javascript-api-reference/#jwplayergetsaferegion
+    y: 0;
+    width: number;
+    height: number;
+}
+
 interface JWPlayer {
 	addButton(icon: string, label: string, handler: () => void, id: string): void;
 	getAudioTracks(): any[];
@@ -243,7 +251,7 @@ interface JWPlayer {
 	getPosition(): number;
 	getQualityLevels(): any[];
 	getRenderingMode(): string;
-	getSafeRegion(): any[];
+	getSafeRegion(): Region;
 	getState(): string;
 	getVolume(): number;
     getEnvironment(): Environment;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.jwplayer.com/jw-player/docs/javascript-api-reference/#jwplayergetsaferegion
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.