### PR TITLE
[@types/react-form] Added getApi optional function to FormProps interface

### DIFF
--- a/types/react-form/index.d.ts
+++ b/types/react-form/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for react-form 2.12
 // Project: https://github.com/tannerlinsley/react-form#readme
 // Definitions by: Cameron McAteer <https://github.com/cameron-mcateer>
+//                 James Pluck <https://github.com/PapaBearNZ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -43,6 +44,7 @@ export interface FormProps {
         [field: string]: (value: FormValue) => Promise<any>
     };
     dontPreventDefault?: boolean;
+    getApi?(formApi: FormApi): void;
 }
 
 export interface FormApi {


### PR DESCRIPTION
Added type for optional getApi prop function to FormProps interface.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <https://react-form.js.org/#/>
- [x ] Increase the version number in the header if appropriate.
- [x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
