### PR TITLE
Add type definition for should-sinon

### DIFF
--- a/types/should-sinon/index.d.ts
+++ b/types/should-sinon/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/shouldjs/sinon
 // Definitions by: AryloYeung <https://github.com/Arylo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
+// TypeScript Version: 2.3
 
 import * as s from "sinon";
 import should = require("should");

--- a/types/should-sinon/index.d.ts
+++ b/types/should-sinon/index.d.ts
@@ -1,0 +1,91 @@
+// Type definitions for should-sinon 0.0
+// Project: https://github.com/shouldjs/sinon
+// Definitions by: AryloYeung <https://github.com/Arylo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+import * as s from "sinon";
+import should = require("should");
+
+declare module "sinon" {
+    interface SinonSpy {
+        should: ShouldSinonAssertion;
+    }
+    interface ShouldSinonAssertion extends should.Assertion {
+        /**
+         * Assert stub was called with given object as this always. So if you call stub several times
+         * all should be with the same object
+         */
+        alwaysCalledOn(obj: any): void;
+        alwaysCalledWith(...args: any[]): void;
+        /**
+         * Passes if the spy was always called with the provided arguments and no others.
+         */
+        alwaysCalledWithExactly(...args: any[]): void;
+        /**
+         * Returns true if spy was always called with matching arguments (and possibly others).
+         */
+        alwaysCalledWithMatch(...args: any[]): void;
+        alwaysCalledWithNew(): void;
+        /**
+         * Passes if the spy always threw the given exception. The exception can be a
+         * string denoting its type, or an actual object. If no argument is
+         * provided, the assertion passes if the spy ever threw any exception.
+         */
+        alwaysThrew(ex: string | Error): void;
+        /**
+         * Assert stub was called at exact number of times
+         */
+        callCount(count: number): void;
+        /**
+         * Assert stub was called at least once
+         */
+        called(): void;
+        /**
+         * Assert stub was called with given object as this
+         */
+        calledOn(obj: any): void;
+        /**
+         * Assert stub was called at exactly once
+         */
+        calledOnce(): void;
+        /**
+         * Assert stub was called at exactly thrice
+         */
+        calledThrice(): void;
+        /**
+         * Assert stub was called at exactly twice
+         */
+        calledTwice(): void;
+        /**
+         * Asserts that stub was called with given arguments
+         */
+        calledWith(...args: any[]): void;
+        /**
+         * Returns true if call received provided arguments and no others.
+         */
+        calledWithExactly(...args: any[]): void;
+        /**
+         * Returns true if spy was called with matching arguments (and possibly others).
+         */
+        calledWithMatch(...args: any[]): void;
+        /**
+         * Asserts that stub was called with new
+         */
+        calledWithNew(): void;
+        /**
+         * Returns true if the spy/stub was never called with the provided arguments.
+         */
+        neverCalledWith(...args: any[]): void;
+        /**
+         * Returns true if the spy/stub was never called with matching arguments.
+         */
+        neverCalledWithMatch(...args: any[]): void;
+        /**
+         * Passes if the spy threw the given exception. The exception can be a
+         * string denoting its type, or an actual object. If no argument is
+         * provided, the assertion passes if the spy ever threw any exception.
+         */
+        threw(ex: string | Error): void;
+    }
+}

--- a/types/should-sinon/package.json
+++ b/types/should-sinon/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "should": "^13.2.1"
+    }
+}

--- a/types/should-sinon/should-sinon-tests.ts
+++ b/types/should-sinon/should-sinon-tests.ts
@@ -1,0 +1,13 @@
+const callback = sinon.spy();
+const obj = { };
+
+callback.should.be.alwaysCalledOn(obj);
+callback.should.be.alwaysCalledWith(1, 2, 3);
+callback.should.have.callCount(0);
+callback.should.be.called();
+callback.should.be.calledOn(obj);
+callback.should.be.calledOnce();
+callback.should.be.calledThrice();
+callback.should.be.calledTwice();
+callback.should.be.calledWith(1, 2, 3);
+callback.should.be.neverCalledWith(1, 2, 3);

--- a/types/should-sinon/tsconfig.json
+++ b/types/should-sinon/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "should-sinon-tests.ts"
+    ]
+}

--- a/types/should-sinon/tslint.json
+++ b/types/should-sinon/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
