### PR TITLE
[retry-as-promised] add type definitions

### DIFF
--- a/types/retry-as-promised/index.d.ts
+++ b/types/retry-as-promised/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for retry-as-promised 2.3
+// Project: https://github.com/mickhansen/retry-as-promised
+// Definitions by: Florian Oellerich <https://github.com/Raigen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import Promise = require('bluebird');
+
+declare namespace retryAsPromised {
+    type MatchOption = string | RegExp | Error;
+    interface Options {
+        $current?: number;
+        max?: number;
+        timeout?: number;
+        match?: MatchOption[] | MatchOption;
+        backoffBase?: number;
+        backoffExponent?: number;
+        report?: (message: string, obj: Options, err?: any) => void;
+        name?: string;
+    }
+
+    type RetryCallback<T> = ({ current }: { current: Options['$current'] }) => Promise.Thenable<T>;
+    type RetryAsPromisedStatic = <T = any>(callback: RetryCallback<T>, options: Options | number) => Promise<T>;
+}
+
+declare const retryAsPromised: retryAsPromised.RetryAsPromisedStatic;
+export = retryAsPromised;

--- a/types/retry-as-promised/retry-as-promised-tests.ts
+++ b/types/retry-as-promised/retry-as-promised-tests.ts
@@ -1,0 +1,27 @@
+import retry = require('retry-as-promised');
+
+interface Product {
+    name: string;
+}
+
+const log = (...args: any[]): void => {};
+
+retry(() => Promise.resolve(), {});
+retry(() => Promise.reject('Error matching values'), {});
+retry(() => Promise.reject(new Error('No matching values')), {});
+retry(() => Promise.resolve(), {
+    max: 100,
+    timeout: 60000,
+    match: ['Error matching values', new Error('No matching values'), new RegExp(/Deadlock/, 'i')],
+    backoffBase: 100,
+    backoffExponent: 1.1,
+    name: 'Source',
+    report: (message, options) => {
+        if (options.name === 'Source') {
+            log(options.name);
+            log('iteration', options.$current);
+        }
+    }
+});
+retry<Product>(() => Promise.resolve({ name: 'test' }) , {});
+retry<Product>(() => Promise.reject(new Error('No matching product')), {});

--- a/types/retry-as-promised/tsconfig.json
+++ b/types/retry-as-promised/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true,
+        "strictFunctionTypes": true
+    },
+    "files": [
+        "index.d.ts",
+        "retry-as-promised-tests.ts"
+    ]
+}

--- a/types/retry-as-promised/tslint.json
+++ b/types/retry-as-promised/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.