### PR TITLE
[sequelize] extend RetryOptions with RegExp and Error

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -10,6 +10,7 @@
 //                 Philippe D'Alva <https://github.com/TitaneBoy>
 //                 Carven Zhang <https://github.com/zjy01>
 //                 Nikola Vidic <https://github.com/nidzov>
+//                 Florian Oellerich <https://github.com/Raigen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -5313,7 +5314,7 @@ declare namespace sequelize {
         /**
          * Only retry a query if the error matches one of these strings.
          */
-        match?: string[];
+        match?: (string|RegExp|Error)[];
 
         /**
          * How many times a failing query is automatically retried. Set to 0 to disable retrying on SQL_BUSY error.

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -1235,7 +1235,7 @@ new Sequelize( {
     username: 'user',
     password: 'pass',
     retry: {
-        match: ['failed'],
+        match: ['failed', /failed/i, Sequelize.ForeignKeyConstraintError],
         max: 3
     },
     typeValidation: true


### PR DESCRIPTION
* Extend `RetryOptions.match` with `RegExp` and `Error` acording to `retry-as-promised`.
* Extend sequelize-tests.ts

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mickhansen/retry-as-promised/blob/master/index.js#L57-L60