### PR TITLE
babel-types: ExportNamedDeclaration#source can be null

### DIFF
--- a/types/babel-types/index.d.ts
+++ b/types/babel-types/index.d.ts
@@ -422,7 +422,7 @@ export interface ExportNamedDeclaration extends Node {
     type: "ExportNamedDeclaration";
     declaration: Declaration;
     specifiers: ExportSpecifier[];
-    source: StringLiteral;
+    source: StringLiteral | null;
 }
 
 export interface ExportSpecifier extends Node {


### PR DESCRIPTION
e.g. this named declaration has a source:
```javascript
export {foo} from './bar.js';
```

and this one does not:
```javascript
export const foo = 10;
```

Try it out at https://astexplorer.net/ to confirm.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/babel/babel/blob/6f3be3a5438739453510ea969136894c9cae12d8/packages/babylon/src/parser/statement.js#L1345
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
