### PR TITLE
[openlayers] Fix the ban-type lint

### DIFF
--- a/types/openlayers/index.d.ts
+++ b/types/openlayers/index.d.ts
@@ -11,7 +11,7 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Definitions partially generated using tsd-jsdoc (https://github.com/englercj/tsd-jsdoc)
 
-declare type GlobalObject = Object;
+interface GlobalObject { [key: string]: any; }
 
 /**
  * @namespace ol
@@ -1490,6 +1490,9 @@ declare module ol {
             constructor();
         }
     }
+
+    /* From ol/typedefs.js */
+    type EventsListenerFunctionType = ((evt: ol.events.Event) => void) | ((evt: ol.events.Event) => boolean);
 
     /**
      * @namespace ol.extent
@@ -7957,7 +7960,7 @@ declare module ol {
          *     will be an array of keys.
          * @api stable
          */
-        on(type: (string | string[]), listener: Function, opt_this?: GlobalObject): (ol.EventsKey | ol.EventsKey[]);
+        on(type: (string | string[]), listener: ol.EventsListenerFunctionType, opt_this?: GlobalObject): (ol.EventsKey | ol.EventsKey[]);
 
         /**
          * Listen once for a certain type of event.
@@ -7969,7 +7972,7 @@ declare module ol {
          *     will be an array of keys.
          * @api stable
          */
-        once(type: (string | string[]), listener: Function, opt_this?: GlobalObject): (ol.EventsKey | ol.EventsKey[]);
+        once(type: (string | string[]), listener: ol.EventsListenerFunctionType, opt_this?: GlobalObject): (ol.EventsKey | ol.EventsKey[]);
 
         /**
          * Unlisten for a certain type of event.
@@ -7979,7 +7982,7 @@ declare module ol {
          * `listener`.
          * @api stable
          */
-        un(type: (string | string[]), listener: Function, opt_this?: GlobalObject): void;
+        un(type: (string | string[]), listener: ol.EventsListenerFunctionType, opt_this?: GlobalObject): void;
     }
 
     /**
@@ -11694,7 +11697,7 @@ declare module ol {
      *     target: (EventTarget|ol.events.EventTarget),
      *     type: string}}
      */
-    type EventsKey = Object;
+    type EventsKey = GlobalObject;
 
     /**
      * An array of numbers representing an extent: `[minx, miny, maxx, maxy]`.
@@ -11995,7 +11998,7 @@ declare module ol {
      * @typedef {{numberOfFeatures: number,
      *            bounds: ol.Extent}}
      */
-    type WFSFeatureCollectionMetadata = Object;
+    type WFSFeatureCollectionMetadata = GlobalObject;
 
     /**
      * Total deleted; total inserted; total updated; array of insert ids.
@@ -12004,7 +12007,7 @@ declare module ol {
      *            totalUpdated: number,
      *            insertIds: Array.<string>}}
      */
-    type WFSTransactionResponse = Object;
+    type WFSTransactionResponse = GlobalObject;
 
     /**
      * @constructor

--- a/types/openlayers/openlayers-tests.ts
+++ b/types/openlayers/openlayers-tests.ts
@@ -6,8 +6,9 @@ let stringValue: string;
 let stringArray: string[];
 let jsonValue: JSON;
 let domEventTarget: EventTarget;
-let fn: Function;
-let object: Object;
+let listener: ol.EventsListenerFunctionType;
+let object: { [key: string]: any };
+let fn: () => void;
 
 // Callback predefinitions for OpenLayers
 let preRenderFunction: ol.PreRenderFunction;
@@ -579,12 +580,12 @@ observable.dispatchEvent({ type: stringValue, a: numberValue, b: stringValue, c:
 observable.dispatchEvent(olEvent);
 observable.dispatchEvent(stringValue);
 numberValue = observable.getRevision();
-eventKeyMixed = observable.on(stringValue, fn);
-eventKeyMixed = observable.on([stringValue, stringValue], fn, {});
-eventKeyMixed = observable.once(stringValue, fn);
-eventKeyMixed = observable.once([stringValue, stringValue], fn, {});
-observable.un(stringValue, fn);
-observable.un([stringValue, stringValue], fn, {});
+eventKeyMixed = observable.on(stringValue, listener);
+eventKeyMixed = observable.on([stringValue, stringValue], listener, {});
+eventKeyMixed = observable.once(stringValue, listener);
+eventKeyMixed = observable.once([stringValue, stringValue], listener, {});
+observable.un(stringValue, listener);
+observable.un([stringValue, stringValue], listener, {});
 
 //
 // ol.proj

--- a/types/openlayers/tslint.json
+++ b/types/openlayers/tslint.json
@@ -1,8 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        // It appears somewhat difficult to remove the Function and Object types
-        "ban-types": false,
         // This currently fails for an option that does not appear to be in OL 4
         "no-any-union": false,
         // Not sure how to work around this, or if it's necessary to        


### PR DESCRIPTION
Fixes the ban-type lint by remove references to `Object` and `Function`. For `Object`, I updated the `GlobalObject` definition to follow the good practices (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes). The `Function` type was used only in the `Observable` class for the listener arg. After checking the openlayers source, I found the listener was an EventsListenerFunctionType (see https://github.com/openlayers/openlayers/blob/master/src/ol/types.js).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: see my comment
- [ ] ~~Increase the version number in the header if appropriate.~~
- [ ] ~~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~~
