### PR TITLE
[hls.js] Add proxy file for light distributed bundle

### DIFF
--- a/types/hls.js/dist/hls.light.d.ts
+++ b/types/hls.js/dist/hls.light.d.ts
@@ -1,0 +1,2 @@
+import Hls = require("../index");
+export = Hls;

--- a/types/hls.js/tsconfig.json
+++ b/types/hls.js/tsconfig.json
@@ -19,6 +19,7 @@
     },
     "files": [
         "index.d.ts",
+        "dist/hls.light.d.ts",
         "hls.js-tests.ts"
     ]
 }


### PR DESCRIPTION
Tiny proxy file to allows importing `hls.js` directly from `hls.js/dist/hls.light` with type safety.
Uses same pattern used in `@types/lodash`.