### PR TITLE
add generics for Options for react-virtualized-select

### DIFF
--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.3
 
 import * as React from "react";
-import { ReactAsyncSelectProps, OptionValues } from "react-select";
+import { ReactSelectProps, LoadOptionsHandler, OptionValues } from "react-select";
 import { ListProps } from "react-virtualized";
 
 export interface VirtualizedOptionRenderOptions<T> {
@@ -26,11 +26,12 @@ export interface VirtualizedOptionRenderOptions<T> {
  * Dummy interface to allow `VirtualizedSelectProps` to have an `optionRenderer` type
  * incompatible with the one in `ReactSelectProps`.
  */
-interface VirtualizedSelectPropsBase<TValue = OptionValues> extends ReactAsyncSelectProps<TValue> {
+interface VirtualizedSelectPropsBase<TValue = OptionValues> extends ReactSelectProps<TValue> {
     optionRenderer?: any;
 }
 export interface VirtualizedSelectProps<TValue = OptionValues> extends VirtualizedSelectPropsBase<TValue> {
     async?: boolean;
+    loadOptions?: LoadOptionsHandler<TValue>;
     maxHeight?: number;
     optionHeight?: number;
     optionRenderer?(options: VirtualizedOptionRenderOptions<any>): JSX.Element;

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.3
 
 import * as React from "react";
-import { ReactSelectProps, LoadOptionsHandler, OptionValues } from "react-select";
+import { ReactSelectProps, ReactAsyncSelectProps, ReactCreatableSelectProps, LoadOptionsHandler, OptionValues } from "react-select";
 import { ListProps } from "react-virtualized";
 
 export interface VirtualizedOptionRenderOptions<T> {
@@ -22,21 +22,20 @@ export interface VirtualizedOptionRenderOptions<T> {
     valueArray: T[];
 }
 
-/**
- * Dummy interface to allow `VirtualizedSelectProps` to have an `optionRenderer` type
- * incompatible with the one in `ReactSelectProps`.
- */
-interface VirtualizedSelectPropsBase<TValue = OptionValues> extends ReactSelectProps<TValue> {
-    optionRenderer?: any;
-}
-export interface VirtualizedSelectProps<TValue = OptionValues> extends VirtualizedSelectPropsBase<TValue> {
-    async?: boolean;
-    loadOptions?: LoadOptionsHandler<TValue>;
+export interface AdditionalVirtualizedSelectProps<TValue> {
     maxHeight?: number;
     optionHeight?: number;
-    optionRenderer?(options: VirtualizedOptionRenderOptions<any>): JSX.Element;
+    optionRenderer?(options: VirtualizedOptionRenderOptions<TValue>): JSX.Element;
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 
-declare class VirtualizedSelect<TValue = OptionValues> extends React.PureComponent<VirtualizedSelectProps<TValue>> {}
+export declare class VirtualizedSelectCreatable<TValue = OptionValues> extends React.Component<ReactCreatableSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue>> {}
+
+export declare class VirtualizedSelectAsync<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue> & { async: true }> {}
+
+export declare class VirtualizedSelectAsyncCreatable<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue>
+& ReactCreatableSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue> & { async: true }> {}
+
+declare class VirtualizedSelect<TValue = OptionValues> extends React.PureComponent<ReactSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue>> {}
+
 export default VirtualizedSelect;

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.3
 
 import * as React from "react";
-import { ReactSelectProps } from "react-select";
+import { ReactAsyncSelectProps, OptionValues } from "react-select";
 import { ListProps } from "react-virtualized";
 
 export interface VirtualizedOptionRenderOptions<T> {
@@ -26,10 +26,10 @@ export interface VirtualizedOptionRenderOptions<T> {
  * Dummy interface to allow `VirtualizedSelectProps` to have an `optionRenderer` type
  * incompatible with the one in `ReactSelectProps`.
  */
-interface VirtualizedSelectPropsBase extends ReactSelectProps {
+interface VirtualizedSelectPropsBase<TValue = OptionValues> extends ReactAsyncSelectProps<TValue> {
     optionRenderer?: any;
 }
-export interface VirtualizedSelectProps extends VirtualizedSelectPropsBase {
+export interface VirtualizedSelectProps<TValue = OptionValues> extends VirtualizedSelectPropsBase<TValue> {
     async?: boolean;
     maxHeight?: number;
     optionHeight?: number;
@@ -37,5 +37,5 @@ export interface VirtualizedSelectProps extends VirtualizedSelectPropsBase {
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 
-declare class VirtualizedSelect extends React.PureComponent<VirtualizedSelectProps> {}
+declare class VirtualizedSelect<TValue = OptionValues> extends React.PureComponent<VirtualizedSelectProps<TValue>> {}
 export default VirtualizedSelect;

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -5,7 +5,7 @@
 // TypeScript Version: 2.3
 
 import * as React from "react";
-import { ReactSelectProps, ReactAsyncSelectProps, ReactCreatableSelectProps, LoadOptionsHandler, OptionValues } from "react-select";
+import { ReactSelectProps, ReactAsyncSelectProps, LoadOptionsHandler, OptionValues } from "react-select";
 import { ListProps } from "react-virtualized";
 
 export interface VirtualizedOptionRenderOptions<T> {
@@ -29,13 +29,8 @@ export interface AdditionalVirtualizedSelectProps<TValue> {
     selectComponent?: React.ComponentClass<any> | React.StatelessComponent<any>;
 }
 
-export declare class VirtualizedSelectCreatable<TValue = OptionValues> extends React.Component<ReactCreatableSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue>> {}
+type VirtualizedSelectProps<TValue = OptionValues> = (ReactAsyncSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue> & { async: true }) |
+    ReactSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue>;
 
-export declare class VirtualizedSelectAsync<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue> & { async: true }> {}
-
-export declare class VirtualizedSelectAsyncCreatable<TValue = OptionValues> extends React.Component<ReactAsyncSelectProps<TValue>
-& ReactCreatableSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue> & { async: true }> {}
-
-declare class VirtualizedSelect<TValue = OptionValues> extends React.PureComponent<ReactSelectProps<TValue> & AdditionalVirtualizedSelectProps<TValue>> {}
-
+declare class VirtualizedSelect<TValue = OptionValues> extends React.PureComponent<VirtualizedSelectProps<TValue>> {}
 export default VirtualizedSelect;

--- a/types/react-virtualized-select/react-virtualized-select-tests.tsx
+++ b/types/react-virtualized-select/react-virtualized-select-tests.tsx
@@ -1,12 +1,29 @@
 import * as React from "react";
 import Select from "react-select";
-import VirtualizedSelect from "react-virtualized-select";
+import VirtualizedSelect, { VirtualizedSelectAsync } from "react-virtualized-select";
 
-<VirtualizedSelect
-  async={true}
-  maxHeight={0}
-  optionHeight={0}
-  optionRenderer={() => <div/>}
-  selectComponent={Select}
-  options={[]}
-/>;
+/*Example TValue.*/
+interface Example {
+	name: string;
+}
+
+/*Example generic class.*/
+class ExampleSelectAsync extends VirtualizedSelectAsync<Example> {
+}
+
+<div>
+	<VirtualizedSelect
+	  maxHeight={0}
+	  optionHeight={0}
+	  optionRenderer={() => <div/>}
+	  selectComponent={Select}
+	  options={[]}
+	/>
+	<ExampleSelectAsync async={true}
+	  maxHeight={0}
+	  optionHeight={0}
+	  optionRenderer={() => <div/>}
+	  selectComponent={Select}
+	  loadOptions={(input: string) => Promise.resolve([{name: 'Hi'}])}
+	/>
+</div>;

--- a/types/react-virtualized-select/react-virtualized-select-tests.tsx
+++ b/types/react-virtualized-select/react-virtualized-select-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Select from "react-select";
-import VirtualizedSelect, { VirtualizedSelectAsync } from "react-virtualized-select";
+import VirtualizedSelect from "react-virtualized-select";
 
 /*Example TValue.*/
 interface Example {
@@ -8,7 +8,7 @@ interface Example {
 }
 
 /*Example generic class.*/
-class ExampleSelectAsync extends VirtualizedSelectAsync<Example> {
+class ExampleSelectAsync extends VirtualizedSelect<Example> {
 }
 
 <div>

--- a/types/react-virtualized-select/tsconfig.json
+++ b/types/react-virtualized-select/tsconfig.json
@@ -8,6 +8,7 @@
         "jsx": "react",
         "noImplicitAny": true,
         "noImplicitThis": true,
+		"strictFunctionTypes": true,
         "strictNullChecks": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
unlike react-select, react-virtualized-select does not support generics for Options and is tied to string | number | boolean. As a consequence, strong typing is not supported for Options of other types.
The pull request modifies the new classes so they are also using generics so the user can define what kind of type the Options really are, just like in pure react-select. In addition, the base class for the props is changed from ReactSelectProps to ReactAsyncSelectProps so async-specific properties like loadOptions are available.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
