### PR TITLE
Add typings for reject/rejects from code 5.0.0

### DIFF
--- a/types/code/code-tests.ts
+++ b/types/code/code-tests.ts
@@ -159,3 +159,11 @@ expect<number[]>(foo).to.equal([]);
 const bar = Object.create(null);
 settings.comparePrototypes = false;
 expect(bar).to.equal({});
+
+const rejection = Promise.reject(new Error('Oh no!'));
+/* await */ expect(rejection).to.reject('Oh no!');
+/* await */  expect(rejection).rejects('Oh no!');
+
+const typedRejection = Promise.reject(new CustomError('Oh no!'));
+/* await */  expect(typedRejection).to.reject(CustomError, 'Oh no!');
+/* await */  expect(typedRejection).rejects(CustomError, 'Oh no!');

--- a/types/code/index.d.ts
+++ b/types/code/index.d.ts
@@ -160,6 +160,10 @@ export interface Values<T> {
     match(regex: RegExp): AssertionChain<T>;
     /** Asserts that the reference value's toString() representation matches the provided regular expression. */
     matches(regex: RegExp): AssertionChain<T>;
+    /** Asserts that the Promise reference value rejects with an exception when called */
+    reject(type?: any, message?: string | RegExp): AssertionChain<T>;
+    /** Asserts that the Promise reference value rejects with an exception when called */
+    rejects(type?: any, message?: string | RegExp): AssertionChain<T>;
     /** Asserts that the reference value satisfies the provided validator function. */
     satisfy(validator: (value: T) => boolean): AssertionChain<T>;
     /** Asserts that the reference value satisfies the provided validator function. */


### PR DESCRIPTION
Documentation:

> * [`await reject([type], [message])`][artm]
>
> Asserts that the `Promise` reference value rejects with an exception
> when called

[artm]: https://github.com/hapijs/code/blob/v5.0.0/API.md#await-rejecttype-message

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/code/blob/v5.0.0/API.md#await-rejecttype-message
