### PR TITLE
@types/bootstrap - adding 2nd  (optional) modal command (show, toggle) parameter 

### DIFF
--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -87,7 +87,7 @@ interface TransitionEventNames {
 interface JQuery {
     modal(options?: ModalOptions): JQuery;
     modal(options?: ModalOptionsBackdropString): JQuery;
-    modal(command: string): JQuery;
+    modal(command: string, relatedTarget?: Element): JQuery;
 
     dropdown(): JQuery;
     dropdown(command: string): JQuery;


### PR DESCRIPTION

https://github.com/twbs/bootstrap/blob/v3.3.7/js/modal.js#L292

used in 

https://github.com/twbs/bootstrap/blob/v3.3.7/js/modal.js#L47-L53

```javascript
Modal.prototype.toggle = function (_relatedTarget) {
    return this.isShown ? this.hide() : this.show(_relatedTarget)
}

Modal.prototype.show = function (_relatedTarget) {
    var that = this
    var e    = $.Event('show.bs.modal', { relatedTarget: _relatedTarget })
    ...
```