### PR TITLE
little change

### DIFF
--- a/types/microrouter/index.d.ts
+++ b/types/microrouter/index.d.ts
@@ -8,12 +8,13 @@
 
 import { IncomingMessage, ServerResponse, Server } from 'http';
 import { RequestHandler } from 'micro';
-
+export type ServerResponse = ServerResponse;
+export type ServerRequest = IncomingMessage & {
+    params: { [key: string]: string },
+    query: { [key: string]: string }
+};
 export type AugmentedRequestHandler = (
-    req: IncomingMessage & {
-        params: {[key: string]: string},
-        query: {[key: string]: string}
-    },
+    req: ServerRequest,
     res: ServerResponse
 ) => any;
 


### PR DESCRIPTION
`import { router, get, ServerRequest, ServerResponse } from 'microrouter';
const notfound = (req: ServerRequest, res: ServerResponse) => send(res, 404, 'Not found route');
export default router(
    get('/', notfound)`
);
