### PR TITLE
Stripe: Add status property to IRefund definition

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -7,6 +7,7 @@
 //                 Brannon Jones <https://github.com/brannon>
 //                 Kyle Kamperschroer <https://github.com/kkamperschroer>
 //                 Kensuke Hoshikawa <https://github.com/starhoshi>
+//                 Thomas Bruun <https://github.com/bruun>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -4688,6 +4689,12 @@ declare namespace Stripe {
              * This is the transaction number that appears on email receipts sent for this refund.
              */
             receipt_number: string;
+
+            /**
+             * Status of the refund. For credit card refunds, this can be succeeded or failed.
+             * For other types of refunds, it can be pending, succeeded, failed, or canceled.
+             */
+            status: "pending" | "succeeded" | "failed" | "canceled";
         }
 
         interface IRefundCreationOptions extends IDataOptionsWithMetadata {

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -66,7 +66,7 @@ stripe.charges.create({
     });
 
     charge.refunds.retrieve("re_15jzA4Ee31JkLCeQcxbTbjaL").then(function (refund) {
-
+        var status: "pending" | "succeeded" | "failed" | "canceled" = refund.status;
     });
 
     charge.refunds.update("re_15jzA4Ee31JkLCeQcxbTbjaL", { metadata: { test: "data" } }).then(function (refund) {


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api/node#refund_object
