### PR TITLE
[smtp-server] correct type of SMTPServerSession.remoteAddress property

### DIFF
--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -109,7 +109,7 @@ export interface SMTPServerEnvelope {
     /**
      * includes an address object or is set to false
      */
-    mailFrom: SMTPServerAddress;
+    mailFrom: SMTPServerAddress | false;
     /**
      * includes an array of address objects
      */

--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -95,6 +95,11 @@ export interface SMTPServerSession {
      * Envelope Object
      */
     envelope: SMTPServerEnvelope;
+    /**
+     *  If true, then the connection is using TLS
+     */
+    secure: boolean;
+
     transmissionType: string;
 
     tlsOptions: tls.TlsOptions;

--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -76,6 +76,10 @@ export interface SMTPServerSession {
      */
     remoteAddress: string;
     /**
+     * port number the connected client
+     */
+    remotePort: number;
+    /**
      * reverse resolved hostname for remoteAddress
      */
     clientHostname: string;

--- a/types/smtp-server/index.d.ts
+++ b/types/smtp-server/index.d.ts
@@ -74,7 +74,7 @@ export interface SMTPServerSession {
     /**
      * the IP address for the connected client
      */
-    remoteAddress: SMTPServerAddress;
+    remoteAddress: string;
     /**
      * reverse resolved hostname for remoteAddress
      */


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/nodemailer/smtp-server/blob/62c78e1acecd00191015fb99c2ef5559c02d4066/lib/smtp-connection.js#L71

https://github.com/nodemailer/smtp-server/blob/62c78e1acecd00191015fb99c2ef5559c02d4066/lib/smtp-connection.js#L72

https://github.com/nodemailer/smtp-server/blob/62c78e1acecd00191015fb99c2ef5559c02d4066/lib/smtp-connection.js#L64

https://nodemailer.com/extras/smtp-server/#session-object
