### PR TITLE
@types/react: Accept null or function returning null in React.Component setState

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -284,7 +284,7 @@ declare namespace React {
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
         // Also, the ` | S` allows intellisense to not be dumbisense
         setState<K extends keyof S>(
-            state: ((prevState: Readonly<S>, props: P) => (Pick<S, K> | S)) | (Pick<S, K> | S),
+            state: ((prevState: Readonly<S>, props: P) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
             callback?: () => void
         ): void;
 

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -95,6 +95,7 @@ class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
       this.setState({ foo: true });
       this.setState({ foo: true, bar: true });
       this.setState({});
+      this.setState(null);
       this.setState({ foo: true, foo2: true }); // $ExpectError
       this.setState(() => ({ foo: '' })); // $ExpectError
       this.setState(() => ({ foo: true }));
@@ -103,6 +104,7 @@ class SetStateTest extends React.Component<{}, { foo: boolean, bar: boolean }> {
       this.setState(() => ({ foo: '', foo2: true })); // $ExpectError
       this.setState(() => ({ })); // ok!
       this.setState({ foo: true, bar: undefined}); // $ExpectError
+      this.setState(prevState => (prevState.bar ? { bar: false } : null));
     }
 }
 


### PR DESCRIPTION
Allow setState to accept an updater which is null or is a function that
may return null.

In React 16, passing null to setState or returning null from the updater
function does not cause an update.

This is intended to fix issue https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23983

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: From [React 16 release announcement](https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes), "Calling setState with null no longer triggers an update. This allows you to decide in an updater function if you want to re-render." The [React 16.2.0 setState](https://github.com/facebook/react/blob/v16.2.0/packages/react/src/ReactBaseClasses.js#L53) docstring is not clear about behavior when passing null, but the invariant check in the code shows that null is an expected value. The partialState [@param](https://github.com/facebook/react/blob/v16.2.0/packages/react/src/ReactBaseClasses.js#L47) in the same file says, "Next partial state or function to produce next partial state to be merged with current state," which suggests that if the function can return null, null can also be passed in directly. I tried adding a call to `this.setState(null)` in a component of mine, and I could see in the debugger that it ran, but did not trigger a render. Using `this.setState({})` did trigger a render.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

@ericanderson
