### PR TITLE
[video.js] Added missing methods to Player interface

### DIFF
--- a/types/video.js/index.d.ts
+++ b/types/video.js/index.d.ts
@@ -71,5 +71,10 @@ declare namespace videojs {
 		removeRemoteTextTrack(track: HTMLTrackElement): void;
 		poster(val?: string): string | Player;
 		playbackRate(rate?: number): number;
+		controls(bool?: boolean): boolean;
+        muted(muted?: boolean): boolean;
+        preload(value?: boolean): string;
+        autoplay(value?: boolean): string;
+        loop(value?: boolean): string;
 	}
 }


### PR DESCRIPTION
Added the following missing methods to video.js's Player interface:

```js
controls(bool?: boolean): boolean;
muted(muted?: boolean): boolean;
preload(value?: boolean): string;
autoplay(value?: boolean): string;
loop(value?: boolean): string;
```

Link to [source file](http://docs.videojs.com/player.js.html)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
* `controls(bool?: boolean): boolean;` - [source](http://docs.videojs.com/player.js.html#line2709)
* `muted(muted?: boolean): boolean;` - [source](http://docs.videojs.com/player.js.html#line1986)
* `preload(value?: boolean): string;` - [source](http://docs.videojs.com/player.js.html#line2548)
* `autoplay(value?: boolean): string;` - [source](http://docs.videojs.com/player.js.html#line2567)
* `loop(value?: boolean): string;` - [source](http://docs.videojs.com/player.js.html#line2629)