### PR TITLE
make graphql typing for getDescription conform with graphql-js

### DIFF
--- a/types/graphql/index.d.ts
+++ b/types/graphql/index.d.ts
@@ -12,6 +12,7 @@
 //                 Tim Griesser <https://github.com/tgriesser>
 //                 Dylan Stewart <https://github.com/dyst5422>
 //                 Alessio Dionisi <https://github.com/adnsio>
+//                 Divyendu Singh <https://github.com/divyenduz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -99,6 +100,9 @@ export {
 
     // Build a GraphQLSchema from a GraphQL schema language document.
     buildSchema,
+
+    // Get the description of an AST node
+    getDescription,
 
     // Extends an existing GraphQLSchema from a parsed GraphQL Schema
     // language AST.

--- a/types/graphql/type/schema.d.ts
+++ b/types/graphql/type/schema.d.ts
@@ -61,6 +61,27 @@ export class GraphQLSchema {
   getDirective(name: string): GraphQLDirective;
 }
 
+export type GraphQLSchemaValidationOptions = {
+  /**
+   * When building a schema from a GraphQL service's introspection result, it
+   * might be safe to assume the schema is valid. Set to true to assume the
+   * produced schema is valid.
+   *
+   * Default: false
+   */
+  assumeValid?: boolean;
+
+  /**
+   * If provided, the schema will consider fields or types with names included
+   * in this list valid, even if they do not adhere to the specification's
+   * schema validation rules.
+   *
+   * This option is provided to ease adoption and may be removed in a future
+   * major release.
+   */
+  allowedLegacyNames?: ReadonlyArray<string>;
+};
+
 export interface GraphQLSchemaConfig {
   query: GraphQLObjectType;
   mutation?: GraphQLObjectType;

--- a/types/graphql/utilities/buildASTSchema.d.ts
+++ b/types/graphql/utilities/buildASTSchema.d.ts
@@ -1,12 +1,17 @@
 import { DocumentNode, Location, StringValueNode } from '../language/ast';
 import { Source } from '../language/source';
-import { GraphQLSchema } from '../type/schema';
+import { GraphQLSchema, GraphQLSchemaValidationOptions } from '../type/schema';
 
-type BuildSchemaOptions = {
-    assumeValid?: boolean;
-    allowedLegacyNames?: ReadonlyArray<string>;
-    commentDescriptions?: boolean;
-};
+interface BuildSchemaOptions extends GraphQLSchemaValidationOptions {
+  /**
+   * Descriptions are defined as preceding string literals, however an older
+   * experimental version of the SDL supported preceding comments as
+   * descriptions. Set to true to enable this deprecated behavior.
+   *
+   * Default: false
+   */
+  commentDescriptions?: boolean;
+}
 
 /**
  * This takes the ast of a schema document produced by the parse function in
@@ -21,13 +26,18 @@ type BuildSchemaOptions = {
 export function buildASTSchema(ast: DocumentNode): GraphQLSchema;
 
 /**
- * Given an ast node, returns its string description based on a contiguous
- * block full-line of comments preceding it.
+ * Given an ast node, returns its string description.
+ *
+ * Accepts options as a second argument:
+ *
+ *    - commentDescriptions:
+ *        Provide true to use preceding comments as the description.
+ *
  */
 export function getDescription(
-    node: { description?: StringValueNode; loc?: Location },
-    options: BuildSchemaOptions
-  ): string;
+  node: { description?: StringValueNode; loc?: Location },
+  options: BuildSchemaOptions
+): string;
 
 /**
  * A helper function to build a GraphQLSchema directly from a source

--- a/types/graphql/utilities/buildASTSchema.d.ts
+++ b/types/graphql/utilities/buildASTSchema.d.ts
@@ -1,6 +1,12 @@
-import { DocumentNode, Location } from '../language/ast';
+import { DocumentNode, Location, StringValueNode } from '../language/ast';
 import { Source } from '../language/source';
 import { GraphQLSchema } from '../type/schema';
+
+type BuildSchemaOptions = {
+    assumeValid?: boolean;
+    allowedLegacyNames?: ReadonlyArray<string>;
+    commentDescriptions?: boolean;
+};
 
 /**
  * This takes the ast of a schema document produced by the parse function in
@@ -18,7 +24,10 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema;
  * Given an ast node, returns its string description based on a contiguous
  * block full-line of comments preceding it.
  */
-export function getDescription(node: { loc?: Location }): string;
+export function getDescription(
+    node: { description?: StringValueNode; loc?: Location },
+    options: BuildSchemaOptions
+  ): string;
 
 /**
  * A helper function to build a GraphQLSchema directly from a source

--- a/types/graphql/utilities/index.d.ts
+++ b/types/graphql/utilities/index.d.ts
@@ -27,7 +27,7 @@ export { getOperationAST } from './getOperationAST';
 export { buildClientSchema } from './buildClientSchema';
 
 // Build a GraphQLSchema from GraphQL Schema language.
-export { buildASTSchema, buildSchema } from './buildASTSchema';
+export { buildASTSchema, buildSchema, getDescription } from './buildASTSchema';
 
 // Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
 export { extendSchema } from './extendSchema';


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/graphql/graphql-js/blob/master/src/utilities/buildASTSchema.js#L465, https://github.com/graphql/graphql-js/pull/1165
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

