### PR TITLE
[webpack-env] Use NodeRequire as callback parameter type

### DIFF
--- a/types/webpack-env/index.d.ts
+++ b/types/webpack-env/index.d.ts
@@ -31,8 +31,7 @@ declare namespace __WebpackModuleApi {
          *
          * This creates a chunk. The chunk can be named. If a chunk with this name already exists, the dependencies are merged into that chunk and that chunk is used.
          */
-        ensure(paths: string[], callback: (require: (id: string) => any) => void, chunkName?: string): void;
-        ensure(paths: string[], callback: (require: <T>(id: string) => T) => void, chunkName?: string): void;
+        ensure(paths: string[], callback: (require: NodeRequire) => void, chunkName?: string): void;
         context(path: string, deep?: boolean, filter?: RegExp): RequireContext;
         /**
          * Returns the module id of a dependency. The call is sync. No request to the server is fired. The compiler ensures that the dependency is available.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I struggled a bit to find relevant documentation and source-code (not a webpack developer, just consumer) so instead just tested in my own source code.

We are doing this pattern:

```ts
require.ensure([], (require) => {
    const stringsContext = require.context('strings/', false, /^\.\/[a-g].+\.json/);
    require("libs/cultures/A-G");
});
```

and seeing a TS compile error saying `Property 'context' does not exist on type '(id: string) => any'.`

This PR makes the `require` object-function passed into the callback use the same types as the global `require`, thus ensuring that `ensure` and `context` are defined inside the callback. This also means we can delete the overload for `ensure`, since `NodeRequire` already defines that overload.

