### PR TITLE
Type definitions for parity-pmd 0.4.0

### DIFF
--- a/types/parity-pmd/index.d.ts
+++ b/types/parity-pmd/index.d.ts
@@ -1,0 +1,26 @@
+// Type definitions for parity-pmd 0.4
+// Project: https://github.com/paritytrading/node-parity-pmd#readme
+// Definitions by: Leonard Vujanić <https://github.com/leovujanic>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="node" />
+
+/**
+ * Declares Parity PMD message structure
+ * Full reference can be found here https://github.com/paritytrading/parity/blob/master/libraries/net/doc/PMD.md
+ */
+export interface PMDMessage {
+    messageType: string;
+    version?: string;
+    timestamp?: number;
+    orderNumber?: number;
+    side?: string;
+    instrument?: string;
+    quantity?: number;
+    price?: number;
+}
+
+export function format(message: PMDMessage): Buffer;
+
+export function parse(buffer: Buffer): PMDMessage;

--- a/types/parity-pmd/index.d.ts
+++ b/types/parity-pmd/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for parity-pmd 0.4
 // Project: https://github.com/paritytrading/node-parity-pmd#readme
 // Definitions by: Leonard Vujanić <https://github.com/leovujanic>
+//                 Vilim Stubičan <https://github.com/jewbre>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 

--- a/types/parity-pmd/parity-pmd-tests.ts
+++ b/types/parity-pmd/parity-pmd-tests.ts
@@ -1,0 +1,28 @@
+/// <reference types="node" />
+import { format, parse, PMDMessage } from 'parity-pmd';
+
+// Arrange
+const buffer = new Buffer(5);
+buffer.writeUInt8(0x56, 0);
+buffer.writeUInt32BE(70, 1);
+const parsedContent: PMDMessage = parse(buffer);
+
+// Act & Assert
+// $ExpectType PMDMessage
+parse(buffer);
+
+// $ExpectType Buffer
+format(parsedContent);
+
+// Invalid type
+// $ExpectError
+parse('');
+
+// $ExpectError
+format({});
+
+// Invalid sub type
+// $ExpectError
+format({
+    messageType: 1
+});

--- a/types/parity-pmd/parity-pmd-tests.ts
+++ b/types/parity-pmd/parity-pmd-tests.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { format, parse, PMDMessage } from 'parity-pmd';
 
 // Arrange

--- a/types/parity-pmd/tsconfig.json
+++ b/types/parity-pmd/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parity-pmd-tests.ts"
+    ]
+}

--- a/types/parity-pmd/tslint.json
+++ b/types/parity-pmd/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These are type definitions for npm library parity-pmd (https://www.npmjs.com/package/parity-pmd). Since original package does not have its own typings, here are they.

Required checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

