### PR TITLE
Allow modern import syntax for koa-conditional-get

### DIFF
--- a/types/koa-conditional-get/index.d.ts
+++ b/types/koa-conditional-get/index.d.ts
@@ -8,4 +8,6 @@ import * as koa from 'koa';
 
 declare function koaConditionalGet(): koa.Middleware;
 
+declare namespace koaConditionalGet {}
+
 export = koaConditionalGet;

--- a/types/koa-conditional-get/koa-conditional-get-tests.ts
+++ b/types/koa-conditional-get/koa-conditional-get-tests.ts
@@ -1,4 +1,4 @@
-import Koa = require('koa');
-import conditional = require('koa-conditional-get');
+import * as Koa from 'koa';
+import * as conditional from 'koa-conditional-get';
 
 new Koa().use(conditional());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
Only change is to allow the modern import syntax `import * as ...`. This change is backwards compatible.
