### PR TITLE
jwplayer :: Add missing getContainer function def

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Martin Duparc <https://github.com/martinduparc>
 //                 Tomer Kruvi <https://github.com/kutomer>
 //                 Philipp Gürtler <https://github.com/philippguertler>
+//                 Daniel McGraw <https://github.com/danielmcgraw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // JW Player is the leading HTML5 & Flash video player, optimized for mobile and the desktop. Easy enough for beginners, advanced enough for pros.
@@ -254,7 +255,8 @@ interface JWPlayer {
 	getSafeRegion(): Region;
 	getState(): string;
 	getVolume(): number;
-    getEnvironment(): Environment;
+  getContainer(): HTMLElement;
+  getEnvironment(): Environment;
 	getWidth(): number;
 	load(playlist: any[]): void;
 	load(playlist: string): void;

--- a/types/jwplayer/tsconfig.json
+++ b/types/jwplayer/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6"
+            "es6",
+            "dom"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [ x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.jwplayer.com/jw-player/docs/javascript-api-reference/#jwplayergetcontainer
- [ x] Increase the version number in the header if appropriate.
- [x ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
