### PR TITLE
fix swagger-schema-official to work with typescript 2.7

### DIFF
--- a/types/swagger-schema-official/index.d.ts
+++ b/types/swagger-schema-official/index.d.ts
@@ -87,7 +87,7 @@ export interface Path {
   options?: Operation;
   head?: Operation;
   patch?: Operation;
-  parameters?: [Parameter];
+  parameters?: Parameter[];
 }
 
 // ----------------------------- Operation -----------------------------------


### PR DESCRIPTION
Typescript 2.7 Changes the behavior of tuples causing the existing definitions to fail.

cc: @mohsen1 , @bsouthga , @nimerritt 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Typescript 2.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#fixed-length-tuples)