### PR TITLE
Fix Loader type in webpack

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -9,12 +9,14 @@
 //                 Ahmed T. Ali <https://github.com/ahmed-taj>
 //                 Alan Agius <https://github.com/alan-agius4>
 //                 Spencer Elliott <https://github.com/elliottsj>
+//                 Jason Cheatham <https://github.com/jason0x43>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
 
 import Tapable = require('tapable');
 import * as UglifyJS from 'uglify-js';
+import { RawSourceMap } from 'source-map';
 
 export = webpack;
 
@@ -1020,7 +1022,7 @@ declare namespace webpack {
 
     namespace loader {
         interface Loader extends Function {
-            (this: LoaderContext, source: string | Buffer, sourceMap: string | Buffer): string | Buffer | void | undefined;
+            (this: LoaderContext, source: string | Buffer, sourceMap?: RawSourceMap): string | Buffer | void | undefined;
 
             /**
              * The order of chained loaders are always called from right to left.
@@ -1040,7 +1042,7 @@ declare namespace webpack {
             raw?: boolean;
         }
 
-        type loaderCallback = (err: Error | undefined | null, content?: string | Buffer, sourceMap?: string | Buffer) => void;
+        type loaderCallback = (err: Error | undefined | null, content?: string | Buffer, sourceMap?: RawSourceMap) => void;
 
         interface LoaderContext {
             /**

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -11,7 +11,6 @@
 //                 Spencer Elliott <https://github.com/elliottsj>
 //                 Jason Cheatham <https://github.com/jason0x43>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
 
 /// <reference types="node" />
 

--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -11,6 +11,7 @@
 //                 Spencer Elliott <https://github.com/elliottsj>
 //                 Jason Cheatham <https://github.com/jason0x43>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
 /// <reference types="node" />
 

--- a/types/webpack/package.json
+++ b/types/webpack/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "source-map": "^0.7.0"
+    }
+}

--- a/types/webpack/package.json
+++ b/types/webpack/package.json
@@ -1,5 +1,4 @@
 {
-    "private": true,
     "dependencies": {
         "source-map": "^0.7.0"
     }

--- a/types/webpack/package.json
+++ b/types/webpack/package.json
@@ -1,4 +1,5 @@
 {
+    "private": true,
     "dependencies": {
         "source-map": "^0.7.0"
     }

--- a/types/webpack/tslint.json
+++ b/types/webpack/tslint.json
@@ -1,7 +1,10 @@
 {
 	"extends": "dtslint/dt.json",
 	"rules": {
+		// TODO
+		"no-any-union": false,
 		"no-unnecessary-qualifier": false,
-		"no-void-expression": false
+		"no-void-expression": false,
+		"space-within-parens": false
 	}
 }

--- a/types/webpack/tslint.json
+++ b/types/webpack/tslint.json
@@ -1,10 +1,7 @@
 {
 	"extends": "dtslint/dt.json",
 	"rules": {
-		// TODO
-		"no-any-union": false,
 		"no-unnecessary-qualifier": false,
-		"no-void-expression": false,
-		"space-within-parens": false
+		"no-void-expression": false
 	}
 }

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -637,7 +637,7 @@ configuration = {
     performance,
 };
 
-function loader(this: webpack.loader.LoaderContext, source: string | Buffer, sourcemap: string | Buffer): void {
+function loader(this: webpack.loader.LoaderContext, source: string | Buffer, sourcemap?: object): void {
     this.cacheable();
 
     this.async();

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -1,4 +1,5 @@
 import webpack = require('webpack');
+import { RawSourceMap } from 'source-map';
 
 const {
     optimize,
@@ -637,7 +638,7 @@ configuration = {
     performance,
 };
 
-function loader(this: webpack.loader.LoaderContext, source: string | Buffer, sourcemap?: object): void {
+function loader(this: webpack.loader.LoaderContext, source: string | Buffer, sourcemap?: RawSourceMap): void {
     this.cacheable();
 
     this.async();


### PR DESCRIPTION
The sourceMap parameter passed to loaders, and that loaders pass to the
callback, is a `RawSourceMap`, not a `string | Buffer`. See the [webpack loader docs](https://webpack.js.org/api/loaders/).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
