### PR TITLE
Fix type for passport-http `passReqToCallback`

### DIFF
--- a/types/passport-http/index.d.ts
+++ b/types/passport-http/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-http
 // Definitions by: Christophe Vidal <https://github.com/krizalys>
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
+//                 Chris Barth <https://githum..com/cjbarth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/passport-http/index.d.ts
+++ b/types/passport-http/index.d.ts
@@ -10,7 +10,7 @@ import express = require("express");
 
 export interface BasicStrategyOptions<req extends boolean = boolean> {
     realm?: string;
-    passReqToCallback?: req;
+    passReqToCallback?: boolean;
 }
 
 export interface DigestStrategyOptions {

--- a/types/passport-http/index.d.ts
+++ b/types/passport-http/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/passport-http
 // Definitions by: Christophe Vidal <https://github.com/krizalys>
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
-//                 Chris Barth <https://githum..com/cjbarth>
+//                 Chris Barth <https://github.com/cjbarth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/passport-http/passport-http-tests.ts
+++ b/types/passport-http/passport-http-tests.ts
@@ -4,6 +4,7 @@
 
 import passport = require("passport");
 import http = require("passport-http");
+import express = require("express");
 
 interface UserInterface {
     username: string;
@@ -46,7 +47,7 @@ passport.use(new http.BasicStrategy((username, password, done) => {
 passport.use(new http.BasicStrategy({
     realm: "User",
     passReqToCallback: true,
-}, (req, username, password, done) => {
+}, (req: express.Request, username: string, password: string, done: (error: any, user?: any) => void) => {
     // with req when needed
 }));
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jaredhanson/passport-http/blob/master/lib/passport-http/strategies/basic.js#L94
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

You'll note from the link provided, that the value is only tested as a boolean. In fact, the tests already treat this as boolean:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cdccfecaadfce9b94c66838bacd947db5ed01b37/types/passport-http/passport-http-tests.ts#L48
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cdccfecaadfce9b94c66838bacd947db5ed01b37/types/passport-http/passport-http-tests.ts#L61

...and so does the base passport module:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8295e5c2330037f6fa4c1676530ae48d9cb2b738/types/passport/index.d.ts#L49