### PR TITLE
[reactstrap] add missing ModalProps

### DIFF
--- a/types/reactstrap/index.d.ts
+++ b/types/reactstrap/index.d.ts
@@ -7,6 +7,7 @@
 //                 FaithForHumans <https://github.com/FaithForHumans>
 //                 Kurt Preston <https://github.com/KurtPreston>
 //                 Kræn Hansen <https://github.com/kraenhansen>
+//                 Tim Chen <https://github.com/timc13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/reactstrap/lib/Modal.d.ts
+++ b/types/reactstrap/lib/Modal.d.ts
@@ -1,4 +1,5 @@
 import { CSSModule } from '../index';
+import { FadeProps } from './Fade';
 
 export interface ModalProps {
   isOpen?: boolean;
@@ -9,6 +10,8 @@ export interface ModalProps {
   backdrop?: boolean | 'static';
   onEnter?: () => void;
   onExit?: () => void;
+  onOpened?: () => void;
+  onClosed?: () => void;
   className?: string;
   cssModule?: CSSModule;
   wrapClassName?: string;
@@ -17,6 +20,8 @@ export interface ModalProps {
   contentClassName?: string;
   zIndex?: number | string;
   fade?: boolean;
+  backdropTransition?: FadeProps;
+  modalTransition?: FadeProps;
 }
 
 declare const Modal: React.StatelessComponent<ModalProps>;


### PR DESCRIPTION
add missing ModalProps according to https://reactstrap.github.io/components/modals/

