### PR TITLE
Meow: allow immutable params, change Result.pkg to type `any`

### DIFF
--- a/types/meow/index.d.ts
+++ b/types/meow/index.d.ts
@@ -31,7 +31,7 @@ declare namespace meow {
     interface Result {
         input: string[];
         flags: { [name: string]: any };
-        pkg: object;
+        pkg: any;
         help: string;
         showHelp(code?: number): void;
         showVersion(): void;

--- a/types/meow/index.d.ts
+++ b/types/meow/index.d.ts
@@ -1,20 +1,27 @@
 // Type definitions for meow 4.x
 // Project: https://github.com/sindresorhus/meow
-// Definitions by: KnisterPeter <https://github.com/KnisterPeter>, Lindsey Smith <https://github.com/praxxis>
+// Definitions by: KnisterPeter <https://github.com/KnisterPeter>
+//                 Lindsey Smith <https://github.com/praxxis>
+//                 Jason Dreyzehner <https://github.com/bitjson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-import * as buildOptions from "minimist-options";
+import * as buildOptions from 'minimist-options';
 
-declare function meow(helpMessage: string | string[], options: meow.Options): meow.Result;
-declare function meow(options: string | string[] | meow.Options): meow.Result;
+declare function meow(
+    helpMessage: string | ReadonlyArray<string>,
+    options: meow.Options
+): meow.Result;
+declare function meow(
+    options: string | ReadonlyArray<string> | meow.Options
+): meow.Result;
 declare namespace meow {
     interface Options {
         description?: string | boolean;
         help?: string | boolean;
         version?: string | boolean;
         pkg?: any;
-        argv?: string[];
+        argv?: ReadonlyArray<string>;
         inferType?: boolean;
         flags?: buildOptions.Options;
         autoHelp?: boolean;

--- a/types/meow/meow-tests.ts
+++ b/types/meow/meow-tests.ts
@@ -14,6 +14,7 @@ const cli = meow('Help text', {
 });
 
 const input: string = cli.input[0];
+const version: string = cli.pkg.version;
 
 const cli2 = meow('Help text');
 

--- a/types/meow/meow-tests.ts
+++ b/types/meow/meow-tests.ts
@@ -1,28 +1,30 @@
 import meow = require('meow');
 
-const cli = meow("Help text",
-    {
-        flags: {
-            unicorn: {
-                type: 'boolean',
-                alias: 'u'
-            },
-            fooBar: {
-                type: 'string',
-                default: 'foo'
-            }
+const cli = meow('Help text', {
+    flags: {
+        unicorn: {
+            type: 'boolean',
+            alias: 'u'
+        },
+        fooBar: {
+            type: 'string',
+            default: 'foo'
         }
     }
-);
+});
 
-const cli2 = meow("Help text");
+const input: string = cli.input[0];
+
+const cli2 = meow('Help text');
+
+const args: ReadonlyArray<string> = ['foo', 'bar'];
 
 const cli3 = meow({
-    description: "version string",
-    help: "help string",
-    version: "1.0.0",
+    description: 'version string',
+    help: 'help string',
+    version: '1.0.0',
     pkg: {},
-    argv: ['foo', 'bar'],
+    argv: args,
     inferType: true,
     autoHelp: true,
     autoVersion: true,


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sindresorhus/meow#meowoptions-minimistoptions
- [x] Increase the version number in the header if appropriate.

---

Any consumers of this definition will currently have to cast `Result.pkg` to `any` before using it. Since it's not possible to provide any more information about the structure of `pkg` (it's the result of a `JSON.parse()`), it's best to [make this more usable by returning `any` rather than `object`](https://github.com/Microsoft/TypeScript/issues/15225#issuecomment-294565052).