### PR TITLE
@types/chart.js doesn't work with plugin's optioions.

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -199,7 +199,7 @@ declare namespace Chart {
         circumference?: number;
         rotation?: number;
         // Plugins can require any options
-        plugins?: any;
+        plugins?: { [plugin: string]: any };
     }
 
     interface ChartFontOptions {

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -198,6 +198,8 @@ declare namespace Chart {
         cutoutPercentage?: number;
         circumference?: number;
         rotation?: number;
+        // Plugins can require any options
+        plugins?: any;
     }
 
     interface ChartFontOptions {


### PR DESCRIPTION
When I tried to use https://github.com/y-takey/chartjs-plugin-stacked100 plugin with chart.js, I found @types/chart.js doesn't have options.plugins property at ChartOptions type.
I added plugins property to ChartOptions, and then the plugin bellow worked well.

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chartjs/Chart.js/blob/b7025fedbec8fbb2d77c8c52a3c566270d5ca4d9/src/core/core.plugins.js#L132
