### PR TITLE
types/urijs: Method expand on URI object

### DIFF
--- a/types/urijs/index.d.ts
+++ b/types/urijs/index.d.ts
@@ -34,6 +34,8 @@ declare namespace uri {
         equals(): boolean;
         equals(url: string | URI): boolean;
 
+        expand(vals: Object): string;
+
         filename(): string;
         filename(file: boolean): string;
         filename(file: string): URI;

--- a/types/urijs/urijs-tests.ts
+++ b/types/urijs/urijs-tests.ts
@@ -64,6 +64,10 @@ URI('http://user:pass@example.org:80/foo/bar.html?foo=bar&bar=baz#frag').equals(
         h: "frag"
     })
 );
+new URI('http://example.org/image/').expand({
+    width: 100,
+    height: 100
+}) === 'http://example.org/image/?width=100&height=100'
 
 /*
 Tests for hasSearch(), hasQuery()


### PR DESCRIPTION
Adds method URI.expand type definition.

Motivation:
new URITemplate('http//example.com').expand({ a: 1, b: 2 }) is a valid code, however typecheck fails here, because of missing method types definition. The test should call new URITemplate().expand() instead of just new URI().expand().

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://medialize.github.io/URI.js/uri-template.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.