### PR TITLE
[fetch-mock] Add Mock Configuration Option overwriteRoutes

### DIFF
--- a/types/fetch-mock/fetch-mock-tests.ts
+++ b/types/fetch-mock/fetch-mock-tests.ts
@@ -61,6 +61,7 @@ fetchMock.patch("http://test.com", 200);
 fetchMock.patchOnce("http://test.com", 200);
 
 fetchMock.get("http://test.com", 200, {method: "GET"});
+fetchMock.get("http://test.com", 200, {method: "GET", overwriteRoutes: true});
 fetchMock.post("http://test.com", 200, {method: "POST"});
 fetchMock.put("http://test.com", 200, {method: "PUT"});
 fetchMock.delete("http://test.com", 200, {method: "DELETE"});

--- a/types/fetch-mock/index.d.ts
+++ b/types/fetch-mock/index.d.ts
@@ -5,6 +5,7 @@
 //                 Risto Keravuori <https://github.com/merrywhether>
 //                 Chris Sinclair <https://github.com/chrissinclair>
 //                 Matt Tennison <https://github.com/matttennison>
+//                 Quentin Bouygues <https://github.com/quentinbouygues>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -120,6 +121,12 @@ declare namespace fetchMock {
          * as specified above
          */
         matcher?: MockMatcher;
+        /**
+         * This option allows for existing routes in a mock to be overwritten.
+         * It’s also possible to define multiple routes with ‘the same’ matcher.
+         * Default behaviour is to error
+         */
+        overwriteRoutes?: boolean;
         /**
          * as specified above
          */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.wheresrhys.co.uk/fetch-mock/v5-v6-upgrade
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This option is not appearing in the [API documentation](http://www.wheresrhys.co.uk/fetch-mock/api) yet, but is in the [update guide](http://www.wheresrhys.co.uk/fetch-mock/v5-v6-upgrade). I guess it was forgotten in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23889