### PR TITLE
[aws-lambda] Include CloudFrontRequest in CloudFrontRequestResult union type

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -631,7 +631,15 @@ let apiGtwProxyHandler: AWSLambda.APIGatewayProxyHandler = (event: AWSLambda.API
 let proxyHandler: AWSLambda.ProxyHandler = (event: AWSLambda.APIGatewayEvent, context: AWSLambda.Context, cb: AWSLambda.ProxyCallback) => { };
 apiGtwProxyHandler = proxyHandler;
 
-let cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWSLambda.CloudFrontRequestEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontRequestCallback) => { };
+let cloudFrontRequestHandler: AWSLambda.CloudFrontRequestHandler = (event: AWSLambda.CloudFrontRequestEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontRequestCallback) => {
+    cb();
+    cb(null);
+    cb(new Error(''));
+    cb(null, { clientIp: str, method: str, uri: str, querystring: str, headers: { } });
+    cb(null, { status: str });
+    // $ExpectError
+    cb(null, { });
+};
 
 let cloudFrontResponseHandler: AWSLambda.CloudFrontResponseHandler = (event: AWSLambda.CloudFrontResponseEvent, context: AWSLambda.Context, cb: AWSLambda.CloudFrontResponseCallback) => { };
 

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -15,6 +15,7 @@
 //                 Palmi Valgeirsson <https://github.com/palmithor>
 //                 Danilo Raisi <https://github.com/daniloraisi>
 //                 Simon Buchan <https://github.com/simonbuchan>
+//                 David Hayden <https://github.com/Haydabase>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -516,7 +517,7 @@ export interface CloudFrontResponseEvent {
     }>;
 }
 
-export type CloudFrontRequestResult = undefined | null | CloudFrontResultResponse;
+export type CloudFrontRequestResult = undefined | null | CloudFrontResultResponse | CloudFrontRequest;
 
 export interface CloudFrontRequestEvent {
     Records: Array<{


### PR DESCRIPTION
A request is a valid callback result type. See example: https://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html#lambda-edge-authoring-functions-example-ab-testing

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html#lambda-edge-authoring-functions-example-ab-testing
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.