### PR TITLE
react-jsonschema-form update to use JSONSchema6 due to AJV5.x dependancy

### DIFF
--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -9,10 +9,10 @@
 
 declare module "react-jsonschema-form" {
     import * as React from "react";
-    import { JSONSchema4 } from "json-schema";
+    import { JSONSchema6 } from "json-schema";
 
     export interface FormProps {
-        schema: JSONSchema4;
+        schema: JSONSchema6;
         uiSchema?: UiSchema;
         formData?: any;
         formContext?: any;
@@ -60,7 +60,7 @@ declare module "react-jsonschema-form" {
 
     export interface WidgetProps extends React.HTMLAttributes<HTMLElement> {
         id: string;
-        schema: JSONSchema4;
+        schema: JSONSchema6;
         value: any;
         required: boolean;
         disabled: boolean;
@@ -74,7 +74,7 @@ declare module "react-jsonschema-form" {
     export type Widget = React.StatelessComponent<WidgetProps> | React.ComponentClass<WidgetProps>;
 
     export interface FieldProps extends React.HTMLAttributes<HTMLElement> {
-        schema: JSONSchema4;
+        schema: JSONSchema6;
         uiSchema: UiSchema;
         idSchema: IdSchema;
         formData: any;
@@ -114,7 +114,7 @@ declare module "react-jsonschema-form" {
         disabled: boolean;
         displayLabel: boolean;
         fields: Field[];
-        schema: JSONSchema4;
+        schema: JSONSchema6;
         uiSchema: UiSchema;
         formContext: any;
     }
@@ -142,7 +142,7 @@ declare module "react-jsonschema-form" {
         onAddClick: (event: any) => (event: any) => void;
         readonly: boolean;
         required: boolean;
-        schema: JSONSchema4;
+        schema: JSONSchema6;
         uiSchema: UiSchema;
         title: string;
         formContext: any;
@@ -161,7 +161,7 @@ declare module "react-jsonschema-form" {
             readonly: boolean;
         }[],
         required: boolean;
-        schema: JSONSchema4;
+        schema: JSONSchema6;
         uiSchema: UiSchema;
         idSchema: IdSchema;
         formData: any;

--- a/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
+++ b/types/react-jsonschema-form/react-jsonschema-form-tests.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import Form, { UiSchema } from "react-jsonschema-form";
-import { JSONSchema4 } from "json-schema";
+import { JSONSchema6 } from "json-schema";
 
 // example taken from the react-jsonschema-form playground:
 // https://github.com/mozilla-services/react-jsonschema-form/blob/fedd830294417969d88e38fb9f6b3a85e6ad105e/playground/samples/simple.js
 
-const schema: JSONSchema4 =  {
+const schema: JSONSchema6 =  {
     "title": "A registration form",
     "type": "object",
     "required": [


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
https://github.com/mozilla-services/react-jsonschema-form/blob/master/package.json#L43
https://github.com/epoberezkin/ajv/releases/tag/5.0.0
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


This Pull Request updates the `react-jsonschema-form` definition to use `JSONSchema6` in place of `JSONSchema4` due to `react-jsonschema-form` depending on AJV 5.x

I feel this change is appropriate as out of the box AJV 5.x will only handle JSON Schema draft-6 schemas and `react-jsonschema-form` currently provides no way to add additional schemas or meta schemas to its internal AVJ instance.

There are a number of type changes between `JSONSchema4` and `JSONSchema6` prohibit them from being used interchangeably in typescript, which causes some issues with making alterations to the schema before passing it into `react-jsonschema-form` when typed as `JSONSchema4`
