### PR TITLE
Fix array definitions for highcharts gauge

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -961,7 +961,7 @@ declare namespace Highcharts {
          * Use this in cases where a linear gradient between a minColor and maxColor is not sufficient.
          * The stops is an array of tuples, where the first item is a float between 0 and 1 assigning the relative position in the gradient, and the second item is the color.
          */
-        stops?: Array<[number, string]>;
+        stops?: Array<Array<number|string>>;
         /**
          * The amount of ticks to draw on the axis. This opens up for aligning the ticks of multiple charts or panes within
          * a chart. This option overrides the tickPixelInterval option.
@@ -3076,7 +3076,7 @@ declare namespace Highcharts {
          * @default ['50%', '50%']
          * @since 2.3.0
          */
-        center?: [number | string, number | string];
+        center?: Array<number|string>;
         /**
          * The end angle of the polar X axis or gauge value axis, given in degrees where 0 is north.
          * @default startAngle + 360

--- a/types/highcharts/test/index.ts
+++ b/types/highcharts/test/index.ts
@@ -1631,12 +1631,18 @@ function test_Gauge() {
             type: 'gauge'
         },
         pane: {
+            center: ['50%', '85%'],
             startAngle: -150,
             endAngle: 150
         },
         yAxis: {
             min: 0,
-            max: 100
+            max: 100,
+            stops: [
+                [0.1, '#DF5353'],
+                [0.5, '#DDDF0D'],
+                [0.9, '#55BF3B'],
+            ],
         },
         plotOptions: {
             gauge: {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

With the current definitions I get the following error:
`Argument of type '{ chart: { type: string; }; title: any; pane: { center: string[]; size: string; startAngle: numbe...' is not assignable to parameter of type 'Options'.`
