### PR TITLE
pg: Changing import of types to use named variants instead of an aliased module

### DIFF
--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -1,10 +1,10 @@
-import * as pg from "pg";
+import { types, Client, QueryArrayConfig, Pool } from "pg";
 
 // https://github.com/brianc/node-pg-types
 // tslint:disable-next-line no-unnecessary-callback-wrapper
-pg.types.setTypeParser(20, val => Number(val));
+types.setTypeParser(20, val => Number(val));
 
-const client = new pg.Client({
+const client = new Client({
   host: 'my.database-server.com',
   port: 5334,
   user: 'database-user',
@@ -65,7 +65,7 @@ client.query(query)
     console.error(e.stack);
   });
 
-const queryArrMode: pg.QueryArrayConfig = {
+const queryArrMode: QueryArrayConfig = {
   name: 'get-name-array',
   text: 'SELECT $1::text',
   values: ['brianc'],
@@ -103,11 +103,11 @@ client.end()
   .then(() => console.log('client has disconnected'))
   .catch(err => console.error('error during disconnection', err.stack));
 
-const poolOne = new pg.Pool({
+const poolOne = new Pool({
   connectionString: 'postgresql://dbuser:secretpassword@database.server.com:3211/mydb'
 });
 
-const pool = new pg.Pool({
+const pool = new Pool({
   host: 'localhost',
   port: 5432,
   user: 'database-user',


### PR DESCRIPTION
When "pg-native" is not available, importing the module as a wildcard
after tsc transpilation can cause the runtime to invoke the getter
for the 'native' export, which will print an annoying message from
the runtime (node, etc):

"Cannot find module 'pg-native'"

Similar to this condition: https://github.com/brianc/node-postgres/issues/838

Submitting this PR because I went down a rabbit hole trying to figure out where that error came from, only because I based my initial setup on the TypeScript tests provided in the typings here

Thanks,

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
