### PR TITLE
Atom: Add id to MarkerLayer

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -719,6 +719,9 @@ function testDisplayMarker() {
 
 // DisplayMarkerLayer =========================================================
 function testDisplayMarkerLayer() {
+    // Properties
+    str = displayMarkerLayer.id;
+
     // Lifecycle
     displayMarkerLayer.destroy();
     displayMarkerLayer.clear();
@@ -1274,6 +1277,9 @@ function testMarker() {
 
 // MarkerLayer ================================================================
 function testMarkerLayer() {
+    // Properties
+    str = markerLayer.id;
+
     // Lifecycle
     markerLayer = markerLayer.copy();
     bool = markerLayer.destroy();

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -654,6 +654,9 @@ export interface DisplayMarker {
  *  This API is experimental and subject to change on any release.
  */
 export interface DisplayMarkerLayer {
+    /** The identifier for the underlying MarkerLayer. */
+    id: string;
+
     // Lifecycle
     /** Destroy this layer. */
     destroy(): void;

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -949,6 +949,9 @@ export interface Marker {
 
 /** Experimental: A container for a related set of markers. */
 export interface MarkerLayer {
+    /** The identifier for this MarkerLayer. */
+    id: string;
+
     // Lifecycle
     /** Create a copy of this layer with markers in the same state and locations. */
     copy(): MarkerLayer;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://atom.io/docs/api/v1.24.0/TextEditor#instance-getMarkerLayer

`MarkerLayer`s can be addressed by `id` but the typings do not currently include this id.