### PR TITLE
Update types used for image creation in Dockerode

### DIFF
--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -833,10 +833,10 @@ declare class Dockerode {
   createContainer(options: Dockerode.ContainerCreateOptions, callback: Callback<Dockerode.Container>): void;
   createContainer(options: Dockerode.ContainerCreateOptions): Promise<Dockerode.Container>;
 
-  createImage(options: {}, callback: Callback<Dockerode.Image>): void;
-  createImage(auth: any, options: {}, callback: Callback<Dockerode.Image>): void;
-  createImage(options: {}): Promise<Dockerode.Image>;
-  createImage(auth: any, options: {}): Promise<Dockerode.Image>;
+  createImage(options: {}, callback: Callback<any>): void;
+  createImage(auth: any, options: {}, callback: Callback<any>): void;
+  createImage(options: {}): Promise<any>;
+  createImage(auth: any, options: {}): Promise<any>;
 
   loadImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<any>): void;
   loadImage(file: string | NodeJS.ReadableStream, callback: Callback<any>): void;

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -833,25 +833,25 @@ declare class Dockerode {
   createContainer(options: Dockerode.ContainerCreateOptions, callback: Callback<Dockerode.Container>): void;
   createContainer(options: Dockerode.ContainerCreateOptions): Promise<Dockerode.Container>;
 
-  createImage(options: {}, callback: Callback<any>): void;
-  createImage(auth: any, options: {}, callback: Callback<any>): void;
-  createImage(options: {}): Promise<any>;
-  createImage(auth: any, options: {}): Promise<any>;
+  createImage(options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+  createImage(auth: any, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+  createImage(options: {}): Promise<NodeJS.ReadableStream>;
+  createImage(auth: any, options: {}): Promise<NodeJS.ReadableStream>;
 
-  loadImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<any>): void;
-  loadImage(file: string | NodeJS.ReadableStream, callback: Callback<any>): void;
-  loadImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<any>;
+  loadImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+  loadImage(file: string | NodeJS.ReadableStream, callback: Callback<NodeJS.ReadableStream>): void;
+  loadImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<NodeJS.ReadableStream>;
 
-  importImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<any>): void;
-  importImage(file: string | NodeJS.ReadableStream, callback: Callback<any>): void;
-  importImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<any>;
+  importImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+  importImage(file: string | NodeJS.ReadableStream, callback: Callback<NodeJS.ReadableStream>): void;
+  importImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<NodeJS.ReadableStream>;
 
   checkAuth(options: any, callback: Callback<any>): void;
   checkAuth(options: any): Promise<any>;
 
-  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, options: {}, callback: Callback<any>): void;
-  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, callback: Callback<any>): void;
-  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, options?: {}): Promise<any>;
+  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, options: {}, callback: Callback<NodeJS.ReadableStream>): void;
+  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, callback: Callback<NodeJS.ReadableStream>): void;
+  buildImage(file: string | NodeJS.ReadableStream | Dockerode.ImageBuildContext, options?: {}): Promise<NodeJS.ReadableStream>;
 
   getContainer(id: string): Dockerode.Container;
 

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -5,6 +5,7 @@
 //                 ByeongHun Yoo <https://github.com/isac322>
 //                 Ray Fang <https://github.com/lazarusx>
 //                 Marius Meisenzahl <https://github.com/meisenzahl>
+//                 Rob Moran <https://github.com/thegecko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 

--- a/types/dockerode/index.d.ts
+++ b/types/dockerode/index.d.ts
@@ -837,13 +837,13 @@ declare class Dockerode {
   createImage(options: {}): Promise<Dockerode.Image>;
   createImage(auth: any, options: {}): Promise<Dockerode.Image>;
 
-  loadImage(file: string, options: {}, callback: Callback<any>): void;
-  loadImage(file: string, callback: Callback<any>): void;
-  loadImage(file: string, options?: {}): Promise<any>;
+  loadImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<any>): void;
+  loadImage(file: string | NodeJS.ReadableStream, callback: Callback<any>): void;
+  loadImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<any>;
 
-  importImage(file: string, options: {}, callback: Callback<any>): void;
-  importImage(file: string, callback: Callback<any>): void;
-  importImage(file: string, options?: {}): Promise<any>;
+  importImage(file: string | NodeJS.ReadableStream, options: {}, callback: Callback<any>): void;
+  importImage(file: string | NodeJS.ReadableStream, callback: Callback<any>): void;
+  importImage(file: string | NodeJS.ReadableStream, options?: {}): Promise<any>;
 
   checkAuth(options: any, callback: Callback<any>): void;
   checkAuth(options: any): Promise<any>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
All file-based functions also accept streams: https://github.com/apocas/dockerode/blob/master/lib/docker.js#L184
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

_Notes_

- Changes were found/tested during the usage of Dockerode with TypeScript
- The return type for createImage is actually `HTTP.IncomingMessage`, but followed the style of using `any` in the same way as similar methods
- IMO, `any` return types should be replaced with correct types in a future PR

