### PR TITLE
@types/stripe-react-elements: add `stripe` to `props` on `StripeProvider`

### DIFF
--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: dan-j <https://github.com/dan-j>
 //                 Santiago Doldan <https://github.com/santiagodoldan>
 //                 sonnysangha <https://github.com/sonnysangha>
+//                 Andrew Goh Yisheng <https://github.com/9y5>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -23,23 +24,14 @@ export namespace ReactStripeElements {
 		error?: { decline_code?: string };
 	};
 
-	interface StripeProviderProps {
-		apiKey: string;
-	}
-
-	interface StripeProps {
-		// I'm not sure what the definition for this is
-		createSource(): void;
-
-		createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
-	}
+    type StripeProviderProps = { apiKey: string; stripe?: never; } | { apiKey?: never; stripe: stripe.Stripe; };
 
 	interface InjectOptions {
 		withRef?: boolean;
 	}
 
 	interface InjectedStripeProps {
-		stripe?: StripeProps;
+		stripe?: stripe.Stripe;
 	}
 
 	interface ElementProps extends ElementsOptions {

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -24,14 +24,21 @@ export namespace ReactStripeElements {
 		error?: { decline_code?: string };
 	};
 
-    type StripeProviderProps = { apiKey: string; stripe?: never; } | { apiKey?: never; stripe: stripe.Stripe | null; };
+    type StripeProviderProps = { apiKey: string; stripe?: never; } | { apiKey?: never; stripe: StripeProps | null; };
+
+	interface StripeProps {
+		// I'm not sure what the definition for this is
+		createSource(): void;
+
+		createToken(options?: TokenOptions): Promise<PatchedTokenResponse>;
+	}
 
 	interface InjectOptions {
 		withRef?: boolean;
 	}
 
 	interface InjectedStripeProps {
-		stripe?: stripe.Stripe;
+		stripe?: StripeProps;
 	}
 
 	interface ElementProps extends ElementsOptions {

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -24,7 +24,7 @@ export namespace ReactStripeElements {
 		error?: { decline_code?: string };
 	};
 
-    type StripeProviderProps = { apiKey: string; stripe?: never; } | { apiKey?: never; stripe: stripe.Stripe; };
+    type StripeProviderProps = { apiKey: string; stripe?: never; } | { apiKey?: never; stripe: stripe.Stripe | null; };
 
 	interface InjectOptions {
 		withRef?: boolean;

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -16,6 +16,7 @@ import ElementChangeResponse = stripe.elements.ElementChangeResponse;
 import ElementsOptions = stripe.elements.ElementsOptions;
 import ElementsCreateOptions = stripe.elements.ElementsCreateOptions;
 import PatchedTokenResponse = ReactStripeElements.PatchedTokenResponse;
+import StripeProps = ReactStripeElements.StripeProps;
 
 const cardElementProps: ElementsOptions = {
     iconStyle: 'solid',
@@ -111,10 +112,8 @@ class WrappedComponent extends React.Component<
     ComponentProps & InjectedStripeProps
 > {
     onSubmit = () => {
-        const elements = this.props.stripe!.elements();
-        const card = elements.create('card', { hidePostalCode: true });
         this.props.stripe!
-            .createToken(card, {
+            .createToken({
                 name: '',
                 address_line1: '',
                 address_line2: '',
@@ -186,7 +185,7 @@ const ElementsDefaultPropsTest: React.SFC = () => (
 const TestStripeProviderProps1: React.SFC = () => <StripeProvider apiKey="" />;
 
 const TestStripeProviderProps2: React.SFC<{
-    stripe: stripe.Stripe;
+    stripe: StripeProps;
 }> = props => <StripeProvider stripe={props.stripe} />;
 
 /**
@@ -194,5 +193,5 @@ const TestStripeProviderProps2: React.SFC<{
  * See: https://github.com/stripe/react-stripe-elements#props-shape
  */
 const TestStripeProviderProps3: React.SFC<{
-    stripe: stripe.Stripe;
+    stripe: StripeProps;
 }> = props => <StripeProvider stripe={null} />;

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -188,3 +188,11 @@ const TestStripeProviderProps1: React.SFC = () => <StripeProvider apiKey="" />;
 const TestStripeProviderProps2: React.SFC<{
     stripe: stripe.Stripe;
 }> = props => <StripeProvider stripe={props.stripe} />;
+
+/**
+ * props.stripe is null until loaded.
+ * See: https://github.com/stripe/react-stripe-elements#props-shape
+ */
+const TestStripeProviderProps3: React.SFC<{
+    stripe: stripe.Stripe;
+}> = props => <StripeProvider stripe={null} />;

--- a/types/react-stripe-elements/react-stripe-elements-tests.tsx
+++ b/types/react-stripe-elements/react-stripe-elements-tests.tsx
@@ -107,18 +107,26 @@ interface ComponentProps {
     tokenCallback(token: PatchedTokenResponse): void;
 }
 
-class WrappedComponent extends React.Component<ComponentProps & InjectedStripeProps> {
+class WrappedComponent extends React.Component<
+    ComponentProps & InjectedStripeProps
+> {
     onSubmit = () => {
-        this.props.stripe!.createToken({
-            name: '',
-            address_line1: '',
-            address_line2: '',
-            address_city: '',
-            address_state: '',
-            address_zip: '',
-            address_country: '',
-            currency: '',
-        }).then((response: PatchedTokenResponse) => this.props.tokenCallback(response));
+        const elements = this.props.stripe!.elements();
+        const card = elements.create('card', { hidePostalCode: true });
+        this.props.stripe!
+            .createToken(card, {
+                name: '',
+                address_line1: '',
+                address_line2: '',
+                address_city: '',
+                address_state: '',
+                address_zip: '',
+                address_country: '',
+                currency: '',
+            })
+            .then((response: PatchedTokenResponse) =>
+                this.props.tokenCallback(response)
+            );
     }
 
     isFormValid = () => {
@@ -170,3 +178,13 @@ const ElementsDefaultPropsTest: React.SFC = () => (
         <PostalCodeElement />
     </div>
 );
+
+/**
+ * StripeProvider should either receive `apiKey` or `stripe`, but not both.
+ * See: https://github.com/stripe/react-stripe-elements/blob/d30b32b6b8df282dd8880a3521667c371e90083f/src/components/Provider.js#L83-L86
+ */
+const TestStripeProviderProps1: React.SFC = () => <StripeProvider apiKey="" />;
+
+const TestStripeProviderProps2: React.SFC<{
+    stripe: stripe.Stripe;
+}> = props => <StripeProvider stripe={props.stripe} />;


### PR DESCRIPTION
* ~Replaced `StripeProps` to `stripe.Stripe` from `@types/stripe-v3`.~
* Add `props.stripe` to `StripeProviderProps` #23058
* Updated tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: #23058
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
