### PR TITLE
atom: add the linterName property to Linter Message

### DIFF
--- a/types/atom/linter/index.d.ts
+++ b/types/atom/linter/index.d.ts
@@ -5,6 +5,10 @@
 
 import { Disposable, Point, Range, TextEditor } from "../index";
 
+export interface Config {
+    name: string;
+}
+
 export interface ReplacementSolution {
     title?: string;
     position: Range;
@@ -60,6 +64,9 @@ export interface Message {
      *  do things like HTTP requests.
      */
     description?: string|(() => Promise<string>|string);
+
+    /** Optionally override the displayed linter name. Defaults to provider name. */
+    linterName?: string;
 }
 
 export interface IndieDelegate {
@@ -73,10 +80,14 @@ export interface IndieDelegate {
     dispose(): void;
 }
 
+export type LintResult = Message[] | null;
+
 export interface LinterProvider {
     name: string;
     scope: "file"|"project";
     lintsOnChange: boolean;
     grammarScopes: string[];
-    lint(textEditor: TextEditor): Message[]|null|Promise<Message[]|null>;
+    lint(editor: TextEditor): LintResult | Promise<LintResult>;
 }
+
+export type IndieProvider = (register: (config: Config) => IndieDelegate) => void;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
[Linter Type Documentation](https://steelbrain.me/linter/)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

~~This updates the bundled definitions for Linter in order to include type definitions for its legacy types. You can see the legacy types within the migration guides.~~
This simply adds the `linterName` property to the Linter Message type, while also introducing a few other types useful when creating a Linter provider.

This is being done to allow [atom-languageclient](https://github.com/atom/atom-languageclient) to use shared types, as discussed within [atom-languageclient#180](https://github.com/atom/atom-languageclient/pull/180).