### PR TITLE
[pg] array mode query results and pooled vs non client release/end

### DIFF
--- a/types/pg-query-stream/pg-query-stream-tests.ts
+++ b/types/pg-query-stream/pg-query-stream-tests.ts
@@ -12,7 +12,7 @@ const pool = new pg.Pool();
 pool.connect((err, client, done) => {
     const stream = client.query(query);
     stream.on('end', () => {
-        client.end();
+        client.release();
     });
     stream.on('data', (data: any) => {
         console.log(data);

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -98,8 +98,8 @@ export class Pool extends events.EventEmitter {
     readonly idleCount: number;
     readonly waitingCount: number;
 
-    connect(): Promise<Client>;
-    connect(callback: (err: Error, client: Client, done: () => void) => void): void;
+    connect(): Promise<PoolClient>;
+    connect(callback: (err: Error, client: PoolClient, done: () => void) => void): void;
 
     end(): Promise<void>;
     end(callback: () => void): void;
@@ -112,20 +112,15 @@ export class Pool extends events.EventEmitter {
     query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): Query;
     query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): Query;
 
-    on(event: "error", listener: (err: Error, client: Client) => void): this;
-    on(event: "connect" | "acquire", listener: (client: Client) => void): this;
+    on(event: "error", listener: (err: Error, client: PoolClient) => void): this;
+    on(event: "connect" | "acquire", listener: (client: PoolClient) => void): this;
 }
 
-export class Client extends events.EventEmitter {
+export class ClientBase extends events.EventEmitter {
     constructor(config: string | ClientConfig);
 
     connect(): Promise<void>;
     connect(callback: (err: Error) => void): void;
-
-    end(): Promise<void>;
-    end(callback: (err: Error) => void): void;
-
-    release(err?: Error): void;
 
     query(queryStream: QueryConfig & stream.Readable): stream.Readable;
     query(queryConfig: QueryArrayConfig): Promise<QueryArrayResult>;
@@ -149,6 +144,17 @@ export class Client extends events.EventEmitter {
     on(event: "notification", listener: (message: Notification) => void): this;
     // tslint:disable-next-line unified-signatures
     on(event: "end", listener: () => void): this;
+}
+
+export class Client extends ClientBase {
+    constructor(config: string | ClientConfig);
+
+    end(): Promise<void>;
+    end(callback: (err: Error) => void): void;
+}
+
+export interface PoolClient extends ClientBase {
+    release(err?: Error): void;
 }
 
 export class Query extends events.EventEmitter {

--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -33,21 +33,24 @@ export interface ClientConfig extends ConnectionConfig {
 }
 
 export interface PoolConfig extends ClientConfig {
-      // properties from module 'node-pool'
-      max?: number;
-      min?: number;
-      connectionTimeoutMillis?: number;
-      idleTimeoutMillis?: number;
+    // properties from module 'node-pool'
+    max?: number;
+    min?: number;
+    connectionTimeoutMillis?: number;
+    idleTimeoutMillis?: number;
 
-      application_name?: string;
-      Promise?: PromiseConstructorLike;
+    application_name?: string;
+    Promise?: PromiseConstructorLike;
 }
 
 export interface QueryConfig {
     name?: string;
     text: string;
     values?: any[];
-    rowMode?: string;
+}
+
+export interface QueryArrayConfig extends QueryConfig {
+    rowMode: 'array';
 }
 
 export interface QueryResult {
@@ -55,6 +58,24 @@ export interface QueryResult {
     rowCount: number;
     oid: number;
     rows: any[];
+}
+
+export interface FieldDef {
+    name: string;
+    tableID: number;
+    columnID: number;
+    dataTypeID: number;
+    dataTypeSize: number;
+    dataTypeModifier: number;
+    format: string;
+}
+
+export interface QueryArrayResult {
+    command: string;
+    rowCount: number;
+    oid: number;
+    rows: any[][];
+    fields: FieldDef[];
 }
 
 export interface Notification {
@@ -84,8 +105,10 @@ export class Pool extends events.EventEmitter {
     end(callback: () => void): void;
 
     query(queryStream: QueryConfig & stream.Readable): stream.Readable;
+    query(queryConfig: QueryArrayConfig): Promise<QueryArrayResult>;
     query(queryConfig: QueryConfig): Promise<QueryResult>;
     query(queryText: string, values?: any[]): Promise<QueryResult>;
+    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): Query;
     query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): Query;
     query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): Query;
 
@@ -105,8 +128,10 @@ export class Client extends events.EventEmitter {
     release(err?: Error): void;
 
     query(queryStream: QueryConfig & stream.Readable): stream.Readable;
+    query(queryConfig: QueryArrayConfig): Promise<QueryArrayResult>;
     query(queryConfig: QueryConfig): Promise<QueryResult>;
     query(queryText: string, values?: any[]): Promise<QueryResult>;
+    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): Query;
     query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): Query;
     query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): Query;
 

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -133,6 +133,12 @@ pool.connect((err, client, done) => {
   });
 });
 
+pool.connect().then(client => {
+  client.query({ text: 'SELECT $1::int AS number', values: ['1'], rowMode: 'array' }).then(result => {
+    console.log(result.rowCount, result.rows[0][0], result.fields[0].name);
+  }).then(() => client.release(), e => client.release(e));
+});
+
 pool.on('error', (err, client) => {
   console.error('idle client error', err.message, err.stack);
 });

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -48,8 +48,7 @@ client.query('SELECT $1::text as name', ['brianc'], (err, res) => {
 const query = {
   name: 'get-name',
   text: 'SELECT $1::text',
-  values: ['brianc'],
-  rowMode: 'array'
+  values: ['brianc']
 };
 client.query(query, (err, res) => {
   if (err) {
@@ -65,6 +64,33 @@ client.query(query)
   .catch(e => {
     console.error(e.stack);
   });
+
+const queryArrMode: pg.QueryArrayConfig = {
+  name: 'get-name-array',
+  text: 'SELECT $1::text',
+  values: ['brianc'],
+  rowMode: 'array'
+};
+client.query(queryArrMode, (err, res) => {
+  if (err) {
+    console.error(err.stack);
+  } else {
+    console.log(res.rows);
+    console.log(res.fields.map(f => f.name));
+  }
+});
+client.query(queryArrMode)
+  .then(res => {
+    console.log(res.rows);
+    console.log(res.fields.map(f => f.name));
+  })
+  .catch(e => {
+    console.error(e.stack);
+  });
+client.query({
+  text: 'select 1',
+  rowMode: 'array',
+}).then(res => console.log(res.fields[0]));
 
 client.end((err) => {
   console.log('client has disconnected');


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://node-postgres.com/features/queries#row-mode
https://github.com/brianc/node-postgres/issues/1430
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

__Row mode__: When querying with `rowMode: 'array'`, the result returned is quite different. Instead of `rows` being an array of objects, we get an array of arrays. There's also a `fields` property on the result that is an array of field definitions, including `name`, that can be used to map names to positions in the `rows` set. I've attempted to encode this in the type signatures by overloading based on the presence of `rowMode: 'array'`, which appears to be the only valid value for the option, if present.

Note that because `const config = { rowMode: 'array', text: '...' };` gets widened to `{ rowMode: string, text: string }` because mutability, you have to explicitly type the config object `pg.QueryArrayConfig` for the overload to match up correctly. That's not necessary with the object as a literal param because the widening does not happen. This should _not_ be breaking, as there was no `fields` property defined previously, and the `rows` signature is basically compatible.

__Client end__: A client created with `new Client` should be closed with `client.end()`, whereas a client retrieved from a pool with `pool.connect()` should _never_ be closed with `client.end()` and should instead be released with `client.release()` (see brianc/node-postgres#1430). I've attempted to encode this in the types for pg by:

1. making a `ClientBase` class that lacks `end` and `release` methods
2. making `Client` inherit `ClientBase` and adding the set of `end` methods
3. making a `PoolClient` that also inherits `ClientBase` and adds a `release` method
4. making the `Pool` type use the `PoolClient` type rather than the `Client` type

I'm really not sure how breaking changes are supposed to be handled for situations like these. Using the `Client` type should continue to work as you'd expect, unless you're using a pool, in which case this should help prevent sadness excepting having to update any existing signatures. I suppose this is probably one of the reasons it's recommended to move type defs into the module.