### PR TITLE
redux-form: Add missing label to WrappedFieldProps

### DIFF
--- a/types/redux-form/lib/Field.d.ts
+++ b/types/redux-form/lib/Field.d.ts
@@ -72,6 +72,7 @@ export class Field<P = GenericFieldHTMLAttributes | BaseFieldProps> extends Comp
 export interface WrappedFieldProps {
     input: WrappedFieldInputProps;
     meta: WrappedFieldMetaProps;
+    label?: string;
 }
 
 export interface WrappedFieldInputProps extends CommonFieldInputProps {

--- a/types/redux-form/redux-form-tests.tsx
+++ b/types/redux-form/redux-form-tests.tsx
@@ -109,6 +109,7 @@ interface MyFieldCustomProps {
 type MyFieldProps = MyFieldCustomProps & WrappedFieldProps;
 const MyField: React.StatelessComponent<MyFieldProps> = ({
     children,
+    label,
     input,
     meta,
     foo


### PR DESCRIPTION
All of the redux-form examples show `label` being passed to the `component` of a `Field`, and `label` is on `BaseFieldProps` for what's passed to the `Field`. However, `label` is missing from `WrappedFieldProps`, which is what's passed to the thing referenced by `component`.

I can't seem to find it in the reference documentation, but my testing shows that it's there, and the following examples use it:
* https://redux-form.com/7.2.3/examples/syncvalidation/
* https://redux-form.com/7.2.3/examples/fieldlevelvalidation/
* https://redux-form.com/7.2.3/examples/submitvalidation/
* https://redux-form.com/7.2.3/examples/asyncvalidation/
* https://redux-form.com/7.2.3/examples/asyncchangevalidation/
* https://redux-form.com/7.2.3/examples/fieldarrays/
* https://redux-form.com/7.2.3/examples/remotesubmit/
* https://redux-form.com/7.2.3/examples/wizard/
* https://redux-form.com/7.2.3/examples/material-ui/
