### PR TITLE
[webdriverio] Nullable Hooks, fix reporterOptions, add `deprecationWarnings`, add `browserstackLocal`

### DIFF
--- a/types/webdriverio/index.d.ts
+++ b/types/webdriverio/index.d.ts
@@ -4,6 +4,7 @@
 //                 Tim Brust <https://github.com/timbru31>
 //                 Fredrik Smedberg <https://github.com/fsmedberg-tc>
 //                 Tanvir ul Islam <https://github.com/tanvirislam06>
+//                 Phil Leger <https://github.com/phil-lgr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node"/>
@@ -397,6 +398,7 @@ declare namespace WebdriverIO {
     interface Options {
         baseUrl?: string;
         bail?: number;
+        deprecationWarnings?: boolean;
         coloredLogs?: boolean;
         capabilities?: DesiredCapabilities[];
         connectionRetryTimeout?: number;

--- a/types/webdriverio/index.d.ts
+++ b/types/webdriverio/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for WebdriverIO 4.8
+// Type definitions for WebdriverIO 4.10.2
 // Project: http://www.webdriver.io/
 // Definitions by: Nick Malaguti <https://github.com/nmalaguti>
 //                 Tim Brust <https://github.com/timbru31>
@@ -334,71 +334,72 @@ declare namespace WebdriverIO {
     }
 
     interface Hooks {
-        onError<T>(error: Error): Promise<T> & undefined;
+        onError?<T>(error: Error): Promise<T> & undefined;
 
-        onPrepare<T>(
+        onPrepare?<T>(
             config: Options,
             capabilities: DesiredCapabilities
         ): Promise<T> & undefined;
 
-        onComplete<T>(exitCode: number): Promise<T> & undefined;
+        onComplete?<T>(exitCode: number): Promise<T> & undefined;
 
-        before<T>(
+        before?<T>(
             capabilities: DesiredCapabilities,
             specs: string[]
         ): Promise<T> & undefined;
 
-        beforeCommand<T>(
+        beforeCommand?<T>(
             commandName: string,
             args: any[]
         ): Promise<T> & undefined;
 
-        beforeFeature<T>(feature: string): Promise<T> & undefined;
-        beforeHook<T>(): Promise<T> & undefined;
-        beforeScenario<T>(scenario: string): Promise<T> & undefined;
+        beforeFeature?<T>(feature: string): Promise<T> & undefined;
+        beforeHook?<T>(): Promise<T> & undefined;
+        beforeScenario?<T>(scenario: string): Promise<T> & undefined;
 
-        beforeSession<T>(
+        beforeSession?<T>(
             config: Options,
             capabilities: DesiredCapabilities,
             specs: string[]
         ): Promise<T> & undefined;
 
-        beforeStep<T>(step: string): Promise<T> & undefined;
-        beforeSuite<T>(suite: Suite): Promise<T> & undefined;
-        beforeTest<T>(test: Test): Promise<T> & undefined;
-        afterHook<T>(): Promise<T> & undefined;
+        beforeStep?<T>(step: string): Promise<T> & undefined;
+        beforeSuite?<T>(suite: Suite): Promise<T> & undefined;
+        beforeTest?<T>(test: Test): Promise<T> & undefined;
+        afterHook?<T>(): Promise<T> & undefined;
 
-        after<T>(
+        after?<T>(
             result: number,
             capabilities: DesiredCapabilities,
             specs: string[]
         ): Promise<T> & undefined;
 
-        afterCommand<T>(
+        afterCommand?<T>(
             commandName: string,
             args: any[],
             result: any,
             error?: Error
         ): Promise<T> & undefined;
 
-        afterScenario<T>(scenario: any): Promise<T> & undefined;
+        afterScenario?<T>(scenario: any): Promise<T> & undefined;
 
-        afterSession<T>(
+        afterSession?<T>(
             config: Options,
             capabilities: DesiredCapabilities,
             specs: string[]
         ): Promise<T> & undefined;
 
-        afterStep<T>(stepResult: any): Promise<T> & undefined;
-        afterSuite<T>(suite: Suite): Promise<T> & undefined;
-        afterTest<T>(test: Test): Promise<T> & undefined;
-        afterFeature<T>(feature: string): Promise<T> & undefined;
+        afterStep?<T>(stepResult: any): Promise<T> & undefined;
+        afterSuite?<T>(suite: Suite): Promise<T> & undefined;
+        afterTest?<T>(test: Test): Promise<T> & undefined;
+        afterFeature?<T>(feature: string): Promise<T> & undefined;
     }
 
     interface Options {
         baseUrl?: string;
         bail?: number;
         deprecationWarnings?: boolean;
+        browserstackLocal?: boolean;
         coloredLogs?: boolean;
         capabilities?: DesiredCapabilities[];
         connectionRetryTimeout?: number;
@@ -415,7 +416,7 @@ declare namespace WebdriverIO {
         path?: string;
         plugins?: { [name: string]: any; };
         reporters?: string[] | ((...args: any[]) => void);
-        reporterOptions?: { outputDir?: string; };
+        reporterOptions?: { outputDir?: string, [reporterName: string]: any };
         logLevel?: string;
         maxInstances?: number;
         maxInstancesPerCapability?: number;

--- a/types/webdriverio/index.d.ts
+++ b/types/webdriverio/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for WebdriverIO 4.10.2
+// Type definitions for WebdriverIO 4.10
 // Project: http://www.webdriver.io/
 // Definitions by: Nick Malaguti <https://github.com/nmalaguti>
 //                 Tim Brust <https://github.com/timbru31>

--- a/types/webdriverio/webdriverio-tests.ts
+++ b/types/webdriverio/webdriverio-tests.ts
@@ -26,7 +26,7 @@ describe.only("my webdriverio tests", () => {
     let client: webdriverio.Client<void>;
 
     before(async () => {
-        client = webdriverio.remote({ desiredCapabilities: { browserName: "phantomjs" } });
+        client = webdriverio.remote({ deprecationWarnings: true, desiredCapabilities: { browserName: "phantomjs" } });
         await client.init();
     });
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

`browserstackLocal` added as boolean: https://github.com/webdriverio/webdriverio/blob/82dd1cabb07bb1c999ed28372d37aa0c8bd1b9d2/docs/guide/services/browserstack.md#configuration

`reporterOptions` should be more flexible to allow reporter custom config: https://github.com/webdriverio/wdio-junit-reporter#configuration

`deprecationWarnings` was introduced in 4.10.2: https://github.com/webdriverio/webdriverio/commits/a8be2255b3700999fe17d3bfde5b56e68d3cd15a/lib/helpers/deprecationWarning.js

I also think we could set all the hook as nullable:

```
before?<T>(
            capabilities: DesiredCapabilities,
            specs: string[]
        ): Promise<T> & undefined;
```

One can choose not to specify a `before` hook in the config file. 

- [X] Increase the version number in the header if appropriate.

I'm running webdriverio 4.10.2 against @types/webdriverio 4.8.0. With those changes it looks good.

```
// Type definitions for WebdriverIO 4.10.2
// Project: http://www.webdriver.io/
// Definitions by: Nick Malaguti <https://github.com/nmalaguti>
//                 Tim Brust <https://github.com/timbru31>
//                 Fredrik Smedberg <https://github.com/fsmedberg-tc>
//                 Tanvir ul Islam <https://github.com/tanvirislam06>
//                 Phil Leger <https://github.com/phil-lgr>
// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

/// <reference types="node"/>
```

is 4.10.2 good or should it be 4.10?
