### PR TITLE
shelljs.test uses string literals for option param

### DIFF
--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -97,7 +97,9 @@ export function mkdir(options: string, ...dir: Array<string | string[]>): void;
  * @param   path   The path.
  * @return        See option parameter.
  */
-export function test(option: "-b" | "-c" | "-d" | "-e" | "-f" | "-L" | "-p" | "-S", path: string): boolean;
+export function test(option: TestOptions, path: string): boolean;
+
+export type TestOptions = "-b" | "-c" | "-d" | "-e" | "-f" | "-L" | "-p" | "-S";
 
 /**
  * Returns a string containing the given file, or a concatenated string containing the files if more than one file is given (a new line character is introduced between each file). Wildcard * accepted.

--- a/types/shelljs/index.d.ts
+++ b/types/shelljs/index.d.ts
@@ -97,7 +97,7 @@ export function mkdir(options: string, ...dir: Array<string | string[]>): void;
  * @param   path   The path.
  * @return        See option parameter.
  */
-export function test(option: string, path: string): boolean;
+export function test(option: "-b" | "-c" | "-d" | "-e" | "-f" | "-L" | "-p" | "-S", path: string): boolean;
 
 /**
  * Returns a string containing the given file, or a concatenated string containing the files if more than one file is given (a new line character is introduced between each file). Wildcard * accepted.


### PR DESCRIPTION
Previously it was just `string`, which makes it hard to know which options are available.

Tests already exist for `shelljs.test`, so I didn't add any.