### PR TITLE
Fix a typo with luxon Settings::resetCaches()

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -372,7 +372,7 @@ declare module 'luxon' {
             let defaultZoneName: string;
             let throwOnInvalid: boolean;
             let now: () => number;
-            function resetCache(): void;
+            function resetCaches(): void;
         }
 
         type ZoneOffsetOptions = {

--- a/types/luxon/luxon-tests.ts
+++ b/types/luxon/luxon-tests.ts
@@ -88,6 +88,7 @@ Settings.defaultLocale = 'en';
 Settings.defaultZoneName = 'Europe/Paris';
 Settings.now();
 Settings.now = () => 0;
+Settings.resetCaches();
 
 // $ExpectError
 Settings.defaultZone = Settings.defaultZone;


### PR DESCRIPTION
See https://moment.github.io/luxon/docs/class/src/settings.js~Settings.html#static-method-resetCaches