### PR TITLE
Lodash: `zip`: add undefined to return values

### DIFF
--- a/types/lodash/array/zip.d.ts
+++ b/types/lodash/array/zip.d.ts
@@ -8,27 +8,27 @@ declare module "../index" {
          * @param arrays The arrays to process.
          * @return Returns the new array of grouped elements.
          */
-        zip<T1, T2>(arrays1: List<T1>, arrays2: List<T2>): Array<[T1, T2]>;
+        zip<T1, T2>(arrays1: List<T1>, arrays2: List<T2>): Array<[T1 | undefined, T2 | undefined]>;
 
         /**
          * @see _.zip
          */
-        zip<T1, T2, T3>(arrays1: List<T1>, arrays2: List<T2>, arrays3: List<T3>): Array<[T1, T2, T3]>;
+        zip<T1, T2, T3>(arrays1: List<T1>, arrays2: List<T2>, arrays3: List<T3>): Array<[T1 | undefined, T2 | undefined, T3 | undefined]>;
 
         /**
          * @see _.zip
          */
-        zip<T1, T2, T3, T4>(arrays1: List<T1>, arrays2: List<T2>, arrays3: List<T3>, arrays4: List<T4>): Array<[T1, T2, T3, T4]>;
+        zip<T1, T2, T3, T4>(arrays1: List<T1>, arrays2: List<T2>, arrays3: List<T3>, arrays4: List<T4>): Array<[T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined]>;
 
         /**
          * @see _.zip
          */
-        zip<T1, T2, T3, T4, T5>(arrays1: List<T1>, arrays2: List<T2>, arrays3: List<T3>, arrays4: List<T4>, arrays5: List<T5>): Array<[T1, T2, T3, T4, T5]>;
+        zip<T1, T2, T3, T4, T5>(arrays1: List<T1>, arrays2: List<T2>, arrays3: List<T3>, arrays4: List<T4>, arrays5: List<T5>): Array<[T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined, T5 | undefined]>;
 
         /**
          * @see _.zip
          */
-        zip<T>(...arrays: Array<List<T> | null | undefined>): T[][];
+        zip<T>(...arrays: Array<List<T> | null | undefined>): (T | undefined)[][];
     }
 
     interface LoDashImplicitWrapper<TValue> {
@@ -76,7 +76,7 @@ declare module "../index" {
         zip<T>(
             this: LoDashImplicitWrapper<List<T> | null | undefined>,
             ...arrays: Array<List<T> | null | undefined>
-        ): LoDashImplicitWrapper<T[][]>;
+        ): LoDashImplicitWrapper<Array<Array<TResult | undefined>>>;
     }
 
     interface LoDashExplicitWrapper<TValue> {
@@ -124,6 +124,6 @@ declare module "../index" {
         zip<T>(
             this: LoDashExplicitWrapper<List<T> | null | undefined>,
             ...arrays: Array<List<T> | null | undefined>
-        ): LoDashExplicitWrapper<T[][]>;
+        ): LoDashExplicitWrapper<Array<Array<TResult | undefined>>>;
     }
 }

--- a/types/lodash/array/zip.d.ts
+++ b/types/lodash/array/zip.d.ts
@@ -76,7 +76,7 @@ declare module "../index" {
         zip<T>(
             this: LoDashImplicitWrapper<List<T> | null | undefined>,
             ...arrays: Array<List<T> | null | undefined>
-        ): LoDashImplicitWrapper<Array<Array<TResult | undefined>>>;
+        ): LoDashImplicitWrapper<Array<Array<T | undefined>>>;
     }
 
     interface LoDashExplicitWrapper<TValue> {
@@ -124,6 +124,6 @@ declare module "../index" {
         zip<T>(
             this: LoDashExplicitWrapper<List<T> | null | undefined>,
             ...arrays: Array<List<T> | null | undefined>
-        ): LoDashExplicitWrapper<Array<Array<TResult | undefined>>>;
+        ): LoDashExplicitWrapper<Array<Array<T | undefined>>>;
     }
 }

--- a/types/lodash/array/zip.d.ts
+++ b/types/lodash/array/zip.d.ts
@@ -38,7 +38,7 @@ declare module "../index" {
         zip<T1, T2>(
             this: LoDashImplicitWrapper<List<T1>>,
             arrays2: List<T2>,
-        ): LoDashImplicitWrapper<Array<[T1, T2]>>;
+        ): LoDashImplicitWrapper<Array<[T1 | undefined, T2 | undefined]>>;
 
         /**
          * @see _.zip
@@ -47,7 +47,7 @@ declare module "../index" {
             this: LoDashImplicitWrapper<List<T1>>,
             arrays2: List<T2>,
             arrays3: List<T3>,
-        ): LoDashImplicitWrapper<Array<[T1, T2, T3]>>;
+        ): LoDashImplicitWrapper<Array<[T1 | undefined, T2 | undefined, T3 | undefined]>>;
 
         /**
          * @see _.zip
@@ -57,7 +57,7 @@ declare module "../index" {
             arrays2: List<T2>,
             arrays3: List<T3>,
             arrays4: List<T4>,
-        ): LoDashImplicitWrapper<Array<[T1, T2, T3, T4]>>;
+        ): LoDashImplicitWrapper<Array<[T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined]>>;
 
         /**
          * @see _.zip
@@ -68,7 +68,7 @@ declare module "../index" {
             arrays3: List<T3>,
             arrays4: List<T4>,
             arrays5: List<T5>,
-        ): LoDashImplicitWrapper<Array<[T1, T2, T3, T4, T5]>>;
+        ): LoDashImplicitWrapper<Array<[T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined, T5 | undefined]>>;
 
         /**
          * @see _.zip
@@ -86,7 +86,7 @@ declare module "../index" {
         zip<T1, T2>(
             this: LoDashExplicitWrapper<List<T1>>,
             arrays2: List<T2>,
-        ): LoDashExplicitWrapper<Array<[T1, T2]>>;
+        ): LoDashExplicitWrapper<Array<[T1 | undefined, T2 | undefined]>>;
 
         /**
          * @see _.zip
@@ -95,7 +95,7 @@ declare module "../index" {
             this: LoDashExplicitWrapper<List<T1>>,
             arrays2: List<T2>,
             arrays3: List<T3>,
-        ): LoDashExplicitWrapper<Array<[T1, T2, T3]>>;
+        ): LoDashExplicitWrapper<Array<[T1 | undefined, T2 | undefined, T3 | undefined]>>;
 
         /**
          * @see _.zip
@@ -105,7 +105,7 @@ declare module "../index" {
             arrays2: List<T2>,
             arrays3: List<T3>,
             arrays4: List<T4>,
-        ): LoDashExplicitWrapper<Array<[T1, T2, T3, T4]>>;
+        ): LoDashExplicitWrapper<Array<[T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined]>>;
 
         /**
          * @see _.zip
@@ -116,7 +116,7 @@ declare module "../index" {
             arrays3: List<T3>,
             arrays4: List<T4>,
             arrays5: List<T5>,
-        ): LoDashExplicitWrapper<Array<[T1, T2, T3, T4, T5]>>;
+        ): LoDashExplicitWrapper<Array<[T1 | undefined, T2 | undefined, T3 | undefined, T4 | undefined, T5 | undefined]>>;
 
         /**
          * @see _.zip

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3197,7 +3197,7 @@ namespace TestXor {
     let list: _.List<TResult> | null | undefined = [] as any;
 
     {
-        let result: TResult[][];
+        let result: Array<Array<TResult | undefined>>;
 
         result = _.zip<TResult>(array);
         result = _.zip<TResult>(array, list);
@@ -3211,7 +3211,7 @@ namespace TestXor {
     }
 
     {
-        let result: _.LoDashImplicitArrayWrapper<TResult[]>;
+        let result: _.LoDashImplicitArrayWrapper<Array<TResult | undefined>>;
 
         result = _(array).zip<TResult>(list);
         result = _(array).zip<TResult>(list, array);
@@ -3221,7 +3221,7 @@ namespace TestXor {
     }
 
     {
-        let result: _.LoDashExplicitArrayWrapper<TResult[]>;
+        let result: _.LoDashExplicitArrayWrapper<Array<TResult | undefined>>;
 
         result = _(array).chain().zip<TResult>(list);
         result = _(array).chain().zip<TResult>(list, array);
@@ -3231,9 +3231,9 @@ namespace TestXor {
     }
 
     {
-        _.zip([1, 2], [3, 4]); // $ExpectType [number, number][]
-        _.zip([1, 2], ["a", "b"]); // $ExpectType [number, string][]
-        _.zip([1, 2], ["a", "b"], [true, false]); // $ExpectType [number, string, boolean][]
+        _.zip([1, 2], [3, 4]); // $ExpectType [number | undefined, number | undefined][]
+        _.zip([1, 2], ["a", "b"]); // $ExpectType [number | undefined, string | undefined][]
+        _.zip([1, 2], ["a", "b"], [true, false]); // $ExpectType [number | undefined, string | undefined, boolean | undefined][]
     }
 }
 

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3197,37 +3197,46 @@ namespace TestXor {
     let list: _.List<TResult> | null | undefined = [] as any;
 
     {
-        let result: Array<Array<TResult | undefined>>;
+        // $ExpectType (TResult | undefined)[][]
+        _.zip<TResult>(array);
+        // $ExpectType (TResult | undefined)[][]
+        _.zip<TResult>(array, list);
+        // $ExpectType (TResult | undefined)[][]
+        _.zip<TResult>(array, list, array);
 
-        result = _.zip<TResult>(array);
-        result = _.zip<TResult>(array, list);
-        result = _.zip<TResult>(array, list, array);
+        // $ExpectType (TResult | undefined)[][]
+        _.zip<TResult>(list);
+        // $ExpectType (TResult | undefined)[][]
+        _.zip<TResult>(list, array);
+        // $ExpectType (TResult | undefined)[][]
+        _.zip<TResult>(list, array, list);
 
-        result = _.zip<TResult>(list);
-        result = _.zip<TResult>(list, array);
-        result = _.zip<TResult>(list, array, list);
-
-        result = _.zip(list, array, list, array, list, array);
+        // $ExpectType (TResult | undefined)[][]
+        _.zip(list, array, list, array, list, array);
     }
 
     {
-        let result: _.LoDashImplicitArrayWrapper<Array<TResult | undefined>>;
+        // $ExpectType LoDashImplicitWrapper<(TResult | undefined)[][]>
+        _(array).zip<TResult>(list);
+        // $ExpectType LoDashImplicitWrapper<(TResult | undefined)[][]>
+        _(array).zip<TResult>(list, array);
 
-        result = _(array).zip<TResult>(list);
-        result = _(array).zip<TResult>(list, array);
-
-        result = _(list).zip<TResult>(array);
-        result = _(list).zip<TResult>(array, list);
+        // $ExpectType LoDashImplicitWrapper<(TResult | undefined)[][]>
+        _(list).zip<TResult>(array);
+        // $ExpectType LoDashImplicitWrapper<(TResult | undefined)[][]>
+        _(list).zip<TResult>(array, list);
     }
 
     {
-        let result: _.LoDashExplicitArrayWrapper<Array<TResult | undefined>>;
+        // $ExpectType LoDashExplicitWrapper<(TResult | undefined)[][]>
+        _(array).chain().zip<TResult>(list);
+        // $ExpectType LoDashExplicitWrapper<(TResult | undefined)[][]>
+        _(array).chain().zip<TResult>(list, array);
 
-        result = _(array).chain().zip<TResult>(list);
-        result = _(array).chain().zip<TResult>(list, array);
-
-        result = _(list).chain().zip<TResult>(array);
-        result = _(list).chain().zip<TResult>(array, list);
+        // $ExpectType LoDashExplicitWrapper<(TResult | undefined)[][]>
+        _(list).chain().zip<TResult>(array);
+        // $ExpectType LoDashExplicitWrapper<(TResult | undefined)[][]>
+        _(list).chain().zip<TResult>(array, list);
     }
 
     {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: Lodash copies the behaviour of Underscore. `zip` will use the length of the largest array, not the shortest, meaning you'll get `undefined` values when the arrays aren't the same length, e.g. `_.zip([1], [1,2]) // => [[1, 1], [undefined, 2]]`. AFAICS this isn't documented but the reasoning can be seen in https://github.com/jashkenas/underscore/issues/1237.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.