### PR TITLE
[copy-webpack-plugin] Upgrade to v4.4.1 from v4.0.0

### DIFF
--- a/types/copy-webpack-plugin/copy-webpack-plugin-tests.ts
+++ b/types/copy-webpack-plugin/copy-webpack-plugin-tests.ts
@@ -51,6 +51,21 @@ const c: Configuration = {
 				to: 'directory/with/extension.ext',
 				toType: 'dir'
 			},
+
+			// transform and cache (cache is always used with transform option).
+			{
+				from: 'src/*.png',
+				to: 'dest/',
+				transform: (content, path) => content,
+				cache: true
+			},
+
+			// Copy glob results (without dot files) to {output}/to/directory/
+			{
+				from: '**/*.png',
+				fromArgs: { dot: false },
+				to: 'to/directory'
+			},
 		], {
 			ignore: [
 				// Doesn't copy any files with a txt extension

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for copy-webpack-plugin v4.4.1
+// Type definitions for copy-webpack-plugin 4.4
 // Project: https://github.com/kevlened/copy-webpack-plugin
 // Definitions by: flying-sheep <https://github.com/flying-sheep>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/copy-webpack-plugin/index.d.ts
+++ b/types/copy-webpack-plugin/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for copy-webpack-plugin v4.0.0
+// Type definitions for copy-webpack-plugin v4.4.1
 // Project: https://github.com/kevlened/copy-webpack-plugin
 // Definitions by: flying-sheep <https://github.com/flying-sheep>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,9 +10,15 @@ interface MiniMatchGlob extends IOptions {
 	glob: string
 }
 
+interface MiniMatchOptions extends IOptions {
+	cwd?: string
+}
+
 interface CopyPattern {
 	/** File source path or glob */
 	from: string | MiniMatchGlob
+	/** See the `node-glob` options in addition to the ones below. (default: `{ cwd: context }`) */
+	fromArgs?: MiniMatchOptions
 	/**
 	 * Path or webpack file-loader patterns. defaults:
 	 * output root if `from` is file or dir.
@@ -38,6 +44,8 @@ interface CopyPattern {
 	ignore?: Array<string | MiniMatchGlob>
 	/** Function that modifies file contents before writing to webpack. (default: `(content, path) => content`) */
 	transform?: (content: string, path: string) => string
+	/** Enable transform caching. You can use `{ cache: { key: 'my-cache-key' } }` to invalidate the cache. (default: `false`) */
+	cache?: boolean | { key: string }
 	/** Overwrites files already in `compilation.assets` (usually added by other plugins; default: `false`) */
 	force?: boolean
 }

--- a/types/copy-webpack-plugin/tslint.json
+++ b/types/copy-webpack-plugin/tslint.json
@@ -7,7 +7,6 @@
         "ban-types": false,
         "callable-types": false,
         "comment-format": false,
-        "dt-header": false,
         "eofline": false,
         "export-just-namespace": false,
         "import-spacing": false,


### PR DESCRIPTION
Add `fromArgs` and `cache` options.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/webpack-contrib/copy-webpack-plugin/tree/v4.4.1
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.