### PR TITLE
update type of bold property

### DIFF
--- a/types/colors/index.d.ts
+++ b/types/colors/index.d.ts
@@ -115,7 +115,7 @@ declare global {
         bgWhite: string;
 
         reset: string;
-        bold: string;
+        bold: () => string;
         dim: string;
         italic: string;
         underline: string;


### PR DESCRIPTION
fix for the issue
node_modules/@types/colors/index.d.ts(118,5): error TS2717: Subsequent property declarations must have the same type.  Property 'bold' must be of type '() => string', but here has type 'string'.

