### PR TITLE
[@feathersjs] add missing dependency to @feathersjs/socketio and @feathersjs/primus packages, add reexports to @feathersjs/express

### DIFF
--- a/types/feathersjs__express/index.d.ts
+++ b/types/feathersjs__express/index.d.ts
@@ -7,7 +7,8 @@
 import { Application as FeathersApplication } from '@feathersjs/feathers';
 import * as express from 'express';
 
-export default function feathersExpress<T>(app: FeathersApplication<T>): express.Application & FeathersApplication<T>;
+export default function feathersExpress<T>(app: FeathersApplication<T>): Application<T>;
+export type Application<T> = express.Application & FeathersApplication<T>;
 
 export function errorHandler(options?: any): express.ErrorRequestHandler;
 export function notFound(): express.RequestHandler;
@@ -17,6 +18,31 @@ export const rest: {
 };
 
 /*
- * Re-export of the express package. Can't be typed properly without just copying everything.
+ * Re-export of the express package.
  **/
-export const original: any;
+
+export {
+    CookieOptions,
+    Errback,
+    ErrorRequestHandler,
+    Express,
+    Handler,
+    IRoute,
+    IRouter,
+    IRouterHandler,
+    IRouterMatcher,
+    json,
+    MediaType,
+    NextFunction,
+    Request,
+    RequestHandler,
+    RequestParamHandler,
+    Response,
+    Router,
+    RouterOptions,
+    Send,
+    static,
+    urlencoded
+} from 'express';
+
+export const original: typeof express;

--- a/types/feathersjs__primus/index.d.ts
+++ b/types/feathersjs__primus/index.d.ts
@@ -3,5 +3,7 @@
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
 
+/// <reference types="feathersjs__socket-commons"/>
+
 // primus removed its typings from the repo https://github.com/primus/primus/pull/623, as of 01/2018 there are none on DT
 export default function feathersPrimus(options: any, callback?: (primus: any) => void): () => void;

--- a/types/feathersjs__primus/index.d.ts
+++ b/types/feathersjs__primus/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://feathersjs.com/
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
+// TypeScript Version: 2.3
 
 /// <reference types="feathersjs__socket-commons"/>
 

--- a/types/feathersjs__socketio/index.d.ts
+++ b/types/feathersjs__socketio/index.d.ts
@@ -2,6 +2,7 @@
 // Project: http://feathersjs.com/
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
+// TypeScript Version: 2.3
 
 /// <reference types="socket.io" />
 /// <reference types="feathersjs__socket-commons"/>

--- a/types/feathersjs__socketio/index.d.ts
+++ b/types/feathersjs__socketio/index.d.ts
@@ -4,6 +4,7 @@
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
 
 /// <reference types="socket.io" />
+/// <reference types="feathersjs__socket-commons"/>
 
 export default function feathersSocketIO(callback: (io: SocketIO.Server) => void): () => void;
 export default function feathersSocketIO(options: number | SocketIO.ServerOptions, callback?: (io: SocketIO.Server) => void): () => void;


### PR DESCRIPTION
Added missing `/// <reference types="feathersjs__socket-commons"/>` to socketio and primus packages.

I'm the package author (#22805)