### PR TITLE
 focused: boolean

### DIFF
--- a/types/prosemirror-model/index.d.ts
+++ b/types/prosemirror-model/index.d.ts
@@ -832,7 +832,7 @@ export class ResolvedPos {
    * its parent node or its parent node isn't a textblock (in which
    * case no marks should be preserved).
    */
-  marksAcross(): Mark[] | null | void;
+  marksAcross($end: ResolvedPos): Mark[] | null | void;
   /**
    * The depth up to which this position and the given (non-resolved)
    * position share the same parent nodes.

--- a/types/prosemirror-view/index.d.ts
+++ b/types/prosemirror-view/index.d.ts
@@ -180,6 +180,8 @@ export class EditorView {
    * Focus the editor.
    */
   focus(): void;
+
+  focused: boolean;
   /**
    * Get the document root in which the editor exists. This will
    * usually be the top-level `document`, but might be a [shadow


### PR DESCRIPTION
`focused` property exists and is accessible on view instance.
see: https://github.com/ProseMirror/prosemirror-view/blob/master/src/index.js:34
It is not mentioned in docs, but this prop is actually the only reliable way to query whether view is focused. `hasFocus()` doesn't seem to work so well.