### PR TITLE
update odata definition

### DIFF
--- a/types/odata/index.d.ts
+++ b/types/odata/index.d.ts
@@ -29,7 +29,6 @@ declare module 'odata' {
         inlinecount: number;        // if inlinecount is set, here the counting is gold
         data: T;                    // holds the data after an callback
         param: {};				    // this object holds all parameter for a route
-        oConfig: Options;		    // the internal config, passed over from the o function
 
         config<T>(options ?: Options) : OHandler<T>
         progress<T>(callback : () => any) : OHandler<T>

--- a/types/odata/index.d.ts
+++ b/types/odata/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for odata v0.3.4
+// Type definitions for odata v0.3
 // Project: https://github.com/janhommes/odata
 // Definitions by: Jan Hommes <https://github.com/janhommes>, Jean-Christophe Chalte <https://github.com/jcchalte>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -26,14 +26,17 @@ declare module 'odata' {
     }
 
     interface OHandler<T> {
-        inlinecount : number
-        data : T
+        inlinecount: number;        // if inlinecount is set, here the counting is gold
+        data: T;                    // holds the data after an callback
+        param: {};				    // this object holds all parameter for a route
+        oConfig: Options;		    // the internal config, passed over from the o function
 
         config<T>(options ?: Options) : OHandler<T>
         progress<T>(callback : () => any) : OHandler<T>
 
-        get<T>(callback ?: (data : T) => void) : Q.Promise<OHandler<T>>
-        save<T>(callback ?: (data : T) => void) : Q.Promise<OHandler<T>>
+        get<T>(callback ?: (data : T) => void, errorCallback?: (status: number) => void) : Q.Promise<OHandler<T>>
+        save<T>(callback ?: (data : T) => void, errorCallback?: (status: number) => void) : Q.Promise<OHandler<T>>
+        query: () => string;
 
         post<T>(params : any) : OHandler<T>
         patch<T>(params : any) : OHandler<T>
@@ -78,8 +81,14 @@ declare module 'odata' {
         deleteRef<T>(resource : string, id : string | number) : OHandler<T>
     }
 
+    interface OHandlerStatic {
+        config: (config: Options) => OHandlerStatic;
+        isEndpoint: () => boolean;
+    }
+
     interface OFn<T> extends OHandler<T> {
-        (options ?: string | Options) : OHandler<T>
+        (): OHandlerStatic;
+        (options?: string | Options): OHandler<T>;
     }
 
     var o : OFn<{}>;

--- a/types/odata/index.d.ts
+++ b/types/odata/index.d.ts
@@ -82,16 +82,13 @@ declare module 'odata' {
     }
 
     interface OHandlerStatic {
+        (): OHandlerStatic;
+        (options?: string | Options): OHandler<{}>;
         config: (config: Options) => OHandlerStatic;
         isEndpoint: () => boolean;
     }
 
-    interface OFn<T> extends OHandler<T> {
-        (): OHandlerStatic;
-        (options?: string | Options): OHandler<T>;
-    }
-
-    var o : OFn<{}>;
+    var o : OHandlerStatic;
 
     export = o
 }

--- a/types/odata/odata-tests.ts
+++ b/types/odata/odata-tests.ts
@@ -72,7 +72,8 @@ o('http://services.odata.org/V4/OData/OData.svc/Products(2)')
     .get<Product>()
     .then(function(oHandler) {
         console.log(oHandler.data);
-    }).fail(function(ex) {
+    })
+    .fail(function(ex) {
         console.log(ex);
     });
 
@@ -114,12 +115,12 @@ o('http://services.odata.org/V4/OData/OData.svc/Products(1)')
 o('http://services.odata.org/V4/OData/OData.svc/Products')
     .find(2)
     .get<Product>()
-    .then(function(data) {
-        data.value[0].Name="NewName";
-        return(this.save<Product>());
+    .then(function(oHandler) {
+        oHandler.data.Name="NewName";
+        return(oHandler.save<Product>());
     })
-    .then(function(data) {
-        console.log(data.value[0].Name); //NewName
+    .then(function(oHandler) {
+        console.log(oHandler.data.Name); //NewName
     })
     .fail(function(ex) {
         console.log("error");
@@ -139,6 +140,9 @@ o('Products').get<Product>(function(data) {
 const oEequest = o('http://services.odata.org/V4/OData/OData.svc/Products')
     .find(2);
 const queryString = oEequest.query();
+if (queryString !== 'http://services.odata.org/V4/OData/OData.svc/Products(2)') {
+    throw new Error('assert error');
+}
 
 //basic config
 o().config({

--- a/types/odata/odata-tests.ts
+++ b/types/odata/odata-tests.ts
@@ -114,12 +114,14 @@ o('http://services.odata.org/V4/OData/OData.svc/Products(1)')
 o('http://services.odata.org/V4/OData/OData.svc/Products')
     .find(2)
     .get<Product>()
-    .then(function(oHandler) {
-        oHandler.data.Name="NewName";
-        return(o.save<Product>());
-    }).then(function(oHandler) {
-        console.log(oHandler.data.Name); //NewName
-    }).fail(function(ex) {
+    .then(function(data) {
+        data.value[0].Name="NewName";
+        return(this.save<Product>());
+    })
+    .then(function(data) {
+        console.log(data.value[0].Name); //NewName
+    })
+    .fail(function(ex) {
         console.log("error");
     });
 

--- a/types/odata/odata-tests.ts
+++ b/types/odata/odata-tests.ts
@@ -20,6 +20,8 @@ interface Category {
 o('http://services.odata.org/V4/OData/OData.svc/Products')
     .get<Product>(function(data) {
         console.log(data); //returns an array of Product data
+    }, function(status) {
+        console.error(status); // error with status
     });
 
 
@@ -132,7 +134,9 @@ o('Products').get<Product>(function(data) {
     //same result like the first example on this page
 });
 
-
+const oEequest = o('http://services.odata.org/V4/OData/OData.svc/Products')
+    .find(2);
+const queryString = oEequest.query();
 
 //basic config
 o().config({


### PR DESCRIPTION

errorCallback for get and save method added
(https://github.com/janhommes/o.js/blob/master/o.js)
from code:
`base.get = function (callback, errorCallback) {`
`base.save = function (callback, errorCallback) {`

query method added, to get the query string

`base.query = function (overrideRes) {`

this module is a constructor function. If you call it without parameter you get the base object, if you call it with a parameter you get an new instance of it with the base object in it back.

```
interface OHandlerStatic {
        (): OHandlerStatic;
        (options?: string | Options): OHandler<{}>;
        config: (config: Options) => OHandlerStatic;
        isEndpoint: () => boolean;
}
```

from code:
```
function o(res) {
    var base = this;
    ...
    if (typeof res === 'undefined') {
        return (base);
    } else {
       return (new oData(res, base.oConfig));
    }
}
```