### PR TITLE
[chroma-js] fix bug with Scale.colors.

### DIFF
--- a/types/chroma-js/chroma-js-tests.ts
+++ b/types/chroma-js/chroma-js-tests.ts
@@ -1,3 +1,6 @@
+import { Color } from "chroma-js";
+import chroma = require("chroma-js");
+
 function test_chroma() {
     chroma('hotpink');
     chroma('#ff3399');
@@ -187,3 +190,9 @@ function test_types() {
     const color: chroma.Color = chroma('orange');
     const scale: chroma.Scale = chroma.scale('RdYlBu');
 }
+
+// the following should actually, pass, but TS can't disambiguate between a parameter
+// which is passed as undefined/null or not passed at all
+// const scaleColors1: Color[] = chroma.scale(['black', 'white']).colors(12);
+const scaleColors2: Color[] = chroma.scale(['black', 'white']).colors(12, null);
+const scaleColors3: Color[] = chroma.scale(['black', 'white']).colors(12, undefined);

--- a/types/chroma-js/index.d.ts
+++ b/types/chroma-js/index.d.ts
@@ -303,10 +303,10 @@ declare namespace chroma {
          * You can call scale.colors(n) to quickly grab `c` equi-distant colors from a color scale. If called with no
          * arguments, scale.colors returns the original array of colors used to create the scale.
          */
-        colors(c?: number, format?: 'hex' | 'name'): string[];
-        colors(c?: number, format?: null | 'alpha' | 'darken' | 'brighten' | 'saturate' | 'desaturate'): Color[];
-        colors(c?: number, format?: 'luminance' | 'temperature'): number[];
-        colors<K extends keyof ColorSpaces>(c?: number, format?: K): Array<ColorSpaces[K]>;
+        colors(c: number | undefined, format: undefined | null | 'alpha' | 'darken' | 'brighten' | 'saturate' | 'desaturate'): Color[];
+        colors(c: number | undefined, format: 'luminance' | 'temperature'): number[];
+        colors<K extends keyof ColorSpaces>(c: number | undefined, format: K): Array<ColorSpaces[K]>;
+        colors(c: number | undefined, format?: 'hex' | 'name'): string[];
 
         /**
          * If you want the scale function to return a distinct set of colors instead of a continuous gradient, you can


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

```ts
> c = require('chroma-js')
> c.scale(['white', c('red')]).colors()
[ '#ffffff', '#ff0000' ]
> c.scale(['white', c('red')]).colors(3)
[ '#ffffff', '#ff8080', '#ff0000' ]
> c.scale(['white', c('red')]).colors(undefined)
[ '#ffffff', '#ff0000' ]
> c.scale(['white', c('red')]).colors(undefined, null)
[ Color { _rgb: [ 255, 255, 255, 1, _clipped: false ] },
  Color { _rgb: [ 255, 0, 0, 1, _clipped: false ] } ]
> c.scale(['white', c('red')]).colors(undefined, undefined)
[ Color { _rgb: [ 255, 255, 255, 1, _clipped: false ] },
  Color { _rgb: [ 255, 0, 0, 1, _clipped: false ] } ]
> c.scale(['white', c('red')]).colors(undefined, 'css')
[ 'rgb(255,255,255)', 'rgb(255,0,0)' ]
```

`colors(2)`  and `colors(2, undefined)` lead to different results ><

- [ ] Increase the version number in the header if appropriate. Not necessary.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. N/A
