### PR TITLE
Allow modern import syntax for stemmer

### DIFF
--- a/types/stemmer/index.d.ts
+++ b/types/stemmer/index.d.ts
@@ -5,4 +5,6 @@
 
 declare function stemmer(value: string): string;
 
+declare namespace stemmer {}
+
 export = stemmer;

--- a/types/stemmer/stemmer-tests.ts
+++ b/types/stemmer/stemmer-tests.ts
@@ -1,3 +1,3 @@
-import stemmer = require('stemmer');
+import * as stemmer from 'stemmer';
 
 stemmer('Working');  // $ExpectType string


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- Only change is to make it compatible with the import syntax `import * as stemmer from 'stemmer'` instead of having to write `import stemmer = require('stemmer')`. It remains backwards compatible.

