### PR TITLE
Catalog: ReactSpecimen supports a 'sourceText' prop

### DIFF
--- a/types/catalog/catalog-tests.tsx
+++ b/types/catalog/catalog-tests.tsx
@@ -36,7 +36,7 @@ render(config, document.body);
 markdown`
 # Test
 
-${<ReactSpecimen>
+${<ReactSpecimen sourceText='.'>
   <div />
 </ReactSpecimen>}
 `;

--- a/types/catalog/index.d.ts
+++ b/types/catalog/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for catalog 2.1
+// Type definitions for catalog 3.2
 // Project: https://github.com/interactivethings/catalog/
 // Definitions by: Peter Gassner <https://github.com/grossbart>, Tomas Carnecky <https://github.com/wereHamster>
 // Definitions: https://github.com/interactivethings/catalog/
@@ -100,6 +100,7 @@ export interface ReactSpecimenProps extends DefaultCatalogProps {
   frame?: boolean;
   state?: any;
   responsive?: boolean | string | string[];
+  sourceText?: string;
 }
 export class ReactSpecimen extends React.Component<ReactSpecimenProps> {}
 


### PR DESCRIPTION
Also update version to 3.2, which is what we claim compatibility with.

The prop is not documented in the official documentation, but it's there, in the proptypes (https://github.com/interactivethings/catalog/blob/35d20c43dafe9628cd7400e855354656428bf1a5/src/specimens/ReactSpecimen/ReactSpecimen.js#L184)
