### PR TITLE
graphql-resolve-batch: improve test coverage and add jsdocs

### DIFF
--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -4,6 +4,21 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
+/**
+ * Creates a GraphQL.js field resolver that batches together multiple resolves
+ * together that share the *exact* same GraphQL field selection.
+ *
+ * Note:
+ *  The batchResolveFunction you supply always expects you to always return an array of TReturn (or a promise with this array).
+ *  This is because you will have to return a TReturn for every source given to you by the batch function.
+ *  For an example of this please see the examples in the original project repository:
+ *  https://github.com/calebmer/graphql-resolve-batch/tree/master/examples
+ *
+ * @template TSource The original type of a single source.
+ * @template TReturn The return type of the field resolver.
+ * @template TArgs The type of supplied arguments.
+ * @template TContext The type of the current resolver context.
+ */
 export function createBatchResolver<
     TSource,
     TReturn,
@@ -13,12 +28,19 @@ export function createBatchResolver<
     batchResolveFn: BatchResolveFunction<TSource, TArgs, TContext, TReturn>
 ): ResolverFunction<TSource, TArgs, TContext, TReturn>;
 
+/**
+ * The resulting field resolver that batches together multiple resolves.
+ * Graphql-resolve-batch will always return a promise for this resulting resolver.
+ */
 export type ResolverFunction<TSource, TArgs, TContext, TReturn> = (
     source: TSource,
     args: TArgs,
     context: TContext
-) => Promise<TReturn> | Promise<TReturn[]>;
+) => Promise<TReturn>;
 
+/**
+ * A batch function to resolve all fields for the given sources in a single batch.
+ */
 export type BatchResolveFunction<TSource, TArgs, TContext, TReturn> = (
     sources: ReadonlyArray<TSource>,
     args: TArgs,

--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -18,6 +18,7 @@
  * @template TReturn The return type of the field resolver.
  * @template TArgs The type of supplied arguments.
  * @template TContext The type of the current resolver context.
+ * @returns A batch function to resolve all fields for the given sources in a single batch.
  */
 export function createBatchResolver<
     TSource,

--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -18,7 +18,7 @@
  * @template TReturn The return type of the field resolver.
  * @template TArgs The type of supplied arguments.
  * @template TContext The type of the current resolver context.
- * @returns A batch function to resolve all fields for the given sources in a single batch.
+ * @param batchResolveFn A batch function to resolve all fields for the given sources in a single batch.
  */
 export function createBatchResolver<
     TSource,

--- a/types/graphql-resolve-batch/index.d.ts
+++ b/types/graphql-resolve-batch/index.d.ts
@@ -9,7 +9,7 @@
  * together that share the *exact* same GraphQL field selection.
  *
  * Note:
- *  The batchResolveFunction you supply always expects you to always return an array of TReturn (or a promise with this array).
+ *  The batchResolveFunction you supply always expects you to return an array of TReturn (or a promise with this array).
  *  This is because you will have to return a TReturn for every source given to you by the batch function.
  *  For an example of this please see the examples in the original project repository:
  *  https://github.com/calebmer/graphql-resolve-batch/tree/master/examples


### PR DESCRIPTION
Adds JSDocs to the exported types, mostly to explain the generic arguments as well as increase test coverage, making sure the resulting resolver is typed correctly in both single value and array version.
Also removed an unnessecary union as return type.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
