### PR TITLE
Add type definitions for graphql-resolve-batch

### DIFF
--- a/types/graphql-resolve-batch/graphql-resolve-batch-tests.ts
+++ b/types/graphql-resolve-batch/graphql-resolve-batch-tests.ts
@@ -1,129 +1,93 @@
 import { createBatchResolver, ResolverFunction } from "graphql-resolve-batch";
 
-// Test cases split up in namespaces to test different type inference scenarios.
-
-namespace WithSourceAndResult {
-    interface SomeTestSource {
-        someSourceProp: string;
-    }
-
-    interface SomeTestResult {
-        someTestResultProp: string;
-    }
-
-    const verify = createBatchResolver<SomeTestSource, SomeTestResult>(
-        (sources, _, __) => {
-            return sources.map(source => {
-                const res: SomeTestResult = {
-                    someTestResultProp: ""
-                };
-
-                return res;
-            });
-        }
-    );
+interface SomeTestSource {
+    someSourceProp: string;
 }
 
-namespace WithSourceAndResultAsPromise {
-    interface SomeTestSource {
-        someSourceProp: string;
-    }
-
-    interface SomeTestResult {
-        someTestResultProp: string;
-    }
-
-    const verify = createBatchResolver<SomeTestSource, SomeTestResult>(
-        (sources, _, __) => {
-            // $ExpectType ReadonlyArray<SomeTestSource>
-            const verifySources = sources;
-
-            return sources.map(source => {
-                return new Promise<SomeTestResult>(resolve => {
-                    const res: SomeTestResult = {
-                        someTestResultProp: ""
-                    };
-
-                    resolve(res);
-                });
-            });
-        }
-    );
+interface SomeTestArgs {
+    someArg: string;
 }
 
-namespace WithSourceAndArgsAndResult {
-    interface SomeTestSource {
-        someSourceProp: string;
-    }
+interface SomeTestContext {
+    someContextProp: string;
+}
 
-    interface SomeTestArgs {
-        someArg: string;
-    }
+interface SomeTestResult {
+    someTestResultProp: string;
+}
 
-    interface SomeTestResult {
-        someTestResultProp: string;
-    }
+const withSourceAndResultTyped = createBatchResolver<
+    SomeTestSource,
+    SomeTestResult
+>((sources, _, __) => {
+    return sources.map(source => {
+        const res: SomeTestResult = {
+            someTestResultProp: ""
+        };
 
-    const verify = createBatchResolver<
-        SomeTestSource,
-        SomeTestResult,
-        SomeTestArgs
-    >((sources, args, _) => {
-        // $ExpectType ReadonlyArray<SomeTestSource>
-        const verifySources = sources;
-        // $ExpectType string
-        const verifyArgs = args.someArg;
+        return res;
+    });
+});
 
-        return sources.map(source => {
-            return new Promise<SomeTestResult>(resolve => {
-                const res: SomeTestResult = {
-                    someTestResultProp: ""
-                };
+const withSourceAndResultTypedAsPromise = createBatchResolver<
+    SomeTestSource,
+    SomeTestResult
+>((sources, _, __) => {
+    // $ExpectType ReadonlyArray<SomeTestSource>
+    const verifySources = sources;
 
-                resolve(res);
-            });
+    return sources.map(source => {
+        return new Promise<SomeTestResult>(resolve => {
+            const res: SomeTestResult = {
+                someTestResultProp: ""
+            };
+
+            resolve(res);
         });
     });
-}
+});
 
-namespace WithSourceAndArgsAndContextAndResult {
-    interface SomeTestSource {
-        someSourceProp: string;
-    }
+const withSourceAndArgsAndResultTyped = createBatchResolver<
+    SomeTestSource,
+    SomeTestResult,
+    SomeTestArgs
+>((sources, args, _) => {
+    // $ExpectType ReadonlyArray<SomeTestSource>
+    const verifySources = sources;
+    // $ExpectType string
+    const verifyArgs = args.someArg;
 
-    interface SomeTestArgs {
-        someArg: string;
-    }
+    return sources.map(source => {
+        return new Promise<SomeTestResult>(resolve => {
+            const res: SomeTestResult = {
+                someTestResultProp: ""
+            };
 
-    interface SomeTestContext {
-        someContextProp: string;
-    }
-
-    interface SomeTestResult {
-        someTestResultProp: string;
-    }
-
-    const verify = createBatchResolver<
-        SomeTestSource,
-        SomeTestResult,
-        SomeTestArgs,
-        SomeTestContext
-    >((sources, args, context) => {
-        // $ExpectType ReadonlyArray<SomeTestSource>
-        const verifySources = sources;
-        // $ExpectType string
-        const verifyArgs = args.someArg;
-        // $ExpectType string
-        const verifyContext = context.someContextProp;
-
-        return sources.map(source => {
-            return new Promise<SomeTestResult>(resolve => {
-                const res: SomeTestResult = {
-                    someTestResultProp: ""
-                };
-
-                resolve(res);
-            });
+            resolve(res);
         });
     });
-}
+});
+
+const withSourceAndArgsAndContextTyped = createBatchResolver<
+    SomeTestSource,
+    SomeTestResult,
+    SomeTestArgs,
+    SomeTestContext
+>((sources, args, context) => {
+    // $ExpectType ReadonlyArray<SomeTestSource>
+    const verifySources = sources;
+    // $ExpectType string
+    const verifyArgs = args.someArg;
+    // $ExpectType string
+    const verifyContext = context.someContextProp;
+
+    return sources.map(source => {
+        return new Promise<SomeTestResult>(resolve => {
+            const res: SomeTestResult = {
+                someTestResultProp: ""
+            };
+
+            resolve(res);
+        });
+    });
+});

--- a/types/graphql-resolve-batch/graphql-resolve-batch-tests.ts
+++ b/types/graphql-resolve-batch/graphql-resolve-batch-tests.ts
@@ -1,0 +1,129 @@
+import { createBatchResolver, ResolverFunction } from "graphql-resolve-batch";
+
+// Test cases split up in namespaces to test different type inference scenarios.
+
+namespace WithSourceAndResult {
+    interface SomeTestSource {
+        someSourceProp: string;
+    }
+
+    interface SomeTestResult {
+        someTestResultProp: string;
+    }
+
+    const verify = createBatchResolver<SomeTestSource, SomeTestResult>(
+        (sources, _, __) => {
+            return sources.map(source => {
+                const res: SomeTestResult = {
+                    someTestResultProp: ""
+                };
+
+                return res;
+            });
+        }
+    );
+}
+
+namespace WithSourceAndResultAsPromise {
+    interface SomeTestSource {
+        someSourceProp: string;
+    }
+
+    interface SomeTestResult {
+        someTestResultProp: string;
+    }
+
+    const verify = createBatchResolver<SomeTestSource, SomeTestResult>(
+        (sources, _, __) => {
+            // $ExpectType ReadonlyArray<SomeTestSource>
+            const verifySources = sources;
+
+            return sources.map(source => {
+                return new Promise<SomeTestResult>(resolve => {
+                    const res: SomeTestResult = {
+                        someTestResultProp: ""
+                    };
+
+                    resolve(res);
+                });
+            });
+        }
+    );
+}
+
+namespace WithSourceAndArgsAndResult {
+    interface SomeTestSource {
+        someSourceProp: string;
+    }
+
+    interface SomeTestArgs {
+        someArg: string;
+    }
+
+    interface SomeTestResult {
+        someTestResultProp: string;
+    }
+
+    const verify = createBatchResolver<
+        SomeTestSource,
+        SomeTestResult,
+        SomeTestArgs
+    >((sources, args, _) => {
+        // $ExpectType ReadonlyArray<SomeTestSource>
+        const verifySources = sources;
+        // $ExpectType string
+        const verifyArgs = args.someArg;
+
+        return sources.map(source => {
+            return new Promise<SomeTestResult>(resolve => {
+                const res: SomeTestResult = {
+                    someTestResultProp: ""
+                };
+
+                resolve(res);
+            });
+        });
+    });
+}
+
+namespace WithSourceAndArgsAndContextAndResult {
+    interface SomeTestSource {
+        someSourceProp: string;
+    }
+
+    interface SomeTestArgs {
+        someArg: string;
+    }
+
+    interface SomeTestContext {
+        someContextProp: string;
+    }
+
+    interface SomeTestResult {
+        someTestResultProp: string;
+    }
+
+    const verify = createBatchResolver<
+        SomeTestSource,
+        SomeTestResult,
+        SomeTestArgs,
+        SomeTestContext
+    >((sources, args, context) => {
+        // $ExpectType ReadonlyArray<SomeTestSource>
+        const verifySources = sources;
+        // $ExpectType string
+        const verifyArgs = args.someArg;
+        // $ExpectType string
+        const verifyContext = context.someContextProp;
+
+        return sources.map(source => {
+            return new Promise<SomeTestResult>(resolve => {
+                const res: SomeTestResult = {
+                    someTestResultProp: ""
+                };
+
+                resolve(res);
+            });
+        });
+    });
+}

--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for graphql-resolve-batch 1.0
+// Project: https://github.com/calebmer/graphql-resolve-batch#readme
+// Definitions by: Rutger Hendrickx <https://github.com/nayni>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+export function createBatchResolver<
+    TSource,
+    TReturn,
+    TArgs = any,
+    TContext = any
+>(
+    batchResolveFn: BatchResolveFunction<TSource, TArgs, TContext, TReturn>
+): ResolverFunction<TSource, TArgs, TContext, TReturn>;
+
+export type ResolverFunction<TSource, TArgs, TContext, TReturn> = (
+    source: TSource,
+    args: TArgs,
+    context: TContext
+) => Promise<TReturn>;
+
+export type BatchResolveFunction<TSource, TArgs, TContext, TReturn> = (
+    sources: ReadonlyArray<TSource>,
+    args: TArgs,
+    context: TContext
+) => TReturn[] | Promise<TReturn>[];

--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -23,4 +23,4 @@ export type BatchResolveFunction<TSource, TArgs, TContext, TReturn> = (
     sources: ReadonlyArray<TSource>,
     args: TArgs,
     context: TContext
-) => TReturn[] | Promise<TReturn>[];
+) => TReturn[] | Array<Promise<TReturn>>;

--- a/types/graphql-resolve-batch/tsconfig.json
+++ b/types/graphql-resolve-batch/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "strictFunctionTypes": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "graphql-resolve-batch-tests.ts"]
+}

--- a/types/graphql-resolve-batch/tslint.json
+++ b/types/graphql-resolve-batch/tslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-namespace": false,
+        "array-type": [true, "array"]
+    }
+}

--- a/types/graphql-resolve-batch/tslint.json
+++ b/types/graphql-resolve-batch/tslint.json
@@ -1,7 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-namespace": false,
-        "array-type": [true, "array"]
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Typings for https://github.com/calebmer/graphql-resolve-batch

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
