### PR TITLE
Added missing FeatureCollection type field

### DIFF
--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -161,5 +161,6 @@ export interface Feature<G extends GeometryObject, P = GeoJsonProperties> extend
  *  https://tools.ietf.org/html/rfc7946#section-3.3
  */
 export interface FeatureCollection<G extends GeometryObject, P = GeoJsonProperties> extends GeoJsonObject {
+    type: "FeatureCollection";
     features: Array<Feature<G, P>>;
 }


### PR DESCRIPTION
All other GeoJSON types have their "type" value restricted to one value, but FeatureCollection was missing this. This PR also adds it for FeatureCollection.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://tools.ietf.org/html/rfc7946#section-3.3
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
