### PR TITLE
Cytoscape: Allow overlay style to be set

### DIFF
--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -3145,7 +3145,7 @@ declare namespace cytoscape {
         /**
          * http://js.cytoscape.org/#style/node-body
          */
-        interface Node extends PaddingNode {
+        interface Node extends Partial<Overlay>, PaddingNode {
             "label"?: string;
             /**
              * The width of the node’s body.
@@ -3320,7 +3320,7 @@ declare namespace cytoscape {
             "pie-i-background-opacity": number;
         }
 
-        interface Edge extends EdgeLine, EdgeArror { }
+        interface Edge extends EdgeLine, EdgeArror, Partial<Overlay> { }
 
         /**
          * These properties affect the styling of an edge’s line:

--- a/types/cytoscape/index.d.ts
+++ b/types/cytoscape/index.d.ts
@@ -8,7 +8,7 @@
 //
 // Translation from Objects in help to Typescript interface.
 // http://js.cytoscape.org/#notation/functions
-//
+// TypeScript Version: 2.2
 
 /**
  * cy   --> Cy.Core


### PR DESCRIPTION
Without this change, trying to set an overlay style fails with a type error.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://js.cytoscape.org/#style/overlay
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.