### PR TITLE
[Three] Updates mesh to use a optional material array.

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5020,10 +5020,10 @@ export class LineSegments extends Line {
 }
 
 export class Mesh extends Object3D {
-    constructor(geometry?: Geometry | BufferGeometry, material?: Material);
+    constructor(geometry?: Geometry | BufferGeometry, material?: Material | Material[]);
 
     geometry: Geometry|BufferGeometry;
-    material: Material;
+    material: Material | Material[];
     drawMode: TrianglesDrawModes;
     morphTargetInfluences?: number[];
     morphTargetDictionary?: { [key: string]: number; };


### PR DESCRIPTION
The material property on Mesh should be a material or an array of materials.