### PR TITLE
hapi: allow joi object to be passed directly to response.schema

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -1381,6 +1381,7 @@ export interface ValidationObject {
 export type RouteOptionsResponseSchema =
     boolean
     | ValidationObject
+    | AnySchema
     | ((value: object | Buffer | string, options: ValidationOptions) => Promise<any>);
 
 /**

--- a/types/hapi/test/route/validation.ts
+++ b/types/hapi/test/route/validation.ts
@@ -11,6 +11,9 @@ const routeOptions: RouteOptions = {
         params: {
             name: Joi.string().min(3).max(10)
         }
+    },
+    response: {
+        schema: Joi.string()
     }
 };
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


Says it accepts a joi object, but currently does not. Let me know if there needs to be more tests for `route.options.response.schema`.
https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsresponseschema

related #23562