### PR TITLE
Make network argument in ECPair.fromWIF method optional

### DIFF
--- a/types/bitcoinjs-lib/index.d.ts
+++ b/types/bitcoinjs-lib/index.d.ts
@@ -85,7 +85,7 @@ export class ECPair {
 
     static fromPublicKeyBuffer(buffer: Buffer, network: Network): ECPair;
 
-    static fromWIF(string: string, network: Network): ECPair;
+    static fromWIF(string: string, network?: Network): ECPair;
 
     static makeRandom(options?: { compressed?: boolean, network?: Network, rng?: Rng }): ECPair;
 }


### PR DESCRIPTION
I corrected the typing for ECPair.fromWIF method so that the network argument is optional as it really should

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) // I think no need to add test for such a small change. I ran the test and all passed.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>> // No need for docs for such a small change,  I just added a single character
- [x] Increase the version number in the header if appropriate. // Not appropriate for such a small change
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
