### PR TITLE
express-session: fix Store#get callback parameter type

### DIFF
--- a/types/express-session/express-session-tests.ts
+++ b/types/express-session/express-session-tests.ts
@@ -37,3 +37,34 @@ app.use((req, res, next) => {
     res.end('welcome to the session demo. refresh!');
   }
 });
+
+// Custom Session Store
+
+class MyStore extends session.Store {
+  private sessions: { [sid: string]: string };
+
+  constructor() {
+    super();
+    this.sessions = {};
+  }
+
+  get = (sid: string, callback: (err: any, session: Express.SessionData) => void): void => {
+    callback(null, JSON.parse(this.sessions[sid]));
+  }
+
+  set = (sid: string, session: Express.Session, callback: (err: any) => void): void => {
+    this.sessions[sid] = JSON.stringify(session);
+    callback(null);
+  }
+
+  destroy = (sid: string, callback: (err: any) => void): void => {
+    this.sessions[sid] = undefined;
+    this.sessions = JSON.parse(JSON.stringify(this.sessions));
+    callback(null);
+  }
+}
+
+app.use(session({
+  secret: 'keyboard cat',
+  store: new MyStore()
+}));

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for express-session 1.15
 // Project: https://www.npmjs.org/package/express-session
-// Definitions by: Hiroki Horiuchi <https://github.com/horiuchi>, Jacob Bogers <https://github.com/jacobbogers>
+// Definitions by: Hiroki Horiuchi <https://github.com/horiuchi>, Jacob Bogers <https://github.com/jacobbogers>, Naoto Yokoyama <https://github.com/builtinnya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -64,7 +64,7 @@ declare namespace session {
   }
 
   interface BaseMemoryStore {
-    get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
+    get: (sid: string, callback: (err: any, session: Express.SessionData) => void) => void;
     set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
     destroy: (sid: string, callback: (err: any) => void) => void;
     length?: (callback: (err: any, length: number) => void) => void;
@@ -78,7 +78,7 @@ declare namespace session {
     load: (sid: string, fn: (err: any, session: Express.Session) => any) => void;
     createSession: (req: express.Request, sess: Express.SessionData) => void;
 
-    get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
+    get: (sid: string, callback: (err: any, session: Express.SessionData) => void) => void;
     set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
     destroy: (sid: string, callback: (err: any) => void) => void;
     all: (callback: (err: any, obj: { [sid: string]: Express.SessionData; }) => void) => void;
@@ -87,7 +87,7 @@ declare namespace session {
   }
 
   class MemoryStore implements BaseMemoryStore {
-    get: (sid: string, callback: (err: any, session: Express.Session) => void) => void;
+    get: (sid: string, callback: (err: any, session: Express.SessionData) => void) => void;
     set: (sid: string, session: Express.Session, callback: (err: any) => void) => void;
     destroy: (sid: string, callback: (err: any) => void) => void;
     all: (callback: (err: any, obj: { [sid: string]: Express.Session; }) => void) => void;


### PR DESCRIPTION
The type of the second parameter of callback for `Store#get` should be `SessionData`,
not `Session`. It's bit confusing because parameter name "session" is
used for both `Session` and `SessionData` on their documentation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - Doc: https://github.com/expressjs/session/blob/89fd7156129210f2b0c350afcbdf226665a8328c/README.md#storegetsid-callback
    - Evidences
        - https://github.com/expressjs/session/blob/89fd7156129210f2b0c350afcbdf226665a8328c/session/session.js#L91
        - https://github.com/expressjs/session/blob/89fd7156129210f2b0c350afcbdf226665a8328c/session/session.js#L94
        - https://github.com/expressjs/session/blob/89fd7156129210f2b0c350afcbdf226665a8328c/session/store.js#L92
        - https://github.com/expressjs/session/blob/89fd7156129210f2b0c350afcbdf226665a8328c/session/session.js#L24
- [x] Increase the version number in the header if appropriate.
    - No need to change
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
    - No substantial change