### PR TITLE
Hapi 17: Fix inability to augment server.plugins type

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -3213,6 +3213,13 @@ export interface HandlerDecorationMethod {
 export type DecorationMethod<T> = (this: T, ...args: any[]) => any;
 
 /**
+ * An empty interface to allow typings of custom plugin properties.
+ */
+/* tslint:disable-next-line:no-empty-interface */
+export interface PluginExposedProperties {
+}
+
+/**
  * The server object is the main application container. The server manages all incoming requests along with all
  * the facilities provided by the framework. Each server supports a single connection (e.g. listen to port 80).
  * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#server)
@@ -3363,7 +3370,7 @@ export class Server extends Podium {
      * the server.plugins[name] object directly or via the server.expose() method.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverplugins)
      */
-    plugins: any;
+    plugins: PluginExposedProperties;
 
     /**
      * The realm object contains sandboxed server settings specific to each plugin or authentication strategy. When

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -334,6 +334,10 @@ export interface RequestLog {
     channel: string;
 }
 
+export interface RequestQuery {
+    [key: string]: string | string[];
+}
+
 /**
  * The request object is created internally for each incoming request. It is not the same object received from the node
  * HTTP server callback (which is available via [request.raw.req](https://github.com/hapijs/hapi/blob/master/API.md#request.raw)). The request properties change throughout
@@ -464,7 +468,7 @@ export interface Request extends Podium {
      * By default the object outputted from node's URL parse() method. Might also be set indirectly via request.setUrl in which case it may be a string (if url is set to an object with the query
      * attribute as an unparsed string).
      */
-    readonly query: any;
+    readonly query: RequestQuery | string;
 
     /**
      * An object containing the Node HTTP server objects. Direct interaction with these raw objects is not recommended.
@@ -1630,6 +1634,13 @@ export interface RouteOptionsValidate {
 export type RouteCompressionEncoderSettings = object;
 
 /**
+ * Empty interface to allow for user-defined augmentations.
+ */
+/* tslint:disable-next-line:no-empty-interface */
+export interface RouteOptionsApp {
+}
+
+/**
  * Each route can be customized to change the default behavior of the request lifecycle.
  * For context [See docs](https://github.com/hapijs/hapi/blob/master/API.md#route-options)
  */
@@ -1638,7 +1649,7 @@ export interface RouteOptions {
      * Application-specific route configuration state. Should not be used by plugins which should use options.plugins[name] instead.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsapp)
      */
-    app?: any;
+    app?: RouteOptionsApp;
 
     /**
      * Route authentication configuration. Value can be:
@@ -2536,6 +2547,13 @@ export interface ServerInfo {
 }
 
 /**
+ * Empty interface to allow for custom augmentation.
+ */
+/* tslint:disable-next-line:no-empty-interface */
+export interface ServerInjectOptionsApp {
+}
+
+/**
  * An object with:
  * * method - (optional) the request HTTP method (e.g. 'POST'). Defaults to 'GET'.
  * * url - (required) the request URL. If the URI includes an authority (e.g. 'example.com:8080'), it is used to automatically set an HTTP 'Host' header, unless one was specified in headers.
@@ -2574,7 +2592,7 @@ export interface ServerInjectOptions extends Shot.RequestOptions {
     /**
      * sets the initial value of request.app, defaults to {}.
      */
-    app?: any;
+    app?: ServerInjectOptionsApp;
     /**
      * sets the initial value of request.plugins, defaults to {}.
      */
@@ -2656,7 +2674,7 @@ export interface ServerMethodOptions {
      * unique key if the function's arguments are all of types 'string', 'number', or 'boolean'. However if the method uses other types of arguments, a key generation function must be provided which
      * takes the same arguments as the function and returns a unique string (or null if no key can be generated).
      */
-    generateKey?: (...args: any[]) => any;
+    generateKey?: (...args: any[]) => string | null;
 }
 
 /**
@@ -2711,6 +2729,13 @@ export interface ServerOptionsCompression {
 }
 
 /**
+ * Empty interface to allow for custom augmentation.
+ */
+/* tslint:disable-next-line:no-empty-interface */
+export interface ServerOptionsApp {
+}
+
+/**
  * The server options control the behavior of the server object. Note that the options object is deeply cloned
  * (with the exception of listener which is shallowly copied) and should not contain any values that are unsafe to perform deep copy on.
  * All options are optionals.
@@ -2732,7 +2757,7 @@ export interface ServerOptions {
      * state.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serveroptionsapp)
      */
-    app?: any;
+    app?: ServerOptionsApp;
 
     /**
      * Default value: true.
@@ -3216,7 +3241,7 @@ export type DecorationMethod<T> = (this: T, ...args: any[]) => any;
  * An empty interface to allow typings of custom plugin properties.
  */
 /* tslint:disable-next-line:no-empty-interface */
-export interface PluginExposedProperties {
+export interface PluginProperties {
 }
 
 /**
@@ -3370,7 +3395,7 @@ export class Server extends Podium {
      * the server.plugins[name] object directly or via the server.expose() method.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverplugins)
      */
-    plugins: PluginExposedProperties;
+    plugins: PluginProperties;
 
     /**
      * The realm object contains sandboxed server settings specific to each plugin or authentication strategy. When

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2547,13 +2547,6 @@ export interface ServerInfo {
 }
 
 /**
- * Empty interface to allow for custom augmentation.
- */
-/* tslint:disable-next-line:no-empty-interface */
-export interface ServerInjectOptionsApp {
-}
-
-/**
  * An object with:
  * * method - (optional) the request HTTP method (e.g. 'POST'). Defaults to 'GET'.
  * * url - (required) the request URL. If the URI includes an authority (e.g. 'example.com:8080'), it is used to automatically set an HTTP 'Host' header, unless one was specified in headers.
@@ -2592,7 +2585,7 @@ export interface ServerInjectOptions extends Shot.RequestOptions {
     /**
      * sets the initial value of request.app, defaults to {}.
      */
-    app?: ServerInjectOptionsApp;
+    app?: ApplicationState;
     /**
      * sets the initial value of request.plugins, defaults to {}.
      */

--- a/types/hapi/test/request/query.ts
+++ b/types/hapi/test/request/query.ts
@@ -1,14 +1,17 @@
 // Added test in addition to docs, for request.query
-import { Lifecycle, Request, ResponseToolkit, Server, ServerOptions, ServerRoute } from "hapi";
+import { Lifecycle, Request, RequestQuery, ResponseToolkit, Server, ServerOptions, ServerRoute } from "hapi";
 
 const options: ServerOptions = {
     port: 8000,
 };
 
 const handlerFn: Lifecycle.Method = (request, h) => {
-    const query = request.query as GetThingQuery;
+    const query1 = request.query as string;
+    console.log(query1);
+
+    const query2 = request.query as RequestQuery;
     // http://localhost:8000/?name=test
-    return `You asked for ${query.name}`;
+    return `You asked for ${query2.name}`;
 };
 
 const serverRoute: ServerRoute = {
@@ -16,10 +19,6 @@ const serverRoute: ServerRoute = {
     method: 'GET',
     handler: handlerFn
 };
-
-interface GetThingQuery {
-    name: string;
-}
 
 const server = new Server(options);
 server.route(serverRoute);

--- a/types/hapi/test/route/route-options.ts
+++ b/types/hapi/test/route/route-options.ts
@@ -102,8 +102,18 @@ const routeOptionsValidate: RouteOptionsValidate = {
     query: true,
 };
 
+declare module 'hapi' {
+    interface RouteOptionsApp {
+        one: number;
+        two: string;
+    }
+}
+
 const routeOptions: RouteOptions = {
-    app: {},
+    app: {
+        one: 1,
+        two: "2"
+    },
     auth: routeOptionsAccess,
     bind: null,
     cache: {

--- a/types/hapi/test/server/server-app.ts
+++ b/types/hapi/test/server/server-app.ts
@@ -8,7 +8,7 @@ const options: ServerOptions = {
 declare module "hapi" {
 	// Demonstrate augmenting the application state.
 	interface ApplicationState {
-		key: string;
+		key?: string;
 	}
 }
 

--- a/types/hapi/test/server/server-expose.ts
+++ b/types/hapi/test/server/server-expose.ts
@@ -2,7 +2,7 @@
 import { Plugin, Server, ServerRegisterOptions } from "hapi";
 
 declare module 'hapi' {
-	interface PluginExposedProperties {
+	interface PluginProperties {
 		example1: {
 			util(): void;
 		};

--- a/types/hapi/test/server/server-expose.ts
+++ b/types/hapi/test/server/server-expose.ts
@@ -1,6 +1,17 @@
 // https://github.com/hapijs/hapi/blob/master/API.md#-serverplugins
 import { Plugin, Server, ServerRegisterOptions } from "hapi";
 
+declare module 'hapi' {
+	interface PluginExposedProperties {
+		example1: {
+			util(): void;
+		};
+		example2: {
+			util(): void;
+		};
+	}
+}
+
 const plugin1: Plugin<any> = {
     name: 'example1',
     async register(server: Server, options: ServerRegisterOptions) {
@@ -22,3 +33,6 @@ const server = new Server({
 server.start();
 server.register(plugin1);
 server.register(plugin2);
+
+server.plugins.example1.util();
+server.plugins.example2.util();

--- a/types/hapi/test/server/server-inject.ts
+++ b/types/hapi/test/server/server-inject.ts
@@ -17,3 +17,16 @@ server.route(serverRoute);
 server.start();
 
 server.inject('/').then(res => console.log(res.result));
+
+declare module 'hapi' {
+	interface ServerInjectOptionsApp {
+		one: number;
+	}
+}
+
+server.inject({
+	url: "test",
+	app: {
+		one: 1
+	}
+});

--- a/types/hapi/test/server/server-inject.ts
+++ b/types/hapi/test/server/server-inject.ts
@@ -19,14 +19,14 @@ server.start();
 server.inject('/').then(res => console.log(res.result));
 
 declare module 'hapi' {
-	interface ServerInjectOptionsApp {
-		one: number;
+	interface ApplicationState {
+		injectState?: number;
 	}
 }
 
 server.inject({
 	url: "test",
 	app: {
-		one: 1
+		injectState: 1
 	}
 });

--- a/types/hapi/test/server/server-method.ts
+++ b/types/hapi/test/server/server-method.ts
@@ -17,7 +17,8 @@ const methodObject: ServerMethodConfigurationObject = {
         cache: {
             expiresIn: 2000,
             generateTimeout: 100
-        }
+        },
+        generateKey: (a: string | undefined) => a === undefined ? null : a
     }
 };
 

--- a/types/hapi/test/server/server-options.ts
+++ b/types/hapi/test/server/server-options.ts
@@ -54,6 +54,14 @@ const routeOptions: RouteOptions = {
     },
 };
 
+declare module 'hapi' {
+    interface ServerOptionsApp {
+        key1?: string;
+        key2?: string;
+        any_thing?: string;
+    }
+}
+
 const options: ServerOptions = {
     address: '0.0.0.0',
     app: {

--- a/types/hapi/test/server/server-plugins.ts
+++ b/types/hapi/test/server/server-plugins.ts
@@ -14,7 +14,7 @@ interface Plugin3 {
 }
 
 declare module 'hapi' {
-	interface PluginExposedProperties {
+	interface PluginProperties {
 		example: {
 			other: string;
 			key: string;

--- a/types/hapi/test/server/server-plugins.ts
+++ b/types/hapi/test/server/server-plugins.ts
@@ -13,6 +13,15 @@ interface Plugin3 {
 	three: 3;
 }
 
+declare module 'hapi' {
+	interface PluginExposedProperties {
+		example: {
+			other: string;
+			key: string;
+		};
+	}
+}
+
 const plugin1: Plugin<Plugin1> = {
     name: 'plugin1',
     register: async (server: Server, options: Plugin1) => {

--- a/types/hapi/test/server/server-settings.ts
+++ b/types/hapi/test/server/server-settings.ts
@@ -1,6 +1,12 @@
 // https://github.com/hapijs/hapi/blob/master/API.md#-serversettings
 import { Server } from "hapi";
 
+declare module 'hapi' {
+	interface ServerOptionsApp {
+		key?: string;
+	}
+}
+
 const server = new Server({
     port: 8000,
     app: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/hapijs/hapi/blob/master/API.md#server.plugins
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
