### PR TITLE
lodash: support `ReadonlyArray` for specifying property names

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -2,7 +2,7 @@ import _ = require("../index");
 type GlobalPartial<T> = Partial<T>;
 declare module "../index" {
     type PartialObject<T> = GlobalPartial<T>;
-    type Many<T> = T | T[];
+    type Many<T> = T | ReadonlyArray<T>;
     interface LoDashStatic {
         /**
         * Creates a lodash object which wraps value to enable implicit method chain sequences.

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3775,77 +3775,75 @@ namespace TestCommit {
 
 // _.prototype.concat
 namespace TestConcat {
-    {
-        let result: _.LoDashImplicitArrayWrapper<number>;
+    const numberROA: ReadonlyArray<number> = [0];
 
-        result = _(1).concat<number>(2);
-        result = _(1).concat<number>(2, 3);
-        result = _(1).concat<number>(2, 3, 4);
+    _.concat(1); // $ExpectType number[]
+    _.concat([1]); // $ExpectType number[]
+    _.concat(numberROA); // $ExpectType number[]
+    _.concat(1, 2); // $ExpectType number[]
+    _.concat(1, [1]); // $ExpectType number[]
+    _.concat(1, [1], numberROA); // $ExpectType number[]
 
-        result = _(1).concat(2);
-        result = _(1).concat(2, 3);
-        result = _(1).concat(2, 3, 4);
-    }
+    _(1).concat(2); // $ExpectType LoDashImplicitWrapper<number[]>
+    _(1).concat([1]); // $ExpectType LoDashImplicitWrapper<number[]>
+    _(1).concat([2], numberROA); // $ExpectType LoDashImplicitWrapper<number[]>
+    _([1]).concat(2); // $ExpectType LoDashImplicitWrapper<number[]>
+    _(numberROA).concat(numberROA); // $ExpectType LoDashImplicitWrapper<number[]>
+    _(numberROA).concat(numberROA, numberROA); // $ExpectType LoDashImplicitWrapper<number[]>
 
-    {
-        let result: _.LoDashImplicitArrayWrapper<string>;
+    _.chain(1).concat(2); // $ExpectType LoDashExplicitWrapper<number[]>
+    _.chain(1).concat([1]); // $ExpectType LoDashExplicitWrapper<number[]>
+    _.chain(1).concat([2], numberROA); // $ExpectType LoDashExplicitWrapper<number[]>
+    _.chain([1]).concat(2); // $ExpectType LoDashExplicitWrapper<number[]>
+    _.chain(numberROA).concat(numberROA); // $ExpectType LoDashExplicitWrapper<number[]>
+    _.chain(numberROA).concat(numberROA, numberROA); // $ExpectType LoDashExplicitWrapper<number[]>
 
-        result = _(['']).concat<string>(['']);
-        result = _(['']).concat<string>([''], ['']);
-        result = _(['']).concat<string>([''], [''], ['']);
+    const stringROA: ReadonlyArray<string> = [''];
 
-        result = _(['']).concat(['']);
-        result = _(['']).concat([''], ['']);
-        result = _(['']).concat([''], [''], ['']);
-    }
+    _.concat('a'); // $ExpectType string[]
+    _.concat(['a']); // $ExpectType string[]
+    _.concat(stringROA); // $ExpectType string[]
+    _.concat('a', 'b'); // $ExpectType string[]
+    _.concat('a', ['a']); // $ExpectType string[]
+    _.concat('a', ['a'], stringROA); // $ExpectType string[]
 
-    {
-        let result: _.LoDashImplicitArrayWrapper<{a: string}>;
+    _('a').concat('b'); // $ExpectType LoDashImplicitWrapper<string[]>
+    _('a').concat(['a']); // $ExpectType LoDashImplicitWrapper<string[]>
+    _('a').concat(['b'], stringROA); // $ExpectType LoDashImplicitWrapper<string[]>
+    _(['a']).concat('b'); // $ExpectType LoDashImplicitWrapper<string[]>
+    _(stringROA).concat(stringROA); // $ExpectType LoDashImplicitWrapper<string[]>
+    _(stringROA).concat(stringROA, stringROA); // $ExpectType LoDashImplicitWrapper<string[]>
 
-        result = _({a: ''}).concat<{a: string}>({a: ''});
-        result = _({a: ''}).concat<{a: string}>({a: ''}, {a: ''});
-        result = _({a: ''}).concat<{a: string}>({a: ''}, {a: ''}, {a: ''});
+    _.chain('a').concat('b'); // $ExpectType LoDashExplicitWrapper<string[]>
+    _.chain('a').concat(['a']); // $ExpectType LoDashExplicitWrapper<string[]>
+    _.chain('a').concat(['b'], stringROA); // $ExpectType LoDashExplicitWrapper<string[]>
+    _.chain(['a']).concat('b'); // $ExpectType LoDashExplicitWrapper<string[]>
+    _.chain(stringROA).concat(stringROA); // $ExpectType LoDashExplicitWrapper<string[]>
+    _.chain(stringROA).concat(stringROA, stringROA); // $ExpectType LoDashExplicitWrapper<string[]>
 
-        result = _({a: ''}).concat({a: ''});
-        result = _({a: ''}).concat({a: ''}, {a: ''});
-        result = _({a: ''}).concat({a: ''}, {a: ''}, {a: ''});
-    }
+    const abcObject: AbcObject = { a: 1, b: 'foo', c: true };
+    const objectROA: ReadonlyArray<AbcObject> = [{ a: 1, b: 'foo', c: true }];
 
-    {
-        let result: _.LoDashExplicitArrayWrapper<number>;
+    _.concat(abcObject); // $ExpectType AbcObject[]
+    _.concat([abcObject]); // $ExpectType AbcObject[]
+    _.concat(objectROA); // $ExpectType AbcObject[]
+    _.concat(abcObject, abcObject); // $ExpectType AbcObject[]
+    _.concat(abcObject, [abcObject]); // $ExpectType AbcObject[]
+    _.concat(abcObject, [abcObject], objectROA); // $ExpectType AbcObject[]
 
-        result = _(1).chain().concat<number>(2);
-        result = _(1).chain().concat<number>(2, 3);
-        result = _(1).chain().concat<number>(2, 3, 4);
+    _(abcObject).concat(abcObject); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
+    _(abcObject).concat([abcObject]); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
+    _(abcObject).concat([abcObject], objectROA); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
+    _([abcObject]).concat(abcObject); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
+    _(objectROA).concat(objectROA); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
+    _(objectROA).concat(objectROA, objectROA); // $ExpectType LoDashImplicitWrapper<AbcObject[]>
 
-        result = _(1).chain().concat(2);
-        result = _(1).chain().concat(2, 3);
-        result = _(1).chain().concat(2, 3, 4);
-    }
-
-    {
-        let result: _.LoDashExplicitArrayWrapper<string>;
-
-        result = _(['']).chain().concat<string>(['']);
-        result = _(['']).chain().concat<string>([''], ['']);
-        result = _(['']).chain().concat<string>([''], [''], ['']);
-
-        result = _(['']).chain().concat(['']);
-        result = _(['']).chain().concat([''], ['']);
-        result = _(['']).chain().concat([''], [''], ['']);
-    }
-
-    {
-        let result: _.LoDashExplicitArrayWrapper<{a: string}>;
-
-        result = _({a: ''}).chain().concat<{a: string}>({a: ''});
-        result = _({a: ''}).chain().concat<{a: string}>({a: ''}, {a: ''});
-        result = _({a: ''}).chain().concat<{a: string}>({a: ''}, {a: ''}, {a: ''});
-
-        result = _({a: ''}).chain().concat({a: ''});
-        result = _({a: ''}).chain().concat({a: ''}, {a: ''});
-        result = _({a: ''}).chain().concat({a: ''}, {a: ''}, {a: ''});
-    }
+    _.chain(abcObject).concat(abcObject); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
+    _.chain(abcObject).concat([abcObject]); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
+    _.chain(abcObject).concat([abcObject], objectROA); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
+    _.chain([abcObject]).concat(abcObject); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
+    _.chain(objectROA).concat(objectROA); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
+    _.chain(objectROA).concat(objectROA, objectROA); // $ExpectType LoDashExplicitWrapper<AbcObject[]>
 }
 
 // _.prototype.plant

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -11800,52 +11800,35 @@ namespace TestOmitBy {
 
 // _.pick
 namespace TestPick {
-    let obj1: AbcObject | null | undefined = anything;
-    let obj2: AbcObject = anything;
+    const obj1: AbcObject | null | undefined = anything;
+    const obj2: AbcObject = anything;
+    const readonlyArray: ReadonlyArray<string> = ['a', 'b'];
+    const literalsArray = ['a' as 'a', 'b' as 'b'];
+    const roLiteralsArray: ReadonlyArray<'a' | 'b'> = literalsArray;
 
-    {
-        let result: Partial<AbcObject>;
+    _.pick(obj1, 'a'); // $ExpectType PartialDeep<AbcObject>
+    _.pick(obj1, 0, 'a'); // $ExpectType PartialDeep<AbcObject>
+    _.pick(obj1, ['b', 1], 0, 'a'); // $ExpectType PartialDeep<AbcObject>
+    _.pick(obj1, readonlyArray); // $ExpectType PartialDeep<AbcObject>
+    _.pick(obj2, 'a', 'b'); // $ExpectType Pick<AbcObject, "a" | "b">
+    _.pick(obj2, literalsArray); // $ExpectType Pick<AbcObject, "a" | "b">
+    _.pick(obj2, roLiteralsArray); // $ExpectType Pick<AbcObject, "a" | "b">
 
-        result = _.pick(obj1, 'a');
-        result = _.pick(obj1, 0, 'a');
-        result = _.pick(obj1, ['b', 1], 0, 'a');
-    }
+    _(obj1).pick('a'); // $ExpectType LoDashImplicitWrapper<Partial<AbcObject>>
+    _(obj1).pick(0, 'a'); // $ExpectType LoDashImplicitWrapper<Partial<AbcObject>>
+    _(obj1).pick(['b', 1], 0, 'a'); // $ExpectType LoDashImplicitWrapper<Partial<AbcObject>>
+    _(obj1).pick(readonlyArray); // $ExpectType LoDashImplicitWrapper<Partial<AbcObject>>
+    _(obj2).pick('a', 'b'); // $ExpectType LoDashImplicitWrapper<Pick<AbcObject, "a" | "b">>
+    _(obj2).pick(literalsArray); // $ExpectType LoDashImplicitWrapper<Pick<AbcObject, "a" | "b">>
+    _(obj2).pick(roLiteralsArray); // $ExpectType LoDashImplicitWrapper<Pick<AbcObject, "a" | "b">>
 
-    {
-        let result: Pick<AbcObject, 'a' | 'b'>;
-        result = _.pick(obj2, 'a', 'b');
-        result = _.pick(obj2, ['a' as 'a', 'b' as 'b']);
-    }
-
-    {
-        let result: _.LoDashImplicitWrapper<Partial<AbcObject>>;
-
-        result = _(obj1).pick('a');
-        result = _(obj1).pick(0, 'a');
-        result = _(obj1).pick(['b', 1], 0, 'a');
-    }
-
-    {
-        let result: _.LoDashImplicitWrapper<Pick<AbcObject, 'a' | 'b'>>;
-
-        result = _(obj2).pick('a', 'b');
-        result = _(obj2).pick(['a' as 'a', 'b' as 'b']);
-    }
-
-    {
-        let result: _.LoDashExplicitWrapper<Partial<AbcObject>>;
-
-        result = _(obj1).chain().pick('a');
-        result = _(obj1).chain().pick(0, 'a');
-        result = _(obj1).chain().pick(['b', 1], 0, 'a');
-    }
-
-    {
-        let result: _.LoDashExplicitWrapper<Pick<AbcObject, 'a' | 'b'>>;
-
-        result = _(obj2).chain().pick('a', 'b');
-        result = _(obj2).chain().pick(['a' as 'a', 'b' as 'b']);
-    }
+    _.chain(obj1).pick('a'); // $ExpectType LoDashExplicitWrapper<Partial<AbcObject>>
+    _.chain(obj1).pick(0, 'a'); // $ExpectType LoDashExplicitWrapper<Partial<AbcObject>>
+    _.chain(obj1).pick(['b', 1], 0, 'a'); // $ExpectType LoDashExplicitWrapper<Partial<AbcObject>>
+    _.chain(obj1).pick(readonlyArray); // $ExpectType LoDashExplicitWrapper<Partial<AbcObject>>
+    _.chain(obj2).pick('a', 'b'); // $ExpectType LoDashExplicitWrapper<Pick<AbcObject, "a" | "b">>
+    _.chain(obj2).pick(literalsArray); // $ExpectType LoDashExplicitWrapper<Pick<AbcObject, "a" | "b">>
+    _.chain(obj2).pick(roLiteralsArray); // $ExpectType LoDashExplicitWrapper<Pick<AbcObject, "a" | "b">>
 }
 
 // _.pickBy


### PR DESCRIPTION
Closes #23278

**Note**: I get out-of-memory errors when I run the tests locally on Windows. See https://github.com/Microsoft/dtslint/issues/106

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23278
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
