### PR TITLE
feat(d3-selection): add minor version 1.3.0 features and strictFunctionTypes

### DIFF
--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -89,10 +89,11 @@ const body5: d3Selection.Selection<HTMLBodyElement, BodyDatum, null, undefined> 
 // d3Selection.select<HTMLBodyElement, BodyDatum>(baseTypeEl.node()!); // fails as baseTypeEl.node() is not of type HTMLBodyElement
 
 // test, when it is not certain, whether an element of the type to be selected exists
-let maybeSVG1: d3Selection.Selection<SVGSVGElement | null, any, HTMLElement, undefined> = d3Selection.select<SVGSVGElement, any>('svg');
+let maybeSVG1: d3Selection.Selection<SVGSVGElement | null, any, HTMLElement, undefined>;
 maybeSVG1 = d3Selection.select<SVGSVGElement | null, any>('svg');
 
 let maybeSVG2: d3Selection.Selection<SVGSVGElement | null, any, null, undefined>;
+// maybeSVG2 = d3Selection.select<SVGSVGElement, any>(maybeSVG1.node()); // fails with strict function types
 maybeSVG2 = d3Selection.select<SVGSVGElement | null, any>(maybeSVG1.node());
 
 // fails, as node type mismatches selection type
@@ -166,12 +167,13 @@ let firstG: d3Selection.Selection<SVGGElement, SVGDatum, HTMLElement, any> = svg
 // firstG = svgEl.select<SVGSVGElement>('svg'); // fails, element type of SVGSVGElement provided, but SVGGElement expexted on left-hand side (silly test to begin with)
 
 // test, when it is not certain, whether an element of the type to be selected exists
-let maybeG: d3Selection.Selection<SVGGElement | null, SVGDatum, HTMLElement, any> = svgEl.select<SVGGElement>('g');
+let maybeG: d3Selection.Selection<SVGGElement | null, SVGDatum, HTMLElement, any>;
+// maybeG = svgEl.select<SVGGElement>('g'); // fails, with strictFunctionTypes
 maybeG = svgEl.select<SVGGElement | null>('g');
 
 // Using select(...) sub-selection with a selector function argument.
 
-function svgGroupSelector(this: SVGSVGElement, d: SVGDatum, i: number, groups: SVGSVGElement[]): SVGGElement {
+function svgGroupSelector(this: SVGSVGElement, d: SVGDatum, i: number, groups: SVGSVGElement[] | ArrayLike<SVGSVGElement>): SVGGElement {
     return this.querySelector('g')!; // this-type compatible with group element-type to which the selector function will be appplied
 }
 
@@ -215,13 +217,14 @@ emptySubSelection = svgEl.selectAll(undefined);
 
 // Using selectAll(...) sub-selection with a string argument.
 
-let elementsUnknownData: d3Selection.Selection<d3Selection.BaseType, any, SVGSVGElement, SVGDatum> = svgEl.selectAll('g');
+let elementsUnknownData: d3Selection.Selection<SVGGElement, any, SVGSVGElement, SVGDatum> = svgEl.selectAll<SVGGElement, any>('g');
+// let elementsAndDataUnknown: d3Selection.Selection<d3Selection.BaseType, any, SVGSVGElement, SVGDatum> = svgEl.selectAll('g'); // fails with strictFunctionTypes
 let gElementsOldData: d3Selection.Selection<SVGGElement, CircleDatum, SVGSVGElement, SVGDatum> = svgEl.selectAll<SVGGElement, CircleDatum>('g');
 // gElementsOldData = svgEl.selectAll('g'); // fails default type parameters of selectAll for group element type and datum type do not match
 
 // Using selectAll(...) sub-selection with a selector function argument.
 
-function svgGroupSelectorAll(this: SVGSVGElement, d: SVGDatum, i: number, groups: SVGSVGElement[]): NodeListOf<SVGGElement> {
+function svgGroupSelectorAll(this: SVGGElement, d: SVGDatum, i: number, groups: SVGSVGElement[] | d3Selection.ArrayLike<SVGSVGElement>): NodeListOf<SVGGElement> {
     return this.querySelectorAll('g'); // this-type compatible with group element-type to which the selector function will be appplied
 }
 
@@ -925,14 +928,14 @@ circles = circles.call(enforceMinRadius, 40); // check chaining return type by r
 
 // on(...) -------------------------------------------------------------------------------
 
-let listener: undefined | ((this: HTMLBodyElement, datum: BodyDatum, index: number, group: HTMLBodyElement[] | ArrayLike<HTMLBodyElement>) => void);
+let listener: undefined | ((this: HTMLBodyElement, datum: BodyDatum, index: number, group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement>) => void);
 
 body = body.on('click', function(d, i, g) {
     const that: HTMLBodyElement = this;
     // const that2: SVGElement  = this; // fails, type mismatch
     const datum: BodyDatum = d;
     const index: number = i;
-    const group: HTMLBodyElement[] | ArrayLike<HTMLBodyElement> = g;
+    const group: HTMLBodyElement[] | d3Selection.ArrayLike<HTMLBodyElement> = g;
     console.log('onclick print body background color: ', this.bgColor); // HTMLBodyElement
     console.log('onclick print "foo" datum property: ', d.foo); // BodyDatum type
 });
@@ -988,13 +991,11 @@ interface SuccessEvent {
 }
 const successEvent = { type: 'wonEuro2016', team: 'Island' };
 
-let customListener: (this: HTMLBodyElement, finalOpponent: string) => string;
-
-customListener = finalOpponent => {
+function customListener(this: HTMLBodyElement | null, finalOpponent: string): string {
     const e = <SuccessEvent> d3Selection.event;
 
     return `${e.team} defeated ${finalOpponent} in the EURO 2016 Cup. Who would have thought!!!`;
-};
+}
 
 const resultText: string = d3Selection.customEvent(successEvent, customListener, body.node(), 'Wales');
 

--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -777,7 +777,7 @@ nRow = td2.data(); // flattened matrix (Array[16] of number)
 // Tests of Alternative DOM Manipulation
 // ---------------------------------------------------------------------------------------
 
-// append(...) and creator(...) ----------------------------------------------------------
+// append(...), creator(...) and create(...) ---------------------------------------------
 
 // without append<...> typing returned selection has group element of type BaseType
 let newDiv: d3Selection.Selection<d3Selection.BaseType, BodyDatum, HTMLElement, any>;
@@ -807,6 +807,12 @@ newDiv2 = body.append(function(d, i, g) {
 // newDiv2 = body.append(function(d) {
 //     return this.ownerDocument.createElement('a'); // fails, HTMLDivElement expected by inference, HTMLAnchorElement returned
 // });
+
+// create a detached element
+
+let detachedDiv: d3Selection.Selection<HTMLDivElement, undefined, null, undefined>;
+
+detachedDiv = d3Selection.create<HTMLDivElement>('div');
 
 // insert(...) ---------------------------------------------------------------------------
 
@@ -849,6 +855,18 @@ newParagraph2 = body.insert(d3Selection.creator<HTMLParagraphElement>('p'));
 newParagraph2 = body.insert(typeValueFunction, 'p.second-paragraph');
 newParagraph2 = body.insert(typeValueFunction, beforeValueFunction);
 newParagraph2 = body.insert(typeValueFunction);
+
+// clone(...) ----------------------------------------------------------------------------
+
+let clonedParagraph: d3Selection.Selection<HTMLParagraphElement, BodyDatum, HTMLElement, any>;
+
+// shallow clone
+clonedParagraph = newParagraph2.clone();
+
+// deep clone
+
+newParagraph.append('span');
+clonedParagraph = newParagraph2.clone(true);
 
 // sort(...) -----------------------------------------------------------------------------
 

--- a/types/d3-selection/d3-selection-tests.ts
+++ b/types/d3-selection/d3-selection-tests.ts
@@ -145,8 +145,7 @@ const xSVGCircleElementList: NodeListOf<SVGCircleElement> = document.querySelect
 const circleSelection: d3Selection.Selection<SVGCircleElement, any, null, undefined> = d3Selection.selectAll(xSVGCircleElementList);
 
 // selectAll(...) accepts HTMLCollection, HTMLCollectionOf<...> argument
-
-const documentLinks: d3Selection.Selection<HTMLAnchorElement | HTMLAreaElement, any, null, undefined> = d3Selection.selectAll(document.links);
+const documentLinks: d3Selection.Selection<HTMLAnchorElement | HTMLAreaElement, any, null, undefined> = d3Selection.selectAll<HTMLAnchorElement | HTMLAreaElement, any>(document.links);
 
 // ---------------------------------------------------------------------------------------
 // Tests of Sub-Selection Functions
@@ -224,7 +223,7 @@ let gElementsOldData: d3Selection.Selection<SVGGElement, CircleDatum, SVGSVGElem
 
 // Using selectAll(...) sub-selection with a selector function argument.
 
-function svgGroupSelectorAll(this: SVGGElement, d: SVGDatum, i: number, groups: SVGSVGElement[] | d3Selection.ArrayLike<SVGSVGElement>): NodeListOf<SVGGElement> {
+function svgGroupSelectorAll(this: SVGSVGElement, d: SVGDatum, i: number, groups: SVGSVGElement[] | d3Selection.ArrayLike<SVGSVGElement>): NodeListOf<SVGGElement> {
     return this.querySelectorAll('g'); // this-type compatible with group element-type to which the selector function will be appplied
 }
 

--- a/types/d3-selection/index.d.ts
+++ b/types/d3-selection/index.d.ts
@@ -1,9 +1,9 @@
-// Type definitions for D3JS d3-selection module 1.2
+// Type definitions for D3JS d3-selection module 1.3
 // Project: https://github.com/d3/d3-selection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Last module patch version validated against: 1.2.0
+// Last module patch version validated against: 1.3.0
 
 // --------------------------------------------------------------------------
 // Shared Type Definitions and Interfaces
@@ -531,6 +531,15 @@ export interface Selection<GElement extends BaseType, Datum, PElement extends Ba
      * Returns this selection (the removed elements) which are now detached from the DOM.
      */
     remove(): this;
+
+    /**
+     * Inserts clones of the selected elements immediately following the selected elements and returns a selection of the newly
+     * added clones. If deep is true, the descendant nodes of the selected elements will be cloned as well. Otherwise, only the elements
+     * themselves will be cloned.
+     *
+     * @param deep Perform deep cloning if this flag is set to true.
+     */
+    clone(deep?: boolean): Selection<GElement, Datum, PElement, PDatum>;
 
     /**
      * Returns a new selection merging this selection with the specified other selection.
@@ -1102,6 +1111,15 @@ export function window(DOMNode: Window | Document | Element): Window;
 // creator.js and matcher.js Complex helper closure generating functions
 // for explicit bound-context dependent use
 // ---------------------------------------------------------------------------
+
+/**
+ * Given the specified element name, returns a single-element selection containing
+ * a detached element of the given name in the current document.
+ *
+ * @param name Tag name of the element to be added. See "namespace" for details on supported namespace prefixes,
+ * such as for SVG elements.
+ */
+export function create<NewGElement extends Element>(name: string): Selection<NewGElement, undefined, null, undefined>;
 
 /**
  * Given the specified element name, returns a function which creates an element of the given name,

--- a/types/d3-selection/tsconfig.json
+++ b/types/d3-selection/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Updates **d3-selection** features to minor version 1.3.0 and imposes `strictFunctionTypes`:
* feat(d3-selection): Adds `d3.create(...)`
* feat(d3-selection): Adds `Selection.clone(...)`
* chore(d3-selection): Updates tests to work with `strictFunctionTypes`
* chore(d3-selection): Bumps minor version number

Closes #23252.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/d3/d3-selection/releases/tag/v1.3.0>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.