### PR TITLE
Added definition for useViewBoxResizing to the dc.js types definition

### DIFF
--- a/types/dc/index.d.ts
+++ b/types/dc/index.d.ts
@@ -176,6 +176,7 @@ declare namespace dc {
         legend: IGetSet<Legend, T>;
         options(optionsObject: any): T;
         renderlet(fn: (chart: T) => any): T;
+        useViewBoxResizing: IGetSet<boolean, T>;
 
         on(event: "renderlet", fn: (chart: T, filter: any) => any): T;
         on(event: "pretransition", fn: (chart: T, filter: any) => any): T;


### PR DESCRIPTION
Include definition for useViewBoxResizing as part of the BaseMixin interface.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://dc-js.github.io/dc.js/docs/html/dc.baseMixin.html#useViewBoxResizing__anchor>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
