### PR TITLE
Types for jQuery Tags Input Plugin

### DIFF
--- a/types/jquery-tags-input/index.d.ts
+++ b/types/jquery-tags-input/index.d.ts
@@ -69,7 +69,7 @@ declare namespace jQueryTagsInput {
          minChars?: number;
 
         /**
-         * Max char length for tag or infinite char length (default)
+         * Max char length for tag
          */
          maxChars?: number;
 
@@ -84,7 +84,7 @@ declare namespace jQueryTagsInput {
      * Transform input field to work with tags
      * @param options for creation
      */
-     tagsInput(options?: object): JQuery;
+     tagsInput(options?: jQueryTagsInput.Options): JQuery;
 
     /**
      * Add a new tag to list

--- a/types/jquery-tags-input/index.d.ts
+++ b/types/jquery-tags-input/index.d.ts
@@ -1,0 +1,112 @@
+// Type definitions for jQuery Tags Input Plugin 1.3
+// Project: https://github.com/xoxco/jQuery-Tags-Input
+// Definitions by: Anderson Friaça <https://github.com/AndersonFriaca>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+
+declare namespace jQueryTagsInput {
+    interface Options {
+        /**
+         * Url for autocomplete
+         */
+         autocomplete_url?: string;
+
+        /**
+         * Autocomplete options
+         */
+         autocomplete?: object;
+
+        /**
+         * Height of tag
+         */
+         height?: string;
+
+        /**
+         * Width of tag
+         */
+         width?: string;
+
+        /**
+         * Interactive tags
+         */
+         interactive?: boolean;
+
+        /**
+         * Placeholder of field when tags is empty
+         */
+         defaultText?: string;
+
+        /**
+         * Callback function on add tag
+         */
+         onAddTag?: (addedValue: string) => void;
+
+        /**
+         * Callback function on remove tag
+         */
+         onRemoveTag?: (removedValue: string) => void;
+
+        /**
+         * Callback function on change list of tags
+         */
+         onChange?: (element: JQuery, changedValue: string) => void;
+
+        /**
+         * Delimiters on tags creation
+         */
+         delimiter?: string[]|string;
+
+        /**
+         * Remove with tag backspace
+         */
+         removeWithBackspace ?: boolean;
+
+        /**
+         * Minimun char length for tag
+         */
+         minChars?: number;
+
+        /**
+         * Max char length for tag or infinite char length (default)
+         */
+         maxChars?: number;
+
+        /**
+         * Placeholder color of tags
+         */
+         placeholderColor?: string;
+     }
+ }
+ interface JQuery {
+    /**
+     * Transform input field to work with tags
+     * @param options for creation
+     */
+     tagsInput(options?: object): JQuery;
+
+    /**
+     * Add a new tag to list
+     * @param tag value
+     */
+     addTag(tag: string): boolean;
+
+    /**
+     * Remove tag with value from list
+     * @param tag to be removed
+     */
+     removeTag(tag: string): boolean;
+
+    /**
+     * Add a new tags
+     * @param tags string separated by delimiter
+     */
+     importTags(tags: string): void;
+
+    /**
+     * Verify if tag exists
+     * @param tag value
+     */
+     tagExist(tag: string): boolean;
+ }

--- a/types/jquery-tags-input/jquery-tags-input-tests.ts
+++ b/types/jquery-tags-input/jquery-tags-input-tests.ts
@@ -5,15 +5,16 @@ $(document).ready(() => {
 	$('#inputTag').tagExist('new tag');
 	$('inputTag').removeTag('new tag');
 	$('#inputTag').importTags('tag1, tag2, tag3');
-});
 
-// with options
-let options: jQueryTagsInput.Options = {
-	height: '100px',
-	width: '300px',
-	minChars: 3,
-	maxChars: 0,
-	onAddTag: (value: string) => {
-		alert('Tag added: ' + value);
-	}
-};
+	// with options
+	const options: jQueryTagsInput.Options = {
+		height: '100px',
+		width: '300px',
+		minChars: 3,
+		maxChars: 0,
+		onAddTag: (value: string) => {
+			alert('Tag added: ' + value);
+		}
+	};
+	$('#inputTag').tagsInput(options);
+});

--- a/types/jquery-tags-input/jquery-tags-input-tests.ts
+++ b/types/jquery-tags-input/jquery-tags-input-tests.ts
@@ -1,0 +1,19 @@
+// basic usage
+$(document).ready(() => {
+	$('#inputTag').tagsInput();
+	$('#inputTag').addTag('new tag');
+	$('#inputTag').tagExist('new tag');
+	$('inputTag').removeTag('new tag');
+	$('#inputTag').importTags('tag1, tag2, tag3');
+});
+
+// with options
+let options: jQueryTagsInput.Options = {
+	height: '100px',
+	width: '300px',
+	minChars: 3,
+	maxChars: 0,
+	onAddTag: (value: string) => {
+		alert('Tag added: ' + value);
+	}
+};

--- a/types/jquery-tags-input/tsconfig.json
+++ b/types/jquery-tags-input/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-tags-input-tests.ts"
+    ]
+}

--- a/types/jquery-tags-input/tslint.json
+++ b/types/jquery-tags-input/tslint.json
@@ -1,0 +1,1 @@
+{"extends": "dtslint/dt.json"}


### PR DESCRIPTION
Types creation of [https://github.com/xoxco/jQuery-Tags-Input](https://github.com/xoxco/jQuery-Tags-Input)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.