### PR TITLE
Select2 options selectionAdapter and resultsAdapter

### DIFF
--- a/types/select2/index.d.ts
+++ b/types/select2/index.d.ts
@@ -92,6 +92,8 @@ interface Select2Options {
     dropdownParent?: JQuery;
     debug?: boolean;
     dropdownAdapter?: any;
+    selectionAdapter?: any;
+    resultsAdapter?: any;
 }
 
 interface Select2JQueryEventObject extends JQueryEventObject {


### PR DESCRIPTION
In reference to the following issue: #24117

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/select2/select2/blob/c90adc102b5e9b2faea2b871b1c764416584ee07/src/js/select2/core.js#L37>>
<<https://github.com/select2/select2/blob/c90adc102b5e9b2faea2b871b1c764416584ee07/src/js/select2/core.js#L49>>
- [ ] Increase the version number in the header if appropriate.

Fixes following compilation errors:

```
Argument of type '{ language: string; closeOnSelect: false; multiple: true; selectionAdapter: any; dropdownAdapter:...' is not assignable to parameter of type 'Select2Options'.
  Object literal may only specify known properties, and 'selectionAdapter' does not exist in type 'Select2Options'.
```

```
Argument of type '{ language: string; closeOnSelect: false; multiple: true; selectionAdapter: any; dropdownAdapter:...' is not assignable to parameter of type 'Select2Options'.
  Object literal may only specify known properties, and 'resultsAdapter' does not exist in type 'Select2Options'.
```