### PR TITLE
hapi: allow for synchronous Hapi plugin register fn

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -120,7 +120,7 @@ export interface PluginBase<T> {
      * * server - the server object with a plugin-specific server.realm.
      * * options - any options passed to the plugin during registration via server.register().
      */
-    register: (server: Server, options: T) => Promise<void>;
+    register: (server: Server, options: T) => void | Promise<void>;
 
     /** (optional) if true, allows the plugin to be registered multiple times with the same server. Defaults to false. */
     multiple?: boolean;

--- a/types/hapi/test/server/server-plugins.ts
+++ b/types/hapi/test/server/server-plugins.ts
@@ -13,6 +13,10 @@ interface Plugin3 {
 	three: 3;
 }
 
+interface Plugin4 {
+	four: 4;
+}
+
 declare module 'hapi' {
 	interface PluginProperties {
 		example: {
@@ -40,6 +44,11 @@ const plugin2: Plugin<Plugin2> = {
 const plugin3: Plugin<Plugin3> = {
 	name: 'plugin3',
 	register: async (server: Server, options: Plugin3) => {}
+};
+
+const plugin4: Plugin<Plugin4> = {
+	name: 'plugin4',
+	register: (server: Server, options: Plugin4) => {}
 };
 
 const server = new Server({
@@ -90,5 +99,9 @@ server.register([
 	{
 		plugin: plugin1,
 		options: {one: 1}
+	},
+	{
+		plugin: plugin4,
+		options: {four: 4}
 	}
 ]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [Hapi `server.register()`](https://hapijs.com/api#server.register())
  - [MDN `await` operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
- [ ] ~Increase the version number in the header if appropriate.~ Same version
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~ already exists

## Description

There are use-cases where an externally used plugin is only defining routes, which is a synchronous operation. Thus the return value might be `void` instead of `Promise<void>`.
`await` operator allows for non-promises as well, so there is no drawback in allowing synchronous plugin registrations.