### PR TITLE
Add typing for .changedAttributes()

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -23,6 +23,9 @@ declare module 'ember-data' {
     type AttributesFor<Model> = keyof Model; // TODO: filter to attr properties only (TS 2.8)
     type RelationshipsFor<Model> = keyof Model; // TODO: filter to hasMany/belongsTo properties only (TS 2.8)
 
+    export interface ChangedAttributes {
+        [key: string]: [any, any] | undefined;
+    }
     interface AttributeMeta<Model extends DS.Model> {
         type: keyof TransformRegistry;
         options: object;
@@ -500,7 +503,7 @@ declare module 'ember-data' {
              * Returns an object, whose keys are changed properties, and value is
              * an [oldProp, newProp] array.
              */
-            changedAttributes(): {};
+            changedAttributes(): ChangedAttributes;
             /**
              * If the model `hasDirtyAttributes` this function will discard any unsaved
              * changes. If the model `isNew` it will be removed from the store.

--- a/types/ember-data/test/model.ts
+++ b/types/ember-data/test/model.ts
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import DS from 'ember-data';
+import DS, { ChangedAttributes } from 'ember-data';
 import { assertType } from "./lib/assert";
 
 const Person = DS.Model.extend({
@@ -30,3 +30,7 @@ assertType<Date>(user.get('createdAt'));
 
 user.serialize();
 user.serialize({ includeId: true });
+user.serialize({ includeId: true });
+
+const attributes = user.changedAttributes();
+assertType<ChangedAttributes>(attributes);


### PR DESCRIPTION
changedAttributes() returns an object with string keys which may be an array `[oldValue, newValue]` or `undefined`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/emberjs/data/blob/v3.0.0/addon/-private/system/model/model.js#L647
