### PR TITLE
Make options hash optional on `DS.Model.destroyRecord()`

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -491,7 +491,7 @@ declare module 'ember-data' {
             /**
              * Same as `deleteRecord`, but saves the record immediately.
              */
-            destroyRecord(options: {}): RSVP.Promise<any>;
+            destroyRecord(options?: {}): RSVP.Promise<any>;
             /**
              * Unloads the record from the store. This will cause the record to be destroyed and freed up for garbage collection.
              */


### PR DESCRIPTION
See API docs here: https://emberjs.com/api/ember-data/3.0/classes/DS.Model/methods/destroyRecord?anchor=destroyRecord

Also it's not explictely listet in the API docs to be optional, check the example code below. Also source code for this: https://github.com/emberjs/data/blob/master/addon/-private/system/model/model.js#L618

Which passes `options` to the `save()` method, which is declared here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ember-data/index.d.ts#L513