### PR TITLE
[atom] File.read can return Promise<null>

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -953,7 +953,8 @@ function testFile() {
 
     // Reading and Writing
     async function readFile() {
-        str = await file.read();
+        const res = await file.read();
+        if (res !== null) str = res;
     }
 
     const stream = file.createReadStream();

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -3547,7 +3547,7 @@ export class File {
 
     // Reading and Writing
     /** Reads the contents of the file. */
-    read(flushCache?: boolean): Promise<string>;
+    read(flushCache?: boolean): Promise<string | null>;
 
     /** Returns a stream to read the content of the file. */
     createReadStream(): ReadStream;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/atom/node-pathwatcher/blob/ea686aeffc33d99445a6480d3eafd477b8738ef8/src/file.coffee#L270
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Ran into this nasty surprise in one of my packages. Apparently `File.read()` will return `null` for nonexistent files.