### PR TITLE
@types/qunit - add `QUnit.todo(name, callback)` fn signature

### DIFF
--- a/types/qunit/index.d.ts
+++ b/types/qunit/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for QUnit v2.0.1
+// Type definitions for QUnit v2.5.0
 // Project: http://qunitjs.com/
 // Definitions by: James Bracy <https://github.com/waratuman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -579,6 +579,21 @@ interface QUnit {
      * @param callback Callback to execute
      */
     testStart(callback: (details: { name: string; module: string;}) => void): void;
+
+    /**
+     * Adds a test which expects at least one failing assertion during its run.
+     *
+     * Use this method to test a unit of code which is still under development
+     * (in a “todo” state). The test will pass as long as one failing assertion
+     * is present.
+     *
+     * If all assertions pass, then the test will fail signaling that QUnit.todo
+     * should be replaced by QUnit.test.
+     *
+     * @param {string} Title of unit being tested
+     * @param callback Function to close over assertions
+     */
+    todo(name: string, callback?: (assert: Assert) => void): void;
 
     /**
      * Are the test running from the server or not.

--- a/types/qunit/qunit-tests.ts
+++ b/types/qunit/qunit-tests.ts
@@ -552,3 +552,7 @@ QUnit.module( "module", {
 QUnit.test( "test with beforeEach and afterEach", function( assert ) {
   assert.expect( 2 );
 });
+
+QUnit.todo( "a todo test", function( assert ) {
+  assert.equal( 0, 1, "0 does not equal 1, so this todo should pass" );
+});


### PR DESCRIPTION
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://api.qunitjs.com/QUnit/todo
- [x] Increase the version number in the header if appropriate.
- ~[x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`~.

cc @waratuman @vvakame 

NOTE: I've only added this function to the interface, but
I bumped the type definitions for QUnit at the top of the file from
`v2.0.1` to `v2.5.0`. This may not accurately reflect the 2.5.0 QUnit
api in full, fyi. (advise if this concerns you).