### PR TITLE
@types/ws: Fix parameter type issue for 'error' event

### DIFF
--- a/types/ws/index.d.ts
+++ b/types/ws/index.d.ts
@@ -68,7 +68,7 @@ declare class WebSocket extends events.EventEmitter {
 
     // Events
     on(event: 'close', listener: (code: number, reason: string) => void): this;
-    on(event: 'error', listener: (event: {error: any, message: any, type: string, target: WebSocket }) => void): this;
+    on(event: 'error', listener: (err: Error) => void): this;
     on(event: 'upgrade', listener: (request: http.IncomingMessage) => void): this;
     on(event: 'message', listener: (data: WebSocket.Data) => void): this;
     on(event: 'open' , listener: () => void): this;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22831/files/859746cc5ff61addb37e1fcc7e9c791fd0a3b16b#r164952325>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.