### PR TITLE
[d3-shape] padAngle for arcs is optional

### DIFF
--- a/types/d3-shape/d3-shape-tests.ts
+++ b/types/d3-shape/d3-shape-tests.ts
@@ -17,6 +17,7 @@ import { HierarchyPointLink, HierarchyPointNode } from 'd3-hierarchy';
 
 let context: CanvasRenderingContext2D | null = document.querySelector('canvas')!.getContext('2d');
 let num: number;
+let padAngleMaybe: number | undefined;
 let pathStringMaybe: string | null;
 
 // -----------------------------------------------------------------------------------
@@ -28,7 +29,7 @@ interface ArcDatum {
     oRadius: number;
     sAngle: number;
     eAngle: number;
-    pAngle: number;
+    pAngle?: number;
 }
 
 const arcDefaultDatum: d3Shape.DefaultArcObject = {
@@ -37,6 +38,13 @@ const arcDefaultDatum: d3Shape.DefaultArcObject = {
     startAngle: 0,
     endAngle: Math.PI / 2,
     padAngle: 0.03
+};
+
+const arcReducedDefaultDatum: d3Shape.DefaultArcObject = {
+    innerRadius: 40,
+    outerRadius: 60,
+    startAngle: 0,
+    endAngle: Math.PI / 2
 };
 
 const arcDatum: ArcDatum = {
@@ -48,6 +56,7 @@ const arcDatum: ArcDatum = {
 };
 
 let accessorArcDatumNumber: (this: any, d: ArcDatum, ...args: any[]) => number;
+let accessorArcDatumNumberOrUndefined: (this: any, d: ArcDatum, ...args: any[]) => number | undefined;
 let accessorArcDatumNumberOrNull: ((this: any, d: ArcDatum, ...args: any[]) => number) | null;
 
 // DefaultArcObject interface ========================================================
@@ -64,7 +73,7 @@ num = defaultArcObject.innerRadius;
 num = defaultArcObject.outerRadius;
 num = defaultArcObject.startAngle;
 num = defaultArcObject.endAngle;
-num = defaultArcObject.padAngle;
+padAngleMaybe = defaultArcObject.padAngle;
 
 // arc(...) create Arc generator =====================================================
 
@@ -134,7 +143,7 @@ canvasArc = canvasArc.padAngle(0);
 svgArc = svgArc.padAngle(d => {
     return d.pAngle; // datum type is ArcDatum
 });
-accessorArcDatumNumber = svgArc.padAngle();
+accessorArcDatumNumberOrUndefined = svgArc.padAngle();
 
 // padRadius(...) ----------------------------------------------------------------------
 

--- a/types/d3-shape/index.d.ts
+++ b/types/d3-shape/index.d.ts
@@ -32,9 +32,9 @@ export interface DefaultArcObject {
      */
     endAngle: number;
     /**
-     * Pad angle of arcin radians.
+     * Optional. Pad angle of arcin radians.
      */
-    padAngle: number;
+    padAngle?: number;
 }
 
 /**
@@ -230,7 +230,7 @@ export interface Arc<This, Datum> {
      * Returns the current pad angle accessor, which defaults to a function returning the padAngle property
      * of the first argument passed into it, or false if no data are passed in or the property is not defined.
      */
-    padAngle(): (this: This, d: Datum, ...args: any[]) => number;
+    padAngle(): (this: This, d: Datum, ...args: any[]) => number | undefined;
     /**
      * Sets the pad angle to the specified number and returns this arc generator.
      *
@@ -248,7 +248,7 @@ export interface Arc<This, Datum> {
      *
      * @param angle Constant angle in radians.
      */
-    padAngle(angle: number): this;
+    padAngle(angle: number | undefined): this;
     /**
      * Sets the pad angle to the specified function and returns this arc generator.
      *
@@ -267,7 +267,7 @@ export interface Arc<This, Datum> {
      * @param angle An accessor function returning a number in radians to be used as an angle. The accessor function is invoked in the same "this" context as the generator was invoked in and
      * receives the same arguments that were passed into the arc generator.
      */
-    padAngle(angle: (this: This, d: Datum, ...args: any[]) => number): this;
+    padAngle(angle: (this: This, d: Datum, ...args: any[]) => number | undefined): this;
 
     /**
      * Returns the current pad radius accessor, which defaults to null, indicating that the pad radius should be automatically computed as sqrt(innerRadius * innerRadius + outerRadius * outerRadius).


### PR DESCRIPTION
Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-shape/blob/acb6053eae36fe6dcdb0b62fe2691bee2acc511b/src/arc.js#L22
- [? ] Increase the version number in the header if appropriate.


Constructing an `arc` works with
```ts
arc()({
    innerRadius: 64,
    outerRadius: 80,
    startAngle: 0,
    endAngle: 0.5 * Math.PI
    //padAngle: 0
});
```

Querying returns the undefined:
```ts
const a = arc();
const b = a.padAngle();
console.log(b({
    innerRadius: 0,
    endAngle: 0,
    outerRadius: 0,
    startAngle: 0
}));
```
