### PR TITLE
bson: add cacheHexString boolean flag to ObjectID

### DIFF
--- a/types/bson/bson-tests.ts
+++ b/types/bson/bson-tests.ts
@@ -1,5 +1,8 @@
 import * as bson from 'bson';
 
+// enable hex string caching
+bson.ObjectID.cacheHexString = true
+
 let BSON = new bson.BSON();
 let Long = bson.Long;
 

--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -135,9 +135,7 @@ export class ObjectID {
     constructor(id?: string | number | ObjectID);
     /** The generation time of this ObjectID instance */
     generationTime: number;
-    /**
-     * If true cache the hex string representation of ObjectID instance
-     */
+    /** If true cache the hex string representation of this ObjectID instance */
     static cacheHexString?: boolean;
     /**
      * Creates an ObjectID from a hex string representation of an ObjectID.

--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -136,6 +136,10 @@ export class ObjectID {
     /** The generation time of this ObjectID instance */
     generationTime: number;
     /**
+     * If true cache the hex string representation of ObjectID instance
+     */
+    static cacheHexString?: boolean;
+    /**
      * Creates an ObjectID from a hex string representation of an ObjectID.
      * @param {string} hexString create a ObjectID from a passed in 24 byte hexstring.
      * @return {ObjectID} return the created ObjectID

--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -135,7 +135,7 @@ export class ObjectID {
     constructor(id?: string | number | ObjectID);
     /** The generation time of this ObjectID instance */
     generationTime: number;
-    /** If true cache the hex string representation of this ObjectID instance */
+    /** If true cache the hex string representation of ObjectID */
     static cacheHexString?: boolean;
     /**
      * Creates an ObjectID from a hex string representation of an ObjectID.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I have changed existed `bson` definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mongodb/js-bson/blob/1.0-branch/lib/bson/objectid.js#L40-L41
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
