### PR TITLE
[bookshelf] Fix return value type of orderBy method.

### DIFF
--- a/types/bookshelf/bookshelf-tests.ts
+++ b/types/bookshelf/bookshelf-tests.ts
@@ -1124,7 +1124,7 @@ ships.on('fetched', (collection, response) => {
 	User.collection()
 		.orderBy('-name')
 		.fetch()
-		.then((users: Bookshelf.Collection<User>) => {
+		.then((users: Bookshelf.Collection<Bookshelf.Model<User>>) => {
 			console.log(users);
 		})
 }

--- a/types/bookshelf/index.d.ts
+++ b/types/bookshelf/index.d.ts
@@ -250,7 +250,7 @@ declare namespace Bookshelf {
 		detach(options?: SyncOptions): BlueBird<any>;
 		fetchOne(options?: CollectionFetchOneOptions): BlueBird<T>;
 		load(relations: string | string[], options?: SyncOptions): BlueBird<Collection<T>>;
-		orderBy(column: string, order?: SortOrder): T;
+		orderBy(column: string, order?: SortOrder): Collection<T>;
 
 		// Declaration order matters otherwise TypeScript gets confused between query() and query(...query: string[])
 		query(): Knex.QueryBuilder;


### PR DESCRIPTION
`collection.orderBy` returns model collection by official document.
In previous definition, it was supposed to return one model.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://bookshelfjs.org/#Collection-instance-orderBy
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.