### PR TITLE
Adds support for any property to TweenConfig

### DIFF
--- a/types/gsap/TweenConfig.d.ts
+++ b/types/gsap/TweenConfig.d.ts
@@ -1,6 +1,9 @@
 declare namespace gsap {
     export interface TweenConfig {
 
+        /** Any tweenable property */
+        [p: string]: any;
+
         /** Amount of delay in seconds (or frames for frames-based tweens) before the animation should begin.*/
         delay?: number;
 

--- a/types/gsap/gsap-tests.ts
+++ b/types/gsap/gsap-tests.ts
@@ -1,8 +1,19 @@
-import { TweenLite } from 'gsap';
+import { TweenLite, TweenMax } from 'gsap';
 
-const tween = TweenLite
+const tweenLiteExample = TweenLite
     .to(document.getElementById('some-div'), 1, {
         width: '200px',
-        height: '200px'
+        height: '200px',
+        x: '100px',
+        y: '200px'
     })
     .seek(0.5);
+
+const tweenMaxExample = TweenMax
+  .to(document.getElementById('some-div'), 1, {
+    width: '200px',
+    height: '200px',
+    x: '100px',
+    y: '200px'
+  })
+  .seek(0.5);

--- a/types/gsap/index.d.ts
+++ b/types/gsap/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for GSAP 1.19
 // Project: http://greensock.com/
-// Definitions by: VILIC VANE <https://vilic.github.io/>, Robert S <https://github.com/codebelt>, Richard Fox <https://github.com/ProbablePrime>
+// Definitions by: VILIC VANE <https://vilic.github.io/>, Robert S <https://github.com/codebelt>, Richard Fox <https://github.com/ProbablePrime>, Philip Bulley <https://github.com/philipbulley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference path="Animation.d.ts"/>


### PR DESCRIPTION
This PR adds `[p: string]: any;` to `TweenConfig`.

**Why?**
`TweenMax` is using the type `TweenConfig` for its third argument, however, `TweenConfig` only specified the configuration properties and not the actual properties that may be tweened (this can be any valid JavaScript object property). Also, the `gsap-tests.ts` only covered a `TweenLite` example (and not `TweenMax`), which doesn't currently use `TweenConfig` so ultimately this error went undetected.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://greensock.com/docs/TweenMax/static.to()
- [x] Increase the version number in the header if appropriate. **n/a**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. **n/a**

