### PR TITLE
Add typing for `hrefTo` in @storybook/addon-links

### DIFF
--- a/types/storybook__addon-links/index.d.ts
+++ b/types/storybook__addon-links/index.d.ts
@@ -9,3 +9,5 @@ import * as React from 'react';
 export type LinkToFunction = (...args: any[]) => string;
 
 export function linkTo<T>(book: string | LinkToFunction, kind?: string | LinkToFunction): React.MouseEventHandler<T>;
+
+export function hrefTo(kind: string, story: string): Promise<string>;

--- a/types/storybook__addon-links/index.d.ts
+++ b/types/storybook__addon-links/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for @storybook/addon-links 3.0
 // Project: https://github.com/storybooks/storybook
-// Definitions by: Joscha Feth <https://github.com/joscha>
+// Definitions by: Joscha Feth <https://github.com/joscha>,
+//                 Jesse Pinho <https://github.com/jessepinho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/storybook__addon-links/index.d.ts
+++ b/types/storybook__addon-links/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for @storybook/addon-links 3.0
+// Type definitions for @storybook/addon-links 3.3
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>,
 //                 Jesse Pinho <https://github.com/jessepinho>

--- a/types/storybook__addon-links/storybook__addon-links-tests.tsx
+++ b/types/storybook__addon-links/storybook__addon-links-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
-import { linkTo } from '@storybook/addon-links';
+import { hrefTo, linkTo } from '@storybook/addon-links';
 
 storiesOf('Button', module)
   .add('First', () => (
@@ -12,3 +12,5 @@ storiesOf('Button', module)
   .add('With function', () => (
     <button onClick={linkTo((arg1, arg2) => 'Button', () => 'First')}>Go to "First"</button>
   ));
+
+hrefTo('Button', 'First').then(link => link);


### PR DESCRIPTION
See [the documentation for `hrefTo`](https://github.com/storybooks/storybook/blob/1a550e912b0c484ae787dc44809add30f6291dc4/addons/links/README.md#hrefto-function).

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/storybooks/storybook/blob/1a550e912b0c484ae787dc44809add30f6291dc4/addons/links/README.md#hrefto-function
- [X] Increase the version number in the header if appropriate.
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~