### PR TITLE
React typings typo: it's vs its

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3723,7 +3723,7 @@ declare namespace React {
     // ----------------------------------------------------------------------
     interface ErrorInfo {
         /**
-         * Captures which component contained the exception, and it's ancestors.
+         * Captures which component contained the exception, and its ancestors.
          */
         componentStack: string;
     }


### PR DESCRIPTION
"its" as the plural, not "it's" as "it is".
