### PR TITLE
puppeteer: add fromCache and fromServiceWorker to Response interface

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for puppeteer 1.0
+// Type definitions for puppeteer 1.1
 // Project: https://github.com/GoogleChrome/puppeteer#readme
 // Definitions by: Marvin Hagemeister <https://github.com/marvinhagemeister>
 //                 Christopher Deutsch <https://github.com/cdeutsch>
@@ -673,6 +673,10 @@ export interface RespondOptions {
 export interface Response {
   /** Promise which resolves to a buffer with response body. */
   buffer(): Promise<Buffer>;
+  /** True if the response was served from either the browser's disk cache or memory cache. */
+  fromCache(): boolean;
+  /** True if the response was served by a service worker. */
+  fromServiceWorker(): boolean;
   /** An object with HTTP headers associated with the response. All header names are lower-case. */
   headers(): Headers;
   /**


### PR DESCRIPTION
Add two functions in Response interface:
- Response.fromCache: https://github.com/GoogleChrome/puppeteer/blob/v1.1.0/docs/api.md#responsefromcache
- Response.fromServiceWorker: https://github.com/GoogleChrome/puppeteer/blob/v1.1.0/docs/api.md#responsefromserviceworker

Bump version number.