### PR TITLE
Update Stripe package with missing subscription items properties

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4331,9 +4331,9 @@ declare namespace Stripe {
 
         interface ISubscriptionCustCreationOptions extends IDataOptionsWithMetadata {
             /**
-             * The identifier of the plan to subscribe the customer to.
+             * @deprecated Use items property instead.
              */
-            plan: string;
+            plan?: string;
 
             /**
              * A positive decimal (with at most two decimal places) between 1 and 100. This represents the percentage of the subscription invoice
@@ -4376,7 +4376,7 @@ declare namespace Stripe {
             /**
              * List of subscription items, each with an attached plan.
              */
-            items: ISubscriptionCreationItem[];
+            items?: ISubscriptionCreationItem[];
 
             /**
              * Either "charge_automatically", or "send_invoice". When charging automatically, Stripe will attempt to pay this subscription at the end of the 
@@ -4408,7 +4408,7 @@ declare namespace Stripe {
             coupon?: string;
 
             /**
-             * The identifier of the plan to update the subscription to. If omitted, the subscription will not change plans.
+             * @deprecated Use items property instead.
              */
             plan?: string;
 
@@ -4455,6 +4455,11 @@ declare namespace Stripe {
              * instructions.
              */
             billing?: SubscriptionBilling;
+
+            /**
+             * List of subscription items, each with an attached plan.
+             */
+            items?: ISubscriptionUpdateItem[];
         }
 
         interface ISubscriptionCancellationOptions extends IDataOptions {
@@ -4491,6 +4496,40 @@ declare namespace Stripe {
              * Plan ID for this item.
              */
             plan: string;
+            
+            /**
+             * Quantity for this item.
+             */
+            quantity?: number
+        }
+
+        interface ISubscriptionUpdateItem {
+            /**
+             * SubscriptionItem to update.
+             */
+            id?: string;
+
+            /**
+             * Delete all usage for a given subscription item. Only allowed when deleted is set to true and the current plan’s 
+             * usage_type is metered.
+             */
+            clear_usage?: boolean;
+
+            /**
+             * Delete the specified item if set to true.
+             */
+            deleted?: boolean;
+
+            /**
+             * Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about
+             * the object in a structured format.
+             */
+            metadata?: IOptionsMetadata;
+
+            /**
+             * Plan ID for this item.
+             */
+            plan?: string;
             
             /**
              * Quantity for this item.

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -4216,6 +4216,7 @@ declare namespace Stripe {
 
     namespace subscriptions {
         type SubscriptionStatus = "trialing" | "active" | "past_due" | "canceled" | "unpaid";
+        type SubscriptionBilling = "charge_automatically" | "send_invoice";
         /**
          * Subscriptions allow you to charge a customer's card on a recurring basis. A subscription ties a customer to
          * a particular plan you've created: https://stripe.com/docs/api#create_plan
@@ -4325,7 +4326,7 @@ declare namespace Stripe {
              * end of the cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an 
              * invoice with payment instructions.
              */
-            billing: "charge_automatically" | "send_invoice";
+            billing: SubscriptionBilling;
         }
 
         interface ISubscriptionCustCreationOptions extends IDataOptionsWithMetadata {
@@ -4375,14 +4376,14 @@ declare namespace Stripe {
             /**
              * List of subscription items, each with an attached plan.
              */
-            items?: ISubscriptionCreationItem;
+            items: ISubscriptionCreationItem[];
 
             /**
              * Either "charge_automatically", or "send_invoice". When charging automatically, Stripe will attempt to pay this subscription at the end of the 
              * cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment 
              * instructions. Defaults to "charge_automatically".
              */
-            billing?: "charge_automatically" | "send_invoice";
+            billing?: SubscriptionBilling;
         }
 
         interface ISubscriptionCreationOptions extends ISubscriptionCustCreationOptions {
@@ -4453,7 +4454,7 @@ declare namespace Stripe {
              * cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment 
              * instructions.
              */
-            billing?: "charge_automatically" | "send_invoice";
+            billing?: SubscriptionBilling;
         }
 
         interface ISubscriptionCancellationOptions extends IDataOptions {
@@ -4467,7 +4468,7 @@ declare namespace Stripe {
             /**
              * The billing mode of the subscriptions to retrieve. Either "charge_automatically" or "send_invoice".
              */
-            billing?: "charge_automatically" | "send_invoice";
+            billing?: SubscriptionBilling;
 
             /**
              * The ID of the customer whose subscriptions will be retrieved

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -254,8 +254,9 @@ stripe.customers.create({
     customer.subscriptions.create({ items: [{ plan: "gold" }] }).then(function (subscription) { });
     customer.subscriptions.create({ items: [{ plan: "gold" }], trial_end: "now" }).then(function (subscription) { });
     customer.subscriptions.create({ items: [{ plan: "gold" }], trial_end: 1516881177 }).then(function (subscription) { });
-    customer.subscriptions.retrieve("sub_8Eluur5KoIKxuy").then(function (subscription) { });
-    customer.subscriptions.update("sub_8Eluur5KoIKxuy", { items: [{ plan: "silver" }] }).then(function (subscription) { });
+    customer.subscriptions.retrieve("sub_8Eluur5KoIKxuy").then(function (subscription) {
+        customer.subscriptions.update("sub_8Eluur5KoIKxuy", { items: [{ id: subscription.items.data[0].id, plan: "silver" }] }).then(function (subscription) { });
+     });
     customer.subscriptions.update("sub_8Eluur5KoIKxuy", { trial_end: "now" });
     customer.subscriptions.update("sub_8Eluur5KoIKxuy", { trial_end: 1516881177 });
     customer.subscriptions.list().then(function (subscriptions) { });

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -255,6 +255,7 @@ stripe.customers.create({
     customer.subscriptions.create({ items: [{ plan: "gold" }], trial_end: "now" }).then(function (subscription) { });
     customer.subscriptions.create({ items: [{ plan: "gold" }], trial_end: 1516881177 }).then(function (subscription) { });
     customer.subscriptions.retrieve("sub_8Eluur5KoIKxuy").then(function (subscription) { });
+    customer.subscriptions.update("sub_8Eluur5KoIKxuy", { items: [{ plan: "silver" }] }).then(function (subscription) { });
     customer.subscriptions.update("sub_8Eluur5KoIKxuy", { trial_end: "now" });
     customer.subscriptions.update("sub_8Eluur5KoIKxuy", { trial_end: 1516881177 });
     customer.subscriptions.list().then(function (subscriptions) { });

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -251,11 +251,10 @@ stripe.customers.create({
     customer.cards.list().then(function (cards) {});
     customer.cards.del("card_17xMvXBoqMA9o2xkq6W5gamx").then(function (confirmation) {});
 
-    customer.subscriptions.create({ plan: "gold" }).then(function (subscription) { });
-    customer.subscriptions.create({ plan: "gold", trial_end: "now" }).then(function (subscription) { });
-    customer.subscriptions.create({ plan: "gold", trial_end: 1516881177 }).then(function (subscription) { });
+    customer.subscriptions.create({ items: [{ plan: "gold" }] }).then(function (subscription) { });
+    customer.subscriptions.create({ items: [{ plan: "gold" }], trial_end: "now" }).then(function (subscription) { });
+    customer.subscriptions.create({ items: [{ plan: "gold" }], trial_end: 1516881177 }).then(function (subscription) { });
     customer.subscriptions.retrieve("sub_8Eluur5KoIKxuy").then(function (subscription) { });
-    customer.subscriptions.update("sub_8Eluur5KoIKxuy", { plan: "silver" }).then(function (subscription) { });
     customer.subscriptions.update("sub_8Eluur5KoIKxuy", { trial_end: "now" });
     customer.subscriptions.update("sub_8Eluur5KoIKxuy", { trial_end: 1516881177 });
     customer.subscriptions.list().then(function (subscriptions) { });
@@ -504,12 +503,12 @@ stripe.customers.retrieveSubscription("cus_5rfJKDJkuxzh5Q", "sub_5rfJxnBLGSwsYp"
     // asynchronously called
 });
 
-stripe.customers.updateSubscription("cus_5rfJKDJkuxzh5Q", "sub_5rfJxnBLGSwsYp", { plan: "platypi-dev" },
+stripe.customers.updateSubscription("cus_5rfJKDJkuxzh5Q", "sub_5rfJxnBLGSwsYp", { items: [{ id: "si_62U5U5BoqBA2o2xp6Eqcl6J7", plan: "platypi-dev" }] },
     function (err, subscription) {
         // asynchronously called
     }
 );
-stripe.customers.updateSubscription("cus_5rfJKDJkuxzh5Q", "sub_5rfJxnBLGSwsYp", { plan: "platypi-dev" }).then(function (subscription) {
+stripe.customers.updateSubscription("cus_5rfJKDJkuxzh5Q", "sub_5rfJxnBLGSwsYp", { items: [{ id: "si_62U5U5BoqBA2o2xp6Eqcl6J7", plan: "platypi-dev" }] }).then(function (subscription) {
     // asynchronously called
 });
 
@@ -1134,11 +1133,18 @@ stripe.plans.list().then(function (plans) {
 //#region Subscriptions tests
 // ##################################################################################
 
-stripe.subscriptions.create({ plan: "platypi-dev", customer: "cus_5rfJKDJkuxzh5Q" }, function(err, subscription) {
+stripe.subscriptions.create({ items: [{ plan: "platypi-dev" }], customer: "cus_5rfJKDJkuxzh5Q" }, function(err, subscription) {
     // asynchronously called
 });
-stripe.subscriptions.create({ plan: "platypi-dev", customer: "cus_5rfJKDJkuxzh5Q" }).then(function(subscription) {
+stripe.subscriptions.create({ items: [{ plan: "platypi-dev" }], customer: "cus_5rfJKDJkuxzh5Q" }).then(function(subscription) {
     // asynchronously called
+
+    stripe.subscriptions.update("sub_8QwCiwZ9tmMSpt", { items: [{ id: subscription.items.data[0].id, plan: "platypi" }] }, function(err, subscription) {
+        // asynchronously called
+    });
+    stripe.subscriptions.update("sub_8QwCiwZ9tmMSpt", { items: [{ id: subscription.items.data[0].id, plan: "platypi" }] }).then(function(subscription) {
+        // asynchronously called
+    });
 });
 
 stripe.subscriptions.retrieve("sub_8QwCiwZ9tmMSpt", function(err, subscription) {
@@ -1152,13 +1158,6 @@ stripe.subscriptions.retrieve("sub_8QwCiwZ9tmMSpt").then(function(subscription) 
     if (typeof subscription.customer === "object") {
         subscription.customer.email;
     }
-});
-
-stripe.subscriptions.update("sub_8QwCiwZ9tmMSpt", { plan: "platypi" }, function(err, subscription) {
-    // asynchronously called
-});
-stripe.subscriptions.update("sub_8QwCiwZ9tmMSpt", { plan: "platypi" }).then(function(subscription) {
-    // asynchronously called
 });
 
 stripe.subscriptions.del("sub_8QwCiwZ9tmMSpt", function(err, subscription) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api#update_subscription-items
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

- Added the missing `items` field when updating a subscription. This also deprecates the old `plan` field, which doesn't exist in the docs any longer.
- Updated tests to reflect changes.