### PR TITLE
[accepts] Fix encoding(s), charset(s), and language(s) signatures

### DIFF
--- a/types/accepts/index.d.ts
+++ b/types/accepts/index.d.ts
@@ -12,24 +12,35 @@ declare namespace accepts {
     interface Accepts {
         /**
          * Return the first accepted charset. If nothing in `charsets` is accepted, then `false` is returned.
+         * If no charsets are supplied, all accepted charsets are returned, in the order of the client's preference
+         * (most preferred first).
          */
+        charset(): string[];
         charset(charsets: string[]): string | false;
         charset(...charsets: string[]): string | false;
 
         /**
-         * Return the charsets that the request accepts, in the order of the client's preference (most preferred first).
+         * Return the first accepted charset. If nothing in `charsets` is accepted, then `false` is returned.
+         * If no charsets are supplied, all accepted charsets are returned, in the order of the client's preference
+         * (most preferred first).
          */
         charsets(): string[];
+        charsets(charsets: string[]): string | false;
+        charsets(...charsets: string[]): string | false;
 
         /**
          * Return the first accepted encoding. If nothing in `encodings` is accepted, then `false` is returned.
+         * If no encodings are supplied, all accepted encodings are returned, in the order of the client's preference
+         * (most preferred first).
          */
         encoding(): string[];
         encoding(encodings: string[]): string | false;
         encoding(...encodings: string[]): string | false;
 
         /**
-         * Return the encodings that the request accepts, in the order of the client's preference (most preferred first).
+         * Return the first accepted encoding. If nothing in `encodings` is accepted, then `false` is returned.
+         * If no encodings are supplied, all accepted encodings are returned, in the order of the client's preference
+         * (most preferred first).
          */
         encodings(): string[];
         encodings(encodings: string[]): string | false;

--- a/types/accepts/index.d.ts
+++ b/types/accepts/index.d.ts
@@ -48,14 +48,39 @@ declare namespace accepts {
 
         /**
          * Return the first accepted language. If nothing in `languages` is accepted, then `false` is returned.
+         * If no languaes are supplied, all accepted languages are returned, in the order of the client's preference
+         * (most preferred first).
          */
+        language(): string[];
         language(languages: string[]): string | false;
         language(...languages: string[]): string | false;
 
         /**
-         * Return the languages that the request accepts, in the order of the client's preference (most preferred first).
+         * Return the first accepted language. If nothing in `languages` is accepted, then `false` is returned.
+         * If no languaes are supplied, all accepted languages are returned, in the order of the client's preference
+         * (most preferred first).
          */
         languages(): string[];
+        languages(languages: string[]): string | false;
+        languages(...languages: string[]): string | false;
+
+        /**
+         * Return the first accepted language. If nothing in `languages` is accepted, then `false` is returned.
+         * If no languaes are supplied, all accepted languages are returned, in the order of the client's preference
+         * (most preferred first).
+         */
+        lang(): string[];
+        lang(languages: string[]): string | false;
+        lang(...languages: string[]): string | false;
+
+        /**
+         * Return the first accepted language. If nothing in `languages` is accepted, then `false` is returned.
+         * If no languaes are supplied, all accepted languages are returned, in the order of the client's preference
+         * (most preferred first).
+         */
+        langs(): string[];
+        langs(languages: string[]): string | false;
+        langs(...languages: string[]): string | false;
 
         /**
          * Return the first accepted type (and it is returned as the same text as what appears in the `types` array). If nothing in `types` is accepted, then `false` is returned.

--- a/types/accepts/index.d.ts
+++ b/types/accepts/index.d.ts
@@ -24,6 +24,7 @@ declare namespace accepts {
         /**
          * Return the first accepted encoding. If nothing in `encodings` is accepted, then `false` is returned.
          */
+        encoding(): string[];
         encoding(encodings: string[]): string | false;
         encoding(...encodings: string[]): string | false;
 
@@ -31,6 +32,8 @@ declare namespace accepts {
          * Return the encodings that the request accepts, in the order of the client's preference (most preferred first).
          */
         encodings(): string[];
+        encodings(encodings: string[]): string | false;
+        encodings(...encodings: string[]): string | false;
 
         /**
          * Return the first accepted language. If nothing in `languages` is accepted, then `false` is returned.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jshttp/accepts/blob/master/index.js#L127
- [ ] Increase the version number in the header if appropriate. _Not sure what this means_
- ~~[ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~

-----

As the linked source code above indicates, each of these pluralized methods is actually just an alias of the same function (i.e. `accepts.encoding` and `accepts.encodings`). So they should have identical type definitions.