### PR TITLE
Add types for jsontoxml

### DIFF
--- a/types/jsontoxml/index.d.ts
+++ b/types/jsontoxml/index.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for jsontoxml 1.0
+// Project: https://github.com/soldair/node-jsontoxml
+// Definitions by: benstevens48 <https://github.com/benstevens48>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace jsontoxml {
+    function escape(str: string): string;
+    function cdata(str: string): string;
+    interface JsonToXmlOptions {
+        escape?: boolean;
+        xmlHeader?: boolean | {standalone?: boolean};
+        docType?: string;
+        prettyPrint?: boolean;
+        indent?: string;
+        removeIllegalNameCharacters?: boolean;
+        html?: boolean;
+    }
+}
+
+declare function jsontoxml(data: any, options?: jsontoxml.JsonToXmlOptions): string;
+
+export = jsontoxml;

--- a/types/jsontoxml/jsontoxml-tests.ts
+++ b/types/jsontoxml/jsontoxml-tests.ts
@@ -1,0 +1,10 @@
+import jsontoxml = require('jsontoxml');
+
+// $ExpectType string
+jsontoxml({foo: 'bar'}, {escape: true, xmlHeader: true});
+
+// $ExpectType string
+jsontoxml.escape('&test');
+
+// $ExpectType string
+jsontoxml.cdata('test');

--- a/types/jsontoxml/tsconfig.json
+++ b/types/jsontoxml/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "esModuleInterop": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsontoxml-tests.ts"
+    ]
+}

--- a/types/jsontoxml/tslint.json
+++ b/types/jsontoxml/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
