### PR TITLE
[@types/react-dates] add daySize to DateRangePickerShape

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -66,6 +66,7 @@ declare namespace ReactDates {
         reopenPickerOnClearDates?: boolean,
         renderCalendarInfo?: () => (string | JSX.Element),
         hideKeyboardShortcutsPanel?: boolean,
+        daySize?: number,
         isRTL?: boolean,
 
         // navigation related props


### PR DESCRIPTION
add missing daySize to DateRangePickerShape
DateRangePicker can use daySize
https://github.com/airbnb/react-dates/blob/master/src/components/DateRangePicker.jsx#L84