### PR TITLE
ember: fix Computed type when imported from '@ember/object/computed'

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -3528,7 +3528,8 @@ declare module '@ember/object' {
 
 declare module '@ember/object/computed' {
     import Ember from 'ember';
-    export default class ComputedProperty<T> extends Ember.ComputedProperty<T> { }
+    type Computed<T> = Ember.ComputedProperty<T>;
+    export default Computed;
     export const alias: typeof Ember.computed.alias;
     export const and: typeof Ember.computed.and;
     export const bool: typeof Ember.computed.bool;

--- a/types/ember/test/computed.ts
+++ b/types/ember/test/computed.ts
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import Component from '@ember/component';
-import { or } from '@ember/object/computed';
+import Computed, { or, alias } from '@ember/object/computed';
 import { assertType } from './lib/assert';
+import Service from "@ember/service";
 
 const Person = Ember.Object.extend({
     firstName: '',
@@ -160,3 +161,17 @@ const component2 = Component.extend({
 }).create();
 
 assertType<boolean>(component2.get('isAnimal'));
+
+export default class MyService extends Service {
+    bool = false;
+    boolAlias: Computed<boolean> = alias('bool');
+
+    isTrue() {
+        return this.get('boolAlias');
+    }
+}
+
+const myService = MyService.create({ bool: true });
+assertType<boolean>(myService.get('bool'));
+assertType<boolean>(myService.get('boolAlias'));
+assertType<boolean>(myService.isTrue());


### PR DESCRIPTION
Fixes a regression caused by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23287
```ts
import Ember from 'ember';
import Computed from '@ember/object/computed';

class Foo extends Ember.Object {
  x: Ember.Computed<string>;
  y: Computed<string>;
}

Foo.create().get('x'); // string (good)
Foo.create().get('y'); // Computed<String> (bad)
```
The `Computed` type should work the same no matter how it's imported