### PR TITLE
[@types/react-dates] Changed wrong parameter type

### DIFF
--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -71,8 +71,8 @@ declare namespace ReactDates {
         // navigation related props
         navPrev?: string | JSX.Element,
         navNext?: string | JSX.Element,
-        onPrevMonthClick?: (e: React.EventHandler<React.MouseEvent<HTMLSpanElement>>) => void,
-        onNextMonthClick?: (e: React.EventHandler<React.MouseEvent<HTMLSpanElement>>) => void,
+        onPrevMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void,
+        onNextMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void,
         onClose?: (final: { startDate: momentPropTypes.momentObj, endDate: momentPropTypes.momentObj }) => void,
         transitionDuration?: number,
 
@@ -166,8 +166,8 @@ declare namespace ReactDates {
         // navigation related props
         navPrev?: string | JSX.Element,
         navNext?: string | JSX.Element,
-        onPrevMonthClick?: (e: React.EventHandler<React.MouseEvent<HTMLSpanElement>>) => void,
-        onNextMonthClick?: (e: React.EventHandler<React.MouseEvent<HTMLSpanElement>>) => void,
+        onPrevMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void,
+        onNextMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void,
         onClose?: (final: { startDate: momentPropTypes.momentObj, endDate: momentPropTypes.momentObj }) => void,
         transitionDuration?: number,
 
@@ -243,8 +243,8 @@ declare namespace ReactDates {
         navPrev?: string | JSX.Element,
         navNext?: string | JSX.Element,
         hideKeyboardShortcutsPanel?: boolean;
-        onPrevMonthClick?: (e: React.EventHandler<React.MouseEvent<HTMLSpanElement>>) => void,
-        onNextMonthClick?: (e: React.EventHandler<React.MouseEvent<HTMLSpanElement>>) => void,
+        onPrevMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void,
+        onNextMonthClick?: (newCurrentMonth: momentPropTypes.momentObj) => void,
         transitionDuration?: number,
 
         // day presentation and interaction related props


### PR DESCRIPTION
Changed parameter type on onPrevMonthClick and onNextMonthClick
https://github.com/airbnb/react-dates/blob/master/src/components/DayPickerRangeController.jsx#L650
https://github.com/airbnb/react-dates/blob/master/src/components/DayPickerSingleDateController.jsx#L367