### PR TITLE
Add encoding option to node.readdir

### DIFF
--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -2598,46 +2598,46 @@ declare module "fs" {
     export function mkdtempSync(prefix: string): string;
     /**
      * Asynchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to a file.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     export function readdir(path: string | Buffer, options: { encoding: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
        /**
      * Asynchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to a file.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     export function readdir(path: string | Buffer, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to a file.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     export function readdir(path: string | Buffer, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, files: Array<string | Buffer>) => void): void;
 
     /**
      * Asynchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to a file.
      */
     export function readdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
         /**
      * Synchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to a file.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     export function readdirSync(path: string | Buffer, options?: { encoding: BufferEncoding | null } | BufferEncoding | null): string[];
 
     /**
      * Synchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to a file.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     export function readdirSync(path: string | Buffer, options: { encoding: "buffer" } | "buffer"): Buffer[];
 
     /**
      * Synchronous readdir(3) - read a directory.
-     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param path A path to a file.
      * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
      */
     export function readdirSync(path: string | Buffer, options?: { encoding?: string | null } | string | null): Array<string | Buffer>;

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -5,6 +5,7 @@
 //                 Wilco Bakker <https://github.com/WilcoBakker>
 //                 Thomas Bouldin <https://github.com/inlined>
 //                 Sebastian Silbermann <https://github.com/eps1lon>
+//                 Alorel <https://github.com/Alorel>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /************************************************

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -2596,11 +2596,51 @@ declare module "fs" {
      * @returns Returns the created folder path.
      */
     export function mkdtempSync(prefix: string): string;
-    export function readdir(path: string | Buffer, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
-    export function readdir(path: string | Buffer, opts: string | {encoding?: string}, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
-    export function readdir(path: string | Buffer, opts: 'buffer' | {encoding: 'buffer'}, callback?: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
-    export function readdirSync(path: string | Buffer, opts?: string | {encoding?: string}): string[];
-    export function readdirSync(path: string | Buffer, opts: 'buffer' | {encoding: 'buffer'}): Buffer[];
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    export function readdir(path: string | Buffer, options: { encoding: BufferEncoding | null } | BufferEncoding | undefined | null, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+       /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    export function readdir(path: string | Buffer, options: { encoding: "buffer" } | "buffer", callback: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
+
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    export function readdir(path: string | Buffer, options: { encoding?: string | null } | string | undefined | null, callback: (err: NodeJS.ErrnoException, files: Array<string | Buffer>) => void): void;
+
+    /**
+     * Asynchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     */
+    export function readdir(path: string | Buffer, callback: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+        /**
+     * Synchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    export function readdirSync(path: string | Buffer, options?: { encoding: BufferEncoding | null } | BufferEncoding | null): string[];
+
+    /**
+     * Synchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    export function readdirSync(path: string | Buffer, options: { encoding: "buffer" } | "buffer"): Buffer[];
+
+    /**
+     * Synchronous readdir(3) - read a directory.
+     * @param path A path to a file. If a URL is provided, it must use the `file:` protocol.
+     * @param options The encoding (or an object specifying the encoding), used as the encoding of the result. If not provided, `'utf8'` is used.
+     */
+    export function readdirSync(path: string | Buffer, options?: { encoding?: string | null } | string | null): Array<string | Buffer>;
     export function close(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function closeSync(fd: number): void;
     export function open(path: string | Buffer, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -2597,7 +2597,9 @@ declare module "fs" {
     export function mkdtempSync(prefix: string): string;
     export function readdir(path: string | Buffer, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
     export function readdir(path: string | Buffer, opts: string | {encoding?: string}, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+    export function readdir(path: string | Buffer, opts: {encoding: 'buffer'}, callback?: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
     export function readdirSync(path: string | Buffer, opts?: string | {encoding?: string}): string[];
+    export function readdirSync(path: string | Buffer, opts: {encoding: 'buffer'}): Buffer[];
     export function close(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function closeSync(fd: number): void;
     export function open(path: string | Buffer, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -2596,7 +2596,8 @@ declare module "fs" {
      */
     export function mkdtempSync(prefix: string): string;
     export function readdir(path: string | Buffer, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
-    export function readdirSync(path: string | Buffer): string[];
+    export function readdir(path: string | Buffer, opts: string | {encoding?: string}, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
+    export function readdirSync(path: string | Buffer, opts?: string | {encoding?: string}): string[];
     export function close(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function closeSync(fd: number): void;
     export function open(path: string | Buffer, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -2598,9 +2598,9 @@ declare module "fs" {
     export function mkdtempSync(prefix: string): string;
     export function readdir(path: string | Buffer, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
     export function readdir(path: string | Buffer, opts: string | {encoding?: string}, callback?: (err: NodeJS.ErrnoException, files: string[]) => void): void;
-    export function readdir(path: string | Buffer, opts: {encoding: 'buffer'}, callback?: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
+    export function readdir(path: string | Buffer, opts: 'buffer' | {encoding: 'buffer'}, callback?: (err: NodeJS.ErrnoException, files: Buffer[]) => void): void;
     export function readdirSync(path: string | Buffer, opts?: string | {encoding?: string}): string[];
-    export function readdirSync(path: string | Buffer, opts: {encoding: 'buffer'}): Buffer[];
+    export function readdirSync(path: string | Buffer, opts: 'buffer' | {encoding: 'buffer'}): Buffer[];
     export function close(fd: number, callback?: (err?: NodeJS.ErrnoException) => void): void;
     export function closeSync(fd: number): void;
     export function open(path: string | Buffer, flags: string | number, callback: (err: NodeJS.ErrnoException, fd: number) => void): void;

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -219,6 +219,21 @@ namespace fs_tests {
     }
 
     {
+        fs.readdir('foo', (err: any, files: string[]) => {})
+        fs.readdir('foo', 'utf8', (err: any, files: string[]) => {});
+        fs.readdir('foo', {encoding: 'utf8'}, (err: any, files: string[]) => {});
+        fs.readdir('foo', 'buffer', (err: any, files: Buffer[]) => {});
+        fs.readdir('foo', {encoding: 'buffer'}, (err: any, files: Buffer[]) => {});
+
+        let fsStringOut: string[] = fs.readdirSync('utf8');
+        fsStringOut = fs.readdirSync('foo', 'utf8');
+        fsStringOut = fs.readdirSync('foo', {encoding: 'utf8'});
+
+        let fsBufferOut: Buffer[] = fs.readdirSync('utf8', 'buffer');
+        fsBufferOut = fs.readdirSync('foo', {encoding: 'buffer'});
+    }
+
+    {
         var errno: number;
         fs.readFile('testfile', (err, data) => {
             if (err && err.errno) {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/docs/v6.0.0/api/fs.html#fs_fs_readdir_path_options_callback
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
