### PR TITLE
fix(ed2curve): Corrected return values

### DIFF
--- a/types/ed2curve/index.d.ts
+++ b/types/ed2curve/index.d.ts
@@ -15,7 +15,7 @@ export as namespace ed2curve;
 export function convertPublicKey(publicKey: SignKeyPair["publicKey"]): BoxKeyPair["publicKey"] | null;
 
 /** Converts Ed25519 secret key to Curve25519 secret key. */
-export function convertSecretKey(secretKey: SignKeyPair["secretKey"]): BoxKeyPair["secretKey"] | null;
+export function convertSecretKey(secretKey: SignKeyPair["secretKey"]): BoxKeyPair["secretKey"];
 
 /** Converts Ed25519 key pair to Curve25519 key pair. */
-export function convertKeyPair(keyPair: SignKeyPair): BoxKeyPair;
+export function convertKeyPair(keyPair: SignKeyPair): BoxKeyPair | null;


### PR DESCRIPTION
Sorry, I added `| null` to the wrong line in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23286.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [`ed2curve/convertSecretKey()`](https://github.com/dchest/ed2curve-js/blob/master/ed2curve.js#L225) and [`ed2curve/convertKeyPair()`](https://github.com/dchest/ed2curve-js/blob/master/ed2curve.js#L236)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
