### PR TITLE
Fix stompjs types

### DIFF
--- a/types/stompjs/index.d.ts
+++ b/types/stompjs/index.d.ts
@@ -55,7 +55,7 @@ export class Frame {
     constructor(command: string, headers?: {}, body?: string);
 
     toString(): string;
-    sizeOfUTF8(s: string): number;
+    static sizeOfUTF8(s: string): number;
     static unmarshall(datas: any): any;
     static marshall(command: string, headers?: {}, body?: string): any;
 }

--- a/types/stompjs/index.d.ts
+++ b/types/stompjs/index.d.ts
@@ -26,7 +26,7 @@ export class Client {
 
     debug(...args: string[]): any;
 
-    connect(headers: { login: string, passcode: string, host?: string }, connectCallback: (frame?: Frame) => any, errorCallback?: (error: string) => any): any;
+    connect(headers: { login?: string, passcode?: string, host?: string }, connectCallback: (frame?: Frame) => any, errorCallback?: (error: string) => any): any;
     connect(login: string, passcode: string, connectCallback: (frame?: Frame) => any, errorCallback?: (error: string) => any, host?: string): any;
     disconnect(disconnectCallback: () => any, headers?: {}): any;
 
@@ -56,8 +56,8 @@ export class Frame {
 
     toString(): string;
     sizeOfUTF8(s: string): number;
-    unmarshall(datas: any): any;
-    marshall(command: string, headers?: {}, body?: string): any;
+    static unmarshall(datas: any): any;
+    static marshall(command: string, headers?: {}, body?: string): any;
 }
 
 export function client(url: string, protocols?: string | Array<string>): Client;

--- a/types/stompjs/index.d.ts
+++ b/types/stompjs/index.d.ts
@@ -26,7 +26,8 @@ export class Client {
 
     debug(...args: string[]): any;
 
-    connect(headers: { login?: string, passcode?: string, host?: string }, connectCallback: (frame?: Frame) => any, errorCallback?: (error: string) => any): any;
+    connect(headers: { login: string, passcode: string, host?: string }, connectCallback: (frame?: Frame) => any, errorCallback?: (error: string) => any): any;
+    connect(headers: { }, connectCallback: (frame?: Frame) => any, errorCallback?: (error: string) => any): any;
     connect(login: string, passcode: string, connectCallback: (frame?: Frame) => any, errorCallback?: (error: string) => any, host?: string): any;
     disconnect(disconnectCallback: () => any, headers?: {}): any;
 

--- a/types/stompjs/stompjs-tests.ts
+++ b/types/stompjs/stompjs-tests.ts
@@ -93,7 +93,7 @@ frame = new Stomp.Frame('command', {}, 'body');
 
 frame.toString();
 
-frame.sizeOfUTF8('abc');
+Stomp.Frame.sizeOfUTF8('abc');
 
 Stomp.Frame.unmarshall(0);
 Stomp.Frame.unmarshall('data');

--- a/types/stompjs/stompjs-tests.ts
+++ b/types/stompjs/stompjs-tests.ts
@@ -44,6 +44,11 @@ client.connect('user', 'pass', () => { }, (error) => { }, 'host');
 client.connect('user', 'pass', (frame) => { }, (error) => { });
 client.connect('user', 'pass', (frame) => { }, (error) => { }, 'host');
 
+client.connect({}, () => { });
+client.connect({}, () => { }, () => { });
+client.connect({}, () => { }, (error) => { });
+client.connect({}, (frame) => { }, (error) => { });
+
 client.disconnect(() => { });
 client.disconnect(() => { }, {});
 
@@ -90,11 +95,11 @@ frame.toString();
 
 frame.sizeOfUTF8('abc');
 
-frame.unmarshall(0);
-frame.unmarshall('data');
-frame.unmarshall({});
-frame.unmarshall([{}, {}]);
+Stomp.Frame.unmarshall(0);
+Stomp.Frame.unmarshall('data');
+Stomp.Frame.unmarshall({});
+Stomp.Frame.unmarshall([{}, {}]);
 
-frame.marshall('command');
-frame.marshall('command', {});
-frame.marshall('command', {}, 'body');
+Stomp.Frame.marshall('command');
+Stomp.Frame.marshall('command', {});
+Stomp.Frame.marshall('command', {}, 'body');


### PR DESCRIPTION
Fix to correctly reflect actual library. Note that `login` and `passcode` are optional headers in the [STOMP protocol](https://stomp.github.io/stomp-specification-1.2.html#CONNECT_or_STOMP_Frame) and `marshall` and `unmarshall` are static methods (denoted by `@` in Coffescript)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jmesnil/stomp-websocket/blob/master/src/stomp.coffee#L97 https://github.com/jmesnil/stomp-websocket/blob/master/src/stomp.coffee#L244
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`
