### PR TITLE
[Ramda] - Remove generic from groupBy curried function

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -679,7 +679,7 @@ declare namespace R {
          * on each element, and grouping the results according to values returned.
          */
         groupBy<T>(fn: (a: T) => string, list: ReadonlyArray<T>): { [index: string]: T[] };
-        groupBy<T>(fn: (a: T) => string): <T>(list: ReadonlyArray<T>) => { [index: string]: T[] };
+        groupBy<T>(fn: (a: T) => string): (list: ReadonlyArray<T>) => { [index: string]: T[] };
 
         /**
          * Takes a list and returns a list of lists where each sublist's elements are all "equal" according to the provided equality function

--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -16,7 +16,7 @@
 //                 Nikita Moshensky <https://github.com/moshensky>
 //                 Ethan Resnick <https://github.com/ethanresnick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.6
 
 declare let R: R.Static;
 

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -665,6 +665,36 @@ interface Obj {
 };
 
 () => {
+    interface MyObject {
+        id: string;
+        quantity: number;
+    }
+
+    const reduceWithCombinedQuantities = (items: MyObject[]) =>
+        items.reduce<MyObject>(
+            (acc, item) => ({...item, quantity: acc.quantity + item.quantity}),
+            {id: '', quantity: 0},
+        );
+
+    const combineMyObjects = R.pipe(
+        R.groupBy<MyObject>(s => s.id),
+        R.values,
+        R.map(reduceWithCombinedQuantities),
+    );
+
+    const combined = combineMyObjects([
+        {id: 'foo', quantity: 4},
+        {id: 'bar', quantity: 3},
+        {id: 'foo', quantity: 2},
+    ]);
+
+    return {
+        id: combined[0].id,
+        quantity: combined[0].quantity
+    };
+};
+
+() => {
     R.groupWith(R.equals)([0, 1, 1, 2, 3, 5, 8, 13, 21]);
 
     R.groupWith(R.equals, [0, 1, 1, 2, 3, 5, 8, 13, 21]);


### PR DESCRIPTION
Fixes an issue when using `groupBy` in TypeScript 2.6+

Also updated TypeScript to 2.6 in header -- was getting an "`Unknown compiler option 'strictFunctionTypes'`" error with 2.4.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] ~Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>~
  *Not necessary* -- this is purely an issue with compiling in TypeScript 2.6+, not with missing/inaccurate types.
- [ ] ~Increase the version number in the header if appropriate.~
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~