### PR TITLE
[Atom] Add readonly qualifier to some properties

### DIFF
--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -39,58 +39,58 @@ export function watchPath(rootPath: string, options: {}, eventCallback: (events:
 export interface AtomEnvironment {
     // Properties
     /** A CommandRegistry instance. */
-    commands: CommandRegistry;
+    readonly commands: CommandRegistry;
 
     /** A Config instance. */
-    config: Config;
+    readonly config: Config;
 
     /** A Clipboard instance. */
-    clipboard: Clipboard;
+    readonly clipboard: Clipboard;
 
     /** A ContextMenuManager instance. */
-    contextMenu: ContextMenuManager;
+    readonly contextMenu: ContextMenuManager;
 
     /** A MenuManager instance. */
-    menu: MenuManager;
+    readonly menu: MenuManager;
 
     /** A KeymapManager instance. */
-    keymaps: KeymapManager;
+    readonly keymaps: KeymapManager;
 
     /** A TooltipManager instance. */
-    tooltips: TooltipManager;
+    readonly tooltips: TooltipManager;
 
     /** A NotificationManager instance. */
-    notifications: NotificationManager;
+    readonly notifications: NotificationManager;
 
     /** A Project instance. */
-    project: Project;
+    readonly project: Project;
 
     /** A GrammarRegistry instance. */
-    grammars: GrammarRegistry;
+    readonly grammars: GrammarRegistry;
 
     /** A HistoryManager instance. */
-    history: HistoryManager;
+    readonly history: HistoryManager;
 
     /** A PackageManager instance. */
-    packages: PackageManager;
+    readonly packages: PackageManager;
 
     /** A ThemeManager instance. */
-    themes: ThemeManager;
+    readonly themes: ThemeManager;
 
     /** A StyleManager instance. */
-    styles: StyleManager;
+    readonly styles: StyleManager;
 
     /** A DeserializerManager instance. */
-    deserializers: DeserializerManager;
+    readonly deserializers: DeserializerManager;
 
     /** A ViewRegistry instance. */
-    views: ViewRegistry;
+    readonly views: ViewRegistry;
 
     /** A Workspace instance. */
-    workspace: Workspace;
+    readonly workspace: Workspace;
 
     /** A TextEditorRegistry instance. */
-    textEditors: TextEditorRegistry;
+    readonly textEditors: TextEditorRegistry;
 
     // Event Subscription
     /** Invoke the given callback whenever ::beep is called. */
@@ -446,7 +446,7 @@ export interface Config {
  */
 export interface Decoration {
     /** The identifier for this Decoration. */
-    id: number;
+    readonly id: number;
 
     // Construction and Destruction
     /**
@@ -654,7 +654,7 @@ export interface DisplayMarker {
  */
 export interface DisplayMarkerLayer {
     /** The identifier for the underlying MarkerLayer. */
-    id: string;
+    readonly id: string;
 
     // Lifecycle
     /** Destroy this layer. */
@@ -839,7 +839,7 @@ export interface LayerDecoration {
  */
 export interface Marker {
     /** The identifier for this Marker. */
-    id: number;
+    readonly id: number;
 
     // Lifecycle
     /**
@@ -952,7 +952,7 @@ export interface Marker {
 /** Experimental: A container for a related set of markers. */
 export interface MarkerLayer {
     /** The identifier for this MarkerLayer. */
-    id: string;
+    readonly id: string;
 
     // Lifecycle
     /** Create a copy of this layer with markers in the same state and locations. */
@@ -1036,7 +1036,7 @@ export class Notification {
 /** A notification manager used to create Notifications to be shown to the user. */
 export interface NotificationManager {
     // Properties
-    notifications: Notification[];
+    readonly notifications: Notification[];
 
     // Events
     /** Invoke the given callback after a notification has been added. */
@@ -1272,8 +1272,8 @@ export class Range {
  *  including cursor and selection positions, folds, and soft wraps.
  */
 export class TextEditor {
-    id: number;
-    buffer: TextBuffer;
+    readonly id: number;
+    readonly buffer: TextBuffer;
 
     // NOTE: undocumented within the public API. Don't go down the rabbit hole.
     constructor(options?: object);
@@ -2984,7 +2984,7 @@ export interface WorkspaceCenter {
  *  Node's ChildProcess.
  */
 export class BufferedProcess {
-    process?: ChildProcess;
+    readonly process?: ChildProcess;
 
     constructor(options: ProcessOptions);
 
@@ -4052,10 +4052,10 @@ export interface MenuManager {
  */
 export interface Package {
     /** The name of the Package. */
-    name: string;
+    readonly name: string;
 
     /** The path to the Package on disk. */
-    path: string;
+    readonly path: string;
 
     // Event Subscription
     /** Invoke the given callback when all packages have been activated. */
@@ -4377,7 +4377,7 @@ export interface Pane {
  */
 export interface Panel<T = object> {
     /** Whether or not the Panel is visible. */
-    visible: boolean;
+    readonly visible: boolean;
 
     // Construction and Destruction
     /** Destroy and remove this panel from the UI. */
@@ -4498,7 +4498,7 @@ export interface Project {
  *  syntax tree to a token including all scope names for the entire path.
  */
 export interface ScopeDescriptor {
-    scopes: string[];
+    readonly scopes: string[];
 
     /** Returns all scopes for this descriptor. */
     getScopesArray(): string[];
@@ -4894,13 +4894,13 @@ export class Task {
  */
 export class TextBuffer {
     /** The unique identifier for this buffer. */
-    id: string;
+    readonly id: string;
 
     /** The number of retainers for the buffer. */
-    refcount: number;
+    readonly refcount: number;
 
     /** Whether or not the bufffer has been destroyed. */
-    destroyed: boolean;
+    readonly destroyed: boolean;
 
     /** Create a new buffer backed by the given file path. */
     static load(filePath: string, params?: BufferLoadOptions): Promise<TextBuffer>;
@@ -6753,11 +6753,11 @@ export interface TokenizeLineResult {
  *  jQuery, which is an expensive dependency we want to eliminate.
  */
 export interface Tooltip {
-    options: TooltipOptions;
-    enabled: boolean;
-    timeout: number;
-    hoverState: "in"|"out"|null;
-    element: HTMLElement;
+    readonly options: TooltipOptions;
+    readonly enabled: boolean;
+    readonly timeout: number;
+    readonly hoverState: "in"|"out"|null;
+    readonly element: HTMLElement;
 
     getTitle(): string;
     getTooltipElement(): HTMLElement;
@@ -6774,11 +6774,11 @@ export interface ViewModel {
 }
 
 export interface WindowLoadSettings {
-    appVersion: string;
-    atomHome: string;
-    devMode: boolean;
-    resourcePath: string;
-    safeMode: boolean;
-    env?: { [key: string]: string|undefined };
-    profileStartup?: boolean;
+    readonly appVersion: string;
+    readonly atomHome: string;
+    readonly devMode: boolean;
+    readonly resourcePath: string;
+    readonly safeMode: boolean;
+    readonly env?: { [key: string]: string|undefined };
+    readonly profileStartup?: boolean;
 }


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.) -- actually, I don't think possible to test for "readonly-ness", since we can't "expect to fail"?
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:
If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: actually, there isn't any *meaningful* url to provide.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

After thinking for a bit on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24075, I thought that those `id` properties should be `readonly`, since those *really* aren't supposed to be changed (stuff *will* break). But when I went to change those, I found a lot of other instances where this is the case.

So I went ahead and added `readonly` qualifiers where I thought appropriate. I tried to keep it very conservative, so where in doubt, I left the properties as-is.

This should be a backwards-compatible change, for the most part. There is one caveat though. I changed a few properties' type from `Array` to `ReadonlyArray` -- mostly because it's easy to *really* mess up stuff by modifying those arrays. This can, however, break correct existing code due to `ReadonlyArray` not being assignable to `Array`. Let me know if you think this change is worth it, I'm on the fence about this one.

Namely, `NotificationManager.notifications` (and subsequently `NotificationManager.getNotifications()`) and `ScopeDescriptor.scopes` (and subsequently `ScopeDescriptor.getScopesArray()`).

As a side note, we have a few properties we *really* shouldn't have, for example, `TextEditor.buffer` is undocumented, *really* shouldn't be assigned to (because it *will* break stuff) and has an accessor function (that is, `TextEditor.getBuffer()`) -- so for all intents and purposes it's private and doesn't seem to actually have any legitimate uses... The same applies to `NotificationManager.notifications` and `ScopeDescriptor.scopes` actually. I would suggest removing those, but backwards compatibility is a bit of a concern. Let me know what you think.