### PR TITLE
Execa: don't require mutable arrays, add missing 'inherit' stdio option

### DIFF
--- a/types/execa/execa-tests.ts
+++ b/types/execa/execa-tests.ts
@@ -1,46 +1,38 @@
 import assert = require('assert');
 import execa = require('execa');
-import { PassThrough } from "stream";
+import { PassThrough } from 'stream';
 
-execa('unicorns')
-    .then(result => {
-        assert(result.cmd === 'unicorns');
-        assert(result.code === 0);
-        assert(result.failed === false);
-        assert(result.killed === false);
-        assert(result.signal === null);
-        assert(result.stderr === 'bad unicorns');
-        assert(result.stdout === 'good unicorns');
-        assert(result.timedOut === false);
-    });
+execa('unicorns').then(result => {
+    assert(result.cmd === 'unicorns');
+    assert(result.code === 0);
+    assert(result.failed === false);
+    assert(result.killed === false);
+    assert(result.signal === null);
+    assert(result.stderr === 'bad unicorns');
+    assert(result.stdout === 'good unicorns');
+    assert(result.timedOut === false);
+});
 
-execa('foo')
-    .catch(error => {
-        assert(error.cmd === 'foo');
-        assert(error.code === 128);
-        assert(error.failed === true);
-        assert(error.killed === false);
-        assert(error.signal === 'SIGINT');
-        assert(error.stderr === 'stderr');
-        assert(error.stdout === 'stdout');
-        assert(error.timedOut === false);
-    });
+execa('foo').catch(error => {
+    assert(error.cmd === 'foo');
+    assert(error.code === 128);
+    assert(error.failed === true);
+    assert(error.killed === false);
+    assert(error.signal === 'SIGINT');
+    assert(error.stderr === 'stderr');
+    assert(error.stdout === 'stdout');
+    assert(error.timedOut === false);
+});
 
-execa('noop', ['foo'])
-    .then(result => result.stderr.toLocaleLowerCase());
+execa('noop', ['foo']).then(result => result.stderr.toLocaleLowerCase());
 
-execa.stdout('unicorns')
-    .then(stdout => stdout.toLocaleLowerCase());
-execa.stdout('echo', ['unicorns'])
-    .then(stdout => stdout.toLocaleLowerCase());
+execa.stdout('unicorns').then(stdout => stdout.toLocaleLowerCase());
+execa.stdout('echo', ['unicorns']).then(stdout => stdout.toLocaleLowerCase());
 
-execa.stderr('unicorns')
-    .then(stderr => stderr.toLocaleLowerCase());
-execa.stderr('echo', ['unicorns'])
-    .then(stderr => stderr.toLocaleLowerCase());
+execa.stderr('unicorns').then(stderr => stderr.toLocaleLowerCase());
+execa.stderr('echo', ['unicorns']).then(stderr => stderr.toLocaleLowerCase());
 
-execa.shell('echo unicorns')
-    .then(result => result.stdout.toLocaleLowerCase());
+execa.shell('echo unicorns').then(result => result.stdout.toLocaleLowerCase());
 
 {
     let result: string;
@@ -54,14 +46,14 @@ execa.shell('echo unicorns')
 execa('echo', ['unicorns']).stdout.pipe(process.stdout);
 execa('echo', ['unicorns']).stderr.pipe(process.stderr);
 
-execa('forever', {extendEnv: false}).pid;
-execa('forever', {argv0: 'hi'}).pid;
-execa('forever', {localDir: '~'}).pid;
-execa('forever', {reject: false}).pid;
-execa('forever', {cleanup: false}).pid;
-execa('forever', {stdin: 1}).pid;
-execa('forever', {stdout: 'ignore'}).pid;
-execa('forever', {stderr: undefined}).pid;
+execa('forever', { extendEnv: false }).pid;
+execa('forever', { argv0: 'hi' }).pid;
+execa('forever', { localDir: '~' }).pid;
+execa('forever', { reject: false }).pid;
+execa('forever', { cleanup: false }).pid;
+execa('forever', { stdin: 1 }).pid;
+execa('forever', { stdout: 'ignore' }).pid;
+execa('forever', { stderr: undefined }).pid;
 
 async () => {
     const { stdout } = await execa('noop', ['foo'], { stripEof: false });
@@ -119,7 +111,9 @@ async () => {
 }
 
 async () => {
-    const { timedOut, code } = await execa('delay', ['3000', '22'], { timeout: 9000 });
+    const { timedOut, code } = await execa('delay', ['3000', '22'], {
+        timeout: 9000
+    });
     assert(timedOut === true);
     assert(code === 22);
 };
@@ -131,3 +125,10 @@ async () => {
 
     assert(stdout === 'foo');
 };
+
+const args: ReadonlyArray<string> = ['bar'];
+const stdio: ReadonlyArray<'ignore'> = ['ignore'];
+execa('foo', args);
+execa('foo', args, {
+    stdio
+});

--- a/types/execa/index.d.ts
+++ b/types/execa/index.d.ts
@@ -91,6 +91,7 @@ declare namespace execa {
         | 'pipe'
         | 'ipc'
         | 'ignore'
+        | 'inherit'
         | Stream
         | number
         | null

--- a/types/execa/index.d.ts
+++ b/types/execa/index.d.ts
@@ -23,7 +23,11 @@ declare namespace execa {
          * Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
          * @returns a `child_process` instance which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
          */
-        (file: string, args?: string[], options?: Options): ExecaChildProcess;
+        (
+            file: string,
+            args?: ReadonlyArray<string>,
+            options?: Options
+        ): ExecaChildProcess;
         (file: string, options?: Options): ExecaChildProcess;
 
         /**
@@ -32,7 +36,11 @@ declare namespace execa {
          * Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
          * @returns a `child_process` instance which is enhanced to also be a `Promise` for `stdout`.
          */
-        stdout(file: string, args?: string[], options?: Options): Promise<string>;
+        stdout(
+            file: string,
+            args?: ReadonlyArray<string>,
+            options?: Options
+        ): Promise<string>;
         stdout(file: string, options?: Options): Promise<string>;
 
         /**
@@ -41,7 +49,11 @@ declare namespace execa {
          * Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
          * @returns a `child_process` instance which is enhanced to also be a `Promise` for `stderr`.
          */
-        stderr(file: string, args?: string[], options?: Options): Promise<string>;
+        stderr(
+            file: string,
+            args?: ReadonlyArray<string>,
+            options?: Options
+        ): Promise<string>;
         stderr(file: string, options?: Options): Promise<string>;
 
         /**
@@ -59,7 +71,11 @@ declare namespace execa {
          * @returns the same result object as `child_process.spawnSync`.
          * @throws an `Error` if the command fails.
          */
-        sync(file: string, args?: string[], options?: SyncOptions): ExecaReturns;
+        sync(
+            file: string,
+            args?: ReadonlyArray<string>,
+            options?: SyncOptions
+        ): ExecaReturns;
         sync(file: string, options?: SyncOptions): ExecaReturns;
 
         /**
@@ -71,7 +87,14 @@ declare namespace execa {
         shellSync(command: string, options?: Options): ExecaReturns;
     }
 
-    type StdIOOption = 'pipe' | 'ipc' | 'ignore' | Stream | number | null | undefined;
+    type StdIOOption =
+        | 'pipe'
+        | 'ipc'
+        | 'ignore'
+        | Stream
+        | number
+        | null
+        | undefined;
 
     interface CommonOptions {
         /**
@@ -103,7 +126,7 @@ declare namespace execa {
          *
          * @see https://nodejs.org/api/child_process.html#child_process_options_stdio
          */
-        stdio?: 'pipe' | 'ignore' | 'inherit' | StdIOOption[];
+        stdio?: 'pipe' | 'ignore' | 'inherit' | ReadonlyArray<StdIOOption>;
         /**
          * Prepare child to run independently of its parent process.
          * Specific behavior depends on the platform.
@@ -253,10 +276,16 @@ declare namespace execa {
     type ExecaError = Error & ExecaReturns;
 
     interface ExecaChildPromise {
-        catch<TResult = never>(onrejected?: ((reason: ExecaError) => TResult | PromiseLike<TResult>) | null): Promise<ExecaReturns | TResult>;
+        catch<TResult = never>(
+            onrejected?:
+                | ((reason: ExecaError) => TResult | PromiseLike<TResult>)
+                | null
+        ): Promise<ExecaReturns | TResult>;
     }
 
-    type ExecaChildProcess = ChildProcess & ExecaChildPromise & Promise<ExecaReturns>;
+    type ExecaChildProcess = ChildProcess &
+        ExecaChildPromise &
+        Promise<ExecaReturns>;
 }
 
 declare var execa: execa.ExecaStatic;

--- a/types/execa/index.d.ts
+++ b/types/execa/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for execa 0.8
+// Type definitions for execa 0.9
 // Project: https://github.com/sindresorhus/execa#readme
 // Definitions by: Douglas Duteil <https://github.com/douglasduteil>
 //                 BendingBender <https://github.com/BendingBender>


### PR DESCRIPTION

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://nodejs.org/api/child_process.html#child_process_options_stdio
- [x] Increase the version number in the header if appropriate.
