### PR TITLE
[clipboard] Update to version 2 (Clipboard => ClipboardJS renaming)

### DIFF
--- a/types/clipboard/clipboard-tests.ts
+++ b/types/clipboard/clipboard-tests.ts
@@ -1,22 +1,22 @@
-import * as Clipboard from "clipboard";
+import * as ClipboardJS from "clipboard";
 
-const cb1 = new Clipboard(".btn");
-const cb2 = new Clipboard(document.getElementById("id"), {
+const cb1 = new ClipboardJS(".btn");
+const cb2 = new ClipboardJS(document.getElementById("id"), {
     action: elem => "copy"
 });
-const cb3 = new Clipboard(document.querySelectorAll("query"), {
+const cb3 = new ClipboardJS(document.querySelectorAll("query"), {
     text: elem => null
 });
-const cb4 = new Clipboard(".btn", {
+const cb4 = new ClipboardJS(".btn", {
     target: elem => null
 });
-const cb5 = new Clipboard(".btn", {
+const cb5 = new ClipboardJS(".btn", {
     action: elem => "copy",
     target: elem => null
 });
 
 cb1.destroy();
-Clipboard.isSupported();
+ClipboardJS.isSupported();
 
 cb2.on("success", e => {
     console.info("Action:", e.action);

--- a/types/clipboard/index.d.ts
+++ b/types/clipboard/index.d.ts
@@ -1,12 +1,12 @@
-// Type definitions for clipboard.js 1.5
+// Type definitions for clipboard.js 2.0
 // Project: https://github.com/zenorocha/clipboard.js
 // Definitions by: Andrei Kurosh <https://github.com/impworks>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Clipboard {
+declare class ClipboardJS {
     constructor(
         selector: string | Element | NodeListOf<Element>,
-        options?: Clipboard.Options
+        options?: ClipboardJS.Options
     );
 
     /**
@@ -14,7 +14,7 @@ declare class Clipboard {
      * @param type Event type ('success' or 'error').
      * @param handler Callback function.
      */
-    on(type: "success" | "error", handler: (e: Clipboard.Event) => void): this;
+    on(type: "success" | "error", handler: (e: ClipboardJS.Event) => void): this;
     on(type: string, handler: (...args: any[]) => void): this;
 
     /**
@@ -28,7 +28,7 @@ declare class Clipboard {
     static isSupported(): boolean;
 }
 
-declare namespace Clipboard {
+declare namespace ClipboardJS {
     interface Options {
         /**
          * Overwrites default command ('cut' or 'copy').
@@ -59,6 +59,6 @@ declare namespace Clipboard {
     }
 }
 
-export = Clipboard;
+export = ClipboardJS;
 
-export as namespace Clipboard;
+export as namespace ClipboardJS;


### PR DESCRIPTION
Changelog: https://github.com/zenorocha/clipboard.js/releases/tag/v2.0.0

As Chrome introduced a `window.Clipboard` object, the constructor/namespace has been renamed to `ClipboardJS` to avoid conflicting.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zenorocha/clipboard.js/releases/tag/v2.0.0
- [x] Increase the version number in the header if appropriate.
