### PR TITLE
bootstrap-datepicker: add enableOnReadonly option

### DIFF
--- a/types/bootstrap-datepicker/index.d.ts
+++ b/types/bootstrap-datepicker/index.d.ts
@@ -58,6 +58,7 @@ interface DatepickerOptions {
     daysOfWeekHighlighted?:string|number[];
     defaultViewDate?:Date|string|DatepickerViewDate;
     updateViewDate?:boolean;
+    enableOnReadonly?: boolean;
 }
 
 interface DatepickerViewDate {


### PR DESCRIPTION
Add missing `enableOnReadonly` option to `bootstrap-datepicker` package.