### PR TITLE
[expo] Fix LinearGradient props

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -520,6 +520,12 @@ KeepAwake.deactivate();
         locations={[1, 2]} />
 );
 
+() => (
+    <LinearGradient
+        colors={['#fff']}
+        style={{ flex: 1 }} />
+);
+
 Permissions.CAMERA === 'camera';
 Permissions.CAMERA_ROLL === 'cameraRoll';
 Permissions.AUDIO_RECORDING === 'audioRecording';

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -4,6 +4,7 @@
 //                 Martynas Kadiša <https://github.com/martynaskadisa>
 //                 Jan Aagaard <https://github.com/janaagaard75>
 //                 Sergio Sánchez <https://github.com/ssanchezmarc>
+//                 Fernando Helwanger <https://github.com/fhelwanger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -1509,11 +1510,11 @@ export class KeepAwake extends Component {
 /**
  * LinearGradient
  */
-export interface LinearGradientProps {
+export interface LinearGradientProps extends ViewProperties {
     colors: string[];
-    start: [number, number];
-    end: [number, number];
-    locations: number[];
+    start?: [number, number];
+    end?: [number, number];
+    locations?: number[];
 }
 
 export class LinearGradient extends Component<LinearGradientProps> { }


### PR DESCRIPTION
* `start`, `end` and `locations` are optional
* `LinearGradient` should extends `ViewProperties`

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.expo.io/versions/latest/sdk/linear-gradient.html
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
