### PR TITLE
dynogels: fix typing of Model.createTable

### DIFF
--- a/types/dynogels/index.d.ts
+++ b/types/dynogels/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for dynogels 8.0
 // Project: https://github.com/clarkie/dynogels#readme
 // Definitions by: Spartan Labs <https://github.com/SpartanLabs>
+//                 Ramon de Klein <https://github.com/ramondeklein>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -76,7 +77,7 @@ export interface Model {
     getItems(items: string[] | Array<{ [key: string]: string }>, options: GetItemOptions, callback: (err: Error, items: any[]) => void): void;
     batchGetItems(items: string[] | Array<{ [key: string]: string }>, callback: (err: Error, items: any[]) => void): void;
     batchGetItems(items: string[] | Array<{ [key: string]: string }>, options: GetItemOptions, callback: (err: Error, items: any[]) => void): void;
-    createTable(options: { [key: string]: CreateTablesOptions } | DynogelsGlobalOptions, callback: (err: Error, data: AWS.DynamoDB.CreateTableOutput) => void): void;
+    createTable(options: CreateTablesOptions, callback: (err: Error, data: AWS.DynamoDB.CreateTableOutput) => void): void;
     createTable(callback: (err: Error, data: AWS.DynamoDB.CreateTableOutput) => void): void;
     updateTable(throughput: Throughput, callback: (err: Error, data: AWS.DynamoDB.UpdateTableOutput) => void): void;
     updateTable(callback: (err: Error, data: AWS.DynamoDB.UpdateTableOutput) => void): void;


### PR DESCRIPTION
The `Model.createTable` requires only the `CreateTablesOptions` for that specific table. So you don't need to specify a hash that contains the table name, but only the options itself.