### PR TITLE
[pify] include and exclude options should allow multiple entries (for TypeScript 2.7+)

### DIFF
--- a/types/pify/index.d.ts
+++ b/types/pify/index.d.ts
@@ -9,8 +9,8 @@ interface PromiseModule {
 
 interface PifyOptions {
     multiArgs?: boolean,
-    include?: [string | RegExp],
-    exclude?: [string | RegExp],
+    include?: Array<string | RegExp>,
+    exclude?: Array<string | RegExp>,
     excludeMain?: boolean,
     errorFirst?: boolean,
     promiseModule?: PromiseModule

--- a/types/pify/pify-tests.ts
+++ b/types/pify/pify-tests.ts
@@ -31,3 +31,20 @@ pify(fs.readFile, { promiseModule: Promise})('bar.txt').then((result: string) =>
 
 
 pify(fs.exists, { errorFirst: false })('foo.txt').then((result: boolean) => assert(result.toString(), true.toString()));
+
+// include/exclude with multiple entries
+const module = {
+    f1: (callback: Function) => callback(),
+    f2: (callback: Function) => callback(),
+    f3: (callback: Function) => callback(),
+};
+
+const include = pify(module, { include: ['f1', 'f2'] });
+if (include.f1 === module.f1) throw new Error();
+if (include.f2 === module.f2) throw new Error();
+if (include.f3 !== module.f3) throw new Error();
+
+const exclude = pify(module, { exclude: ['f1', 'f2'] });
+if (include.f1 !== module.f1) throw new Error();
+if (include.f2 !== module.f2) throw new Error();
+if (include.f3 === module.f3) throw new Error();


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/pify/blob/e64328eb378e2ecd6bf8c0eb40aa3277680aaff4/index.js#L62
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Description:

`include` and `exclude` were typed as tuples with length = 1

In TypeScript 2.7+ [tuples are now fixed-length](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#fixed-length-tuples)

Usage:
```ts
pify({ f1, f2, f3 }, { include: ['f1', 'f2'] });
```

> note: for some reason when I run `npm run test` or `npm run lint pify`, only syntax/dtslint checking is run, I was not able to see exceptions by `throw new Error()`. Should I remove changes in tests?
