### PR TITLE
Add use method to Pool<T> that was added in generic-pool 3.3.0

### DIFF
--- a/types/generic-pool/generic-pool-tests.ts
+++ b/types/generic-pool/generic-pool-tests.ts
@@ -41,6 +41,9 @@ const opts = {
 
 const pool = genericPool.createPool<Connection>(factory, opts);
 
+pool.use((conn: Connection) => 'test')
+    .then((result: string) => { });
+
 pool.acquire()
     .then((conn: Connection) => {
         return pool.release(conn);

--- a/types/generic-pool/index.d.ts
+++ b/types/generic-pool/index.d.ts
@@ -22,6 +22,7 @@ export class Pool<T> extends EventEmitter {
     destroy(resource: T): void;
     drain(): PromiseLike<undefined>;
     clear(): PromiseLike<undefined[]>;
+    use<U>(cb: (resource: T) => U): PromiseLike<U>;
 }
 
 export interface Factory<T> {


### PR DESCRIPTION
Adding a definition for the [#use](https://github.com/coopernurse/node-pool#pooluse) method that was added in[ generic-pool 3.3.0](https://github.com/coopernurse/node-pool/blob/master/CHANGELOG.md#330---december-27-2017)

It passes listing and works correctly in my codebase. This is my first contribution to DefinitelyTyped, so let me know if I missed anything.