### PR TITLE
Add a default export to big.js

### DIFF
--- a/types/big.js/index.d.ts
+++ b/types/big.js/index.d.ts
@@ -295,6 +295,7 @@ export const Big: BigConstructor;
 export type Big_ = Big;
 export type BigConstructor_ = BigConstructor;
 export type BigSource_ = BigSource;
+export default Big;
 
 declare global {
     namespace BigJs {

--- a/types/big.js/test/big.js-import-default-tests.ts
+++ b/types/big.js/test/big.js-import-default-tests.ts
@@ -1,0 +1,12 @@
+/*
+
+  This file contains tests for the named export definitions of big.js.
+  Import the default Big constructor from 'big.js'
+
+*/
+
+import Big from 'big.js'
+
+function constructorTests() {
+    const x = new Big(9); // '9'
+}

--- a/types/big.js/test/big.js-import-default-tests.ts
+++ b/types/big.js/test/big.js-import-default-tests.ts
@@ -5,7 +5,7 @@
 
 */
 
-import Big from 'big.js'
+import Big from 'big.js';
 
 function constructorTests() {
     const x = new Big(9); // '9'

--- a/types/big.js/tsconfig.json
+++ b/types/big.js/tsconfig.json
@@ -19,6 +19,7 @@
     "files": [
         "index.d.ts",
         "test/big.js-module-tests.ts",
-        "test/big.js-global-tests.ts"
+        "test/big.js-global-tests.ts",
+        "test/big.js-import-default-tests.ts"
     ]
 }


### PR DESCRIPTION
As can be seen on https://github.com/MikeMcl/big.js/blob/master/big.js#L925, big.js exposes a default export.
Expose this in the Typescript bindings as well.