### PR TITLE
@types/w3c-permissions Add Web Permissions API type definitions

### DIFF
--- a/types/w3c-permissions/index.d.ts
+++ b/types/w3c-permissions/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for W3C Permissions API
+// Type definitions for W3C Permissions API 1.0
 // Project: https://www.w3.org/TR/permissions/
 // Definitions by: Julien Bérubé <https://github.com/jberube>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/w3c-permissions/index.d.ts
+++ b/types/w3c-permissions/index.d.ts
@@ -1,0 +1,92 @@
+// Type definitions for W3C Image Capture 1.0
+// Project: https://www.w3.org/TR/permissions/
+// Definitions by: Julien Bérubé <https://github.com/jberube>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+// https://www.w3.org/TR/permissions/#permissions-interface
+declare class Permissions {
+    query(permissionDesc: PermissionDescriptor): Promise<PermissionStatus>;
+}
+
+// https://www.w3.org/TR/permissions/#status-of-a-permission
+type PermissionState = "granted" | "denied" | "prompt";
+
+// https://www.w3.org/TR/permissions/#permission-registry
+type PermissionName =
+    "geolocation" |
+    "notifications" |
+    "push" |
+    "midi" |
+    "camera" |
+    "microphone" |
+    "speaker" |
+    "device-info" |
+    "background-sync" |
+    "bluetooth" |
+    "persistent-storage" |
+    "ambient-light-sensor" |
+    "accelerometer" |
+    "gyroscope" |
+    "magnetometer" |
+    "clipboard";
+
+// https://www.w3.org/TR/permissions/#status-of-a-permission
+declare class PermissionStatus extends EventTarget {
+    readonly state: PermissionState;
+    onchange(): (this: this, ev: Event) => any;
+}
+
+// https://www.w3.org/TR/permissions/#permission-descriptor
+interface PermissionDescriptor {
+    name: string;
+}
+
+// https://www.w3.org/TR/permissions/#geolocation
+type GeolocationPermissionDescriptor = PermissionDescriptor;
+
+// https://www.w3.org/TR/permissions/#notifications
+type NotificationsPermissionDescriptor = PermissionDescriptor;
+
+// https://www.w3.org/TR/permissions/#push
+interface PushPermissionDescriptor extends PermissionDescriptor {
+    userVisibleOnly?: boolean;
+}
+
+// https://www.w3.org/TR/permissions/#midi
+interface MidiPermissionDescriptor extends PermissionDescriptor {
+    sysex: boolean;
+}
+
+// https://www.w3.org/TR/permissions/#media-devices
+interface DevicePermissionDescriptor extends PermissionDescriptor {
+    deviceId: string;
+}
+
+// https://www.w3.org/TR/permissions/#background-sync
+type BackgroundSyncPermissionDescriptor = PermissionDescriptor;
+
+// https://www.w3.org/TR/permissions/#ambient-light-sensor
+type AmbientLightSensorPermissionDescriptor = PermissionDescriptor;
+
+// https://www.w3.org/TR/permissions/#accelerometer
+type AccelerometerPermissionDescriptor = PermissionDescriptor;
+
+// https://www.w3.org/TR/permissions/#gyroscope
+type GyroscopePermissionDescriptor = PermissionDescriptor;
+
+// https://www.w3.org/TR/permissions/#magnetometer
+type MagnetometerPermissionDescriptor = PermissionDescriptor;
+
+// https://www.w3.org/TR/permissions/#clipboard
+type ClipboardPermissionDescriptor = PermissionDescriptor;
+
+// https://www.w3.org/TR/permissions/#navigator-and-workernavigator-extension
+interface Navigator {
+    readonly permissions: Permissions;
+}
+
+// https://www.w3.org/TR/permissions/#navigator-and-workernavigator-extension
+interface WorkerNavigator {
+    readonly permissions: Permissions;
+}

--- a/types/w3c-permissions/index.d.ts
+++ b/types/w3c-permissions/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for W3C Image Capture 1.0
+// Type definitions for W3C Permissions API
 // Project: https://www.w3.org/TR/permissions/
 // Definitions by: Julien Bérubé <https://github.com/jberube>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/w3c-permissions/tsconfig.json
+++ b/types/w3c-permissions/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "w3c-permissions-tests.ts"
+    ]
+}

--- a/types/w3c-permissions/tslint.json
+++ b/types/w3c-permissions/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/w3c-permissions/w3c-permissions-tests.ts
+++ b/types/w3c-permissions/w3c-permissions-tests.ts
@@ -1,8 +1,6 @@
 // Modified from Permissions API spec: https://w3c.github.io/permissions/#examples
 // NOTE: Code kept as close to spec examples as possible
 
-// import {} from ".";
-
 // Example 3
 function showLocalNewsWithGeolocation() {}
 function showButtonToEnableLocalNews() {}

--- a/types/w3c-permissions/w3c-permissions-tests.ts
+++ b/types/w3c-permissions/w3c-permissions-tests.ts
@@ -1,0 +1,47 @@
+// Modified from Permissions API spec: https://w3c.github.io/permissions/#examples
+// NOTE: Code kept as close to spec examples as possible
+
+// import {} from ".";
+
+// Example 3
+function showLocalNewsWithGeolocation() {}
+function showButtonToEnableLocalNews() {}
+
+const test = navigator.permissions.query({ name: "geolocation" }).then(({ state }) => {
+    switch (state) {
+      case "granted":
+        showLocalNewsWithGeolocation();
+        break;
+      case "prompt":
+        showButtonToEnableLocalNews();
+        break;
+      default:
+        // Don’t do anything if the permission was denied.
+        break;
+    }
+});
+
+// Example 4
+function updateNotificationButton(state: PermissionState) {
+    const button = document.getElementById('chat-notification-button');
+    if (button) {
+        button.setAttribute('disabled', state === 'denied' ? 'disabled' : '');
+    }
+}
+
+navigator.permissions.query({ name: 'notifications' }).then((result) => {
+    updateNotificationButton(result.state);
+    result.addEventListener('change', () => {
+        updateNotificationButton(result.state);
+    });
+});
+
+// Example 5
+Promise.all([
+    navigator.permissions.query({ name: "geolocation" }),
+    navigator.permissions.query({ name: "notifications" })
+])
+.then(([{ state: geoState }, { state: notifState }]) => {
+    console.log("Geolocation permission state is:", geoState);
+    console.log("Notifications permission state is:", notifState);
+});


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [X] The package does not provide its own types, and you can not add them.
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

I could not find the correct parameters for adding to an existing DOM API using `dts-gen`. I had to base myself on /types/w3c-web-usb.