### PR TITLE
Add 'attribute' property to SortableOptions in jqueryui

### DIFF
--- a/types/jqueryui/index.d.ts
+++ b/types/jqueryui/index.d.ts
@@ -720,6 +720,7 @@ declare namespace JQueryUI {
 
     interface SortableOptions extends SortableEvents {
         appendTo?: any; // jQuery, Element, Selector or string
+        attribute?: string;
         axis?: string;
         cancel?: any; // Selector
         connectWith?: any; // Selector


### PR DESCRIPTION
The [documentation](http://api.jqueryui.com/sortable/#method-toArray) for the `toArray` method allows for passing a custom attribute, used to reorder the items. The default value is `id`.

I didn't edit the test file because I can't figure out how to run the tests in [jqueryui-tests.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jqueryui/jqueryui-tests.ts). A comment at the top of the file would help.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.