### PR TITLE
webpack: Add hash options to config

### DIFF
--- a/types/webpack/index.d.ts
+++ b/types/webpack/index.d.ts
@@ -134,7 +134,7 @@ declare namespace webpack {
     }
 
     interface Output {
-        /** The output directory as absolute path (required). */
+        /** The output directory as absolute path. */
         path?: string;
         /** The filename of the entry chunk as relative path inside the output.path directory. */
         filename?: string;
@@ -190,8 +190,14 @@ declare namespace webpack {
         sourcePrefix?: string;
         /** This option enables cross-origin loading of chunks. */
         crossOriginLoading?: string | boolean;
+        /** The encoding to use when generating the hash, defaults to 'hex' */
+        hashDigest?: 'hex' | 'latin1' | 'base64';
+        /** The prefix length of the hash digest to use, defaults to 20. */
+        hashDigestLength?: number;
         /** Algorithm used for generation the hash (see node.js crypto package) */
         hashFunction?: string | ((algorithm: string, options?: any) => any);
+        /** An optional salt to update the hash via Node.JS' hash.update. */
+        hashSalt?: string;
         /** An expression which is used to address the global object/scope in runtime code. */
         globalObject?: string;
     }

--- a/types/webpack/v3/index.d.ts
+++ b/types/webpack/v3/index.d.ts
@@ -129,7 +129,7 @@ declare namespace webpack {
         /** The output directory as absolute path */
         path?: string;
         /** (Required) The filename of the entry chunk as relative path inside the output.path directory. */
-        filename: string;
+        filename?: string;
         /** The filename of non-entry chunks as relative path inside the output.path directory. */
         chunkFilename?: string;
         /** The filename of the SourceMaps for the JavaScript files. They are inside the output.path directory. */

--- a/types/webpack/v3/index.d.ts
+++ b/types/webpack/v3/index.d.ts
@@ -126,10 +126,10 @@ declare namespace webpack {
     }
 
     interface Output {
-        /** The output directory as absolute path (required). */
+        /** The output directory as absolute path */
         path?: string;
-        /** The filename of the entry chunk as relative path inside the output.path directory. */
-        filename?: string;
+        /** (Required) The filename of the entry chunk as relative path inside the output.path directory. */
+        filename: string;
         /** The filename of non-entry chunks as relative path inside the output.path directory. */
         chunkFilename?: string;
         /** The filename of the SourceMaps for the JavaScript files. They are inside the output.path directory. */
@@ -182,6 +182,14 @@ declare namespace webpack {
         sourcePrefix?: string;
         /** This option enables cross-origin loading of chunks. */
         crossOriginLoading?: string | boolean;
+        /** The encoding to use when generating the hash, defaults to 'hex' */
+        hashDigest?: 'hex' | 'latin1' | 'base64';
+        /** The prefix length of the hash digest to use, defaults to 20. */
+        hashDigestLength?: number;
+        /** Algorithm used for generation the hash (see node.js crypto package) */
+        hashFunction?: string | ((algorithm: string, options?: any) => any);
+        /** An optional salt to update the hash via Node.JS' hash.update. */
+        hashSalt?: string;
     }
 
     interface BaseModule {

--- a/types/webpack/webpack-tests.ts
+++ b/types/webpack/webpack-tests.ts
@@ -100,7 +100,9 @@ configuration = {
         path: path.join(__dirname, "assets", "[hash]"),
         publicPath: "assets/[hash]/",
         filename: "output.[hash].bundle.js",
-        chunkFilename: "[id].[hash].bundle.js"
+        chunkFilename: "[id].[hash].bundle.js",
+        hashFunction: 'sha256',
+        hashDigestLength: 64,
     }
 };
 


### PR DESCRIPTION
## Changes

Adds the following to webpack's options:

- [`hashDigest`](https://webpack.js.org/configuration/output/#output-hashdigest)
- [`hashDigestLength`](https://webpack.js.org/configuration/output/#output-hashdigestlength)
- [`hashSalt`](https://webpack.js.org/configuration/output/#output-hashsalt)

## PR State

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I have actually run both `npm test` and `npm run lint webpack`, but my setup is generating errors on the `master` branch with no changes, so I'm leaving them unmarked. I'm a bit baffled, and would like to see what the CI makes of this.