### PR TITLE
GeoJSON - Activate Strict Null Checks

### DIFF
--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -231,7 +231,7 @@ interface TestProperty {
 }
 
 const testProps: TestProperty = {
-    foo: "bar",
+    foo: "baz",
     hello: "world"
 };
 

--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -248,3 +248,77 @@ const typedPropertiesFeatureCollection: FeatureCollection<Point> = {
     type: "FeatureCollection",
     features: [typedPropertiesFeature]
 };
+
+// Strict Null Checks
+
+let isNull: null;
+let isPoint: Point;
+let isPointOrNull: Point | null;
+let isProperty: TestProperty;
+let isPropertyOrNull: TestProperty | null;
+
+const featureAllNull: Feature<null, null> = {
+    type: "Feature",
+    properties: null,
+    geometry: null
+};
+
+const featurePropertyNull: Feature<Point, null> = {
+    type: "Feature",
+    properties: null,
+    geometry: point
+};
+
+const featureGeometryNull: Feature<null, TestProperty> = {
+    type: "Feature",
+    properties: testProps,
+    geometry: null
+};
+
+const featureNoNull: Feature<Point, TestProperty> = {
+    type: "Feature",
+    properties: testProps,
+    geometry: point
+};
+
+const collectionAllNull: FeatureCollection<null, null> = {
+    type: "FeatureCollection",
+    features: [featureAllNull],
+};
+
+const collectionMaybeNull: FeatureCollection<Point | null, TestProperty | null> = {
+    type: "FeatureCollection",
+    features: [featureAllNull, featurePropertyNull, featureGeometryNull, featureNoNull],
+};
+
+const collectionPropertyMaybeNull: FeatureCollection<Point, TestProperty | null> = {
+    type: "FeatureCollection",
+    features: [featurePropertyNull, featureNoNull],
+};
+
+const collectionGeometryMaybeNull: FeatureCollection<Point | null, TestProperty> = {
+    type: "FeatureCollection",
+    features: [featureGeometryNull, featureNoNull],
+};
+
+const collectionNoNull: FeatureCollection<Point, TestProperty> = {
+    type: "FeatureCollection",
+    features: [featureNoNull],
+};
+
+isNull = featureAllNull.geometry;
+isPoint = featurePropertyNull.geometry;
+isNull = featureAllNull.properties;
+isProperty = featureGeometryNull.properties;
+
+isNull = collectionAllNull.features[0].geometry;
+isPointOrNull = collectionMaybeNull.features[0].geometry;
+isPoint = collectionPropertyMaybeNull.features[0].geometry;
+isPointOrNull = collectionGeometryMaybeNull.features[0].geometry;
+isPoint = collectionNoNull.features[0].geometry;
+
+isNull = collectionAllNull.features[0].properties;
+isPropertyOrNull = collectionMaybeNull.features[0].properties;
+isPropertyOrNull = collectionPropertyMaybeNull.features[0].properties;
+isProperty = collectionGeometryMaybeNull.features[0].properties;
+isProperty = collectionNoNull.features[0].properties;

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -160,7 +160,7 @@ export interface Feature<G extends GeometryObject | null, P = GeoJsonProperties>
  * A collection of feature objects.
  *  https://tools.ietf.org/html/rfc7946#section-3.3
  */
-export interface FeatureCollection<G extends GeometryObject | null, P = GeoJsonProperties | null> extends GeoJsonObject {
+export interface FeatureCollection<G extends GeometryObject | null, P = GeoJsonProperties> extends GeoJsonObject {
     type: "FeatureCollection";
     features: Array<Feature<G, P>>;
 }

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -139,12 +139,12 @@ export type GeoJsonProperties = { [name: string]: any; } | null;
  * A feature object which contains a geometry and associated properties.
  * https://tools.ietf.org/html/rfc7946#section-3.2
  */
-export interface Feature<G extends GeometryObject, P = GeoJsonProperties> extends GeoJsonObject {
+export interface Feature<G extends GeometryObject | null, P = GeoJsonProperties> extends GeoJsonObject {
     type: "Feature";
     /**
      * The feature's geometry
      */
-    geometry: G | null;
+    geometry: G;
     /**
      * A value that uniquely identifies this feature in a
      * https://tools.ietf.org/html/rfc7946#section-3.2.
@@ -153,14 +153,14 @@ export interface Feature<G extends GeometryObject, P = GeoJsonProperties> extend
     /**
      * Properties associated with this feature.
      */
-    properties: P | null;
+    properties: P;
 }
 
 /**
  * A collection of feature objects.
  *  https://tools.ietf.org/html/rfc7946#section-3.3
  */
-export interface FeatureCollection<G extends GeometryObject, P = GeoJsonProperties> extends GeoJsonObject {
+export interface FeatureCollection<G extends GeometryObject | null, P = GeoJsonProperties | null> extends GeoJsonObject {
     type: "FeatureCollection";
     features: Array<Feature<G, P>>;
 }

--- a/types/geojson/tsconfig.json
+++ b/types/geojson/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
Activate Strict Null Checks in GeoJSON and made the necessary changes:
- Set strictNullChecks to true
- Make `geometry` and `properties` _optionally_ nullable
- Add tests

More explanations can be found in this comment: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23794#issuecomment-368652409 
See also: [GeoJson rfc7946 – Section 3.2 and 3.3](https://tools.ietf.org/html/rfc7946#section-3.2).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [GeoJson rfc7946 – Section 3.2 and 3.3](https://tools.ietf.org/html/rfc7946#section-3.2)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
