### PR TITLE
Add @babel/code-frame

### DIFF
--- a/types/babel__code-frame/babel__code-frame-tests.ts
+++ b/types/babel__code-frame/babel__code-frame-tests.ts
@@ -1,0 +1,26 @@
+import codeFrame, { codeFrameColumns } from "@babel/code-frame";
+
+const code = `
+    const number = 1;
+    var string = 'foo';
+
+    function print(name: string) {
+        console.log(string + name);
+    }
+`;
+
+codeFrame(code, 5, 22);
+codeFrame(code, 5, 22, { forceColor: true });
+codeFrame(code, 2, 2, { highlightCode: true });
+
+codeFrameColumns(code, { start: { line: 5, column: 22 } });
+codeFrameColumns(
+    code,
+    { start: { line: 5, column: 22 } },
+    { forceColor: true }
+);
+codeFrameColumns(
+    code,
+    { start: { line: 2, column: 2 } },
+    { highlightCode: true }
+);

--- a/types/babel__code-frame/index.d.ts
+++ b/types/babel__code-frame/index.d.ts
@@ -1,0 +1,57 @@
+// Type definitions for @babel/code-frame 7.0
+// Project: https://github.com/babel/babel/tree/master/packages/babel-code-frame
+// Definitions by: Mohsen Azimi <https://github.com/mohsen1>
+//                 Forbes Lindesay <https://github.com/ForbesLindesay>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface Location {
+    start: { line: number; column?: number };
+    end?: { line: number; column?: number };
+}
+declare function codeFrameColumns(
+    rawLines: string,
+    location: Location,
+    options?: BabelCodeFrameOptions
+): string;
+export { codeFrameColumns };
+
+export interface BabelCodeFrameOptions {
+    /** Syntax highlight the code as JavaScript for terminals. default: false */
+    highlightCode?: boolean;
+    /**  The number of lines to show above the error. default: 2 */
+    linesAbove?: number;
+    /**  The number of lines to show below the error. default: 3 */
+    linesBelow?: number;
+    /**
+     * Forcibly syntax highlight the code as JavaScript (for non-terminals);
+     * overrides highlightCode.
+     * default: false
+     */
+    forceColor?: boolean;
+    /**
+     * Pass in a string to be displayed inline (if possible) next to the
+     * highlighted location in the code. If it can't be positioned inline,
+     * it will be placed above the code frame.
+     * default: nothing
+     */
+    message?: string;
+}
+
+/**
+ * Generate errors that contain a code frame that point to source locations.
+ *
+ * @param rawLines Raw lines to frame
+ * @param lineNumber Line number (1 indexed)
+ * @param colNumber Column number
+ * @param options Additional options
+ *
+ * @returns Framed code
+ */
+declare function codeFrame(
+    rawLines: string,
+    lineNumber: number,
+    colNumber: number,
+    options?: BabelCodeFrameOptions
+): string;
+
+export default codeFrame;

--- a/types/babel__code-frame/index.d.ts
+++ b/types/babel__code-frame/index.d.ts
@@ -4,13 +4,13 @@
 //                 Forbes Lindesay <https://github.com/ForbesLindesay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export interface Location {
+export interface SourceLocation {
     start: { line: number; column?: number };
     end?: { line: number; column?: number };
 }
 declare function codeFrameColumns(
     rawLines: string,
-    location: Location,
+    location: SourceLocation,
     options?: BabelCodeFrameOptions
 ): string;
 export { codeFrameColumns };

--- a/types/babel__code-frame/index.d.ts
+++ b/types/babel__code-frame/index.d.ts
@@ -8,12 +8,11 @@ export interface SourceLocation {
     start: { line: number; column?: number };
     end?: { line: number; column?: number };
 }
-declare function codeFrameColumns(
+export function codeFrameColumns(
     rawLines: string,
     location: SourceLocation,
     options?: BabelCodeFrameOptions
 ): string;
-export { codeFrameColumns };
 
 export interface BabelCodeFrameOptions {
     /** Syntax highlight the code as JavaScript for terminals. default: false */
@@ -47,11 +46,9 @@ export interface BabelCodeFrameOptions {
  *
  * @returns Framed code
  */
-declare function codeFrame(
+export default function codeFrame(
     rawLines: string,
     lineNumber: number,
     colNumber: number,
     options?: BabelCodeFrameOptions
 ): string;
-
-export default codeFrame;

--- a/types/babel__code-frame/tsconfig.json
+++ b/types/babel__code-frame/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "paths": {
+            "@babel/code-frame": ["babel__code-frame"]
+        }
+    },
+    "files": ["index.d.ts", "babel__code-frame-tests.ts"]
+}

--- a/types/babel__code-frame/tslint.json
+++ b/types/babel__code-frame/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
This is based on the definition for babel-code-frame, but adds the new codeFrameColumns method. See https://github.com/babel/babel/tree/master/packages/babel-code-frame for project documentation.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project. **I based this off `babel-code-frame` since the new project is so similar**
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

