### PR TITLE
Highcharts added date format to datapoint interface

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -5523,7 +5523,7 @@ declare namespace Highcharts {
         /**
          * The x value of the point. For datetime axes, the X value is the timestamp in milliseconds since 1970.
          */
-        x?: number;
+        x?: number | Date;
         /**
          * The y value of the point.
          */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: DefinitelyTyped/types/highcharts/index.d.ts
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

When adding a DataPoint to a chart, the x property is defined in types to be a number, but it can actually also be a Date format. i simply update the interface for the DataPoint to be either number or Date.

tested by running 

``` javascript
const pointObject = {
        name: 'some name',
        id: 5,
        y: 200,
        x: date,
      };
this.chart.addPoint(pointObject, 0);
```

this works perfectly and highcharts understand that the x axis of the chart should be date formatted.
