### PR TITLE
atom: fix callback signature for Directory.getEntries()

### DIFF
--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -3341,7 +3341,7 @@ export class Directory {
     getEntriesSync(): Array<File|Directory>;
 
     /** Reads file entries in this directory from disk asynchronously. */
-    getEntries(callback: (error: Error, entries: Array<File|Directory>) => void): void;
+    getEntries(callback: (error: Error|null, entries: Array<File|Directory>) => void): void;
 
     /**
      *  Determines if the given path (real or symbolic) is inside this directory. This


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://atom.io/docs/api/v1.23.3/Directory#instance-getEntries
https://github.com/atom/node-pathwatcher/blob/v8.0.1/src/directory.coffee#L251
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This PR is a one-line fix that modifies the signature of the callback to `Directory.getEntries()`. Currently, the signature indicates that an `Error` will *always* be passed to the callback; obviously this is incorrect. According to the API, the correct type for the `error` parameter is `Error | null`.