### PR TITLE
globalize - add missing timeZone property and loadTimeZone method

### DIFF
--- a/types/globalize/index.d.ts
+++ b/types/globalize/index.d.ts
@@ -30,6 +30,12 @@ interface DateFormatterOptions {
 	 * Note this is NOT recommended for i18n in general. Use skeleton instead.
 	 */
 	raw?: string;
+
+	/**
+	 * String based on the time zone names of the IANA time zone database, 
+	 * such as "Asia/Shanghai", "Asia/Kolkata", "America/New_York".
+	 */
+	timeZone?: string;
 }
 
 interface CommonNumberFormatterOptions {
@@ -125,6 +131,13 @@ interface UnitFormatterOptions {
 interface GlobalizeStatic {
 
 	cldr: Cldr.CldrStatic;
+
+	/**
+	 * Globalize.loadTimeZone ( ianaTzData, ... )
+	 * This method allows you to load IANA time zone data to enable options.timeZone feature on date formatters and parsers.
+	 * @param {Object} ianaTzData A JSON object with zdumped IANA timezone data. Get the data via https://github.com/rxaviers/iana-tz-data
+	 */
+	loadTimeZone(ianaTzData: Object): void;
 
 	/**
 	 * Globalize.load( json, ... )


### PR DESCRIPTION
package: globalize
description: Add missing timeZone property to DateFormatterOptions interface and missing loadTimeZone method to Globalize interface.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/globalizejs/globalize/blob/master/doc/api/date/date-formatter.md
https://github.com/globalizejs/globalize/blob/master/doc/api/date/load-iana-time-zone.md
- [X] Increase the version number in the header if appropriate.
There was no version in file's header
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
No substantial changes