### PR TITLE
Changed 'import *' syntax for 'require()' in Listr

### DIFF
--- a/types/listr/listr-tests.ts
+++ b/types/listr/listr-tests.ts
@@ -1,4 +1,4 @@
-import * as Listr from "listr";
+import Listr = require("listr");
 import * as fs from "fs";
 
 const tasks = new Listr([


### PR DESCRIPTION
Changed the Listr tests to the correct module loading strategy.