### PR TITLE
Fix(VIS) Updated property to the correct type

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -290,7 +290,7 @@ export interface TimelineEventPropertiesResult {
   /**
    * The id of the clicked item.
    */
-  item?: number | null;
+  item?: IdType | null;
 
   /**
    * Absolute horizontal position of the click event.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

The [documentation](http://visjs.org/docs/timeline/#getEventProperties) states that the item is either a number of null but in practice, it can also be a string

<img width="764" alt="screen shot 2018-02-05 at 10 26 25" src="https://user-images.githubusercontent.com/814639/35798609-90307ffe-0a63-11e8-9ae7-d05652f631e2.png">
