### PR TITLE
ember: fix TS2344 error when not using ember-data

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -2100,6 +2100,12 @@ declare module 'ember' {
         }
     }
 }
+declare module 'ember-test-helpers' {
+    import DS from 'ember-data';
+    interface TestContext {
+        store: DS.Store;
+    }
+}
 declare module 'ember-data/adapter' {
     import DS from 'ember-data';
     export default DS.Adapter;

--- a/types/ember-test-helpers/index.d.ts
+++ b/types/ember-test-helpers/index.d.ts
@@ -8,7 +8,6 @@
 
 declare module 'ember-test-helpers' {
     import Ember from 'ember';
-    import DS from 'ember-data';
     import { TemplateFactory } from 'htmlbars-inline-precompile';
     import RSVP from "rsvp";
 
@@ -40,7 +39,6 @@ declare module 'ember-test-helpers' {
         container: Ember.Container;
         dispatcher: Ember.EventDispatcher;
         application: Ember.Application;
-        store: DS.Store;
         register(fullName: string, factory: any): void;
         factory(fullName: string): any;
         inject: {


### PR DESCRIPTION
This fixes a compile error when ember-data is _not_ a project dependency:
https://github.com/typed-ember/ember-cli-typescript#fixing-the-ember-data-error-ts2344-problem
