### PR TITLE
Highcharts: add support for importing from "highcharts/js/highcharts"

### DIFF
--- a/types/highcharts/js/highcharts/index.d.ts
+++ b/types/highcharts/js/highcharts/index.d.ts
@@ -1,0 +1,2 @@
+import * as Highcharts from '../..';
+export = Highcharts;

--- a/types/highcharts/js/highcharts/index.d.ts
+++ b/types/highcharts/js/highcharts/index.d.ts
@@ -1,2 +1,2 @@
-import * as Highcharts from '../..';
+import Highcharts = require('../..');
 export = Highcharts;

--- a/types/highcharts/tsconfig.json
+++ b/types/highcharts/tsconfig.json
@@ -26,6 +26,7 @@
         "modules/offline-exporting.d.ts",
         "highcharts-more.d.ts",
         "highstock.d.ts",
+        "js/highcharts/index.d.ts",
         "test/boost.ts",
         "test/exporting.ts",
         "test/highstock.ts",


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.highcharts.com/docs/chart-design-and-style/style-by-css
- [ ] Increase the version number in the header if appropriate.
**N/A**
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
**N/A**

Highcharts has _styled mode_ (see link above) which allows Highcharts to be styled by css rather than by options. The way to use _styled mode_ is to import Highcharts from "highcharts/js/highcharts". Currently this type definition is unaware that the library can be imported this way so types are lost. This PR is to add the "/js/highcharts" module.

I've never issued a PR against DefinitelyTyped so I apologize in advance if I'm missing anything, but I'll be more than happy to correct or add anything!
