### PR TITLE
[recompose] Make StateHandler use Partial<TState>

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -133,7 +133,7 @@ declare module 'recompose' {
     >;
 
     // withStateHandlers: https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
-    type StateHandler<TState> = (...payload: any[]) => TState | undefined;
+    type StateHandler<TState> = (...payload: any[]) => Partial<TState> | undefined;
     type StateHandlerMap<TState> = {
       [updaterName: string]: StateHandler<TState>;
     };


### PR DESCRIPTION
The state handlers in withStateHandlers do not need to return the full
state every time, since recompose will merge the states together. Their
own flow-types specify $Shape<State>, which as far as I can tell is
analogous to Partial<TState>.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/acdlite/recompose/blob/master/types/flow-typed/recompose_v0.24.x/flow_v0.55.x-/recompose_v0.24.x.js#L96-L103
https://github.com/acdlite/recompose/blob/master/src/packages/recompose/withStateHandlers.js#L24-L26