### PR TITLE
Add tag to SortEvent in react-sortable-hoc

### DIFF
--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -18,11 +18,11 @@ export interface SortStart {
 
 export type SortEvent = React.MouseEvent<any> | React.TouchEvent<any>;
 
-export interface Tag extends React.EventTarget {
-    tagName: string;
+export type SortEventWithTag = SortEvent & {
+  target: {
+    tagName: string
+  }
 }
-
-export type SortEventWithTag = SortEvent & { target: Tag }
 
 export type SortStartHandler = (sort: SortStart, event: SortEvent) => void;
 

--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -18,13 +18,11 @@ export interface SortStart {
 
 export type SortEvent = React.MouseEvent<any> | React.TouchEvent<any>;
 
-interface Tag extends React.EventTarget {
+export interface Tag extends React.EventTarget {
     tagName: string;
 }
 
-export interface SortEventWithTag extends SortEvent {
-    target: Tag;
-}
+export type SortEventWithTag = SortEvent & { target: Tag }
 
 export type SortStartHandler = (sort: SortStart, event: SortEvent) => void;
 

--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -18,6 +18,14 @@ export interface SortStart {
 
 export type SortEvent = React.MouseEvent<any> | React.TouchEvent<any>;
 
+interface Tag extends React.EventTarget {
+    tagName: string;
+}
+
+export interface SortEventWithTag extends SortEvent {
+    target: Tag;
+}
+
 export type SortStartHandler = (sort: SortStart, event: SortEvent) => void;
 
 export type SortMoveHandler = (event: SortEvent) => void;
@@ -45,7 +53,7 @@ export interface SortableContainerProps {
     pressDelay?: number;
     pressThreshold?: number;
     distance?: number;
-    shouldCancelStart?: (event: SortEvent) => boolean;
+    shouldCancelStart?: (event: SortEvent | SortEventWithTag) => boolean;
     onSortStart?: SortStartHandler;
     onSortMove?: SortMoveHandler;
     onSortEnd?: SortEndHandler;

--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -22,7 +22,7 @@ export type SortEventWithTag = SortEvent & {
   target: {
     tagName: string
   }
-}
+};
 
 export type SortStartHandler = (sort: SortStart, event: SortEvent) => void;
 


### PR DESCRIPTION
In order to check if the event target is a hyperlink and cancel sort if the user clicks a link, the recommended pattern is to check SortEvent.target.tagName. (see https://stackoverflow.com/questions/15661343/check-if-event-target-is-hyperlink). However, the typings do not support this pattern as SortEvent.target does not expect a tag attribute.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/15661343/check-if-event-target-is-hyperlink

