### PR TITLE
Jui - Update error method

### DIFF
--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -376,7 +376,7 @@ export interface AnySchema extends JoiObject {
      * override, that error will be returned and the override will be ignored (unless the `abortEarly`
      * option has been set to `false`).
      */
-    error?(err: Error | ValidationErrorFunction): this;
+    error(err: Error | ValidationErrorFunction): this;
 
     /**
      * Returns a plain object representing the schema's rules and properties

--- a/types/joi/index.d.ts
+++ b/types/joi/index.d.ts
@@ -10,6 +10,7 @@
 //                 Youngrok Kim <https://github.com/rokoroku>
 //                 Dan Kraus <https://github.com/dankraus>
 //                 Anjun Wang <https://github.com/wanganjun>
+//                 Marcin Baszczewski <https://github.com/baszczewski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -140,7 +141,7 @@ export interface WhenOptions {
     /**
      * the required condition joi type.
      */
-    is: SchemaLike;
+    is?: SchemaLike;
     /**
      * the alternative schema type if the condition is true. Required if otherwise is missing.
      */
@@ -341,6 +342,7 @@ export interface AnySchema extends JoiObject {
      */
     when(ref: string, options: WhenOptions): AlternativesSchema;
     when(ref: Reference, options: WhenOptions): AlternativesSchema;
+    when(ref: Schema, options: WhenOptions): AlternativesSchema;
 
     /**
      * Overrides the key name in error messages.


### PR DESCRIPTION
Fix for TS error "Cannot invoke an object which is possibly 'undefined'." on TypeScript 2.7.1. My test example was: 
```ts
const schema = Joi.object().keys({
    name: Joi.string().alphanum().min(3).max(20).required().error(new Error("Invalid name.")),
});
```
