### PR TITLE
Type definitions for parity-poe 0.3

### DIFF
--- a/types/parity-poe/index.d.ts
+++ b/types/parity-poe/index.d.ts
@@ -1,0 +1,33 @@
+// Type definitions for Parity POE 0.3
+// Project: https://github.com/paritytrading/node-parity-poe
+// Definitions by: Leo Vujanić <https://github.com/leovujanic>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="node" />
+
+/**
+ * Declares Parity POE message structure
+ * Full reference can be found here https://github.com/paritytrading/parity/blob/master/libraries/net/doc/POE.md
+ */
+export interface POEMessage {
+    messageType: string;
+    orderId?: string;
+    timestamp?: number;
+    canceledQuantity?: number;
+    reason?: string;
+    liquidityFlag?: string;
+    matchNumber?: number;
+    side?: string;
+    instrument?: string;
+    quantity?: number;
+    price?: number;
+}
+
+export function formatInbound(message: POEMessage): Buffer;
+
+export function parseInbound(buffer: Buffer): POEMessage;
+
+export function formatOutbound(message: POEMessage): Buffer;
+
+export function parseOutbound(buffer: Buffer): POEMessage;

--- a/types/parity-poe/parity-poe-tests.ts
+++ b/types/parity-poe/parity-poe-tests.ts
@@ -1,0 +1,69 @@
+/// <reference types="node" />
+import { formatInbound, parseInbound, formatOutbound, parseOutbound, POEMessage } from "parity-poe";
+
+const buffer = new Buffer("test");
+const message: POEMessage = {
+    messageType: 'A'
+};
+
+/**
+ * formatInbound tests
+ */
+
+// $ExpectType Buffer
+formatInbound(message);
+
+// Invalid type
+// $ExpectError
+formatInbound('');
+
+// $ExpectError
+formatInbound({});
+
+// Invalid sub type
+// $ExpectError
+formatInbound({
+    messageType: 1
+});
+
+/**
+ *  parseInbound tests
+ */
+
+// $ExpectType POEMessage
+parseInbound(buffer);
+
+// Invalid type
+// $ExpectError
+parseInbound('');
+
+/**
+ * formatOutbound tests
+ */
+
+// $ExpectType Buffer
+formatOutbound(message);
+
+// Invalid type
+// $ExpectError
+formatOutbound('');
+
+// $ExpectError
+formatOutbound({});
+
+// Invalid sub type
+// $ExpectError
+formatOutbound({
+    messageType: 1
+});
+
+/**
+ * parseOutbound tests
+ */
+
+// $ExpectType POEMessage
+parseOutbound(buffer);
+
+// Invalid type
+// $ExpectError
+parseOutbound('');

--- a/types/parity-poe/parity-poe-tests.ts
+++ b/types/parity-poe/parity-poe-tests.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { formatInbound, parseInbound, formatOutbound, parseOutbound, POEMessage } from "parity-poe";
 
 const buffer = new Buffer("test");

--- a/types/parity-poe/tsconfig.json
+++ b/types/parity-poe/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "parity-poe-tests.ts"
+    ]
+}

--- a/types/parity-poe/tslint.json
+++ b/types/parity-poe/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These are type definitions for npm library [parity-poe](https://www.npmjs.com/package/parity-poe)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
