### PR TITLE
luxon: Fixing incorrect property name

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -287,7 +287,7 @@ declare module 'luxon' {
         type Features = {
             intl: boolean;
             intlTokens: boolean;
-            timezones: boolean;
+            zones: boolean;
         };
 
         namespace Info {

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -78,6 +78,9 @@ i.toString();
 /* Info */
 Info.months();
 Info.weekdays('long');
+Info.features().intl;
+Info.features().intlTokens;
+Info.features().zones;
 
 /* Settings */
 Settings.defaultLocale;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/moment/luxon/blob/master/src/info.js#L163
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
