### PR TITLE
Expand typings for package jss to represent exported SheetsRegistry class

### DIFF
--- a/types/jss/index.d.ts
+++ b/types/jss/index.d.ts
@@ -5,7 +5,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-export interface toCSSOptions {
+export interface ToCssOptions {
 	indent?: number;
 }
 
@@ -66,7 +66,7 @@ export interface StyleSheet<T> {
 	/**
 	 * Convert rules to a CSS string.
 	 */
-	toString(options?: toCSSOptions): string;
+	toString(options?: ToCssOptions): string;
 }
 export type GenerateClassName<T> = (rule: Rule, sheet?: StyleSheet<T>) => string;
 export interface Style {
@@ -107,7 +107,7 @@ export declare class SheetsRegistry {
     add(sheet: StyleSheet<any>): void;
     reset(): void;
     remove(sheet: StyleSheet<any>): void;
-    toString(options?: toCSSOptions): string;
+    toString(options?: ToCssOptions): string;
 }
 declare class JSS {
 	constructor(options?: Partial<JSSOptions>);

--- a/types/jss/index.d.ts
+++ b/types/jss/index.d.ts
@@ -103,7 +103,7 @@ export interface RuleOptions {
 export declare class SheetsRegistry {
     constructor();
     registry: ReadonlyArray<StyleSheet<any>>;
-    index(): number;
+    readonly index: number;
     add(sheet: StyleSheet<any>): void;
     reset(): void;
     remove(sheet: StyleSheet<any>): void;

--- a/types/jss/index.d.ts
+++ b/types/jss/index.d.ts
@@ -5,6 +5,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+export interface toCSSOptions {
+	indent?: number;
+}
+
 export interface Rule {
 	className: string;
 	selector: string;
@@ -62,7 +66,7 @@ export interface StyleSheet<T> {
 	/**
 	 * Convert rules to a CSS string.
 	 */
-	toString(options?: { indent?: number }): string;
+	toString(options?: toCSSOptions): string;
 }
 export type GenerateClassName<T> = (rule: Rule, sheet?: StyleSheet<T>) => string;
 export interface Style {
@@ -95,6 +99,15 @@ export interface RuleFactoryOptions {
 export interface RuleOptions {
 	index: number;
 	className: string;
+}
+export declare class SheetsRegistry {
+    constructor();
+    registry: ReadonlyArray<StyleSheet<any>>;
+    index(): number;
+    add(sheet: StyleSheet<any>): void;
+    reset(): void;
+    remove(sheet: StyleSheet<any>): void;
+    toString(options?: toCSSOptions): string;
 }
 declare class JSS {
 	constructor(options?: Partial<JSSOptions>);

--- a/types/jss/jss-tests.ts
+++ b/types/jss/jss-tests.ts
@@ -2,7 +2,8 @@
 
 import {
 	create as createJSS,
-	default as sharedInstance
+	SheetsRegistry,
+	default as sharedInstance,
 } from 'jss';
 
 const jss = createJSS().setup({});
@@ -21,28 +22,30 @@ const styleSheet = jss.createStyleSheet(
 	{
 		link: true,
 	}
-).attach();
+);
 
-styleSheet.classes.container; // $ExpectType string
-styleSheet.classes.ruleWithMockObservable; // $ExpectType string
+const attachedStyleSheet = styleSheet.attach();
 
-const rule = styleSheet.addRule('dynamicRule', { color: 'indigo' });
+attachedStyleSheet.classes.container; // $ExpectType string
+attachedStyleSheet.classes.ruleWithMockObservable; // $ExpectType string
+
+const rule = attachedStyleSheet.addRule('dynamicRule', { color: 'indigo' });
 rule.prop('border-radius', 5).prop('color'); // $ExpectType string
-styleSheet.classes.dynamicRule; // $ExpectType string
+attachedStyleSheet.classes.dynamicRule; // $ExpectType string
 
-styleSheet.deleteRule('dynamicRule');
+attachedStyleSheet.deleteRule('dynamicRule');
 
 // test that `addRule` supports the shorthand signature
-const dynamicRule = styleSheet.addRule({ color: 'red' });
+const dynamicRule = attachedStyleSheet.addRule({ color: 'red' });
 
 const div = document.createElement('div');
 dynamicRule.applyTo(div);
 
-const containerRule = styleSheet.getRule('container');
+const containerRule = attachedStyleSheet.getRule('container');
 const containerJSON = containerRule.toJSON();
-const css = styleSheet.toString();
+const css = attachedStyleSheet.toString();
 
-styleSheet.addRules({
+attachedStyleSheet.addRules({
 	rule1: {
 		fontFamily: 'Roboto',
 		color: '#FFFFFF',
@@ -53,10 +56,41 @@ styleSheet.addRules({
 	},
 });
 
-styleSheet.detach();
+attachedStyleSheet.detach();
 
 sharedInstance.createStyleSheet({
 	container: {
 		background: '#000099',
 	}
 });
+
+/* SheetsRegistry test */
+const sheetsRegistry = new SheetsRegistry();
+sheetsRegistry.add(styleSheet);
+
+const secondStyleSheet = jss.createStyleSheet(
+	{
+		ruleWithMockObservable: {
+			subscribe() {}
+		},
+		container2: {
+			display: 'flex',
+			width: 150,
+			opacity: .8,
+		},
+	},
+	{
+		link: true,
+	}
+);
+
+sheetsRegistry.add(secondStyleSheet);
+sheetsRegistry.registry.length; // $ExpectType number
+sheetsRegistry.remove(secondStyleSheet);
+
+sheetsRegistry.index(); // $ExpectType number
+sheetsRegistry.toString(); // $ExpectType string
+// With css options
+sheetsRegistry.toString({indent: 5}); // $ExpectType string
+
+sheetsRegistry.reset();

--- a/types/jss/jss-tests.ts
+++ b/types/jss/jss-tests.ts
@@ -89,6 +89,7 @@ sheetsRegistry.registry.length; // $ExpectType number
 sheetsRegistry.remove(secondStyleSheet);
 
 sheetsRegistry.index(); // $ExpectType number
+sheetsRegistry.index; // $ExpectType () => number
 sheetsRegistry.toString(); // $ExpectType string
 // With css options
 sheetsRegistry.toString({indent: 5}); // $ExpectType string

--- a/types/jss/jss-tests.ts
+++ b/types/jss/jss-tests.ts
@@ -88,8 +88,8 @@ sheetsRegistry.add(secondStyleSheet);
 sheetsRegistry.registry.length; // $ExpectType number
 sheetsRegistry.remove(secondStyleSheet);
 
-sheetsRegistry.index(); // $ExpectType number
-sheetsRegistry.index; // $ExpectType () => number
+sheetsRegistry.index; // $ExpectType number
+sheetsRegistry.index = 5; // $ExpectError
 sheetsRegistry.toString(); // $ExpectType string
 // With css options
 sheetsRegistry.toString({indent: 5}); // $ExpectType string


### PR DESCRIPTION
**Expand typings for package jss to represent exported SheetsRegistry class**
package: jss

- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint jss` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://cssinjs.org/js-api?v=v9.8.0>, chapter "Style Sheets registry"
- [x] Increase the version number in the header if appropriate.
Not appropriate, already existing in earlier versions