### PR TITLE
[Quill] Add priority for transformPosition definition

### DIFF
--- a/types/quill/index.d.ts
+++ b/types/quill/index.d.ts
@@ -84,9 +84,9 @@ export interface DeltaStatic {
     concat(other: DeltaStatic): DeltaStatic;
     diff(other: DeltaStatic, index?: number): DeltaStatic;
     eachLine(predicate: (line: DeltaStatic, attributes: StringMap, idx: number) => any, newline?: string): DeltaStatic;
-    transform(index: number): number;
+    transform(index: number, priority?: boolean): number;
     transform(other: DeltaStatic, priority: boolean): DeltaStatic;
-    transformPosition(index: number): number;
+    transformPosition(index: number, priority?: boolean): number;
 }
 
 export class Delta implements DeltaStatic {

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -310,10 +310,14 @@ function test_DeltaTransform() {
     const d1: DeltaStatic = a.transform(b, true);  // new Delta().retain(1).insert('b').retain(5).insert('c');
     const d2: DeltaStatic = a.transform(b, false); // new Delta().insert('b').retain(6).insert('c');
     const n1: number = a.transform(5);
+    const n2: number = a.transform(5, true);
+    const n3: number = a.transform(5, false);
 }
 
 function test_DeltatransformPosition() {
     const delta = new Delta().retain(5).insert('a');
     const n1: number = delta.transformPosition(4); // 4
     const n2: number = delta.transformPosition(5); // 6
+    const n3: number = delta.transformPosition(5, true);
+    const n4: number = delta.transformPosition(5, false);
 }


### PR DESCRIPTION
Delta `transformPosition` also takes a priority argument: https://github.com/quilljs/delta/blob/7bd06c62b768f1a045acd41e785a83f35d4b0e94/lib/delta.js#L305
