### PR TITLE
Existing "QueryResult" interface is  missing property "fields"

### DIFF
--- a/types/pg/index.d.ts
+++ b/types/pg/index.d.ts
@@ -53,13 +53,6 @@ export interface QueryArrayConfig extends QueryConfig {
     rowMode: 'array';
 }
 
-export interface QueryResult {
-    command: string;
-    rowCount: number;
-    oid: number;
-    rows: any[];
-}
-
 export interface FieldDef {
     name: string;
     tableID: number;
@@ -70,12 +63,19 @@ export interface FieldDef {
     format: string;
 }
 
-export interface QueryArrayResult {
+export interface QueryResultBase {
     command: string;
     rowCount: number;
     oid: number;
-    rows: any[][];
     fields: FieldDef[];
+}
+
+export interface QueryResult extends QueryResultBase {
+    rows: any[];
+}
+
+export interface QueryArrayResult extends QueryResultBase {
+    rows: any[][];
 }
 
 export interface Notification {

--- a/types/pg/pg-tests.ts
+++ b/types/pg/pg-tests.ts
@@ -55,11 +55,13 @@ client.query(query, (err, res) => {
     console.error(err.stack);
   } else {
     console.log(res.rows);
+    console.log(res.fields.map(f => f.name));
   }
 });
 client.query(query)
   .then(res => {
     console.log(res.rows);
+    console.log(res.fields.map(f => f.name));
   })
   .catch(e => {
     console.error(e.stack);


### PR DESCRIPTION
Existing `QueryResult` interface is  missing property `fields`
only the array `QueryArrayResult` variant contained the `fields`
property

Added a new `QueryResultBase` interface with the shared set of
fields between the object/array results and refactored both
`QueryResult` and `QueryArrayResult` to extend from it, each now
only needing to specify their own type variation of the `row`
property for the type of results they contain (object vs array)

Modified the tests to reference the `fields` array on object
select results similarly to how it was done for the array
select results

According to https://node-postgres.com/api/result every `Result` will contain the expected `fields` property (and verified via testing)

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
