### PR TITLE
ramda: propOr can handle undefined for the propName

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -1508,9 +1508,9 @@ declare namespace R {
          * If the given, non-null object has an own property with the specified name, returns the value of that property.
          * Otherwise returns the provided default value.
          */
-        propOr<T, U, V>(val: T, p: string, obj: U): V;
-        propOr<T>(val: T, p: string): <U, V>(obj: U) => V;
-        propOr<T>(val: T): <U, V>(p: string, obj: U) => V;
+        propOr<T, U, V>(val: T, propName: string | undefined, obj: U): V;
+        propOr<T>(val: T, propName: string | undefined): <U, V>(obj: U) => V;
+        propOr<T>(val: T): <U, V>(propName: string | undefined, obj: U) => V;
 
         /**
          * Returns the value at the specified property.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://ramdajs.com/docs/#propOr (manually testing ramda reveals propOr does accept undefined for the prop name)
- [ ] Increase the version number in the header if appropriate. (not sure it is?)
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

