### PR TITLE
jquery.colorpicker: make disable field in options optional

### DIFF
--- a/types/jquery.colorpicker/index.d.ts
+++ b/types/jquery.colorpicker/index.d.ts
@@ -31,7 +31,7 @@ interface JQueryColorpickerOptions {
     closeOnOutside?: boolean;
     color?: string;
     colorFormat?: string;
-    disabled: boolean;
+    disabled?: boolean;
     draggable?: boolean;
     duration?: string;
     format?: string;

--- a/types/jquery.colorpicker/jquery.colorpicker-tests.ts
+++ b/types/jquery.colorpicker/jquery.colorpicker-tests.ts
@@ -70,6 +70,9 @@ colorpicker.colorpicker("destroy");
 colorpicker.colorpicker("setColor", "#deadbeef");
 colorpicker.colorpicker("option", "disabled", true);
 
+// check if all options are optional
+let defaultColorpicker = $("<input type=\"text\"/>").colorpicker({});
+
 // example plugins provided
 
 $.colorpicker.parts["memory"] = function (inst) {


### PR DESCRIPTION
This is a fix for my previous pull-request #23320, where I forgot to mark `disabled` field of `JQueryColorpickerOptions` optional.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zaeder/colorpicker/blob/817145ba2a5c359448b07f69c811d65a39cbf008/jquery.colorpicker.js#L2329
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.