### PR TITLE
Improve auth0-lock namespacing

### DIFF
--- a/types/auth0-lock/auth0-lock-tests.ts
+++ b/types/auth0-lock/auth0-lock-tests.ts
@@ -1,16 +1,16 @@
 import * as auth0 from 'auth0-js';
-import Auth0Lock from 'auth0-lock';
+import Auth0Lock, * as auth0Lock from 'auth0-lock';
 
 const CLIENT_ID = "YOUR_AUTH0_APP_CLIENTID";
 const DOMAIN = "YOUR_DOMAIN_AT.auth0.com";
 
-const lock: Auth0LockStatic = new Auth0Lock(CLIENT_ID, DOMAIN);
+const lock: Auth0Lock = new Auth0Lock(CLIENT_ID, DOMAIN);
 
 lock.show();
 lock.hide();
 lock.logout(() => {});
 
-lock.checkSession({}, function(error: auth0.Auth0Error, authResult: AuthResult): void {
+lock.checkSession({}, function(error: auth0.Auth0Error, authResult: auth0Lock.AuthResult): void {
   if (error || !authResult) {
     lock.show();
   } else {
@@ -23,7 +23,7 @@ lock.checkSession({}, function(error: auth0.Auth0Error, authResult: AuthResult):
 
 // Show supports UI arguments
 
-const showOptions : Auth0LockShowOptions = {
+const showOptions : auth0Lock.ShowOptions = {
   allowedConnections: [ "twitter", "facebook" ],
   allowSignUp: true,
   allowForgotPassword: false,
@@ -48,7 +48,7 @@ lock.show(showOptions);
 
 // "on" event-driven example
 
-lock.on("authenticated", function(authResult: AuthResult) {
+lock.on("authenticated", function(authResult: auth0Lock.AuthResult) {
   lock.getProfile(authResult.idToken, function(error: auth0.Auth0Error, profile: auth0.Auth0UserProfile) {
     if (error) {
       // Handle error
@@ -60,7 +60,7 @@ lock.on("authenticated", function(authResult: AuthResult) {
   });
 });
 
-lock.on("authenticated", function(authResult: AuthResult) {
+lock.on("authenticated", function(authResult: auth0Lock.AuthResult) {
   lock.getUserInfo(authResult.accessToken, function(error, profile) {
     if (error) {
       // Handle error
@@ -74,7 +74,7 @@ lock.on("authenticated", function(authResult: AuthResult) {
 
 // test theme
 
-const themeOptions : Auth0LockConstructorOptions = {
+const themeOptions : auth0Lock.ConstructorOptions = {
   theme: {
     authButtons: {
       fooProvider: {
@@ -97,7 +97,7 @@ new Auth0Lock(CLIENT_ID, DOMAIN, themeOptions);
 
 // test empty theme
 
-const themeOptionsEmpty : Auth0LockConstructorOptions = {
+const themeOptionsEmpty : auth0Lock.ConstructorOptions = {
   theme: { }
 };
 
@@ -105,7 +105,7 @@ new Auth0Lock(CLIENT_ID, DOMAIN, themeOptions);
 
 // test authentication
 
-const authOptions : Auth0LockConstructorOptions = {
+const authOptions : auth0Lock.ConstructorOptions = {
   auth: {
    params: { state: "foo" },
    redirect: true,
@@ -119,7 +119,7 @@ new Auth0Lock(CLIENT_ID, DOMAIN, authOptions);
 
 // test multi-variant example
 
-const multiVariantOptions : Auth0LockConstructorOptions = {
+const multiVariantOptions : auth0Lock.ConstructorOptions = {
   container: "myContainer",
   closable: false,
   languageDictionary: {
@@ -133,7 +133,7 @@ new Auth0Lock(CLIENT_ID, DOMAIN, multiVariantOptions);
 
 // test text-field additional sign up field
 
-const textFieldOptions : Auth0LockConstructorOptions = {
+const textFieldOptions : auth0Lock.ConstructorOptions = {
   additionalSignUpFields: [{
     name: "address",
     placeholder: "enter your address",
@@ -153,7 +153,7 @@ new Auth0Lock(CLIENT_ID, DOMAIN, textFieldOptions);
 
 // test select-field additional sign up field
 
-const selectFieldOptions : Auth0LockConstructorOptions = {
+const selectFieldOptions : auth0Lock.ConstructorOptions = {
   additionalSignUpFields: [{
     type: "select",
     name: "location",
@@ -173,7 +173,7 @@ new Auth0Lock(CLIENT_ID, DOMAIN, selectFieldOptions);
 
 // test select-field additional sign up field with callbacks for
 
-const selectFieldOptionsWithCallbacks : Auth0LockConstructorOptions = {
+const selectFieldOptionsWithCallbacks : auth0Lock.ConstructorOptions = {
   additionalSignUpFields: [{
     type: "select",
     name: "location",
@@ -206,7 +206,7 @@ new Auth0Lock(CLIENT_ID, DOMAIN, selectFieldOptionsWithCallbacks);
 
 // test checkbox-field additional sign up field
 
-const checkboxFieldOptions : Auth0LockConstructorOptions = {
+const checkboxFieldOptions : auth0Lock.ConstructorOptions = {
     additionalSignUpFields: [{
       type: "checkbox",
       name: "remember",
@@ -219,9 +219,9 @@ const checkboxFieldOptions : Auth0LockConstructorOptions = {
 
 // test Avatar options
 
-const avatarOptions : Auth0LockConstructorOptions = {
+const avatarOptions : auth0Lock.ConstructorOptions = {
   avatar: {
-    url: (email : string, cb : Auth0LockAvatarUrlCallback) => {
+    url: (email : string, cb : auth0Lock.AvatarUrlCallback) => {
       // obtain url for email, in case of error you call cb with the error in
       // the first arg instead of null
 
@@ -229,7 +229,7 @@ const avatarOptions : Auth0LockConstructorOptions = {
 
       cb(null, url);
     },
-    displayName: (email : string, cb : Auth0LockAvatarDisplayNameCallback) => {
+    displayName: (email : string, cb : auth0Lock.AvatarDisplayNameCallback) => {
       // obtain displayName for email, in case of error you call cb with the
       // error in the first arg instead of null
 
@@ -242,7 +242,7 @@ const avatarOptions : Auth0LockConstructorOptions = {
 
 new Auth0Lock(CLIENT_ID, DOMAIN, avatarOptions);
 
-const authResult : AuthResult = {
+const authResult : auth0Lock.AuthResult = {
     accessToken: 'fake_access_token',
     idToken: 'fake_id_token',
     idTokenPayload: {

--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -7,190 +7,186 @@
 
 /// <reference types="auth0-js" />
 
-interface Auth0LockAdditionalSignUpFieldOption {
-  value: string;
-  label: string;
-}
-
-type Auth0LockAdditionalSignUpFieldOptionsCallback =
-    (error: auth0.Auth0Error, options: Auth0LockAdditionalSignUpFieldOption[]) => void;
-
-type Auth0LockAdditionalSignUpFieldOptionsFunction =
-    (callback: Auth0LockAdditionalSignUpFieldOptionsCallback) => void;
-
-type Auth0LockAdditionalSignUpFieldPrefillCallback =
-    (error: auth0.Auth0Error, prefill: string) => void;
-
-type Auth0LockAdditionalSignUpFieldPrefillFunction =
-    (callback: Auth0LockAdditionalSignUpFieldPrefillCallback) => void;
-
-interface Auth0LockAdditionalTextSignUpField {
-    type?: "text";
-    icon?: string;
-    name: string;
-    options?: Auth0LockAdditionalSignUpFieldOption[] | Auth0LockAdditionalSignUpFieldOptionsFunction;
-    placeholder: string;
-    prefill?: string | Auth0LockAdditionalSignUpFieldPrefillFunction;
-    validator?: (input: string) => { valid: boolean; hint?: string };
-}
-
-interface Auth0LockAdditionalSelectSignUpField {
-    type?: "select";
-    icon?: string;
-    name: string;
-    options?: Auth0LockAdditionalSignUpFieldOption[] | Auth0LockAdditionalSignUpFieldOptionsFunction;
-    placeholder: string;
-    prefill?: string | Auth0LockAdditionalSignUpFieldPrefillFunction;
-    validator?: (input: string) => { valid: boolean; hint?: string };
-}
-
-interface Auth0LockAdditionalCheckboxSignUpField {
-    type?: "checkbox";
-    icon?: string;
-    name: string;
-    placeholder: string;
-    prefill: "true" | "false";
-    validator?: (input: string) => { valid: boolean, hint?: string };
-}
-
-type Auth0LockAdditionalSignUpField = Auth0LockAdditionalSelectSignUpField |Auth0LockAdditionalTextSignUpField |Auth0LockAdditionalCheckboxSignUpField;
-
-type Auth0LockAvatarUrlCallback = (error: auth0.Auth0Error, url: string) => void;
-type Auth0LockAvatarDisplayNameCallback = (error: auth0.Auth0Error, displayName: string) => void;
-
-interface Auth0LockAvatarOptions {
-    url: (email: string, callback: Auth0LockAvatarUrlCallback) => void;
-    displayName: (email: string, callback: Auth0LockAvatarDisplayNameCallback) => void;
-}
-
-interface Auth0LockThemeButton {
-    displayName: string;
-    primaryColor?: string;
-    foregroundColor?: string;
-    icon?: string;
-}
-interface Auth0LockThemeButtonOptions {
-    [provider: string]: Auth0LockThemeButton;
-}
-
-interface Auth0LockThemeOptions {
-    authButtons?: Auth0LockThemeButtonOptions;
-    labeledSubmitButton?: boolean;
-    logo?: string;
-    primaryColor?: string;
-}
-
-// https://auth0.com/docs/libraries/lock/v10/sending-authentication-parameters
-interface Auth0LockAuthParamsOptions {
-    access_token?: any;
-    connection_scopes?: any;
-    device?: any;
-    nonce?: any;
-    protocol?: any;
-    request_id?: any;
-    scope?: string;
-    state?: string;
-}
-
-interface Auth0LockAuthOptions {
-    params?: Auth0LockAuthParamsOptions;
-    redirect?: boolean;
-    redirectUrl?: string;
-    responseType?: string;
-    sso?: boolean;
-    audience?: string;
-}
-
-interface Auth0LockPopupOptions {
-    width: number;
-    height: number;
-    left: number;
-    top: number;
-}
-
-interface Auth0LockConstructorOptions {
-    additionalSignUpFields?: Auth0LockAdditionalSignUpField[];
-    allowedConnections?: string[];
-    allowForgotPassword?: boolean;
-    allowLogin?: boolean;
-    allowSignUp?: boolean;
-    assetsUrl?: string;
-    auth?: Auth0LockAuthOptions;
-    autoclose?: boolean;
-    autofocus?: boolean;
-    avatar?: Auth0LockAvatarOptions;
-    closable?: boolean;
-    container?: string;
-    defaultADUsernameFromEmailPrefix?: string;
-    defaultDatabaseConnection?: string;
-    defaultEnterpriseConnection?: string;
-    forgotPasswordLink?: string;
-    initialScreen?: "login" | "signUp" | "forgotPassword";
-    language?: string;
-    languageDictionary?: any;
-    loginAfterSignUp?: boolean;
-    mustAcceptTerms?: boolean;
-    popupOptions?: Auth0LockPopupOptions;
-    prefill?: { email?: string, username?: string};
-    rememberLastLogin?: boolean;
-    signupLink?: string;
-    socialButtonStyle?: "big" | "small";
-    theme?: Auth0LockThemeOptions;
-    usernameStyle?: string;
-    oidcConformant?: boolean;
-}
-
-interface Auth0LockFlashMessageOptions {
-    type: "success" | "error";
-    text: string;
-}
-
-interface Auth0LockShowOptions {
-    allowedConnections?: string[];
-    allowForgotPassword?: boolean;
-    allowLogin?: boolean;
-    allowSignUp?: boolean;
-    auth?: Auth0LockAuthOptions;
-    initialScreen?: "login" | "signUp" | "forgotPassword";
-    flashMessage?: Auth0LockFlashMessageOptions;
-    rememberLastLogin?: boolean;
-}
-
-interface AuthResult {
-    accessToken: string;
-    idToken: string;
-    idTokenPayload: {
-        aud: string;
-        exp: number;
-        iat: number;
-        iss: string;
-        sub: string;
-    };
-    refreshToken?: string;
-    state: string;
-}
-
-interface Auth0LockStatic {
-    new (clientId: string, domain: string, options?: Auth0LockConstructorOptions): Auth0LockStatic;
-
-    // deprecated
-    getProfile(token: string, callback: (error: auth0.Auth0Error, profile: auth0.Auth0UserProfile) => void): void;
-    getUserInfo(token: string, callback: (error: auth0.Auth0Error, profile: auth0.Auth0UserProfile) => void): void;
-    checkSession(options: any, callback: (error: auth0.Auth0Error, authResult: AuthResult | undefined) => void): void;
-    // https://github.com/auth0/lock#resumeauthhash-callback
-    resumeAuth(hash: string, callback: (error: auth0.Auth0Error, authResult: AuthResult) => void): void;
-    show(options?: Auth0LockShowOptions): void;
-    hide(): void;
-    logout(query: any): void;
-
-    on(event: "show" | "hide", callback: () => void): void;
-    on(event: "unrecoverable_error" | "authorization_error", callback: (error: auth0.Auth0Error) => void): void;
-    on(event: "authenticated", callback: (authResult: AuthResult) => void): void;
-    on(event: string, callback: (...args: any[]) => void): void;
-}
-
-declare var Auth0Lock: Auth0LockStatic;
-
 declare module "auth0-lock" {
-    export default Auth0Lock;
+    export default class Auth0Lock {
+        constructor(clientId: string, domain: string, options?: ConstructorOptions);
+
+        // deprecated
+        getProfile(token: string, callback: (error: auth0.Auth0Error, profile: auth0.Auth0UserProfile) => void): void;
+        getUserInfo(token: string, callback: (error: auth0.Auth0Error, profile: auth0.Auth0UserProfile) => void): void;
+        checkSession(options: any, callback: (error: auth0.Auth0Error, authResult: AuthResult | undefined) => void): void;
+        // https://github.com/auth0/lock#resumeauthhash-callback
+        resumeAuth(hash: string, callback: (error: auth0.Auth0Error, authResult: AuthResult) => void): void;
+        show(options?: ShowOptions): void;
+        hide(): void;
+        logout(query: any): void;
+
+        on(event: "show" | "hide", callback: () => void): void;
+        on(event: "unrecoverable_error" | "authorization_error", callback: (error: auth0.Auth0Error) => void): void;
+        on(event: "authenticated", callback: (authResult: AuthResult) => void): void;
+        on(event: string, callback: (...args: any[]) => void): void;
+    }
+
+    interface AdditionalSignUpFieldOption {
+        value: string;
+        label: string;
+    }
+
+    type AdditionalSignUpFieldOptionsCallback =
+        (error: auth0.Auth0Error, options: AdditionalSignUpFieldOption[]) => void;
+
+    type AdditionalSignUpFieldOptionsFunction =
+        (callback: AdditionalSignUpFieldOptionsCallback) => void;
+
+    type AdditionalSignUpFieldPrefillCallback =
+        (error: auth0.Auth0Error, prefill: string) => void;
+
+    type AdditionalSignUpFieldPrefillFunction =
+        (callback: AdditionalSignUpFieldPrefillCallback) => void;
+
+    interface AdditionalTextSignUpField {
+        type?: "text";
+        icon?: string;
+        name: string;
+        options?: AdditionalSignUpFieldOption[] | AdditionalSignUpFieldOptionsFunction;
+        placeholder: string;
+        prefill?: string | AdditionalSignUpFieldPrefillFunction;
+        validator?: (input: string) => { valid: boolean; hint?: string };
+    }
+
+    interface AdditionalSelectSignUpField {
+        type?: "select";
+        icon?: string;
+        name: string;
+        options?: AdditionalSignUpFieldOption[] | AdditionalSignUpFieldOptionsFunction;
+        placeholder: string;
+        prefill?: string | AdditionalSignUpFieldPrefillFunction;
+        validator?: (input: string) => { valid: boolean; hint?: string };
+    }
+
+    interface AdditionalCheckboxSignUpField {
+        type?: "checkbox";
+        icon?: string;
+        name: string;
+        placeholder: string;
+        prefill: "true" | "false";
+        validator?: (input: string) => { valid: boolean, hint?: string };
+    }
+
+    type AdditionalSignUpField = AdditionalSelectSignUpField | AdditionalTextSignUpField | AdditionalCheckboxSignUpField;
+
+    type AvatarUrlCallback = (error: auth0.Auth0Error, url: string) => void;
+    type AvatarDisplayNameCallback = (error: auth0.Auth0Error, displayName: string) => void;
+
+    interface AvatarOptions {
+        url: (email: string, callback: AvatarUrlCallback) => void;
+        displayName: (email: string, callback: AvatarDisplayNameCallback) => void;
+    }
+
+    interface ThemeButton {
+        displayName: string;
+        primaryColor?: string;
+        foregroundColor?: string;
+        icon?: string;
+    }
+    interface ThemeButtonOptions {
+        [provider: string]: ThemeButton;
+    }
+
+    interface ThemeOptions {
+        authButtons?: ThemeButtonOptions;
+        labeledSubmitButton?: boolean;
+        logo?: string;
+        primaryColor?: string;
+    }
+
+    // https://auth0.com/docs/libraries/lock/v10/sending-authentication-parameters
+    interface AuthParamsOptions {
+        access_token?: any;
+        connection_scopes?: any;
+        device?: any;
+        nonce?: any;
+        protocol?: any;
+        request_id?: any;
+        scope?: string;
+        state?: string;
+    }
+
+    interface AuthOptions {
+        params?: AuthParamsOptions;
+        redirect?: boolean;
+        redirectUrl?: string;
+        responseType?: string;
+        sso?: boolean;
+        audience?: string;
+    }
+
+    interface PopupOptions {
+        width: number;
+        height: number;
+        left: number;
+        top: number;
+    }
+
+    interface ConstructorOptions {
+        additionalSignUpFields?: AdditionalSignUpField[];
+        allowedConnections?: string[];
+        allowForgotPassword?: boolean;
+        allowLogin?: boolean;
+        allowSignUp?: boolean;
+        assetsUrl?: string;
+        auth?: AuthOptions;
+        autoclose?: boolean;
+        autofocus?: boolean;
+        avatar?: AvatarOptions;
+        closable?: boolean;
+        container?: string;
+        defaultADUsernameFromEmailPrefix?: string;
+        defaultDatabaseConnection?: string;
+        defaultEnterpriseConnection?: string;
+        forgotPasswordLink?: string;
+        initialScreen?: "login" | "signUp" | "forgotPassword";
+        language?: string;
+        languageDictionary?: any;
+        loginAfterSignUp?: boolean;
+        mustAcceptTerms?: boolean;
+        popupOptions?: PopupOptions;
+        prefill?: { email?: string, username?: string };
+        rememberLastLogin?: boolean;
+        signupLink?: string;
+        socialButtonStyle?: "big" | "small";
+        theme?: ThemeOptions;
+        usernameStyle?: string;
+        oidcConformant?: boolean;
+    }
+
+    interface FlashMessageOptions {
+        type: "success" | "error";
+        text: string;
+    }
+
+    interface ShowOptions {
+        allowedConnections?: string[];
+        allowForgotPassword?: boolean;
+        allowLogin?: boolean;
+        allowSignUp?: boolean;
+        auth?: AuthOptions;
+        initialScreen?: "login" | "signUp" | "forgotPassword";
+        flashMessage?: FlashMessageOptions;
+        rememberLastLogin?: boolean;
+    }
+
+    interface AuthResult {
+        accessToken: string;
+        idToken: string;
+        idTokenPayload: {
+            aud: string;
+            exp: number;
+            iat: number;
+            iss: string;
+            sub: string;
+        };
+        refreshToken?: string;
+        state: string;
+    }
 }


### PR DESCRIPTION
Putting the interfaces inside the module means that they
have to be imported explicitly.
    
Also means that they don't need the name prefix on every type.
    
Exporting the default class as an actual class means you don't need the
extra "static" type.