### PR TITLE
@types/tinymce table plugin types added

### DIFF
--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -57,6 +57,30 @@ export function init(settings: Settings): void;
 export interface Settings {
   table_toolbar?: string;
 
+  table_appearance_options?: boolean;
+
+  table_clone_elements?: string;
+
+  table_grid?: boolean;
+
+  table_tab_navigation?: boolean;
+
+  table_default_attributes?: object | string;
+
+  table_default_styles?: object | string;
+
+  table_class_list?: object[];
+
+  table_cell_class_list?: object[];
+
+  table_row_class_list?: object[];
+
+  table_advtab?: boolean;
+
+  table_cell_advtab?: boolean;
+
+  table_row_advtab?: boolean;
+
   auto_focus?: string;
 
   cache_suffix?: string;

--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for TinyMCE 4.5
 // Project: https://github.com/tinymce/tinymce
-// Definitions by: Martin Duparc <https://github.com/martinduparc>, Poul Poulsen <https://github.com/ipoul>
+// Definitions by: Martin Duparc <https://github.com/martinduparc>
+//                 Poul Poulsen <https://github.com/ipoul>
+//                 Nico Hartto <https://github.com/nicohartto>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -53,7 +55,7 @@ export function walk(o: {}, f: () => void, n?: string, s?: string): void;
 export function init(settings: Settings): void;
 
 export interface Settings {
-  table_toolbar?: boolean;
+  table_toolbar?: string;
 
   auto_focus?: string;
 

--- a/types/tinymce/tinymce-tests.ts
+++ b/types/tinymce/tinymce-tests.ts
@@ -1,14 +1,14 @@
 import * as tinymce from 'tinymce';
 
-tinymce.init({
+const settings: tinymce.Settings = {
   selector: 'textarea',
   height: 500,
   menubar: false,
   plugins: [
-    'advlist autolink lists link image charmap print preview anchor',
-    'searchreplace visualblocks code fullscreen',
-    'insertdatetime media table contextmenu paste code',
-    'autosave imagetools'
+      'advlist autolink lists link image charmap print preview anchor',
+      'searchreplace visualblocks code fullscreen',
+      'insertdatetime media table contextmenu paste code',
+      'autosave imagetools'
   ],
   autosave_ask_before_unload: false,
   autosave_interval: "20s",
@@ -18,7 +18,38 @@ tinymce.init({
   toolbar: 'undo redo | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image',
   content_css: '//www.tinymce.com/css/codepen.min.css',
   imagetools_cors_hosts: ['mydomain.com', 'otherdomain.com'],
-  imagetools_proxy: "proxy.php"
-});
+  imagetools_proxy: "proxy.php",
+  table_toolbar: "tableprops tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol",
+  table_appearance_options: false,
+  table_clone_elements: "strong em a",
+  table_grid: false,
+  table_tab_navigation: false,
+  table_default_attributes: {
+    title: 'My table'
+  },
+  table_default_styles: {
+    fontWeight: 'bold'
+  },
+  table_class_list: [
+    {title: 'None', value: ''},
+    {title: 'Dog', value: 'dog'},
+    {title: 'Cat', value: 'cat'}
+  ],
+  table_cell_class_list: [
+    {title: 'None', value: ''},
+    {title: 'Dog', value: 'dog'},
+    {title: 'Cat', value: 'cat'}
+  ],
+  table_row_class_list: [
+    {title: 'None', value: ''},
+    {title: 'Dog', value: 'dog'},
+    {title: 'Cat', value: 'cat'}
+  ],
+  table_advtab: false,
+  table_cell_advtab: false,
+  table_row_advtab: false,
+};
+
+tinymce.init(settings);
 
 const t = new tinymce.util.Color('#FFFFFF');


### PR DESCRIPTION
Updated typings to better reflect table plugin. table_toolbar was incorrectly typed as boolean, it should be string as per documentation for the plugin. Added rest of table plugin field types. If it seems that these shouldn't be included, I suggest that the table_toolbar is removed also from the typings so people can augment as needed per plugin.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.tinymce.com/docs/plugins/table/
