### PR TITLE
Stripe card numbers are strings:

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for stripe 6.0
+// Type definitions for stripe 5.0
 // Project: https://github.com/stripe/stripe-node/
 // Definitions by: William Johnston <https://github.com/wjohnsto>
 //                 Peter Harris <https://github.com/codeanimal>

--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for stripe 5.0
+// Type definitions for stripe 6.0
 // Project: https://github.com/stripe/stripe-node/
 // Definitions by: William Johnston <https://github.com/wjohnsto>
 //                 Peter Harris <https://github.com/codeanimal>
@@ -4051,7 +4051,7 @@ declare namespace Stripe {
             /**
              * The card number
              */
-            number: number;
+            number: string;
 
             /**
              * Card brand. Can be Visa, American Express, MasterCard, Discover, JCB, Diners Club, or Unknown.
@@ -4167,7 +4167,7 @@ declare namespace Stripe {
             /**
              * The card number, as a string without any separators.
              */
-            number: number;
+            number: string;
 
             /**
              * Card security code. Required unless your account is registered in

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -243,7 +243,7 @@ stripe.customers.create({
 }).then( function (customer) {
     // asynchronously called
     customer.cards.create({ card: "tok_17wV94BoqMA9o2xkhlAd3ALf"}).then(function (customer) {});
-    customer.cards.retrieve("card_17xMvXBoqMA9o2xkq6W5gamx").then(function (card) { 
+    customer.cards.retrieve("card_17xMvXBoqMA9o2xkq6W5gamx").then(function (card) {
         let strCustomer: string = <string>card.customer;
         let objCustomer: customers.ICustomer = <customers.ICustomer>card.customer;
     });
@@ -394,7 +394,7 @@ stripe.customers.createSource(
             object: "card",
             exp_month: 1,
             exp_year: 16,
-            number: 4242424242424242
+            number: '4242424242424242'
         }
     },
     function (err, card) {
@@ -409,7 +409,7 @@ stripe.customers.createSource(
             object: "card",
             exp_month: 1,
             exp_year: 16,
-            number: 4242424242424242
+            number: '4242424242424242'
         }
     }).then(
     function (card) {


### PR DESCRIPTION
The Stripe API for Node documentation of [Create a card token][cct]
gives the example code:

```
var stripe = require("stripe")(
  "sk_test_BQokikJOvBiI2HlWgH4olfQ2"
);

stripe.tokens.create({
  card: {
    "number": '4242424242424242',
    "exp_month": 12,
    "exp_year": 2019,
    "cvc": '123'
  }
}, function(err, token) {
  // asynchronously called
});
```

[cct]: https://stripe.com/docs/api/node#create_card_token

Relevant typings history:

* @borisyankov first added `StripeTokenData.number: number` in 2013-09

* @codeanimal substantially reworked the typings in 2016-04 with
`ISourceCreationOptions.number: string` but giving it the comment:

  > The card number, as a string without any separators.

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.

Note I've bumped the major version in the typings' header because this is a breaking change, but not made a copy of the old one for ongoing maintenance because the upgrade effort is low.
