### PR TITLE
[FIX] googlemaps

### DIFF
--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -392,8 +392,8 @@ declare namespace google.maps {
     export module Data {
         export interface DataOptions {
             controlPosition?: ControlPosition;
-            controls?: string[];
-            drawingMode?: string;
+            controls?: DrawingMode[];
+            drawingMode?: DrawingMode;
             featureFactory?: (geometry: Data.Geometry) => Data.Feature;
             map?: Map;
             style?: Data.StylingFunction|Data.StyleOptions;
@@ -1863,7 +1863,8 @@ declare namespace google.maps {
         getZIndex(): number;
         setMap(map: Map | null): void;
         setUrl(url: string): void;
-        setZIndez(zIndex: number): void;
+        setZIndex(zIndex: number): void;
+        setOptions(options: KmlLayerOptions): void;
     }
 
     export interface KmlLayerOptions {

--- a/types/googlemaps/index.d.ts
+++ b/types/googlemaps/index.d.ts
@@ -392,8 +392,8 @@ declare namespace google.maps {
     export module Data {
         export interface DataOptions {
             controlPosition?: ControlPosition;
-            controls?: DrawingMode[];
-            drawingMode?: DrawingMode;
+            controls?: DrawingMode[] | null;
+            drawingMode?: DrawingMode | null;
             featureFactory?: (geometry: Data.Geometry) => Data.Feature;
             map?: Map;
             style?: Data.StylingFunction|Data.StyleOptions;


### PR DESCRIPTION
- Update google.maps.Data.DataOptions.controls to use DrawingMode instead of string
- Update google.maps.Data.DataOptions.drawingMode to use DrawingMode instead of string
- Fix typo in KmlLayer (setZIndez -> setZIndex)
- Add setOptions to KmlLayer

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://developers.google.com/maps/documentation/javascript/reference/3/#Data>>
<<https://developers.google.com/maps/documentation/javascript/reference/3/#KmlLayer>>
