### PR TITLE
types/got: timeout can also be object, not just number

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -52,6 +52,20 @@ got('todomvc.com', {
     encoding: 'utf8',
     hostname: 'todomvc'
 }).then(response => str = response.body);
+got('todomvc.com', {
+    form: true,
+    body: [{}],
+    encoding: 'utf8',
+    hostname: 'todomvc',
+    timeout: 2000
+}).then(response => str = response.body);
+got('todomvc.com', {
+    form: true,
+    body: [{}],
+    encoding: 'utf8',
+    hostname: 'todomvc',
+    timeout: {connect: 20, request: 20, socket: 20}
+}).then(response => str = response.body);
 // following must lead to type checking error: got('todomvc.com', {form: true, body: ''}).then(response => str = response.body);
 
 got('todomvc.com', {encoding: null, hostname: 'todomvc'}).then(response => buf = response.body);

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -98,7 +98,11 @@ declare namespace got {
         json?: boolean;
     }
 
-    type GotOptions<E extends string | null> = http.RequestOptions & {
+    interface TimoutRequestOptions extends http.RequestOptions {
+        timeout?: any;
+    }
+
+    interface GotOptions<E extends string | null> extends TimoutRequestOptions {
         encoding?: E;
         query?: string | object;
         timeout?: number | TimeoutOptions;
@@ -106,7 +110,7 @@ declare namespace got {
         followRedirect?: boolean;
         decompress?: boolean;
         useElectronNet?: boolean;
-    };
+    }
 
     interface TimeoutOptions {
         connect?: number;


### PR DESCRIPTION
Hi maintainers, timeout can also take an object: https://github.com/sindresorhus/got#options

I'm not sure how we can accomplish this with type merging or interface extension.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.