### PR TITLE
XRM - Updated .then definition to include errorCode and message as parameters in the definition.

### DIFF
--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -1256,10 +1256,11 @@ declare namespace Xrm {
             then<U>(onFulfilled?: (value: T) => U | PromiseLike<U>, onRejected?: (error: any) => U | PromiseLike<U>):
                 PromiseLike<U>;
             then<U>(onFulfilled?: (value: T) => U | PromiseLike<U>, onRejected?: (error: any) => void): PromiseLike<U>;
-	    // https://msdn.microsoft.com/en-us/library/dn481607.aspx shows errorCode and message
-            then<U>(onFulfilled?: (value: T) => U | PromiseLike<U>, onRejected?: (errorCode: string, message: string) => U | PromiseLike<U>):
-            PromiseLike<U>;
-        
+
+            // https://msdn.microsoft.com/en-us/library/dn481607.aspx shows errorCode and message
+            then<U>(onFulfilled?: (value: T) => U | PromiseLike<U>, onRejected?: (errorCode: string, message: string) => U
+            | PromiseLike<U>): PromiseLike<U>;
+
             /**
              * UNDOCUMENTED (Web Client only) Add handlers to be called when the Deferred object is rejected.
              */

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -992,7 +992,7 @@ declare namespace Xrm {
          * @param message The message.
          * @param onCloseCallback The "OK" callback.
          */
-        alertDialog(message: string, onCloseCallback: () => void): void;
+        alertDialog(message: string, onCloseCallback?: () => void): void;
 
         /**
          * Displays a confirmation dialog, with "OK" and "Cancel" buttons.
@@ -1002,7 +1002,7 @@ declare namespace Xrm {
          * @param yesCloseCallback The "OK" callback.
          * @param noCloseCallback The "Cancel" callback.
          */
-        confirmDialog(message: string, yesCloseCallback: () => void, noCloseCallback: () => void): void;
+        confirmDialog(message: string, yesCloseCallback: () => void, noCloseCallback?: () => void): void;
 
         /**
          * Query if 'entityType' is an Activity entity.
@@ -4354,14 +4354,14 @@ declare namespace Xrm {
          * @param alertStrings The strings to be used in the alert dialog.
          * @param alertOptions The height and width options for alert dialog
          */
-        openAlertDialog(alertStrings: Navigation.AlertStrings, alertOptions: Navigation.DialogSizeOptions): Async.PromiseLike<any>;
+        openAlertDialog(alertStrings: Navigation.AlertStrings, alertOptions?: Navigation.DialogSizeOptions): Async.PromiseLike<any>;
 
         /**
          * Displays a confirmation dialog box containing a message and two buttons.
          * @param confirmStrings The strings to be used in the confirm dialog.
          * @param confirmOptions The height and width options for alert dialog
          */
-        openConfirmDialog(confirmStrings: Navigation.ConfirmStrings, confirmOptions: Navigation.DialogSizeOptions): Async.PromiseLike<Navigation.ConfirmResult>;
+        openConfirmDialog(confirmStrings: Navigation.ConfirmStrings, confirmOptions?: Navigation.DialogSizeOptions): Async.PromiseLike<Navigation.ConfirmResult>;
 
         /**
          * Displays an error dialog.
@@ -4378,7 +4378,7 @@ declare namespace Xrm {
         /**
          * Opens an entity form or a quick create form.
          */
-        openForm(entityFormOptions: Navigation.EntityFormOptions, formParameters: Utility.OpenParameters): Async.PromiseLike<any>;
+        openForm(entityFormOptions: Navigation.EntityFormOptions, formParameters?: Utility.OpenParameters): Async.PromiseLike<any>;
 
         /**
          * Opens a URL, including file URLs.

--- a/types/xrm/index.d.ts
+++ b/types/xrm/index.d.ts
@@ -1256,11 +1256,15 @@ declare namespace Xrm {
             then<U>(onFulfilled?: (value: T) => U | PromiseLike<U>, onRejected?: (error: any) => U | PromiseLike<U>):
                 PromiseLike<U>;
             then<U>(onFulfilled?: (value: T) => U | PromiseLike<U>, onRejected?: (error: any) => void): PromiseLike<U>;
-
+	    // https://msdn.microsoft.com/en-us/library/dn481607.aspx shows errorCode and message
+            then<U>(onFulfilled?: (value: T) => U | PromiseLike<U>, onRejected?: (errorCode: string, message: string) => U | PromiseLike<U>):
+            PromiseLike<U>;
+        
             /**
              * UNDOCUMENTED (Web Client only) Add handlers to be called when the Deferred object is rejected.
              */
             fail<U>(onRejected?: (reason: ErrorResponse) => U | PromiseLike<U>): PromiseLike<U>;
+            fail<U>(onRejected?: (errorCode: string, message: string) => U | PromiseLike<U>): PromiseLike<U>;
 
             /**
              * UNDOCUMENTED (Web Client only): Add handlers to be called when the Deferred object is either resolved or rejected.


### PR DESCRIPTION
Updated then callback to include the errorcode and mesage according to the api documentation.

Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: [Refresh API Documentation](https://msdn.microsoft.com/en-us/library/dn481607.aspx)
- [X] Increase the version number in the header if appropriate. - No
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. - Not substantial
