### PR TITLE
fix gifffer

### DIFF
--- a/types/gifffer/gifffer-tests.ts
+++ b/types/gifffer/gifffer-tests.ts
@@ -1,4 +1,4 @@
-import Gifffer from 'gifffer';
+import * as Gifffer from 'gifffer';
 
 let gifs: HTMLButtonElement[];
 

--- a/types/gifffer/gifffer-tests.ts
+++ b/types/gifffer/gifffer-tests.ts
@@ -1,4 +1,4 @@
-import * as Gifffer from 'gifffer';
+import Gifffer = require('gifffer');
 
 let gifs: HTMLButtonElement[];
 

--- a/types/gifffer/index.d.ts
+++ b/types/gifffer/index.d.ts
@@ -3,15 +3,21 @@
 // Definitions by: William Lohan <https://github.com/gatimus>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/**
- * @see {@link https://github.com/krasimir/gifffer#styling|Styling}
- */
-export interface GiffferOptions {
-    playButtonStyles: { [style: string]: string; };
-    playButtonIconStyles: { [style: string]: string; };
+declare namespace Gifffer {
+    /**
+     * @see {@link https://github.com/krasimir/gifffer#styling|Styling}
+     */
+    interface GiffferOptions {
+        playButtonStyles: { [style: string]: string; };
+        playButtonIconStyles: { [style: string]: string; };
+    }
 }
 
 /**
  * @see {@link https://github.com/krasimir/gifffer#usage|Usage}
  */
-export default function Gifffer(options?: GiffferOptions): HTMLButtonElement[];
+declare function Gifffer(options?: Gifffer.GiffferOptions): HTMLButtonElement[];
+
+export as namespace Gifffer;
+
+export = Gifffer;

--- a/types/gifffer/tsconfig.json
+++ b/types/gifffer/tsconfig.json
@@ -15,8 +15,7 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true,
-        "esModuleInterop": true
+        "forceConsistentCasingInFileNames": true
     },
     "files": [
         "index.d.ts",

--- a/types/gifffer/tsconfig.json
+++ b/types/gifffer/tsconfig.json
@@ -15,7 +15,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<none>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Now use: `import * as Gifffer from 'gifffer';`
Fixes:

> TypeError: gifffer_1.default is not a function