### PR TITLE
Make videoId optional in PlayerOptions

### DIFF
--- a/types/youtube/index.d.ts
+++ b/types/youtube/index.d.ts
@@ -383,7 +383,7 @@ declare namespace YT
 		/**
 		 * ID of the video to load.
 		 */
-		videoId: string;
+		videoId?: string;
 
 		/**
 		 * Player parameters.


### PR DESCRIPTION
It could be optional based on the "Example 1: Use API with existing <iframe>" here:
https://developers.google.com/youtube/iframe_api_reference#Examples

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/youtube/iframe_api_reference#Examples>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
