### PR TITLE
Add name member to Database interface.

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -581,6 +581,9 @@ declare namespace PouchDB {
     }
 
     interface Database<Content extends {} = {}>  {
+        /** The name passed to the PouchDB constructor and unique identifier of the database. */
+        name: string;
+
         /** Fetch all documents matching the given options. */
         allDocs<Model>(options?: Core.AllDocsWithKeyOptions | Core.AllDocsWithKeysOptions | Core.AllDocsWithinRangeOptions | Core.AllDocsOptions):
             Promise<Core.AllDocsResponse<Content & Model>>;


### PR DESCRIPTION
Looking at the PouchDB source, this member is always set[1] (earlier in that function we throw if the name is not a string).

[1] https://github.com/pouchdb/pouchdb/blob/master/packages/node_modules/pouchdb-core/src/constructor.js#L68

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/pouchdb/pouchdb/blob/master/packages/node_modules/pouchdb-core/src/constructor.js#L68
- [n/a] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.