### PR TITLE
[@types/reactstrap] Added invalid to InputProps

### DIFF
--- a/types/reactstrap/lib/Input.d.ts
+++ b/types/reactstrap/lib/Input.d.ts
@@ -32,6 +32,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   bsSize?: 'lg' | 'sm';
   state?: string;
   valid?: boolean;
+  invalid?: boolean;
   tag?: React.ReactType;
   innerRef?: string | ((instance: HTMLInputElement) => any);
   plaintext?: boolean;


### PR DESCRIPTION
The optional `invalid` prop of type `boolean` was not present in the InputProps declaration. I have added this.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Increase the version number in the header if appropriate.
