### PR TITLE
Allow belongsTo to return a resolved Model

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -34,6 +34,14 @@ declare module 'ember-data' {
                 inverse?: string | null;
                 polymorphic?: boolean;
             }
+        ): ModelRegistry[K];
+        function belongsTo<K extends keyof ModelRegistry>(
+            modelName: K,
+            options: {
+                async: false;
+                inverse?: string | null;
+                polymorphic?: boolean;
+            }
         ): Ember.ComputedProperty<ModelRegistry[K]>;
         function belongsTo<K extends keyof ModelRegistry>(
             modelName: K,


### PR DESCRIPTION
When trying to using `model.set('blogPost', blogPost)` for example would result in

```
Argument of type 'BlogPost' is not assignable to parameter of type 'BlogPost & PromiseObject<BlogPost>'.
  Type 'BlogPost' is not assignable to type 'PromiseObject<BlogPost>'.
    Property 'content' is missing in type 'BlogPost'.
``` 

I think this is caused because the current definition requires it to either be a `ComputedProperty<BlogPost>` or `BlogPost & PromiseObject<BlogPost>`

Not 100% that this approach to fixing the issue will be correct, but appreciate feedback