### PR TITLE
[pdfjs-dist] Add ArrayBuffer type param to getDocument

### DIFF
--- a/types/pdfjs-dist/index.d.ts
+++ b/types/pdfjs-dist/index.d.ts
@@ -460,21 +460,7 @@ declare namespace PDF {
      * @return A promise that is resolved with PDFDocumentProxy object.
      **/
     getDocument(
-        source: string,
-        pdfDataRangeTransport?: any,
-        passwordCallback?: (fn: (password: string) => void, reason: string) => string,
-        progressCallback?: (progressData: PDFProgressData) => void)
-        : PDFPromise<PDFDocumentProxy>;
-
-    getDocument(
-        source: Uint8Array,
-        pdfDataRangeTransport?: any,
-        passwordCallback?: (fn: (password: string) => void, reason: string) => string,
-        progressCallback?: (progressData: PDFProgressData) => void)
-        : PDFPromise<PDFDocumentProxy>;
-
-    getDocument(
-        source: PDFSource,
+        source: string | Uint8Array | PDFSource | ArrayBuffer,
         pdfDataRangeTransport?: any,
         passwordCallback?: (fn: (password: string) => void, reason: string) => string,
         progressCallback?: (progressData: PDFProgressData) => void)


### PR DESCRIPTION
According to https://github.com/mozilla/pdf.js/blob/29d77dedad84dafdfed04c8ca7d07b680c6cfce3/src/display/api.js#L177, it accepts ArrayBuffer as an input type.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mozilla/pdf.js/blob/29d77dedad84dafdfed04c8ca7d07b680c6cfce3/src/display/api.js#L177
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.