### PR TITLE
webrtc: RTCPeerConnection: Add connectionState property

### DIFF
--- a/types/webrtc/RTCPeerConnection.d.ts
+++ b/types/webrtc/RTCPeerConnection.d.ts
@@ -314,6 +314,7 @@ interface RTCPeerConnection extends EventTarget {
     addIceCandidate(candidate?: RTCIceCandidateInit | RTCIceCandidate): Promise<void>;
 
     readonly signalingState: RTCSignalingState;
+    readonly connectionState: RTCPeerConnectionState;
 
     getConfiguration(): RTCConfiguration;
     setConfiguration(configuration: RTCConfiguration): void;

--- a/types/webrtc/test/RTCPeerConnection.ts
+++ b/types/webrtc/test/RTCPeerConnection.ts
@@ -56,6 +56,12 @@ pc.onconnectionstatechange = ev => console.log(ev.type);
 pc.ontrack = ev => console.log(ev.receiver);
 pc.ondatachannel = ev => console.log(ev.channel);
 
+// State properties
+console.log(pc.signalingState);
+console.log(pc.iceGatheringState);
+console.log(pc.iceConnectionState);
+console.log(pc.connectionState);
+
 // Legacy interface extensions
 pc.createOffer(
     (sdp: RTCSessionDescription) => console.log(sdp.sdp),


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection
- [x] Increase the version number in the header if appropriate.  (-> not applicable I think)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. (-> already there)