### PR TITLE
Adds types for google.analytics `ga` 'require' and 'provide' calls

### DIFF
--- a/types/google.analytics/google.analytics-tests.ts
+++ b/types/google.analytics/google.analytics-tests.ts
@@ -34,6 +34,7 @@ describe('UniversalAnalytics', () => {
         ga('trackerName.send', 'event', 'load');
 
         ga('require', 'somePlugin');
+        ga('require', 'somePlugin', 'option');
         ga('require', 'somePlugin', { some: 'options' });
         ga('provide', 'somePlugin', () => {});
         ga('provide', 'somePlugin', tracker => {});

--- a/types/google.analytics/google.analytics-tests.ts
+++ b/types/google.analytics/google.analytics-tests.ts
@@ -33,6 +33,12 @@ describe('UniversalAnalytics', () => {
         ga('send', 'timing', {timingCategory: 'category', timingVar: 'lookup', timingValue: 123, timingLabel: 'label'});
         ga('trackerName.send', 'event', 'load');
 
+        ga('require', 'somePlugin');
+        ga('require', 'somePlugin', { some: 'options' });
+        ga('provide', 'somePlugin', () => {});
+        ga('provide', 'somePlugin', tracker => {});
+        ga('provide', 'somePlugin', (tracker, options) => {});
+
         ga.create('UA-65432-1', 'auto');
         ga.create('UA-65432-1', {some: 'config'});
         ga.create('UA-65432-1', 'auto', {some: 'config'});

--- a/types/google.analytics/index.d.ts
+++ b/types/google.analytics/index.d.ts
@@ -601,7 +601,7 @@ declare namespace UniversalAnalytics {
             }): void;
         (command: 'send', fieldsObject: FieldsObject): void;
         (command: string, hitType: HitType, ...fields: any[]): void;
-        (command: 'require', pluginName: string, pluginOptions?: Object): void;
+        (command: 'require', pluginName: string, pluginOptions?: any): void;
         (command: 'provide', pluginName: string, pluginConstructor: (tracker: Tracker, pluginOptions?: Object) => void): void;
 
         (command: 'create', trackingId: string, cookieDomain?: string, name?: string, fieldsObject?: FieldsObject): void;

--- a/types/google.analytics/index.d.ts
+++ b/types/google.analytics/index.d.ts
@@ -601,6 +601,8 @@ declare namespace UniversalAnalytics {
             }): void;
         (command: 'send', fieldsObject: FieldsObject): void;
         (command: string, hitType: HitType, ...fields: any[]): void;
+        (command: 'require', pluginName: string, pluginOptions?: Object): void;
+        (command: 'provide', pluginName: string, pluginConstructor: (tracker: Tracker, pluginOptions?: Object) => void): void;
 
         (command: 'create', trackingId: string, cookieDomain?: string, name?: string, fieldsObject?: FieldsObject): void;
         (command: 'remove'): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  * url: https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#require
  * note: Google says the type of `pluginOptions` is `Object`, but in practice, any type works.
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
