### PR TITLE
[winston] Allow LoggerInstance.remove to take string

### DIFF
--- a/types/winston/index.d.ts
+++ b/types/winston/index.d.ts
@@ -223,7 +223,7 @@ declare namespace winston {
         unhandleExceptions(...transports: TransportInstance[]): void;
         add(transport: TransportInstance, options?: TransportOptions, created?: boolean): LoggerInstance;
         clear(): void;
-        remove(transport: TransportInstance): LoggerInstance;
+        remove(transport: string | TransportInstance): LoggerInstance;
         startTimer(): ProfileHandler;
         profile(id: string, msg?: string, meta?: any, callback?: (err: Error, level: string, msg: string, meta: any) => void): LoggerInstance;
         configure(options: LoggerOptions): void;

--- a/types/winston/winston-tests.ts
+++ b/types/winston/winston-tests.ts
@@ -260,6 +260,9 @@ logger = new (winston.Logger)({
   ]
 });
 
+/* Remove transport by name */
+logger = logger.remove('nooo');
+
 /* Reconfigure logger */
 logger.configure({ level: 'silly' });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/winstonjs/winston/tree/2.x#multiple-transports-of-the-same-type, fixes #23410
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

