### PR TITLE
fix(jest): re-add global `spyOn`

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -548,6 +548,16 @@ declare namespace jest {
 // Relevant parts of Jasmine's API are below so they can be changed and removed over time.
 // This file can't reference jasmine.d.ts since the globals aren't compatible.
 
+declare function spyOn(object: any, method: string): jasmine.Spy;
+/**
+ * If you call the function pending anywhere in the spec body,
+ * no matter the expectations, the spec will be marked pending.
+ */
+declare function pending(reason?: string): void;
+/**
+ * Fails a test when called within one.
+ */
+declare function fail(error?: any): void;
 declare namespace jasmine {
     let DEFAULT_TIMEOUT_INTERVAL: number;
     function clock(): Clock;


### PR DESCRIPTION
While `jest` is not `jasmine`, jest does expose a global `spyOn` and can even be seen in the flow-types that are shipped with jest

https://github.com/facebook/jest/blob/master/flow-typed/npm/jest_v21.x.x.js#L557

To be clear jest.spyOn and spyOn are different. One is a jest-jasmine spyOn and the other one is jest spyOn they have different types an different sub methods. like .and, .stub etc..

For me it doesn't make sense to install @types/jasmine to have typings for the global spyOn

While I agree that it's best to use jest.spyOn. Jest does expose the jasmine spyOn and thus, it should be in the typings. I believe.

This PR is following the change done here: #23226 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/facebook/jest/blob/master/flow-typed/npm/jest_v21.x.x.js#L557>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
