### PR TITLE
zen-observable changed import style to es6 default, following its docs

### DIFF
--- a/types/zen-observable/index.d.ts
+++ b/types/zen-observable/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for zen-observable 0.5
+// Type definitions for zen-observable 0.8
 // Project: https://github.com/zenparsing/zen-observable
 // Definitions by: Kombu <https://github.com/aicest>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -59,4 +59,4 @@ declare class Observable<T> {
 declare namespace Observable {
 }
 
-export = Observable;
+export default Observable;

--- a/types/zen-observable/zen-observable-tests.ts
+++ b/types/zen-observable/zen-observable-tests.ts
@@ -1,4 +1,4 @@
-import Observable = require('zen-observable');
+import Observable from 'zen-observable';
 
 function assert(val: boolean) {
     if (!val) {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [URL](https://github.com/zenparsing/zen-observable#usage)
- [x] Increase the version number in the header if appropriate.
- [x] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`~~.