### PR TITLE
Fix the return type of pouchdb-core's bulkDocs to include Error values

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -594,7 +594,7 @@ declare namespace PouchDB {
          */
         bulkDocs<Model>(docs: Array<Core.PutDocument<Content & Model>>,
                         options: Core.BulkDocsOptions | null,
-                        callback: Core.Callback<Core.Response[]>): void;
+                        callback: Core.Callback<Array<Core.Response | Core.Error>>): void;
 
         /**
          * Create, update or delete multiple documents. The docs argument is an array of documents.
@@ -604,7 +604,7 @@ declare namespace PouchDB {
          * Finally, to delete a document, include a _deleted parameter with the value true.
          */
         bulkDocs<Model>(docs: Array<Core.PutDocument<Content & Model>>,
-                        options?: Core.BulkDocsOptions): Promise<Core.Response[]>;
+                        options?: Core.BulkDocsOptions): Promise<Array<Core.Response | Core.Error >>;
 
         /** Compact the database */
         compact(options?: Core.CompactOptions): Promise<Core.Response>;

--- a/types/pouchdb-core/pouchdb-core-tests.ts
+++ b/types/pouchdb-core/pouchdb-core-tests.ts
@@ -47,10 +47,19 @@ function testBulkDocs() {
     const model = { property: 'test' };
     const model2 = { property: 'test' };
 
+    const isError = (
+        result: PouchDB.Core.Response | PouchDB.Core.Error
+    ): result is PouchDB.Core.Error => {
+        return !!(<PouchDB.Core.Error> result).error;
+    };
+
     db.bulkDocs([model, model2]).then((result) => {
-        result.forEach(({ ok, id, rev }) => {
+        result.forEach(result => {
+          if (!isError(result)) {
+            const { ok, id, rev } = result;
             isString(id);
             isString(rev);
+          }
         });
     });
 


### PR DESCRIPTION
As per [1]:

> The response contains an array of the familiar ok/rev/id from the
> put()/post() API. If there are any errors, they will be provided
> individually

Demo: https://square-shape.glitch.me/

[1] https://pouchdb.com/api.html#batch_create

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://pouchdb.com/api.html#batch_create
- [n/a] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.