### PR TITLE
missing arg for marksAcross($end)

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -832,7 +832,7 @@ export class ResolvedPos {
    * its parent node or its parent node isn't a textblock (in which
    * case no marks should be preserved).
    */
-  marksAcross(): Mark[] | null | void;
+  marksAcross($end: ResolvedPos): Mark[] | null | void;
   /**
    * The depth up to which this position and the given (non-resolved)
    * position share the same parent nodes.


### PR DESCRIPTION
arg for marksAcross was missing.
see: https://prosemirror.net/docs/ref/#model.ResolvedPos.marksAcross