### PR TITLE
Chrome Package has TS7006  error on showNativeTouchCallibration

### DIFF
--- a/types/chrome/chrome-app.d.ts
+++ b/types/chrome/chrome-app.d.ts
@@ -1189,7 +1189,7 @@ declare namespace chrome.system.display {
      * @param {string} id The display's unique identifier.
      * @param {(success) => void} callback Optional callback to inform the caller that the touch calibration has ended. The argument of the callback informs if the calibration was a success or not.
      */
-    export function showNativeTouchCalibration(id: string, callback: (success) => void): void;
+    export function showNativeTouchCalibration(id: string, callback: (success: boolean) => void): void;
 
     /**
      * @description Starts custom touch calibration for a display. This should be called when using a custom UX for collecting calibration data. If another touch calibration is already in progress this will throw an error.


### PR DESCRIPTION
Compiling with `noImplicitAny` set to `true` generated the following warning:

> node_modules/@types/chrome/chrome-app.d.ts(1192,71): error TS7006: Parameter 'success' implicitly has an 'any' type.

The method `showNativeTouchCalibration` is documented here: https://developer.chrome.com/apps/system_display#method-showNativeTouchCalibration

It describes callback as such:

> If you specify the callback parameter, it should be a function that looks like this:
>
> `function(boolean success) {...};`

<h4 />
Please fill in this template.

- [X ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ X] Test the change in your own code. (Compile and run.)
- [ X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If changing an existing definition:
- [X ] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.chrome.com/apps/system_display#method-showNativeTouchCalibration
- [NA ] Increase the version number in the header if appropriate.
- [ NA] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
