### PR TITLE
Type definitions for parity-pmr 0.1

### DIFF
--- a/types/parity-pmr/index.d.ts
+++ b/types/parity-pmr/index.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for parity-pmr 0.1
+// Project: https://github.com/paritytrading/node-parity-pmr#readme
+// Definitions by: Leo Vujanić <https://github.com/leovujanic>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+/**
+ * Declares Parity PMR message structure
+ * Full reference can be found here https://github.com/paritytrading/parity/blob/master/libraries/net/doc/PMR.md
+ */
+export interface PMRMessage {
+    messageType: string;
+    version?: number;
+    timestamp?: number;
+    username?: string;
+    orderNumber?: string;
+    side?: string;
+    instrument?: string;
+    quantity?: number;
+    price?: number;
+    canceledQuantity?: number;
+    matchNumber?: number;
+    restingOrderNumber?: number;
+    incomingOrderNumber?: number;
+}
+
+export function format(message: PMRMessage): Buffer;
+
+export function parse(buffer: Buffer): PMRMessage;

--- a/types/parity-pmr/parity-pmr-tests.ts
+++ b/types/parity-pmr/parity-pmr-tests.ts
@@ -1,0 +1,30 @@
+/// <reference types="node" />
+import { format, parse, PMRMessage } from "parity-pmr";
+
+const buffer = new Buffer("test");
+const message: PMRMessage = {
+    messageType: 'E'
+};
+
+// $ExpectType Buffer
+format(message);
+
+// Invalid type
+// $ExpectError
+format('');
+
+// $ExpectError
+format({});
+
+// Invalid sub type
+// $ExpectError
+format({
+    messageType: 1
+});
+
+// $ExpectType PMRMessage
+parse(buffer);
+
+// Invalid type
+// $ExpectError
+parse('');

--- a/types/parity-pmr/parity-pmr-tests.ts
+++ b/types/parity-pmr/parity-pmr-tests.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { format, parse, PMRMessage } from "parity-pmr";
 
 const buffer = new Buffer("test");

--- a/types/parity-pmr/tsconfig.json
+++ b/types/parity-pmr/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parity-pmr-tests.ts"
+    ]
+}

--- a/types/parity-pmr/tslint.json
+++ b/types/parity-pmr/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These are type definitions for npm library [parity-pmr](https://www.npmjs.com/package/parity-pmr).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:


If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
