### PR TITLE
[aws-lambda] Add Handler and Callback types for each trigger.

### DIFF
--- a/types/apex.js/apex.js-tests.ts
+++ b/types/apex.js/apex.js-tests.ts
@@ -1,4 +1,4 @@
-import * as λ from "apex.js";
+import λ = require("apex.js");
 
 const handler = λ((event, context) => {
     console.log("Event: " + JSON.stringify(event));

--- a/types/apex.js/index.d.ts
+++ b/types/apex.js/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/apex/node-apex
 // Definitions by: Yoriki Yamaguchi <https://github.com/y13i>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="aws-lambda" />
 

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -1,28 +1,34 @@
-let str: string;
-let date: Date;
-let anyObj: any;
-let num: number;
-let error: Error;
-let b: boolean;
-let apiGwEvtReqCtx: AWSLambda.APIGatewayEventRequestContext;
-let apiGwEvt: AWSLambda.APIGatewayEvent;
-let customAuthorizerEvt: AWSLambda.CustomAuthorizerEvent;
-let clientCtx: AWSLambda.ClientContext;
-let clientContextEnv: AWSLambda.ClientContextEnv;
-let clientContextClient: AWSLambda.ClientContextClient;
-let context: AWSLambda.Context;
-let identity: AWSLambda.CognitoIdentity;
-let proxyResult: AWSLambda.ProxyResult;
-let authResponse: AWSLambda.AuthResponse;
-let policyDocument: AWSLambda.PolicyDocument;
-let statement: AWSLambda.Statement;
-let authResponseContext: AWSLambda.AuthResponseContext;
-let snsEvt: AWSLambda.SNSEvent;
-let snsEvtRecs: AWSLambda.SNSEventRecord[];
-let snsEvtRec: AWSLambda.SNSEventRecord;
-let snsMsg: AWSLambda.SNSMessage;
-let snsMsgAttr: AWSLambda.SNSMessageAttribute;
-let snsMsgAttrs: AWSLambda.SNSMessageAttributes;
+declare let str: string;
+declare let strOrNull: string | null;
+declare let strOrUndefined: string | undefined;
+declare let date: Date;
+declare let anyObj: any;
+declare let num: number;
+declare let error: Error;
+declare let bool: boolean;
+declare let boolOrUndefined: boolean | undefined;
+declare let apiGwEvtReqCtx: AWSLambda.APIGatewayEventRequestContext;
+declare let apiGwEvt: AWSLambda.APIGatewayEvent;
+declare let customAuthorizerEvt: AWSLambda.CustomAuthorizerEvent;
+declare let clientCtx: AWSLambda.ClientContext;
+declare let clientCtxOrUndefined: AWSLambda.ClientContext | undefined;
+declare let clientContextEnv: AWSLambda.ClientContextEnv;
+declare let clientContextClient: AWSLambda.ClientContextClient;
+declare let context: AWSLambda.Context;
+declare let identity: AWSLambda.CognitoIdentity;
+declare let identityOrUndefined: AWSLambda.CognitoIdentity | undefined;
+declare let proxyResult: AWSLambda.ProxyResult;
+declare let authResponse: AWSLambda.AuthResponse;
+declare let policyDocument: AWSLambda.PolicyDocument;
+declare let statement: AWSLambda.Statement;
+declare let authResponseContext: AWSLambda.AuthResponseContext;
+declare let authResponseContextOpt: AWSLambda.AuthResponseContext | null | undefined;
+declare let snsEvt: AWSLambda.SNSEvent;
+declare let snsEvtRecs: AWSLambda.SNSEventRecord[];
+declare let snsEvtRec: AWSLambda.SNSEventRecord;
+declare let snsMsg: AWSLambda.SNSMessage;
+declare let snsMsgAttr: AWSLambda.SNSMessageAttribute;
+declare let snsMsgAttrs: AWSLambda.SNSMessageAttributes;
 const S3EvtRec: AWSLambda.S3EventRecord = {
     eventVersion: '2.0',
     eventSource: 'aws:s3',
@@ -72,44 +78,44 @@ declare const scheduledEvent: AWSLambda.ScheduledEvent;
 /* API Gateway Event request context */
 str = apiGwEvtReqCtx.accountId;
 str = apiGwEvtReqCtx.apiId;
-authResponseContext = apiGwEvtReqCtx.authorizer;
+authResponseContextOpt = apiGwEvtReqCtx.authorizer;
 str = apiGwEvtReqCtx.httpMethod;
-str = apiGwEvtReqCtx.identity.accessKey;
-str = apiGwEvtReqCtx.identity.accountId;
-str = apiGwEvtReqCtx.identity.apiKey;
-str = apiGwEvtReqCtx.identity.caller;
-str = apiGwEvtReqCtx.identity.cognitoAuthenticationProvider;
-str = apiGwEvtReqCtx.identity.cognitoAuthenticationType;
-str = apiGwEvtReqCtx.identity.cognitoIdentityId;
-str = apiGwEvtReqCtx.identity.cognitoIdentityPoolId;
+strOrNull = apiGwEvtReqCtx.identity.accessKey;
+strOrNull = apiGwEvtReqCtx.identity.accountId;
+strOrNull = apiGwEvtReqCtx.identity.apiKey;
+strOrNull = apiGwEvtReqCtx.identity.caller;
+strOrNull = apiGwEvtReqCtx.identity.cognitoAuthenticationProvider;
+strOrNull = apiGwEvtReqCtx.identity.cognitoAuthenticationType;
+strOrNull = apiGwEvtReqCtx.identity.cognitoIdentityId;
+strOrNull = apiGwEvtReqCtx.identity.cognitoIdentityPoolId;
 str = apiGwEvtReqCtx.identity.sourceIp;
-str = apiGwEvtReqCtx.identity.user;
-str = apiGwEvtReqCtx.identity.userAgent;
-str = apiGwEvtReqCtx.identity.userArn;
+strOrNull = apiGwEvtReqCtx.identity.user;
+strOrNull = apiGwEvtReqCtx.identity.userAgent;
+strOrNull = apiGwEvtReqCtx.identity.userArn;
 str = apiGwEvtReqCtx.stage;
 str = apiGwEvtReqCtx.requestId;
 str = apiGwEvtReqCtx.resourceId;
 str = apiGwEvtReqCtx.resourcePath;
 
 /* API Gateway Event */
-str = apiGwEvt.body;
+strOrNull = apiGwEvt.body;
 str = apiGwEvt.headers["example"];
 str = apiGwEvt.httpMethod;
-b = apiGwEvt.isBase64Encoded;
+bool = apiGwEvt.isBase64Encoded;
 str = apiGwEvt.path;
-str = apiGwEvt.pathParameters["example"];
-str = apiGwEvt.queryStringParameters["example"];
-str = apiGwEvt.stageVariables["example"];
+str = apiGwEvt.pathParameters!["example"];
+str = apiGwEvt.queryStringParameters!["example"];
+str = apiGwEvt.stageVariables!["example"];
 apiGwEvtReqCtx = apiGwEvt.requestContext;
 str = apiGwEvt.resource;
 
 /* API Gateway CustomAuthorizer Event */
 str = customAuthorizerEvt.type;
 str = customAuthorizerEvt.methodArn;
-str = customAuthorizerEvt.authorizationToken;
-str = apiGwEvt.pathParameters["example"];
-str = apiGwEvt.queryStringParameters["example"];
-str = apiGwEvt.stageVariables["example"];
+strOrUndefined = customAuthorizerEvt.authorizationToken;
+str = apiGwEvt.pathParameters!["example"];
+str = apiGwEvt.queryStringParameters!["example"];
+str = apiGwEvt.stageVariables!["example"];
 apiGwEvtReqCtx = apiGwEvt.requestContext;
 
 /* DynamoDB Stream Event */
@@ -234,17 +240,17 @@ str = snsMsgAttr.Value;
 
 /* Lambda Proxy Result */
 num = proxyResult.statusCode;
-proxyResult.headers["example"] = str;
-proxyResult.headers["example"] = b;
-proxyResult.headers["example"] = num;
-b = proxyResult.isBase64Encoded;
+proxyResult.headers!["example"] = str;
+proxyResult.headers!["example"] = bool;
+proxyResult.headers!["example"] = num;
+boolOrUndefined = proxyResult.isBase64Encoded;
 str = proxyResult.body;
 
 /* API Gateway CustomAuthorizer AuthResponse */
 authResponseContext = {
     stringKey: str,
     numberKey: num,
-    booleanKey: b
+    booleanKey: bool
 };
 
 statement = {
@@ -300,36 +306,36 @@ cognitoUserPoolEvent.triggerSource === "TokenGeneration_AuthenticateDevice";
 cognitoUserPoolEvent.triggerSource === "TokenGeneration_RefreshTokens";
 str = cognitoUserPoolEvent.region;
 str = cognitoUserPoolEvent.userPoolId;
-str = cognitoUserPoolEvent.userName;
+strOrUndefined = cognitoUserPoolEvent.userName;
 str = cognitoUserPoolEvent.callerContext.awsSdkVersion;
 str = cognitoUserPoolEvent.callerContext.clientId;
 str = cognitoUserPoolEvent.request.userAttributes["email"];
-str = cognitoUserPoolEvent.request.validationData["k1"];
-str = cognitoUserPoolEvent.request.codeParameter;
-str = cognitoUserPoolEvent.request.usernameParameter;
-b = cognitoUserPoolEvent.request.newDeviceUsed;
-cognitoUserPoolEvent.request.session[0].challengeName === "CUSTOM_CHALLENGE";
-cognitoUserPoolEvent.request.session[0].challengeName === "PASSWORD_VERIFIER";
-cognitoUserPoolEvent.request.session[0].challengeName === "SMS_MFA";
-cognitoUserPoolEvent.request.session[0].challengeName === "DEVICE_SRP_AUTH";
-cognitoUserPoolEvent.request.session[0].challengeName === "DEVICE_PASSWORD_VERIFIER";
-cognitoUserPoolEvent.request.session[0].challengeName === "ADMIN_NO_SRP_AUTH";
-b = cognitoUserPoolEvent.request.session[0].challengeResult;
-str = cognitoUserPoolEvent.request.session[0].challengeMetaData;
-str = cognitoUserPoolEvent.request.challengeName;
-str = cognitoUserPoolEvent.request.privateChallengeParameters["answer"];
-str = cognitoUserPoolEvent.request.challengeAnswer["answer"];
-b = cognitoUserPoolEvent.response.answerCorrect;
-str = cognitoUserPoolEvent.response.smsMessage;
-str = cognitoUserPoolEvent.response.emailMessage;
-str = cognitoUserPoolEvent.response.emailSubject;
-str = cognitoUserPoolEvent.response.challengeName;
-b = cognitoUserPoolEvent.response.issueTokens;
-b = cognitoUserPoolEvent.response.failAuthentication;
-str = cognitoUserPoolEvent.response.publicChallengeParameters["captchaUrl"];
-str = cognitoUserPoolEvent.response.privateChallengeParameters["answer"];
-str = cognitoUserPoolEvent.response.challengeMetaData;
-b = cognitoUserPoolEvent.response.answerCorrect;
+str = cognitoUserPoolEvent.request.validationData!["k1"];
+strOrUndefined = cognitoUserPoolEvent.request.codeParameter;
+strOrUndefined = cognitoUserPoolEvent.request.usernameParameter;
+boolOrUndefined = cognitoUserPoolEvent.request.newDeviceUsed;
+cognitoUserPoolEvent.request.session![0].challengeName === "CUSTOM_CHALLENGE";
+cognitoUserPoolEvent.request.session![0].challengeName === "PASSWORD_VERIFIER";
+cognitoUserPoolEvent.request.session![0].challengeName === "SMS_MFA";
+cognitoUserPoolEvent.request.session![0].challengeName === "DEVICE_SRP_AUTH";
+cognitoUserPoolEvent.request.session![0].challengeName === "DEVICE_PASSWORD_VERIFIER";
+cognitoUserPoolEvent.request.session![0].challengeName === "ADMIN_NO_SRP_AUTH";
+bool = cognitoUserPoolEvent.request.session![0].challengeResult;
+strOrUndefined = cognitoUserPoolEvent.request.session![0].challengeMetaData;
+strOrUndefined = cognitoUserPoolEvent.request.challengeName;
+str = cognitoUserPoolEvent.request.privateChallengeParameters!["answer"];
+str = cognitoUserPoolEvent.request.challengeAnswer!["answer"];
+boolOrUndefined = cognitoUserPoolEvent.response.answerCorrect;
+strOrUndefined = cognitoUserPoolEvent.response.smsMessage;
+strOrUndefined = cognitoUserPoolEvent.response.emailMessage;
+strOrUndefined = cognitoUserPoolEvent.response.emailSubject;
+strOrUndefined = cognitoUserPoolEvent.response.challengeName;
+boolOrUndefined = cognitoUserPoolEvent.response.issueTokens;
+boolOrUndefined = cognitoUserPoolEvent.response.failAuthentication;
+str = cognitoUserPoolEvent.response.publicChallengeParameters!["captchaUrl"];
+str = cognitoUserPoolEvent.response.privateChallengeParameters!["answer"];
+strOrUndefined = cognitoUserPoolEvent.response.challengeMetaData;
+boolOrUndefined = cognitoUserPoolEvent.response.answerCorrect;
 
 // CloudFormation Custom Resource
 switch (cloudformationCustomResourceEvent.RequestType) {
@@ -353,7 +359,7 @@ switch (cloudformationCustomResourceEvent.RequestType) {
 anyObj = cloudformationCustomResourceResponse.Data;
 str = cloudformationCustomResourceResponse.LogicalResourceId;
 str = cloudformationCustomResourceResponse.PhysicalResourceId;
-str = cloudformationCustomResourceResponse.Reason;
+strOrUndefined = cloudformationCustomResourceResponse.Reason;
 str = cloudformationCustomResourceResponse.RequestId;
 str = cloudformationCustomResourceResponse.StackId;
 str = cloudformationCustomResourceResponse.Status;
@@ -368,7 +374,7 @@ str = scheduledEvent.source;
 str = scheduledEvent.time;
 
 /* Context */
-b = context.callbackWaitsForEmptyEventLoop;
+bool = context.callbackWaitsForEmptyEventLoop;
 str = context.functionName;
 str = context.functionVersion;
 str = context.invokedFunctionArn;
@@ -376,8 +382,8 @@ num = context.memoryLimitInMB;
 str = context.awsRequestId;
 str = context.logGroupName;
 str = context.logStreamName;
-identity = context.identity;
-clientCtx = context.clientContext;
+identityOrUndefined = context.identity;
+clientCtxOrUndefined = context.clientContext;
 
 /* CognitoIdentity */
 str = identity.cognitoIdentityId;
@@ -420,7 +426,7 @@ function callback(cb: AWSLambda.Callback) {
     cb(null);
     cb(error);
     cb(null, anyObj);
-    cb(null, b);
+    cb(null, bool);
     cb(null, str);
     cb(null, num);
 }

--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -584,8 +584,72 @@ context.fail(str);
 
 /* Handler */
 let handler: AWSLambda.Handler = (event: any, context: AWSLambda.Context, cb: AWSLambda.Callback) => { };
+
+// async methods return Promise, test assignability
 let asyncHandler: AWSLambda.Handler = async (event: any, context: AWSLambda.Context, cb: AWSLambda.Callback) => { };
+
+let inferredHandler: AWSLambda.S3Handler = (event, context, cb) => {
+    // $ExpectType S3Event
+    event;
+    str = event.Records[0].eventName;
+    // $ExpectType Context
+    context;
+    str = context.functionName;
+    // $ExpectType Callback<void>
+    cb;
+    cb();
+    cb(null);
+    cb(new Error());
+    // $ExpectError
+    cb(null, { });
+};
+
+// Test using default Callback type still works.
+let defaultCallbackHandler: AWSLambda.APIGatewayProxyHandler = (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, cb: AWSLambda.Callback) => { };
+
+// Specific types
+let s3Handler: AWSLambda.S3Handler = (event: AWSLambda.S3Event, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+// Test old name
+let s3CreateHandler: AWSLambda.S3Handler = (event: AWSLambda.S3CreateEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+s3Handler = s3CreateHandler;
+
+let dynamoDBStreamHandler: AWSLambda.DynamoDBStreamHandler = (event: AWSLambda.DynamoDBStreamEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+
+let snsHandler: AWSLambda.SNSHandler = (event: AWSLambda.SNSEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+
+let cognitoUserPoolHandler: AWSLambda.CognitoUserPoolTriggerHandler = (event: AWSLambda.CognitoUserPoolEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+
+let cloudFormationCustomResourceHandler: AWSLambda.CloudFormationCustomResourceHandler =
+    (event: AWSLambda.CloudFormationCustomResourceEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+
+let cloudWatchLogsHandler: AWSLambda.CloudWatchLogsHandler = (event: AWSLambda.CloudWatchLogsEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+
+let scheduledHandler: AWSLambda.ScheduledHandler = (event: AWSLambda.ScheduledEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => {};
+
+let apiGtwProxyHandler: AWSLambda.APIGatewayProxyHandler = (event: AWSLambda.APIGatewayProxyEvent, context: AWSLambda.Context, cb: AWSLambda.APIGatewayProxyCallback) => { };
+// Test old names
 let proxyHandler: AWSLambda.ProxyHandler = (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, cb: AWSLambda.ProxyCallback) => { };
-let asyncProxyHandler: AWSLambda.ProxyHandler = async (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, cb: AWSLambda.ProxyCallback) => { };
+apiGtwProxyHandler = proxyHandler;
+
+let cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWSLambda.CloudFrontRequestEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontRequestCallback) => { };
+
+let cloudFrontResponseHandler: AWSLambda.CloudFrontResponseHandler = (event: AWSLambda.CloudFrontResponseEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontResponseCallback) => { };
+
 let customAuthorizerHandler: AWSLambda.CustomAuthorizerHandler = (event: AWSLambda.CustomAuthorizerEvent, context: AWSLambda.Context, cb: AWSLambda.CustomAuthorizerCallback) => { };
-let asyncCustomAuthorizerHandler: AWSLambda.CustomAuthorizerHandler = async (event: AWSLambda.CustomAuthorizerEvent, context: AWSLambda.Context, cb: AWSLambda.CustomAuthorizerCallback) => { };
+
+interface CustomEvent { eventString: string; eventBool: boolean; }
+interface CustomResult { resultString: string; resultBool?: boolean; }
+type CustomCallback = AWSLambda.Callback<CustomResult>;
+let customHandler: AWSLambda.Handler<CustomEvent, CustomResult> = (event, context, cb) => {
+    // $ExpectType CustomEvent
+    event;
+    str = event.eventString;
+    bool = event.eventBool;
+    // $ExpectType Context
+    context;
+    // $ExpectType Callback<CustomResult>
+    cb;
+    cb(null, { resultString: str, resultBool: bool });
+    // $ExpectError
+    cb(null, { resultString: bool });
+};

--- a/types/aws-lambda/tsconfig.json
+++ b/types/aws-lambda/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Motivation
---

The connection between the trigger event and the result types can be
confusing sometimes - for example `CloudFormationCustomResourceResponse`
is *not* returned from the lambda, but instead should be sent to the
*Request `ResponseUrl`. This PR tries to help by providing pre-baked
`Handler` types for each of the triggers (that have types already), so the
handler type can be used to infer the parameter types.

There's also a few niggles with naming and the handler signature that
have been bothering me for a while.

Changes
---

This PR:

- Adds defaulted generic parameters to the existing `Handler` and
  `Callback` types. This increases the minimum TS version to 2.3.

- Makes the `callback` parameter to `Handler`s "required" - this
  probably originally was meant to represent the Node 0.10 runtime,
  which did not pass a callback parameter, but that is no longer
  selectable when creating or editing a Lambda and makes the normal,
  recommended usage more annoying. In case anyone is confused, this doesn't
  break any code: it is required to be provided *when being called by AWS*, your
  handlers don't need to declare it. I'm not removing the legacy node 0.10
  runtime methods `context.done()` etc., since they still work.

- In the spirit of #21874, make the default result type for
  `Handler`, `Callback` `any`, since the only requirement is
  that it be `JSON.stringify()`able, and there are things like
  `.toJSON()`, etc. so there is no meaningful type restriction
  here.

- Revert the definition changes of #22588, which changed the `Handler`
  result types to `void | Promise<void>`, which is misleading: Lambda
  will not accept or wait for a promise result (it by default waits
  for the node event loop to empty). This is not a breaking change for
  code that does return promises, since a `void` result type is
  compatible with any result type, even with strict function types.
  (Which is why the tests still pass.)

- Adds `FooHandler` and `FooCallback` types for all `FooEvent`s and
  `FooResult`s.

- Renamed, (with aliases to the old name to prevent breaking changes),
  top-level types (`*Event`, `*Result`, `*Handler`, `*Callback`) to align them,
  for example:
  - `APIGatewayEvent` -> `APIGatewayProxyEvent`
  - `ProxyHandler` -> `APIGatewayProxyHandler`
  - (new)  -> `APIGatewayProxyCallback`
  - `ProxyResult` -> `APIGatewayProxyResult`

- `CloudFront{Request,Response}Result` (not the same type as `CloudFrontResponse`!)
  was missing for some reason.

- Enabled `strictNullChecks` and updated tests as per FAQ.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] ~~Provide a URL to documentation or source code which provides context for the suggested changes:~~ relevant doc links in declaration comments already.
- [x] ~~Increase the version number in the header if appropriate.~~ currently doesn't have a declared version number: should it be added? We could use the runtime version.
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~ already exists.
