### PR TITLE
Sync nes and hapi-auth-basic plugin definitions to Hapi 17.

### DIFF
--- a/types/hapi-auth-basic/hapi-auth-basic-tests.ts
+++ b/types/hapi-auth-basic/hapi-auth-basic-tests.ts
@@ -2,9 +2,9 @@
 
 import Bcrypt = require('bcrypt');
 import Basic = require('hapi-auth-basic');
-import * as Hapi from 'hapi';
+import { Server } from 'hapi';
 
-const server = new Hapi.Server();
+const server = new Server();
 
 interface User {
     username: string;

--- a/types/hapi-auth-basic/index.d.ts
+++ b/types/hapi-auth-basic/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
-import * as Hapi from 'hapi';
+import { Plugin, Request, ResponseToolkit } from 'hapi';
 
 declare namespace Basic {
     interface ValidateCustomResponse {
@@ -18,10 +18,10 @@ declare namespace Basic {
     }
 
     interface Validate {
-        (request: Hapi.Request, username: string, password: string, h: object): Promise<ValidateResponse | ValidateCustomResponse>;
+        (request: Request, username: string, password: string, h: ResponseToolkit): Promise<ValidateResponse | ValidateCustomResponse>;
     }
 }
 
-declare var Basic: Hapi.PluginFunction<{}>;
+declare var Basic: Plugin<{}>;
 
 export = Basic;

--- a/types/hapi-auth-basic/tsconfig.json
+++ b/types/hapi-auth-basic/tsconfig.json
@@ -16,9 +16,6 @@
         "paths": {
             "boom": [
                 "boom/v4"
-            ],
-            "hapi": [
-                "hapi/v16"
             ]
         },
         "noEmit": true,

--- a/types/nes/index.d.ts
+++ b/types/nes/index.d.ts
@@ -23,17 +23,19 @@
  *      failing test demonstrating use if so.
  */
 
-import * as Hapi from 'hapi';
+import { Plugin } from 'hapi';
 import NesClient = require('nes/client');
 
-declare module 'hapi' {
+declare module 'hapi/definitions/server/server' {
     interface Server {
         broadcast(message: any, options?: nes.ServerBroadcastOptions): void;
         subscription(path: string, options?: nes.ServerSubscriptionOptions): void;
         publish(path: string, message: any, options?: nes.ServerPublishOptions): void;
         eachSocket(each: (socket: nes.Socket) => void, options?: nes.ServerEachSocketOptions): void;
     }
+}
 
+declare module 'hapi/definitions/request/request' {
     interface Request {
         socket: nes.Socket;
     }
@@ -129,8 +131,6 @@ interface NesClassExports {
     };
 }
 
-interface NesAllExports extends NesClassExports, Hapi.PluginFunction<{}> {}
-
-declare var nes: NesAllExports;
+declare var nes: NesClassExports & Plugin<{}>;
 
 export = nes;

--- a/types/nes/test/broadcast-server.ts
+++ b/types/nes/test/broadcast-server.ts
@@ -1,9 +1,9 @@
 // from https://github.com/hapijs/nes#broadcast
 
-import Hapi = require('hapi');
+import { Server } from 'hapi';
 import Nes = require('nes');
 
-var server = new Hapi.Server();
+const server = new Server();
 
 server.register(Nes).then(() => {
 

--- a/types/nes/test/client-require.ts
+++ b/types/nes/test/client-require.ts
@@ -5,8 +5,8 @@
 
 import Client = require('nes/client');
 
-var options: Client.ClientConnectOptions = {
+const options: Client.ClientConnectOptions = {
     delay: 3
 }
 
-var client: Client = new Client('ws://localhost', options);
+const client: Client = new Client('ws://localhost', options);

--- a/types/nes/test/nes-tests.ts
+++ b/types/nes/test/nes-tests.ts
@@ -1,18 +1,18 @@
-import Hapi = require('hapi');
+import { Request, ResponseToolkit, Server } from 'hapi';
 import Nes = require('nes');
 
-var server: Hapi.Server = new Hapi.Server();
+const server = new Server();
 
 server.register(Nes).then(() => {
     // No longer need to cast to Nes.Server as Hapi.Server has been modified directly.
     // let wsServer: Nes.Server = server as Nes.Server;
-    let wsServer: Hapi.Server = server;
+    let wsServer = server;
     wsServer.subscription('/item/{id}');
-    wsServer.route( {
+    wsServer.route({
         method: 'GET',
         path: '/test',
         config: {
-            handler: (request, h) => {
+            handler: (request: Request, h: ResponseToolkit) => {
                 return {test: 'passes ' + request.socket.id};
             }
         }

--- a/types/nes/test/route-authentication-server.ts
+++ b/types/nes/test/route-authentication-server.ts
@@ -1,12 +1,18 @@
 // from https://github.com/hapijs/nes#route-authentication
 
-import Hapi = require('hapi');
+import { AuthCredentials, Request, ResponseToolkit, Server } from 'hapi';
 import Basic = require('hapi-auth-basic');
 import Bcrypt = require('bcrypt');
 import Nes = require('nes');
 
-var server = new Hapi.Server();
-server.connection();
+const server = new Server();
+
+declare module 'hapi/definitions/request/request-auth' {
+    interface AuthCredentials {
+        id: string;
+        name: string;
+    }
+}
 
 server.register([Basic, Nes]).then(() => {
 
@@ -19,7 +25,7 @@ server.register([Basic, Nes]).then(() => {
         id: string;
     }
 
-    var users: {[index: string]: User} = {
+    const users: { [index: string]: User } = {
         john: {
             username: 'john',
             password: '$2a$10$iqJSHD.BGr0E2IxQwYgJmeP3NvhPrXAeLSaGCj6IR/XU5QtjVu5Tm',   // 'secret'
@@ -28,9 +34,9 @@ server.register([Basic, Nes]).then(() => {
         }
     };
 
-    var validate: Basic.Validate = async (request, username, password, h) => {
+    const validate: Basic.Validate = async (request, username, password, h) => {
 
-        var user = users[username];
+        const user = users[username];
         if (!user) {
             return { credentials: null, isValid: false };
         }
@@ -40,7 +46,7 @@ server.register([Basic, Nes]).then(() => {
         return { isValid, credentials: { id: user.id, name: user.name } };
     };
 
-    server.auth.strategy('simple', 'basic', { validateFunc: validate });
+    server.auth.strategy('simple', 'basic', {validateFunc: validate});
     server.auth.default('simple');
 
     // Configure route with authentication
@@ -50,7 +56,7 @@ server.register([Basic, Nes]).then(() => {
         path: '/h',
         config: {
             id: 'hello',
-            handler: function (request, h) {
+            handler: function (request: Request, h: ResponseToolkit) {
 
                 return 'Hello ' + request.auth.credentials.name;
             }

--- a/types/nes/test/route-invocation-server.ts
+++ b/types/nes/test/route-invocation-server.ts
@@ -1,9 +1,9 @@
 // from https://github.com/hapijs/nes#route-invocation
 
-import Hapi = require('hapi');
+import { Request, ResponseToolkit, Server } from 'hapi';
 import Nes = require('nes');
 
-var server = new Hapi.Server();
+const server = new Server();
 
 server.register(Nes).then(() => {
 
@@ -12,7 +12,7 @@ server.register(Nes).then(() => {
         path: '/h',
         config: {
             id: 'hello',
-            handler: (request, h) => {
+            handler: (request: Request, h: ResponseToolkit) => {
 
                 return 'world!';
             }

--- a/types/nes/test/subscription-filter-client.ts
+++ b/types/nes/test/subscription-filter-client.ts
@@ -8,7 +8,7 @@ var client = new Nes.Client('ws://localhost');
 
 client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }).then(() => {
 
-    var handler: Nes.Handler = (update) => {
+    const handler: Nes.Handler = (update) => {
 
         // First publish is not received (filtered due to updater key)
         // update -> { id: 6, status: 'initial', updater: 'steve' }
@@ -27,7 +27,7 @@ var client = new NesClient('ws://localhost');
 
 client.connect({ auth: { headers: { authorization: 'Basic am9objpzZWNyZXQ=' } } }).then(() => {
 
-    var handler: NesClient.Handler = (update) => {
+    const handler: NesClient.Handler = (update) => {
 
         // First publish is not received (filtered due to updater key)
         // update -> { id: 6, status: 'initial', updater: 'steve' }

--- a/types/nes/test/subscription-filter-server.ts
+++ b/types/nes/test/subscription-filter-server.ts
@@ -1,11 +1,11 @@
 // from https://github.com/hapijs/nes#subscription-filter
 
-import Hapi = require('hapi');
+import {Server} from 'hapi';
 import Basic = require('hapi-auth-basic');
 import Bcrypt = require('bcrypt');
 import Nes = require('nes');
 
-var server = new Hapi.Server();
+var server = new Server();
 
 server.register([Basic, Nes]).then(() => {
 
@@ -18,7 +18,7 @@ server.register([Basic, Nes]).then(() => {
         id: string;
     }
 
-    var users: {[index: string]: User} = {
+    const users: {[index: string]: User} = {
         john: {
             username: 'john',
             password: '$2a$10$iqJSHD.BGr0E2IxQwYgJmeP3NvhPrXAeLSaGCj6IR/XU5QtjVu5Tm',   // 'secret'
@@ -27,9 +27,9 @@ server.register([Basic, Nes]).then(() => {
         }
     };
 
-    var validate: Basic.Validate = async (request, username, password, h) => {
+    const validate: Basic.Validate = async (request, username, password, h) => {
 
-        var user = users[username];
+        const user = users[username];
         if (!user) {
             return { credentials: null, isValid: false };
         }

--- a/types/nes/test/subscriptions-client.ts
+++ b/types/nes/test/subscriptions-client.ts
@@ -3,9 +3,9 @@
 import Nes = require('nes');
 
 var client = new Nes.Client('ws://localhost');
-    client.connect().then(() => {;
+client.connect().then(() => {
 
-    var handler: Nes.Handler = (update, flags) => {
+    const handler: Nes.Handler = (update, flags) => {
 
         // update -> { id: 5, status: 'complete' }
         // Second publish is not received (doesn't match)
@@ -21,7 +21,7 @@ import NesClient = require('nes/client');
 var client = new NesClient('ws://localhost');
 client.connect().then(() => {
 
-    var handler: NesClient.Handler = (update, flags) => {
+    const handler: NesClient.Handler = (update, flags) => {
 
         // update -> { id: 5, status: 'complete' }
         // Second publish is not received (doesn't match)

--- a/types/nes/test/subscriptions-server.ts
+++ b/types/nes/test/subscriptions-server.ts
@@ -1,11 +1,11 @@
 // from https://github.com/hapijs/nes#subscriptions
 
-import Hapi = require('hapi');
+import { Server } from 'hapi';
 import Nes = require('nes');
 
-var server = new Hapi.Server();
+var server = new Server();
 
-server.register(Nes).then(() =>{;
+server.register(Nes).then(() => {
 
     server.subscription('/item/{id}');
 

--- a/types/nes/tsconfig.json
+++ b/types/nes/tsconfig.json
@@ -16,9 +16,6 @@
         "paths": {
             "boom": [
                 "boom/v4"
-            ],
-            "hapi": [
-                "hapi/v16"
             ]
         },
         "noEmit": true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This might change based on https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23562 resolution, but it's better to merge this anyway since the types are Hapi >= 17 exclusive.