### PR TITLE
Sinon: Fix typing for `useFakeTimers` (changed since Sinon 3.0.0)

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -232,10 +232,15 @@ declare namespace Sinon {
         setSystemTime(date: Date): void;
     }
 
+    interface SinonFakeTimersConfig {
+        now: number | Date;
+        toFake: string[];
+        shouldAdvanceTime: boolean;
+    }
+
     interface SinonFakeTimersStatic {
-        (): SinonFakeTimers;
         (now?: number | Date): SinonFakeTimers;
-        (config: { now?: number | Date, toFake?: string[], shouldAdvanceTime?: boolean }): SinonFakeTimers;
+        (config?: Partial<SinonFakeTimersConfig>): SinonFakeTimers;
     }
 
     interface SinonStatic {

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -234,8 +234,8 @@ declare namespace Sinon {
 
     interface SinonFakeTimersStatic {
         (): SinonFakeTimers;
-        (...timers: string[]): SinonFakeTimers;
-        (now: number, ...timers: string[]): SinonFakeTimers;
+        (now?: number | Date): SinonFakeTimers;
+        (config: { now?: number | Date, toFake?: string[], shouldAdvanceTime?: boolean }): SinonFakeTimers;
     }
 
     interface SinonStatic {

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -121,6 +121,10 @@ function testSandbox() {
         sandbox.mock(objectUnderTest).expects("process").once();
     }
     sandbox.useFakeTimers();
+    sandbox.useFakeTimers({
+        now: 1,
+        toFake: ['Date']
+    });
     sandbox.useFakeXMLHttpRequest();
     sandbox.useFakeServer();
     sandbox.restore();


### PR DESCRIPTION
The parameters for `useFakeTimers()` changed in Sinon 3.0.0. It now expects a `config` property instead.

See http://sinonjs.org/releases/v4.3.0/fake-timers/ for more details.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.