### PR TITLE
[Node.js] Fix require.resolve() signature for 8.9.x

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -118,7 +118,7 @@ interface NodeRequireFunction {
 }
 
 interface NodeRequire extends NodeRequireFunction {
-    resolve(id: string): string;
+    resolve(id: string, options?: { paths?: string[] }): string;
     cache: any;
     extensions: NodeExtensions;
     main: NodeModule | undefined;


### PR DESCRIPTION
Fix according to https://nodejs.org/api/modules.html#modules_require_resolve_request_options:

```
require.resolve(request[, options])
    request <string> The module path to resolve.
    options <Object>
        paths <Array> Paths to resolve module location from. If present, these paths
        are used instead of the default resolution paths. Note that each of these paths
        is used as a starting point for the module resolution algorithm, meaning that
        the node_modules hierarchy is checked from this location.
    Returns: <string>
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/modules.html#modules_require_resolve_request_options
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
