### PR TITLE
graphql-relay: make connection config relay spec compliant

### DIFF
--- a/types/graphql-relay/index.d.ts
+++ b/types/graphql-relay/index.d.ts
@@ -21,6 +21,9 @@ import {
     GraphQLOutputType,
     GraphQLFieldResolver,
     GraphQLTypeResolver,
+    GraphQLUnionType,
+    GraphQLEnumType,
+    GraphQLScalarType,
     Thunk
 } from "graphql";
 
@@ -58,9 +61,20 @@ export const backwardConnectionArgs: GraphQLFieldConfigArgumentMap & {
  */
 export const connectionArgs: GraphQLFieldConfigArgumentMap & ForwardConnectionArgs & BackwardConnectionArgs;
 
+export type ConnectionConfigNodeTypeNullable =
+    | GraphQLScalarType
+    | GraphQLObjectType
+    | GraphQLInterfaceType
+    | GraphQLUnionType
+    | GraphQLEnumType;
+
+export type ConnectionConfigNodeType =
+    | ConnectionConfigNodeTypeNullable
+    | GraphQLNonNull<ConnectionConfigNodeTypeNullable>;
+
 export interface ConnectionConfig {
     name?: string | null;
-    nodeType: GraphQLObjectType;
+    nodeType: ConnectionConfigNodeType;
     resolveNode?: GraphQLFieldResolver<any, any> | null;
     resolveCursor?: GraphQLFieldResolver<any, any> | null;
     edgeFields?: Thunk<GraphQLFieldConfigMap<any, any>> | null;


### PR DESCRIPTION
This PR makes the typing for the graphql-relay bindings more spec compliant. According to the [relay spec](https://facebook.github.io/relay/graphql/connections.htm#sec-Node), edge nodes may be "Scalar, Enum, Object, Interface, Union, or a Non‐Null wrapper around one of those types".

Tested with `graphql-relay` version 0.5.4.
