### PR TITLE
fix nw.js JSON type as any

### DIFF
--- a/types/nw.js/index.d.ts
+++ b/types/nw.js/index.d.ts
@@ -372,7 +372,7 @@ declare module NWJS_Helpers {
          * The paper size spec
          * example: 'mediaSize':{'name': 'CUSTOM', 'width_microns': 279400, 'height_microns': 215900, 'custom_display_name':'Letter', 'is_default': true}
          */
-        mediaSize: JSON;
+        mediaSize: any;
 
         /**
          * Whether to print CSS backgrounds
@@ -1072,9 +1072,9 @@ declare module NWJS_Helpers {
          * Enumerate the printers in the system.
          *
          * @param callback {function(dev_win?)} callback with the native window of the DevTools window.
-         * - (optional) printers {JSON[]} An array of JSON objects for the printer information.
+         * - (optional) printers {any[]} An array of json objects for the printer information.
          */
-        getPrinters( callback: ( printers?: JSON[] ) => void ): void;
+        getPrinters( callback: ( printers?: any[] ) => void ): void;
 
         /**
          * Query the status of devtools window.
@@ -1084,9 +1084,9 @@ declare module NWJS_Helpers {
         /**
          * Print the web contents in the window without the need for user’s interaction.
          *
-         * @param options {Object} Specify whether to close the window forcely and bypass close event.
+         * @param options {any | PrintOption} Specify whether to close the window forcely and bypass close event.
          */
-        print( options: JSON | PrintOption ): void;
+        print( options: any | PrintOption ): void;
 
         /**
          * Set window's maximum size.
@@ -1381,9 +1381,9 @@ declare namespace nw {
         dataPath: string;
 
         /**
-         * Get the JSON object of the manifest file.
+         * Get the json object of the manifest file.
          */
-        manifest: JSON;
+        manifest: any;
 
         /**
          * Clear the HTTP cache in memory and the one on disk. This method call is synchronized.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.typescriptlang.org/docs/handbook/basic-types.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Explanation:

The `JSON` type used by types/nw.js is considered as ES6 [JSON Global Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON).
This is not a valid type, replace all `JSON` by `any`.
