### PR TITLE
AngularJS: rename confusing identifiers in tests

### DIFF
--- a/types/angular/angular-tests.ts
+++ b/types/angular/angular-tests.ts
@@ -289,25 +289,25 @@ foo.then((x) => {
 
 // $q signature tests
 namespace TestQ {
-    interface TResult {
+    interface AbcObject {
         a: number;
         b: string;
         c: boolean;
     }
-    interface TValue {
+    interface EfObject {
         e: number;
         f: boolean;
     }
-    interface TOther {
+    interface GhObject {
         g: string;
         h: number;
     }
-    const tResult: TResult = null;
-    const promiseTResult: angular.IPromise<TResult> = null;
-    const tValue: TValue = null;
-    const promiseTValue: angular.IPromise<TValue> = null;
-    const tOther: TOther = null;
-    const promiseTOther: angular.IPromise<TOther> = null;
+    const abcObject: AbcObject = null;
+    const abcObjectPromise: angular.IPromise<AbcObject> = null;
+    const efObject: EfObject = null;
+    const efObjectPromise: angular.IPromise<EfObject> = null;
+    const ghObject: GhObject = null;
+    const ghObjectPromise: angular.IPromise<GhObject> = null;
 
     const $q: angular.IQService = null;
     const promiseAny: angular.IPromise<any> = null;
@@ -316,11 +316,11 @@ namespace TestQ {
 
     // $q constructor
     {
-        let result: angular.IPromise<TResult>;
-        result = new $q<TResult>((resolve: (value: TResult) => any) => {});
-        result = new $q<TResult>((resolve: (value: TResult) => any, reject: (value: any) => any) => {});
-        result = $q<TResult>((resolve: (value: TResult) => any) => {});
-        result = $q<TResult>((resolve: (value: TResult) => any, reject: (value: any) => any) => {});
+        let result: angular.IPromise<AbcObject>;
+        result = new $q<AbcObject>((resolve: (value: AbcObject) => any) => {});
+        result = new $q<AbcObject>((resolve: (value: AbcObject) => any, reject: (value: any) => any) => {});
+        result = $q<AbcObject>((resolve: (value: AbcObject) => any) => {});
+        result = $q<AbcObject>((resolve: (value: AbcObject) => any, reject: (value: any) => any) => {});
     }
 
     // $q.all
@@ -332,8 +332,8 @@ namespace TestQ {
         $q.all([1, $q.when(2), '3']).then(([ n1, n2, n3 ]) => n1.toFixed() + n2.toFixed() + n3.slice(1));
     }
     {
-        let result: angular.IPromise<TResult[]>;
-        result = $q.all<TResult>([promiseAny, promiseAny]);
+        let result: angular.IPromise<AbcObject[]>;
+        result = $q.all<AbcObject>([promiseAny, promiseAny]);
     }
     {
         let result: angular.IPromise<{[id: string]: any; }>;
@@ -356,13 +356,13 @@ namespace TestQ {
 
     // $q.defer
     {
-        let result: angular.IDeferred<TResult>;
-        result = $q.defer<TResult>();
-        result.resolve(tResult);
+        let result: angular.IDeferred<AbcObject>;
+        result = $q.defer<AbcObject>();
+        result.resolve(abcObject);
         const anyValue: any = null;
         result.reject(anyValue);
         result.promise.then(result => {
-            return $q.resolve<TResult>(result);
+            return $q.resolve<AbcObject>(result);
         });
     }
 
@@ -380,10 +380,10 @@ namespace TestQ {
         result = $q.resolve();
     }
     {
-        let result: angular.IPromise<TResult>;
-        result = $q.resolve<TResult>(tResult);
-        result = $q.resolve<TResult>(promiseTResult);
-        const result2: angular.IPromise<TResult | TOther> = $q.resolve<TResult | TOther>(Math.random() > 0.5 ? tResult : promiseTOther);
+        let result: angular.IPromise<AbcObject>;
+        result = $q.resolve<AbcObject>(abcObject);
+        result = $q.resolve<AbcObject>(abcObjectPromise);
+        const result2: angular.IPromise<AbcObject | GhObject> = $q.resolve<AbcObject | GhObject>(Math.random() > 0.5 ? abcObject : ghObjectPromise);
     }
 
     // $q.when
@@ -392,32 +392,32 @@ namespace TestQ {
         result = $q.when();
     }
     {
-        let result: angular.IPromise<TResult>;
-        let resultOther: angular.IPromise<TResult | TOther>;
+        let result: angular.IPromise<AbcObject>;
+        let resultOther: angular.IPromise<AbcObject | GhObject>;
 
-        result = $q.when<TResult>(tResult);
-        result = $q.when<TResult>(promiseTResult);
+        result = $q.when<AbcObject>(abcObject);
+        result = $q.when<AbcObject>(abcObjectPromise);
 
-        result = $q.when<TResult, TValue>(tValue, (result: TValue) => tResult);
-        result = $q.when<TResult, TValue>(tValue, (result: TValue) => tResult, (any) => any);
-        result = $q.when<TResult, TValue>(tValue, (result: TValue) => tResult, (any) => any, (any) => any);
+        result = $q.when<AbcObject, EfObject>(efObject, (result: EfObject) => abcObject);
+        result = $q.when<AbcObject, EfObject>(efObject, (result: EfObject) => abcObject, (any) => any);
+        result = $q.when<AbcObject, EfObject>(efObject, (result: EfObject) => abcObject, (any) => any, (any) => any);
 
-        result = $q.when<TResult, TValue>(promiseTValue, (result: TValue) => tResult);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => tResult, (any) => tOther);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => tResult, (any) => tOther);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => tResult, (any) => tOther, (any) => any);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => tResult, (any) => promiseTOther);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => tResult, (any) => promiseTOther, (any) => any);
+        result = $q.when<AbcObject, EfObject>(efObjectPromise, (result: EfObject) => abcObject);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObject, (any) => ghObject);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObject, (any) => ghObject);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObject, (any) => ghObject, (any) => any);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObject, (any) => ghObjectPromise);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObject, (any) => ghObjectPromise, (any) => any);
 
-        result = $q.when<TResult, TValue>(tValue, (result: TValue) => promiseTResult);
-        result = $q.when<TResult, TValue>(tValue, (result: TValue) => promiseTResult, (any) => any);
-        result = $q.when<TResult, TValue>(tValue, (result: TValue) => promiseTResult, (any) => any, (any) => any);
+        result = $q.when<AbcObject, EfObject>(efObject, (result: EfObject) => abcObjectPromise);
+        result = $q.when<AbcObject, EfObject>(efObject, (result: EfObject) => abcObjectPromise, (any) => any);
+        result = $q.when<AbcObject, EfObject>(efObject, (result: EfObject) => abcObjectPromise, (any) => any, (any) => any);
 
-        result = $q.when<TResult, TValue>(promiseTValue, (result: TValue) => promiseTResult);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => promiseTResult, (any) => tOther);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => promiseTResult, (any) => tOther, (any) => any);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => promiseTResult, (any) => promiseTOther);
-        resultOther = $q.when<TResult, TOther, TValue>(promiseTValue, (result: TValue) => promiseTResult, (any) => promiseTOther, (any) => any);
+        result = $q.when<AbcObject, EfObject>(efObjectPromise, (result: EfObject) => abcObjectPromise);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObjectPromise, (any) => ghObject);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObjectPromise, (any) => ghObject, (any) => any);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObjectPromise, (any) => ghObjectPromise);
+        resultOther = $q.when<AbcObject, GhObject, EfObject>(efObjectPromise, (result: EfObject) => abcObjectPromise, (any) => ghObjectPromise, (any) => any);
     }
 }
 
@@ -440,41 +440,41 @@ httpFoo.then((response: ng.IHttpResponse<any>) => {
 
 // Deferred signature tests
 namespace TestDeferred {
-    const any: any = null;
+    const anything: any = null;
 
-    interface TResult {
+    interface AbcObject {
         a: number;
         b: string;
         c: boolean;
     }
-    const tResult: TResult = null;
+    const abcObject: AbcObject = null;
 
-    const deferred: angular.IDeferred<TResult> = null;
+    const deferred: angular.IDeferred<AbcObject> = null;
 
     // deferred.resolve
     {
         let result: void;
         result = deferred.resolve();
-        result = deferred.resolve(tResult);
+        result = deferred.resolve(abcObject);
     }
 
     // deferred.reject
     {
         let result: void;
         result = deferred.reject();
-        result = deferred.reject(any);
+        result = deferred.reject(anything);
     }
 
     // deferred.notify
     {
         let result: void;
         result = deferred.notify();
-        result = deferred.notify(any);
+        result = deferred.notify(anything);
     }
 
     // deferred.promise
     {
-        let result: angular.IPromise<TResult>;
+        let result: angular.IPromise<AbcObject>;
         result = deferred.promise;
     }
 }
@@ -517,139 +517,139 @@ namespace TestInjector {
 
 // Promise signature tests
 namespace TestPromise {
-    const any: any = null;
+    const anything: any = null;
 
-    interface TResult {
-        kind: 'result';
+    interface AbcObject {
+        kind: 'abc';
         a: number;
         b: string;
         c: boolean;
     }
 
-    interface TOther {
-        kind: 'other';
+    interface DefObject {
+        kind: 'def';
         d: number;
         e: string;
         f: boolean;
     }
 
-    function isTResult(x: TResult | TOther): x is TResult {
-        return x.kind === 'result';
+    function isAbcObject(x: AbcObject | DefObject): x is AbcObject {
+        return x.kind === 'abc';
     }
 
-    const tresult: TResult = null;
-    const tresultPromise: ng.IPromise<TResult> = null;
-    const tresultHttpPromise: ng.IHttpPromise<TResult> = null;
+    const abcObject: AbcObject = null;
+    const abcObjectPromise: ng.IPromise<AbcObject> = null;
+    const abcObjectHttpPromise: ng.IHttpPromise<AbcObject> = null;
 
-    const tother: TOther = null;
-    const totherPromise: ng.IPromise<TOther> = null;
-    const totherHttpPromise: ng.IHttpPromise<TOther> = null;
+    const defObject: DefObject = null;
+    const defObjectPromise: ng.IPromise<DefObject> = null;
+    const defObjectHttpPromise: ng.IHttpPromise<DefObject> = null;
 
-    const promise: angular.IPromise<TResult> = null;
+    const promise: angular.IPromise<AbcObject> = null;
     const $q: angular.IQService = null;
 
-    const reject = $q.reject();
+    const rejectedPromise = $q.reject();
 
     // promise.then
     // $ExpectType IPromise<any>
-    promise.then(result => any);
+    promise.then(result => anything);
     // $ExpectType IPromise<any>
-    promise.then(result => any, any => any);
+    promise.then(result => anything, any => any);
     // $ExpectType IPromise<any>
-    promise.then(result => any, any => any, any => any);
+    promise.then(result => anything, any => any, any => any);
 
     // $ExpectType IPromise<never>
-    promise.then(result => reject);
+    promise.then(result => rejectedPromise);
     // $ExpectType IPromise<never>
-    promise.then(result => reject, any => reject);
+    promise.then(result => rejectedPromise, any => rejectedPromise);
     // $ExpectType IPromise<never>
-    promise.then(result => reject, any => reject, any => any);
+    promise.then(result => rejectedPromise, any => rejectedPromise, any => any);
 
-    // $ExpectType IPromise<TResult>
+    // $ExpectType IPromise<AbcObject>
     promise.then(result => result);
-    // $ExpectType IPromise<TResult>
-    promise.then(result => tresult);
-    // $ExpectType IPromise<TResult>
-    promise.then(result => tresultPromise);
+    // $ExpectType IPromise<AbcObject>
+    promise.then(result => abcObject);
+    // $ExpectType IPromise<AbcObject>
+    promise.then(result => abcObjectPromise);
     // $ExpectType IPromise<any>
     promise.then(result => result, any => any);
-    // $ExpectType IPromise<number | TResult>
+    // $ExpectType IPromise<number | AbcObject>
     promise.then(result => result, any => Math.random());
     // $ExpectType IPromise<any>
     promise.then(result => result, any => any, any => any);
-    // $ExpectType IPromise<number | TResult>
+    // $ExpectType IPromise<number | AbcObject>
     promise.then(result => result, any => Math.random(), any => any);
-    // $ExpectType IPromise<TResult>
-    promise.then(result => result, any => reject, any => any);
+    // $ExpectType IPromise<AbcObject>
+    promise.then(result => result, any => rejectedPromise, any => any);
 
-    // $ExpectType IPromise<TResult>
-    promise.then(result => anyOf2(reject, result));
-    // $ExpectType IPromise<TResult>
-    promise.then(result => anyOf3(result, tresultPromise, reject));
-    // $ExpectType IPromise<TResult>
+    // $ExpectType IPromise<AbcObject>
+    promise.then(result => anyOf2(rejectedPromise, result));
+    // $ExpectType IPromise<AbcObject>
+    promise.then(result => anyOf3(result, abcObjectPromise, rejectedPromise));
+    // $ExpectType IPromise<AbcObject>
     promise.then(
-        result => anyOf3(reject, result, tresultPromise),
-        reason => anyOf3(reject, tresult, tresultPromise)
+        result => anyOf3(rejectedPromise, result, abcObjectPromise),
+        reason => anyOf3(rejectedPromise, abcObject, abcObjectPromise)
     );
 
-    // $ExpectType IPromise<IHttpResponse<TResult>>
-    promise.then(result => tresultHttpPromise);
+    // $ExpectType IPromise<IHttpResponse<AbcObject>>
+    promise.then(result => abcObjectHttpPromise);
 
-    // $ExpectType IPromise<TResult | TOther>
-    promise.then(result => result, any => tother);
+    // $ExpectType IPromise<AbcObject | DefObject>
+    promise.then(result => result, any => defObject);
 
     // These are broken and seemingly can't be made to work
     // with the current limitations of TypeScript.
 
-    // xExpectType IPromise<TResult | TOther>
-    // promise.then(result => anyOf2(result, totherPromise));
-    // xExpectType IPromise<TResult | TOther>
-    // promise.then(result => anyOf3(reject, result, totherPromise));
-    // xExpectType IPromise<TResult | TOther>
+    // xExpectType IPromise<AbcObject | DefObject>
+    // promise.then(result => anyOf2(result, defObjectPromise));
+    // xExpectType IPromise<AbcObject | DefObject>
+    // promise.then(result => anyOf3(rejectedPromise, result, defObjectPromise));
+    // xExpectType IPromise<AbcObject | DefObject>
     // const a4 = promise.then(
-    //     result => anyOf3(reject, result, totherPromise),
-    //     reason => anyOf3(reject, tother, tresultPromise)
+    //     result => anyOf3(rejectedPromise, result, defObjectPromise),
+    //     reason => anyOf3(rejectedPromise, defObject, abcObjectPromise)
     // );
 
-    // $ExpectType IPromise<TResult | TOther>
-    promise.then<TResult | TOther, TResult>(result =>
-        anyOf3(tresultPromise, result, totherPromise)
+    // $ExpectType IPromise<AbcObject | DefObject>
+    promise.then<AbcObject | DefObject, AbcObject>(result =>
+        anyOf3(abcObjectPromise, result, defObjectPromise)
     );
 
-    // $ExpectType IPromise<TResult | TOther>
-    promise.then(result => result, any => tother, any => any);
-    // $ExpectType IPromise<TResult | TOther>
-    promise.then(result => tresultPromise, any => totherPromise);
-    // $ExpectType IPromise<TResult | TOther>
-    promise.then(result => tresultPromise, any => totherPromise, any => any);
-    // $ExpectType IPromise<IHttpResponse<TResult> | IHttpResponse<TOther>>
-    promise.then(result => tresultHttpPromise, any => totherHttpPromise);
-    // $ExpectType IPromise<IHttpResponse<TResult> | IHttpResponse<TOther>>
-    promise.then(result => tresultHttpPromise, any => totherHttpPromise, any => any);
+    // $ExpectType IPromise<AbcObject | DefObject>
+    promise.then(result => result, any => defObject, any => any);
+    // $ExpectType IPromise<AbcObject | DefObject>
+    promise.then(result => abcObjectPromise, any => defObjectPromise);
+    // $ExpectType IPromise<AbcObject | DefObject>
+    promise.then(result => abcObjectPromise, any => defObjectPromise, any => any);
+    // $ExpectType IPromise<IHttpResponse<AbcObject> | IHttpResponse<DefObject>>
+    promise.then(result => abcObjectHttpPromise, any => defObjectHttpPromise);
+    // $ExpectType IPromise<IHttpResponse<AbcObject> | IHttpResponse<DefObject>>
+    promise.then(result => abcObjectHttpPromise, any => defObjectHttpPromise, any => any);
 
-    // $ExpectType IPromise<TOther>
-    promise.then(result => tother);
+    // $ExpectType IPromise<DefObject>
+    promise.then(result => defObject);
     // $ExpectType IPromise<any>
-    promise.then(result => tother, any => any);
+    promise.then(result => defObject, any => any);
     // $ExpectType IPromise<any>
-    promise.then(result => tother, any => any, any => any);
-    // $ExpectType IPromise<TOther>
-    promise.then(result => totherPromise);
+    promise.then(result => defObject, any => any, any => any);
+    // $ExpectType IPromise<DefObject>
+    promise.then(result => defObjectPromise);
     // $ExpectType IPromise<any>
-    promise.then(result => totherPromise, any => any);
+    promise.then(result => defObjectPromise, any => any);
     // $ExpectType IPromise<any>
-    promise.then(result => totherPromise, any => any, any => any);
-    // $ExpectType IPromise<IHttpResponse<TOther>>
-    promise.then(result => totherHttpPromise);
+    promise.then(result => defObjectPromise, any => any, any => any);
+    // $ExpectType IPromise<IHttpResponse<DefObject>>
+    promise.then(result => defObjectHttpPromise);
     // $ExpectType IPromise<any>
-    promise.then(result => totherHttpPromise, any => any);
+    promise.then(result => defObjectHttpPromise, any => any);
     // $ExpectType IPromise<any>
-    promise.then(result => totherHttpPromise, any => any, any => any);
+    promise.then(result => defObjectHttpPromise, any => any, any => any);
 
     // $ExpectType IPromise<boolean>
     promise
-        .then(result => tresult, any => tother)
-        .then(ambiguous => (isTResult(ambiguous) ? ambiguous.c : ambiguous.f));
+        .then(result => abcObject, any => defObject)
+        .then(ambiguous => (isAbcObject(ambiguous) ? ambiguous.c : ambiguous.f));
 
     // promise.then + $q.reject:
 
@@ -668,38 +668,38 @@ namespace TestPromise {
     // $ExpectType IPromise<any>
     promise.catch(err => err);
     // $ExpectType IPromise<any>
-    promise.catch(err => any);
-    // $ExpectType IPromise<TResult>
-    promise.catch(err => tresult);
-    // $ExpectType IPromise<TResult>
-    promise.catch(err => anyOf2(tresult, reject));
-    // $ExpectType IPromise<TResult>
-    promise.catch(err => anyOf3(tresult, tresultPromise, reject));
-    // $ExpectType IPromise<TResult>
-    promise.catch(err => tresultPromise);
-    // $ExpectType IPromise<TResult | IHttpResponse<TResult>>
-    promise.catch(err => tresultHttpPromise);
-    // $ExpectType IPromise<TResult | TOther>
-    promise.catch(err => tother);
-    // $ExpectType IPromise<TResult | TOther>
-    promise.catch(err => totherPromise);
-    // $ExpectType IPromise<TResult | IHttpResponse<TOther>>
-    promise.catch(err => totherHttpPromise);
+    promise.catch(err => anything);
+    // $ExpectType IPromise<AbcObject>
+    promise.catch(err => abcObject);
+    // $ExpectType IPromise<AbcObject>
+    promise.catch(err => anyOf2(abcObject, rejectedPromise));
+    // $ExpectType IPromise<AbcObject>
+    promise.catch(err => anyOf3(abcObject, abcObjectPromise, rejectedPromise));
+    // $ExpectType IPromise<AbcObject>
+    promise.catch(err => abcObjectPromise);
+    // $ExpectType IPromise<AbcObject | IHttpResponse<AbcObject>>
+    promise.catch(err => abcObjectHttpPromise);
+    // $ExpectType IPromise<AbcObject | DefObject>
+    promise.catch(err => defObject);
+    // $ExpectType IPromise<AbcObject | DefObject>
+    promise.catch(err => defObjectPromise);
+    // $ExpectType IPromise<AbcObject | IHttpResponse<DefObject>>
+    promise.catch(err => defObjectHttpPromise);
 
     // $ExpectType IPromise<boolean>
     promise
-        .catch(err => tother)
+        .catch(err => defObject)
         .then(
-            ambiguous => (isTResult(ambiguous) ? ambiguous.c : ambiguous.f)
+            ambiguous => (isAbcObject(ambiguous) ? ambiguous.c : ambiguous.f)
         );
 
     // promise.finally
-    // $ExpectType IPromise<TResult>
-    promise.finally(() => any);
-    // $ExpectType IPromise<TResult>
-    promise.finally(() => tresult);
-    // $ExpectType IPromise<TResult>
-    promise.finally(() => tother);
+    // $ExpectType IPromise<AbcObject>
+    promise.finally(() => anything);
+    // $ExpectType IPromise<AbcObject>
+    promise.finally(() => abcObject);
+    // $ExpectType IPromise<AbcObject>
+    promise.finally(() => defObject);
 }
 
 function test_angular_forEach() {
@@ -726,12 +726,12 @@ let elementReadyFn = angular.element(() => {
 
 // $timeout signature tests
 namespace TestTimeout {
-    interface TResult {
+    interface AbcObject {
         a: number;
         b: string;
         c: boolean;
     }
-    const fnTResult: (...args: any[]) => TResult = null;
+    const abcObjectFn: (...args: any[]) => AbcObject = null;
     const promiseAny: angular.IPromise<any> = null;
     const $timeout: angular.ITimeoutService = null;
 
@@ -746,13 +746,13 @@ namespace TestTimeout {
         result = $timeout(1, true);
     }
     {
-        let result: angular.IPromise<TResult>;
-        result = $timeout(fnTResult);
-        result = $timeout(fnTResult, 1);
-        result = $timeout(fnTResult, 1, true);
-        result = $timeout(fnTResult, 1, true, 1);
-        result = $timeout(fnTResult, 1, true, 1, '');
-        result = $timeout(fnTResult, 1, true, 1, '', true);
+        let result: angular.IPromise<AbcObject>;
+        result = $timeout(abcObjectFn);
+        result = $timeout(abcObjectFn, 1);
+        result = $timeout(abcObjectFn, 1, true);
+        result = $timeout(abcObjectFn, 1, true, 1);
+        result = $timeout(abcObjectFn, 1, true, 1, '');
+        result = $timeout(abcObjectFn, 1, true, 1, '', true);
     }
 
     // $timeout.cancel


### PR DESCRIPTION
A tests-only change.
See the justification here: #23307