### PR TITLE
React; <font> tag has ommitted.

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3514,6 +3514,7 @@ declare namespace React {
         fieldset: DetailedHTMLFactory<FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>;
         figcaption: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         figure: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
+        font: DetailedHTMLFactory<HTMLAttributes<HTMLFontElement>, HTMLFontElement>;
         footer: DetailedHTMLFactory<HTMLAttributes<HTMLElement>, HTMLElement>;
         form: DetailedHTMLFactory<FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
         h1: DetailedHTMLFactory<HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;
@@ -3788,6 +3789,7 @@ declare global {
             fieldset: React.DetailedHTMLProps<React.FieldsetHTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>;
             figcaption: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             figure: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+            font: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFontElement>, HTMLFontElement>;
             footer: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
             form: React.DetailedHTMLProps<React.FormHTMLAttributes<HTMLFormElement>, HTMLFormElement>;
             h1: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>;


### PR DESCRIPTION
From the PR, using `<font>`tag in TypeScript is possible.