### PR TITLE
[three] Rename AxisHelper to AxesHelper

### DIFF
--- a/types/three/test/webgl/webgl_geometries.ts
+++ b/types/three/test/webgl/webgl_geometries.ts
@@ -20,7 +20,7 @@
 
         scene = new THREE.Scene();
 
-        var light: THREE.DirectionalLight, object: THREE.Mesh | THREE.AxisHelper | THREE.ArrowHelper;
+        var light: THREE.DirectionalLight, object: THREE.Mesh | THREE.AxesHelper | THREE.ArrowHelper;
 
         scene.add(new THREE.AmbientLight(0x404040));
 
@@ -96,7 +96,7 @@
         object.position.set(0, 0, -200);
         scene.add(object);
 
-        object = new THREE.AxisHelper(50);
+        object = new THREE.AxesHelper(50);
         object.position.set(200, 0, -200);
         scene.add(object);
 

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -6951,7 +6951,7 @@ export class ArrowHelper extends Object3D {
     setColor(hex: number): void;
 }
 
-export class AxisHelper extends LineSegments {
+export class AxesHelper extends LineSegments {
     constructor(size?: number);
 }
 


### PR DESCRIPTION
The `AxisHelper` class [was renamed to `AxesHelper`](https://github.com/mrdoob/three.js/commit/845999e06fb8c64c30d413bf668aa9da68357e01).

*`AxisHelper` is still supported, but displays a deprecation warning.
Should the type definitions include both classes?*