### PR TITLE
React-DnD - Add optional `offsetX` and `offsetY` properties to DragPreviewOptions

### DIFF
--- a/types/react-dnd/index.d.ts
+++ b/types/react-dnd/index.d.ts
@@ -125,6 +125,8 @@ declare module __ReactDnd {
         captureDraggingState?: boolean;
         anchorX?: number;
         anchorY?: number;
+        offsetX?: number;
+        offsetY?: number;
     }
 
     type ConnectDragSource = DragElementWrapper<DragSourceOptions>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [https://react-dnd.github.io/react-dnd/docs-drag-source-connector.html](https://react-dnd.github.io/react-dnd/docs-drag-source-connector.html)