### PR TITLE
knex: Add alias definition to QueryBuilder#select

### DIFF
--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -177,6 +177,7 @@ declare namespace Knex {
     interface Table {
         (tableName: string): QueryBuilder;
         (callback: Function): QueryBuilder;
+        (raw: Raw): QueryBuilder;
     }
 
     interface Distinct extends ColumnNameQueryBuilder {

--- a/types/knex/index.d.ts
+++ b/types/knex/index.d.ts
@@ -171,6 +171,7 @@ declare namespace Knex {
     }
 
     interface Select extends ColumnNameQueryBuilder {
+        (aliases: { [alias: string]: string }): QueryBuilder;
     }
 
     interface Table {

--- a/types/knex/knex-tests.ts
+++ b/types/knex/knex-tests.ts
@@ -160,6 +160,7 @@ var knex = Knex({
 
 // Knex Query Builder
 knex.select('title', 'author', 'year').from('books');
+knex.select({ name: 'title', writer: 'author' }).from(knex.raw('books'));
 knex.select().table('books');
 
 knex.avg('sum_column1').from(function() {


### PR DESCRIPTION
QueryBuilder#select also accepts arguments in form of alias object:

    knex.select({ owner: "user.name" });

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://knexjs.org/#Builder-identifier-syntax
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.