### PR TITLE
Allow modern import syntax for koa-etag

### DIFF
--- a/types/koa-etag/index.d.ts
+++ b/types/koa-etag/index.d.ts
@@ -9,4 +9,6 @@ import * as etag from 'etag';
 
 declare function koaEtag(options?: etag.Options): koa.Middleware;
 
+declare namespace koaEtag {}
+
 export = koaEtag;

--- a/types/koa-etag/koa-etag-tests.ts
+++ b/types/koa-etag/koa-etag-tests.ts
@@ -1,4 +1,4 @@
-import koaEtag = require('koa-etag');
+import * as koaEtag from 'koa-etag';
 import * as Koa from 'koa';
 
 new Koa().use(koaEtag());


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
Only change is to allow the modern import syntax `import * as ...`. This change is backwards-compatible.
