### PR TITLE
THREE: Improve documentation of deprecated features

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -457,6 +457,9 @@ export class CubeCamera extends Object3D {
 
     renderTarget: WebGLRenderTargetCube;
 
+    /**
+     * @deprecated
+     */
     updateCubeMap(renderer: Renderer, scene: Scene): void;
 
     update(renderer: Renderer, scene: Scene): void;
@@ -911,11 +914,27 @@ export class BufferGeometry extends EventDispatcher {
      * @deprecated
      */
     drawcalls: any;
+
+    /**
+     * @deprecated
+     */
     offsets: any;
 
+    /**
+     * @deprecated
+     */
     addIndex(index: any): void;
+
+    /**
+     * @deprecated
+     */
     addDrawCall(start: any, count: any, indexOffset?: any): void;
+
+    /**
+     * @deprecated
+     */
     clearDrawCalls(): void;
+
     addAttribute(name: any, array: any, itemSize: any): any;
 }
 
@@ -2101,6 +2120,9 @@ export class Loader {
      */
     crossOrigin: string;
 
+    /**
+     * @deprecated
+     */
     extractUrlBase(url: string): string;
     initMaterials(materials: Material[], texturePath: string): Material[];
     createMaterial(m: Material, texturePath: string, crossOrigin?: string): boolean;
@@ -2934,6 +2956,9 @@ export class MeshPhysicalMaterial extends MeshStandardMaterial {
 
 // MultiMaterial does not inherit the Material class in the original code. However, it should treat as Material class.
 // See tests/canvas/canvas_materials.ts.
+/**
+ * @deprecated Use an Array instead.
+ */
 export class MultiMaterial extends Material {
     constructor(materials?: Material[]);
 
@@ -3547,8 +3572,14 @@ export namespace Math {
 
     export function isPowerOfTwo(value: number): boolean;
 
+    /**
+     * @deprecated
+     */
     export function nearestPowerOfTwo(value: number): number;
 
+    /**
+     * @deprecated
+     */
     export function nextPowerOfTwo(value: number): number;
 }
 
@@ -3613,6 +3644,10 @@ export class Matrix3 implements Matrix {
     clone(): this;
     copy(m: this): this;
     setFromMatrix4(m: Matrix4): Matrix3;
+
+    /**
+     * @deprecated
+     */
     applyToBuffer(buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
     multiplyScalar(s: number): Matrix3;
     determinant(): number;
@@ -3647,8 +3682,16 @@ export class Matrix3 implements Matrix {
      * @deprecated
      */
     multiplyVector3(vector: Vector3): any;
+
+    /**
+     * @deprecated
+     */
     multiplyVector3Array(a: any): any;
     getInverse(matrix: Matrix4, throwOnDegenerate?: boolean): Matrix3;
+
+    /**
+     * @deprecated
+     */
     flattenToArrayOffset(array: number[], offset: number): number[];
 }
 
@@ -3719,6 +3762,8 @@ export class Matrix4 implements Matrix {
     /**
      * Sets this matrix to a x b and stores the result into the flat array r.
      * r can be either a regular Array or a TypedArray.
+     *
+     * @deprecated
      */
     multiplyToArray(a: Matrix4, b: Matrix4, r: number[]): Matrix4;
 
@@ -3726,6 +3771,10 @@ export class Matrix4 implements Matrix {
      * Multiplies this matrix by s.
      */
     multiplyScalar(s: number): Matrix4;
+
+    /**
+     * @deprecated
+     */
     applyToBuffer( buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
     /**
      * Computes determinant of this matrix.
@@ -3831,12 +3880,40 @@ export class Matrix4 implements Matrix {
      * @deprecated
      */
     extractPosition(m: Matrix4): Matrix4;
+
+    /**
+     * @deprecated
+     */
     setRotationFromQuaternion(q: Quaternion): Matrix4;
+
+    /**
+     * @deprecated
+     */
     multiplyVector3(v: any): any;
+
+    /**
+     * @deprecated
+     */
     multiplyVector4(v: any): any;
+
+    /**
+     * @deprecated
+     */
     multiplyVector3Array(array: number[]): number[];
+
+    /**
+     * @deprecated
+     */
     rotateAxis(v: any): void;
+
+    /**
+     * @deprecated
+     */
     crossVector(v: any): void;
+
+    /**
+     * @deprecated
+     */
     flattenToArrayOffset(array: number[], offset: number): number[];
 }
 
@@ -4041,7 +4118,15 @@ export class Ray {
      * @deprecated
      */
     isIntersectionBox(b: any): any;
+
+    /**
+     * @deprecated
+     */
     isIntersectionPlane(p: any): any;
+
+    /**
+     * @deprecated
+     */
     isIntersectionSphere(s: any): any;
 }
 
@@ -4322,6 +4407,10 @@ export class Vector2 implements Vector {
      * Computes length of this vector.
      */
     length(): number;
+
+    /**
+     * @deprecated
+     */
     lengthManhattan(): number;
 
     /**
@@ -4343,6 +4432,10 @@ export class Vector2 implements Vector {
      * Computes squared distance of this vector to v.
      */
     distanceToSquared(v: Vector2): number;
+
+    /**
+     * @deprecated
+     */
     distanceToManhattan(v: Vector2): number;
 
     /**
@@ -4366,6 +4459,26 @@ export class Vector2 implements Vector {
     fromBufferAttribute( attribute: BufferAttribute, index: number, offset?: number): Vector2;
 
     rotateAround( center: Vector2, angle: number ): Vector2;
+
+    /**
+     * Computes the Manhattan length of this vector.
+     *
+     * @return {number}
+     *
+     * @see {@link http://en.wikipedia.org/wiki/Taxicab_geometry|Wikipedia: Taxicab Geometry}
+     */
+    manhattanLength(): number;
+
+    /**
+     * Computes the Manhattan length (distance) from this vector to the given vector v
+     *
+     * @param {Vector2} v
+     *
+     * @return {number}
+     *
+     * @see {@link http://en.wikipedia.org/wiki/Taxicab_geometry|Wikipedia: Taxicab Geometry}
+     */
+    manhattanDistanceTo(v: Vector2): number;
 }
 
 /**
@@ -4502,9 +4615,30 @@ export class Vector3 implements Vector {
     /**
      * Computes Manhattan length of this vector.
      * http://en.wikipedia.org/wiki/Taxicab_geometry
+     *
+     * @deprecated
      */
     lengthManhattan(): number;
-    manhattanDistanceTo(v:Vector3):number;
+
+    /**
+     * Computes the Manhattan length of this vector.
+     *
+     * @return {number}
+     *
+     * @see {@link http://en.wikipedia.org/wiki/Taxicab_geometry|Wikipedia: Taxicab Geometry}
+     */
+    manhattanLength(): number;
+
+    /**
+     * Computes the Manhattan length (distance) from this vector to the given vector v
+     *
+     * @param {Vector3} v
+     *
+     * @return {number}
+     *
+     * @see {@link http://en.wikipedia.org/wiki/Taxicab_geometry|Wikipedia: Taxicab Geometry}
+     */
+    manhattanDistanceTo(v: Vector3): number;
 
     /**
      * Normalizes this vector.
@@ -4542,6 +4676,10 @@ export class Vector3 implements Vector {
      * Computes squared distance of this vector to v.
      */
     distanceToSquared(v: Vector3): number;
+
+    /**
+     * @deprecated
+     */
     distanceToManhattan(v: Vector3): number;
 
     setFromSpherical(s: Spherical): Vector3;
@@ -4562,7 +4700,15 @@ export class Vector3 implements Vector {
      * @deprecated
      */
     getPositionFromMatrix(m: Matrix4): Vector3;
+
+    /**
+     * @deprecated
+     */
     getScaleFromMatrix(m: Matrix4): Vector3;
+
+    /**
+     * @deprecated
+     */
     getColumnFromMatrix(index: number, matrix: Matrix4): Vector3;
 }
 
@@ -4700,7 +4846,20 @@ export class Vector4 implements Vector {
      * Computes length of this vector.
      */
     length(): number;
+
+    /**
+     * @deprecated
+     */
     lengthManhattan(): number;
+
+    /**
+     * Computes the Manhattan length of this vector.
+     *
+     * @return {number}
+     *
+     * @see {@link http://en.wikipedia.org/wiki/Taxicab_geometry|Wikipedia: Taxicab Geometry}
+     */
+    manhattanLength(): number;
 
     /**
      * Normalizes this vector.
@@ -4904,8 +5063,11 @@ export class PointCloud extends Points {}
 export class ParticleSystem extends Points {}
 
 export class Skeleton {
-    constructor(bones: Bone[], boneInverses?: Matrix4[], useVertexTexture?: boolean);
+    constructor(bones: Bone[], boneInverses?: Matrix4[]);
 
+    /**
+     * @deprecated
+     */
     useVertexTexture: boolean;
     identityMatrix: Matrix4;
     bones: Bone[];
@@ -5139,8 +5301,16 @@ export class WebGLRenderer implements Renderer {
     getContextAttributes(): any;
     forceContextLoss(): void;
 
+    /**
+     * @deprecated
+     */
     getMaxAnisotropy(): number;
+
+    /**
+     * @deprecated
+     */
     getPrecision(): string;
+
     getPixelRatio(): number;
     setPixelRatio(value: number): void;
 
@@ -5195,6 +5365,10 @@ export class WebGLRenderer implements Renderer {
     clearDepth(): void;
     clearStencil(): void;
     clearTarget(renderTarget: WebGLRenderTarget, color: boolean, depth: boolean, stencil: boolean): void;
+
+    /**
+     * @deprecated
+     */
     resetGLState(): void;
     dispose(): void;
 
@@ -5240,18 +5414,65 @@ export class WebGLRenderer implements Renderer {
      * @deprecated
      */
     gammaFactor: number;
+
+    /**
+     * @deprecated
+     */
     shadowMapEnabled: boolean;
+
+    /**
+     * @deprecated
+     */
     shadowMapType: ShadowMapType;
+
+    /**
+     * @deprecated
+     */
     shadowMapCullFace: CullFace;
 
+    /**
+     * @deprecated
+     */
     supportsFloatTextures(): any;
+
+    /**
+     * @deprecated
+     */
     supportsHalfFloatTextures(): any;
+
+    /**
+     * @deprecated
+     */
     supportsStandardDerivatives(): any;
+
+    /**
+     * @deprecated
+     */
     supportsCompressedTextureS3TC(): any;
+
+    /**
+     * @deprecated
+     */
     supportsCompressedTexturePVRTC(): any;
+
+    /**
+     * @deprecated
+     */
     supportsBlendMinMax(): any;
+
+    /**
+     * @deprecated
+     */
     supportsVertexTextures(): any;
+
+    /**
+     * @deprecated
+     */
     supportsInstancedArrays(): any;
+
+    /**
+     * @deprecated
+     */
     enableScissorTest(boolean: any): any;
 }
 
@@ -5625,17 +5846,23 @@ export namespace UniformsUtils {
 export class Uniform {
     constructor(value: any);
     /**
-     *  @deprecated
+     * @deprecated
      */
     constructor(type: string, value: any);
     /**
-     *  @deprecated
+     * @deprecated
      */
     type: string;
     value: any;
+    /**
+     * @deprecated
+     */
     dynamic: boolean;
     onUpdateCallback: Function;
 
+    /**
+     * @deprecated
+     */
     onUpdate(callback: Function): Uniform;
 }
 
@@ -5729,11 +5956,11 @@ export class WebGLProgram {
     vertexShader: WebGLShader;
     fragmentShader: WebGLShader;
     /**
-     *  @deprecated Use getUniforms() instead.
+     * @deprecated Use getUniforms() instead.
      */
     uniforms: any;
     /**
-     *  @deprecated Use getAttributes() instead.
+     * @deprecated Use getAttributes() instead.
      */
     attributes: any;
 
@@ -6132,9 +6359,19 @@ export class VideoTexture extends Texture {
  * @deprecated Use TextureLoader instead.
  */
 export namespace ImageUtils {
+    /**
+     * @deprecated
+     */
     export let crossOrigin: string;
 
+    /**
+     * @deprecated
+     */
     export function loadTexture(url: string, mapping?: Mapping, onLoad?: (texture: Texture) => void, onError?: (message: string) => void): Texture;
+
+    /**
+     * @deprecated
+     */
     export function loadTextureCube(array: string[], mapping?: Mapping, onLoad?: (texture: Texture) => void , onError?: (message: string) => void ): Texture;
 }
 
@@ -6335,8 +6572,18 @@ export class CurvePath<T extends Vector> extends Curve<T> {
     getCurveLengths(): number[];
     getSpacedPoints(divisions?: number): T[];
     getPoints(divisions?: number): T[];
+
+    /**
+     * @deprecated
+     */
     createPointsGeometry(divisions: number): Geometry;
+    /**
+     * @deprecated
+     */
     createSpacedPointsGeometry(divisions: number): Geometry;
+    /**
+     * @deprecated
+     */
     createGeometry(points: T[]): Geometry;
 }
 
@@ -6363,7 +6610,11 @@ export class Path extends CurvePath<Vector2> {
 
     currentPoint: Vector2;
 
+    /**
+     * @deprecated
+     */
     fromPoints(vectors: Vector2[]): void;
+    setFromPoints(vectors: Vector2[]): void;
     moveTo(x: number, y: number): void;
     lineTo(x: number, y: number): void;
     quadraticCurveTo(aCPx: number, aCPy: number, aX: number, aY: number): void;
@@ -6397,9 +6648,20 @@ export class Shape extends Path {
 
     holes: Path[];
 
+    /**
+     * @deprecated
+     */
     extrude(options?: any): ExtrudeGeometry;
+
+    /**
+     * @deprecated
+     */
     makeGeometry(options?: any): ShapeGeometry;
     getPointsHoles(divisions: number): Vector2[][];
+
+    /**
+     * @deprecated
+     */
     extractAllPoints(divisions: number): {
         shape: Vector2[];
         holes: Vector2[][];
@@ -6955,6 +7217,9 @@ export class AxisHelper extends LineSegments {
     constructor(size?: number);
 }
 
+/**
+ * @deprecated
+ */
 export class BoundingBoxHelper extends Mesh {
     constructor(object?: Object3D, hex?: number);
 
@@ -6989,6 +7254,9 @@ export class DirectionalLightHelper extends Object3D {
     update(): void;
 }
 
+/**
+ * @deprecated
+ */
 export class EdgesHelper extends LineSegments {
     constructor(object: Object3D, hex?: number, thresholdAngle?: number);
 }
@@ -7058,6 +7326,9 @@ export class VertexNormalsHelper extends LineSegments {
     update(object?: Object3D): void;
 }
 
+/**
+ * @deprecated
+ */
 export class WireframeHelper extends LineSegments {
     constructor(object: Object3D, hex?: number);
 }

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -458,7 +458,7 @@ export class CubeCamera extends Object3D {
     renderTarget: WebGLRenderTargetCube;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link CubeCamera#update .update()} instead
      */
     updateCubeMap(renderer: Renderer, scene: Scene): void;
 
@@ -638,7 +638,7 @@ export class PerspectiveCamera extends Camera {
     toJSON(meta?: any): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link PerspectiveCamera#setFocalLength .setFocalLength()} and {@link PerspectiveCamera#filmGauge .filmGauge} instead.
      */
     setLens(focalLength: number, frameHeight?: number): void;
 }
@@ -704,7 +704,7 @@ export class BufferAttribute {
     setXYZ(index: number, x: number, y: number, z: number): BufferAttribute;
     setXYZW(index: number, x: number, y: number, z: number, w: number): BufferAttribute;
     /**
-     * @deprecated Use count instead.
+     * @deprecated Use {@link BufferAttribute#count .count} instead.
      */
     length: number;
 }
@@ -809,7 +809,7 @@ export class Float64BufferAttribute extends BufferAttribute {
 }
 
 /**
- * @deprecated, use new THREE.BufferAttribute().setDynamic( true ).
+ * @deprecated Use {@link BufferAttribute#setDynamic THREE.BufferAttribute().setDynamic( true )} instead.
  */
 export class DynamicBufferAttribute extends BufferAttribute {}
 
@@ -911,27 +911,27 @@ export class BufferGeometry extends EventDispatcher {
     dispose(): void;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link BufferGeometry#groups .groups} instead.
      */
     drawcalls: any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link BufferGeometry#groups .groups} instead.
      */
     offsets: any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link BufferGeometry#setIndex .setIndex()} instead.
      */
     addIndex(index: any): void;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link BufferGeometry#addGroup .addGroup()} instead.
      */
     addDrawCall(start: any, count: any, indexOffset?: any): void;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link BufferGeometry#clearGroups .clearGroups()} instead.
      */
     clearDrawCalls(): void;
 
@@ -1173,7 +1173,7 @@ export class Face3 {
 }
 
 /**
- * @deprecated Use Face3 instead.
+ * @deprecated Use {@link Face3} instead.
  */
 export class Face4 extends Face3 {}
 
@@ -1428,11 +1428,11 @@ export class Geometry extends EventDispatcher {
  */
 export namespace GeometryUtils {
     /**
-     * @deprecated Use geometry.merge( geometry2, matrix, materialIndexOffset ).
+     * @deprecated Use {@link Geometry#merge geometry.merge( geometry2, matrix, materialIndexOffset )} instead.
      */
     export function merge(geometry1: any, geometry2: any, materialIndexOffset?: any): any;
     /**
-     * @deprecated Use geometry.center().
+     * @deprecated Use {@link Geometry#center geometry.center()} instead.
      */
     export function center(geometry: any): any;
 }
@@ -1517,7 +1517,7 @@ export class InterleavedBufferAttribute {
     setXYZ(index: number, x: number, y: number, z: number): InterleavedBufferAttribute;
     setXYZW(index: number, x: number, y: number, z: number, w: number): InterleavedBufferAttribute;
     /**
-     * @deprecated Use count instead.
+     * @deprecated Use {@link InterleavedBufferAttribute#count .count} instead.
      */
     length: number;
 }
@@ -2121,7 +2121,7 @@ export class Loader {
     crossOrigin: string;
 
     /**
-     * @deprecated
+     * @deprecated Use THREE.LoaderUtils.extractUrlBase() instead.
      */
     extractUrlBase(url: string): string;
     initMaterials(materials: Material[], texturePath: string): Material[];
@@ -2323,7 +2323,7 @@ export class DataTextureLoader {
 }
 
 /**
- * @deprecated since 0.84.0. Use DataTextureLoader (renamed)
+ * @deprecated since 0.84.0. Use {@link DataTextureLoader} (renamed)
  */
 export class BinaryTextureLoader extends DataTextureLoader {}
 
@@ -2932,7 +2932,7 @@ export class MeshPhongMaterial extends Material {
     morphTargets: boolean;
     morphNormals: boolean;
     /**
-     * @deprecated
+     * @deprecated Use {@link MeshStandardMaterial THREE.MeshStandardMaterial} instead.
      */
     metal: boolean;
 
@@ -2971,7 +2971,7 @@ export class MultiMaterial extends Material {
 }
 
 /**
- * @deprecated Use MultiMaterial instead.
+ * @deprecated Use {@link MultiMaterial} instead.
  */
 export class MeshFaceMaterial extends MultiMaterial {}
 
@@ -2994,15 +2994,15 @@ export class PointsMaterial extends Material {
 }
 
 /**
- * @deprecated
+ * @deprecated Use {@link PointsMaterial THREE.PointsMaterial} instead
  */
 export class PointCloudMaterial extends PointsMaterial {}
 /**
- * @deprecated
+ * @deprecated Use {@link PointsMaterial THREE.PointsMaterial} instead
  */
 export class ParticleBasicMaterial extends PointsMaterial {}
 /**
- * @deprecated
+ * @deprecated Use {@link PointsMaterial THREE.PointsMaterial} instead
  */
 export class ParticleSystemMaterial extends PointsMaterial {}
 
@@ -3037,7 +3037,7 @@ export class ShaderMaterial extends Material {
     morphTargets: boolean;
     morphNormals: boolean;
     /**
-     * @deprecated Use extensions.derivatives instead.
+     * @deprecated Use {@link ShaderMaterial#extensions.derivatives extensions.derivatives} instead.
      */
     derivatives: any;
     extensions: { derivatives: boolean; fragDepth: boolean; drawBuffers: boolean; shaderTextureLOD: boolean };
@@ -3103,11 +3103,11 @@ export class Box2 {
     translate(offset: Vector2): Box2;
     equals(box: Box2): boolean;
     /**
-     * @deprecated Use isEmpty() instead.
+     * @deprecated Use {@link Box2#isEmpty .isEmpty()} instead.
      */
     empty(): any;
     /**
-     * @deprecated Use intersectsBox() instead.
+     * @deprecated Use {@link Box2#intersectsBox .intersectsBox()} instead.
      */
     isIntersectionBox(b: any): any;
 }
@@ -3148,15 +3148,15 @@ export class Box3 {
     translate(offset: Vector3): Box3;
     equals(box: Box3): boolean;
     /**
-     * @deprecated Use isEmpty() instead.
+     * @deprecated Use {@link Box3#isEmpty .isEmpty()} instead.
      */
     empty(): any;
     /**
-     * @deprecated Use intersectsBox() instead.
+     * @deprecated Use {@link Box3#intersectsBox .intersectsBox()} instead.
      */
     isIntersectionBox(b: any): any;
     /**
-     * @deprecated Use intersectsSphere() instead.
+     * @deprecated Use {@link Box3#intersectsSphere .intersectsSphere()} instead.
      */
     isIntersectionSphere(s: any): any;
 }
@@ -3547,7 +3547,8 @@ export namespace Math {
     /**
      * Random float from 0 to 1 with 16 bits of randomness.
      * Standard Math.random() creates repetitive patterns when applied over larger space.
-     * @deprecated Use Math.random()
+     *
+     * @deprecated Use {@link Math#random Math.random()}
      */
     export function random16(): number;
 
@@ -3573,14 +3574,19 @@ export namespace Math {
     export function isPowerOfTwo(value: number): boolean;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Math#floorPowerOfTwo .floorPowerOfTwo()}
      */
     export function nearestPowerOfTwo(value: number): number;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Math#ceilPowerOfTwo .ceilPowerOfTwo()}
      */
     export function nextPowerOfTwo(value: number): number;
+
+    export function floorPowerOfTwo(value: number): number;
+
+    export function ceilPowerOfTwo(value: number): number;
+
 }
 
 /**
@@ -3646,9 +3652,12 @@ export class Matrix3 implements Matrix {
     setFromMatrix4(m: Matrix4): Matrix3;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Matrix3#applyToBufferAttribute matrix3.applyToBufferAttribute( attribute )} instead.
      */
     applyToBuffer(buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
+
+    applyToBufferAttribute(attribute: BufferAttribute): BufferAttribute;
+
     multiplyScalar(s: number): Matrix3;
     determinant(): number;
     getInverse(matrix: Matrix3, throwOnDegenerate?: boolean): Matrix3;
@@ -3679,18 +3688,18 @@ export class Matrix3 implements Matrix {
     multiplyMatrices(a: Matrix3, b: Matrix3): Matrix3;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector3.applyMatrix3 vector.applyMatrix3( matrix )} instead.
      */
     multiplyVector3(vector: Vector3): any;
 
     /**
-     * @deprecated
+     * @deprecated This method has been removed completely.
      */
     multiplyVector3Array(a: any): any;
     getInverse(matrix: Matrix4, throwOnDegenerate?: boolean): Matrix3;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Matrix3#toArray .toArray()} instead.
      */
     flattenToArrayOffset(array: number[], offset: number): number[];
 }
@@ -3763,7 +3772,7 @@ export class Matrix4 implements Matrix {
      * Sets this matrix to a x b and stores the result into the flat array r.
      * r can be either a regular Array or a TypedArray.
      *
-     * @deprecated
+     * @deprecated This method has been removed completely.
      */
     multiplyToArray(a: Matrix4, b: Matrix4, r: number[]): Matrix4;
 
@@ -3773,9 +3782,12 @@ export class Matrix4 implements Matrix {
     multiplyScalar(s: number): Matrix4;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Matrix4#applyToBufferAttribute matrix4.applyToBufferAttribute( attribute )} instead.
      */
     applyToBuffer( buffer: BufferAttribute, offset?: number, length?: number): BufferAttribute;
+
+    applyToBufferAttribute(attribute: BufferAttribute): BufferAttribute;
+
     /**
      * Computes determinant of this matrix.
      * Based on http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm
@@ -3787,13 +3799,10 @@ export class Matrix4 implements Matrix {
      */
     transpose(): Matrix4;
 
-
-
     /**
      * Sets the position component for this matrix from vector v.
      */
     setPosition(v: Vector3): Matrix4;
-
 
     /**
      * Sets this matrix to the inverse of matrix m.
@@ -3877,42 +3886,42 @@ export class Matrix4 implements Matrix {
     toArray(): number[];
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Matrix4#copyPosition .copyPosition()} instead.
      */
     extractPosition(m: Matrix4): Matrix4;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Matrix4#makeRotationFromQuaternion .makeRotationFromQuaternion()} instead.
      */
     setRotationFromQuaternion(q: Quaternion): Matrix4;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector3#applyMatrix4 vector.applyMatrix4( matrix )} instead.
      */
     multiplyVector3(v: any): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector4#applyMatrix4 vector.applyMatrix4( matrix )} instead.
      */
     multiplyVector4(v: any): any;
 
     /**
-     * @deprecated
+     * @deprecated This method has been removed completely.
      */
     multiplyVector3Array(array: number[]): number[];
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector3#transformDirection Vector3.transformDirection( matrix )} instead.
      */
     rotateAxis(v: any): void;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector3#applyMatrix4 vector.applyMatrix4( matrix )} instead.
      */
     crossVector(v: any): void;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Matrix4#toArray .toArray()} instead.
      */
     flattenToArrayOffset(array: number[], offset: number): number[];
 }
@@ -3944,7 +3953,7 @@ export class Plane {
     equals(plane: Plane): boolean;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Plane#intersectsLine .intersectsLine()} instead.
      */
     isIntersectionLine(l: any): any;
 }
@@ -4082,7 +4091,7 @@ export class Quaternion {
     static slerpFlat(dst: number[], dstOffset: number, src0: number[], srcOffset: number, src1: number[], stcOffset1: number, t: number): Quaternion;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector#applyQuaternion vector.applyQuaternion( quaternion )} instead.
      */
     multiplyVector3(v: any): any;
 }
@@ -4115,17 +4124,17 @@ export class Ray {
     equals(ray: Ray): boolean;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Ray#intersectsBox .intersectsBox()} instead.
      */
     isIntersectionBox(b: any): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Ray#intersectsPlane .intersectsPlane()} instead.
      */
     isIntersectionPlane(p: any): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Ray#intersectsSphere .intersectsSphere()} instead.
      */
     isIntersectionSphere(s: any): any;
 }
@@ -4409,7 +4418,7 @@ export class Vector2 implements Vector {
     length(): number;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector2#manhattanLength .manhattanLength()} instead.
      */
     lengthManhattan(): number;
 
@@ -4434,7 +4443,7 @@ export class Vector2 implements Vector {
     distanceToSquared(v: Vector2): number;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector2#manhattanDistanceTo .manhattanDistanceTo()} instead.
      */
     distanceToManhattan(v: Vector2): number;
 
@@ -4616,7 +4625,7 @@ export class Vector3 implements Vector {
      * Computes Manhattan length of this vector.
      * http://en.wikipedia.org/wiki/Taxicab_geometry
      *
-     * @deprecated
+     * @deprecated Use {@link Vector3#manhattanLength .manhattanLength()} instead.
      */
     lengthManhattan(): number;
 
@@ -4678,7 +4687,7 @@ export class Vector3 implements Vector {
     distanceToSquared(v: Vector3): number;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector3#manhattanDistanceTo .manhattanDistanceTo()} instead.
      */
     distanceToManhattan(v: Vector3): number;
 
@@ -4697,23 +4706,23 @@ export class Vector3 implements Vector {
     fromBufferAttribute( attribute: BufferAttribute, index: number, offset?: number): Vector3;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector3#setFromMatrixPosition .setFromMatrixPosition()} instead.
      */
     getPositionFromMatrix(m: Matrix4): Vector3;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector3#setFromMatrixScale .setFromMatrixScale()} instead.
      */
     getScaleFromMatrix(m: Matrix4): Vector3;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector3#setFromMatrixColumn .setFromMatrixColumn()} instead.
      */
     getColumnFromMatrix(index: number, matrix: Matrix4): Vector3;
 }
 
 /**
- * @deprecated use THREE.Vector3 instead.
+ * @deprecated use {@link Vector3 THREE.Vector3} instead.
  */
 export class Vertex extends Vector3 {}
 
@@ -4848,7 +4857,7 @@ export class Vector4 implements Vector {
     length(): number;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Vector4#manhattanLength .manhattanLength()} instead.
      */
     lengthManhattan(): number;
 
@@ -4948,7 +4957,7 @@ export class LOD extends Object3D {
     toJSON(meta: any): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link LOD#levels .levels} instead.
      */
     objects: any[];
 }
@@ -5054,11 +5063,11 @@ export class Points extends Object3D {
 }
 
 /**
- * @deprecated
+ * @deprecated Use {@link Points THREE.Points} instead.
  */
 export class PointCloud extends Points {}
 /**
- * @deprecated
+ * @deprecated Use {@link Points THREE.Points} instead.
  */
 export class ParticleSystem extends Points {}
 
@@ -5066,7 +5075,7 @@ export class Skeleton {
     constructor(bones: Bone[], boneInverses?: Matrix4[]);
 
     /**
-     * @deprecated
+     * @deprecated This property has been removed completely.
      */
     useVertexTexture: boolean;
     identityMatrix: Matrix4;
@@ -5113,7 +5122,7 @@ export class Sprite extends Object3D {
 }
 
 /**
- * @deprecated Use Sprite instead.
+ * @deprecated Use {@link Sprite Sprite} instead.
  */
 export class Particle extends Sprite {}
 
@@ -5302,12 +5311,12 @@ export class WebGLRenderer implements Renderer {
     forceContextLoss(): void;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLCapabilities#getMaxAnisotropy .capabilities.getMaxAnisotropy()} instead.
      */
     getMaxAnisotropy(): number;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLCapabilities#precision .capabilities.precision} instead.
      */
     getPrecision(): string;
 
@@ -5367,7 +5376,7 @@ export class WebGLRenderer implements Renderer {
     clearTarget(renderTarget: WebGLRenderTarget, color: boolean, depth: boolean, stencil: boolean): void;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLState#reset .state.reset()} instead.
      */
     resetGLState(): void;
     dispose(): void;
@@ -5404,7 +5413,7 @@ export class WebGLRenderer implements Renderer {
     setTextureCube(texture: Texture, slot: number): void;
     getRenderTarget(): RenderTarget;
 	/**
-     * @deprecated Use getRenderTarget instead.
+     * @deprecated Use {@link WebGLRenderer#getRenderTarget .getRenderTarget()} instead.
      */
     getCurrentRenderTarget(): RenderTarget;
     setRenderTarget(renderTarget: RenderTarget): void;
@@ -5416,62 +5425,62 @@ export class WebGLRenderer implements Renderer {
     gammaFactor: number;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLShadowMap#enabled .shadowMap.enabled} instead.
      */
     shadowMapEnabled: boolean;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLShadowMap#type .shadowMap.type} instead.
      */
     shadowMapType: ShadowMapType;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLShadowMap#cullFace .shadowMap.cullFace} instead.
      */
     shadowMapCullFace: CullFace;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLExtensions#get .extensions.get( 'OES_texture_float' )} instead.
      */
     supportsFloatTextures(): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLExtensions#get .extensions.get( 'OES_texture_half_float' )} instead.
      */
     supportsHalfFloatTextures(): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLExtensions#get .extensions.get( 'OES_standard_derivatives' )} instead.
      */
     supportsStandardDerivatives(): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLExtensions#get .extensions.get( 'WEBGL_compressed_texture_s3tc' )} instead.
      */
     supportsCompressedTextureS3TC(): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLExtensions#get .extensions.get( 'WEBGL_compressed_texture_pvrtc' )} instead.
      */
     supportsCompressedTexturePVRTC(): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLExtensions#get .extensions.get( 'EXT_blend_minmax' )} instead.
      */
     supportsBlendMinMax(): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLCapabilities#vertexTextures .capabilities.vertexTextures} instead.
      */
     supportsVertexTextures(): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLExtensions#get .extensions.get( 'ANGLE_instanced_arrays' )} instead.
      */
     supportsInstancedArrays(): any;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLRenderer#setScissorTest .setScissorTest()} instead.
      */
     enableScissorTest(boolean: any): any;
 }
@@ -5536,43 +5545,43 @@ export class WebGLRenderTarget extends EventDispatcher {
     stencilBuffer: boolean;
     depthTexture: Texture;
     /**
-     * @deprecated Use texture.wrapS instead.
+     * @deprecated Use {@link Texture#wrapS texture.wrapS} instead.
      */
     wrapS: any;
     /**
-     * @deprecated Use texture.wrapT instead.
+     * @deprecated Use {@link Texture#wrapT texture.wrapT} instead.
      */
     wrapT: any;
     /**
-     * @deprecated Use texture.magFilter instead.
+     * @deprecated Use {@link Texture#magFilter texture.magFilter} instead.
      */
     magFilter: any;
     /**
-     * @deprecated Use texture.minFilter instead.
+     * @deprecated Use {@link Texture#minFilter texture.minFilter} instead.
      */
     minFilter: any;
     /**
-     * @deprecated Use texture.anisotropy instead.
+     * @deprecated Use {@link Texture#anisotropy texture.anisotropy} instead.
      */
     anisotropy: any;
     /**
-     * @deprecated Use texture.offset instead.
+     * @deprecated Use {@link Texture#offset texture.offset} instead.
      */
     offset: any;
     /**
-     * @deprecated Use texture.repeat instead.
+     * @deprecated Use {@link Texture#repeat texture.repeat} instead.
      */
     repeat: any;
     /**
-     * @deprecated Use texture.format instead.
+     * @deprecated Use {@link Texture#format texture.format} instead.
      */
     format: any;
     /**
-     * @deprecated Use texture.type instead.
+     * @deprecated Use {@link Texture#type texture.type} instead.
      */
     type: any;
     /**
-     * @deprecated Use texture.generateMipmaps instead.
+     * @deprecated Use {@link Texture#generateMipmaps texture.generateMipmaps} instead.
      */
     generateMipmaps: any;
 
@@ -5855,13 +5864,13 @@ export class Uniform {
     type: string;
     value: any;
     /**
-     * @deprecated
+     * @deprecated Use {@link Object3D#onBeforeRender object.onBeforeRender()} instead.
      */
     dynamic: boolean;
     onUpdateCallback: Function;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Object3D#onBeforeRender object.onBeforeRender()} instead.
      */
     onUpdate(callback: Function): Uniform;
 }
@@ -5956,11 +5965,11 @@ export class WebGLProgram {
     vertexShader: WebGLShader;
     fragmentShader: WebGLShader;
     /**
-     * @deprecated Use getUniforms() instead.
+     * @deprecated Use {@link WebGLProgram#getUniforms getUniforms()} instead.
      */
     uniforms: any;
     /**
-     * @deprecated Use getAttributes() instead.
+     * @deprecated Use {@link WebGLProgram#getAttributes getAttributes()} instead.
      */
     attributes: any;
 
@@ -6030,7 +6039,7 @@ export class WebGLShadowMap {
     render(scene: Scene, camera: Camera): void;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link WebGLShadowMap#renderReverseSided .shadowMap.renderReverseSided} instead.
      */
     cullFace: any;
 }
@@ -6356,7 +6365,7 @@ export class VideoTexture extends Texture {
 // Extras /////////////////////////////////////////////////////////////////////
 
 /**
- * @deprecated Use TextureLoader instead.
+ * @deprecated Use {@link TextureLoader} instead.
  */
 export namespace ImageUtils {
     /**
@@ -6365,12 +6374,12 @@ export namespace ImageUtils {
     export let crossOrigin: string;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link TextureLoader THREE.TextureLoader()} instead.
      */
     export function loadTexture(url: string, mapping?: Mapping, onLoad?: (texture: Texture) => void, onError?: (message: string) => void): Texture;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link CubeTextureLoader THREE.CubeTextureLoader()} instead.
      */
     export function loadTextureCube(array: string[], mapping?: Mapping, onLoad?: (texture: Texture) => void , onError?: (message: string) => void ): Texture;
 }
@@ -6425,7 +6434,7 @@ export class Audio extends Object3D {
     getVolume(): number;
     setVolume(value: number): Audio;
     /**
-     * @deprecated Use AudioLoader instead.
+     * @deprecated Use {@link AudioLoader} instead.
      */
     load(file: string): Audio;
 }
@@ -6440,7 +6449,7 @@ export class AudioAnalyser {
     getAverageFrequency(): number;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link AudioAnalyser#getFrequencyData .getFrequencyData()} instead.
      */
     getData(file: any): any;
 }
@@ -6574,15 +6583,15 @@ export class CurvePath<T extends Vector> extends Curve<T> {
     getPoints(divisions?: number): T[];
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Geometry#setFromPoints new THREE.Geometry().setFromPoints( points )} instead.
      */
     createPointsGeometry(divisions: number): Geometry;
     /**
-     * @deprecated
+     * @deprecated Use {@link Geometry#setFromPoints new THREE.Geometry().setFromPoints( points )} instead.
      */
     createSpacedPointsGeometry(divisions: number): Geometry;
     /**
-     * @deprecated
+     * @deprecated Use {@link Geometry#setFromPoints new THREE.Geometry().setFromPoints( points )} instead.
      */
     createGeometry(points: T[]): Geometry;
 }
@@ -6611,7 +6620,7 @@ export class Path extends CurvePath<Vector2> {
     currentPoint: Vector2;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Path#setFromPoints .setFromPoints()} instead.
      */
     fromPoints(vectors: Vector2[]): void;
     setFromPoints(vectors: Vector2[]): void;
@@ -6649,18 +6658,18 @@ export class Shape extends Path {
     holes: Path[];
 
     /**
-     * @deprecated
+     * @deprecated Use {@link ExtrudeGeometry ExtrudeGeometry()} instead.
      */
     extrude(options?: any): ExtrudeGeometry;
 
     /**
-     * @deprecated
+     * @deprecated Use {@link ShapeGeometry ShapeGeometry()} instead.
      */
     makeGeometry(options?: any): ShapeGeometry;
     getPointsHoles(divisions: number): Vector2[][];
 
     /**
-     * @deprecated
+     * @deprecated Use {@link Shape#extractPoints .extractPoints()} instead.
      */
     extractAllPoints(divisions: number): {
         shape: Vector2[];
@@ -6801,7 +6810,7 @@ export class BoxGeometry extends Geometry {
 }
 
 /**
- * @deprecated Use BoxGeometry instead.
+ * @deprecated Use {@link BoxGeometry} instead.
  */
 export class CubeGeometry extends BoxGeometry {}
 
@@ -7218,7 +7227,7 @@ export class AxisHelper extends LineSegments {
 }
 
 /**
- * @deprecated
+ * @deprecated Use {@link BoxHelper THREE.BoxHelper} instead.
  */
 export class BoundingBoxHelper extends Mesh {
     constructor(object?: Object3D, hex?: number);
@@ -7255,7 +7264,7 @@ export class DirectionalLightHelper extends Object3D {
 }
 
 /**
- * @deprecated
+ * @deprecated Use {@link EdgesGeometry THREE.EdgesGeometry}
  */
 export class EdgesHelper extends LineSegments {
     constructor(object: Object3D, hex?: number, thresholdAngle?: number);
@@ -7273,7 +7282,7 @@ export class FaceNormalsHelper extends LineSegments {
 export class GridHelper extends LineSegments {
     constructor(size: number, divisions: number, color1?: Color|number, color2?: Color|number);
     /**
-     * @deprecated
+     * @deprecated Colors should be specified in the constructor.
      */
     setColors(color1?: Color|number, color2?: Color|number): void;
 }
@@ -7327,7 +7336,7 @@ export class VertexNormalsHelper extends LineSegments {
 }
 
 /**
- * @deprecated
+ * @deprecated Use {@link WireframeGeometry THREE.WireframeGeometry} instead.
  */
 export class WireframeHelper extends LineSegments {
     constructor(object: Object3D, hex?: number);


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [DeprecatedList](https://threejs.org/docs/#api/deprecated/DeprecatedList)
- [ ] Increase the version number in the header if appropriate.

I've just been through the whole Three.Legacy file, making sure three-core.d.ts matches, and that as many `@deprecated` tags have messages as possible.

I've also added `{@link}` tags where relevant, and a few missing methods that were referred to by the deprecation messages, such as `Path#setFromPoint` and the renamed manhattan methods for the Vector classes.

I'm unsure if it's appropriate to increase the version number, so I've left that unticked for now.