### PR TITLE
types/chai-http let the request be the superagent's request as the implementation does

### DIFF
--- a/types/chai-http/chai-http-tests.ts
+++ b/types/chai-http/chai-http-tests.ts
@@ -44,17 +44,17 @@ const cert = fs.readFileSync('cert.pem');
 const callback = (err: any, res: ChaiHttp.Response) => {};
 
 chai.request(app)
-    .post('/secure')
-    .ca(ca)
-    .key(key)
-    .cert(cert)
-    .end(callback);
+	.post('/secure')
+	.ca(ca)
+	.key(key)
+	.cert(cert)
+	.end(callback);
 
 const pfx = fs.readFileSync('cert.pfx');
 chai.request(app)
-    .post('/secure')
-    .pfx(pfx)
-    .end(callback);
+	.post('/secure')
+	.pfx(pfx)
+	.end(callback);
 
 chai.request(app)
 	.get('/search')

--- a/types/chai-http/chai-http-tests.ts
+++ b/types/chai-http/chai-http-tests.ts
@@ -37,6 +37,25 @@ chai.request(app)
 	.get('/protected')
 	.auth('user', 'pass');
 
+// HTTPS request, from: https://github.com/visionmedia/superagent/commit/6158efbf42cb93d77c1a70887284be783dd7dabe
+const ca = fs.readFileSync('ca.cert.pem');
+const key = fs.readFileSync('key.pem');
+const cert = fs.readFileSync('cert.pem');
+const callback = (err: any, res: ChaiHttp.Response) => {};
+
+chai.request(app)
+    .post('/secure')
+    .ca(ca)
+    .key(key)
+    .cert(cert)
+    .end(callback);
+
+const pfx = fs.readFileSync('cert.pfx');
+chai.request(app)
+    .post('/secure')
+    .pfx(pfx)
+    .end(callback);
+
 chai.request(app)
 	.get('/search')
 	.query({ name: 'foo', limit: 10 });

--- a/types/chai-http/index.d.ts
+++ b/types/chai-http/index.d.ts
@@ -10,7 +10,7 @@
 /// <reference types="node" />
 /// <reference types="chai" />
 
-import request = require('superagent');
+import * as request from 'superagent';
 
 declare global {
 	namespace Chai {

--- a/types/chai-http/index.d.ts
+++ b/types/chai-http/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Wim Looman <https://github.com/Nemo157>
 //                 Liam Jones <https://github.com/G1itcher>
 //                 Federico Caselli <https://github.com/CaselIT>
+//                 Bas Luksenburg <https://github.com/bas-l>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/chai-http/index.d.ts
+++ b/types/chai-http/index.d.ts
@@ -9,6 +9,8 @@
 /// <reference types="node" />
 /// <reference types="chai" />
 
+import request = require('superagent');
+
 declare global {
 	namespace Chai {
 		interface ChaiStatic {
@@ -53,31 +55,14 @@ declare global {
 			on(event: string, fn: (...args: any[]) => void): void;
 		}
 
-		interface Request extends FinishedRequest {
-			attach(field: string, file: string|Buffer, filename: string): Request;
-			set(field: string, val: string): Request;
-			query(params: any): Request;
-			send(data: any): Request;
-			auth(user: string, name: string): Request;
-			field(name: string, val: string): Request;
-			buffer(): Request;
-			parse(fn: (res: Response, cb: (e?: Error, r?: any) => void) => void): Request;
-			end(callback?: (err: any, res: Response) => void): FinishedRequest;
-		}
-
-		interface FinishedRequest<T = Response> {
-			then<TR1 = T, TR2 = void>(success?: (res: T) => TR1 | PromiseLike<TR1>, failure?: (err: any) => TR2 | PromiseLike<TR2>): FinishedRequest<TR1>;
-			catch(failure?: (err: any) => void): FinishedRequest<T>;
-		}
-
-		interface Agent {
-			get(url: string, callback?: (err: any, res: Response) => void): Request;
-			post(url: string, callback?: (err: any, res: Response) => void): Request;
-			put(url: string, callback?: (err: any, res: Response) => void): Request;
-			head(url: string, callback?: (err: any, res: Response) => void): Request;
-			del(url: string, callback?: (err: any, res: Response) => void): Request;
-			options(url: string, callback?: (err: any, res: Response) => void): Request;
-			patch(url: string, callback?: (err: any, res: Response) => void): Request;
+		interface Agent  {
+			get(url: string, callback?: (err: any, res: Response) => void): request.Request;
+			post(url: string, callback?: (err: any, res: Response) => void): request.Request;
+			put(url: string, callback?: (err: any, res: Response) => void): request.Request;
+			head(url: string, callback?: (err: any, res: Response) => void): request.Request;
+			del(url: string, callback?: (err: any, res: Response) => void): request.Request;
+			options(url: string, callback?: (err: any, res: Response) => void): request.Request;
+			patch(url: string, callback?: (err: any, res: Response) => void): request.Request;
 		}
 
 		interface TypeComparison {


### PR DESCRIPTION
The request is now the superagent's request.Request as the implementation by chai-http also uses that Request.

Main reason to do this: access to the ca, cert and key methods of the request that are already available (if casted to any). Tested the changes in my own application.

If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: 
This is the implementation the types are meant for:
https://github.com/chaijs/chai-http/blob/master/lib/request.js
