### PR TITLE
lodash: remove _.flip from function/delay.d.ts

### DIFF
--- a/types/lodash/function/delay.d.ts
+++ b/types/lodash/function/delay.d.ts
@@ -35,30 +35,4 @@ declare module "../index" {
             ...args: any[]
         ): LoDashExplicitWrapper<number>;
     }
-
-    interface LoDashStatic {
-        /**
-         * Creates a function that invokes `func` with arguments reversed.
-         *
-         * @category Function
-         * @param func The function to flip arguments for.
-         * @returns Returns the new function.
-         * @example
-         *
-         * var flipped = _.flip(function() {
-         *   return _.toArray(arguments);
-         * });
-         *
-         * flipped('a', 'b', 'c', 'd');
-         * // => ['d', 'c', 'b', 'a']
-         */
-        flip<T extends (...args: any[]) => any>(func: T): T;
-    }
-
-    interface LoDashWrapper<TValue> {
-        /**
-         * @see _.flip
-         */
-        flip(): this;
-    }
 }


### PR DESCRIPTION
It erroneously ended up there in the course of the big split-up (#23100). `flip.d.ts` contains it too.