### PR TITLE
[Relay] Various improvements

### DIFF
--- a/types/react-relay/classic.d.ts
+++ b/types/react-relay/classic.d.ts
@@ -117,7 +117,7 @@ export class DefaultNetworkLayer implements RelayNetworkLayer {
 }
 
 export function createContainer<T>(
-    component: React.ComponentClass<T> | React.StatelessComponent<T>,
+    component: React.ComponentType<T>,
     params?: CreateContainerOpts
 ): RelayContainerClass<T>;
 export function injectNetworkLayer(networkLayer: RelayNetworkLayer): any;

--- a/types/react-relay/compat.d.ts
+++ b/types/react-relay/compat.d.ts
@@ -1,12 +1,8 @@
-export {
-    QueryRenderer,
-    fetchQuery,
-    graphql,
-} from "./index";
+export { QueryRenderer, fetchQuery, graphql } from "./index";
 import {
     ConnectionConfig,
     RelayPaginationProp as RelayModernPaginationProp,
-    RelayRefetchProp as RelayModernRefetchProp
+    RelayRefetchProp as RelayModernRefetchProp,
 } from "./index";
 import * as RelayRuntimeTypes from "relay-runtime";
 import { RelayEnvironmentInterface } from "./classic";

--- a/types/react-relay/compat.d.ts
+++ b/types/react-relay/compat.d.ts
@@ -4,14 +4,13 @@ import {
     RelayPaginationProp as RelayModernPaginationProp,
     RelayRefetchProp as RelayModernRefetchProp,
 } from "./index";
+export { ConcreteFragment, ConcreteRequest, ConcreteBatchRequest } from "relay-runtime";
 import * as RelayRuntimeTypes from "relay-runtime";
 import { RelayEnvironmentInterface } from "./classic";
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // Maybe Fix
 // ~~~~~~~~~~~~~~~~~~~~~
-export type ConcreteFragment = any;
-export type ConcreteBatch = any;
 export type ConcreteFragmentDefinition = object;
 export type ConcreteOperationDefinition = object;
 

--- a/types/react-relay/compat.d.ts
+++ b/types/react-relay/compat.d.ts
@@ -26,7 +26,6 @@ export interface StatelessWithFragment<T> extends React.StatelessComponent<T> {
     getFragment: typeof getFragment;
 }
 export type ReactFragmentComponent<T> = ComponentWithFragment<T> | StatelessWithFragment<T>;
-export type ReactBaseComponent<T> = React.ComponentClass<T> | React.StatelessComponent<T>;
 export type RelayClassicEnvironment = RelayEnvironmentInterface;
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -64,18 +63,18 @@ export interface GeneratedNodeMap {
 }
 
 export function createFragmentContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap
 ): ReactFragmentComponent<T>;
 
 export function createRefetchContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     taggedNode: RelayRuntimeTypes.GraphQLTaggedNode
 ): ReactFragmentComponent<T>;
 
 export function createPaginationContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     connectionConfig: ConnectionConfig<T>
 ): ReactFragmentComponent<T>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -19,6 +19,14 @@ import * as React from "react";
 import * as RelayRuntimeTypes from "relay-runtime";
 
 // ~~~~~~~~~~~~~~~~~~~~~
+// Utility types
+// ~~~~~~~~~~~~~~~~~~~~~
+type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
+type Omit<T, K extends keyof T> = { [P in Diff<keyof T, K>]: T[P] };
+
+type RemoveRelayProp<P> = Omit<P & { relay: never }, "relay">;
+
+// ~~~~~~~~~~~~~~~~~~~~~
 // Maybe Fix
 // ~~~~~~~~~~~~~~~~~~~~~
 export type ConcreteFragmentDefinition = object;
@@ -82,7 +90,7 @@ export class QueryRenderer extends ReactRelayQueryRenderer {}
 export function createFragmentContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap
-): React.ComponentType<T>;
+): React.ComponentType<RemoveRelayProp<T>>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createPaginationContainer
@@ -130,7 +138,7 @@ export function createPaginationContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     connectionConfig: ConnectionConfig<T>
-): React.ComponentType<T>;
+): React.ComponentType<RemoveRelayProp<T>>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createRefetchContainer
@@ -153,4 +161,4 @@ export function createRefetchContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     taggedNode: RelayRuntimeTypes.GraphQLTaggedNode
-): React.ComponentType<T>;
+): React.ComponentType<RemoveRelayProp<T>>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -24,7 +24,6 @@ export type ConcreteFragment = any;
 export type ConcreteBatch = any;
 export type ConcreteFragmentDefinition = object;
 export type ConcreteOperationDefinition = object;
-export type ReactBaseComponent<T> = React.ComponentClass<T> | React.StatelessComponent<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // RelayProp
@@ -87,9 +86,9 @@ export class QueryRenderer extends ReactRelayQueryRenderer {}
 // createFragmentContainer
 // ~~~~~~~~~~~~~~~~~~~~~
 export function createFragmentContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap
-): ReactBaseComponent<T>;
+): React.ComponentType<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createPaginationContainer
@@ -134,13 +133,13 @@ export interface ConnectionConfig<T> {
     query: GraphQLTaggedNode;
 }
 export function createPaginationContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
     connectionConfig: ConnectionConfig<T>
-): ReactBaseComponent<T>;
+): React.ComponentType<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
-// createFragmentContainer
+// createRefetchContainer
 // ~~~~~~~~~~~~~~~~~~~~~
 export interface RefetchOptions {
     force?: boolean;
@@ -157,7 +156,7 @@ export type RelayRefetchProp = RelayProp & {
     ): RelayRuntimeTypes.Disposable;
 };
 export function createRefetchContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
     taggedNode: GraphQLTaggedNode
-): ReactBaseComponent<T>;
+): React.ComponentType<T>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -92,7 +92,7 @@ export class QueryRenderer extends ReactRelayQueryRenderer {}
 export function createFragmentContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap
-): React.ComponentType<RemoveRelayProp<T>>;
+): React.ComponentType<RemoveRelayProp<T> & { componentRef?: any }>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createPaginationContainer
@@ -140,7 +140,7 @@ export function createPaginationContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     connectionConfig: ConnectionConfig<T>
-): React.ComponentType<RemoveRelayProp<T>>;
+): React.ComponentType<RemoveRelayProp<T> & { componentRef?: any }>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createRefetchContainer
@@ -163,4 +163,4 @@ export function createRefetchContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     taggedNode: RelayRuntimeTypes.GraphQLTaggedNode
-): React.ComponentType<RemoveRelayProp<T>>;
+): React.ComponentType<RemoveRelayProp<T> & { componentRef?: any }>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -28,8 +28,13 @@ type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: n
 // tslint:disable-next-line:strict-export-declare-modifiers
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
-// tslint:disable-next-line:strict-export-declare-modifiers
-type RemoveRelayProp<P> = Omit<P & { relay: never }, "relay">;
+export type RemoveRelayProp<P> = Omit<P & { relay: never }, "relay">;
+
+export interface ComponentRef {
+    componentRef?: (ref: any) => void;
+}
+
+export type RelayContainer<T> = React.ComponentType<RemoveRelayProp<T> & ComponentRef>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // Maybe Fix
@@ -95,7 +100,7 @@ export class QueryRenderer extends ReactRelayQueryRenderer {}
 export function createFragmentContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap
-): React.ComponentType<RemoveRelayProp<T> & { componentRef?: any }>;
+): RelayContainer<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createPaginationContainer
@@ -143,7 +148,7 @@ export function createPaginationContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     connectionConfig: ConnectionConfig<T>
-): React.ComponentType<RemoveRelayProp<T> & { componentRef?: any }>;
+): RelayContainer<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createRefetchContainer
@@ -166,4 +171,4 @@ export function createRefetchContainer<T>(
     Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     taggedNode: RelayRuntimeTypes.GraphQLTaggedNode
-): React.ComponentType<RemoveRelayProp<T> & { componentRef?: any }>;
+): RelayContainer<T>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -23,9 +23,12 @@ import * as RelayRuntimeTypes from "relay-runtime";
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // Taken from https://github.com/pelotom/type-zoo
+// tslint:disable-next-line:strict-export-declare-modifiers
 type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
+// tslint:disable-next-line:strict-export-declare-modifiers
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
+// tslint:disable-next-line:strict-export-declare-modifiers
 type RemoveRelayProp<P> = Omit<P & { relay: never }, "relay">;
 
 // ~~~~~~~~~~~~~~~~~~~~~

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -21,8 +21,10 @@ import * as RelayRuntimeTypes from "relay-runtime";
 // ~~~~~~~~~~~~~~~~~~~~~
 // Utility types
 // ~~~~~~~~~~~~~~~~~~~~~
+
+// Taken from https://github.com/pelotom/type-zoo
 type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-type Omit<T, K extends keyof T> = { [P in Diff<keyof T, K>]: T[P] };
+type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
 type RemoveRelayProp<P> = Omit<P & { relay: never }, "relay">;
 

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -11,6 +11,7 @@ export {
     commitLocalUpdate,
     commitRelayModernMutation as commitMutation,
     fetchRelayModernQuery as fetchQuery,
+    GraphQLTaggedNode,
     requestRelaySubscription as requestSubscription,
 } from "relay-runtime";
 
@@ -20,8 +21,6 @@ import * as RelayRuntimeTypes from "relay-runtime";
 // ~~~~~~~~~~~~~~~~~~~~~
 // Maybe Fix
 // ~~~~~~~~~~~~~~~~~~~~~
-export type ConcreteFragment = any;
-export type ConcreteBatch = any;
 export type ConcreteFragmentDefinition = object;
 export type ConcreteOperationDefinition = object;
 
@@ -39,24 +38,19 @@ export interface RelayProp {
 export function RelayQL(strings: string[], ...substitutions: any[]): RelayRuntimeTypes.RelayConcreteNode;
 
 // ~~~~~~~~~~~~~~~~~~~~~
-// RelayModernGraphQLTag
+// ReactRelayTypes
 // ~~~~~~~~~~~~~~~~~~~~~
 export interface GeneratedNodeMap {
-    [key: string]: GraphQLTaggedNode;
+    [key: string]: RelayRuntimeTypes.GraphQLTaggedNode;
 }
-export type GraphQLTaggedNode =
-    | (() => ConcreteFragment | ConcreteBatch)
-    | {
-          modern(): ConcreteFragment | ConcreteBatch;
-          classic(relayQL: typeof RelayQL): ConcreteFragmentDefinition | ConcreteOperationDefinition;
-      };
+
 /**
  * Runtime function to correspond to the `graphql` tagged template function.
  * All calls to this function should be transformed by the plugin.
  */
 export interface GraphqlInterface {
-    (strings: string[] | TemplateStringsArray): GraphQLTaggedNode;
-    experimental(strings: string[] | TemplateStringsArray): GraphQLTaggedNode;
+    (strings: string[] | TemplateStringsArray): RelayRuntimeTypes.GraphQLTaggedNode;
+    experimental(strings: string[] | TemplateStringsArray): RelayRuntimeTypes.GraphQLTaggedNode;
 }
 export const graphql: GraphqlInterface;
 
@@ -66,7 +60,7 @@ export const graphql: GraphqlInterface;
 export interface QueryRendererProps {
     cacheConfig?: RelayRuntimeTypes.CacheConfig;
     environment: RelayRuntimeTypes.Environment;
-    query: GraphQLTaggedNode;
+    query: RelayRuntimeTypes.GraphQLTaggedNode;
     render(readyState: ReadyState): React.ReactElement<any> | undefined | null;
     variables: RelayRuntimeTypes.Variables;
     rerunParamExperimental?: RelayRuntimeTypes.RerunParam;
@@ -87,7 +81,7 @@ export class QueryRenderer extends ReactRelayQueryRenderer {}
 // ~~~~~~~~~~~~~~~~~~~~~
 export function createFragmentContainer<T>(
     Component: React.ComponentType<T>,
-    fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap
+    fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap
 ): React.ComponentType<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -130,11 +124,11 @@ export interface ConnectionConfig<T> {
         paginationInfo: { count: number; cursor?: string },
         fragmentVariables: RelayRuntimeTypes.Variables
     ): RelayRuntimeTypes.Variables;
-    query: GraphQLTaggedNode;
+    query: RelayRuntimeTypes.GraphQLTaggedNode;
 }
 export function createPaginationContainer<T>(
     Component: React.ComponentType<T>,
-    fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
+    fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     connectionConfig: ConnectionConfig<T>
 ): React.ComponentType<T>;
 
@@ -157,6 +151,6 @@ export type RelayRefetchProp = RelayProp & {
 };
 export function createRefetchContainer<T>(
     Component: React.ComponentType<T>,
-    fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
-    taggedNode: GraphQLTaggedNode
+    fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
+    taggedNode: RelayRuntimeTypes.GraphQLTaggedNode
 ): React.ComponentType<T>;

--- a/types/react-relay/test/react-relay-classic-tests.tsx
+++ b/types/react-relay/test/react-relay-classic-tests.tsx
@@ -1,15 +1,14 @@
 import * as React from "react";
 import * as Relay from "react-relay/classic";
 
+import { CompatContainer } from "./react-relay-compat-tests";
+
 interface Props {
     text: string;
     userId: string;
 }
 
-// tslint:disable-next-line no-empty-interface
-interface Response {}
-
-export default class AddTweetMutation extends Relay.Mutation<Props, Response> {
+export default class AddTweetMutation extends Relay.Mutation<Props, {}> {
     getMutation() {
         return Relay.QL`mutation{addTweet}`;
     }
@@ -64,6 +63,7 @@ const ArtworkContainer = Relay.createContainer(Artwork, {
         artwork: () => Relay.QL`
             fragment on Artwork {
                 title
+                ${CompatContainer.getFragment("whatever")}
             }
         `,
     },
@@ -83,7 +83,7 @@ class StubbedArtwork extends React.Component {
                 setVariables: () => {},
                 forceFetch: () => {},
                 hasOptimisticUpdate: () => false,
-                getPendingTransactions: (): Relay.RelayMutationTransaction[] => [],
+                getPendingTransactions: (): any => undefined,
                 commitUpdate: () => {},
             },
         };

--- a/types/react-relay/test/react-relay-compat-tests.tsx
+++ b/types/react-relay/test/react-relay-compat-tests.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import {
+    QueryRenderer as CompatQueryRenderer,
+    createFragmentContainer as createFragmentContainerCompat,
+    commitMutation as commitMutationCompat,
+    CompatEnvironment,
+    RelayPaginationProp as RelayPaginationPropCompat,
+} from "react-relay/compat";
+
+import { configs, mutation, optimisticResponse } from "./react-relay-tests";
+
+// testting compat mutation with classic environment
+function markNotificationAsReadCompat(environment: CompatEnvironment, source: string, storyID: string) {
+    const variables = {
+        input: {
+            source,
+            storyID,
+        },
+    };
+
+    commitMutationCompat(environment, {
+        configs,
+        mutation,
+        optimisticResponse,
+        variables,
+        onCompleted: (response, errors) => {
+            console.log("Response received from server.");
+        },
+        onError: err => console.error(err),
+        updater: (store, data) => {
+            const field = store.get(storyID);
+            if (field) {
+                field.setValue(data.story, "story");
+            }
+        }
+    });
+}
+
+interface CompatProps {
+    relay: RelayPaginationPropCompat;
+}
+
+class CompatComponent extends React.Component<CompatProps> {
+    markNotificationAsRead(source: string, storyID: string) {
+        markNotificationAsReadCompat(this.props.relay.environment, source, storyID);
+    }
+
+    render() {
+        return (<div/>);
+    }
+}
+
+export const CompatContainer = createFragmentContainerCompat(CompatComponent, {});

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -1,3 +1,5 @@
+// tslint:disable:interface-over-type-literal
+
 import * as React from "react";
 import { Environment, Network, RecordSource, Store, ConnectionHandler, ConcreteFragment } from "relay-runtime";
 
@@ -59,14 +61,14 @@ const MyQueryRenderer = (props: { name: string }) => (
 type StoryLike = (storyID: string) => void;
 
 // Artifact produced by relay-compiler-language-typescript
-enum _Story_story$ref {}
+const enum _Story_story$ref {}
 type Story_story$ref = _Story_story$ref & ConcreteFragment;
-interface Story_story {
+type Story_story = {
     readonly id: string;
     readonly text: string;
     readonly isPublished: boolean;
     readonly " $refType": Story_story$ref;
-}
+};
 
 const Story = (() => {
     interface Props {
@@ -142,9 +144,9 @@ const Story = (() => {
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // Artifact produced by relay-compiler-language-typescript
-enum _FeedStories_feed$ref {}
+const enum _FeedStories_feed$ref {}
 type FeedStories_feed$ref = _FeedStories_feed$ref & ConcreteFragment;
-interface FeedStories_feed {
+type FeedStories_feed = {
     readonly edges: ReadonlyArray<{
         readonly node: {
             readonly id: string;
@@ -152,7 +154,7 @@ interface FeedStories_feed {
         };
     }>;
     readonly " $refType": FeedStories_feed$ref;
-}
+};
 
 const Feed = (() => {
     interface Props {
@@ -203,9 +205,9 @@ const Feed = (() => {
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // Artifact produced by relay-compiler-language-typescript
-enum _UserFeed_user$ref {}
+const enum _UserFeed_user$ref {}
 type UserFeed_user$ref = _UserFeed_user$ref & ConcreteFragment;
-interface UserFeed_user {
+type UserFeed_user = {
     readonly feed: {
         readonly pageInfo: {
             readonly endCursor?: string | null;
@@ -214,7 +216,7 @@ interface UserFeed_user {
         readonly " $fragmentRefs": FeedStories_feed$ref;
     };
     readonly " $refType": UserFeed_user$ref;
-}
+};
 
 () => {
     interface Props {

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -80,6 +80,10 @@ const MyQueryRenderer = (props: { name: string }) => (
             `,
         }
     );
+
+    function doesNotRequireRelayPropToBeProvided() {
+        <MyFragmentContainer publicProp="is available" />;
+    }
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -141,6 +145,11 @@ const MyQueryRenderer = (props: { name: string }) => (
             }
         `
     );
+
+    function doesNotRequireRelayPropToBeProvided() {
+        const feed = { stories: { edges: [] }}; // TODO
+        <FeedRefetchContainer loadMoreTitle="Load More" feed={feed} />;
+    }
 };
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -232,6 +241,10 @@ const MyQueryRenderer = (props: { name: string }) => (
             `,
         }
     );
+
+    function doesNotRequireRelayPropToBeProvided() {
+        const user = { feed: { edges: [] }}; // TODO
+        <FeedPaginationContainer loadMoreTitle="Load More" user={user} />;
     }
 };
 

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -1,5 +1,3 @@
-// tslint:disable:interface-over-type-literal
-
 import * as React from "react";
 import { Environment, Network, RecordSource, Store, ConnectionHandler, FragmentReference } from "relay-runtime";
 
@@ -61,8 +59,10 @@ const MyQueryRenderer = (props: { name: string }) => (
 type StoryLike = (storyID: string) => void;
 
 // Artifact produced by relay-compiler-language-typescript
+// tslint:disable-next-line:no-const-enum
 const enum _Story_story$ref {}
 type Story_story$ref = _Story_story$ref & FragmentReference;
+// tslint:disable-next-line:interface-over-type-literal
 type Story_story = {
     readonly id: string;
     readonly text: string;
@@ -145,8 +145,10 @@ const Story = (() => {
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // Artifact produced by relay-compiler-language-typescript
+// tslint:disable-next-line:no-const-enum
 const enum _FeedStories_feed$ref {}
 type FeedStories_feed$ref = _FeedStories_feed$ref & FragmentReference;
+// tslint:disable-next-line:interface-over-type-literal
 type FeedStories_feed = {
     readonly edges: ReadonlyArray<{
         readonly node: {
@@ -207,8 +209,10 @@ const Feed = (() => {
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // Artifact produced by relay-compiler-language-typescript
+// tslint:disable-next-line:no-const-enum
 const enum _UserFeed_user$ref {}
 type UserFeed_user$ref = _UserFeed_user$ref & FragmentReference;
+// tslint:disable-next-line:interface-over-type-literal
 type UserFeed_user = {
     readonly feed: {
         readonly pageInfo: {

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -1,7 +1,7 @@
 // tslint:disable:interface-over-type-literal
 
 import * as React from "react";
-import { Environment, Network, RecordSource, Store, ConnectionHandler, ConcreteFragment } from "relay-runtime";
+import { Environment, Network, RecordSource, Store, ConnectionHandler, FragmentReference } from "relay-runtime";
 
 import {
     graphql,
@@ -62,7 +62,7 @@ type StoryLike = (storyID: string) => void;
 
 // Artifact produced by relay-compiler-language-typescript
 const enum _Story_story$ref {}
-type Story_story$ref = _Story_story$ref & ConcreteFragment;
+type Story_story$ref = _Story_story$ref & FragmentReference;
 type Story_story = {
     readonly id: string;
     readonly text: string;
@@ -145,7 +145,7 @@ const Story = (() => {
 
 // Artifact produced by relay-compiler-language-typescript
 const enum _FeedStories_feed$ref {}
-type FeedStories_feed$ref = _FeedStories_feed$ref & ConcreteFragment;
+type FeedStories_feed$ref = _FeedStories_feed$ref & FragmentReference;
 type FeedStories_feed = {
     readonly edges: ReadonlyArray<{
         readonly node: {
@@ -206,7 +206,7 @@ const Feed = (() => {
 
 // Artifact produced by relay-compiler-language-typescript
 const enum _UserFeed_user$ref {}
-type UserFeed_user$ref = _UserFeed_user$ref & ConcreteFragment;
+type UserFeed_user$ref = _UserFeed_user$ref & FragmentReference;
 type UserFeed_user = {
     readonly feed: {
         readonly pageInfo: {

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -75,6 +75,7 @@ const Story = (() => {
         relay: RelayRefetchProp;
         story: Story_story;
         onLike: StoryLike;
+        ignoreMe?: {};
     }
 
     interface State {
@@ -161,6 +162,7 @@ const Feed = (() => {
         relay: RelayProp;
         feed: FeedStories_feed;
         onStoryLike: StoryLike;
+        ignoreMe?: {};
     }
 
     const FeedStories: React.SFC<Props> = ({ feed, onStoryLike, relay }) => {
@@ -223,6 +225,7 @@ type UserFeed_user = {
         relay: RelayPaginationProp;
         loadMoreTitle: string;
         user: UserFeed_user;
+        ignoreMe?: {};
     }
 
     class UserFeed extends React.Component<Props> {

--- a/types/react-relay/tsconfig.json
+++ b/types/react-relay/tsconfig.json
@@ -24,6 +24,7 @@
         "classic.d.ts",
         "compat.d.ts",
         "test/react-relay-tests.tsx",
+        "test/react-relay-compat-tests.tsx",
         "test/react-relay-classic-tests.tsx"
     ]
 }

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -38,11 +38,13 @@ export type RelayContainer = any;
 
 // File: https://github.com/facebook/relay/blob/fe0e70f10bbcba1fff89911313ea69f24569464b/packages/relay-runtime/util/RelayConcreteNode.js
 // Using enum here to create a distinct types.
-export const enum ConcreteFragment {}
-export const enum ConcreteRequest {}
-export const enum ConcreteBatchRequest {}
+export type ConcreteFragment = any;
+export type ConcreteRequest = any;
+export type ConcreteBatchRequest = any;
 
 export type RequestNode = ConcreteRequest | ConcreteBatchRequest;
+
+export const enum FragmentReference {}
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // RelayQL

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -17,8 +17,6 @@ export type RelayConcreteNode = any;
 export type RelayMutationTransaction = any;
 export type RelayMutationRequest = any;
 export type RelayQueryRequest = any;
-export type ConcreteFragment = any;
-export type ConcreteBatch = any;
 export type ConcreteFragmentDefinition = object;
 export type ConcreteOperationDefinition = object;
 
@@ -33,6 +31,19 @@ export type ConcreteOperationDefinition = object;
 export type RelayContainer = any;
 
 // ~~~~~~~~~~~~~~~~~~~~~
+// Used in artifacts
+// emitted by
+// relay-compiler
+// ~~~~~~~~~~~~~~~~~~~~~
+
+// File: https://github.com/facebook/relay/blob/fe0e70f10bbcba1fff89911313ea69f24569464b/packages/relay-runtime/util/RelayConcreteNode.js
+export type ConcreteFragment = any;
+export type ConcreteRequest = any;
+export type ConcreteBatchRequest = any;
+
+export type RequestNode = ConcreteRequest | ConcreteBatchRequest;
+
+// ~~~~~~~~~~~~~~~~~~~~~
 // RelayQL
 // ~~~~~~~~~~~~~~~~~~~~~
 export type RelayQL = (strings: string[], ...substitutions: any[]) => RelayConcreteNode;
@@ -44,9 +55,9 @@ export interface GeneratedNodeMap {
     [key: string]: GraphQLTaggedNode;
 }
 export type GraphQLTaggedNode =
-    | (() => ConcreteFragment | ConcreteBatch)
+    | (() => ConcreteFragment | RequestNode)
     | {
-          modern(): ConcreteFragment | ConcreteBatch;
+          modern(): ConcreteFragment | RequestNode;
           classic(relayQL: RelayQL): ConcreteFragmentDefinition | ConcreteOperationDefinition;
       };
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -85,7 +96,7 @@ export interface PayloadError {
  * May return an Observable or Promise of a raw server response.
  */
 export function FetchFunction(
-    operation: ConcreteBatch,
+    operation: RequestNode,
     variables: Variables,
     cacheConfig: CacheConfig,
     uploadables?: UploadableMap
@@ -99,7 +110,7 @@ export function FetchFunction(
  * fourth parameter.
  */
 export type SubscribeFunction = (
-    operation: ConcreteBatch,
+    operation: RequestNode,
     variables: Variables,
     cacheConfig: CacheConfig,
     observer: LegacyObserver<QueryPayload>

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -37,9 +37,10 @@ export type RelayContainer = any;
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // File: https://github.com/facebook/relay/blob/fe0e70f10bbcba1fff89911313ea69f24569464b/packages/relay-runtime/util/RelayConcreteNode.js
-export type ConcreteFragment = any;
-export type ConcreteRequest = any;
-export type ConcreteBatchRequest = any;
+// Using enum here to create a distinct types.
+export enum ConcreteFragment {}
+export enum ConcreteRequest {}
+export enum ConcreteBatchRequest {}
 
 export type RequestNode = ConcreteRequest | ConcreteBatchRequest;
 

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -38,9 +38,9 @@ export type RelayContainer = any;
 
 // File: https://github.com/facebook/relay/blob/fe0e70f10bbcba1fff89911313ea69f24569464b/packages/relay-runtime/util/RelayConcreteNode.js
 // Using enum here to create a distinct types.
-export enum ConcreteFragment {}
-export enum ConcreteRequest {}
-export enum ConcreteBatchRequest {}
+export const enum ConcreteFragment {}
+export const enum ConcreteRequest {}
+export const enum ConcreteBatchRequest {}
 
 export type RequestNode = ConcreteRequest | ConcreteBatchRequest;
 

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -37,13 +37,14 @@ export type RelayContainer = any;
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // File: https://github.com/facebook/relay/blob/fe0e70f10bbcba1fff89911313ea69f24569464b/packages/relay-runtime/util/RelayConcreteNode.js
-// Using enum here to create a distinct types.
 export type ConcreteFragment = any;
 export type ConcreteRequest = any;
 export type ConcreteBatchRequest = any;
 
 export type RequestNode = ConcreteRequest | ConcreteBatchRequest;
 
+// Using `enum` here to create a distinct type and `const` to ensure it doesn’t leave any generated code.
+// tslint:disable-next-line:no-const-enum
 export const enum FragmentReference {}
 
 // ~~~~~~~~~~~~~~~~~~~~~

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -1,4 +1,12 @@
-import { Environment, Network, RecordSource, Store, ConnectionHandler, ViewerHandler, RecordSourceInspector } from "relay-runtime";
+import {
+    Environment,
+    Network,
+    RecordSource,
+    Store,
+    ConnectionHandler,
+    ViewerHandler,
+    RecordSourceInspector,
+} from "relay-runtime";
 
 const source = new RecordSource();
 const store = new Store(source);


### PR DESCRIPTION
This PR does a few things.

* Remove our own definition of `React.ComponentType`
* Add all type names that will be emitted by the first version of https://github.com/kastermester/relay-compiler-language-typescript
* Removes the `relay` prop from components generated by `create*Container`
* Adds the `componentRef` prop to components generated by `create*Container`
* Some normalisation/cleanup of where types are defined to bring it in line with upstream Relay
* Split tests up more
* Better test coverage
* Better test examples:
  - A pagination container that does pagination of the feed
  - A fragment container that represents the paginated feed
  - A refetch container that updates the status of a story in the feed

A lot more around `FragmentReference` is to come in the near future, as discussed [here](https://github.com/alloy/DefinitelyTyped/pull/1), but I left out anything related to it for now, as it would _seem_ to unsuspecting users as needlessly complex while they can’t reap the benefits yet.

@kastermester Would appreciate a review from you specifically.