### PR TITLE
Added chmod method to rsync types

### DIFF
--- a/types/rsync/index.d.ts
+++ b/types/rsync/index.d.ts
@@ -48,7 +48,7 @@ interface Rsync {
         stdout: StreamDataHandler,
         stderr: StreamDataHandler
     ): child_process.ChildProcess;
-    
+
     // cwd
     cwd(cwd: string): string;
 
@@ -63,6 +63,7 @@ interface Rsync {
     quiet(): Rsync;
     dirs(): Rsync;
     links(): Rsync;
+    chmod(flags: string): Rsync;
     dry(): Rsync;
 
     // accessor methods

--- a/types/rsync/rsync-tests.ts
+++ b/types/rsync/rsync-tests.ts
@@ -114,6 +114,7 @@ rsync.shell('ssh')
     .quiet()
     .dirs()
     .links()
+    .chmod("ug=rwX")
     .dry();
 
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/mattijs/node-rsync/blob/master/rsync.js#L626-L635>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
