### PR TITLE
Importing into TypeScript shows a 'non-module entity' error @ types/pad

### DIFF
--- a/types/pad/index.d.ts
+++ b/types/pad/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for pad 1.0
+// Type definitions for pad 1.1
 // Project: https://github.com/wdavidw/node-pad#readme
 // Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
+//                 windware <https://github.com/windware>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = pad;
@@ -13,3 +14,5 @@ declare function pad(length: number, text: string, options?: { char?: string, co
 declare function pad(text: string, length: number, char?: string): string;
 // tslint:disable-next-line unified-signatures
 declare function pad(text: string, length: number, options?: { char?: string, colors?: boolean, strip?: boolean }): string;
+
+declare namespace pad {}


### PR DESCRIPTION
Fixes the error,

>Module "./node_modules/@ types/pad/index" resolves to a non-module entity and cannot be imported using this construct.

using,

> import * as pad from 'pad'

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
