### PR TITLE
iban - Fix incorrect function signatures, regarding the separator of printed formats

### DIFF
--- a/types/iban/iban-tests.ts
+++ b/types/iban/iban-tests.ts
@@ -39,7 +39,7 @@ function testIsValidBBAN() {
  */
 function testPrintFormat() {
     var iban: string = 'BE68539007547034';
-    var separator: string[] = ['fr'];
+    var separator: string = ' ';
     var format: string = IBAN.printFormat(iban, separator);
 }
 
@@ -48,6 +48,6 @@ function testPrintFormat() {
  */
 function testToBBAN() {
     var iban: string = 'BE68539007547034';
-    var separator: string[] = ['-'];
+    var separator: string = '-';
     var bban: string = IBAN.toBBAN(iban, separator);
 }

--- a/types/iban/index.d.ts
+++ b/types/iban/index.d.ts
@@ -42,17 +42,17 @@ interface IBANStatic {
     /** 
      * @summary Returns the IBAN in a print format.
      * @param {string} iban The IBAN to convert.
-     * @param {string} The IBAN in print format.
+     * @param {string} separator The separator to use between IBAN blocks, defaults to ' '.
      */
-    printFormat(iban: string, separator: string[]): string;
+    printFormat(iban: string, separator?: string): string;
 
     /**
      * @summary Convert the passed IBAN to a country-specific BBAN.
      * @param {string} iban The IBAN to convert.
-     * @param {string[]} Separator the separator to use between BBAN blocks.
+     * @param {string} separator The separator to use between BBAN blocks, defaults to ' '.
      * @returns {string} The BBAN
      */
-    toBBAN(iban: string, separator: string[]): string;
+    toBBAN(iban: string, separator?: string): string;
 }
 
 declare var IBAN: IBANStatic;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/arhs/iban.js/blob/master/iban.js#L359
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Here is the code for the two functions of iban@1.3.0:

```js
    /**
     * Convert an IBAN to a BBAN.
     *
     * @param iban
     * @param {String} [separator] the separator to use between the blocks of the BBAN, defaults to ' '
     * @returns {string|*}
     */
    exports.toBBAN = function(iban, separator){
        if (typeof separator == 'undefined'){
            separator = ' ';
        }
        iban = electronicFormat(iban);
        var countryStructure = countries[iban.slice(0,2)];
        if (!countryStructure) {
            throw new Error('No country with code ' + iban.slice(0,2));
        }
        return countryStructure.toBBAN(iban, separator);
    };

    exports.printFormat = function(iban, separator){
        if (typeof separator == 'undefined'){
            separator = ' ';
        }
        return electronicFormat(iban).replace(EVERY_FOUR_CHARS, "$1" + separator);
    };
```