### PR TITLE
resolve: add option preserveSymlinks

### DIFF
--- a/types/resolve/index.d.ts
+++ b/types/resolve/index.d.ts
@@ -63,40 +63,46 @@ declare function resolveSync(id: string, opts?: resolve.SyncOpts): string;
 
 /**
  * Return whether a package is in core
- *
- * @param id
  */
-declare function resolveIsCore(id: string): boolean;
+declare function resolveIsCore(id: string): boolean | undefined;
 
 declare namespace resolve {
   interface Opts {
-    // directory to begin resolving from (defaults to __dirname)
+    /** directory to begin resolving from (defaults to __dirname) */
     basedir?: string;
-    // package.json data applicable to the module being loaded
+    /** package.json data applicable to the module being loaded */
     package?: any;
-    // array of file extensions to search in order (defaults to ['.js'])
+    /** array of file extensions to search in order (defaults to ['.js']) */
     extensions?: string | string[];
-    // transform the parsed package.json contents before looking at the "main" field
+    /** transform the parsed package.json contents before looking at the "main" field */
     packageFilter?: (pkg: any, pkgfile: string) => any;
-    // transform a path within a package
+    /** transform a path within a package */
     pathFilter?: (pkg: any, path: string, relativePath: string) => string;
-    // require.paths array to use if nothing is found on the normal node_modules recursive walk (probably don't use this)
+    /** require.paths array to use if nothing is found on the normal node_modules recursive walk (probably don't use this) */
     paths?: string | string[];
-    // directory (or directories) in which to recursively look for modules. (default to 'node_modules')
+    /** directory (or directories) in which to recursively look for modules. (default to 'node_modules') */
     moduleDirectory?: string | string[]
+    /**
+     * if true, doesn't resolve `basedir` to real path before resolving.
+     * This is the way Node resolves dependencies when executed with the --preserve-symlinks flag.
+     *
+     * Note: this property is currently true by default but it will be changed to false in the next major version because Node's resolution
+     * algorithm does not preserve symlinks by default.
+    */
+    preserveSymlinks?: boolean;
   }
 
   export interface AsyncOpts extends Opts {
-    // how to read files asynchronously (defaults to fs.readFile)
+    /** how to read files asynchronously (defaults to fs.readFile) */
     readFile?: (file: string, cb: readFileCallback) => void;
-    // function to asynchronously test whether a file exists
+    /** function to asynchronously test whether a file exists */
     isFile?: (file: string, cb: isFileCallback) => void;
   }
 
   export interface SyncOpts extends Opts {
-    // how to read files synchronously (defaults to fs.readFileSync)
+    /** how to read files synchronously (defaults to fs.readFileSync) */
     readFileSync?: (file: string, charset: string) => string | Buffer;
-    // function to synchronously test whether a file exists
+    /** function to synchronously test whether a file exists */
     isFile?: (file: string) => boolean;
   }
 

--- a/types/resolve/resolve-tests.ts
+++ b/types/resolve/resolve-tests.ts
@@ -41,7 +41,8 @@ function test_options_async() {
           return cb(null, stat.isFile());
         }
       });
-    }
+    },
+    preserveSymlinks: false,
   }, function(error, resolved, pkg) {
     if (error) {
       console.error(error.message);
@@ -72,7 +73,8 @@ function test_options_sync() {
       } catch (error) {
         return false;
       }
-    }
+    },
+    preserveSymlinks: true,
   });
   console.log(resolved);
   resolved = resolve.sync('typescript', {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/browserify/resolve#resolveid-opts-cb
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Added `preserveSymlinks` option.
Converted comments of each option to JSDoc.
Changed the return type of `resolve.isCore` to `boolean | undefined`, because it actually returns undefined for non-core modules. Is only returns false if a module is not a core module in the current version, e.g. `http2` in node.js v4
```
> require('resolve').isCore('foo')
undefined
```