### PR TITLE
wicg-mediasession: Fixed errors in the interface definition of MediaSession.

### DIFF
--- a/types/wicg-mediasession/index.d.ts
+++ b/types/wicg-mediasession/index.d.ts
@@ -19,10 +19,10 @@ interface MediaSession {
   // Current media session playback state.
   playbackState: MediaSessionPlaybackState;
   // Current media session meta data.
-  metadata?: MediaMetadata|null;
+  metadata: MediaMetadata|null;
 
   // Set/Unset actions handlers.
-  setActionHandler(action: MediaSessionAction, listener?: () => void): void;
+  setActionHandler(action: MediaSessionAction, listener: (() => void)|null): void;
 }
 
 interface MediaImage {


### PR DESCRIPTION
Fixed errors in the interface definition of MediaSession. The "metadata" property is supposed to be nullable, but not optional. The second parameter of the "setActionHandler" method is also supposed to be nullable, but not optional.

https://wicg.github.io/mediasession/#the-mediasession-interface
https://heycam.github.io/webidl/#dfn-nullable-type

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://wicg.github.io/mediasession/#the-mediasession-interface https://heycam.github.io/webidl/#dfn-nullable-type
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
