### PR TITLE
redis: Change redis.print declaration to comply to callback signature.

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -6,6 +6,7 @@
 //                 Stuart Schechter <https://github.com/UppaJung>
 //                 Junyoung Choi <https://github.com/Rokt33r>
 //                 James Garbutt <https://github.com/43081j>
+//                 Bartek Szczepański <https://github.com/barnski>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Imported from: https://github.com/types/npm-redis
@@ -1238,4 +1239,4 @@ export function createClient(unix_socket: string, options?: ClientOpts): RedisCl
 export function createClient(redis_url: string, options?: ClientOpts): RedisClient;
 export function createClient(options?: ClientOpts): RedisClient;
 
-export function print(err: Error | undefined, reply: any): void;
+export function print(err: Error | null, reply: any): void;

--- a/types/redis/redis-tests.ts
+++ b/types/redis/redis-tests.ts
@@ -121,3 +121,7 @@ client.uncork();
 // Add command
 client.add_command('my command');
 client.addCommand('my other command');
+
+// redis.print as callback
+client.set(str, str, redis.print);
+client.get(str, redis.print);


### PR DESCRIPTION
As shown in node_redis examples redis.print is nice utility to be used as callback.

With current type declarations it was not possible due to mismatch null vs. undefined.

I decided to update redis.print signature to not break other methods by changing Callback

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/NodeRedis/node_redis#usage-example>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
