### PR TITLE
[@types/graphql-relay] Fix #23499. Add nodes field to GraphQLNodeDefinitions

### DIFF
--- a/types/graphql-relay/graphql-relay-tests.ts
+++ b/types/graphql-relay/graphql-relay-tests.ts
@@ -122,7 +122,8 @@ const idFetcher = (id: string, context: number, info: GraphQLResolveInfo) => {
     info.fieldName = "f";
 };
 const nodeDef = nodeDefinitions<number>(idFetcher, resolver);
-const fieldConfig: GraphQLFieldConfig<any, any> = nodeDef.nodeField;
+const nodeFieldConfig: GraphQLFieldConfig<any, any> = nodeDef.nodeField;
+const nodesFieldConfig: GraphQLFieldConfig<any, any> = nodeDef.nodesField;
 const interfaceType: GraphQLInterfaceType = nodeDef.nodeInterface;
 // toGlobalId takes a type name and an ID specific to that type name, and returns a "global ID" that is unique among all types.
 toGlobalId("t", "i").toLowerCase();

--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -245,6 +245,7 @@ export function mutationWithClientMutationId(
 export interface GraphQLNodeDefinitions {
     nodeInterface: GraphQLInterfaceType;
     nodeField: GraphQLFieldConfig<any, any>;
+    nodesField: GraphQLFieldConfig<any, any>;
 }
 
 export type typeResolverFn = ((any: any) => GraphQLObjectType) |


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/graphql/graphql-relay-js/commit/d72b351f63d828180d420f65e1f3de58f216e79a#diff-ca9890ee3978e68ab141ce9e3a0b4232>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fixes #23499.

/cc @andy-ms
/cc @arvitaly
/cc @nitintutlani
/cc @Grelinfo