### PR TITLE
[Sequelize] add returning option to upsert and change return type accordingly

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Sequelize 4.27.0
+// Type definitions for Sequelize 4.27.8
 // Project: http://sequelizejs.com
 // Definitions by: samuelneff <https://github.com/samuelneff>
 //                 Peter Harris <https://github.com/codeanimal>

--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3445,7 +3445,7 @@ declare namespace sequelize {
     /**
  * Options for Model.upsert method
      */
-    interface UpsertOptions extends FieldsOptions, LoggingOptions, SearchPathOptions {
+    interface UpsertOptions extends FieldsOptions, LoggingOptions, SearchPathOptions, ReturningOptions {
     }
 
     /**
@@ -3993,8 +3993,10 @@ declare namespace sequelize {
  * because SQLite always runs INSERT OR IGNORE + UPDATE, in a single query, so there is no way to know
  * whether the row was inserted or not.
  */
-        upsert(values: TAttributes, options?: UpsertOptions): Promise<boolean>;
-        insertOrUpdate(values: TAttributes, options?: UpsertOptions): Promise<boolean>;
+        upsert(values: TAttributes, options?: UpsertOptions & { returning: false | undefined }): Promise<boolean>;
+        upsert(values: TAttributes, options?: UpsertOptions & { returning: true }): Promise<[boolean, TInstance]>;
+        insertOrUpdate(values: TAttributes, options?: UpsertOptions & { returning: false | undefined }): Promise<boolean>;
+        insertOrUpdate(values: TAttributes, options?: UpsertOptions & { returning: true }): Promise<[boolean, TInstance]>;
 
         /**
          * Create and insert multiple instances in bulk.

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -1036,7 +1036,9 @@ findOrRetVal = User.findOrCreate( { where : { id : undefined }, defaults : { nam
 findOrRetVal = User.findOrCreate( { where : { email : 'unique.email.@d.com', companyId : Math.floor( Math.random() * 5 ) } } );
 findOrRetVal = User.findOrCreate( { where : { objectId : 1 }, defaults : { bool : false } } );
 
-User.upsert( { id : 42, username : 'doe', foo : s.fn( 'upper', 'mixedCase2' ) } );
+let upsertPromiseNoOptions: Bluebird<boolean> = User.upsert( { id : 42, username : 'doe', foo : s.fn( 'upper', 'mixedCase2' ) } );
+let upsertPromiseReturning: Bluebird<[boolean, AnyInstance]> = User.upsert( { id : 42, username : 'doe', foo : s.fn( 'upper', 'mixedCase2' ) }, { returning: true } );
+let upsertPromiseNotReturning: Bluebird<boolean> = User.upsert( { id : 42, username : 'doe', foo : s.fn( 'upper', 'mixedCase2' ) }, { returning: false } );
 
 User.bulkCreate( [{ aNumber : 10 }, { aNumber : 12 }] ).then( ( i ) => i[0].isNewRecord );
 User.bulkCreate( [{ username : 'bar' }, { username : 'bar' }, { username : 'bar' }] );


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-upsert / https://github.com/sequelize/sequelize/pull/8924/files
- [x] Increase the version number in the header if appropriate.

A fairly [recent feature](https://github.com/sequelize/sequelize/pull/8924/files) in Sequelize is to pass a `returning` option to the `upsert` call to have the return value include the instance upserted.  My reading of that PR is that a value will only ever be returned when `returning === true`, so the types that are included in this PR reflect that.
