### PR TITLE
Make the async parameter of Bloodhound.search optional

### DIFF
--- a/types/typeahead/index.d.ts
+++ b/types/typeahead/index.d.ts
@@ -1186,7 +1186,7 @@ declare class Bloodhound<T> {
      * @param async Async callback.
      * @returns The data that matches query.
      */
-    public search(query: string, sync: (datums: T[]) => void, async: (datums: T[]) => void): T[];
+    public search(query: string, sync: (datums: T[]) => void, async?: (datums: T[]) => void): T[];
 
     /**
      * Returns all items from the internal search index.

--- a/types/typeahead/typeahead-tests.ts
+++ b/types/typeahead/typeahead-tests.ts
@@ -213,10 +213,11 @@ function test_bloodhout() {
         // search
         var sync: (datums: string[]) => {};
         var async: (datums: string[]) => {};
-        var data2: string[] = engine.search("query", sync, async);
+        var data2: string[] = engine.search("query", sync);
+        var data3: string[] = engine.search("query", sync, async);
 
         // all
-        var data3: string[] = engine.all();
+        var data4: string[] = engine.all();
 
         // clear
         var engine1: Bloodhound<string> = engine.clear();


### PR DESCRIPTION
The search function assigns a noop call inside the function body if the async parameter is omitted ([bloodhound.js line 137](https://github.com/corejavascript/typeahead.js/blob/7c8aa88c9c6b79af7e9a870dd59c254d9dc0c86c/src/bloodhound/bloodhound.js#L137)), so it's safe to make this optional in the type signature.
