### PR TITLE
Fixes compiling hapi with esModuleInterop enabled

### DIFF
--- a/types/hapi/definitions/server/server.d.ts
+++ b/types/hapi/definitions/server/server.d.ts
@@ -1,6 +1,6 @@
 import * as http from "http";
 import * as zlib from "zlib";
-import * as Podium from "podium";
+import Podium = require("podium");
 import {
     ApplicationState,
     Lifecycle,


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/issues/21872
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Fixes compiling of hapi 17 definitions with esModuleInterop enabled per https://github.com/Microsoft/TypeScript/issues/21872