### PR TITLE
Leaflet: Add private methods and properties

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -392,7 +392,6 @@ export interface InteractiveLayerOptions extends LayerOptions {
 }
 
 export class Layer extends Evented {
-    _map: Map;
     constructor(options?: LayerOptions);
     addTo(map: Map|LayerGroup): this;
     remove(): this;
@@ -425,6 +424,8 @@ export class Layer extends Evented {
     getEvents?(): {[name: string]: (event: LeafletEvent) => void};
     getAttribution?(): string | null;
     beforeAdd?(map: Map): this;
+
+    protected _map: Map;
 }
 
 export interface GridLayerOptions {
@@ -443,6 +444,8 @@ export interface GridLayerOptions {
     className?: string;
     keepBuffer?: number;
 }
+
+export type DoneCallback = (error?: Error, tile?: HTMLElement) => void;
 
 export interface InternalTiles {
     [key: string]: {
@@ -466,10 +469,11 @@ export class GridLayer extends Layer {
     redraw(): this;
     getTileSize(): Point;
 
-    _tileCoordsToKey(coords: Coords): string;
+    protected createTile(coords: Coords, done: DoneCallback): HTMLElement;
+    protected _tileCoordsToKey(coords: Coords): string;
 
-    _tiles: InternalTiles;
-    _tileZoom?: number;
+    protected _tiles: InternalTiles;
+    protected _tileZoom?: number;
 }
 
 export function gridLayer(options?: GridLayerOptions): GridLayer;
@@ -489,15 +493,12 @@ export interface TileLayerOptions extends GridLayerOptions {
     [name: string]: any;
 }
 
-export type DoneCallback = (error?: Error, tile?: HTMLElement) => void;
-
 export class TileLayer extends GridLayer {
     constructor(urlTemplate: string, options?: TileLayerOptions);
-    createTile(coords: Coords, done: DoneCallback): HTMLElement;
     setUrl(url: string, noRedraw?: boolean): this;
 
-    _abortLoading(): void;
-    _getZoomForUrl(): number;
+    protected _abortLoading(): void;
+    protected _getZoomForUrl(): number;
 
     options: TileLayerOptions;
 }

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -182,6 +182,10 @@ export class Point {
     y: number;
 }
 
+export interface Coords extends Point {
+    z: number;
+}
+
 export type PointExpression = Point | PointTuple;
 
 export function point(x: number, y: number, round?: boolean): Point;
@@ -388,6 +392,7 @@ export interface InteractiveLayerOptions extends LayerOptions {
 }
 
 export class Layer extends Evented {
+    _map: Map;
     constructor(options?: LayerOptions);
     addTo(map: Map|LayerGroup): this;
     remove(): this;
@@ -439,6 +444,17 @@ export interface GridLayerOptions {
     keepBuffer?: number;
 }
 
+export interface InternalTiles {
+    [key: string]: {
+        active?: boolean,
+        coords: Coords,
+        current: boolean,
+        el: HTMLElement,
+        loaded?: Date,
+        retain?: boolean,
+    };
+}
+
 export class GridLayer extends Layer {
     constructor(options?: GridLayerOptions);
     bringToFront(): this;
@@ -449,6 +465,11 @@ export class GridLayer extends Layer {
     isLoading(): boolean;
     redraw(): this;
     getTileSize(): Point;
+
+    _tileCoordsToKey(coords: Coords): string;
+
+    _tiles: InternalTiles;
+    _tileZoom?: number;
 }
 
 export function gridLayer(options?: GridLayerOptions): GridLayer;
@@ -468,9 +489,15 @@ export interface TileLayerOptions extends GridLayerOptions {
     [name: string]: any;
 }
 
+export type DoneCallback = (error?: Error, tile?: HTMLElement) => void;
+
 export class TileLayer extends GridLayer {
     constructor(urlTemplate: string, options?: TileLayerOptions);
+    createTile(coords: Coords, done: DoneCallback): HTMLElement;
     setUrl(url: string, noRedraw?: boolean): this;
+
+    _abortLoading(): void;
+    _getZoomForUrl(): number;
 
     options: TileLayerOptions;
 }


### PR DESCRIPTION
The goal is to make writing plugins easier for developers by adding
private methods and properties.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

References for changes:

- [`_map` is created in the `_layerAdd` method of `Layer.js`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/Layer.js#L99)
- the `Coords` class does not exist, Leaflet effectively uses a [`Point` class with an extra `z` property, created in `GridLayer.js`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L674). Being able to use this type is necessary if overriding `createTile` in either `GridLayer` or `TileLayer`.
- [The `_tileCoordsToKey` code is pretty self-explanatory](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L755) and demonstrates the utility of the `Coords` interface
- [`_this.tiles` is first created as an empty object in `GridLayer.js`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L160). When creating a tile, [a property in the object is assigned the `el`, `coords`, and `current` properties](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L829). The [`active`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L868) and [`loaded`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L862) properties are set later if the tile image loads. Finally, if a tile is not pruned during the pruning stage, it will have the [`retain`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L426) property set.
- [`this._tileZoom` is set in `GridLayer`'s `_setView`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L557) according to the zoom parameter, which is a number (see [here](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L525) as an example of a number, following the definition of `Map.getZoom()`)
- [_getZoomForUrl](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/TileLayer.js#L203)
- [`GridLayer`'s `createTile`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/GridLayer.js#L261). Here is [`createTile` on `TileLayer`](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/TileLayer.js#L130) for reference.
- [_abortLoading](https://github.com/Leaflet/Leaflet/blob/018bac0e9e7446426c6127e16bb6baed566b8a7f/src/layer/tile/TileLayer.js#L222)
