### PR TITLE
cucumber: Add optional StepDefinitionOptions param for defineStep function signature

### DIFF
--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -60,6 +60,7 @@ export function BeforeAll(options: HookOptions | string, code: GlobalHookCode): 
 
 export function defineParameterType(transform: Transform): void;
 export function defineStep(pattern: RegExp | string, code: StepDefinitionCode): void;
+export function defineStep(pattern: RegExp | string, options: StepDefinitionOptions, code: StepDefinitionCode): void;
 
 export function Given(pattern: RegExp | string, code: StepDefinitionCode): void;
 export function Given(pattern: RegExp | string, options: StepDefinitionOptions, code: StepDefinitionCode): void;


### PR DESCRIPTION
As `Given`, `When`, and `Then` are all aliases to `defineStep`, then `defineStep` should also follow the same signature.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md
