### PR TITLE
Added null as valid argument type to ssh2-sftp-client get

### DIFF
--- a/types/ssh2-sftp-client/index.d.ts
+++ b/types/ssh2-sftp-client/index.d.ts
@@ -10,7 +10,7 @@ export = sftp;
 declare class sftp {
   connect(options: ssh2.ConnectConfig): Promise<void>;
   list(remoteFilePath: string): Promise<sftp.FileInfo[]>;
-  get(remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<NodeJS.ReadableStream>;
+  get(remoteFilePath: string, useCompression?: boolean, encoding?: string | null): Promise<NodeJS.ReadableStream>;
   put(input: string | Buffer | NodeJS.ReadableStream, remoteFilePath: string, useCompression?: boolean, encoding?: string): Promise<void>;
   mkdir(remoteFilePath: string, recursive?: boolean): Promise<void>;
   rmdir(remoteFilePath: string, recursive?: boolean): Promise<void>;

--- a/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
+++ b/types/ssh2-sftp-client/ssh2-sftp-client-tests.ts
@@ -12,7 +12,8 @@ client.connect({
 client.list('/remote/path').then(() => null);
 
 client.get('/remote/path').then(stream => stream.read(0));
-client.get('/remote/path', true, 'binary').then(stream => stream.read(0));
+client.get('/remote/path', true, 'utf8').then(stream => stream.read(0));
+client.get('/remote/path', true, null).then(stream => stream.read(0));
 
 client.put('/local/path', '/remote/path').then(() => null);
 client.put(new Buffer('content'), '/remote/path').then(() => null);

--- a/types/ssh2-sftp-client/tsconfig.json
+++ b/types/ssh2-sftp-client/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: According to https://www.npmjs.com/package/ssh2-sftp-client , the argument for encoding should be set to null for binary files when calling get.

