### PR TITLE
[elasticsearch] allow routing key in CreateDocumentParams

### DIFF
--- a/types/elasticsearch/elasticsearch-tests.ts
+++ b/types/elasticsearch/elasticsearch-tests.ts
@@ -61,6 +61,14 @@ client.create({
 }, (err, repsonse, status) => {
 });
 
+client.create({
+  id: '123',
+  index: 'index',
+  type: 'type',
+  routing: 'parent_123',
+}, (err, repsonse, status) => {
+});
+
 client.cluster.getSettings({
   masterTimeout: '100s'
 }, (err, response) => {

--- a/types/elasticsearch/index.d.ts
+++ b/types/elasticsearch/index.d.ts
@@ -7,6 +7,7 @@
 //                 Margus Lamp <https://github.com/mlamp>
 //                 Ahmad Ferdous Bin Alam <https://github.com/ahmadferdous>
 //                 Simon Schick <https://github.com/SimonSchick>
+//                 Paul Brabban <https://github.com/brabster>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -199,6 +200,7 @@ export interface CreateDocumentParams extends GenericParams {
     waitForActiveShards?: string;
     parent?: string;
     refresh?: Refresh;
+    routing?: string;
     timeout?: TimeSpan;
     timestamp?: Date | number;
     ttl?: TimeSpan;


### PR DESCRIPTION
Adds a missing `routing` optional key to the document `create` function.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference-5-0.html#api-create-5-0
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
