### PR TITLE
Fix Enumerable#isAny second param type

### DIFF
--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1182,7 +1182,7 @@ declare module 'ember' {
              * argument for all items in the enumerable. This method is often simpler/faster
              * than using a callback.
              */
-            isEvery(key: string, value: boolean): boolean;
+            isEvery(key: string, value: any): boolean;
             /**
              * Returns `true` if the passed function returns true for any item in the
              * enumeration.
@@ -1193,7 +1193,7 @@ declare module 'ember' {
              * argument for any item in the enumerable. This method is often simpler/faster
              * than using a callback.
              */
-            isAny(key: string, value?: string): boolean;
+            isAny(key: string, value?: any): boolean;
             /**
              * This will combine the values of the enumerator into a single value. It
              * is a useful way to collect a summary value from an enumeration. This

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -1193,7 +1193,7 @@ declare module 'ember' {
              * argument for any item in the enumerable. This method is often simpler/faster
              * than using a callback.
              */
-            isAny(key: string, value?: boolean): boolean;
+            isAny(key: string, value?: string): boolean;
             /**
              * This will combine the values of the enumerator into a single value. It
              * is a useful way to collect a summary value from an enumeration. This

--- a/types/ember/test/array.ts
+++ b/types/ember/test/array.ts
@@ -15,7 +15,7 @@ const people = Ember.A([
 assertType<number>(people.get('length'));
 assertType<Person>(people.get('lastObject'));
 assertType<boolean>(people.isAny('isHappy'));
-assertType<boolean>(people.isAny('isHappy', false));
+assertType<boolean>(people.isAny('isHappy', 'false'));
 assertType<Ember.Enumerable<Person>>(people.filterBy('isHappy'));
 assertType<Ember.Enumerable<Person>>(people.rejectBy('isHappy'));
 assertType<Ember.Enumerable<Person>>(people.filter((person) => person.get('name') === 'Yehuda'));

--- a/types/ember/test/ember-tests.ts
+++ b/types/ember/test/ember-tests.ts
@@ -131,7 +131,7 @@ const isHappy = (person: typeof Person3.prototype): boolean => {
 people2.every(isHappy);
 people2.any(isHappy);
 people2.isEvery('isHappy', true);
-people2.isAny('isHappy', true);
+people2.isAny('isHappy', 'true');
 people2.isAny('isHappy');
 
 // Examples taken from http://emberjs.com/api/classes/Em.RSVP.Promise.html


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://emberjs.com/api/ember/3.0/classes/Ember.NativeArray/methods/isAny?anchor=isAny>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

