### PR TITLE
Add type definitions for datadog-tracer

### DIFF
--- a/types/datadog-tracer/datadog-tracer-tests.ts
+++ b/types/datadog-tracer/datadog-tracer-tests.ts
@@ -1,0 +1,9 @@
+import Tracer = require('datadog-tracer');
+
+const tracer = new Tracer({
+    service: 'test'
+});
+
+tracer.on('error', (e: any) => {
+    void(0);
+});

--- a/types/datadog-tracer/index.d.ts
+++ b/types/datadog-tracer/index.d.ts
@@ -1,0 +1,24 @@
+// Type definitions for datadog-tracer 0.4
+// Project: https://github.com/rochdev/datadog-tracer-js#readme
+// Definitions by: Dinesh Saravanan Kumaraswamy <https://github.com/dineshsaravanan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+import * as opentracing from "opentracing";
+import { EventEmitter } from "events";
+
+export as namespace Tracer;
+export = Tracer;
+
+interface TracerOptions {
+    service: string;
+    hostname?: string;
+    port?: number;
+    protocol?: string;
+    endpoint?: string;
+}
+
+declare class Tracer extends opentracing.Tracer {
+    constructor(tracerOptions: TracerOptions);
+
+    on(method: "error", cb?: (e: any) => void): void;
+    addEventListener(method: "error", cb?: (e: any) => void): void;
+}

--- a/types/datadog-tracer/package.json
+++ b/types/datadog-tracer/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "opentracing": "^0.14.1"
+    }
+}

--- a/types/datadog-tracer/tsconfig.json
+++ b/types/datadog-tracer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "datadog-tracer-tests.ts"
+    ]
+}

--- a/types/datadog-tracer/tslint.json
+++ b/types/datadog-tracer/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dt.json",
+    "rules": {
+        "strict-export-declare-modifiers": false
+    }
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.


The library [https://github.com/rochdev/datadog-tracer-js](datadog-tracer) extends the `opentracing` library which provides its own types, but also emits an `error` event.  