### PR TITLE
[@types/expo] Improve Facebook's Response type definition

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -166,12 +166,7 @@ async () => {
 };
 
 async () => {
-    const result = await Facebook.logInWithReadPermissionsAsync('appId');
-
-    if (result.type === 'success') {
-        result.expires;
-        result.token;
-    }
+    const { type, expires, token } = await Facebook.logInWithReadPermissionsAsync("appId");
 };
 
 () => (

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -730,11 +730,9 @@ export namespace Facebook {
         behavior?: 'web' | 'native' | 'browser' | 'system';
     }
     type Response = {
-        type: 'success';
-        token: string;
-        expires: number;
-    } | {
-        type: 'cancel';
+        type: 'cancel' | 'success';
+        token?: string;
+        expires?: number;
     };
     function logInWithReadPermissionsAsync(appId: string, options?: Options): Promise<Response>;
 }

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -729,11 +729,11 @@ export namespace Facebook {
         permissions?: string[];
         behavior?: 'web' | 'native' | 'browser' | 'system';
     }
-    type Response = {
+    interface Response {
         type: 'cancel' | 'success';
         token?: string;
         expires?: number;
-    };
+    }
     function logInWithReadPermissionsAsync(appId: string, options?: Options): Promise<Response>;
 }
 

--- a/types/expo/v23/expo-tests.tsx
+++ b/types/expo/v23/expo-tests.tsx
@@ -159,12 +159,7 @@ async () => {
 };
 
 async () => {
-    const result = await Facebook.logInWithReadPermissionsAsync('appId');
-
-    if (result.type === 'success') {
-        result.expires;
-        result.token;
-    }
+    const { type, expires, token } = await Facebook.logInWithReadPermissionsAsync("appId");
 };
 
 () => (

--- a/types/expo/v23/index.d.ts
+++ b/types/expo/v23/index.d.ts
@@ -726,11 +726,11 @@ export namespace Facebook {
         permissions?: string[];
         behavior?: 'web' | 'native' | 'browser' | 'system';
     }
-    type Response = {
+    interface Response {
         type: 'cancel' | 'success';
         token?: string;
         expires?: number;
-    };
+    }
     function logInWithReadPermissionsAsync(appId: string, options?: Options): Promise<Response>;
 }
 

--- a/types/expo/v23/index.d.ts
+++ b/types/expo/v23/index.d.ts
@@ -727,11 +727,9 @@ export namespace Facebook {
         behavior?: 'web' | 'native' | 'browser' | 'system';
     }
     type Response = {
-        type: 'success';
-        token: string;
-        expires: number;
-    } | {
-        type: 'cancel';
+        type: 'cancel' | 'success';
+        token?: string;
+        expires?: number;
     };
     function logInWithReadPermissionsAsync(appId: string, options?: Options): Promise<Response>;
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/latest/sdk/facebook.html#returns
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

***

Hi there,

with the previous definition for the type `Response` it was required to do some type casting in order to access the `token` property (since union only allows to access common members). This change, otherwise, respects the response definition from Expo but does not force the user to check the response type in order to access its members.

The compiler was raising an error when working with the following code:

```typescript
const { token } = await Facebook.logInWithReadPermissionsAsync(appId, {
    behavior: 'system',
    permissions,
});
```

Let me know if there is something more I can do! :)
