### PR TITLE
[vimeo__player] Player should be the default export

### DIFF
--- a/types/vimeo__player/index.d.ts
+++ b/types/vimeo__player/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for @vimeo/player 2.0
 // Project: https://github.com/vimeo/player.js
-// Definitions by: Denis Yılmaz <https://github.com/denisyilmaz>, Felix Albert <f.albert.work@icloud.com>
+// Definitions by: Denis Yılmaz <https://github.com/denisyilmaz>
+//                 Felix Albert <f.albert.work@icloud.com>
+//                 Tim Chen <https://github.com/timc13>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export function myMethod(a: string): string;
@@ -23,7 +25,7 @@ export interface TypeError extends Error {name: "TypeError"; message: string; me
 export type EventName = "play" | "pause" | "ended" | "timeupdate" | "progress" | "seeked" | "texttrackchange" | "cuechange" | "cuepoint" | "volumechange" | "error" | "loaded" |  string;
 export type EventCallback = (data: any) => any;
 
-export class Player {
+export default class Player {
     constructor(element: HTMLIFrameElement|HTMLElement|string, options: Options);
 
     on(event: EventName, callback: EventCallback): void;

--- a/types/vimeo__player/vimeo__player-tests.ts
+++ b/types/vimeo__player/vimeo__player-tests.ts
@@ -1,4 +1,4 @@
-import { Player } from '@vimeo/player';
+import Player from '@vimeo/player';
 
 // based on README.md of @vimeo/player >> https://github.com/vimeo/player.js
 


### PR DESCRIPTION
This has always been the case.  https://github.com/vimeo/player.js/blob/master/src/player.js#L853

Also see: https://stackoverflow.com/questions/44589936/how-do-i-get-vimeo-player-to-work-on-my-angular2-typescript-project/44972280#comment76170091_44590798

The [README](https://github.com/vimeo/player.js#using-with-a-module-bundler) also says to import it like 
```
import Player from '@vimeo/player';
```
and NOT like
```
import { Player } from '@vimeo/player';
```