### PR TITLE
[jest] updated toHaveProperty method of Matchers

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -470,7 +470,7 @@ declare namespace jest {
          * and it is set to a certain numeric value.
          */
         toHaveLength(expected: number): R;
-        toHaveProperty(propertyPath: string, value?: any): R;
+        toHaveProperty(propertyPath: string | any[], value?: any): R;
         /**
          * Check that a string matches a regular expression.
          */

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -642,6 +642,22 @@ describe('rejects', () => {
     });
 });
 
+// https://facebook.github.io/jest/docs/en/expect.html#tohavepropertykeypath-value
+describe('toHaveProperty', () => {
+    it('it accepts a keyPath as string', () => {
+        expect({ a: { b: {}}}).toHaveProperty('a');
+    });
+    it('it accepts a keyPath as string with dot notation', () => {
+        expect({ a: { b: {}}}).toHaveProperty('a.b');
+    });
+    it('it accepts a keyPath as an array', () => {
+      expect({ a: { b: {}}}).toHaveProperty(['a', 'b']);
+    });
+    it('it accepts a keyPath as an array containing non-string values', () => {
+      expect({ a: ['b']}).toHaveProperty(['a', 0]);
+    });
+});
+
 class MyTransformer implements jest.Transformer {
     process(text: string, path: string) {
         return `


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Jest Documentation](https://facebook.github.io/jest/docs/en/expect.html#tohavepropertykeypath-value) and [Flow Annotated Source](https://github.com/facebook/jest/blob/v22.1.0/packages/expect/src/matchers.js#L489)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.