### PR TITLE
[redux-actions] Fix createActions argument types

### DIFF
--- a/types/redux-actions/index.d.ts
+++ b/types/redux-actions/index.d.ts
@@ -163,7 +163,7 @@ export interface ActionMap<Payload, Meta> {
 }
 
 export function createActions<Payload>(
-    actionMap: ActionMap<Payload, any>,
+    actionMapOrIdentityAction: ActionMap<Payload, any> | string,
     ...identityActions: string[]
 ): {
     [actionName: string]: ActionFunctionAny<Action<Payload>>


### PR DESCRIPTION
`createActions` does not have actionMap as a required parameter, it can take just a series of string identityActions, so the types need to be adjusted to support that case.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reduxactions/redux-actions/blob/master/src/createActions.js#L27
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
