### PR TITLE
[spotify-web-playback-sdk] Reflect new changes

### DIFF
--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -86,6 +86,10 @@ declare namespace Spotify {
         FULL_REPEAT = 2,
     }
 
+    type ErrorListener = (err: Error) => void;
+    type PlaybackInstanceListener = (inst: WebPlaybackInstance) => void;
+    type PlaybackStateListener = (s: PlaybackState) => void;
+
     class SpotifyPlayer {
         constructor(options: PlayerInit);
 
@@ -95,9 +99,17 @@ declare namespace Spotify {
         getVolume(): Promise<number>;
         nextTrack(): Promise<void>;
 
-        on(event: 'ready', cb: (pb: WebPlaybackInstance) => void): void;
-        on(event: 'player_state_changed', cb: (pb: PlaybackState) => void): void;
-        on(event: ErrorTypes, cb: (err: Error) => void): void;
+        addListener(event: 'ready', cb: PlaybackInstanceListener): void;
+        addListener(event: 'player_state_changed', cb: PlaybackStateListener): void;
+        addListener(event: ErrorTypes, cb: ErrorListener): void;
+        on(event: 'ready', cb: PlaybackInstanceListener): void;
+        on(event: 'player_state_changed', cb: PlaybackStateListener): void;
+        on(event: ErrorTypes, cb: ErrorListener): void;
+
+        removeListener(
+            event: 'ready' | 'player_state_changed' | ErrorTypes,
+            cb?: ErrorListener | PlaybackInstanceListener | PlaybackStateListener,
+        ): void;
 
         pause(): Promise<void>;
         previousTrack(): Promise<void>;

--- a/types/spotify-web-playback-sdk/index.d.ts
+++ b/types/spotify-web-playback-sdk/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for spotify-web-playback-sdk 0.1
 // Project: https://beta.developer.spotify.com/documentation/web-playback-sdk/reference/
 // Definitions by: Festify Dev Team <https://github.com/Festify>
+//                 Marcus Weiner <https://github.com/mraerino>
+//                 Moritz Gunz <https://github.com/NeoLegends>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface Window {

--- a/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
+++ b/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
@@ -20,7 +20,7 @@ player.connect().then((success) => {
 
 player.disconnect();
 
-player.on("ready", (data) => {
+player.addListener("ready", (data) => {
     console.log("The Web Playback SDK is ready to play music!");
 });
 
@@ -68,12 +68,12 @@ player.nextTrack().then(() => {
     console.log("Skipped to next track!");
 });
 
-player.on("ready", (data) => {
+player.addListener("ready", (data) => {
     const { device_id } = data;
     console.log("Connected with Device ID", device_id);
 });
 
-player.on("player_state_changed", (playbackState) => {
+player.addListener("player_state_changed", (playbackState) => {
     const { position, duration } = playbackState;
     const { current_track } = playbackState.track_window;
 
@@ -82,7 +82,7 @@ player.on("player_state_changed", (playbackState) => {
     console.log("Duration of Song", duration);
 });
 
-player.on('initialization_error', (e) => {
+player.addListener('initialization_error', (e) => {
     console.error("Failed to initialize", e.message);
 });
 
@@ -94,6 +94,12 @@ player.on('account_error', (e) => {
     console.error("Failed to validate Spotify account", e.message);
 });
 
-player.on('playback_error', (e) => {
+const listener = (e: any) => {
     console.error("Failed to perform playback", e.message);
-});
+};
+player.addListener('playback_error', listener);
+player.addListener('playback_error', () => {});
+player.removeListener('playback_error', () => {});
+
+player.removeListener('playback_error');
+player.removeListener('playback_error', listener);

--- a/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
+++ b/types/spotify-web-playback-sdk/spotify-web-playback-sdk-tests.ts
@@ -5,14 +5,14 @@
 
 const player = new Spotify.Player({
     name: "Carly Rae Jepsen Player",
-    getOAuthToken: (callback) => {
+    getOAuthToken: (callback: (t: string) => void) => {
         // Run code to get a fresh access token
         callback("access token here");
     },
     volume: 0.5
 });
 
-player.connect().then((success) => {
+player.connect().then((success: boolean) => {
     if (success) {
         console.log("The Web Playback SDK successfully connected to Spotify!");
     }
@@ -24,7 +24,7 @@ player.addListener("ready", (data) => {
     console.log("The Web Playback SDK is ready to play music!");
 });
 
-player.getCurrentState().then((playbackState) => {
+player.getCurrentState().then((playbackState: Spotify.PlaybackState | null) => {
     if (playbackState) {
         const { current_track, next_tracks } = playbackState.track_window;
 
@@ -35,7 +35,7 @@ player.getCurrentState().then((playbackState) => {
     }
 });
 
-player.getVolume().then((volume) => {
+player.getVolume().then((volume: number) => {
     const volume_percentage = (volume * 100);
     console.log(`The volume of the player is ${volume_percentage}%`);
 });
@@ -68,12 +68,12 @@ player.nextTrack().then(() => {
     console.log("Skipped to next track!");
 });
 
-player.addListener("ready", (data) => {
+player.on("ready", (data: Spotify.WebPlaybackInstance) => {
     const { device_id } = data;
     console.log("Connected with Device ID", device_id);
 });
 
-player.addListener("player_state_changed", (playbackState) => {
+player.on("player_state_changed", (playbackState: Spotify.PlaybackState) => {
     const { position, duration } = playbackState;
     const { current_track } = playbackState.track_window;
 
@@ -82,19 +82,19 @@ player.addListener("player_state_changed", (playbackState) => {
     console.log("Duration of Song", duration);
 });
 
-player.addListener('initialization_error', (e) => {
+player.addListener('initialization_error', (e: Spotify.Error) => {
     console.error("Failed to initialize", e.message);
 });
 
-player.on('authentication_error', (e) => {
+player.addListener('authentication_error', (e: Spotify.Error) => {
     console.error("Failed to authenticate", e.message);
 });
 
-player.on('account_error', (e) => {
+player.addListener('account_error', (e: Spotify.Error) => {
     console.error("Failed to validate Spotify account", e.message);
 });
 
-const listener = (e: any) => {
+const listener = (e: Spotify.Error) => {
     console.error("Failed to perform playback", e.message);
 };
 player.addListener('playback_error', listener);


### PR DESCRIPTION











Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://beta.developer.spotify.com/documentation/web-playback-sdk/reference/#api-spotify-player-addlistener
- [X] Increase the version number in the header if appropriate.

----

Spotify has added new methods for adding and removing event handlers to their web playback sdk. `addListener` behaves exactly like `on`. There has been no pendant for `removeListener` before. This has been added in.