### PR TITLE
Fully implement generics in Yup

### DIFF
--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -118,7 +118,7 @@ export interface DateSchema extends Schema<Date> {
 }
 
 export interface ArraySchemaConstructor {
-    (): ArraySchema<{}>;
+    <T>(schema?: Schema<T>): ArraySchema<T>;
     new(): ArraySchema<{}>;
 }
 

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -34,12 +34,12 @@ export interface Schema<T> {
     meta(): any;
     describe(): SchemaDescription;
     concat(schema: this): this;
-    validate<U>(value: U, options?: ValidateOptions): Promise<ValidationError|U>;
-    validateSync<U>(value: U, options?: ValidateOptions): ValidationError|U;
-    isValid(value: any, options?: any): Promise<boolean>;
-    isValidSync(value: any, options?: any): boolean;
-    cast(value: any, options?: any): any;
-    isType(value: any): boolean;
+    validate(value: T, options?: ValidateOptions): Promise<ValidationError|T>;
+    validateSync(value: T, options?: ValidateOptions): ValidationError|T;
+    isValid(value: T, options?: any): Promise<boolean>;
+    isValidSync(value: T, options?: any): boolean;
+    cast(value: any, options?: any): T;
+    isType(value: any): value is T;
     strict(isStrict: boolean): this;
     strip(strip: boolean): this;
     withMutation(fn: (current: this) => void): void;

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -131,7 +131,7 @@ export interface ArraySchema<T> extends Schema<T[]> {
 }
 
 export interface ObjectSchemaConstructor {
-    <T>(fields?: T): ObjectSchema<T>;
+    <T>(fields?: { [field in keyof T]: Schema<T[field]> }): ObjectSchema<T>;
     new (): ObjectSchema<{}>;
 }
 

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -118,12 +118,12 @@ export interface DateSchema extends Schema<Date> {
 }
 
 export interface ArraySchemaConstructor {
-    <T>(): ArraySchema<T>;
-    new<T>(): ArraySchema<T>;
+    (): ArraySchema<{}>;
+    new(): ArraySchema<{}>;
 }
 
 export interface ArraySchema<T> extends Schema<T[]> {
-    of(type: Schema<T>): ArraySchema<T>;
+    of<U>(type: Schema<U>): ArraySchema<U>;
     min(limit: number | Ref, message?: string): ArraySchema<T>;
     max(limit: number | Ref, message?: string): ArraySchema<T>;
     ensure(): ArraySchema<T>;
@@ -132,7 +132,7 @@ export interface ArraySchema<T> extends Schema<T[]> {
 
 export interface ObjectSchemaConstructor {
     <T>(fields?: T): ObjectSchema<T>;
-    new <T>(): ObjectSchema<T>;
+    new (): ObjectSchema<{}>;
 }
 
 export interface ObjectSchema<T> extends Schema<T> {

--- a/types/yup/index.d.ts
+++ b/types/yup/index.d.ts
@@ -1,13 +1,13 @@
 // Type definitions for yup 0.24
 // Project: https://github.com/jquense/yup
-// Definitions by: Dominik Hardtke <https://github.com/dhardtke>, Vladyslav Tserman <https://github.com/vtserman>
+// Definitions by: Dominik Hardtke <https://github.com/dhardtke>, Vladyslav Tserman <https://github.com/vtserman>, Moreton Bay Regional Council <https://github.com/MoretonBayRC>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-export function reach(schema: Schema, path: string, value?: any, context?: any): Schema;
-export function addMethod<T extends Schema>(schemaCtor: AnySchemaConstructor, name: string, method: (this: T, ...args: any[]) => T): void;
+export function reach<T>(schema: Schema<T>, path: string, value?: any, context?: any): Schema<T>;
+export function addMethod<T extends Schema<any>>(schemaCtor: AnySchemaConstructor, name: string, method: (this: T, ...args: any[]) => T): void;
 export function ref(path: string, options?: { contextPrefix: string }): Ref;
-export function lazy(fn: (value: any) => Schema): Lazy;
+export function lazy<T>(fn: (value: T) => Schema<T>): Lazy;
 export function ValidationError(errors: string | string[], value: any, path: string, type?: any): ValidationError;
 
 export const mixed: MixedSchemaConstructor;
@@ -27,7 +27,7 @@ export type AnySchemaConstructor = MixedSchemaConstructor
     | ArraySchemaConstructor
     | ObjectSchemaConstructor;
 
-export interface Schema {
+export interface Schema<T> {
     clone(): this;
     label(label: string): this;
     meta(metadata: any): this;
@@ -61,7 +61,7 @@ export interface MixedSchemaConstructor {
 }
 
 // tslint:disable-next-line:no-empty-interface
-export interface MixedSchema extends Schema {
+export interface MixedSchema extends Schema<any> {
 }
 
 export interface StringSchemaConstructor {
@@ -69,7 +69,7 @@ export interface StringSchemaConstructor {
     new(): StringSchema;
 }
 
-export interface StringSchema extends Schema {
+export interface StringSchema extends Schema<string> {
     min(limit: number | Ref, message?: string): StringSchema;
     max(limit: number | Ref, message?: string): StringSchema;
     matches(regex: RegExp, message?: string): StringSchema;
@@ -86,7 +86,7 @@ export interface NumberSchemaConstructor {
     new(): NumberSchema;
 }
 
-export interface NumberSchema extends Schema {
+export interface NumberSchema extends Schema<number> {
     min(limit: number | Ref, message?: string): NumberSchema;
     max(limit: number | Ref, message?: string): NumberSchema;
     lessThan(limit: number | Ref, message?: string): NumberSchema;
@@ -104,7 +104,7 @@ export interface BooleanSchemaConstructor {
 }
 
 // tslint:disable-next-line:no-empty-interface
-export interface BooleanSchema extends Schema {
+export interface BooleanSchema extends Schema<boolean> {
 }
 
 export interface DateSchemaConstructor {
@@ -112,36 +112,36 @@ export interface DateSchemaConstructor {
     new(): DateSchema;
 }
 
-export interface DateSchema extends Schema {
+export interface DateSchema extends Schema<Date> {
     min(limit: Date | string | Ref, message?: string): DateSchema;
     max(limit: Date | string | Ref, message?: string): DateSchema;
 }
 
 export interface ArraySchemaConstructor {
-    (): ArraySchema;
-    new(): ArraySchema;
+    <T>(): ArraySchema<T>;
+    new<T>(): ArraySchema<T>;
 }
 
-export interface ArraySchema extends Schema {
-    of(type: Schema): ArraySchema;
-    min(limit: number | Ref, message?: string): ArraySchema;
-    max(limit: number | Ref, message?: string): ArraySchema;
-    ensure(): ArraySchema;
-    compact(rejector: (value: any) => boolean): ArraySchema;
+export interface ArraySchema<T> extends Schema<T[]> {
+    of(type: Schema<T>): ArraySchema<T>;
+    min(limit: number | Ref, message?: string): ArraySchema<T>;
+    max(limit: number | Ref, message?: string): ArraySchema<T>;
+    ensure(): ArraySchema<T>;
+    compact(rejector: (value: any) => boolean): ArraySchema<T>;
 }
 
 export interface ObjectSchemaConstructor {
-    (fields?: any): ObjectSchema;
-    new(): ObjectSchema;
+    <T>(fields?: T): ObjectSchema<T>;
+    new <T>(): ObjectSchema<T>;
 }
 
-export interface ObjectSchema extends Schema {
-    shape(fields: any, noSortEdges?: Array<[string, string]>): ObjectSchema;
-    from(fromKey: string, toKey: string, alias?: boolean): ObjectSchema;
-    noUnknown(onlyKnownKeys: boolean, message?: string): ObjectSchema;
+export interface ObjectSchema<T> extends Schema<T> {
+    shape(fields: { [field in keyof T]: Schema<T[field]> }, noSortEdges?: Array<[string, string]>): ObjectSchema<T>;
+    from(fromKey: string, toKey: string, alias?: boolean): ObjectSchema<T>;
+    noUnknown(onlyKnownKeys: boolean, message?: string): ObjectSchema<T>;
     transformKeys(callback: (key: any) => any): void;
-    camelCase(): ObjectSchema;
-    constantCase(): ObjectSchema;
+    camelCase(): ObjectSchema<T>;
+    constantCase(): ObjectSchema<T>;
 }
 
 export type TransformFunction<T> = ((this: T, value: any, originalValue: any) => any);
@@ -240,7 +240,7 @@ export interface Ref {
 }
 
 // tslint:disable-next-line:no-empty-interface
-export interface Lazy extends Schema {
+export interface Lazy extends Schema<any> {
 }
 
 export interface LocaleObject {
@@ -250,6 +250,6 @@ export interface LocaleObject {
   boolean?: { [key in keyof BooleanSchema]?: string };
   bool?: { [key in keyof BooleanSchema]?: string };
   date?: { [key in keyof DateSchema]?: string };
-  array?: { [key in keyof ArraySchema]?: string };
-  object?: { [key in keyof ObjectSchema]?: string };
+  array?: { [key in keyof ArraySchema<any>]?: string };
+  object?: { [key in keyof ObjectSchema<any>]?: string };
 }

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -35,7 +35,7 @@ schema = yup.object().shape({
 schema.cast({ foo: { bar: 'boom' } }, { context: { x: 5 } });
 
 // lazy function
-const node: ObjectSchema = yup.object().shape({
+const node: ObjectSchema<any> = yup.object().shape({
     id: yup.number(),
     child: yup.lazy(() =>
       node.default(undefined)

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -273,10 +273,10 @@ interface SubInterface {
     testField: string;
 }
 
-const typedSchema = yup.object<MyInterface>().shape({
+const typedSchema = yup.object<MyInterface>({
     stringField: yup.string().required(),
     numberField: yup.number().required(),
-    subFields: yup.object<SubInterface>().shape({
+    subFields: yup.object({
         testField: yup.string().required(),
     }).required(),
     arrayField: yup.array().of(yup.string()).required(),

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -266,6 +266,7 @@ interface MyInterface {
     stringField: string;
     numberField: number;
     subFields: SubInterface;
+    arrayField: string[];
 }
 
 interface SubInterface {
@@ -278,6 +279,7 @@ const typedSchema = yup.object<MyInterface>().shape({
     subFields: yup.object<SubInterface>().shape({
         testField: yup.string().required(),
     }).required(),
+    arrayField: yup.array().of(yup.string()).required(),
 });
 
 const testObject = {
@@ -286,6 +288,7 @@ const testObject = {
     subFields: {
         testField: "test2"
     },
+    arrayField: ["hi"],
 };
 
 typedSchema.validate(testObject);
@@ -296,6 +299,7 @@ const untypedSchema = yup.object().shape({
     subFields: yup.object().shape({
         testField: yup.string().required(),
     }).required(),
+    arrayField: yup.array().of(yup.string()).required(),
 });
 
 untypedSchema.validate(testObject);

--- a/types/yup/yup-tests.ts
+++ b/types/yup/yup-tests.ts
@@ -261,3 +261,41 @@ setLocale({
     number: { max: "Max message", min: "Min message" },
     string: { email: "String message"}
 });
+
+interface MyInterface {
+    stringField: string;
+    numberField: number;
+    subFields: SubInterface;
+}
+
+interface SubInterface {
+    testField: string;
+}
+
+const typedSchema = yup.object<MyInterface>().shape({
+    stringField: yup.string().required(),
+    numberField: yup.number().required(),
+    subFields: yup.object<SubInterface>().shape({
+        testField: yup.string().required(),
+    }).required(),
+});
+
+const testObject = {
+    stringField: "test1",
+    numberField: 123,
+    subFields: {
+        testField: "test2"
+    },
+};
+
+typedSchema.validate(testObject);
+
+const untypedSchema = yup.object().shape({
+    stringField: yup.string().required(),
+    numberField: yup.number().required(),
+    subFields: yup.object().shape({
+        testField: yup.string().required(),
+    }).required(),
+});
+
+untypedSchema.validate(testObject);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
  - (Examples are in `yup-tests.ts` file)
- [ ] Increase the version number in the header if appropriate.
  - (Same yup version: 0.24)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
  - (Already there)


This change allows Yup schemas to be more strongly typed.

For example, you can cast `yup.object` to a specific interface type, and all child fields must match that interface. The reason why we want this is because when adding fields to/from our Typescript interfaces, we also need to be sure that they're in the Yup schema as well.

Also, when an interface isn't defined, this change also provides some type inference, so that when specifying:
```
yup.object({
    num: yup.number()
});
```
It infers the type as:
```
ObjectSchema<{
    num: number;
}>
```
And so, if the `validate` functions succeed without a `ValidationError`, you will receive an object of type:
```
{
    num: number;
}
```