### PR TITLE
Fix import

### DIFF
--- a/types/chai-subset/index.d.ts
+++ b/types/chai-subset/index.d.ts
@@ -17,4 +17,5 @@ declare global {
 }
 
 declare function chaiSubset(chai: any, utils: any): void;
+declare namespace chaiSubset { }
 export = chaiSubset;


### PR DESCRIPTION
Fix Module '".../node_modules/@types/chai-subset/index"' resolves to a non-module entity and cannot be imported using this construct with
```ts
import * as chaiSubset from "chai-subset";
```