### PR TITLE
import and use `Url` properly

### DIFF
--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -175,7 +175,7 @@ declare class Mail extends EventEmitter {
     setupProxy(proxyUrl: string): void;
 
     set(key: 'oauth2_provision_cb', value: (user: string, renew: boolean, callback: (err: Error | null, accessToken?: string, expires?: number) => void) => void): Map<string, any>;
-    set(key: 'proxy_handler_http' | 'proxy_handler_https' | 'proxy_handler_socks' | 'proxy_handler_socks5' | 'proxy_handler_socks4' | 'proxy_handler_socks4a', value: (proxy: URL, options: TransportOptions, callback: (err: Error | null, socketOptions?: { connection: Socket }) => void) => void): Map<string, any>;
+    set(key: 'proxy_handler_http' | 'proxy_handler_https' | 'proxy_handler_socks' | 'proxy_handler_socks5' | 'proxy_handler_socks4' | 'proxy_handler_socks4a', value: (proxy: Url, options: TransportOptions, callback: (err: Error | null, socketOptions?: { connection: Socket }) => void) => void): Map<string, any>;
     set(key: string, value: any): Map<string, any>;
 
     get(key: 'oauth2_provision_cb'): (user: string, renew: boolean, callback: (err: Error | null, accessToken: string, expires: number) => void) => void;

--- a/types/nodemailer/lib/mailer/index.d.ts
+++ b/types/nodemailer/lib/mailer/index.d.ts
@@ -3,7 +3,7 @@
 import { EventEmitter } from 'events';
 import { Socket } from 'net';
 import { Readable } from 'stream';
-import { URL } from 'url';
+import { Url } from 'url';
 
 import { SentMessageInfo, Transport, TransportOptions } from '../..';
 import * as shared from '../shared';
@@ -34,7 +34,7 @@ declare namespace Mail {
         /** String, Buffer or a Stream contents for the attachmentent */
         content?: string | Buffer | Readable;
         /** path to a file or an URL (data uris are allowed as well) if you want to stream the file instead of including it (better for larger attachments) */
-        path?: string | URL;
+        path?: string | Url;
     }
 
     interface Attachment extends AttachmentLike {
@@ -179,7 +179,7 @@ declare class Mail extends EventEmitter {
     set(key: string, value: any): Map<string, any>;
 
     get(key: 'oauth2_provision_cb'): (user: string, renew: boolean, callback: (err: Error | null, accessToken: string, expires: number) => void) => void;
-    get(key: 'proxy_handler_http' | 'proxy_handler_https' | 'proxy_handler_socks' | 'proxy_handler_socks5' | 'proxy_handler_socks4' | 'proxy_handler_socks4a'): (proxy: URL, options: TransportOptions, callback: (err: Error | null, socketOptions: { connection: Socket }) => void) => void;
+    get(key: 'proxy_handler_http' | 'proxy_handler_https' | 'proxy_handler_socks' | 'proxy_handler_socks5' | 'proxy_handler_socks4' | 'proxy_handler_socks4a'): (proxy: Url, options: TransportOptions, callback: (err: Error | null, socketOptions: { connection: Socket }) => void) => void;
     get(key: string): any;
 
     addListener(event: 'error', listener: (err: Error) => void): this;


### PR DESCRIPTION
currently imports a `URL` from 'url' library, except that `URL` does not exist; however `Url` does exist. 

Discovered upon trying to run tsc and getting the following error message: `node_modules/@types/nodemailer/lib/mailer/index.d.ts(6,10): error TS2305: Module '"url"' has no exported member 'URL'.`

As soon as I replaced `URL` with `Url` tsc correctly compiled.

