### PR TITLE
[UIKit] updated `upload` definition due to UIKit api changes

### DIFF
--- a/types/uikit/index.d.ts
+++ b/types/uikit/index.d.ts
@@ -1436,6 +1436,5 @@ declare namespace UIkit {
     const sticky: Sticky;
     const timepicker: Timepicker;
     const tooltip: Tooltip;
-    const uploadSelect: Upload;
-    const uploadDrop: Upload;
+    const upload: Upload;
 }

--- a/types/uikit/uikit-tests.ts
+++ b/types/uikit/uikit-tests.ts
@@ -164,19 +164,19 @@ function testUpload() {
             }
         };
 
-        const select = UIkit.uploadSelect($("#upload-select"), settings);
-        const drop   = UIkit.uploadDrop($("#upload-drop"), settings);
+        const select = UIkit.upload($("#upload-select"), settings);
+        const drop   = UIkit.upload($("#upload-drop"), settings);
     });
 
     // Test with object literal
-    const select2 = UIkit.uploadSelect($("#upload-select"), {
+    const select2 = UIkit.upload($("#upload-select"), {
         action: '/', // upload url
         allow: '*.(jpg|jpeg|gif|png)', // allow only images
         loadstart: () => {},
         progress: (percent: number) => {},
         allcomplete: (response: any) => {}
     });
-    const drop2 = UIkit.uploadDrop($("#upload-drop"), {
+    const drop2 = UIkit.upload($("#upload-drop"), {
         action: '/', // upload url
         allow: '*.(jpg|jpeg|gif|png)', // allow only images
         loadstart: () => {},


### PR DESCRIPTION
@andy-ms please review the change.
UIKit has now only `UIKit.upload()` method for file upload.
Therefore old ones are removed in the [latest version](https://getuikit.com/docs/upload).