### PR TITLE
update jsonrpc-serializer definitions

### DIFF
--- a/types/jsonrpc-serializer/index.d.ts
+++ b/types/jsonrpc-serializer/index.d.ts
@@ -1,28 +1,113 @@
 // Type definitions for jsonrpc-serializer 0.2
-// Project: https://github.com/soggie/jsonrpc-serializer#readme
-// Definitions by: Akim95 <https://github.com/Akim95>
+// Project: https://github.com/soggie/jsonrpc-serializer
+// Definitions by: Akim95 <https://github.com/Akim95>, many20 <https://github.com/many20>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.5
 
-export function request<T>(id: string | number, method: string, params?: T): string;
-export function notification<T>(method: string, params?: T): string;
-export function success<T>(id: string, result: T): string;
-export function error<T>(id: string, error: T): string;
-export function deserialize<T>(msg: string): T;
-export function requestObject<T>(id: string | number, method: string, params?: T): string;
-export function notificationObject<T>(method: string, params?: T): string;
-export function successObject<T>(id: string, result: T): string;
-export function errorObject<T>(id: string, error: T): string;
-export function deserializeObject<T>(msg: T): void;
+export type PayloadType = 'request' | 'notification' | 'success' | 'error';
+// export const PayloadType = {
+//    request: 'request' as PayloadType,
+//    notification: 'notification' as PayloadType,
+//    success: 'success' as PayloadType,
+//    error: 'error' as PayloadType
+// };
 
-export const errorHandler: any;
+export interface DeserializeObject {
+    type: PayloadType;
+    payload: RequestPayloadObject | NotificationPayloadObject | SuccessPayloadObject | ErrorPayloadObject;
+}
+
+export interface PayloadObject {
+    id?: string | number;
+    method?: string;
+    params?: any;
+    result?: any;
+    error?: SerializerError;
+}
+
+export interface RequestPayloadObject extends PayloadObject {
+    id: string;
+    method: string;
+    params: any;
+}
+
+export interface NotificationPayloadObject extends PayloadObject {
+    method: string;
+    params: any;
+}
+
+export interface SuccessPayloadObject extends PayloadObject {
+    id: string | number;
+    result: any;
+}
+
+export interface ErrorPayloadObject extends PayloadObject {
+    id: string | number;
+    error: SerializerError;
+}
+
+export interface SerializerError extends Error {
+    name: string;
+    code: number;
+    message: string;
+    data?: any[];
+}
+
+export function request(id: string | number, method: string, params?: any): string;
+export function notification(method: string, params?: any): string;
+export function success(id: string | number, result: any): string;
+export function error(id: string | number, error: err.JsonRpcError): string;
+export function deserialize(msg: string): DeserializeObject;
+export function requestObject(id: string | number, method: string, params?: any): PayloadObject;
+export function notificationObject(method: string, params?: any): PayloadObject;
+export function successObject(id: string | number, result: any): PayloadObject;
+export function errorObject(id: string | number, error: SerializerError): PayloadObject;
+export function deserializeObject(msg: PayloadObject): DeserializeObject;
+
+export type errorHandler = (errors: string[] | null) => void;
 
 export namespace err {
-    class JsonRpcError {
-        constructor(msg: string);
-        serialize(): any;
+    type ErrorName = 'JsonRpcError' | 'ParseError' | 'InvalidRequestError' | 'MethodNotFoundError' | 'InvalidParamsError';
+    // const ErrorName = {
+    //    JsonRpcError: 'JsonRpcError' as ErrorName,
+    //    ParseError: 'ParseError' as ErrorName,
+    //    InvalidRequestError: 'InvalidRequestError' as ErrorName,
+    //    MethodNotFoundError: 'MethodNotFoundError' as ErrorName,
+    //    InvalidParamsError: 'InvalidParamsError' as ErrorName
+    // };
+
+    type ErrorCode = -32603 | -32700 | -32600 | -32601 | -32602;
+    // const ErrorCode = {
+    //    JsonRpcError: -32603 as ErrorCode,
+    //    ParseError: -32700 as ErrorCode,
+    //    InvalidRequestError: -32600 as ErrorCode,
+    //    MethodNotFoundError: -32601 as ErrorCode,
+    //    InvalidParamsError: -32602 as ErrorCode
+    // };
+
+    class JsonRpcError extends Error implements SerializerError {
+        name: string | ErrorName;
+        code: number | ErrorCode;
+        message: string;
+        data?: any[];
+
+        constructor(msg: string, ...args: any[]);
+        serialize(): string;
     }
-    class InvalidParamsError {}
-    class InvalidRequestError {}
-    class MethodNotFoundError {}
-    class ParseError {}
+
+    class InvalidParamsError extends JsonRpcError {
+        constructor(...args: any[]);
+    }
+
+    class InvalidRequestError extends JsonRpcError {
+        constructor(...args: any[]);
+    }
+
+    class MethodNotFoundError extends JsonRpcError {
+        constructor(...args: any[]);
+    }
+
+    class ParseError extends JsonRpcError {
+        constructor(...args: any[]);
+    }
 }

--- a/types/jsonrpc-serializer/jsonrpc-serializer-tests.ts
+++ b/types/jsonrpc-serializer/jsonrpc-serializer-tests.ts
@@ -1,3 +1,4 @@
+import * as uuid from 'node-uuid';
 import * as jrs from 'jsonrpc-serializer';
 
 // request tests
@@ -46,3 +47,40 @@ const request = {
 
 jrs.deserialize(JSON.stringify(request));
 jrs.deserializeObject(request);
+
+// ---
+
+const request2 = jrs.request('request-id', 'request-method');
+
+// ---> "{\"jsonrpc\":\"2.0\",\"id\":\"request-id\",\"method:\":\"request-method\"}"
+
+const ok1 = "{\"jsonrpc\":\"2.0\",\"id\":\"request-id\",\"result\":\"success!!\"}";
+
+const response1 = jrs.deserialize(ok1);
+
+// ---
+
+const payload2 = jrs.request(
+    uuid.v4(),   // generates a V4 UUID string
+    'saveUser',  // the method to call
+    {
+        name  : 'Ruben Tan',
+        email : 'foo@bar.com',
+        race  : 'unicorn'
+    }
+);
+
+// ---
+
+const payload3 = jrs.notification(
+    'newMessage',  // the method to call
+    {
+        subject : 'Test message',
+        message : 'This is a test message'
+    }
+);
+
+// ---
+
+const err1 = new jrs.err.JsonRpcError('This is an error');
+const str1 = err1.serialize();


### PR DESCRIPTION
update with more detailed definitions.

return type of requestObject(), notificationObject, successObject, errorObject, deserializeObject are not string or void, you get Objects of type PayloadObject.

the Error classes have a base class of JsonRpcError
