### PR TITLE
add abort() into the websocket client

### DIFF
--- a/types/websocket/index.d.ts
+++ b/types/websocket/index.d.ts
@@ -571,6 +571,12 @@ declare class client extends events.EventEmitter {
     connect(requestUrl: url.Url, protocols?: string, origin?: string, headers?: object, extraRequestOptions?: http.RequestOptions): void;
     connect(requestUrl: string, protocols?: string, origin?: string, headers?: object, extraRequestOptions?: http.RequestOptions): void;
 
+    /**
+     * Will cancel an in-progress connection request before either the `connect` event or the `connectFailed` event has been emitted.
+     * If the `connect` or `connectFailed` event has already been emitted, calling `abort()` will do nothing.
+     */
+    abort(): void;
+
     // Events
     on(event: string, listener: () => void): this;
     on(event: 'connect', cb: (connection: connection) => void): this;

--- a/types/websocket/websocket-tests.ts
+++ b/types/websocket/websocket-tests.ts
@@ -180,8 +180,18 @@ function clientTest2() {
     
 }
 
+function testClientAbortApi() {
+    var ipArray = getLocalIpArray();
+    var client = new websocket.client();
+    client.connect(`ws://${ipArray[0]}:8888`, undefined, undefined, undefined, {
+        localAddress: ipArray[0]
+    });
+    client.abort();
+}
+
 {
     console.log(`websocket test start.`);
     serverTest2();
     clientTest2();
+    testClientAbortApi();
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/theturtle32/WebSocket-Node/blob/662f8ccd57eb8eed85cabe46597d55ef6cdb6b70/lib/WebSocketClient.js#L342
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
