### PR TITLE
Added type definitions for svg-path-bounding-box

### DIFF
--- a/types/svg-path-bounding-box/index.d.ts
+++ b/types/svg-path-bounding-box/index.d.ts
@@ -1,0 +1,85 @@
+// Type definitions for svg-path-bounding-box 1.0
+// Project: https://github.com/icons8/svg-path-bounding-box
+// Definitions by: Tiger Oakes <https://github.com/NotWoods>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = svgPathBoundingBox;
+
+declare function svgPathBoundingBox(
+    path: string,
+): svgPathBoundingBox.BoundingBoxView;
+
+declare namespace svgPathBoundingBox {
+    /**
+     * pass in initial points if you want
+     * @see https://github.com/gabelerner/canvg/blob/860e418aca67b9a41e858a223d74d375793ec364/canvg.js#L449
+     */
+    class BoundingBox {
+        x1: number;
+        y1: number;
+        x2: number;
+        y2: number;
+
+        constructor(x1: number, y1: number, x2: number, y2: number);
+
+        width(): number;
+
+        height(): number;
+
+        addPoint(x: number, y: number): void;
+
+        addX(x: number): void;
+
+        addY(y: number): void;
+
+        addQuadraticCurve(
+            p0x: number,
+            p0y: number,
+            p1x: number,
+            p1y: number,
+            p2x: number,
+            p2y: number,
+        ): void;
+
+        /** @see http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html */
+        addBezierCurve(
+            p0x: number,
+            p0y: number,
+            p1x: number,
+            p1y: number,
+            p2x: number,
+            p2y: number,
+            p3x: number,
+            p3y: number,
+        ): void;
+    }
+
+    class BoundingBoxView {
+        x1: number;
+        y1: number;
+        x2: number;
+        y2: number;
+        minX: number;
+        minY: number;
+        maxX: number;
+        maxY: number;
+        width: number;
+        height: number;
+
+        constructor(boundingBox: BoundingBox);
+
+        round(precision?: number): this;
+
+        scale(scale?: number): this;
+
+        toString(): string;
+    }
+
+    class Path {
+        d: string;
+
+        constructor(d: string);
+
+        getBoundingBox(): BoundingBoxView;
+    }
+}

--- a/types/svg-path-bounding-box/svg-path-bounding-box-tests.ts
+++ b/types/svg-path-bounding-box/svg-path-bounding-box-tests.ts
@@ -1,0 +1,22 @@
+import * as svgPathBoundingBox from 'svg-path-bounding-box';
+
+const bbox = svgPathBoundingBox('M300,200 h-150 a150,150 0 1,0 150,-150 z');
+
+const x1: number = bbox.x1;
+const y1: number = bbox.y1;
+const x2: number = bbox.x2;
+const y2: number = bbox.y2;
+const minX: number = bbox.minX;
+const minY: number = bbox.minY;
+const maxX: number = bbox.maxX;
+const maxY: number = bbox.maxY;
+const width: number = bbox.width;
+const height: number = bbox.height;
+
+const rounded: svgPathBoundingBox.BoundingBoxView = bbox.round(2);
+const scaled: svgPathBoundingBox.BoundingBoxView = bbox.scale(2);
+const roundedString: string = rounded.toString();
+
+const path = new svgPathBoundingBox.Path('M300,200 h-150 a150,150 0 1,0 150,-150 z');
+const d: string = path.d;
+const bbox2: svgPathBoundingBox.BoundingBoxView = path.getBoundingBox();

--- a/types/svg-path-bounding-box/tsconfig.json
+++ b/types/svg-path-bounding-box/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "svg-path-bounding-box-tests.ts"
+    ]
+}

--- a/types/svg-path-bounding-box/tslint.json
+++ b/types/svg-path-bounding-box/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
