### PR TITLE
Add type definitions for react-redux-epic

### DIFF
--- a/types/react-redux-epic/client.d.ts
+++ b/types/react-redux-epic/client.d.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { Observable } from 'rxjs/Observable';
+
+export function render<P>(
+    element: React.ReactElement<P>,
+    container: Element
+): Observable<undefined>;

--- a/types/react-redux-epic/client.d.ts
+++ b/types/react-redux-epic/client.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Observable } from 'rxjs/Observable';
 
-export function render<P>(
-    element: React.ReactElement<P>,
+export function render(
+    element: React.ReactElement<any>,
     container: Element
 ): Observable<undefined>;

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -12,11 +12,9 @@ export interface Action {
     type: string;
 }
 
-export function wrapRootEpic<T extends Action>(
-    epic: Epic<T, any, any>
-): typeof epic;
+export function wrapRootEpic(epic: Epic<any, any>): typeof epic;
 
-export function renderToString<T extends Action>(
+export function renderToString(
     element: React.ReactElement<any>,
-    wrappedEpic: Epic<T, any, any>
+    wrappedEpic: Epic<any, any>
 ): Observable<{ markup: string }>;

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -13,10 +13,10 @@ export interface Action {
 }
 
 export function wrapRootEpic<T extends Action, S, D = any>(
-    epic: Epic<T, S, D>
+    epic: Epic<T, S, D> // tslint:disable-line no-unnecessary-generics
 ): typeof epic;
 
-export function renderToString<P, T extends Action, S, D = any>(
-    element: React.ReactElement<P>,
-    wrappedEpic: Epic<T, S, D>
+export function renderToString<T extends Action, S, D = any>(
+    element: React.ReactElement<any>,
+    wrappedEpic: Epic<T, S, D> // tslint:disable-line no-unnecessary-generics
 ): Observable<{ markup: string }>;

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -12,11 +12,11 @@ export interface Action {
     type: string;
 }
 
-export function wrapRootEpic<T extends Action, S, D = any>(
-    epic: Epic<T, S, D> // tslint:disable-line no-unnecessary-generics
+export function wrapRootEpic<T extends Action>(
+    epic: Epic<T, any, any>
 ): typeof epic;
 
-export function renderToString<T extends Action, S, D = any>(
+export function renderToString<T extends Action>(
     element: React.ReactElement<any>,
-    wrappedEpic: Epic<T, S, D> // tslint:disable-line no-unnecessary-generics
+    wrappedEpic: Epic<T, any, any>
 ): Observable<{ markup: string }>;

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for react-redux-epic 1.1
+// Project: https://github.com/BerkeleyTrue/react-redux-epic#readme
+// Definitions by: forabi <https://github.com/forabi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as React from 'react';
+import { Observable } from 'rxjs/Observable';
+import { Epic } from 'redux-observable';
+
+export interface Action {
+    type: string;
+}
+
+export function wrapRootEpic<T extends Action, S, D = any>(
+    epic: Epic<T, S, D>
+): typeof epic;
+
+export function renderToString<P, T extends Action, S, D = any>(
+    element: React.ReactElement<P>,
+    wrappedEpic: Epic<T, S, D>
+): Observable<{ markup: string }>;

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -12,7 +12,9 @@ export interface Action {
     type: string;
 }
 
-export function wrapRootEpic(epic: Epic<any, any>): typeof epic;
+export function wrapRootEpic<T, S, D, O extends T>(
+    epic: Epic<T, S, D, O>
+): Epic<T, S, D, O>;
 
 export function renderToString(
     element: React.ReactElement<any>,

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/BerkeleyTrue/react-redux-epic#readme
 // Definitions by: forabi <https://github.com/forabi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.6
 
 import * as React from 'react';
 import { Observable } from 'rxjs/Observable';

--- a/types/react-redux-epic/package.json
+++ b/types/react-redux-epic/package.json
@@ -1,0 +1,7 @@
+{
+    "private": true,
+    "dependencies": {
+        "rxjs": "^5.5.5",
+        "redux-observable": "^0.18.0"
+    }
+}

--- a/types/react-redux-epic/react-redux-epic-tests.tsx
+++ b/types/react-redux-epic/react-redux-epic-tests.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Epic } from 'redux-observable';
+import { renderToString, wrapRootEpic } from 'react-redux-epic';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/ignoreElements';
+
+interface Action {
+    type: string;
+    payload: any;
+}
+
+const rootEpic: Epic<Action, {}> = action$ => {
+    return action$
+        .do(action => {
+            // Action dispatched
+        })
+        .ignoreElements();
+};
+
+const wrappedRootEpic = wrapRootEpic(rootEpic);
+
+renderToString(<div>Hello, world</div>, wrappedRootEpic).subscribe({
+    next({ markup }) {
+        // Done
+    }
+});

--- a/types/react-redux-epic/tsconfig.json
+++ b/types/react-redux-epic/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": ["../"],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.d.ts", "client.d.ts"]
+}

--- a/types/react-redux-epic/tsconfig.json
+++ b/types/react-redux-epic/tsconfig.json
@@ -6,11 +6,12 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "strictFunctionTypes": true,
+        "jsx": "React",
         "baseUrl": "../",
         "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.d.ts", "client.d.ts"]
+    "files": ["index.d.ts", "client.d.ts", "react-redux-epic-tests.tsx"]
 }

--- a/types/react-redux-epic/tslint.json
+++ b/types/react-redux-epic/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "no-unnecessary-generics": false
+    }
+}

--- a/types/react-redux-epic/tslint.json
+++ b/types/react-redux-epic/tslint.json
@@ -1,6 +1,3 @@
 {
-    "extends": "dtslint/dt.json",
-    "rules": {
-        "no-unnecessary-generics": false
-    }
+    "extends": "dtslint/dt.json"
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
