### PR TITLE
[redux-form] typing for version 7.2 (adds clearFields action, update Validator type)

### DIFF
--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for redux-form 7.0
+// Type definitions for redux-form 7.2
 // Project: https://github.com/erikras/redux-form
 // Definitions by: Carson Full <https://github.com/carsonf>
 //                 Daniel Lytkin <https://github.com/aikoven>
@@ -6,6 +6,7 @@
 //                 Luka Zakrajsek <https://github.com/bancek>
 //                 Alex Young <https://github.com/alsiola>
 //                 Anton Novik <https://github.com/tehbi4>
+//                 Huw Martin <https://github.com/huwmartin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 

--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -14,7 +14,7 @@ import { Dispatch } from "redux";
 export type Normalizer = (value: any, previousValue?: any, allValues?: any, previousAllValues?: any) => any;
 export type Formatter = (value: any, name: string) => any;
 export type Parser = (value: any, name: string) => any;
-export type Validator = (value: any, allValues?: any, props?: any) => any;
+export type Validator = (value: any, allValues?: any, props?: any, name?: any) => any;
 
 export type EventHandler<Event> = (event: Event) => void;
 export type EventWithDataHandler<Event> = (event?: Event, newValue?: any, previousValue?: any) => void;

--- a/types/redux-form/lib/FieldArray.d.ts
+++ b/types/redux-form/lib/FieldArray.d.ts
@@ -47,11 +47,11 @@ interface FieldsProps<FieldValue> {
 
 interface FieldArrayMetaProps {
     dirty: boolean;
-    error?: string;
+    error?: any;
     form: string;
     invalid: boolean;
     pristine: boolean;
     submitting: boolean;
     valid: boolean;
-    warning?: string;
+    warning?: any;
 }

--- a/types/redux-form/lib/actionTypes.d.ts
+++ b/types/redux-form/lib/actionTypes.d.ts
@@ -15,6 +15,7 @@ export interface ActionTypes {
     CLEAR_SUBMIT: string;
     CLEAR_SUBMIT_ERRORS: string;
     CLEAR_ASYNC_ERROR: string;
+    CLEAR_FIELDS: string;
     DESTROY: string;
     FOCUS: string;
     INITIALIZE: string;

--- a/types/redux-form/lib/actions.d.ts
+++ b/types/redux-form/lib/actions.d.ts
@@ -41,6 +41,7 @@ export declare function submit(form: string): FormAction;
 export declare function clearSubmit(form: string): FormAction;
 export declare function clearSubmitErrors(form: string): FormAction;
 export declare function clearAsyncError(form: string, field: string): FormAction;
+export declare function clearFields(form: string, keepTouched: boolean, persistentSubmitErrors: boolean, ...fields: string[]): FormAction;
 export declare function touch(form: string, ...fields: string[]): FormAction;
 export declare function unregisterField(form: string, name: string): FormAction;
 export declare function untouch(form: string, ...fields: string[]): FormAction;
@@ -64,6 +65,7 @@ declare const actions: {
     clearSubmit: typeof clearSubmit,
     clearSubmitErrors: typeof clearSubmitErrors,
     clearAsyncError: typeof clearAsyncError,
+    clearFields: typeof clearFields,
     destroy: typeof destroy,
     focus: typeof focus,
     initialize: typeof initialize,

--- a/types/redux-form/lib/reduxForm.d.ts
+++ b/types/redux-form/lib/reduxForm.d.ts
@@ -116,6 +116,8 @@ export interface ConfigProps<FormData = {}, P = {}> {
     propNamespace?: string;
     pure?: boolean;
     shouldValidate?(params: ValidateCallback<FormData, P>): boolean;
+    shouldError?(params: ValidateCallback<FormData, P>): boolean;
+    shouldWarn?(params: ValidateCallback<FormData, P>): boolean;
     shouldAsyncValidate?(params: AsyncValidateCallback<FormData>): boolean;
     touchOnBlur?: boolean;
     touchOnChange?: boolean;

--- a/types/redux-form/lib/selectors.d.ts
+++ b/types/redux-form/lib/selectors.d.ts
@@ -11,6 +11,7 @@ export const getFormMeta: DataSelector;
 export const getFormAsyncErrors: ErrorSelector;
 export const getFormSyncWarnings: ErrorSelector;
 export const getFormSubmitErrors: ErrorSelector;
+export const getFormError: ErrorSelector;
 export function getFormNames(state: any): string[];
 export const isDirty: BooleanSelector;
 export const isPristine: BooleanSelector;


### PR DESCRIPTION
This pull request makes the following changes to the type definitions for redux form:
* add definition for `clearFields` action added in [7.2.0](https://github.com/erikras/redux-form/releases/tag/v7.2.0)
* update Validator type to accept optional name argument added in [7.1.0](https://github.com/erikras/redux-form/releases/tag/v7.1.0)
* update FieldArray meta props to type `any`;
* add `shouldError` and `shouldWarn` config props to reduxForm added in [7.1.0](https://github.com/erikras/redux-form/releases/tag/v7.1.0)
* add `getFormError` selector added in [7.1.0](https://github.com/erikras/redux-form/releases/tag/v7.1.0)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://redux-form.com/7.2.0/docs/api/
For changes to actions: https://redux-form.com/7.2.0/docs/api/actioncreators.md/ see `clearFields`
For changes to Field: https://redux-form.com/7.2.0/docs/api/field.md/ see `validate`
For changes to FieldArray: https://redux-form.com/7.2.0/docs/api/fieldarray.md/ see also https://github.com/erikras/redux-form/pull/3502/files
For changes to reduxForm: https://redux-form.com/7.2.0/docs/api/reduxform.md/ see `shouldError`/`shouldWarn`
For changes to selectors: https://redux-form.com/7.2.0/docs/api/selectors.md/ see `getFormError`
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.