### PR TITLE
Add typings for anchor-js

### DIFF
--- a/types/anchor-js/anchor-js-tests.ts
+++ b/types/anchor-js/anchor-js-tests.ts
@@ -1,0 +1,16 @@
+anchors.add();
+anchors.add('h1');
+anchors.add().add('h2');
+
+anchors.remove();
+anchors.remove('h1');
+anchors.remove().remove('h2');
+
+anchors.removeAll();
+
+const headerAnchors = new AnchorJS();
+
+const footerAnchors = new AnchorJS({
+    placement: 'right',
+});
+footerAnchors.remove('.links');

--- a/types/anchor-js/index.d.ts
+++ b/types/anchor-js/index.d.ts
@@ -1,0 +1,41 @@
+// Type definitions for anchor-js 4.1
+// Project: https://github.com/bryanbraun/anchorjs
+// Definitions by: Brian Surowiec <https://github.com/xt0rted>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace anchorjs {
+    interface Anchor {
+        options: AnchorOptions;
+
+        add(selector?: string): Anchor;
+        remove(selector?: string): Anchor;
+        removeAll(): void;
+    }
+
+    type AnchorPlacement = 'left' | 'right';
+    type AnchorVisibility = 'always' | 'hover' | 'touch';
+
+    interface AnchorOptions {
+        arialabel?: string;
+        class?: string;
+        icons?: string;
+        placement?: AnchorPlacement;
+        truncate?: number;
+        visible?: AnchorVisibility;
+    }
+
+    interface AnchorStatic {
+        new(options?: AnchorOptions): Anchor;
+    }
+}
+
+declare const anchors: anchorjs.Anchor;
+declare const AnchorJS: anchorjs.AnchorStatic;
+
+export = AnchorJS;
+
+export as namespace AnchorJS;
+
+declare global {
+    const anchors: anchorjs.Anchor;
+}

--- a/types/anchor-js/tsconfig.json
+++ b/types/anchor-js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "anchor-js-tests.ts"
+    ]
+}

--- a/types/anchor-js/tslint.json
+++ b/types/anchor-js/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Since I last added a typing the process has changed, so I followed the instructions using `dts-gen` but had a couple issues with it. The first was the `tsconfig.json` didn't include `"strictFunctionTypes": true,` so linting failed right away. The second was the generated `tslint.json` didn't include any rules so linting was also failing until I coppied the rules from another folder. I'm not sure if these things are safe defaults/required or not, but if they are it'd be nice if they were included when using `dts-gen` since they're extra manual steps.