### PR TITLE
[pg] Allow to type rows in QueryResult

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for pg 7.4
 // Project: https://github.com/brianc/node-postgres
 // Definitions by: Phips Peter <https://github.com/pspeter3>
+//                 Arnaud Benhamdine <https://github.com/abenhamdine>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -53,11 +54,11 @@ export interface QueryArrayConfig extends QueryConfig {
     rowMode: 'array';
 }
 
-export interface QueryResult {
+export interface QueryResult<T=any> {
     command: string;
     rowCount: number;
     oid: number;
-    rows: any[];
+    rows: T[];
 }
 
 export interface FieldDef {
@@ -70,11 +71,11 @@ export interface FieldDef {
     format: string;
 }
 
-export interface QueryArrayResult {
+export interface QueryArrayResult<T=any> {
     command: string;
     rowCount: number;
     oid: number;
-    rows: any[][];
+    rows: T[][];
     fields: FieldDef[];
 }
 
@@ -84,8 +85,8 @@ export interface Notification {
     payload?: string;
 }
 
-export interface ResultBuilder extends QueryResult {
-    addRow(row: any): void;
+export interface ResultBuilder<T=any> extends QueryResult<T> {
+    addRow(row: T): void;
 }
 
 export class Pool extends events.EventEmitter {
@@ -105,12 +106,12 @@ export class Pool extends events.EventEmitter {
     end(callback: () => void): void;
 
     query(queryStream: QueryConfig & stream.Readable): stream.Readable;
-    query(queryConfig: QueryArrayConfig): Promise<QueryArrayResult>;
-    query(queryConfig: QueryConfig): Promise<QueryResult>;
-    query(queryText: string, values?: any[]): Promise<QueryResult>;
-    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): Query;
-    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): Query;
-    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): Query;
+    query<T=any>(queryConfig: QueryArrayConfig): Promise<QueryArrayResult<T>>;
+    query<T=any>(queryConfig: QueryConfig): Promise<QueryResult<T>>;
+    query<T=any>(queryText: string, values?: any[]): Promise<QueryResult<T>>;
+    query<T=any>(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult<T>) => void): Query;
+    query<T=any>(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult<T>) => void): Query;
+    query<T=any>(queryText: string, values: any[], callback: (err: Error, result: QueryResult<T>) => void): Query;
 
     on(event: "error", listener: (err: Error, client: PoolClient) => void): this;
     on(event: "connect" | "acquire" | "remove", listener: (client: PoolClient) => void): this;
@@ -123,12 +124,12 @@ export class ClientBase extends events.EventEmitter {
     connect(callback: (err: Error) => void): void;
 
     query(queryStream: QueryConfig & stream.Readable): stream.Readable;
-    query(queryConfig: QueryArrayConfig): Promise<QueryArrayResult>;
-    query(queryConfig: QueryConfig): Promise<QueryResult>;
-    query(queryText: string, values?: any[]): Promise<QueryResult>;
-    query(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult) => void): Query;
-    query(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult) => void): Query;
-    query(queryText: string, values: any[], callback: (err: Error, result: QueryResult) => void): Query;
+    query<T=any>(queryConfig: QueryArrayConfig): Promise<QueryArrayResult<T>>;
+    query<T=any>(queryConfig: QueryConfig): Promise<QueryResult<T>>;
+    query<T=any>(queryText: string, values?: any[]): Promise<QueryResult<T>>;
+    query<T=any>(queryConfig: QueryArrayConfig, callback: (err: Error, result: QueryArrayResult<T>) => void): Query;
+    query<T=any>(queryTextOrConfig: string | QueryConfig, callback: (err: Error, result: QueryResult<T>) => void): Query;
+    query<T=any>(queryText: string, values: any[], callback: (err: Error, result: QueryResult<T>) => void): Query;
 
     copyFrom(queryText: string): stream.Writable;
     copyTo(queryText: string): stream.Readable;

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -166,3 +166,27 @@ pool.end().then(() => console.log('pool has ended'));
   await client.query('SELECT NOW()');
   client.release();
 })();
+
+/* tests of type parameters for QueryResult */
+// this is the interface for row object that we'll pass to pg.query type result
+interface MyRow {
+  x: number,
+  y: string
+}
+
+// type parameter for callback API
+client.query<MyRow>('SELECT NOW()', (err, res) => {
+  const someRows: MyRow[] = res.rows
+});
+
+// type parameter for promise api
+client.query<MyRow>('SELECT NOW()').then(res => {
+  const someRows: MyRow[] = res.rows
+});
+
+// type parameter with async/await
+(async () => {
+  const client = await pool.connect();
+  const result: { rows: MyRow[] } = await client.query<MyRow>('SELECT NOW()');
+  client.release();
+})();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

**Type parameter for rows**
This change allows to type rows in QueryResult object, with a `<T>` parameter.
In the QueryResult object, property `rows` is currenty typed with `any`
This change allows to pass a type to `query` method, in order to type the rows, depending on what the user expects.
Use accordingly with a library who generates typings from the db schema (such as https://github.com/SweetIQ/schemats), it allows to type reliably results from the db.

Note that the type parameter defaults to `any`, to avoid breaking current type checks.

Exemple of use :  
```ts
interface User {
  name: string,
  email: string
}

client.query<User>('SELECT * FROM user', (err, res) => {
  const users: User[] = res.rows
});
```

