### PR TITLE
[@storybook/addon-actions]: Fix faulty decorateAction definition.

### DIFF
--- a/types/storybook__addon-actions/index.d.ts
+++ b/types/storybook__addon-actions/index.d.ts
@@ -7,5 +7,5 @@
 export type HandlerFunction = (...args: any[]) => undefined;
 export type DecoratorFunction = (args: any[]) => any[];
 
-export function decorateAction(decorators: DecoratorFunction[]): HandlerFunction;
+export function decorateAction(decorators: DecoratorFunction[]): (name: string) => HandlerFunction;
 export function action(name: string): HandlerFunction;

--- a/types/storybook__addon-actions/storybook__addon-actions-tests.tsx
+++ b/types/storybook__addon-actions/storybook__addon-actions-tests.tsx
@@ -19,3 +19,21 @@ storiesOf('Button', module)
           Hello World!
         </button>
     ));
+
+interface CustomComponentProps {
+    id: string;
+    setValues(id: string, values: string[]): void;
+}
+class CustomComponent extends React.Component<CustomComponentProps> {
+    setSomeValues = () => {
+        this.props.setValues(this.props.id, ['one', 'two', 'three']);
+    }
+    render() {
+        return <button onClick={this.setSomeValues}>Set some values</button>;
+    }
+}
+
+storiesOf('CustomComponent', module)
+    .add('decorated custom action', () => (
+        <CustomComponent id="test" setValues={firstArgAction('set-values')} />
+    ));


### PR DESCRIPTION
The decorateAction function is supposed to return a function equivalent
to the action function, rather than the return value of running the
action function. The reason that the original tests were passing was
because it is valid typescript to set the onClick handler of a button to
undefined.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/storybooks/storybook/blob/0fe88b6b828dee79b0b4c4686ff0d216e19db301/addons/actions/src/preview.js#L24-L32
- [X] Increase the version number in the header if appropriate - N/A
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }` - N/A
