### PR TITLE
[sinon] add calledOnceWithExactly() and calledOnceWith() added in 4.3.0

### DIFF
--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Sinon 4.1
+// Type definitions for Sinon 4.3
 // Project: http://sinonjs.org/
 // Definitions by: William Sears <https://github.com/mrbigdog2u>
 //                 Jonathan Little <https://github.com/rationull>
@@ -26,6 +26,8 @@ declare namespace Sinon {
         calledOn(obj: any): boolean;
         calledWith(...args: any[]): boolean;
         calledWithExactly(...args: any[]): boolean;
+        calledOnceWith(...args: any[]): boolean;
+        calledOnceWithExactly(...args: any[]): boolean;
         calledWithMatch(...args: any[]): boolean;
         notCalledWith(...args: any[]): boolean;
         notCalledWithMatch(...args: any[]): boolean;

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -85,6 +85,8 @@ function testNine() {
     callback.alwaysCalledWithMatch({ y: 5 });
     callback.neverCalledWithMatch({ x: 6 });
     callback.notCalledWithMatch({ x: 6 });
+    callback.calledOnceWith({ x: 5, y: 5 });
+    callback.calledOnceWithExactly({ x: 5, y: 5 });
     sinon.assert.calledWithMatch(callback, { x: 5 });
     sinon.assert.alwaysCalledWithMatch(callback, { y: 5 });
     sinon.assert.neverCalledWithMatch(callback, { x: 6 });


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://sinonjs.org/releases/v4.4.0/spies/
https://github.com/sinonjs/sinon/pull/1686
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

