### PR TITLE
[Dragula] updated moves() function arguments in DragulaOptions

### DIFF
--- a/types/dragula/index.d.ts
+++ b/types/dragula/index.d.ts
@@ -13,7 +13,7 @@ declare namespace dragula {
     interface DragulaOptions {
         containers?: Element[];
         isContainer?: (el?: Element) => boolean;
-        moves?: (el?: Element, container?: Element, handle?: Element) => boolean;
+        moves?: (el?: Element, container?: Element, handle?: Element, sibling?: Element) => boolean;
         accepts?: (el?: Element, target?: Element, source?: Element, sibling?: Element) => boolean;
         invalid?: (el?: Element, target?: Element) => boolean;
         direction?: string;


### PR DESCRIPTION
Updated `moves()` function arguments in `DragulaOptions` to include an optional `sibling` argument.

As seen in the [source](https://github.com/bevacqua/dragula/blob/master/dist/dragula.js#L216) or [docs](https://github.com/bevacqua/dragula#dragulacontainers-options)


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source](https://github.com/bevacqua/dragula/blob/master/dist/dragula.js#L216)