### PR TITLE
Umzug: Improve typing of storage option needed when providing custom storage

### DIFF
--- a/types/umzug/index.d.ts
+++ b/types/umzug/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/sequelize/umzug
 // Definitions by: Ivan Drinchev <https://github.com/drinchev>
 //                 Margus Lamp <https://github.com/mlamp>
+//                 Troy McKinnon <https://github.com/trodi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -39,10 +40,32 @@ declare namespace umzug {
          * for examples.
          */
         customResolver?(path: string): { up: () => Promise<any>, down?: () => Promise<any> };
-        
+
     }
 
-    interface JSONStorageOptions {
+    /**
+     * In order to keep track of already executed tasks, umzug logs successfully executed migrations.
+     * This is done in order to allow rollbacks of tasks. This is the interface these `Storages` must
+     * follow.
+     */
+    interface Storage {
+        /**
+         * Logs migration to be considered as executed.
+         *
+         * @param migrationName - Name of the migration to be logged.
+         */
+        logMigration(migrationName: string): Promise<void>;
+        /**
+         * Unlogs migration to be considered as pending.
+         *
+         * @param migrationName - Name of the migration to be unlogged.
+         */
+        unlogMigration(migrationName: string): Promise<void>;
+        /** Gets list of executed migrations. */
+        executed(): Promise<String[]>;
+    }
+
+    interface JSONStorageOptions extends Storage {
 
         /**
          * The path to the json storage.
@@ -52,7 +75,7 @@ declare namespace umzug {
 
     }
 
-    interface SequelizeStorageOptions {
+    interface SequelizeStorageOptions extends Storage {
 
         /**
          * The configured instance of Sequelize.
@@ -99,12 +122,10 @@ declare namespace umzug {
     }
 
     interface UmzugOptions {
-
         /**
          * The storage.
-         * Possible values: 'json', 'sequelize', an object
          */
-        storage?: string;
+        storage?: "json" | "sequelize" | Storage;
 
         /**
          * The options for the storage.


### PR DESCRIPTION
I've updated type type for UmzugOptions.storage as it can take specific strings (names of shipped storages) or a custom storage, which I provided the typing.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Documentation](https://github.com/sequelize/umzug#persistence), [Source code of the Storage class](https://github.com/sequelize/umzug/blob/master/src/storages/Storage.js)
- [x] Increase the version number in the header if appropriate. **Not appropriate**
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
