### PR TITLE
Adding subscribe() method to Parse.Query<T>

### DIFF
--- a/types/parse/index.d.ts
+++ b/types/parse/index.d.ts
@@ -4,6 +4,7 @@
 //                  David Poetzsch-Heffter <https://github.com/dpoetzsch>
 //                  Cedric Kemp <https://github.com/jaeggerr>
 //                  Flavio Negrão <https://github.com/flavionegrao>
+//                  Wes Grimes <https://github.com/wesleygrimes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -644,6 +645,7 @@ declare namespace Parse {
         select(...keys: string[]): Query<T>;
         skip(n: number): Query<T>;
         startsWith(key: string, prefix: string): Query<T>;
+        subscribe(): Events;
         withinGeoBox(key: string, southwest: GeoPoint, northeast: GeoPoint): Query<T>;
         withinKilometers(key: string, point: GeoPoint, maxDistance: number): Query<T>;
         withinMiles(key: string, point: GeoPoint, maxDistance: number): Query<T>;

--- a/types/parse/parse-tests.ts
+++ b/types/parse/parse-tests.ts
@@ -491,3 +491,16 @@ function test_batch_operations() {
     Parse.Object.fetchAllIfNeeded(games, { sessionToken: '' })
 }
 
+function test_query_subscribe() {
+    // create new query from Game object type
+    const query = new Parse.Query(Game);
+
+    // create subscription to Game object
+    const subscription = query.subscribe();
+
+    // listen for new Game objects created on Parse server
+    subscription.on('create', (game: any) => {
+        console.log(game);
+    });
+}
+


### PR DESCRIPTION
This PR does the following:

- Adds subscribe() method to Parse.Query<T> that is missing based on current documentation from Parse

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: [Parse JS SDK Docs - Create Subscription](http://docs.parseplatform.org/js/guide/#create-a-subscription)
- [ ] Increase the version number in the header if appropriate.