### PR TITLE
improve the type of the stringify function

### DIFF
--- a/types/comment-json/comment-json-tests.ts
+++ b/types/comment-json/comment-json-tests.ts
@@ -14,3 +14,11 @@ const result = commentJson.parse(`
 // comment at the bottom
 `);
 const str = commentJson.stringify(result);
+
+const numericallyIndexed = commentJson.stringify(result, (key, value) => {
+return key && Number.isInteger(Number(key))
+    ? value
+    : undefined;
+});
+
+const whiteListed = commentJson.stringify(result, ['a', 1]);

--- a/types/comment-json/index.d.ts
+++ b/types/comment-json/index.d.ts
@@ -4,5 +4,19 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export type Reviver = (k: number | string, v: any) => any;
+
+/**
+  * Converts a JavaScript Object Notation (JSON) string into an object.
+  * @param json A valid JSON string.
+  * @param reviver A function that transforms the results. This function is called for each member of the object.
+  * If a member contains nested objects, the nested objects are transformed before the parent object is.
+  */
 export function parse(json: string, reviver?: Reviver, removes_comments?: boolean): any;
-export function stringify(value: any, replacer?: any, space?: string | number): string;
+
+/**
+  * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+  * @param value A JavaScript value, usually an object or array, to be converted.
+  * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
+  * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+  */
+export function stringify(value: any, replacer?: ((key: string, value: any) => any) | (number | string)[] | null, space?: string | number): string;

--- a/types/comment-json/index.d.ts
+++ b/types/comment-json/index.d.ts
@@ -19,4 +19,4 @@ export function parse(json: string, reviver?: Reviver, removes_comments?: boolea
   * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
   * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
   */
-export function stringify(value: any, replacer?: ((key: string, value: any) => any) | (number | string)[] | null, space?: string | number): string;
+export function stringify(value: any, replacer?: ((key: string, value: any) => any) | Array<number | string> | null, space?: string | number): string;

--- a/types/comment-json/index.d.ts
+++ b/types/comment-json/index.d.ts
@@ -9,6 +9,7 @@ export type Reviver = (k: number | string, v: any) => any;
  * Converts a JavaScript Object Notation (JSON) string into an object.
  * @param json A valid JSON string.
  * @param reviver A function that transforms the results. This function is called for each member of the object.
+ * @param removes_comments If true, the comments won't be maintained, which is often used when we want to get a clean object.
  * If a member contains nested objects, the nested objects are transformed before the parent object is.
  */
 export function parse(json: string, reviver?: Reviver, removes_comments?: boolean): any;

--- a/types/comment-json/index.d.ts
+++ b/types/comment-json/index.d.ts
@@ -6,17 +6,17 @@
 export type Reviver = (k: number | string, v: any) => any;
 
 /**
-  * Converts a JavaScript Object Notation (JSON) string into an object.
-  * @param json A valid JSON string.
-  * @param reviver A function that transforms the results. This function is called for each member of the object.
-  * If a member contains nested objects, the nested objects are transformed before the parent object is.
-  */
+ * Converts a JavaScript Object Notation (JSON) string into an object.
+ * @param json A valid JSON string.
+ * @param reviver A function that transforms the results. This function is called for each member of the object.
+ * If a member contains nested objects, the nested objects are transformed before the parent object is.
+ */
 export function parse(json: string, reviver?: Reviver, removes_comments?: boolean): any;
 
 /**
-  * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
-  * @param value A JavaScript value, usually an object or array, to be converted.
-  * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
-  * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
-  */
+ * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+ * @param value A JavaScript value, usually an object or array, to be converted.
+ * @param replacer A function that transforms the results or an array of strings and numbers that acts as a approved list for selecting the object properties that will be stringified.
+ * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+ */
 export function stringify(value: any, replacer?: ((key: string, value: any) => any) | Array<number | string> | null, space?: string | number): string;


### PR DESCRIPTION
Updated the type signature of the stringify function based on the corresponding declaration in `lib.es5.d.ts` for JSON.parse.

This fixes `--noImplicitAny` errors that are introduced when using this library in place of the standard `JSON` object and using the `replacer` parameter to provide a transformation function.

Added documentation taken from `lib.es5.t.ts` to both functions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kaelzhang/node-comment-json#jsonparsestring-revivernull-removes_commentsfalse
https://github.com/kaelzhang/node-comment-json#jsonstringifyobject-replacer-space
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.