### PR TITLE
feat: add missing `addDevServerEntrypoints` in `API`

### DIFF
--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -15,9 +15,11 @@ import * as spdy from 'spdy';
 import * as httpProxyMiddleware from 'http-proxy-middleware';
 
 declare namespace WebpackDevServer {
-    type ListeningApp = { address(): { port?: number } };
+    interface ListeningApp {
+        address(): { port?: number };
+    }
 
-    function addDevServerEntrypoints(webpack: webpack.Compiler | webpack.MultiCompiler, config: WebpackDevServer.Configuration, listeningApp?: ListeningApp): void
+    function addDevServerEntrypoints(webpack: webpack.Compiler | webpack.MultiCompiler, config: Configuration, listeningApp?: ListeningApp): void;
 
     interface proxyConfigMap {
         [url: string]: string | httpProxyMiddleware.Config;

--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -15,6 +15,10 @@ import * as spdy from 'spdy';
 import * as httpProxyMiddleware from 'http-proxy-middleware';
 
 declare namespace WebpackDevServer {
+    type ListeningApp = { address(): { port?: number } };
+
+    function addDevServerEntrypoints(webpack: webpack.Compiler | webpack.MultiCompiler, config: WebpackDevServer.Configuration, listeningApp?: ListeningApp): void
+
     interface proxyConfigMap {
         [url: string]: string | httpProxyMiddleware.Config;
     }

--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -81,7 +81,7 @@ declare class WebpackDevServer {
     );
 
     static addDevServerEntrypoints(
-        webpack: webpack.Compiler | webpack.MultiCompiler,
+        webpackOptions: webpack.Configuration | webpack.Configuration[],
         config: WebpackDevServer.Configuration,
         listeningApp?: WebpackDevServer.ListeningApp
     ): void;

--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -19,8 +19,6 @@ declare namespace WebpackDevServer {
         address(): { port?: number };
     }
 
-    function addDevServerEntrypoints(webpack: webpack.Compiler | webpack.MultiCompiler, config: Configuration, listeningApp?: ListeningApp): void;
-
     interface proxyConfigMap {
         [url: string]: string | httpProxyMiddleware.Config;
     }
@@ -81,6 +79,12 @@ declare class WebpackDevServer {
         webpack: webpack.Compiler | webpack.MultiCompiler,
         config: WebpackDevServer.Configuration
     );
+
+    static addDevServerEntrypoints(
+        webpack: webpack.Compiler | webpack.MultiCompiler,
+        config: WebpackDevServer.Configuration,
+        listeningApp?: WebpackDevServer.ListeningApp
+    ): void;
 
     listen(port: number, hostname: string, callback?: (error?: Error) => void): http.Server;
 

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -75,7 +75,7 @@ const config: WebpackDevServer.Configuration = {
 
 // API example
 server = new WebpackDevServer(compiler, config);
-server.listen(8080, "localhost", () => {});
+server.listen(8080, "localhost", () => { });
 
 // HTTPS example
 server = new WebpackDevServer(compiler, {
@@ -83,10 +83,25 @@ server = new WebpackDevServer(compiler, {
     https: true
 });
 
-server.listen(8080, "localhost", () => {});
+server.listen(8080, "localhost", () => { });
 
 server.close();
 
-// multiple compilers
+WebpackDevServer.addDevServerEntrypoints(compiler, {
+    publicPath: "/assets/",
+    https: true
+});
 
+WebpackDevServer.addDevServerEntrypoints(
+    compiler,
+    {
+        publicPath: "/assets/",
+        https: true
+    },
+    {
+        address: () => ({ port: 80 })
+    }
+);
+
+// multiple compilers
 server = new WebpackDevServer(multipleCompiler, config);

--- a/types/webpack-dev-server/webpack-dev-server-tests.ts
+++ b/types/webpack-dev-server/webpack-dev-server-tests.ts
@@ -87,13 +87,13 @@ server.listen(8080, "localhost", () => { });
 
 server.close();
 
-WebpackDevServer.addDevServerEntrypoints(compiler, {
+WebpackDevServer.addDevServerEntrypoints(config, {
     publicPath: "/assets/",
     https: true
 });
 
 WebpackDevServer.addDevServerEntrypoints(
-    compiler,
+    [config],
     {
         publicPath: "/assets/",
         https: true


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://webpack.js.org/guides/hot-module-replacement/#via-the-node-js-api>>, <<https://github.com/webpack/webpack-dev-server/blob/00e8500b0853312be3cf369976509fbce2a4b7dc/lib/util/addDevServerEntrypoints.js#L7>>
- [] Increase the version number in the header if appropriate.
- [] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
