### PR TITLE
update types for heapdump

### DIFF
--- a/types/heapdump/index.d.ts
+++ b/types/heapdump/index.d.ts
@@ -3,4 +3,4 @@
 // Definitions by: weekens <https://github.com/weekens>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function writeSnapshot(dumpFileName: string, callback: (err?: Error) => void): void;
+export function writeSnapshot(dumpFileName?: string, callback?: (err?: Error, filename?: string) => void): void;


### PR DESCRIPTION
- all arguments are optional
- callback also return name of file

see [package usage](https://github.com/bnoordhuis/node-heapdump#usage)
