### PR TITLE
react-relay - improve props and relay variables typing

### DIFF
--- a/types/react-relay/classic.d.ts
+++ b/types/react-relay/classic.d.ts
@@ -209,7 +209,7 @@ export type OnReadyStateChange = (
     }
 ) => void;
 
-export interface RelayProp<V> {
+export interface RelayProp<V = any> {
     readonly route: { name: string }; // incomplete, also has params and queries
     readonly variables: V;
     readonly pendingVariables?: V;

--- a/types/react-relay/classic.d.ts
+++ b/types/react-relay/classic.d.ts
@@ -219,3 +219,7 @@ export interface RelayProp<V> {
     getPendingTransactions(record: any): RelayMutationTransaction[];
     commitUpdate(mutation: Mutation<any, any>, callbacks?: StoreUpdateCallbacks<any>): any;
 }
+
+export interface RelayProps<V> {
+    readonly relay: RelayProp<V>
+}

--- a/types/react-relay/classic.d.ts
+++ b/types/react-relay/classic.d.ts
@@ -221,5 +221,5 @@ export interface RelayProp<V> {
 }
 
 export interface RelayProps<V> {
-    readonly relay: RelayProp<V>
+    readonly relay: RelayProp<V>;
 }

--- a/types/react-relay/classic.d.ts
+++ b/types/react-relay/classic.d.ts
@@ -209,12 +209,12 @@ export type OnReadyStateChange = (
     }
 ) => void;
 
-export interface RelayProp {
+export interface RelayProp<V> {
     readonly route: { name: string }; // incomplete, also has params and queries
-    readonly variables: any;
-    readonly pendingVariables?: any;
-    setVariables(variables: any, onReadyStateChange?: OnReadyStateChange): void;
-    forceFetch(variables: any, onReadyStateChange?: OnReadyStateChange): void;
+    readonly variables: V;
+    readonly pendingVariables?: V;
+    setVariables(variables: V, onReadyStateChange?: OnReadyStateChange): void;
+    forceFetch(variables: V, onReadyStateChange?: OnReadyStateChange): void;
     hasOptimisticUpdate(record: any): boolean;
     getPendingTransactions(record: any): RelayMutationTransaction[];
     commitUpdate(mutation: Mutation<any, any>, callbacks?: StoreUpdateCallbacks<any>): any;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Johannes Schickling <https://github.com/graphcool>
 //                 Matt Martin <https://github.com/voxmatt>
 //                 Eloy Durán <https://github.com/alloy>
+//                 Nicolas Pirotte <https://github.com/npirotte>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/react-relay/test/react-relay-classic-tests.tsx
+++ b/types/react-relay/test/react-relay-classic-tests.tsx
@@ -43,11 +43,14 @@ export default class AddTweetMutation extends Relay.Mutation<Props, Response> {
     }
 }
 
-interface ArtworkProps {
+interface ArtwokRelayVariables {
+    artworkID: string;
+}
+
+interface ArtworkProps extends Relay.RelayProps<ArtwokRelayVariables> {
     artwork: {
         title: string;
     };
-    relay: Relay.RelayProp;
 }
 
 class Artwork extends React.Component<ArtworkProps> {

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -424,11 +424,14 @@ export default class AddTweetMutation extends Relay.Mutation<Props, {}> {
     }
 }
 
-interface ArtworkProps {
+interface ArtwokRelayVariables {
+    artworkID: string;
+}
+
+interface ArtworkProps extends Relay.RelayProps<ArtwokRelayVariables> {
     artwork: {
         title: string;
     };
-    relay: Relay.RelayProp;
 }
 
 class Artwork extends React.Component<ArtworkProps> {


### PR DESCRIPTION
- Adds generic type for RelayProps to type variables.
- Adds RelayProps interface that can be used to fully abstract relay prop injection.

```ts
interface IProps extends Relay.RelayProps<ComponentRelayVariables> {
  // Everything but no relay.
}
```
