### PR TITLE
[Jest]: Adding type support for matchers on primitive types.

### DIFF
--- a/types/jest-in-case/jest-in-case-tests.ts
+++ b/types/jest-in-case/jest-in-case-tests.ts
@@ -41,10 +41,10 @@ test('array', () => {
     expect(global.test).toHaveBeenCalledTimes(3);
     expect(tester).toHaveBeenCalledTimes(3);
 
-    expect(global.describe.mock.calls[0][0]).toBe(title);
-    expect(global.test.mock.calls[0][0]).toBe(testCases[0].name);
-    expect(global.test.mock.calls[1][0]).toBe(testCases[1].name);
-    expect(global.test.mock.calls[2][0]).toBe(testCases[2].name);
+    expect(<string> global.describe.mock.calls[0][0]).toBe(title);
+    expect(<string> global.test.mock.calls[0][0]).toBe(testCases[0].name);
+    expect(<string> global.test.mock.calls[1][0]).toBe(testCases[1].name);
+    expect(<string> global.test.mock.calls[2][0]).toBe(testCases[2].name);
     expect(global.test.mock.calls[0][1]).toHaveLength(0);
     expect(global.test.mock.calls[1][1]).toHaveLength(0);
     expect(global.test.mock.calls[2][1]).toHaveLength(0);
@@ -75,10 +75,10 @@ test('object', () => {
     expect(global.test).toHaveBeenCalledTimes(3);
     expect(tester).toHaveBeenCalledTimes(3);
 
-    expect(global.describe.mock.calls[0][0]).toBe(title);
-    expect(global.test.mock.calls[0][0]).toBe('1 - 1 = 0');
-    expect(global.test.mock.calls[1][0]).toBe('2 - 1 = 1');
-    expect(global.test.mock.calls[2][0]).toBe('3 - 1 = 2');
+    expect(<string> global.describe.mock.calls[0][0]).toBe(title);
+    expect(<string> global.test.mock.calls[0][0]).toBe('1 - 1 = 0');
+    expect(<string> global.test.mock.calls[1][0]).toBe('2 - 1 = 1');
+    expect(<string> global.test.mock.calls[2][0]).toBe('3 - 1 = 2');
     expect(global.test.mock.calls[0][1]).toHaveLength(0);
     expect(global.test.mock.calls[1][1]).toHaveLength(0);
     expect(global.test.mock.calls[2][1]).toHaveLength(0);
@@ -93,8 +93,8 @@ test('no names', () => {
         {},
     ]);
 
-    expect(global.test.mock.calls[0][0]).toBe('case: 1');
-    expect(global.test.mock.calls[1][0]).toBe('case: 2');
+    expect(<string> global.test.mock.calls[0][0]).toBe('case: 1');
+    expect(<string> global.test.mock.calls[1][0]).toBe('case: 2');
 });
 
 test('only', () => {
@@ -103,8 +103,8 @@ test('only', () => {
         { only: true },
     ]);
 
-    expect(global.test.mock.calls[0][0]).toBe('case: 1');
-    expect(global.test.only.mock.calls[0][0]).toBe('case: 2');
+    expect(<string> global.test.mock.calls[0][0]).toBe('case: 1');
+    expect(<string> global.test.only.mock.calls[0][0]).toBe('case: 2');
 });
 
 test('skip', () => {
@@ -113,6 +113,6 @@ test('skip', () => {
         { skip: true },
     ]);
 
-    expect(global.test.mock.calls[0][0]).toBe('case: 1');
-    expect(global.test.skip.mock.calls[0][0]).toBe('case: 2');
+    expect(<string> global.test.mock.calls[0][0]).toBe('case: 1');
+    expect(<string> global.test.skip.mock.calls[0][0]).toBe('case: 2');
 });

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -56,7 +56,8 @@ declare namespace jest {
      */
     function autoMockOn(): typeof jest;
     /**
-     * @deprecated use resetAllMocks instead
+     * Clears the mock.calls and mock.instances properties of all mocks.
+     * Equivalent to calling .mockClear() on every mocked function.
      */
     function clearAllMocks(): typeof jest;
     /**
@@ -301,7 +302,12 @@ declare namespace jest {
          *
          * @param actual The value to apply matchers against.
          */
+        (actual: boolean): MatchersBoolean<boolean>;
+        (actual: number): MatchersNumber<number>;
+        (actual: string): MatchersString<string>;
+        <R>(actual: R[]): MatchersList<R>;
         (actual: any): Matchers<void>;
+
         anything(): any;
         /**
          * Matches anything that was created with the given constructor.
@@ -348,7 +354,145 @@ declare namespace jest {
         stringContaining(str: string): any;
     }
 
-    interface Matchers<R> {
+    interface MatchersShared<R> {
+        /**
+         * Checks that a value is what you expect. It uses `===` to check strict equality.
+         * Don't use `toBe` with floating-point numbers.
+         */
+        toBe(expected: R): void;
+        /**
+         * Used when you want to check that two objects have the same value.
+         * This matcher recursively checks the equality of all fields, rather than checking for object identity.
+         */
+        toEqual(expected: R): void;
+        /**
+         * Ensure that a variable is not undefined.
+         */
+        toBeDefined(): R;
+        /**
+         * Used to check that a variable is NaN.
+         */
+        toBeNaN(): R;
+        /**
+         * This is the same as `.toBe(null)` but the error messages are a bit nicer.
+         * So use `.toBeNull()` when you want to check that something is null.
+         */
+        toBeNull(): void;
+        /**
+         * Used to check that a variable is undefined.
+         */
+        toBeUndefined(): void;
+    }
+
+    interface MatchersBoolean<R> extends MatchersShared<R> {
+        /**
+         * If you know how to test something, `.not` lets you test its opposite.
+         */
+        not: MatchersBoolean<R>;
+        /**
+         * Use resolves to unwrap the value of a fulfilled promise so any other
+         * matcher can be chained. If the promise is rejected the assertion fails.
+         */
+        resolves: MatchersBoolean<Promise<R>>;
+        /**
+         * Unwraps the reason of a rejected promise so any other matcher can be chained.
+         * If the promise is fulfilled the assertion fails.
+         */
+        rejects: MatchersBoolean<Promise<R>>;
+        /**
+         * When you don't care what a value is, you just want to
+         * ensure a value is false in a boolean context.
+         */
+        toBeFalsy(): void;
+        /**
+         * Use when you don't care what a value is, you just want to ensure a value
+         * is true in a boolean context. In JavaScript, there are six falsy values:
+         * `false`, `0`, `''`, `null`, `undefined`, and `NaN`. Everything else is truthy.
+         */
+        toBeTruthy(): void;
+    }
+
+    interface MatchersNumber<R> extends MatchersShared<R> {
+        /**
+         * If you know how to test something, `.not` lets you test its opposite.
+         */
+        not: MatchersNumber<R>;
+        /**
+         * Use resolves to unwrap the value of a fulfilled promise so any other
+         * matcher can be chained. If the promise is rejected the assertion fails.
+         */
+        resolves: MatchersNumber<Promise<R>>;
+        /**
+         * Unwraps the reason of a rejected promise so any other matcher can be chained.
+         * If the promise is fulfilled the assertion fails.
+         */
+        rejects: MatchersNumber<Promise<R>>;
+
+        /**
+         * Using exact equality with floating point numbers is a bad idea.
+         * Rounding means that intuitive things fail.
+         * The default for numDigits is 2.
+         */
+        toBeCloseTo(expected: R, numDigits?: R): void;
+
+        /**
+         * For comparing floating point numbers.
+         */
+        toBeGreaterThan(expected: R): void;
+        /**
+         * For comparing floating point numbers.
+         */
+        toBeGreaterThanOrEqual(expected: R): void;
+
+        /**
+         * For comparing floating point numbers.
+         */
+        toBeLessThan(expected: R): void;
+        /**
+         * For comparing floating point numbers.
+         */
+        toBeLessThanOrEqual(expected: R): void;
+    }
+
+    interface MatchersString<R> extends MatchersShared<R> {
+        /**
+         * If you know how to test something, `.not` lets you test its opposite.
+         */
+        not: MatchersString<R>;
+        /**
+         * Use resolves to unwrap the value of a fulfilled promise so any other
+         * matcher can be chained. If the promise is rejected the assertion fails.
+         */
+        resolves: MatchersString<Promise<R>>;
+        /**
+         * Unwraps the reason of a rejected promise so any other matcher can be chained.
+         * If the promise is fulfilled the assertion fails.
+         */
+        rejects: MatchersString<Promise<R>>;
+        /**
+         * Used to check that an object has a `.length` property
+         * and it is set to a certain numeric value.
+         */
+        toHaveLength(expected: number): void;
+        /**
+         * Check that a string matches a regular expression.
+         */
+        toMatch(expected: string | RegExp): void;
+    }
+
+    interface MatchersList<R> extends MatchersShared<R[]> {
+        /**
+         * Used when you want to check that an item is in a list.
+         * For testing the items in the list, this uses `===`, a strict equality check.
+         */
+        toContain(expected: R): void;
+        /**
+         * Used to check that an object has a `.length` property
+         * and it is set to a certain numeric value.
+         */
+        toHaveLength(expected: number): void;
+    }
+    interface Matchers<R> extends MatchersShared<R> {
         /**
          * If you know how to test something, `.not` lets you test its opposite.
          */
@@ -365,11 +509,6 @@ declare namespace jest {
         rejects: Matchers<Promise<R>>;
         lastCalledWith(...args: any[]): R;
         /**
-         * Checks that a value is what you expect. It uses `===` to check strict equality.
-         * Don't use `toBe` with floating-point numbers.
-         */
-        toBe(expected: any): R;
-        /**
          * Ensures that a mock function is called.
          */
         toBeCalled(): R;
@@ -383,10 +522,6 @@ declare namespace jest {
          * The default for numDigits is 2.
          */
         toBeCloseTo(expected: number, numDigits?: number): R;
-        /**
-         * Ensure that a variable is not undefined.
-         */
-        toBeDefined(): R;
         /**
          * When you don't care what a value is, you just want to
          * ensure a value is false in a boolean context.
@@ -414,24 +549,11 @@ declare namespace jest {
          */
         toBeLessThanOrEqual(expected: number): R;
         /**
-         * This is the same as `.toBe(null)` but the error messages are a bit nicer.
-         * So use `.toBeNull()` when you want to check that something is null.
-         */
-        toBeNull(): R;
-        /**
          * Use when you don't care what a value is, you just want to ensure a value
          * is true in a boolean context. In JavaScript, there are six falsy values:
          * `false`, `0`, `''`, `null`, `undefined`, and `NaN`. Everything else is truthy.
          */
         toBeTruthy(): R;
-        /**
-         * Used to check that a variable is undefined.
-         */
-        toBeUndefined(): R;
-        /**
-         * Used to check that a variable is NaN.
-         */
-        toBeNaN(): R;
         /**
          * Used when you want to check that an item is in a list.
          * For testing the items in the list, this uses `===`, a strict equality check.

--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -359,12 +359,12 @@ declare namespace jest {
          * Checks that a value is what you expect. It uses `===` to check strict equality.
          * Don't use `toBe` with floating-point numbers.
          */
-        toBe(expected: R): void;
+        toBe(expected: R): R;
         /**
          * Used when you want to check that two objects have the same value.
          * This matcher recursively checks the equality of all fields, rather than checking for object identity.
          */
-        toEqual(expected: R): void;
+        toEqual(expected: R): R;
         /**
          * Ensure that a variable is not undefined.
          */
@@ -377,11 +377,11 @@ declare namespace jest {
          * This is the same as `.toBe(null)` but the error messages are a bit nicer.
          * So use `.toBeNull()` when you want to check that something is null.
          */
-        toBeNull(): void;
+        toBeNull(): R;
         /**
          * Used to check that a variable is undefined.
          */
-        toBeUndefined(): void;
+        toBeUndefined(): R;
     }
 
     interface MatchersBoolean<R> extends MatchersShared<R> {
@@ -403,13 +403,13 @@ declare namespace jest {
          * When you don't care what a value is, you just want to
          * ensure a value is false in a boolean context.
          */
-        toBeFalsy(): void;
+        toBeFalsy(): R;
         /**
          * Use when you don't care what a value is, you just want to ensure a value
          * is true in a boolean context. In JavaScript, there are six falsy values:
          * `false`, `0`, `''`, `null`, `undefined`, and `NaN`. Everything else is truthy.
          */
-        toBeTruthy(): void;
+        toBeTruthy(): R;
     }
 
     interface MatchersNumber<R> extends MatchersShared<R> {
@@ -433,25 +433,25 @@ declare namespace jest {
          * Rounding means that intuitive things fail.
          * The default for numDigits is 2.
          */
-        toBeCloseTo(expected: R, numDigits?: R): void;
+        toBeCloseTo(expected: R, numDigits?: R): R;
 
         /**
          * For comparing floating point numbers.
          */
-        toBeGreaterThan(expected: R): void;
+        toBeGreaterThan(expected: R): R;
         /**
          * For comparing floating point numbers.
          */
-        toBeGreaterThanOrEqual(expected: R): void;
+        toBeGreaterThanOrEqual(expected: R): R;
 
         /**
          * For comparing floating point numbers.
          */
-        toBeLessThan(expected: R): void;
+        toBeLessThan(expected: R): R;
         /**
          * For comparing floating point numbers.
          */
-        toBeLessThanOrEqual(expected: R): void;
+        toBeLessThanOrEqual(expected: R): R;
     }
 
     interface MatchersString<R> extends MatchersShared<R> {
@@ -473,11 +473,11 @@ declare namespace jest {
          * Used to check that an object has a `.length` property
          * and it is set to a certain numeric value.
          */
-        toHaveLength(expected: number): void;
+        toHaveLength(expected: number): R;
         /**
          * Check that a string matches a regular expression.
          */
-        toMatch(expected: string | RegExp): void;
+        toMatch(expected: string | RegExp): R;
     }
 
     interface MatchersList<R> extends MatchersShared<R[]> {
@@ -485,12 +485,12 @@ declare namespace jest {
          * Used when you want to check that an item is in a list.
          * For testing the items in the list, this uses `===`, a strict equality check.
          */
-        toContain(expected: R): void;
+        toContain(expected: R): R;
         /**
          * Used to check that an object has a `.length` property
          * and it is set to a certain numeric value.
          */
-        toHaveLength(expected: number): void;
+        toHaveLength(expected: number): R;
     }
     interface Matchers<R> extends MatchersShared<R> {
         /**


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Increase the version number in the header **if** appropriate.

---

Pretty sure there is a better way of doing this, but this uses primitive Typescript types to select appropriate matchers. 

```typescript
test('testing boolean matchers', () => {
    expect(false).toBeFalsy()
    expect(true).not.toBeFalsy()
    expect(false).toBe(false)
    // expect(false).toBe("false") // error 

})

test('testing string matchers', () => {
    expect("false").toBe("false")
    expect("false").not.toBe("true")
    // expect("false").toBe(1) // error 
    // expect("false").toBe(1) // error 
})

test('testing number matchers', () => {
    expect(1).toBe(1)
    expect(1).not.toBe(2)
    // expect(1).toBe("lol") // error 
})

test('testing list matchers', () => {
    expect([1, 2]).toEqual([1,2])
    expect([1, 2, 3]).toContain(3)
    //   expect([1,2,3]).toContain("3") // error 
    expect(["1", "2"]).toEqual(["1", "2"])
    expect(["1", "2", "3"]).toContain("1")
    // expect(["1"]).toContain(3) // error 
})

```
