### PR TITLE
Update type for/ webpack.Options.SplitChunksOptions

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -545,7 +545,7 @@ declare namespace webpack {
             /** Give chunks created a name (chunks with equal name are merged) */
             name?: boolean | string | ((...args: any[]) => any);
             /** Assign modules to a cache group (modules from different cache groups are tried to keep in separate chunks) */
-            cacheGroups?: false | string | ((...args: any[]) => any) | RegExp | CacheGroupsOptions;
+            cacheGroups?: false | string | ((...args: any[]) => any) | RegExp | Map<string, CacheGroupsOptions>;
         }
         interface RuntimeChunkOptions {
             /** The name or name factory for the runtime chunks. */

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -580,6 +580,21 @@ configuration = {
     }
 };
 
+configuration = {
+    mode: "production",
+    optimization: {
+        splitChunks: {
+            cacheGroups: {
+                commons: {
+                    test: /node_modules/,
+                    name: "vendor",
+                    chunks: "all"
+                }
+            }
+        }
+    }
+};
+
 plugin = new webpack.SplitChunksPlugin({ chunks: "async", minChunks: 2 });
 
 class SingleEntryDependency extends webpack.compilation.Dependency {}


### PR DESCRIPTION
The cacheGroups option in webpack4 takes a map of name to
CacheGroupOptions, such as:

```
  optimization: {
    splitChunks: {
      cacheGroups: {
        commons: {
          test: /node_modules/,
          name: "vendor",
          chunks: "all"
        }
      }
    }
  }
```

The existing types block the above config, which works for splitting out
a common vendor chunk. Using CacheGroupOptions directly does not seem to
work, but it was left in the definition because I'm not certain that
there isn't a way in which that form can be used that I just don't
understand.

However, Map<string, CacheGroupOptions> definitely works and is the form
in the examples and that produces functional chunk splitting.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**NOTE** Added a test case but `npm run lint` fails. I don't understand why and would love some advice on what I'm doing wrong.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://gist.github.com/sokra/1522d586b8e5c0f5072d7565c2bee693#configurate-cache-groups
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.733442
