### PR TITLE
[@types/react-table] Added definition for original to RowInfo interface

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -624,6 +624,9 @@ export interface RowInfo {
 
     /** An array of any expandable sub-rows contained in this row */
     subRows: any[];
+
+    /** Original object passed to row */
+    original: any;
 }
 
 export interface FinalState extends TableProps {


### PR DESCRIPTION
A RowInfo object has the original data passed tothe row for rendering stored in 'original'. This commit adds that to the RowInnfo ingerface.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.) _I get compile errors that stem from the react package_
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-table.js.org/#/story/readme (under "Custom Cell, Header and Footer Rendering")
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. _It was already there._
