### PR TITLE
Updated angular-translate with missing function getAvailableLanguageKeys

### DIFF
--- a/types/angular-translate/index.d.ts
+++ b/types/angular-translate/index.d.ts
@@ -71,6 +71,7 @@ declare module 'angular' {
             isReady(): boolean;
             onReady(): angular.IPromise<void>;
             resolveClientLocale(): string;
+            getAvailableLanguageKeys(): string[];
         }
 
         interface ITranslateProvider extends angular.IServiceProvider {


### PR DESCRIPTION
Updated angular-translate `ITranslateService`  interface with a missing `getAvailableLanguageKeys()` function.

see [source code](https://github.com/angular-translate/angular-translate/blob/master/src/service/translate.js#L2346)


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source code](https://github.com/angular-translate/angular-translate/blob/master/src/service/translate.js#L2346)