### PR TITLE
[@types/react-table] added a possible return type to FilterFunction type def

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -19,7 +19,7 @@ export type ComponentPropsGetterC = (finalState: any, rowInfo?: undefined, colum
 export type ComponentPropsGetterRC = (finalState: any, rowInfo?: RowInfo, column?: Column, instance?: any) => object | undefined;
 
 export type DefaultFilterFunction = (filter: any, row: any, column: any) => boolean;
-export type FilterFunction = (filter: any, rows: any[], column: any) => boolean;
+export type FilterFunction = (filter: any, rows: any[], column: any) => boolean | any[];
 export type SubComponentFunction = (rowInfo: RowInfo) => React.ReactNode;
 export type PageChangeFunction = (page: number) => void;
 export type PageSizeChangeFunction = (newPageSize: number, newPage: number) => void;


### PR DESCRIPTION
The react-table FilterFunction is documented in the [readme](https://react-table.js.org/#/story/readme) as "A function returning a boolean" `filterMethod: (filter, row || rows, column) => {return true}`. However, when it's described in use with the filterAll prop set to true, the function actually returns an array. See line 42 [here](https://react-table.js.org/#/story/custom-filtering). 

I'm successfully using this implementation in a few tables with pagination, where I still want to filter all rows, not just visible ones. Unfortunately, I then get a TS error in my column definition: `Type '(filter: any, rows: any[]) => any[]' is not assignable to type 'FilterFunction'`. This PR fixes that.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) _I get compile errors that stem from the react package_
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://react-table.js.org/#/story/custom-filtering and https://react-table.js.org/#/story/readme
- [ ] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
