### PR TITLE
Correct default function for esnext style import

### DIFF
--- a/types/next/dynamic.d.ts
+++ b/types/next/dynamic.d.ts
@@ -24,6 +24,6 @@ export class SameLoopPromise<T> extends Promise<T> {
     runIfNeeded(): void;
 }
 export default function<TCProps, TLProps>(
-    componentPromise: Promise<React.ComponentType<TCProps>>,
+    componentPromise: Promise<React.ComponentType<TCProps> | any>,
     options?: DynamicOptions<TCProps, TLProps>,
 ): React.ComponentType<TCProps & TLProps>;


### PR DESCRIPTION
When one uses the [esnext import style](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/next/test/next-dynamic-tests.tsx#L4), next/dynamic types don't type check.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

