### PR TITLE
Add missing types to expect

### DIFF
--- a/types/expect/expect-tests.ts
+++ b/types/expect/expect-tests.ts
@@ -1018,6 +1018,36 @@ describe('expect(array).toNotMatch', () => {
   });
 });
 
+describe('expect(object).toMatchObject', () => {
+  it('does not throw when the actual value matches', () => {
+    expect(() => {
+      expect({
+        statusCode: 200,
+        headers: {
+          server: 'express web server'
+        }
+      }).toMatchObject({
+        statusCode: 200,
+        headers: {}
+      });
+    }).toNotThrow();
+  });
+
+  it('throws when the actual value does not match', () => {
+    expect(() => {
+      expect({
+        statusCode: 200,
+        headers: {
+          server: 'nginx web server'
+        }
+      }).toMatchObject({
+        statusCode: 201,
+        headers: {}
+      });
+    }).toThrow(/to match/);
+  });
+});
+
 describe('toNotEqual', () => {
   it('works', () => {
     expect('actual').toNotEqual('expected');

--- a/types/expect/expect-tests.ts
+++ b/types/expect/expect-tests.ts
@@ -88,6 +88,12 @@ describe('A spy', () => {
     expect(spy).toHaveBeenCalledWith(1, 2, 3);
   });
 
+  it('knows the arguments it was last called with', () => {
+    spy(0, 1, 2);
+    spy(1, 2, 3);
+    expect(spy).toHaveBeenLastCalledWith(1, 2, 3);
+  });
+
   it('accepts to have been called with any object', () => {
     spy({});
     expect(spy).toHaveBeenCalledWith(expect.any(Object));

--- a/types/expect/expect-tests.ts
+++ b/types/expect/expect-tests.ts
@@ -88,6 +88,11 @@ describe('A spy', () => {
     expect(spy).toHaveBeenCalledWith(1, 2, 3);
   });
 
+  it('accepts to have been called with any object', () => {
+    spy({});
+    expect(spy).toHaveBeenCalledWith(expect.any(Object));
+  });
+
   describe('that calls some other function', () => {
     let otherContext: any;
     let otherArguments: any;

--- a/types/expect/expect-tests.ts
+++ b/types/expect/expect-tests.ts
@@ -1160,3 +1160,17 @@ describe('withContext', () => {
     }).toThrow(/must be a function/);
   });
 });
+
+describe('not', () => {
+  it('does not throw on different values', () => {
+    expect(() => {
+      expect(1).not.toEqual(2);
+    }).toNotThrow();
+  });
+
+  it('throws on equal values', () => {
+    expect(() => {
+      expect(1).not.toEqual(1);
+    }).toThrow();
+  });
+});

--- a/types/expect/expect-tests.ts
+++ b/types/expect/expect-tests.ts
@@ -462,6 +462,66 @@ describe('toBeFalsy', () => {
   });
 });
 
+describe('toBeDefined', () => {
+  it('does not throw on defined actual values', () => {
+    expect(() => {
+      expect(1).toBeDefined();
+      expect(0).toBeDefined();
+      expect(null).toBeDefined();
+    }).toNotThrow();
+  });
+
+  it('throws on undefined actual values', () => {
+    expect(() => {
+      expect(undefined).toBeDefined();
+    }).toThrow();
+  });
+});
+
+describe('toBeUndefined', () => {
+  it('throws on defined values', () => {
+    expect(() => {
+      expect(42).toBeUndefined();
+    }).toThrow();
+
+    expect(() => {
+      expect(0).toBeUndefined();
+    }).toThrow();
+
+    expect(() => {
+      expect(null).toBeUndefined();
+    }).toThrow();
+  });
+
+  it('does not throw with undefined actual values', () => {
+    expect(() => {
+      expect(undefined).toBeUndefined();
+    }).toNotThrow();
+  });
+});
+
+describe('toBeNull', () => {
+  it('throws on non-null values', () => {
+    expect(() => {
+      expect(42).toBeNull();
+    }).toThrow();
+
+    expect(() => {
+      expect(0).toBeNull();
+    }).toThrow();
+
+    expect(() => {
+      expect(undefined).toBeNull();
+    }).toThrow();
+  });
+
+  it('does not throw with null actual values', () => {
+    expect(() => {
+      expect(null).toBeNull();
+    }).toNotThrow();
+  });
+});
+
 describe('toEqual', () => {
   it('works', () => {
     expect(() => {

--- a/types/expect/index.d.ts
+++ b/types/expect/index.d.ts
@@ -59,6 +59,7 @@ declare namespace expect {
         toHaveBeenCalled(message?: string): Expectation<T>;
         toNotHaveBeenCalled(message?: string): Expectation<T>;
         toHaveBeenCalledWith(...args: any[]): Expectation<T>;
+        toHaveBeenLastCalledWith(...args: any[]): Expectation<T>;
 
         not: Expectation<T>;
 

--- a/types/expect/index.d.ts
+++ b/types/expect/index.d.ts
@@ -60,7 +60,7 @@ declare namespace expect {
         toHaveBeenCalledWith(...args: any[]): Expectation<T>;
 
         not: Expectation<T>;
-        
+
         // deprecated
         withContext(context: any): Expectation<T>;
         withArgs(...args: any[]): Expectation<T>;
@@ -95,6 +95,7 @@ declare namespace expect {
     function restoreSpies(): void;
     function assert(condition: boolean, messageFormat: string, ...extraArgs: any[]): void;
     function extend(extension: Extension): void;
+    function any<T>(ctor: { new (): T }): T;
 }
 
 declare function expect<T>(actual: T): expect.Expectation<T>;

--- a/types/expect/index.d.ts
+++ b/types/expect/index.d.ts
@@ -14,6 +14,9 @@ declare namespace expect {
         toBeTruthy(message?: string): Expectation<T>;
         toNotExist(message?: string): Expectation<T>;
         toBeFalsy(message?: string): Expectation<T>;
+        toBeNull(message?: string): Expectation<T>;
+        toBeDefined(message?: string): Expectation<T>;
+        toBeUndefined(message?: string): Expectation<T>;
 
         toBe(value: T, message?: string): Expectation<T>;
         toNotBe(value: any, message?: string): Expectation<T>;

--- a/types/expect/index.d.ts
+++ b/types/expect/index.d.ts
@@ -59,6 +59,8 @@ declare namespace expect {
         toNotHaveBeenCalled(message?: string): Expectation<T>;
         toHaveBeenCalledWith(...args: any[]): Expectation<T>;
 
+        not: Expectation<T>;
+        
         // deprecated
         withContext(context: any): Expectation<T>;
         withArgs(...args: any[]): Expectation<T>;

--- a/types/expect/index.d.ts
+++ b/types/expect/index.d.ts
@@ -31,6 +31,7 @@ declare namespace expect {
         toNotBeAn(value: string | {}, message?: string): Expectation<T>;
         toMatch(value: string | RegExp | {}, message?: string): Expectation<T>;
         toNotMatch(value: string | RegExp | {}, message?: string): Expectation<T>;
+        toMatchObject(value: {}, message?: string): Expectation<T>;
 
         toBeLessThan(value: number, message?: string): Expectation<T>;
         toBeLessThanOrEqualTo(value: number, messasge?: string): Expectation<T>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


The added types are available in expect, but are missing in these type definitions. See jest docs on expect:
https://facebook.github.io/jest/docs/en/expect.html
