### PR TITLE
express-serve-static-core: Generic Body type on Response interface

### DIFF
--- a/types/api-error-handler/index.d.ts
+++ b/types/api-error-handler/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/api-error-handler
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/body-parser/index.d.ts
+++ b/types/body-parser/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/body-parser
 // Definitions by: Santi Albo <https://github.com/santialbo>, Vilic Vane <https://github.com/vilic>, Jonathan Häberle <https://github.com/dreampulse>, Gevik Babakhani <https://github.com/blendsdk>, Tomasz Łaziuk <https://github.com/tlaziuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/compression/index.d.ts
+++ b/types/compression/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/compression
 // Definitions by: Santi Albo <https://github.com/santialbo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/connect-busboy/index.d.ts
+++ b/types/connect-busboy/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mscdex/connect-busboy
 // Definitions by: Pinguet62 <https://github.com/pinguet62>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as busboy from 'busboy';
 import { RequestHandler } from 'express';

--- a/types/connect-ensure-login/index.d.ts
+++ b/types/connect-ensure-login/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/connect-ensure-login
 // Definitions by: Pavel Puchkov <https://github.com/0x6368656174>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { RequestHandler } from "express";
 

--- a/types/connect-flash/index.d.ts
+++ b/types/connect-flash/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/connect-flash
 // Definitions by: Andreas Gassmann <https://github.com/AndreasGassmann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="express" />
 

--- a/types/connect-history-api-fallback/index.d.ts
+++ b/types/connect-history-api-fallback/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bripkens/connect-history-api-fallback#readme
 // Definitions by: Douglas Duteil <https://github.com/douglasduteil>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/connect-modrewrite/index.d.ts
+++ b/types/connect-modrewrite/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tinganho/connect-modrewrite
 // Definitions by: Tingan Ho <https://github.com/tinganho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/connect-redis/index.d.ts
+++ b/types/connect-redis/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Xavier Stouder <https://github.com/xstoudi>
 //                 Albert Kurniawan <https://github.com/morcerf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="express" />
 /// <reference types="express-session" />

--- a/types/connect-slashes/index.d.ts
+++ b/types/connect-slashes/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/avinoamr/connect-slashes
 // Definitions by: Sam Herrmann <https://github.com/samherrmann>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/cookie-parser/index.d.ts
+++ b/types/cookie-parser/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Santi Albo <https://github.com/santialbo>
 //                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/cookie-session/index.d.ts
+++ b/types/cookie-session/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/cookie-session
 // Definitions by: Borislav Zhivkov <https://github.com/borislavjivkov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="express" />
 

--- a/types/cors/index.d.ts
+++ b/types/cors/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/troygoode/node-cors/
 // Definitions by: Mihhail Lapushkin <https://github.com/mihhail-lapushkin/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/easy-jsend/index.d.ts
+++ b/types/easy-jsend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/DeadAlready/easy-jsend
 // Definitions by: Karl Düüna <https://github.com/DeadAlready>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/easy-xapi-utils/index.d.ts
+++ b/types/easy-xapi-utils/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/DeadAlready/easy-xapi-utils
 // Definitions by: Karl Düüna <https://github.com/DeadAlready>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/easy-xapi/index.d.ts
+++ b/types/easy-xapi/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/DeadAlready/easy-xapi
 // Definitions by: Karl Düüna <https://github.com/DeadAlready>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="easy-jsend" />
 /// <reference types="bunyan" />

--- a/types/ejs-locals/index.d.ts
+++ b/types/ejs-locals/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/randometc/ejs-locals
 // Definitions by: jt000 <https://github.com/jt000>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/express-busboy/index.d.ts
+++ b/types/express-busboy/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/yahoo/express-busboy
 // Definitions by: Pinguet62 <https://github.com/pinguet62>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as connectBusboy from 'connect-busboy';
 import * as express from 'express';

--- a/types/express-ejs-layouts/index.d.ts
+++ b/types/express-ejs-layouts/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Soarez/express-ejs-layouts
 // Definitions by: Erik Mavrinac <https://github.com/erikma>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/express-flash-2/index.d.ts
+++ b/types/express-flash-2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jack2gs/express-flash-2
 // Definitions by: Matheus Salmi <https://github.com/mathsalmi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/express-formidable/index.d.ts
+++ b/types/express-formidable/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/noraesae/express-formidable
 // Definitions by: Torkild Dyvik Olsen <https://github.com/tdolsen>, Evan Shortiss <https://github.com/evanshortiss>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from "express";
 import { Fields, Files } from "formidable";

--- a/types/express-handlebars/index.d.ts
+++ b/types/express-handlebars/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ericf/express-handlebars
 // Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>, Igor Dultsev <https://github.com/yhaskell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 interface PartialTemplateOptions {
     cache?: boolean;

--- a/types/express-less/index.d.ts
+++ b/types/express-less/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/express-less
 // Definitions by: xyb <https://github.com/xieyubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/express-oauth-server/index.d.ts
+++ b/types/express-oauth-server/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oauthjs/express-oauth-server#readme
 // Definitions by: Arne Schubert <https://github.com/atd-schubert>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 import * as OAuth2Server from 'oauth2-server';

--- a/types/express-openapi/index.d.ts
+++ b/types/express-openapi/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kogosoftwarellc/express-openapi
 // Definitions by: TANAKA Koichi <https://github.com/mugeso>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
  import express = require('express');

--- a/types/express-partials/index.d.ts
+++ b/types/express-partials/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/publicclass/express-partials
 // Definitions by: jt000 <https://github.com/jt000>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/express-rate-limit/index.d.ts
+++ b/types/express-rate-limit/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nfriedly/express-rate-limit
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>, makepost <https://github.com/makepost>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require("express");
 

--- a/types/express-route-fs/index.d.ts
+++ b/types/express-route-fs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kripod/express-route-fs
 // Definitions by: Kristóf Poduszló <https://github.com/kripod>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 /**

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -6,7 +6,7 @@
 //                 Satana Charuwichitratana <https://github.com/micksatana>
 //                 Sami Jaber <https://github.com/samijaber>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 // This extracts the core definitions from express to prevent a circular dependency between express and serve-static
 /// <reference types="node" />

--- a/types/express-serve-static-core/index.d.ts
+++ b/types/express-serve-static-core/index.d.ts
@@ -459,13 +459,13 @@ export interface MediaType {
     subtype: string;
 }
 
-export type Send = (body?: any) => Response;
+export type Send<Body = any> = (body?: Body) => Response<Body>;
 
-export interface Response extends http.ServerResponse, Express.Response {
+export interface Response<Body = any> extends http.ServerResponse, Express.Response {
     /**
      * Set status `code`.
      */
-    status(code: number): Response;
+    status(code: number): Response<Body>;
 
     /**
      * Set the response HTTP status code to `statusCode` and send its string representation as the response body.
@@ -478,7 +478,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *    res.sendStatus(404); // equivalent to res.status(404).send('Not Found')
      *    res.sendStatus(500); // equivalent to res.status(500).send('Internal Server Error')
      */
-    sendStatus(code: number): Response;
+    sendStatus(code: number): Response<Body>;
 
     /**
      * Set Link header field with the given `links`.
@@ -490,7 +490,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *      last: 'http://api.example.com/users?page=5'
      *    });
      */
-    links(links: any): Response;
+    links(links: any): Response<Body>;
 
     /**
      * Send a response.
@@ -503,7 +503,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *     res.send(404, 'Sorry, cant find that');
      *     res.send(404);
      */
-    send: Send;
+    send: Send<Body>;
 
     /**
      * Send JSON response.
@@ -515,7 +515,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *     res.json(500, 'oh noes!');
      *     res.json(404, 'I dont have that');
      */
-    json: Send;
+    json: Send<Body>;
 
     /**
      * Send JSON response with JSONP callback support.
@@ -527,7 +527,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *     res.jsonp(500, 'oh noes!');
      *     res.jsonp(404, 'I dont have that');
      */
-    jsonp: Send;
+    jsonp: Send<Body>;
 
     /**
      * Transfer the file at the given `path`.
@@ -618,7 +618,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *     res.type('application/json');
      *     res.type('png');
      */
-    contentType(type: string): Response;
+    contentType(type: string): Response<Body>;
 
     /**
      * Set _Content-Type_ response header with `type` through `mime.lookup()`
@@ -632,7 +632,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *     res.type('application/json');
      *     res.type('png');
      */
-    type(type: string): Response;
+    type(type: string): Response<Body>;
 
     /**
      * Respond to the Acceptable formats using an `obj`
@@ -686,12 +686,12 @@ export interface Response extends http.ServerResponse, Express.Response {
      * a `.default` callback it will be invoked
      * instead.
      */
-    format(obj: any): Response;
+    format(obj: any): Response<Body>;
 
     /**
      * Set _Content-Disposition_ header to _attachment_ with optional `filename`.
      */
-    attachment(filename?: string): Response;
+    attachment(filename?: string): Response<Body>;
 
     /**
      * Set header `field` to `val`, or pass
@@ -705,11 +705,11 @@ export interface Response extends http.ServerResponse, Express.Response {
      *
      * Aliased as `res.header()`.
      */
-    set(field: any): Response;
-    set(field: string, value?: string): Response;
+    set(field: any): Response<Body>;
+    set(field: string, value?: string): Response<Body>;
 
-    header(field: any): Response;
-    header(field: string, value?: string): Response;
+    header(field: any): Response<Body>;
+    header(field: string, value?: string): Response<Body>;
 
     // Property indicating if HTTP headers has been sent for the response.
     headersSent: boolean;
@@ -718,7 +718,7 @@ export interface Response extends http.ServerResponse, Express.Response {
     get(field: string): string;
 
     /** Clear cookie `name`. */
-    clearCookie(name: string, options?: any): Response;
+    clearCookie(name: string, options?: any): Response<Body>;
 
     /**
      * Set cookie `name` to `val`, with the given `options`.
@@ -737,9 +737,9 @@ export interface Response extends http.ServerResponse, Express.Response {
      *    // save as above
      *    res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true })
      */
-    cookie(name: string, val: string, options: CookieOptions): Response;
-    cookie(name: string, val: any, options: CookieOptions): Response;
-    cookie(name: string, val: any): Response;
+    cookie(name: string, val: string, options: CookieOptions): Response<Body>;
+    cookie(name: string, val: any, options: CookieOptions): Response<Body>;
+    cookie(name: string, val: any): Response<Body>;
 
     /**
      * Set the location header to `url`.
@@ -767,7 +767,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *
      *      res.location('/login');
      */
-    location(url: string): Response;
+    location(url: string): Response<Body>;
 
     /**
      * Redirect to the given `url` with optional response `status`
@@ -813,7 +813,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *     res.vary('User-Agent').render('docs');
      *
      */
-    vary(field: string): Response;
+    vary(field: string): Response<Body>;
 
     app: Application;
 
@@ -826,7 +826,7 @@ export interface Response extends http.ServerResponse, Express.Response {
      *
      * @since 4.11.0
      */
-    append(field: string, value?: string[]|string): Response;
+    append(field: string, value?: string[]|string): Response<Body>;
 }
 
 export interface Handler extends RequestHandler { }

--- a/types/express-session/index.d.ts
+++ b/types/express-session/index.d.ts
@@ -5,7 +5,7 @@
 //                 Naoto Yokoyama <https://github.com/builtinnya>
 //                 Ryan Cannon <https://github.com/ry7n>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/express-useragent/index.d.ts
+++ b/types/express-useragent/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.org/package/express-useragent
 // Definitions by: Isman Usoh <https://github.com/isman-usoh/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="express" />
 

--- a/types/express-winston/index.d.ts
+++ b/types/express-winston/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bithavoc/express-winston#readme
 // Definitions by: Alex Brick <https://github.com/bricka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { ErrorRequestHandler, Handler, Request, Response } from 'express';
 import { TransportInstance, Winston } from 'winston';

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://expressjs.com
 // Definitions by: Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/feathersjs__authentication-jwt/index.d.ts
+++ b/types/feathersjs__authentication-jwt/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://feathersjs.com/
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Application } from '@feathersjs/feathers';
 import { Request } from 'express';

--- a/types/feathersjs__authentication-local/index.d.ts
+++ b/types/feathersjs__authentication-local/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://feathersjs.com/
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import {
     Application,

--- a/types/feathersjs__authentication-oauth1/index.d.ts
+++ b/types/feathersjs__authentication-oauth1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://feathersjs.com/
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import {
     Application,

--- a/types/feathersjs__authentication-oauth2/index.d.ts
+++ b/types/feathersjs__authentication-oauth2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://feathersjs.com/
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import {
     Application,

--- a/types/feathersjs__errors/index.d.ts
+++ b/types/feathersjs__errors/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://feathersjs.com/
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 export class FeathersError extends Error {
     constructor(msg: string | Error, name: string, code: number, className: string, data: any)

--- a/types/feathersjs__express/index.d.ts
+++ b/types/feathersjs__express/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://feathersjs.com/
 // Definitions by: Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Application as FeathersApplication } from '@feathersjs/feathers';
 import * as express from 'express';

--- a/types/gulp-connect/index.d.ts
+++ b/types/gulp-connect/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/avevlad/gulp-connect#readme
 // Definitions by: Andre Wiggins <https://github.com/andrewiggins>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as http from "http";
 import * as https from "https";

--- a/types/http-assert/index.d.ts
+++ b/types/http-assert/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jshttp/http-assert
 // Definitions by: jKey Lu <https://github.com/jkeylu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /**
  * @param status the status code

--- a/types/http-errors/index.d.ts
+++ b/types/http-errors/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 export = createHttpError;
 

--- a/types/http-proxy-middleware/index.d.ts
+++ b/types/http-proxy-middleware/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Zebulon McCorkle <https://github.com/zebMcCorkle>
 //                 BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/i18n/index.d.ts
+++ b/types/i18n/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Maxime LUCE <https://github.com/SomaticIT>
 //                 FindQ <https://github.com/FindQ>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 declare namespace i18n {
     interface ConfigurationOptions {

--- a/types/jsforce/index.d.ts
+++ b/types/jsforce/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Dolan Miu <https://github.com/dolanmiu>
 //                 Kamil Ejsymont <https://github.com/netes>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as fs from 'fs';
 import * as stream from 'stream';

--- a/types/kraken-js/index.d.ts
+++ b/types/kraken-js/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://krakenjs.com
 // Definitions by: Timur Manyanov <https://github.com/darkwebdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { Express } from 'express';
 import { EventEmitter } from 'events';

--- a/types/kue/index.d.ts
+++ b/types/kue/index.d.ts
@@ -4,7 +4,7 @@
 //                 Amiram Korach <https://github.com/amiram>
 //                 Christian D. <https://github.com/pc-jedi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/lusca/index.d.ts
+++ b/types/lusca/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/krakenjs/lusca#readme
 // Definitions by: Corbin Crutchley <https://github.com/crutchcorn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/morgan/index.d.ts
+++ b/types/morgan/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: James Roland Cabresos <https://github.com/staticfunction>
 //                 Paolo Scanferla <https://github.com/pscanf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 

--- a/types/multer-s3/index.d.ts
+++ b/types/multer-s3/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: KIM Jaesuck a.k.a. gim tcaesvk <https://github.com/tcaesvk>
 //                 Gal Talmor <https://github.com/galtalmor>
 // Definitions: https://github.com/DefinitelyType/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as AWS from "aws-sdk";
 import { StorageEngine } from "multer";

--- a/types/multer/index.d.ts
+++ b/types/multer/index.d.ts
@@ -6,7 +6,7 @@
 //                 Michael Ledin <https://github.com/mxl>
 //                 HyunSeob Lee <https://github.com/hyunseob>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from 'express';
 

--- a/types/node-sass-middleware/index.d.ts
+++ b/types/node-sass-middleware/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/sass/node-sass-middleware
 // Definitions by: Pascal Garber <http://www.jumplink.eu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/oauth2-server/index.d.ts
+++ b/types/oauth2-server/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by:  Robbie Van Gorkom <https://github.com/vangorra>,
 //                  Charles Irick <https://github.com/cirick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import Express = require("express");
 

--- a/types/oauth2orize/index.d.ts
+++ b/types/oauth2orize/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jaredhanson/oauth2orize/
 // Definitions by: Wonshik Kim <https://github.com/wokim>, Kei Son <https://github.com/heycalmdown>, Steve Hipwell <https://github.com/stevehipwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 /// <reference types="express" />

--- a/types/promisify-supertest/index.d.ts
+++ b/types/promisify-supertest/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/promisify-supertest
 // Definitions by: Leo Liang <https://github.com/aleung>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 // Mostly copy-pasted from supertest.d.ts
 

--- a/types/response-time/index.d.ts
+++ b/types/response-time/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/response-time
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>, TonyYang <https://github.com/TonyPythoneer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 /* =================== USAGE ===================

--- a/types/saml2-js/index.d.ts
+++ b/types/saml2-js/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Clever/saml2
 // Definitions by: horiuchi <https://github.com/horiuchi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 declare module "saml2-js" {
 

--- a/types/send/index.d.ts
+++ b/types/send/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pillarjs/send
 // Definitions by: Mike Jerred <https://github.com/MikeJerred>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/serve-favicon/index.d.ts
+++ b/types/serve-favicon/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/serve-favicon
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/serve-index/index.d.ts
+++ b/types/serve-index/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expressjs/serve-index
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 
 

--- a/types/serve-static/index.d.ts
+++ b/types/serve-static/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Uros Smolnik <https://github.com/urossmolnik>
 //                 Linus Unnebäck <https://github.com/LinusU>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/session-file-store/index.d.ts
+++ b/types/session-file-store/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Gevik Babakhani <https://github.com/blendsdk>
 //                 Junyoung Choi <https://github.com/rokt33r>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as express from "express";
 import * as session from "express-session";

--- a/types/socket.io.users/index.d.ts
+++ b/types/socket.io.users/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nodets/socket.io.users
 // Definitions by: Makis Maropoulos <https://github.com/kataras>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 

--- a/types/sticky-cluster/index.d.ts
+++ b/types/sticky-cluster/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/uqee/sticky-cluster
 // Definitions by: Austin Turner <https://github.com/paustint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node"/>
 import * as http from 'http';

--- a/types/streaming-json-stringify/index.d.ts
+++ b/types/streaming-json-stringify/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/stream-utils/streaming-json-stringify#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 import * as stream from 'stream';

--- a/types/supertest/index.d.ts
+++ b/types/supertest/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/visionmedia/supertest
 // Definitions by: Alex Varju <https://github.com/varju>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as superagent from "superagent"
 

--- a/types/swagger-jsdoc/index.d.ts
+++ b/types/swagger-jsdoc/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/surnet/swagger-jsdoc
 // Definitions by: Daniel Grove <https://github.com/drGrove>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /* =================== USAGE ===================
 

--- a/types/type-is/index.d.ts
+++ b/types/type-is/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jshttp/type-is#readme
 // Definitions by: BendingBender <https://github.com/BendingBender>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 /// <reference types="node" />
 import { IncomingMessage } from 'http';

--- a/types/universal-analytics/index.d.ts
+++ b/types/universal-analytics/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/peaksandpies/universal-analytics
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Iker Pérez Brunelli <https://github.com/DarkerTV>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 declare namespace ua {
     type Callback = (error: Error | null, count: number) => void;

--- a/types/vitalsigns/index.d.ts
+++ b/types/vitalsigns/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/TomFrost/node-vitalsigns
 // Definitions by: Cyril Schumacher <https://github.com/cyrilschumacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 ///<reference types="express"/>
 

--- a/types/webpack-dev-middleware/index.d.ts
+++ b/types/webpack-dev-middleware/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
 //                 reduckted <https://github.com/reduckted>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as webpack from 'webpack';
 import * as loglevel from 'loglevel';

--- a/types/webpack-dev-middleware/v1/index.d.ts
+++ b/types/webpack-dev-middleware/v1/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>
 //                 reduckted <https://github.com/reduckted>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { NextHandleFunction } from 'connect';
 import * as webpack from 'webpack';

--- a/types/webpack-dev-server/index.d.ts
+++ b/types/webpack-dev-server/index.d.ts
@@ -5,7 +5,7 @@
 //                 Zheyang Song <https://github.com/ZheyangSong>
 //                 Alan Agius <https://github.com/alan-agius4>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import * as webpack from 'webpack';
 import * as core from 'express-serve-static-core';

--- a/types/webpack-hot-middleware/index.d.ts
+++ b/types/webpack-hot-middleware/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/glenjamin/webpack-hot-middleware#readme
 // Definitions by: Benjamin Lim <https://github.com/bumbleblym>, Ron Martinez <https://github.com/icylace>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { NextHandleFunction } from 'connect';
 import * as webpack from 'webpack';

--- a/types/yog-bigpipe/index.d.ts
+++ b/types/yog-bigpipe/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/fex-team/yog-bigpipe
 // Definitions by: ssddi456 <https://github.com/ssddi456>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import { EventEmitter } from 'events';
 import { Readable } from 'stream';

--- a/types/zipkin-instrumentation-express/index.d.ts
+++ b/types/zipkin-instrumentation-express/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/openzipkin/zipkin-js#readme
 // Definitions by: York Yao <https://github.com/plantain-00>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.3
 
 import express = require('express');
 import { Tracer } from 'zipkin';


### PR DESCRIPTION
This PR suggests to upgrade `express-serve-static-core` and all its direct and indirect dependencies to use TypeScript 2.3 or above. This is required to be able to use generic parameter defaults: https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#generic-parameter-defaults

If I didn't update the dependent types `npm test` fails.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present):
   - I ran this for `express-serve-static-core`, `express` and `serve-static`

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: N/A
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

# ToDo

- [ ] Implement a test exercising the new generic type (I would like a pointer to where that would be appropriate).

---

When implementing a request handler using express it would be awesome if the developer could optionally specify the expected type of the response body to be sent:

```
interface User {
  name: string;
  email: string;
}

app.get('/user', function (req: Request, res: Response<User>) {
  const user = { name: 'John Doe' };
  res.status(200).send(user); // Would fail as the argument is missing an `email`
});
```

More specifically this PR is:
1. Adding an optional generic type named `Body` (or `B` - whichever is preferred?) to the `Response` interface: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/express-serve-static-core/index.d.ts#L464
2. Including the `Body` on all recursive uses of `Request` as return types in the `Response` interface definition (status, sendStatus, links, contentType, type, format, attachment, set, header, clearCookie, cookie, location, vary and append)
3. Turning the `Send` type into a generic type with `any` as its default and use that type for the `body` argument.
4. Changing the lowest supported typescript version from 2.2 to 2.3, to use default values for the generic `Body` type. I believe that is worth it as it significantly increases usability: See https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#generic-parameter-defaults.