### PR TITLE
Fix express.static() with esModuleInterop

### DIFF
--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -15,7 +15,7 @@
 /// <reference types="serve-static" />
 
 import * as bodyParser from "body-parser";
-import * as serveStatic from "serve-static";
+import serveStatic = require("serve-static");
 import * as core from "express-serve-static-core";
 
 /**


### PR DESCRIPTION
TLDR; `esModuleInterop` (TypeScript 2.7) does not like definitions with a function and a namespace having the same name.
<br><br>

~~/!\ Not to be merged, please discuss~~
<br><br>

Example with [serve-static](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/a436740d5ddaff62e522da2ae212031acb7ef935/types/serve-static) (this problem will happen with other definitions).

- [serve-static/index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a436740d5ddaff62e522da2ae212031acb7ef935/types/serve-static/index.d.ts):
```TypeScript
declare function serveStatic(...): ...;
declare namespace serveStatic {
  ...
}
export = serveStatic;
```

- [express/index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a436740d5ddaff62e522da2ae212031acb7ef935/types/express/index.d.ts):
```TypeScript
import * as serveStatic from 'serve-static';
declare namespace e {
  var static: typeof serveStatic;
  ...
}
export = e;
```

- [Use of express.static()](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a436740d5ddaff62e522da2ae212031acb7ef935/types/express/express-tests.ts):
```TypeScript
import express from 'express';
const server = express();
express.static.mime.define({'application/fx': ['fx']});
server.use(express.static('.')); // With esModuleInterop: Cannot invoke an expression whose type lacks a call signature. Type 'typeof serveStatic' has no compatible call signatures.
```

Error with `esModuleInterop`: `Cannot invoke an expression whose type lacks a call signature. Type 'typeof serveStatic' has no compatible call signatures.`

If inside express/index.d.ts, `import * as serveStatic` is changed to `import serveStatic` then it works with `esModuleInterop`. Problem: it does not work without it (`Module '"serve-static/index"' has no default export`).

Any suggestion?