### PR TITLE
react-native-datepicker: add onPressDate, onPressCancel methods to instances

### DIFF
--- a/types/react-native-datepicker/index.d.ts
+++ b/types/react-native-datepicker/index.d.ts
@@ -38,6 +38,9 @@ export interface DatePickerProps {
 
 declare class DatePicker extends React.Component<DatePickerProps> {
     constructor(props: DatePickerProps);
+
+    onPressDate(): void;
+    onPressCancel(): void;
 }
 
 export default DatePicker;

--- a/types/react-native-datepicker/react-native-datepicker-tests.tsx
+++ b/types/react-native-datepicker/react-native-datepicker-tests.tsx
@@ -6,14 +6,23 @@ interface MyDatePickerState {
 }
 
 export default class MyDatePicker extends React.Component<{}, MyDatePickerState> {
+    datepicker: DatePicker | null;
+
     constructor(props: {}) {
         super(props);
         this.state = {date: "2016-05-15"};
     }
 
+    componentDidMount() {
+        if (this.datepicker) {
+            this.datepicker.onPressDate();
+        }
+    }
+
     render() {
         return (
             <DatePicker
+                ref={datepicker => this.datepicker = datepicker}
                 style={{width: 200}}
                 date={this.state.date}
                 mode="date"


### PR DESCRIPTION
These two methods are available on instances and documented at the bottom of the README.md here: https://github.com/xgfe/react-native-datepicker#instance-methods.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/xgfe/react-native-datepicker#instance-methods
- [x] Increase the version number in the header if appropriate. n/a
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. n/a