### PR TITLE
Fixed types for echarts: getInstanceByDom return type should be Echarts

### DIFF
--- a/types/echarts/index.d.ts
+++ b/types/echarts/index.d.ts
@@ -24,7 +24,7 @@ declare namespace echarts {
 
     function dispose(target: ECharts | HTMLDivElement | HTMLCanvasElement): void;
 
-    function getInstanceByDom(target: HTMLDivElement | HTMLCanvasElement): void;
+    function getInstanceByDom(target: HTMLDivElement | HTMLCanvasElement): ECharts;
 
     function registerMap(mapName: string, geoJson: Object, specialAreas?: Object): void;
 


### PR DESCRIPTION
see [echarts.getInstanceByDom](http://echarts.baidu.com/api.html#echarts.getInstanceByDom)