### PR TITLE
sequelize: Correct some typings definitions

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -3136,11 +3136,11 @@ declare namespace sequelize {
         $ilike: string | WherePGStatement;
         $notLike: string | WherePGStatement;
         $notILike: string | WherePGStatement;
-        $between: [number, number];
+        $between: [number, number] | [Date, Date];
         "..": [number, number];
         $notBetween: [number, number];
         "!..": [number, number];
-        $overlap: [number, number];
+        $overlap: [number, number] | [string, string];
         "&&": [number, number];
         $contains: any;
         "@>": any;
@@ -3155,7 +3155,7 @@ declare namespace sequelize {
      * typesafety, but there is no way to pass the tests if we just remove it.
      */
     type WhereOptions<T> = {
-        [P in keyof T]?: string | number | boolean | WhereLogic | WhereOptions<T[P]> | col | and | or | WhereGeometryOptions | Array<string | number> | null;
+        [P in keyof T]?: string | number | boolean | WhereLogic | WhereOptions<T[P]> | col | and | or | WhereGeometryOptions | WhereNested | Array<string | number> | null;
     };
 
     /**

--- a/types/sequelize/sequelize-tests.ts
+++ b/types/sequelize/sequelize-tests.ts
@@ -915,6 +915,8 @@ User.findAll( { where : { intVal : { '!..' : [8, 10] } } } );
 User.findAll( { where : { theDate : { between : ['2013-01-02', '2013-01-11'] } } } );
 User.findAll( { where : { theDate : { between : ['2013-01-02', '2013-01-11'] }, intVal : 10 } } );
 User.findAll( { where : { theDate : { between : ['2012-12-10', '2013-01-02'] } } } );
+User.findAll( { where : { theDate : { between : [1, 3] } } } );
+User.findAll( { where : { theDate : { between : [new Date(0), new Date(1000)] } } } );
 User.findAll( { where : { theDate : { nbetween : ['2013-01-04', '2013-01-20'] } } } );
 User.findAll( { order : [s.col( 'name' )] } );
 User.findAll( { order : [['theDate', 'DESC']] } );
@@ -948,6 +950,11 @@ User.findAll( { where: s.where(s.fn('lower', s.col('email')), s.fn('lower', 'TES
 User.findAll( { subQuery: false, include : [User], order : [[User, User, 'numYears', 'c']] } );
 User.findAll( { rejectOnEmpty: true });
 
+User.findAll( { where: { $and:[ { username: "user" }, { theDate: new Date() } ] } } );
+User.findAll( { where: { $or:[ { username: "user" }, { theDate: new Date() } ] } } );
+User.findAll( { where: { $and:[ { username: { $not: "user" } }, { theDate: new Date() } ] } } );
+User.findAll( { where: { $or:[ { username: { $not: "user" } }, { theDate: new Date() } ] } } );
+User.findAll( { where: { emails: { $overlap: ["me@mail.com", "you@mail.com"] } } } );
 
 User.findById( 'a string' );
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
For the nested where options `WhereNested`: this issue https://github.com/sequelize/sequelize/issues/3527 reflects how it's possible to have something like
```ts
User.findAll({ where: { $and: [conditions] } } ) 
 ```

For the `$overlap` and `$between` changes, they are not constrained by the documentation (https://www.postgresql.org/docs/9.1/static/functions-array.html) and I've been using them for a while with `Date` and `string` to generate the expected result. On Postgres documentation, for example, it only states an array and that's all

- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.