### PR TITLE
Add new chrome.devtools.inspectedWindow.eval overload

### DIFF
--- a/types/chrome/index.d.ts
+++ b/types/chrome/index.d.ts
@@ -1679,6 +1679,17 @@ declare namespace chrome.devtools.inspectedWindow {
      */
     export function eval<T>(expression: string, callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void): void;
     /**
+     * Evaluates a JavaScript expression in the context of the main frame of the inspected page. The expression must evaluate to a JSON-compliant object, otherwise an exception is thrown. The eval function can report either a DevTools-side error or a JavaScript exception that occurs during evaluation. In either case, the result parameter of the callback is undefined. In the case of a DevTools-side error, the isException parameter is non-null and has isError set to true and code set to an error code. In the case of a JavaScript error, isException is set to true and value is set to the string value of thrown object.
+     * @param expression An expression to evaluate.
+     * @param options The options parameter can contain one or more options.
+     * @param callback A function called when evaluation completes.
+     * If you specify the callback parameter, it should be a function that looks like this:
+     * function(object result, object exceptionInfo) {...};
+     * Parameter result: The result of evaluation.
+     * Parameter exceptionInfo: An object providing details if an exception occurred while evaluating the expression.
+     */
+    export function eval<T>(expression: string, options: EvalOptions, callback?: (result: T, exceptionInfo: EvaluationExceptionInfo) => void): void;
+    /**
      * Retrieves the list of resources from the inspected page.
      * @param callback A function that receives the list of resources when the request completes.
      * The callback parameter should be a function that looks like this:
@@ -1690,6 +1701,15 @@ declare namespace chrome.devtools.inspectedWindow {
     export var onResourceAdded: ResourceAddedEvent;
     /** Fired when a new revision of the resource is committed (e.g. user saves an edited version of the resource in the Developer Tools). */
     export var onResourceContentCommitted: ResourceContentCommittedEvent;
+
+    export interface EvalOptions {
+        /** If specified, the expression is evaluated on the iframe whose URL matches the one specified. By default, the expression is evaluated in the top frame of the inspected page. */
+        frameURL?: string;
+        /** Evaluate the expression in the context of the content script of the calling extension, provided that the content script is already injected into the inspected page. If not, the expression is not evaluated and the callback is invoked with the exception parameter set to an object that has the isError field set to true and the code field set to E_NOTFOUND. */
+        useContentScriptContext?: boolean;
+        /** Evaluate the expression in the context of a content script of an extension that matches the specified origin. If given, contextSecurityOrigin overrides the 'true' setting on userContentScriptContext. */
+        contextSecurityOrigin?: string;
+    }
 }
 
 ////////////////////


### PR DESCRIPTION
There is a new overload to the eval method which accepts an options parameter.

I'd love to add a `@since` attribute on this one, but unfortunenately the [Google Chrome API deocumentation](https://developer.chrome.com/apps/api_index) has just replaced all `@since` to read `Since Chrome 38.` which is definetly wrong for this API.

This PR fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23597.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [chrome.devtools.inspectedWindow.eval(string expression, object options, function callback) ](https://developer.chrome.com/extensions/devtools_inspectedWindow#method-eval)
