### PR TITLE
[react-navigation] Fix tabBarOnPress to destructure arguments

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -347,10 +347,10 @@ export interface NavigationTabScreenOptions extends NavigationScreenOptions {
     > | string | null));
   tabBarVisible?: boolean;
   tabBarTestIDProps?: { testID?: string, accessibilityLabel?: string };
-  tabBarOnPress?: (
+  tabBarOnPress?: (options: {
     scene: TabScene,
     jumpToIndex: (index: number) => void
-  ) => void;
+  }) => void;
 }
 
 export interface NavigationDrawerScreenOptions extends NavigationScreenOptions {

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -140,7 +140,7 @@ const tabNavigatorScreenOptions: NavigationTabScreenOptions = {
     tabBarVisible: true,
     tabBarIcon: <View />,
     tabBarLabel: 'label',
-    tabBarOnPress: (scene, index) => {}
+    tabBarOnPress: ({scene, jumpToIndex}) => {}
 };
 
 const tabNavigatorConfig: TabNavigatorConfig = {
@@ -152,6 +152,15 @@ const tabNavigatorConfig: TabNavigatorConfig = {
 const tabNavigatorConfigWithInitialLayout: TabNavigatorConfig = {
   ...tabNavigatorConfig,
   initialLayout: { height: 0, width: 100 },
+};
+
+const tabNavigatorConfigWithNavigationOptions: TabNavigatorConfig = {
+    ...tabNavigatorConfig,
+    navigationOptions: {
+        tabBarOnPress: ({scene, jumpToIndex}) => {
+            jumpToIndex(scene.index);
+        }
+    },
 };
 
 const BasicTabNavigator = TabNavigator(


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-navigation/react-navigation/pull/1335

### Details

Looks like the tabBarOnPress actually needs to spread {scene, jumpToIndex}.  
I tested logging out the params for tabBarOnPress and got:  
```typescript
navigationOptions: {
        tabBarOnPress: (params) => {
            console.log(params)
        },
},
/* Output
{
  "jumpToIndex": [Function anonymous],
  "previousScene": Object {
    "key": "Home",
    "params": undefined,
    "routeName": "Home",
  },
  "scene": Object {
    "focused": false,
    "index": 3,
    "route": Object {
      "key": "Settings",
      "params": undefined,
      "routeName": "Settings",
    },
  },
}*/
```
### Example usage from my code base:
```typescript
const tabNavigatorConfig: TabNavigatorConfig = {
    tabBarComponent: TabBarBottom,
    tabBarPosition: 'bottom',
    animationEnabled: false,
    swipeEnabled: false,
    navigationOptions: {
        tabBarOnPress: ({ scene, jumpToIndex }) => {
            jumpToIndex(scene.index)
            if (scene.route.routeName === 'Map') {
                StatusBar.setBarStyle('dark-content')
            } else {
                StatusBar.setBarStyle('light-content')
            }
        },
    },
}

export default TabNavigator(routeConfigMap, tabNavigatorConfig)
```
