### PR TITLE
playcanvas: assets prefix, app.loadScene

### DIFF
--- a/types/playcanvas/engine/asset/asset-registry.d.ts
+++ b/types/playcanvas/engine/asset/asset-registry.d.ts
@@ -11,6 +11,8 @@ declare namespace pc {
     class AssetRegistry {
         constructor(loader: pc.ResourceLoader)
 
+        prefix: string;
+
         /**
         * @function
         * @name pc.AssetRegistry#list

--- a/types/playcanvas/engine/framework/application.d.ts
+++ b/types/playcanvas/engine/framework/application.d.ts
@@ -207,6 +207,25 @@ declare namespace pc {
         loadSceneSettings(url: string, callback: (...args: any[]) => {}): void;
 
         /**
+        * @function
+        * @name pc.Application#loadScene
+        * @description Load a scene file.
+        * @param {String} url The URL of the scene file. Usually this will be "scene_id.json"
+        * @param {Function} callback The function to call after loading, passed (err, entity) where err is null if no errors occurred.
+        * @example
+        *
+        * app.loadScene("1000.json", function (err, entity) {
+        *     if (!err) {
+        *       var e = app.root.find("My New Entity");
+        *     } else {
+        *       // error
+        *     }
+        *   }
+        * });
+        */
+       loadScene(url: string, callback: (...args: any[]) => {}): void;
+
+        /**
          * @function
          * @name pc.Application#start
          * @description Start the Application updating


### PR DESCRIPTION
assets.prefix was mentioned in metadata, but the attribute
was not defined in the class.

app.loadScene appears to be undocumented, but is supposed to be used
when using the engine programmatically.

Ref:

  - https://github.com/playcanvas/engine/blob/master/src/framework/application.js#L491
  - https://github.com/playcanvas/engine/issues/1095
  - https://github.com/playcanvas/engine/pull/284

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/playcanvas/engine/pull/284
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.