### PR TITLE
fix(googlemaps): add null as valid type to DrawingManager.setDrawingMode parameter

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -2684,7 +2684,7 @@ declare namespace google.maps {
             constructor(options?: DrawingManagerOptions);
             getDrawingMode(): OverlayType;
             getMap(): Map;
-            setDrawingMode(drawingMode: OverlayType): void;
+            setDrawingMode(drawingMode: OverlayType | null): void;
             setMap(map: Map | null): void;
             setOptions(options: DrawingManagerOptions): void;
         }


### PR DESCRIPTION
Notice the docs here https://developers.google.com/maps/documentation/javascript/3.exp/reference#DrawingManager in the description it says `null` is a valid argument

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.