### PR TITLE
Allow tabIndex as a string

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2462,7 +2462,7 @@ declare namespace React {
         slot?: string;
         spellCheck?: boolean;
         style?: CSSProperties;
-        tabIndex?: number;
+        tabIndex?: string | number;
         title?: string;
 
         // Unknown
@@ -3207,7 +3207,7 @@ declare namespace React {
 
         // Other HTML properties supported by SVG elements in browsers
         role?: string;
-        tabIndex?: number;
+        tabIndex?: string | number;
 
         // SVG Specific attributes
         accentHeight?: number | string;


### PR DESCRIPTION
I'm proposing this change based on:
- https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html#why-are-we-changing-this
-
 https://github.com/facebook/react/blob/86914cb30a7654d13a17d34a3b3a5af97c2d2855/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js#L439
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23515
