### PR TITLE
@types/leaflet enhance return types of L.Polyline.getLatLngs() to support nested arrays of LatLng

### DIFF
--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -583,7 +583,7 @@ export interface PolylineOptions extends PathOptions {
 export class Polyline<T extends geojson.GeometryObject = geojson.LineString | geojson.MultiLineString, P = any> extends Path {
     constructor(latlngs: LatLngExpression[], options?: PolylineOptions);
     toGeoJSON(): geojson.Feature<T, P>;
-    getLatLngs(): LatLng[];
+    getLatLngs(): LatLng[] | LatLng[][] | LatLng[][][];
     setLatLngs(latlngs: LatLngExpression[]): this;
     isEmpty(): boolean;
     getCenter(): LatLng;

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/Leaflet/Leaflet
 // Definitions by: Alejandro Sánchez <https://github.com/alejo90>
 //                 Arne Schubert <https://github.com/atd-schubert>
+//                 Michael Auer <https://github.com/mcauer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 


### PR DESCRIPTION
This method is also inherited by L.Polygon and if it is a polygon with holes or a multipolygon you get the types LatLng[][] or LatLng[][][] as suggested by this fix.
@alejo90 , @atd-schubert 

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://leafletjs.com/reference-1.2.0.html#polyline-getlatlngs
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

