### PR TITLE
Add 3D Secure and Payment Request types to stripe-v3

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -45,8 +45,6 @@ export namespace ReactStripeElements {
 	interface ElementProps extends ElementsOptions {
 		className?: string;
 
-		paymentRequest?: object;
-
 		elementRef?(): void;
 
 		onChange?(event: ElementChangeResponse): void;

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -173,9 +173,6 @@ declare namespace stripe {
     type checkType = 'pass' | 'fail' | 'unavailable' | 'unchecked';
     type fundingType = 'credit' | 'debit' | 'prepaid' | 'unknown';
     type tokenizationType = 'apple_pay' | 'android_pay';
-    enum ThreeDSecureSupport {
-        Required = 'required', Recommended = 'recommended', Optional = 'optional', NotSupported = 'not_supported'
-    }
     interface Card {
         id: string;
         object: string;
@@ -200,7 +197,7 @@ declare namespace stripe {
         metadata: any;
         name?: string;
         tokenization_method?: tokenizationType;
-        three_d_secure?: ThreeDSecureSupport;
+        three_d_secure?: 'required' | 'recommended' | 'optional' | 'not_supported';
     }
 
     interface RetrieveSourceOptions {
@@ -219,7 +216,7 @@ declare namespace stripe {
         interface StripePaymentRequestUpdateOptions {
             currency: string;
             total: DisplayItem;
-            displayItems?: Array<DisplayItem>;
+            displayItems?: DisplayItem[];
             shippingOptions?: ShippingOption[];
         }
 
@@ -231,13 +228,10 @@ declare namespace stripe {
             requestShipping?: boolean;
         }
 
-        enum UpdateDetailsStatus {
-            Success = 'success', Fail = 'fail', InvalidShippingAddress = 'invalid_shipping_address'
-        }
         interface UpdateDetails {
-            status: UpdateDetailsStatus;
+            status: 'success' | 'fail' | 'invalid_shipping_address';
             total?: DisplayItem;
-            displayItems?: Array<DisplayItem>;
+            displayItems?: DisplayItem[];
             shippingOptions?: ShippingOption[];
         }
 

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -173,6 +173,9 @@ declare namespace stripe {
     type checkType = 'pass' | 'fail' | 'unavailable' | 'unchecked';
     type fundingType = 'credit' | 'debit' | 'prepaid' | 'unknown';
     type tokenizationType = 'apple_pay' | 'android_pay';
+    enum ThreeDSecureSupport {
+        Required = 'required', Recommended = 'recommended', Optional = 'optional', NotSupported = 'not_supported'
+    }
     interface Card {
         id: string;
         object: string;
@@ -197,7 +200,7 @@ declare namespace stripe {
         metadata: any;
         name?: string;
         tokenization_method?: tokenizationType;
-        three_d_secure?: 'required' | 'recommended' | 'optional' | 'not_supported';
+        three_d_secure?: ThreeDSecureSupport;
     }
 
     interface RetrieveSourceOptions {
@@ -207,18 +210,16 @@ declare namespace stripe {
 
     // Container for all payment request related types
     namespace paymentRequest {
+        interface DisplayItem {
+            amount: number;
+            label: string;
+            pending?: boolean;
+        }
+
         interface StripePaymentRequestUpdateOptions {
             currency: string;
-            total: {
-                amount: number;
-                label: string;
-                pending?: boolean;
-            };
-            displayItems?: Array<{
-                amount: number;
-                label: string;
-                pending?: boolean;
-            }>;
+            total: DisplayItem;
+            displayItems?: Array<DisplayItem>;
             shippingOptions?: ShippingOption[];
         }
 
@@ -230,18 +231,13 @@ declare namespace stripe {
             requestShipping?: boolean;
         }
 
+        enum UpdateDetailsStatus {
+            Success = 'success', Fail = 'fail', InvalidShippingAddress = 'invalid_shipping_address'
+        }
         interface UpdateDetails {
-            status: 'success' | 'fail' | 'invalid_shipping_address';
-            total?: {
-                amount: number;
-                label: string;
-                pending?: boolean;
-            };
-            displayItems?: Array<{
-                amount: number;
-                label: string;
-                pending?: boolean;
-            }>;
+            status: UpdateDetailsStatus;
+            total?: DisplayItem;
+            displayItems?: Array<DisplayItem>;
             shippingOptions?: ShippingOption[];
         }
 

--- a/types/stripe-v3/index.d.ts
+++ b/types/stripe-v3/index.d.ts
@@ -12,18 +12,23 @@ declare var Stripe: stripe.StripeStatic;
 
 declare namespace stripe {
     interface StripeStatic {
-        (publicKey: string): Stripe;
+        (publicKey: string, options?: StripeOptions): Stripe;
         version: number;
     }
 
     interface Stripe {
         elements(options?: elements.ElementsCreateOptions): elements.Elements;
         createToken(element: elements.Element, options?: TokenOptions): Promise<TokenResponse>;
+        createToken(name: 'bank_account', options: BankAccountTokenOptions): Promise<TokenResponse>;
+        createToken(name: 'pii', options: PiiTokenOptions): Promise<TokenResponse>;
+        createSource(element: elements.Element, options?: {owner?: OwnerInfo}): Promise<SourceResponse>;
         createSource(options: SourceOptions): Promise<SourceResponse>;
+        retrieveSource(options: RetrieveSourceOptions): Promise<SourceResponse>;
+        paymentRequest(options: paymentRequest.StripePaymentRequestOptions): paymentRequest.StripePaymentRequest;
     }
 
     interface StripeOptions {
-      stripeAccount: string;
+      stripeAccount?: string;
     }
 
     interface TokenOptions {
@@ -37,6 +42,33 @@ declare namespace stripe {
         currency?: string;
     }
 
+    interface BankAccountTokenOptions {
+        country: string;
+        currency: string;
+        routing_number: string;
+        account_number: string;
+        account_holder_name: string;
+        account_holder_type: string;
+    }
+
+    interface PiiTokenOptions {
+        personal_id_number: string;
+    }
+
+    interface OwnerInfo {
+        address?: {
+            city?: string;
+            country?: string;
+            line1?: string;
+            line2?: string;
+            postal_code?: string;
+            state?: string;
+        };
+        name?: string;
+        email?: string;
+        phone?: string;
+    }
+
     interface SourceOptions {
         type: string;
         flow?: 'redirect' | 'receiver' | 'code_verification' | 'none';
@@ -45,19 +77,7 @@ declare namespace stripe {
         };
         currency?: string;
         amount?: number;
-        owner?: {
-            address?: {
-                city?: string;
-                country?: string;
-                line1?: string;
-                line2?: string;
-                postal_code?: string;
-                state?: string;
-            };
-            name?: string;
-            email?: string;
-            phone?: string;
-        };
+        owner?: OwnerInfo;
         metadata?: {};
         statement_descriptor?: string;
         redirect?: {
@@ -65,6 +85,9 @@ declare namespace stripe {
         };
         token?: string;
         usage?: 'reusable' | 'single_use';
+        three_d_secure?: {
+            card: string;
+        };
     }
 
     interface Token {
@@ -105,6 +128,15 @@ declare namespace stripe {
             fingerprint: string;
             last4: string;
             mandate_reference: string;
+        };
+        card?: Card;
+        status?: string;
+        redirect?: {
+            status: string;
+            url: string;
+        };
+        three_d_secure?: {
+            authenticated: boolean;
         };
     }
 
@@ -165,6 +197,94 @@ declare namespace stripe {
         metadata: any;
         name?: string;
         tokenization_method?: tokenizationType;
+        three_d_secure?: 'required' | 'recommended' | 'optional' | 'not_supported';
+    }
+
+    interface RetrieveSourceOptions {
+        id: string;
+        client_secret: string;
+    }
+
+    // Container for all payment request related types
+    namespace paymentRequest {
+        interface StripePaymentRequestUpdateOptions {
+            currency: string;
+            total: {
+                amount: number;
+                label: string;
+                pending?: boolean;
+            };
+            displayItems?: Array<{
+                amount: number;
+                label: string;
+                pending?: boolean;
+            }>;
+            shippingOptions?: ShippingOption[];
+        }
+
+        interface StripePaymentRequestOptions extends StripePaymentRequestUpdateOptions {
+            country: string;
+            requestPayerName?: boolean;
+            requestPayerEmail?: boolean;
+            requestPayerPhone?: boolean;
+            requestShipping?: boolean;
+        }
+
+        interface UpdateDetails {
+            status: 'success' | 'fail' | 'invalid_shipping_address';
+            total?: {
+                amount: number;
+                label: string;
+                pending?: boolean;
+            };
+            displayItems?: Array<{
+                amount: number;
+                label: string;
+                pending?: boolean;
+            }>;
+            shippingOptions?: ShippingOption[];
+        }
+
+        interface ShippingOption {
+            id: string;
+            label: string;
+            detail?: string;
+            amount: number;
+        }
+
+        interface ShippingAddress {
+            country: string;
+            addressLine: string[];
+            region: string;
+            city: string;
+            postalCode: string;
+            recipient: string;
+            phone: string;
+            sortingCode?: string;
+            dependentLocality?: string;
+        }
+
+        interface StripePaymentResponse {
+            token?: Token;
+            source?: Source;
+            complete: (status: string) => void;
+            payerName?: string;
+            payerEmail?: string;
+            payerPhone?: string;
+            shippingAddress?: ShippingAddress;
+            shippingOption?: ShippingOption;
+            methodName: string;
+        }
+
+        interface StripePaymentRequest {
+            canMakePayment(): Promise<{applePay?: boolean} | null>;
+            show(): void;
+            update(options: StripePaymentRequestUpdateOptions): void;
+            on(event: 'token' | 'source', handler: (response: StripePaymentResponse) => void): void;
+            on(event: 'cancel', handler: () => void): void;
+            on(event: 'shippingaddresschange', handler: (response: {updateWith: (options: UpdateDetails) => void, shippingAddress: ShippingAddress}) => void): void;
+            on(event: 'shippingoptionchange', handler: (response: {updateWith: (options: UpdateDetails) => void, shippingOption: ShippingOption}) => void): void;
+        }
     }
 
     // Container for all elements related types
@@ -181,6 +301,7 @@ declare namespace stripe {
             // Cannot find name 'HTMLElement'
             mount(domElement: any): void;
             on(event: eventTypes, handler: handler): void;
+            on(event: 'click', handler: (response: {preventDefault: () => void}) => void): void;
             focus(): void;
             blur(): void;
             clear(): void;
@@ -202,9 +323,9 @@ declare namespace stripe {
             locale?: string;
         }
 
-        type elementsType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'postalCode';
+        type elementsType = 'card' | 'cardNumber' | 'cardExpiry' | 'cardCvc' | 'postalCode' | 'paymentRequestButton';
         interface Elements {
-            create(type: elementsType, options: ElementsOptions): Element;
+            create(type: elementsType, options?: ElementsOptions): Element;
         }
 
         interface ElementsOptions {
@@ -219,13 +340,16 @@ declare namespace stripe {
             hidePostalCode?: boolean;
             hideIcon?: boolean;
             iconStyle?: 'solid' | 'default';
+            placeholder?: string;
             style?: {
                 base?: Style;
                 complete?: Style;
                 empty?: Style;
                 invalid?: Style;
+                paymentRequestButton?: PaymentRequestButtonStyleOptions;
             };
             value?: string | { [objectKey: string]: string; };
+            paymentRequest?: paymentRequest.StripePaymentRequest;
         }
 
         interface Style extends StyleOptions {
@@ -234,11 +358,13 @@ declare namespace stripe {
             '::placeholder'?: StyleOptions;
             '::selection'?: StyleOptions;
             ':-webkit-autofill'?: StyleOptions;
+            '::-ms-clear'?: StyleOptions;
         }
 
         interface Font {
             family?: string;
             src?: string;
+            display?: string;
             style?: string;
             unicodeRange?: string;
             weight?: string;
@@ -255,9 +381,16 @@ declare namespace stripe {
             iconColor?: string;
             lineHeight?: string;
             letterSpacing?: string;
+            textAlign?: string;
             textDecoration?: string;
             textShadow?: string;
             textTransform?: string;
+        }
+
+        interface PaymentRequestButtonStyleOptions {
+            type?: 'default' | 'donate' | 'buy';
+            theme: 'dark' | 'light' | 'light-outline';
+            height: string;
         }
     }
 }

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -5,8 +5,8 @@ declare function it(desc: string, fn: () => void): void;
 
 describe("Stripe", () => {
     it("should excercise all Stripe API", () => {
-        const stripe = Stripe('public-key');
-        const elements = stripe.elements();
+        const stripeInstance = Stripe('public-key');
+        const elements = stripeInstance.elements();
         const style = {
             base: {
                 color: '#32325d',
@@ -31,7 +31,7 @@ describe("Stripe", () => {
         card.on('change', (resp: stripe.elements.ElementChangeResponse) => {
             console.log(resp.brand);
         });
-        stripe.createToken(card, {
+        stripeInstance.createToken(card, {
             name: 'Jimmy',
             address_city: 'Toronto',
             address_country: 'Canada'
@@ -51,20 +51,20 @@ describe("Stripe", () => {
                 postal_code: 'XYZ'
             }
         };
-        stripe.createSource(card, { owner: ownerInfo }).then(result => {
+        stripeInstance.createSource(card, { owner: ownerInfo }).then(result => {
             if (result.error) {
-                console.log(result.error.message);
+                // handle error
                 return Promise.resolve(null);
             }
             if (!result.source) {
-                console.log('error');
+                // handle error
                 return Promise.resolve(null);
             }
-            if (!result.source.card || result.source.card.three_d_secure === 'not_supported') {
+            if (!result.source.card || result.source.card.three_d_secure === stripe.ThreeDSecureSupport.NotSupported) {
                 // make regular payment...
                 return Promise.resolve(null);
             }
-            return stripe.createSource({
+            return stripeInstance.createSource({
                 type: 'three_d_secure',
                 amount: 100,
                 currency: 'usd',
@@ -84,14 +84,14 @@ describe("Stripe", () => {
                     // make regular payment...
                     return Promise.resolve(null);
                 }
-                console.log('error');
+                // handle error
                 return Promise.resolve(null);
             }
             if (!threeDSource.source || threeDSource.source.status === 'failed' || !threeDSource.source.redirect) {
                 // make regular payment...
                 return Promise.resolve(null);
             }
-            if (threeDSource.source.redirect.status === 'succeeded') {
+            if (threeDSource.source.status === 'chargeable') {
                 // make charge...
                 return Promise.resolve(null);
             }
@@ -101,7 +101,7 @@ describe("Stripe", () => {
         });
         card.destroy();
         // test payment request
-        const paymentRequest = stripe.paymentRequest({
+        const paymentRequest = stripeInstance.paymentRequest({
             country: 'US',
             currency: 'usd',
             total: {

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -5,8 +5,8 @@ declare function it(desc: string, fn: () => void): void;
 
 describe("Stripe", () => {
     it("should excercise all Stripe API", () => {
-        const stripeInstance = Stripe('public-key');
-        const elements = stripeInstance.elements();
+        const stripe = Stripe('public-key');
+        const elements = stripe.elements();
         const style = {
             base: {
                 color: '#32325d',
@@ -31,7 +31,7 @@ describe("Stripe", () => {
         card.on('change', (resp: stripe.elements.ElementChangeResponse) => {
             console.log(resp.brand);
         });
-        stripeInstance.createToken(card, {
+        stripe.createToken(card, {
             name: 'Jimmy',
             address_city: 'Toronto',
             address_country: 'Canada'
@@ -51,7 +51,7 @@ describe("Stripe", () => {
                 postal_code: 'XYZ'
             }
         };
-        stripeInstance.createSource(card, { owner: ownerInfo }).then(result => {
+        stripe.createSource(card, { owner: ownerInfo }).then(result => {
             if (result.error) {
                 // handle error
                 return Promise.resolve(null);
@@ -60,11 +60,11 @@ describe("Stripe", () => {
                 // handle error
                 return Promise.resolve(null);
             }
-            if (!result.source.card || result.source.card.three_d_secure === stripe.ThreeDSecureSupport.NotSupported) {
+            if (!result.source.card || result.source.card.three_d_secure === 'not_supported') {
                 // make regular payment...
                 return Promise.resolve(null);
             }
-            return stripeInstance.createSource({
+            return stripe.createSource({
                 type: 'three_d_secure',
                 amount: 100,
                 currency: 'usd',
@@ -101,7 +101,7 @@ describe("Stripe", () => {
         });
         card.destroy();
         // test payment request
-        const paymentRequest = stripeInstance.paymentRequest({
+        const paymentRequest = stripe.paymentRequest({
             country: 'US',
             currency: 'usd',
             total: {

--- a/types/stripe-v3/stripe-v3-tests.ts
+++ b/types/stripe-v3/stripe-v3-tests.ts
@@ -42,7 +42,93 @@ describe("Stripe", () => {
             (error: stripe.Error) => {
                 console.error(error);
             });
+        // test 3D secure
+        const threeDSecureFrame = <HTMLIFrameElement> document.getElementById('3d-secure-frame');
+        const ownerInfo = {
+            name: 'Jimmy',
+            address: {
+                line1: '1 High Street',
+                postal_code: 'XYZ'
+            }
+        };
+        stripe.createSource(card, { owner: ownerInfo }).then(result => {
+            if (result.error) {
+                console.log(result.error.message);
+                return Promise.resolve(null);
+            }
+            if (!result.source) {
+                console.log('error');
+                return Promise.resolve(null);
+            }
+            if (!result.source.card || result.source.card.three_d_secure === 'not_supported') {
+                // make regular payment...
+                return Promise.resolve(null);
+            }
+            return stripe.createSource({
+                type: 'three_d_secure',
+                amount: 100,
+                currency: 'usd',
+                three_d_secure: {
+                    card: result.source.id
+                },
+                redirect: {
+                    return_url: location.origin + '/3d-secure-processing-page'
+                }
+            });
+        }).then(threeDSource => {
+            if (!threeDSource) {
+                return Promise.resolve(null);
+            }
+            if (threeDSource.error) {
+                if (threeDSource.error.code === 'payment_method_not_available') {
+                    // make regular payment...
+                    return Promise.resolve(null);
+                }
+                console.log('error');
+                return Promise.resolve(null);
+            }
+            if (!threeDSource.source || threeDSource.source.status === 'failed' || !threeDSource.source.redirect) {
+                // make regular payment...
+                return Promise.resolve(null);
+            }
+            if (threeDSource.source.redirect.status === 'succeeded') {
+                // make charge...
+                return Promise.resolve(null);
+            }
+            threeDSecureFrame.setAttribute('src', threeDSource.source.redirect.url);
+            // now wait until chargeable then make the charge
+            return Promise.resolve(null);
+        });
         card.destroy();
+        // test payment request
+        const paymentRequest = stripe.paymentRequest({
+            country: 'US',
+            currency: 'usd',
+            total: {
+                label: 'Demo total',
+                amount: 1000,
+            }
+        });
+        const prButton = elements.create('paymentRequestButton', { paymentRequest });
+        paymentRequest.canMakePayment().then(result => {
+            if (result) {
+                prButton.mount('#payment-request-button');
+            } else {
+                document.getElementById('payment-request-button')!.style.display = 'none';
+            }
+        });
+        paymentRequest.on('token', ev => {
+            const body = JSON.stringify({token: ev.token!.id});
+            // post to server...
+            Promise.resolve({ok: true})
+            .then(response => {
+                if (response.ok) {
+                    ev.complete('success');
+                } else {
+                    ev.complete('fail');
+                }
+            });
+        });
     });
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://stripe.com/docs/stripe-js/reference> and <https://stripe.com/docs/sources/three-d-secure> and <https://stripe.com/docs/stripe-js/elements/payment-request-button>.

I'm not sure whether to increase the version number in the header since this still applies to v3 and I can't see any subversion numbers.

I've tested the 3D secure process in my own code, but not the payment request. I added this to support everything in the Stripe.js reference.