### PR TITLE
Add types for creating async functions in Jest 22.2 for @types/jest

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Jest 22.1
+// Type definitions for Jest 22.2
 // Project: http://facebook.github.io/jest/
 // Definitions by: Asana <https://asana.com>
 //                 Ivo Stratev <https://github.com/NoHomey>
@@ -527,16 +527,20 @@ declare namespace jest {
     } & T;
 
     interface MockInstance<T> {
+        getMockName(): string;
         mock: MockContext<T>;
         mockClear(): void;
         mockReset(): void;
         mockImplementation(fn: (...args: any[]) => any): Mock<T>;
         mockImplementationOnce(fn: (...args: any[]) => any): Mock<T>;
+        mockName(name: string): Mock<T>;
         mockReturnThis(): Mock<T>;
         mockReturnValue(value: any): Mock<T>;
         mockReturnValueOnce(value: any): Mock<T>;
-        mockName(name: string): Mock<T>;
-        getMockName(): string;
+        mockResolvedValue(value: any): Mock<T>;
+        mockResolvedValueOnce(value: any): Mock<T>;
+        mockRejectedValue(value: any): Mock<T>;
+        mockRejectedValueOnce(value: any): Mock<T>;
     }
 
     interface MockContext<T> {

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -309,7 +309,7 @@ describe('missing tests', () => {
        expect(spy).lastCalledWith('jest');
        expect(spy).toBeCalledWith('jest');
        expect(jest.isMockFunction(spy)).toBeTruthy();
-   });
+    });
 
     it('tests all missing Mocks functionality', () => {
        type FruitsGetter = () => string[];
@@ -328,6 +328,35 @@ describe('missing tests', () => {
        expect(thisMock()).toBe(this);
    });
 
+    it('async test with mockResolvedValue and mockResolvedValueOnce', async () => {
+      const asyncMock = jest
+        .fn()
+        .mockResolvedValue('default')
+        .mockResolvedValueOnce('first call')
+        .mockResolvedValueOnce('second call');
+
+      await asyncMock(); // first call
+      await asyncMock(); // second call
+      await asyncMock(); // default
+      await asyncMock(); // default
+    });
+
+    it('async test with mockRejectedValue', async () => {
+      const asyncMock = jest.fn().mockRejectedValue(new Error('Async error'));
+
+      await asyncMock(); // throws "Async error"
+    });
+
+    it('async test with mockResolvedValueOnce and mockRejectedValueOnce', async () => {
+      const asyncMock = jest
+        .fn()
+        .mockResolvedValueOnce('first call')
+        .mockRejectedValueOnce(new Error('Async error'));
+
+      await asyncMock(); // first call
+      await asyncMock(); // throws "Async error"
+    });
+
     it('tests mock name functionality', () => {
         const mock: jest.Mock = jest.fn();
         mock.mockName('Carrot');
@@ -339,27 +368,27 @@ describe('missing tests', () => {
        const render: () => string = require('./render');
        expect(render()).toMatch(/Link/);
        jest.enableAutomock();
-   });
+    });
 
     it('runs only pending timers', () => {
         jest.useRealTimers();
         setTimeout(() => expect(1).not.toEqual(0), 3000);
         jest.runOnlyPendingTimers().runTimersToTime(300);
-   });
+    });
 
     it('runs all timers', () => {
         jest.clearAllTimers();
         jest.useFakeTimers();
         setTimeout(() => expect(0).not.toEqual(1), 3000);
         jest.runAllTimers();
-   });
+    });
 
     it('cleares cache', () => {
        const sum1 = require('../sum');
        jest.resetModules();
        const sum2 = require('../sum');
        expect(sum1).not.toBe(sum2);
-   });
+    });
 });
 
 describe('toMatchSnapshot', () => {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/jest/docs/en/mock-function-api.html#mockfnmockresolvedvaluevalue
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
