### PR TITLE
[@types/three] Fix function signatures for some Animation related classes

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -286,7 +286,7 @@ export class AnimationMixer extends EventDispatcher {
 
     clipAction(clip: AnimationClip, root?: any): AnimationAction;
     existingAction(clip: AnimationClip, root?: any): AnimationAction;
-    stopAllAction(clip: AnimationClip, root?: any): AnimationMixer;
+    stopAllAction(): AnimationMixer;
     update(deltaTime: number): AnimationMixer;
     getRoot(): any;
     uncacheClip(clip: AnimationClip): void;

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -271,7 +271,7 @@ export class AnimationClip {
     optimize(): AnimationClip;
 
     static CreateFromMorphTargetSequence( name: string, morphTargetSequence: MorphTarget[], fps: number, noLoop: boolean ): AnimationClip;
-    static findByName( clipArray: AnimationClip, name: string ): AnimationClip;
+    static findByName( clipArray: AnimationClip[], name: string ): AnimationClip;
     static CreateClipsFromMorphTargetSequences( morphTargets: MorphTarget[], fps: number, noLoop: boolean ): AnimationClip[];
     static parse( json: any ): AnimationClip;
     static parseAnimation( animation: any, bones: Bone[], nodeName: string ): AnimationClip;


### PR DESCRIPTION
Please fill in this template.
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Hi threejs maintainers, first of all thanks for the work on the type definitions for threejs. I've got a couple of small fixes for Animation related functions which I'm using in my projects.

First one is `stopAllAction` - this function takes no arguments.
Source: https://github.com/mrdoob/three.js/blob/dev/src/animation/AnimationMixer.js#L594

Second one is `findByName` - this is a little trickier, docs say it takes an `objectOrClipArray`. I understand why it was typed this way. However; it still should be an array.
Docs: https://threejs.org/docs/#api/animation/AnimationClip.findByName
Source: https://github.com/mrdoob/three.js/blob/dev/src/animation/AnimationClip.js#L118

Cheers!