### PR TITLE
[p-event] Fix test to work with latest typescript

### DIFF
--- a/types/p-event/p-event-tests.ts
+++ b/types/p-event/p-event-tests.ts
@@ -8,14 +8,14 @@ class MyEmitter extends events.EventEmitter {
 }
 
 class MyDomEmitter implements EventTarget {
-    addEventListener(type: 'foo', listener?: (event: Event) => void): void {
+    addEventListener(type: 'foo', listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void {
     }
 
     dispatchEvent(event: Event): boolean {
         return false;
     }
 
-    removeEventListener(type: 'foo', listener?: (event: Event) => void): void {
+    removeEventListener(type: 'foo', listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void {
     }
 }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: 
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

No change in definition itself, just fix test as I got following error:
```
Error: c:/Workspaces/GithubForks/DefinitelyTyped/types/p-event/p-event-tests.ts:11:5
ERROR: 11:5  expect  TypeScript@next compile error:
Property 'addEventListener' in type 'MyDomEmitter' is not assignable to the same property in base type 'EventTarget'.
  Type '(type: "foo", listener?: ((event: Event) => void) | undefined) => void' is not assignable to type '(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListener...'.
    Types of parameters 'listener' and 'listener' are incompatible.
      Type 'EventListenerOrEventListenerObject' is not assignable to type '((event: Event) => void) | undefined'.
        Type 'EventListenerObject' is not assignable to type '((event: Event) => void) | undefined'.
          Type 'EventListenerObject' is not assignable to type '(event: Event) => void'.
            Type 'EventListenerObject' provides no match for the signature '(event: Event): void'.
ERROR: 18:5  expect  TypeScript@next compile error:
Property 'removeEventListener' in type 'MyDomEmitter' is not assignable to the same property in base type 'EventTarget'.
  Type '(type: "foo", listener?: ((event: Event) => void) | undefined) => void' is not assignable to type '(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOpt...'.
    Types of parameters 'listener' and 'listener' are incompatible.
      Type 'EventListenerOrEventListenerObject' is not assignable to type '((event: Event) => void) | undefined'.
        Type 'EventListenerObject' is not assignable to type '((event: Event) => void) | undefined'.
          Type 'EventListenerObject' is not assignable to type '(event: Event) => void'.
            Type 'EventListenerObject' provides no match for the signature '(event: Event): void'.
```