### PR TITLE
[Puppeteer] added missing member on LaunchOptions

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1203,6 +1203,8 @@ export interface Target {
 }
 
 export interface LaunchOptions {
+  /** Whether to open chrome in appMode. Defaults to false. */
+  appMode?: boolean;
   /** Whether to ignore HTTPS errors during navigation. Defaults to false. */
   ignoreHTTPSErrors?: boolean;
   /** Do not use `puppeteer.defaultArgs()` for launching Chromium. Defaults to false. */


### PR DESCRIPTION
added `appMode`

It's used here:
* https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js#L68
* https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js#L104