### PR TITLE
atom: remove jQuery as a dependency.

### DIFF
--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -9,7 +9,6 @@
 // NOTE: only those classes exported within this file should be retain that status below.
 // https://github.com/atom/atom/blob/v1.24.0/exports/atom.js
 
-/// <reference types="jquery" />
 /// <reference types="node" />
 
 import { ReadStream, WriteStream } from "fs";
@@ -6754,7 +6753,7 @@ export interface Tooltip {
     enabled: boolean;
     timeout: number;
     hoverState: "in"|"out"|null;
-    element: JQuery|HTMLElement;
+    element: HTMLElement;
 
     getTitle(): string;
     getTooltipElement(): HTMLElement;

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -2524,6 +2524,10 @@ export interface TextEditorRegistry {
     observe(callback: (editor: TextEditor) => void): Disposable;
 }
 
+export interface JQueryCompatible<Element extends Node = HTMLElement> extends Iterable<Element> {
+    jquery: string;
+}
+
 export type TooltipPlacement =
     |"top"|"bottom"|"left"|"right"
     |"auto"|"auto top"|"auto bottom"|"auto left"|"auto right";
@@ -2531,7 +2535,7 @@ export type TooltipPlacement =
 /** Associates tooltips with HTML elements or selectors. */
 export interface TooltipManager {
     /** Add a tooltip to the given element. */
-    add(target: HTMLElement, options: {
+    add(target: HTMLElement | JQueryCompatible, options: {
         item?: object,
     } | {
         title?: string|(() => string),


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:

The type of the element of the JQuery interface is defined [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0428c407f07b7c5619c790cd96fe2deb88644a95/types/jquery/index.d.ts#L3101) as:
```
interface JQuery<TElement extends Node = HTMLElement> extends Iterable<TElement> { .. }
```

Atom hasn't used jQuery internally for some time, yet we still reference it within the definitions. This pull request removes our dependency on `@types/jquery`. The implementation of this tooltip type can be found [here](https://github.com/atom/atom/blob/v1.24.0/src/tooltip-manager.js), with the documentation for the `TooltipManager` being found [here](https://atom.io/docs/api/v1.24.1/TooltipManager). If we look into the source for the TooltipManager, Atom does still correctly handle elements that are jQuery objects.

We currently do not allow for any element that doesn't inherit from `HTMLElement` to be added as a tooltip using `TooltipManager.add`, with Atom itself creating the tooltip if we do not provide that element. There are also several fields within the `Tooltip` type that assume we're dealing with an HTMLElement. It's possible that all of these are wrong and should be the `Node` type instead. Within this PR, they are assumed to have the correct type of HTMLElement.