### PR TITLE
[React Native] Update AnimatedValue type

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7726,8 +7726,7 @@ export interface EasingStatic {
 }
 
 export namespace Animated {
-    // Most (all?) functions where AnimatedValue is used any subclass of Animated can be used as well.
-    type AnimatedValue = Animated;
+    type AnimatedValue = Value;
     type AnimatedValueXY = ValueXY;
 
     type Base = Animated;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/animations.html


The old type definition of `type AnimatedValue = Animated` caused issues when trying to access methods in a ValueXY pair.

Example:
```
let animatedValue: Animated.AnimatedValueXY = new Animated.ValueXY()
animatedValue.x.interpolate({
    inputRange: [0, 1],
    outputRange: [0, 100]
})

// Causes error:
// [ts] Property 'interpolate' does not exist on type 'Animated'
```

The simple change `type AnimatedValue = Value;` fixes this issue.
I've run the test suite and local tests in my project, and did not experience any problems with the updated type definition.
