### PR TITLE
(electron-store) Keyof and lookup types so typed store can be used

### DIFF
--- a/types/electron-store/electron-store-tests.ts
+++ b/types/electron-store/electron-store-tests.ts
@@ -1,20 +1,20 @@
 import ElectronStore = require('electron-store');
 
 new ElectronStore({
-  defaults: {}
+    defaults: {}
 });
 
 new ElectronStore({
-  name: 'myConfiguration',
-  cwd: 'unicorn'
+    name: 'myConfiguration',
+    cwd: 'unicorn'
 });
 
 const electronStore = new ElectronStore();
 
 electronStore.set('foo', 'bar');
 electronStore.set({
-  foo: 'bar',
-  foo2: 'bar2'
+    foo: 'bar',
+    foo2: 'bar2'
 });
 electronStore.delete('foo');
 electronStore.get('foo');
@@ -28,7 +28,27 @@ electronStore.size;
 electronStore.store;
 
 electronStore.store = {
-  foo: 'bar'
+    foo: 'bar'
 };
 
 electronStore.path;
+
+interface SampleStore {
+    enabled: boolean;
+    interval: number;
+}
+
+const typedElectronStore = new ElectronStore<SampleStore>({
+    defaults: {
+        enabled: true,
+        interval: 30000,
+    },
+});
+
+const interval: number = typedElectronStore.get('interval');
+const enabled = false;
+typedElectronStore.set('enabled', enabled);
+typedElectronStore.set({
+    enabled: true,
+    interval: 10000,
+});

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -36,27 +36,30 @@ declare module 'electron-store' {
     /**
      * Sets an item.
      */
+    set<K extends keyof T>(key: K, value: T[K]): void;
     set(key: string, value: any): void;
 
     /**
      * Sets multiple items at once.
      */
-    set(object: {}): void;
+    set<K extends keyof T>(object: Pick<T, K> | T): void;
+    set(object: JSONObject): void
 
     /**
      * Retrieves an item.
      */
+    get<K extends keyof T>(key: K, defaultValue?: JSONValue): T[K];
     get(key: string, defaultValue?: any): any;
 
     /**
      * Checks if an item exists.
      */
-    has(key: string): boolean;
+    has<K extends keyof T>(key: K | string): boolean;
 
     /**
      * Deletes an item.
      */
-    delete(key: string): void;
+    delete<K extends keyof T>(key: K | string): void;
 
     /**
      * Deletes all items.

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -1,113 +1,112 @@
-// Type definitions for electron-store 1.2
+// Type definitions for electron-store 1.3
 // Project: https://github.com/sindresorhus/electron-store
 // Definitions by: Daniel Perez Alvarez <https://github.com/unindented>
 //                 Jakub Synowiec <https://github.com/jsynowiec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// TypeScript Version: 2.3
+
 /// <reference types="node" />
 
-declare module 'electron-store' {
-    type JSONValue = string | number | boolean | JSONObject | JSONArray;
+type JSONValue = string | number | boolean | JSONObject | JSONArray;
 
-    interface JSONObject {
-        [x: string]: JSONValue;
-    }
-
-    interface JSONArray extends Array<JSONValue> {}
-
-    interface ElectronStoreOptions<T = JSONObject> {
-        /**
-         * Default data.
-         */
-        defaults?: T;
-
-        /**
-         * Name of the storage file (without extension).
-         */
-        name?: string;
-
-        /**
-         * Storage file location. Don't specify this unless absolutely necessary!
-         */
-        cwd?: string;
-
-        /**
-         * When specified, the store will be encrypted using the aes-256-cbc encryption algorithm.
-         */
-        encryptionKey?: string | Buffer;
-    }
-
-    class ElectronStore<T> implements Iterable<[keyof T, JSONValue]> {
-        constructor(options?: ElectronStoreOptions<T>);
-
-        /**
-         * Set an item.
-         */
-        set<K extends keyof T>(key: K, value: T[K]): void;
-        set(key: string, value: any): void;
-
-        /**
-         * Set multiple items at once.
-         */
-        set<K extends keyof T>(object: Pick<T, K> | T): void;
-        set(object: JSONObject): void;
-
-        /**
-         * Get an item or defaultValue if the item does not exist.
-         */
-        get<K extends keyof T>(key: K, defaultValue?: JSONValue): T[K];
-        get(key: string, defaultValue?: any): any;
-
-        /**
-         * Check if an item exists.
-         */
-        has<K extends keyof T>(key: K | string): boolean;
-
-        /**
-         * Delete an item.
-         */
-        delete<K extends keyof T>(key: K | string): void;
-
-        /**
-         * Delete all items.
-         */
-        clear(): void;
-
-        /**
-         * Watches the given key, calling callback on any changes. When a key is first set oldValue
-         * will be undefined, and when a key is deleted newValue will be undefined.
-         */
-        onDidChange<K extends keyof T>(
-            key: K,
-            callback: (newValue: T[K], oldValue: T[K]) => void
-        ): void;
-        onDidChange(
-            key: string,
-            callback: (newValue: JSONValue, oldValue: JSONValue) => void
-        ): void;
-
-        /**
-         * Get the item count.
-         */
-        size: number;
-
-        /**
-         * Get all the data as an object or replace the current data with an object.
-         */
-        store: T;
-
-        /**
-         * Get the path to the storage file.
-         */
-        path: string;
-
-        /**
-         * Open the storage file in the user's editor.
-         */
-        openInEditor(): void;
-
-        [Symbol.iterator](): Iterator<[keyof T, JSONValue]>;
-    }
-
-    export = ElectronStore;
+interface JSONObject {
+    [x: string]: JSONValue;
 }
+
+interface JSONArray extends Array<JSONValue> {}
+
+interface ElectronStoreOptions<T> {
+    /**
+     * Default data.
+     */
+    defaults?: T;
+
+    /**
+     * Name of the storage file (without extension).
+     */
+    name?: string;
+
+    /**
+     * Storage file location. Don't specify this unless absolutely necessary!
+     */
+    cwd?: string;
+
+    /**
+     * When specified, the store will be encrypted using the aes-256-cbc encryption algorithm.
+     */
+    encryptionKey?: string | Buffer;
+}
+
+declare class ElectronStore<T = {}> implements Iterable<[string, JSONValue]> {
+    constructor(options?: ElectronStoreOptions<T>);
+
+    /**
+     * Set an item.
+     */
+    set<K extends keyof T>(key: K, value: T[K]): void;
+    set(key: string, value: any): void;
+
+    /**
+     * Set multiple items at once.
+     */
+    set(object: Pick<T, keyof T> | T | JSONObject): void;
+
+    /**
+     * Get an item or defaultValue if the item does not exist.
+     */
+    get<K extends keyof T>(key: K, defaultValue?: JSONValue): T[K];
+    get(key: string, defaultValue?: any): any;
+
+    /**
+     * Check if an item exists.
+     */
+    has(key: keyof T | string): boolean;
+
+    /**
+     * Delete an item.
+     */
+    delete(key: keyof T | string): void;
+
+    /**
+     * Delete all items.
+     */
+    clear(): void;
+
+    /**
+     * Watches the given key, calling callback on any changes. When a key is first set oldValue
+     * will be undefined, and when a key is deleted newValue will be undefined.
+     */
+    onDidChange<K extends keyof T>(
+        key: K,
+        callback: (newValue: T[K], oldValue: T[K]) => void
+    ): void;
+    onDidChange(
+        key: string,
+        callback: (newValue: JSONValue, oldValue: JSONValue) => void
+    ): void;
+
+    /**
+     * Get the item count.
+     */
+    size: number;
+
+    /**
+     * Get all the data as an object or replace the current data with an object.
+     */
+    store: T;
+
+    /**
+     * Get the path to the storage file.
+     */
+    path: string;
+
+    /**
+     * Open the storage file in the user's editor.
+     */
+    openInEditor(): void;
+
+    [Symbol.iterator](): Iterator<[string, JSONValue]>;
+}
+
+export = ElectronStore;

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -14,83 +14,87 @@ declare module 'electron-store' {
     interface JSONArray extends Array<JSONValue> {}
 
     interface ElectronStoreOptions<T = JSONObject> {
-    /**
-     * Default config.
-     */
-    defaults?: T;
+      /**
+       * Default data.
+       */
+      defaults?: T;
 
-    /**
-     * Name of the config file (without extension).
-     */
-    name?: string;
+      /**
+       * Name of the storage file (without extension).
+       */
+      name?: string;
 
-    /**
-     * Storage file location. *Don't specify this unless absolutely necessary!*
-     */
-    cwd?: string;
+      /**
+       * Storage file location. Don't specify this unless absolutely necessary!
+       */
+      cwd?: string;
     }
 
     class ElectronStore<T> implements Iterable<[keyof T, JSONValue]> {
-    constructor(options?: ElectronStoreOptions<T>);
+      constructor(options?: ElectronStoreOptions<T>);
 
-    /**
-     * Sets an item.
-     */
-    set<K extends keyof T>(key: K, value: T[K]): void;
-    set(key: string, value: any): void;
+      /**
+       * Set an item.
+       */
+      set<K extends keyof T>(key: K, value: T[K]): void;
+      set(key: string, value: any): void;
 
-    /**
-     * Sets multiple items at once.
-     */
-    set<K extends keyof T>(object: Pick<T, K> | T): void;
-    set(object: JSONObject): void
+      /**
+       * Set multiple items at once.
+       */
+      set<K extends keyof T>(object: Pick<T, K> | T): void;
+      set(object: JSONObject): void
 
-    /**
-     * Retrieves an item.
-     */
-    get<K extends keyof T>(key: K, defaultValue?: JSONValue): T[K];
-    get(key: string, defaultValue?: any): any;
+      /**
+       * Get an item or defaultValue if the item does not exist.
+       */
+      get<K extends keyof T>(key: K, defaultValue?: JSONValue): T[K];
+      get(key: string, defaultValue?: any): any;
 
-    /**
-     * Checks if an item exists.
-     */
-    has<K extends keyof T>(key: K | string): boolean;
+      /**
+       * Check if an item exists.
+       */
+      has<K extends keyof T>(key: K | string): boolean;
 
-    /**
-     * Deletes an item.
-     */
-    delete<K extends keyof T>(key: K | string): void;
+      /**
+       * Delete an item.
+       */
+      delete<K extends keyof T>(key: K | string): void;
 
-    /**
-     * Deletes all items.
-     */
-    clear(): void;
+      /**
+       * Delete all items.
+       */
+      clear(): void;
 
-    /**
-     * Open the storage file in the user's editor.
-     */
-    openInEditor(): void;
+      /**
+       * Watches the given key, calling callback on any changes. When a key is first set oldValue
+       * will be undefined, and when a key is deleted newValue will be undefined.
+       */
+      onDidChange<K extends keyof T>(key: K, callback: (newValue: T[K], oldValue: T[K]) => void): void;
+      onDidChange(key: string, callback: (newValue: JSONValue, oldValue: JSONValue) => void): void;
 
-    onDidChange<K extends keyof T>(key: K, callback: (newValue: T[K], oldValue: T[K]) => void): void;
-    onDidChange(key: string, callback: (newValue: JSONValue, oldValue: JSONValue) => void): void;
+      /**
+       * Get the item count.
+       */
+      size: number;
 
-    /**
-     * Gets the item count.
-     */
-    size: number;
+      /**
+       * Get all the data as an object or replace the current data with an object.
+       */
+      store: T;
 
-    /**
-     * Gets all the config as an object or replace the current config with an object.
-     */
-    store: T;
+      /**
+       * Get the path to the storage file.
+       */
+      path: string;
 
-    /**
-     * Gets the path to the config file.
-     */
-    path: string;
+      /**
+       * Open the storage file in the user's editor.
+       */
+      openInEditor(): void;
 
-    [Symbol.iterator](): Iterator<[keyof T, JSONValue]>;
+      [Symbol.iterator](): Iterator<[keyof T, JSONValue]>;
     }
 
     export = ElectronStore;
-}
+  }

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -5,6 +5,14 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module 'electron-store' {
+    type JSONValue = string | number | boolean | JSONObject | JSONArray;
+
+    interface JSONObject {
+        [x: string]: JSONValue;
+    }
+
+    interface JSONArray extends Array<JSONValue> {}
+
     interface ElectronStoreOptions {
     /**
      * Default config.

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -71,6 +71,9 @@ declare module 'electron-store' {
      */
     openInEditor(): void;
 
+    onDidChange<K extends keyof T>(key: K, callback: (newValue: T[K], oldValue: T[K]) => void): void;
+    onDidChange(key: string, callback: (newValue: JSONValue, oldValue: JSONValue) => void): void;
+
     /**
      * Gets the item count.
      */

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -13,11 +13,11 @@ declare module 'electron-store' {
 
     interface JSONArray extends Array<JSONValue> {}
 
-    interface ElectronStoreOptions {
+    interface ElectronStoreOptions<T = JSONObject> {
     /**
      * Default config.
      */
-    defaults?: {};
+    defaults?: T;
 
     /**
      * Name of the config file (without extension).
@@ -30,8 +30,8 @@ declare module 'electron-store' {
     cwd?: string;
     }
 
-    class ElectronStore implements Iterable<[string, string | number | boolean | symbol | {}]> {
-    constructor(options?: ElectronStoreOptions);
+    class ElectronStore<T> implements Iterable<[keyof T, JSONValue]> {
+    constructor(options?: ElectronStoreOptions<T>);
 
     /**
      * Sets an item.
@@ -83,7 +83,7 @@ declare module 'electron-store' {
      */
     path: string;
 
-    [Symbol.iterator](): Iterator<[string, string | number | boolean | symbol | {}]>;
+    [Symbol.iterator](): Iterator<[keyof T, JSONValue]>;
     }
 
     export = ElectronStore;

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -4,6 +4,8 @@
 //                 Jakub Synowiec <https://github.com/jsynowiec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+/// <reference types="node" />
+
 declare module 'electron-store' {
     type JSONValue = string | number | boolean | JSONObject | JSONArray;
 
@@ -28,6 +30,11 @@ declare module 'electron-store' {
        * Storage file location. Don't specify this unless absolutely necessary!
        */
       cwd?: string;
+
+        /**
+         * When specified, the store will be encrypted using the aes-256-cbc encryption algorithm.
+         */
+        encryptionKey?: string | Buffer;
     }
 
     class ElectronStore<T> implements Iterable<[keyof T, JSONValue]> {

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -1,79 +1,82 @@
 // Type definitions for electron-store 1.2
 // Project: https://github.com/sindresorhus/electron-store
 // Definitions by: Daniel Perez Alvarez <https://github.com/unindented>
+//                 Jakub Synowiec <https://github.com/jsynowiec>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface ElectronStoreOptions {
-  /**
-   * Default config.
-   */
-  defaults?: {};
+declare module 'electron-store' {
+    interface ElectronStoreOptions {
+    /**
+     * Default config.
+     */
+    defaults?: {};
 
-  /**
-   * Name of the config file (without extension).
-   */
-  name?: string;
+    /**
+     * Name of the config file (without extension).
+     */
+    name?: string;
 
-  /**
-   * Storage file location. *Don't specify this unless absolutely necessary!*
-   */
-  cwd?: string;
+    /**
+     * Storage file location. *Don't specify this unless absolutely necessary!*
+     */
+    cwd?: string;
+    }
+
+    class ElectronStore implements Iterable<[string, string | number | boolean | symbol | {}]> {
+    constructor(options?: ElectronStoreOptions);
+
+    /**
+     * Sets an item.
+     */
+    set(key: string, value: any): void;
+
+    /**
+     * Sets multiple items at once.
+     */
+    set(object: {}): void;
+
+    /**
+     * Retrieves an item.
+     */
+    get(key: string, defaultValue?: any): any;
+
+    /**
+     * Checks if an item exists.
+     */
+    has(key: string): boolean;
+
+    /**
+     * Deletes an item.
+     */
+    delete(key: string): void;
+
+    /**
+     * Deletes all items.
+     */
+    clear(): void;
+
+    /**
+     * Open the storage file in the user's editor.
+     */
+    openInEditor(): void;
+
+    /**
+     * Gets the item count.
+     */
+    size: number;
+
+    /**
+     * Gets all the config as an object or replace the current config with an object.
+     */
+    store: {};
+
+    /**
+     * Gets the path to the config file.
+     */
+    path: string;
+
+    [Symbol.iterator](): Iterator<[string, string | number | boolean | symbol | {}]>;
+    }
+
+    export = ElectronStore;
 }
-
-declare class ElectronStore implements Iterable<[string, string | number | boolean | symbol | {}]> {
-  constructor(options?: ElectronStoreOptions);
-
-  /**
-   * Sets an item.
-   */
-  set(key: string, value: any): void;
-
-  /**
-   * Sets multiple items at once.
-   */
-  set(object: {}): void;
-
-  /**
-   * Retrieves an item.
-   */
-  get(key: string, defaultValue?: any): any;
-
-  /**
-   * Checks if an item exists.
-   */
-  has(key: string): boolean;
-
-  /**
-   * Deletes an item.
-   */
-  delete(key: string): void;
-
-  /**
-   * Deletes all items.
-   */
-  clear(): void;
-
-  /**
-   * Open the storage file in the user's editor.
-   */
-  openInEditor(): void;
-
-  /**
-   * Gets the item count.
-   */
-  size: number;
-
-  /**
-   * Gets all the config as an object or replace the current config with an object.
-   */
-  store: {};
-
-  /**
-   * Gets the path to the config file.
-   */
-  path: string;
-
-  [Symbol.iterator](): Iterator<[string, string | number | boolean | symbol | {}]>;
-}
-
-export = ElectronStore;

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -82,7 +82,7 @@ declare module 'electron-store' {
     /**
      * Gets all the config as an object or replace the current config with an object.
      */
-    store: {};
+    store: T;
 
     /**
      * Gets the path to the config file.

--- a/types/electron-store/index.d.ts
+++ b/types/electron-store/index.d.ts
@@ -16,20 +16,20 @@ declare module 'electron-store' {
     interface JSONArray extends Array<JSONValue> {}
 
     interface ElectronStoreOptions<T = JSONObject> {
-      /**
-       * Default data.
-       */
-      defaults?: T;
+        /**
+         * Default data.
+         */
+        defaults?: T;
 
-      /**
-       * Name of the storage file (without extension).
-       */
-      name?: string;
+        /**
+         * Name of the storage file (without extension).
+         */
+        name?: string;
 
-      /**
-       * Storage file location. Don't specify this unless absolutely necessary!
-       */
-      cwd?: string;
+        /**
+         * Storage file location. Don't specify this unless absolutely necessary!
+         */
+        cwd?: string;
 
         /**
          * When specified, the store will be encrypted using the aes-256-cbc encryption algorithm.
@@ -38,70 +38,76 @@ declare module 'electron-store' {
     }
 
     class ElectronStore<T> implements Iterable<[keyof T, JSONValue]> {
-      constructor(options?: ElectronStoreOptions<T>);
+        constructor(options?: ElectronStoreOptions<T>);
 
-      /**
-       * Set an item.
-       */
-      set<K extends keyof T>(key: K, value: T[K]): void;
-      set(key: string, value: any): void;
+        /**
+         * Set an item.
+         */
+        set<K extends keyof T>(key: K, value: T[K]): void;
+        set(key: string, value: any): void;
 
-      /**
-       * Set multiple items at once.
-       */
-      set<K extends keyof T>(object: Pick<T, K> | T): void;
-      set(object: JSONObject): void
+        /**
+         * Set multiple items at once.
+         */
+        set<K extends keyof T>(object: Pick<T, K> | T): void;
+        set(object: JSONObject): void;
 
-      /**
-       * Get an item or defaultValue if the item does not exist.
-       */
-      get<K extends keyof T>(key: K, defaultValue?: JSONValue): T[K];
-      get(key: string, defaultValue?: any): any;
+        /**
+         * Get an item or defaultValue if the item does not exist.
+         */
+        get<K extends keyof T>(key: K, defaultValue?: JSONValue): T[K];
+        get(key: string, defaultValue?: any): any;
 
-      /**
-       * Check if an item exists.
-       */
-      has<K extends keyof T>(key: K | string): boolean;
+        /**
+         * Check if an item exists.
+         */
+        has<K extends keyof T>(key: K | string): boolean;
 
-      /**
-       * Delete an item.
-       */
-      delete<K extends keyof T>(key: K | string): void;
+        /**
+         * Delete an item.
+         */
+        delete<K extends keyof T>(key: K | string): void;
 
-      /**
-       * Delete all items.
-       */
-      clear(): void;
+        /**
+         * Delete all items.
+         */
+        clear(): void;
 
-      /**
-       * Watches the given key, calling callback on any changes. When a key is first set oldValue
-       * will be undefined, and when a key is deleted newValue will be undefined.
-       */
-      onDidChange<K extends keyof T>(key: K, callback: (newValue: T[K], oldValue: T[K]) => void): void;
-      onDidChange(key: string, callback: (newValue: JSONValue, oldValue: JSONValue) => void): void;
+        /**
+         * Watches the given key, calling callback on any changes. When a key is first set oldValue
+         * will be undefined, and when a key is deleted newValue will be undefined.
+         */
+        onDidChange<K extends keyof T>(
+            key: K,
+            callback: (newValue: T[K], oldValue: T[K]) => void
+        ): void;
+        onDidChange(
+            key: string,
+            callback: (newValue: JSONValue, oldValue: JSONValue) => void
+        ): void;
 
-      /**
-       * Get the item count.
-       */
-      size: number;
+        /**
+         * Get the item count.
+         */
+        size: number;
 
-      /**
-       * Get all the data as an object or replace the current data with an object.
-       */
-      store: T;
+        /**
+         * Get all the data as an object or replace the current data with an object.
+         */
+        store: T;
 
-      /**
-       * Get the path to the storage file.
-       */
-      path: string;
+        /**
+         * Get the path to the storage file.
+         */
+        path: string;
 
-      /**
-       * Open the storage file in the user's editor.
-       */
-      openInEditor(): void;
+        /**
+         * Open the storage file in the user's editor.
+         */
+        openInEditor(): void;
 
-      [Symbol.iterator](): Iterator<[keyof T, JSONValue]>;
+        [Symbol.iterator](): Iterator<[keyof T, JSONValue]>;
     }
 
     export = ElectronStore;
-  }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html
- [x] Increase the version number in the header if appropriate.

**Example:**
```typescript
interface SampleSettings {
  enabled: boolean;
  interval: number;
}

const store = new ElectronStore<SampleSettings>({
  defaults: {
    enabled: true,
    interval: 3000,
  },
});

const interval = store.get('interval'); // interval is inferred as number
```

**Limitation:**
No strict type checking for _set_ functions due to `(key: string, value: any)` overload that is required to retain dot notation access and a bit more flexible/forgiving set/get calls on store.