### PR TITLE
GeoJSON: default generics; switch type inference

### DIFF
--- a/types/d3-geo/index.d.ts
+++ b/types/d3-geo/index.d.ts
@@ -47,7 +47,7 @@ export interface ExtendedGeometryCollection<GeometryType extends GeoGeometryObje
  * A GeoJSON-style Feature which support features built on GeoJSON GeometryObjects
  * or GeoSphere
  */
-export interface ExtendedFeature<GeometryType extends GeoGeometryObjects, Properties> extends GeoJSON.GeoJsonObject {
+export interface ExtendedFeature<GeometryType extends GeoGeometryObjects, Properties> extends GeoJSON.BaseGeoJsonObject {
     geometry: GeometryType;
     properties: Properties;
     id?: string | number;
@@ -57,7 +57,7 @@ export interface ExtendedFeature<GeometryType extends GeoGeometryObjects, Proper
  * A GeoJSON-style FeatureCollection which supports GeoJSON features
  * and features built on GeoSphere
  */
-export interface ExtendedFeatureCollection<FeatureType extends ExtendedFeature<GeoGeometryObjects, any>> extends GeoJSON.GeoJsonObject {
+export interface ExtendedFeatureCollection<FeatureType extends ExtendedFeature<GeoGeometryObjects, any>> extends GeoJSON.BaseGeoJsonObject {
     features: FeatureType[];
 }
 

--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -1,5 +1,6 @@
 import {
     BBox,
+    GeoJsonObject, Position,
     Feature, FeatureCollection, GeometryCollection, LineString,
     MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, GeometryObject
 } from "geojson";
@@ -129,7 +130,7 @@ const geometryCollection: GeometryCollection = {
     ]
 };
 
-let feature: Feature<GeometryObject> = {
+let feature: Feature = {
     type: "Feature",
     geometry: lineString,
     properties: null
@@ -244,7 +245,38 @@ const typedPropertiesFeature: Feature<Point> = {
     }
 };
 
+const typedPropertiesFeatureDefault: Feature = {
+    type: "Feature",
+    properties: testProps,
+    geometry: {
+        type: "Polygon",
+        coordinates: [
+            [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]
+        ]
+    }
+};
+
 const typedPropertiesFeatureCollection: FeatureCollection<Point> = {
     type: "FeatureCollection",
     features: [typedPropertiesFeature]
+};
+
+const typedPropertiesFeatureCollectionDefault: FeatureCollection = {
+    type: "FeatureCollection",
+    features: [typedPropertiesFeature, typedPropertiesFeatureDefault]
+};
+
+export const extractCoordsFromGeoJSON = (geojson: GeoJsonObject): Position[][][][] => {
+    switch (geojson.type) {
+        case 'GeometryCollection':
+            return geojson.geometries.map(extractCoordsFromGeoJSON);
+        case 'Feature':
+            return extractCoordsFromGeoJSON(geojson.geometry);
+        case 'FeatureCollection':
+            return geojson.features.map(extractCoordsFromGeoJSON);
+        case 'Polygon':
+            return [[geojson.coordinates.slice(0, 2)]];
+        case 'MultiPolygon':
+            return [geojson.coordinates.slice(0, 2)];
+    }
 };

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -40,14 +40,15 @@ export type BBox = [number, number, number, number] | [number, number, number, n
 export type Position = number[]; // [number, number] | [number, number, number];
 
 /**
- * The base GeoJSON object.
+ * The base GeoJSON interface extended by most of the interfaces
+ * See GeoJsonObject at the end of the file for a stricter type
  * https://tools.ietf.org/html/rfc7946#section-3
  * The GeoJSON specification also allows foreign members
  * (https://tools.ietf.org/html/rfc7946#section-6.1)
  * Developers should use "&" type in TypeScript or extend the interface
  * to add these foreign members.
  */
-export interface GeoJsonObject {
+export interface BaseGeoJsonObject {
     // Don't include foreign members directly into this type def.
     // in order to preserve type safety.
     // [key: string]: any;
@@ -63,10 +64,11 @@ export interface GeoJsonObject {
 }
 
 /**
- * A geometry object.
+ * Base interface for geometry objects.
+ * See also the GeometryObject type below
  * https://tools.ietf.org/html/rfc7946#section-3
  */
-export interface GeometryObject extends GeoJsonObject {
+export interface BaseGeometryObject extends BaseGeoJsonObject {
     type: GeoJsonGeometryTypes;
 }
 
@@ -74,7 +76,7 @@ export interface GeometryObject extends GeoJsonObject {
  * Point geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.2
  */
-export interface Point extends GeometryObject {
+export interface Point extends BaseGeometryObject {
     type: "Point";
     coordinates: Position;
 }
@@ -83,7 +85,7 @@ export interface Point extends GeometryObject {
  * MultiPoint geometry object.
  *  https://tools.ietf.org/html/rfc7946#section-3.1.3
  */
-export interface MultiPoint extends GeometryObject {
+export interface MultiPoint extends BaseGeometryObject {
     type: "MultiPoint";
     coordinates: Position[];
 }
@@ -92,7 +94,7 @@ export interface MultiPoint extends GeometryObject {
  * LineString geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.4
  */
-export interface LineString extends GeometryObject {
+export interface LineString extends BaseGeometryObject {
     type: "LineString";
     coordinates: Position[];
 }
@@ -101,7 +103,7 @@ export interface LineString extends GeometryObject {
  * MultiLineString geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.5
  */
-export interface MultiLineString extends GeometryObject {
+export interface MultiLineString extends BaseGeometryObject {
     type: "MultiLineString";
     coordinates: Position[][];
 }
@@ -110,7 +112,7 @@ export interface MultiLineString extends GeometryObject {
  * Polygon geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.6
  */
-export interface Polygon extends GeometryObject {
+export interface Polygon extends BaseGeometryObject {
     type: "Polygon";
     coordinates: Position[][];
 }
@@ -119,7 +121,7 @@ export interface Polygon extends GeometryObject {
  * MultiPolygon geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.7
  */
-export interface MultiPolygon extends GeometryObject {
+export interface MultiPolygon extends BaseGeometryObject {
     type: "MultiPolygon";
     coordinates: Position[][][];
 }
@@ -128,10 +130,16 @@ export interface MultiPolygon extends GeometryObject {
  * Geometry Collection
  * https://tools.ietf.org/html/rfc7946#section-3.1.8
  */
-export interface GeometryCollection extends GeometryObject {
+export interface GeometryCollection extends BaseGeometryObject {
     type: "GeometryCollection";
     geometries: Array<Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon>;
 }
+
+/**
+ * A geometry object.
+ * https://tools.ietf.org/html/rfc7946#section-3
+ */
+export type GeometryObject = GeometryCollection | LineString | MultiLineString | MultiPoint | MultiPolygon | Point | Polygon;
 
 export type GeoJsonProperties = { [name: string]: any; } | null;
 
@@ -139,7 +147,7 @@ export type GeoJsonProperties = { [name: string]: any; } | null;
  * A feature object which contains a geometry and associated properties.
  * https://tools.ietf.org/html/rfc7946#section-3.2
  */
-export interface Feature<G extends GeometryObject, P = GeoJsonProperties> extends GeoJsonObject {
+export interface Feature<G extends GeometryObject = GeometryObject, P = GeoJsonProperties> extends BaseGeoJsonObject {
     type: "Feature";
     /**
      * The feature's geometry
@@ -160,7 +168,17 @@ export interface Feature<G extends GeometryObject, P = GeoJsonProperties> extend
  * A collection of feature objects.
  *  https://tools.ietf.org/html/rfc7946#section-3.3
  */
-export interface FeatureCollection<G extends GeometryObject, P = GeoJsonProperties> extends GeoJsonObject {
+export interface FeatureCollection<G extends GeometryObject = GeometryObject, P = GeoJsonProperties> extends BaseGeoJsonObject {
     type: "FeatureCollection";
     features: Array<Feature<G, P>>;
 }
+
+/**
+ * GeoJSON object to be used when accepting aribtrary GeoJSON
+ * https://tools.ietf.org/html/rfc7946#section-3
+ * The GeoJSON specification also allows foreign members
+ * (https://tools.ietf.org/html/rfc7946#section-6.1)
+ * Developers should use "&" type in TypeScript or extend the interface
+ * to add these foreign members.
+ */
+export type GeoJsonObject = GeometryObject | Feature | FeatureCollection;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

This PR seeks out to do two things:

- allow for `Feature` and `FeatureCollection` to be used with defaults (`Feature` instead of `Feature<GeometryObject>`)
- allow Typescript to infer types of `GeoJsonObjects` in switch statements

At the moment, the following code in Typescript will error.

```typescript
export const extractCoordsFromGeoJSON = (geojson: GeoJsonObject): Position[][][][] => {
  switch (geojson.type) {
    case 'GeometryCollection':
      return geojson.geometries.map(extractCoordsFromGeoJSON)
    case 'Feature':
      return extractCoordsFromGeoJSON(geojson.geometry)
    case 'FeatureCollection':
      return geojson.features.map(extractCoordsFromGeoJSON)
    case 'Polygon':
      return [[geojson.coordinates.slice(0, 2)]]
    case 'MultiPolygon':
      return [geojson.coordinates.slice(0, 2)]
  }
}
```


The errors in question are printed below.

```
Property 'geometries' does not exist on type 'GeoJsonObject'.
Property 'geometry' does not exist on type 'GeoJsonObject'.
Property 'features' does not exist on type 'GeoJsonObject'.
Property 'coordinates' does not exist on type 'GeoJsonObject'.
Property 'coordinates' does not exist on type 'GeoJsonObject'.
```

The goal is to allow the switch statement to work without needing to introduce more code (such as type narrowers/guards).

We change `GeoJsonObject` so that it is the union of the various types, rather than the base interface being extended. The code above is included as a new test.