### PR TITLE
@types/google-map-react: Added a missing 'draggable' boolean property to Props.

### DIFF
--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -84,6 +84,7 @@ export interface Props {
   options?: Options | ((maps: Maps) => Options);
   margin?: any[];
   debounced?: boolean;
+  draggable?: boolean;
   layerTypes?: string[];
   onClick?(value: ClickEventValue): any;
   onChange?(value: ChangeEventValue): any;


### PR DESCRIPTION
I have tested it and it worked.

Here is the draggable property context from source code:
https://github.com/istarkov/google-map-react/blob/master/src/google_map.js#L124
