### PR TITLE
[react-helmet] Export HelmetProps

### DIFF
--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -6,7 +6,7 @@
 
 import * as React from "react";
 
-interface HelmetProps {
+export interface HelmetProps {
     base?: any;
     bodyAttributes?: Object;
     defaultTitle?: string;


### PR DESCRIPTION
I need access to this interface because I am creating a wrapper of `Helmet` component so basically my wrap expects the exact props