### PR TITLE
[cleave.js] Add missing type for htmlRef prop

### DIFF
--- a/types/cleave.js/index.d.ts
+++ b/types/cleave.js/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for cleave.js 1.0
+// Type definitions for cleave.js 1.1
 // Project: https://github.com/nosir/cleave.js
 // Definitions by: C Lentfort <https://github.com/clentfort>,
 //                 J Giancono <https://github.com/jasongi-at-sportsbet>,

--- a/types/cleave.js/index.d.ts
+++ b/types/cleave.js/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for cleave.js 1.0
 // Project: https://github.com/nosir/cleave.js
-// Definitions by: C Lentfort <https://github.com/clentfort>, J Giancono <https://github.com/jasongi-at-sportsbet>
+// Definitions by: C Lentfort <https://github.com/clentfort>,
+//                 J Giancono <https://github.com/jasongi-at-sportsbet>,
+//                 Alex Shakun <https://github.com/sashashakun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/cleave.js/react/index.d.ts
+++ b/types/cleave.js/react/index.d.ts
@@ -6,6 +6,7 @@ type InitHandler = (owner: React.ReactInstance) => void;
 interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
     onInit?: InitHandler;
     options: CleaveOptions;
+    htmlRef?: (i: any) => void;
 }
 
 declare var Cleave: React.ComponentClass<Props>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/nosir/cleave.js/blob/master/doc/reactjs-component-usage.md#how-to-get-ref-of-the-input-field
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
