### PR TITLE
Use import require when call or construct signatures are needed to improve compat with esModuleInterop

### DIFF
--- a/types/bluebird-global/index.d.ts
+++ b/types/bluebird-global/index.d.ts
@@ -44,7 +44,7 @@
  *   d. target es6, latest "es20xx", e.g. "es2017"
  */
 
-import * as Bluebird from "bluebird";
+import Bluebird = require("bluebird");
 
 declare global {
     /*

--- a/types/egjs__axes/Axes.d.ts
+++ b/types/egjs__axes/Axes.d.ts
@@ -1,4 +1,4 @@
-import * as Component from "@egjs/component";
+import Component = require("@egjs/component");
 import { AnimationManager } from "./AnimationManager";
 import { EventManager } from "./EventManager";
 import { InterruptManager } from "./InterruptManager";

--- a/types/flux/lib/FluxReduceStore.d.ts
+++ b/types/flux/lib/FluxReduceStore.d.ts
@@ -1,4 +1,4 @@
-import * as Store from "./FluxStore";
+import Store = require("./FluxStore");
 
 declare namespace FluxReduceStore { }
 

--- a/types/lodash/array/chunk.d.ts
+++ b/types/lodash/array/chunk.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/compact.d.ts
+++ b/types/lodash/array/compact.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/concat.d.ts
+++ b/types/lodash/array/concat.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/difference.d.ts
+++ b/types/lodash/array/difference.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/differenceBy.d.ts
+++ b/types/lodash/array/differenceBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/differenceWith.d.ts
+++ b/types/lodash/array/differenceWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/drop.d.ts
+++ b/types/lodash/array/drop.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/dropRight.d.ts
+++ b/types/lodash/array/dropRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/dropRightWhile.d.ts
+++ b/types/lodash/array/dropRightWhile.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/dropWhile.d.ts
+++ b/types/lodash/array/dropWhile.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/fill.d.ts
+++ b/types/lodash/array/fill.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/findIndex.d.ts
+++ b/types/lodash/array/findIndex.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/findLastIndex.d.ts
+++ b/types/lodash/array/findLastIndex.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/first.d.ts
+++ b/types/lodash/array/first.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         first: typeof _.head; // tslint:disable-line:no-unnecessary-qualifier

--- a/types/lodash/array/flatten.d.ts
+++ b/types/lodash/array/flatten.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/flattenDeep.d.ts
+++ b/types/lodash/array/flattenDeep.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/flattenDepth.d.ts
+++ b/types/lodash/array/flattenDepth.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
        /**

--- a/types/lodash/array/fromPairs.d.ts
+++ b/types/lodash/array/fromPairs.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/head.d.ts
+++ b/types/lodash/array/head.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/indexOf.d.ts
+++ b/types/lodash/array/indexOf.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/initial.d.ts
+++ b/types/lodash/array/initial.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/intersection.d.ts
+++ b/types/lodash/array/intersection.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/intersectionBy.d.ts
+++ b/types/lodash/array/intersectionBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/intersectionWith.d.ts
+++ b/types/lodash/array/intersectionWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/join.d.ts
+++ b/types/lodash/array/join.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/last.d.ts
+++ b/types/lodash/array/last.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/lastIndexOf.d.ts
+++ b/types/lodash/array/lastIndexOf.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/nth.d.ts
+++ b/types/lodash/array/nth.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/pull.d.ts
+++ b/types/lodash/array/pull.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/pullAll.d.ts
+++ b/types/lodash/array/pullAll.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/pullAllBy.d.ts
+++ b/types/lodash/array/pullAllBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/pullAllWith.d.ts
+++ b/types/lodash/array/pullAllWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/pullAt.d.ts
+++ b/types/lodash/array/pullAt.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/remove.d.ts
+++ b/types/lodash/array/remove.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/reverse.d.ts
+++ b/types/lodash/array/reverse.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/slice.d.ts
+++ b/types/lodash/array/slice.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/sortedIndex.d.ts
+++ b/types/lodash/array/sortedIndex.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/sortedIndexBy.d.ts
+++ b/types/lodash/array/sortedIndexBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/sortedIndexOf.d.ts
+++ b/types/lodash/array/sortedIndexOf.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/sortedLastIndex.d.ts
+++ b/types/lodash/array/sortedLastIndex.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/sortedLastIndexBy.d.ts
+++ b/types/lodash/array/sortedLastIndexBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/sortedLastIndexOf.d.ts
+++ b/types/lodash/array/sortedLastIndexOf.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/sortedUniq.d.ts
+++ b/types/lodash/array/sortedUniq.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/sortedUniqBy.d.ts
+++ b/types/lodash/array/sortedUniqBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/tail.d.ts
+++ b/types/lodash/array/tail.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/take.d.ts
+++ b/types/lodash/array/take.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/takeRight.d.ts
+++ b/types/lodash/array/takeRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/takeRightWhile.d.ts
+++ b/types/lodash/array/takeRightWhile.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/takeWhile.d.ts
+++ b/types/lodash/array/takeWhile.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/union.d.ts
+++ b/types/lodash/array/union.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/unionBy.d.ts
+++ b/types/lodash/array/unionBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/unionWith.d.ts
+++ b/types/lodash/array/unionWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/uniq.d.ts
+++ b/types/lodash/array/uniq.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/uniqBy.d.ts
+++ b/types/lodash/array/uniqBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/uniqWith.d.ts
+++ b/types/lodash/array/uniqWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/unzip.d.ts
+++ b/types/lodash/array/unzip.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/unzipWith.d.ts
+++ b/types/lodash/array/unzipWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/without.d.ts
+++ b/types/lodash/array/without.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/xor.d.ts
+++ b/types/lodash/array/xor.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/xorBy.d.ts
+++ b/types/lodash/array/xorBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/xorWith.d.ts
+++ b/types/lodash/array/xorWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/zip.d.ts
+++ b/types/lodash/array/zip.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/zipObject.d.ts
+++ b/types/lodash/array/zipObject.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/zipObjectDeep.d.ts
+++ b/types/lodash/array/zipObjectDeep.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/array/zipWith.d.ts
+++ b/types/lodash/array/zipWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/countBy.d.ts
+++ b/types/lodash/collection/countBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/each.d.ts
+++ b/types/lodash/collection/each.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         each: typeof _.forEach; // tslint:disable-line:no-unnecessary-qualifier

--- a/types/lodash/collection/eachRight.d.ts
+++ b/types/lodash/collection/eachRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         eachRight: typeof _.forEachRight; // tslint:disable-line:no-unnecessary-qualifier

--- a/types/lodash/collection/every.d.ts
+++ b/types/lodash/collection/every.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/filter.d.ts
+++ b/types/lodash/collection/filter.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/find.d.ts
+++ b/types/lodash/collection/find.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/findLast.d.ts
+++ b/types/lodash/collection/findLast.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/flatMap.d.ts
+++ b/types/lodash/collection/flatMap.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/flatMapDeep.d.ts
+++ b/types/lodash/collection/flatMapDeep.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/flatMapDepth.d.ts
+++ b/types/lodash/collection/flatMapDepth.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/forEach.d.ts
+++ b/types/lodash/collection/forEach.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/forEachRight.d.ts
+++ b/types/lodash/collection/forEachRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/groupBy.d.ts
+++ b/types/lodash/collection/groupBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/includes.d.ts
+++ b/types/lodash/collection/includes.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/invokeMap.d.ts
+++ b/types/lodash/collection/invokeMap.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/keyBy.d.ts
+++ b/types/lodash/collection/keyBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/map.d.ts
+++ b/types/lodash/collection/map.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/orderBy.d.ts
+++ b/types/lodash/collection/orderBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/partition.d.ts
+++ b/types/lodash/collection/partition.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/reduce.d.ts
+++ b/types/lodash/collection/reduce.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/reduceRight.d.ts
+++ b/types/lodash/collection/reduceRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/reject.d.ts
+++ b/types/lodash/collection/reject.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/sample.d.ts
+++ b/types/lodash/collection/sample.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/sampleSize.d.ts
+++ b/types/lodash/collection/sampleSize.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/shuffle.d.ts
+++ b/types/lodash/collection/shuffle.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/size.d.ts
+++ b/types/lodash/collection/size.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/some.d.ts
+++ b/types/lodash/collection/some.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/collection/sortBy.d.ts
+++ b/types/lodash/collection/sortBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 type GlobalPartial<T> = Partial<T>;
 declare module "../index" {
     type PartialObject<T> = GlobalPartial<T>;

--- a/types/lodash/date/now.d.ts
+++ b/types/lodash/date/now.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/after.d.ts
+++ b/types/lodash/function/after.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/ary.d.ts
+++ b/types/lodash/function/ary.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/before.d.ts
+++ b/types/lodash/function/before.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/bind.d.ts
+++ b/types/lodash/function/bind.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface FunctionBind {
         placeholder: any;

--- a/types/lodash/function/bindKey.d.ts
+++ b/types/lodash/function/bindKey.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface FunctionBindKey {
         placeholder: any;

--- a/types/lodash/function/curry.d.ts
+++ b/types/lodash/function/curry.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/curryRight.d.ts
+++ b/types/lodash/function/curryRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/debounce.d.ts
+++ b/types/lodash/function/debounce.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface DebounceSettings {
         /**

--- a/types/lodash/function/defer.d.ts
+++ b/types/lodash/function/defer.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/delay.d.ts
+++ b/types/lodash/function/delay.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/flip.d.ts
+++ b/types/lodash/function/flip.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
        /**

--- a/types/lodash/function/memoize.d.ts
+++ b/types/lodash/function/memoize.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface MemoizedFunction {
         cache: MapCache;

--- a/types/lodash/function/negate.d.ts
+++ b/types/lodash/function/negate.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/once.d.ts
+++ b/types/lodash/function/once.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/overArgs.d.ts
+++ b/types/lodash/function/overArgs.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
    interface LoDashStatic {
        /**

--- a/types/lodash/function/partial.d.ts
+++ b/types/lodash/function/partial.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/partialRight.d.ts
+++ b/types/lodash/function/partialRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/rearg.d.ts
+++ b/types/lodash/function/rearg.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/rest.d.ts
+++ b/types/lodash/function/rest.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/spread.d.ts
+++ b/types/lodash/function/spread.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/throttle.d.ts
+++ b/types/lodash/function/throttle.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface ThrottleSettings {
         /**

--- a/types/lodash/function/unary.d.ts
+++ b/types/lodash/function/unary.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/function/wrap.d.ts
+++ b/types/lodash/function/wrap.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/castArray.d.ts
+++ b/types/lodash/lang/castArray.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/clone.d.ts
+++ b/types/lodash/lang/clone.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/cloneDeep.d.ts
+++ b/types/lodash/lang/cloneDeep.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/cloneDeepWith.d.ts
+++ b/types/lodash/lang/cloneDeepWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type CloneDeepWithCustomizer<TObject> = (value: any, key: number | string | undefined, object: TObject | undefined, stack: any) => any;
 

--- a/types/lodash/lang/cloneWith.d.ts
+++ b/types/lodash/lang/cloneWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type CloneWithCustomizer<TValue, TResult> = (value: TValue, key: number | string | undefined, object: any, stack: any) => TResult;
 

--- a/types/lodash/lang/conformsTo.d.ts
+++ b/types/lodash/lang/conformsTo.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
 
     interface LoDashStatic {

--- a/types/lodash/lang/eq.d.ts
+++ b/types/lodash/lang/eq.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/gt.d.ts
+++ b/types/lodash/lang/gt.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/gte.d.ts
+++ b/types/lodash/lang/gte.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isArguments.d.ts
+++ b/types/lodash/lang/isArguments.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isArray.d.ts
+++ b/types/lodash/lang/isArray.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isArrayBuffer.d.ts
+++ b/types/lodash/lang/isArrayBuffer.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isArrayLike.d.ts
+++ b/types/lodash/lang/isArrayLike.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isArrayLikeObject.d.ts
+++ b/types/lodash/lang/isArrayLikeObject.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isBoolean.d.ts
+++ b/types/lodash/lang/isBoolean.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isBuffer.d.ts
+++ b/types/lodash/lang/isBuffer.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isDate.d.ts
+++ b/types/lodash/lang/isDate.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isElement.d.ts
+++ b/types/lodash/lang/isElement.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isEmpty.d.ts
+++ b/types/lodash/lang/isEmpty.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isEqual.d.ts
+++ b/types/lodash/lang/isEqual.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isEqualWith.d.ts
+++ b/types/lodash/lang/isEqualWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type IsEqualCustomizer = (value: any, other: any, indexOrKey: PropertyName | undefined, parent: any, otherParent: any, stack: any) => boolean|undefined;
 

--- a/types/lodash/lang/isError.d.ts
+++ b/types/lodash/lang/isError.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isFinite.d.ts
+++ b/types/lodash/lang/isFinite.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isFunction.d.ts
+++ b/types/lodash/lang/isFunction.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isInteger.d.ts
+++ b/types/lodash/lang/isInteger.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isLength.d.ts
+++ b/types/lodash/lang/isLength.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isMap.d.ts
+++ b/types/lodash/lang/isMap.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isMatch.d.ts
+++ b/types/lodash/lang/isMatch.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type isMatchCustomizer = (value: any, other: any, indexOrKey?: PropertyName) => boolean;
 

--- a/types/lodash/lang/isMatchWith.d.ts
+++ b/types/lodash/lang/isMatchWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type isMatchWithCustomizer = (value: any, other: any, indexOrKey: PropertyName) => boolean;
 

--- a/types/lodash/lang/isNaN.d.ts
+++ b/types/lodash/lang/isNaN.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isNative.d.ts
+++ b/types/lodash/lang/isNative.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isNil.d.ts
+++ b/types/lodash/lang/isNil.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isNull.d.ts
+++ b/types/lodash/lang/isNull.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isNumber.d.ts
+++ b/types/lodash/lang/isNumber.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isObject.d.ts
+++ b/types/lodash/lang/isObject.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isObjectLike.d.ts
+++ b/types/lodash/lang/isObjectLike.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isPlainObject.d.ts
+++ b/types/lodash/lang/isPlainObject.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isRegExp.d.ts
+++ b/types/lodash/lang/isRegExp.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isSafeInteger.d.ts
+++ b/types/lodash/lang/isSafeInteger.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isSet.d.ts
+++ b/types/lodash/lang/isSet.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isString.d.ts
+++ b/types/lodash/lang/isString.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isSymbol.d.ts
+++ b/types/lodash/lang/isSymbol.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isTypedArray.d.ts
+++ b/types/lodash/lang/isTypedArray.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isUndefined.d.ts
+++ b/types/lodash/lang/isUndefined.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isWeakMap.d.ts
+++ b/types/lodash/lang/isWeakMap.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/isWeakSet.d.ts
+++ b/types/lodash/lang/isWeakSet.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/lt.d.ts
+++ b/types/lodash/lang/lt.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/lte.d.ts
+++ b/types/lodash/lang/lte.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/toArray.d.ts
+++ b/types/lodash/lang/toArray.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/toFinite.d.ts
+++ b/types/lodash/lang/toFinite.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/toInteger.d.ts
+++ b/types/lodash/lang/toInteger.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/toLength.d.ts
+++ b/types/lodash/lang/toLength.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/toNumber.d.ts
+++ b/types/lodash/lang/toNumber.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/toPlainObject.d.ts
+++ b/types/lodash/lang/toPlainObject.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/toSafeInteger.d.ts
+++ b/types/lodash/lang/toSafeInteger.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/lang/toString.d.ts
+++ b/types/lodash/lang/toString.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/add.d.ts
+++ b/types/lodash/math/add.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/ceil.d.ts
+++ b/types/lodash/math/ceil.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/divide.d.ts
+++ b/types/lodash/math/divide.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
        /**

--- a/types/lodash/math/floor.d.ts
+++ b/types/lodash/math/floor.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/max.d.ts
+++ b/types/lodash/math/max.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
          /**

--- a/types/lodash/math/maxBy.d.ts
+++ b/types/lodash/math/maxBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/mean.d.ts
+++ b/types/lodash/math/mean.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/meanBy.d.ts
+++ b/types/lodash/math/meanBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
       /**

--- a/types/lodash/math/min.d.ts
+++ b/types/lodash/math/min.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/minBy.d.ts
+++ b/types/lodash/math/minBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/multiply.d.ts
+++ b/types/lodash/math/multiply.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/round.d.ts
+++ b/types/lodash/math/round.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/subtract.d.ts
+++ b/types/lodash/math/subtract.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/sum.d.ts
+++ b/types/lodash/math/sum.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/math/sumBy.d.ts
+++ b/types/lodash/math/sumBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/number/clamp.d.ts
+++ b/types/lodash/number/clamp.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/number/inRange.d.ts
+++ b/types/lodash/number/inRange.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/number/random.d.ts
+++ b/types/lodash/number/random.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/assign.d.ts
+++ b/types/lodash/object/assign.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/assignIn.d.ts
+++ b/types/lodash/object/assignIn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/assignInWith.d.ts
+++ b/types/lodash/object/assignInWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type AssignCustomizer = (objectValue: any, sourceValue: any, key?: string, object?: {}, source?: {}) => any;
 

--- a/types/lodash/object/assignWith.d.ts
+++ b/types/lodash/object/assignWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/at.d.ts
+++ b/types/lodash/object/at.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/create.d.ts
+++ b/types/lodash/object/create.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/defaults.d.ts
+++ b/types/lodash/object/defaults.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/defaultsDeep.d.ts
+++ b/types/lodash/object/defaultsDeep.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/entries.d.ts
+++ b/types/lodash/object/entries.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/entriesIn.d.ts
+++ b/types/lodash/object/entriesIn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/extend.d.ts
+++ b/types/lodash/object/extend.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/extendWith.d.ts
+++ b/types/lodash/object/extendWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/findKey.d.ts
+++ b/types/lodash/object/findKey.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/findLastKey.d.ts
+++ b/types/lodash/object/findLastKey.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/forIn.d.ts
+++ b/types/lodash/object/forIn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/forInRight.d.ts
+++ b/types/lodash/object/forInRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/forOwn.d.ts
+++ b/types/lodash/object/forOwn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/forOwnRight.d.ts
+++ b/types/lodash/object/forOwnRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/functions.d.ts
+++ b/types/lodash/object/functions.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/functionsIn.d.ts
+++ b/types/lodash/object/functionsIn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/get.d.ts
+++ b/types/lodash/object/get.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/has.d.ts
+++ b/types/lodash/object/has.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/hasIn.d.ts
+++ b/types/lodash/object/hasIn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/invert.d.ts
+++ b/types/lodash/object/invert.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/invertBy.d.ts
+++ b/types/lodash/object/invertBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/invoke.d.ts
+++ b/types/lodash/object/invoke.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/keys.d.ts
+++ b/types/lodash/object/keys.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/keysIn.d.ts
+++ b/types/lodash/object/keysIn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/mapKeys.d.ts
+++ b/types/lodash/object/mapKeys.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/mapValues.d.ts
+++ b/types/lodash/object/mapValues.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/merge.d.ts
+++ b/types/lodash/object/merge.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/mergeWith.d.ts
+++ b/types/lodash/object/mergeWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type MergeWithCustomizer = { bivariantHack(value: any, srcValue: any, key: string, object: any, source: any): any; }["bivariantHack"]
 

--- a/types/lodash/object/omit.d.ts
+++ b/types/lodash/object/omit.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/omitBy.d.ts
+++ b/types/lodash/object/omitBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/pick.d.ts
+++ b/types/lodash/object/pick.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/pickBy.d.ts
+++ b/types/lodash/object/pickBy.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/result.d.ts
+++ b/types/lodash/object/result.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/set.d.ts
+++ b/types/lodash/object/set.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/setWith.d.ts
+++ b/types/lodash/object/setWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type SetWithCustomizer<T> = (nsValue: any, key: string, nsObject: T) => any;
 

--- a/types/lodash/object/toPairs.d.ts
+++ b/types/lodash/object/toPairs.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/toPairsIn.d.ts
+++ b/types/lodash/object/toPairsIn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/transform.d.ts
+++ b/types/lodash/object/transform.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/unset.d.ts
+++ b/types/lodash/object/unset.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/update.d.ts
+++ b/types/lodash/object/update.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/updateWith.d.ts
+++ b/types/lodash/object/updateWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/values.d.ts
+++ b/types/lodash/object/values.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/object/valuesIn.d.ts
+++ b/types/lodash/object/valuesIn.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/seq/chain.d.ts
+++ b/types/lodash/seq/chain.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/seq/prototype.at.d.ts
+++ b/types/lodash/seq/prototype.at.d.ts
@@ -1,4 +1,4 @@
-// import * as _ from "../index";
+// import _ = require("../index");
 // declare module "../index" {
 //     interface LoDashWrapper<TValue> {
 //         /**

--- a/types/lodash/seq/prototype.chain.d.ts
+++ b/types/lodash/seq/prototype.chain.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/seq/prototype.commit.d.ts
+++ b/types/lodash/seq/prototype.commit.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashWrapper<TValue> {
         /**

--- a/types/lodash/seq/prototype.plant.d.ts
+++ b/types/lodash/seq/prototype.plant.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashImplicitWrapper<TValue> {
         /**

--- a/types/lodash/seq/prototype.reverse.d.ts
+++ b/types/lodash/seq/prototype.reverse.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashWrapper<TValue> {
         /**

--- a/types/lodash/seq/prototype.toJSON.d.ts
+++ b/types/lodash/seq/prototype.toJSON.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashWrapper<TValue> {
         /**

--- a/types/lodash/seq/prototype.toString.d.ts
+++ b/types/lodash/seq/prototype.toString.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashWrapper<TValue> {
         /**

--- a/types/lodash/seq/prototype.value.d.ts
+++ b/types/lodash/seq/prototype.value.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashWrapper<TValue> {
         /**

--- a/types/lodash/seq/prototype.valueOf.d.ts
+++ b/types/lodash/seq/prototype.valueOf.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashWrapper<TValue> {
         /**

--- a/types/lodash/seq/tap.d.ts
+++ b/types/lodash/seq/tap.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/seq/thru.d.ts
+++ b/types/lodash/seq/thru.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/camelCase.d.ts
+++ b/types/lodash/string/camelCase.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/capitalize.d.ts
+++ b/types/lodash/string/capitalize.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/deburr.d.ts
+++ b/types/lodash/string/deburr.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/endsWith.d.ts
+++ b/types/lodash/string/endsWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/escape.d.ts
+++ b/types/lodash/string/escape.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/escapeRegExp.d.ts
+++ b/types/lodash/string/escapeRegExp.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/kebabCase.d.ts
+++ b/types/lodash/string/kebabCase.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/lowerCase.d.ts
+++ b/types/lodash/string/lowerCase.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/lowerFirst.d.ts
+++ b/types/lodash/string/lowerFirst.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/pad.d.ts
+++ b/types/lodash/string/pad.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/padEnd.d.ts
+++ b/types/lodash/string/padEnd.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/padStart.d.ts
+++ b/types/lodash/string/padStart.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/parseInt.d.ts
+++ b/types/lodash/string/parseInt.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/repeat.d.ts
+++ b/types/lodash/string/repeat.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/replace.d.ts
+++ b/types/lodash/string/replace.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/snakeCase.d.ts
+++ b/types/lodash/string/snakeCase.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/split.d.ts
+++ b/types/lodash/string/split.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/startCase.d.ts
+++ b/types/lodash/string/startCase.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/startsWith.d.ts
+++ b/types/lodash/string/startsWith.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/template.d.ts
+++ b/types/lodash/string/template.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface TemplateOptions extends TemplateSettings {
         /**

--- a/types/lodash/string/toLower.d.ts
+++ b/types/lodash/string/toLower.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/toUpper.d.ts
+++ b/types/lodash/string/toUpper.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/trim.d.ts
+++ b/types/lodash/string/trim.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/trimEnd.d.ts
+++ b/types/lodash/string/trimEnd.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/trimStart.d.ts
+++ b/types/lodash/string/trimStart.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/truncate.d.ts
+++ b/types/lodash/string/truncate.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface TruncateOptions {
         /** The maximum string length. */

--- a/types/lodash/string/unescape.d.ts
+++ b/types/lodash/string/unescape.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/upperCase.d.ts
+++ b/types/lodash/string/upperCase.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/upperFirst.d.ts
+++ b/types/lodash/string/upperFirst.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/string/words.d.ts
+++ b/types/lodash/string/words.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/attempt.d.ts
+++ b/types/lodash/util/attempt.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/bindAll.d.ts
+++ b/types/lodash/util/bindAll.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/cond.d.ts
+++ b/types/lodash/util/cond.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/conforms.d.ts
+++ b/types/lodash/util/conforms.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     type ConformsPredicateObject<T> = {
         [P in keyof T]?: (val: T[P]) => boolean;

--- a/types/lodash/util/constant.d.ts
+++ b/types/lodash/util/constant.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/defaultTo.d.ts
+++ b/types/lodash/util/defaultTo.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/flow.d.ts
+++ b/types/lodash/util/flow.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/flowRight.d.ts
+++ b/types/lodash/util/flowRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/identity.d.ts
+++ b/types/lodash/util/identity.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/iteratee.d.ts
+++ b/types/lodash/util/iteratee.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/matches.d.ts
+++ b/types/lodash/util/matches.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/matchesProperty.d.ts
+++ b/types/lodash/util/matchesProperty.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/method.d.ts
+++ b/types/lodash/util/method.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/methodOf.d.ts
+++ b/types/lodash/util/methodOf.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/mixin.d.ts
+++ b/types/lodash/util/mixin.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface MixinOptions {
         chain?: boolean;

--- a/types/lodash/util/noConflict.d.ts
+++ b/types/lodash/util/noConflict.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/noop.d.ts
+++ b/types/lodash/util/noop.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/nthArg.d.ts
+++ b/types/lodash/util/nthArg.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/over.d.ts
+++ b/types/lodash/util/over.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/overEvery.d.ts
+++ b/types/lodash/util/overEvery.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/overSome.d.ts
+++ b/types/lodash/util/overSome.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/property.d.ts
+++ b/types/lodash/util/property.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/propertyOf.d.ts
+++ b/types/lodash/util/propertyOf.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/range.d.ts
+++ b/types/lodash/util/range.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/rangeRight.d.ts
+++ b/types/lodash/util/rangeRight.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/runInContext.d.ts
+++ b/types/lodash/util/runInContext.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/stubArray.d.ts
+++ b/types/lodash/util/stubArray.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/stubFalse.d.ts
+++ b/types/lodash/util/stubFalse.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/stubObject.d.ts
+++ b/types/lodash/util/stubObject.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/stubString.d.ts
+++ b/types/lodash/util/stubString.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/stubTrue.d.ts
+++ b/types/lodash/util/stubTrue.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/times.d.ts
+++ b/types/lodash/util/times.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/toPath.d.ts
+++ b/types/lodash/util/toPath.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/lodash/util/uniqueId.d.ts
+++ b/types/lodash/util/uniqueId.d.ts
@@ -1,4 +1,4 @@
-import * as _ from "../index";
+import _ = require("../index");
 declare module "../index" {
     interface LoDashStatic {
         /**

--- a/types/moment-timezone/index.d.ts
+++ b/types/moment-timezone/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Michel Salib <https://github.com/michelsalib>, Alan Brazil Lins <https://github.com/alanblins>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import * as moment from 'moment';
+import moment = require('moment');
 
 // require("moment-timezone") === require("moment")
 export = moment;

--- a/types/parse-torrent/index.d.ts
+++ b/types/parse-torrent/index.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="node" />
 
-import * as MagnetUri from 'magnet-uri';
+import MagnetUri = require('magnet-uri');
 import * as ParseTorrentFile from 'parse-torrent-file';
 
 declare const ParseTorrent: ParseTorrent.ParseTorrent;

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -13,7 +13,7 @@
 
 /// <reference types="node" />
 
-import * as Tapable from 'tapable';
+import Tapable = require('tapable');
 import * as UglifyJS from 'uglify-js';
 
 export = webpack;


### PR DESCRIPTION
Most failures when enabling `esModuleInterop` for all dt packages are in their tests (meaning the tests should use a different import style when that flag is on, but are otherwise fine) - from what I can see only the failures caused by these packages (also [this one](https://github.com/apollographql/apollo-link/pull/457)) were caused by reexporting/reusing called/constructed namespace imports. It's not that many root packages with issues, since the only way it would be an issue is places where we've allowed the old namespace hack through.

Technically, only 5 of the lodash files _had_ to be changed, but I changed them all so they would stay consistent. `webpack` (`Tapable` is used as a class but was a namespace import) and `lodash` are the popular ones that had a break within them.