### PR TITLE
Types for bootstrap-3-typeahead

### DIFF
--- a/types/bootstrap-3-typeahead/bootstrap-3-typeahead-tests.ts
+++ b/types/bootstrap-3-typeahead/bootstrap-3-typeahead-tests.ts
@@ -1,0 +1,19 @@
+$(document).ready(() => {
+    // basic usage
+    $('#typeahead').typeahead();
+    $('#typeahead').typeahead('lookup');
+    $('#typeahead').typeahead('lookup', 'Display name 1');
+    $('#typeahead').typeahead('getActive');
+    $('#typeahead').typeahead('destroy');
+
+    // with options example
+    const options: Bootstrap3Typeahead.Options = {
+        source: [
+            {id: 'someId1', name: 'Display name 1'},
+            {id: 'someId2', name: 'Display name 2'}
+        ],
+        autoSelect: true
+    };
+
+    $('#typeahead').typeahead(options);
+});

--- a/types/bootstrap-3-typeahead/index.d.ts
+++ b/types/bootstrap-3-typeahead/index.d.ts
@@ -1,0 +1,107 @@
+// Type definitions for Bootstrap 3 Typeahead 4.0
+// Project: https://github.com/bassjobsen/Bootstrap-3-Typeahead
+// Definitions by: Anderson Friaça <https://github.com/AndersonFriaca>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+
+declare namespace Bootstrap3Typeahead {
+    interface Options {
+        /**
+         * The data source to query against
+         */
+        source?: string[] | object[] | ((query?: string, process?: ((callback: any) => string|string[]|object[])) => void);
+
+        /**
+         * The max number of items to display in the dropdown
+         */
+        items?: number;
+
+        /**
+         * The minimum character length needed before triggering autocomplete suggestions
+         */
+        minLength?: number;
+
+        /**
+         * If hints should be shown as soon as the input gets focus
+         */
+        showHintOnFocus?: boolean | 'all';
+
+        /**
+         * Number of pixels the scrollable parent container scrolled down
+         */
+        scrollHeight?: number | (() => number);
+
+        /**
+         * The method used to determine if a query matches an item
+         */
+        matcher?: (item: string) => boolean;
+
+        /**
+         * Method used to sort autocomplete results
+         */
+        sorter?: (items: string[]) => string[];
+
+        /**
+         * The method used to return selected item
+         */
+        updater?: (item: string) => string;
+
+        /**
+         * Method used to highlight autocomplete results
+         */
+        highlighter?: (item: string) => string;
+
+        /**
+         * Method used to get textual representation of an item of the sources
+         */
+        displayText?: (item: string|{name: string}) => string;
+
+        /**
+         * Allows you to dictate whether or not the first suggestion is selected automatically
+         */
+        autoSelect?: boolean;
+
+        /**
+         * Call back function to execute after selected an item
+         */
+        afterSelect?: (item: string) => void;
+
+        /**
+         * Adds a delay between lookups
+         */
+        delay?: number;
+
+        /**
+         * Use this option to add the menu to another div
+         */
+        appendTo?: JQuery;
+
+        /**
+         * Set to true if you want the menu to be the same size than the input it is attached to
+         */
+        fitToElement?: boolean;
+
+        /**
+         * Adds an item to the end of the list
+         */
+        addItem?: object;
+    }
+}
+interface JQuery {
+    /**
+     * Initialize or destroy Typeahead
+     */
+    typeahead(methodOrOptions?: 'destroy' | Bootstrap3Typeahead.Options): JQuery;
+
+    /**
+     * To get the currently active item
+     */
+    typeahead(method: 'getActive'): undefined|string|object;
+
+    /**
+     * To trigger the lookup function externally
+     */
+    typeahead(method: 'lookup', defaultValue?: string): JQuery;
+}

--- a/types/bootstrap-3-typeahead/tsconfig.json
+++ b/types/bootstrap-3-typeahead/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "bootstrap-3-typeahead-tests.ts"
+    ]
+}

--- a/types/bootstrap-3-typeahead/tslint.json
+++ b/types/bootstrap-3-typeahead/tslint.json
@@ -1,0 +1,1 @@
+{"extends": "dtslint/dt.json"}


### PR DESCRIPTION
Types creation of [https://github.com/bassjobsen/Bootstrap-3-Typeahead](https://github.com/bassjobsen/Bootstrap-3-Typeahead)
NPM: [https://www.npmjs.com/package/bootstrap-3-typeahead](https://www.npmjs.com/package/bootstrap-3-typeahead)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If adding a new definition:
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.