### PR TITLE
ui-grid: added defaultSort property to columnDef

### DIFF
--- a/types/ui-grid/index.d.ts
+++ b/types/ui-grid/index.d.ts
@@ -3545,6 +3545,8 @@ declare namespace uiGrid {
     export interface IGridColumnOf<TEntity> {
         /** Column definition */
         colDef: uiGrid.IColumnDefOf<TEntity>;
+        /** Default sort on this column */
+        defaultSort?: ISortInfo;
         /**
          * Column name that will be shown in the header.
          * If displayName is not provided then one is generated using the name.
@@ -3683,6 +3685,8 @@ declare namespace uiGrid {
          * @default false
          */
         cellTooltip?: boolean | string | ICellTooltipGetter<TEntity>;
+        /** Default object of sort information */
+        defaultSort?: ISortInfo;
         /**
          * Column name that will be shown in the header.
          * If displayName is not provided then one is generated using the name.

--- a/types/ui-grid/index.d.ts
+++ b/types/ui-grid/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for ui-grid
 // Project: http://www.ui-grid.info/
-// Definitions by: Ben Tesser <https://github.com/btesser>, Joe Skeen <https://github.com/joeskeen>
+// Definitions by: Ben Tesser <https://github.com/btesser>
+//                 Joe Skeen <https://github.com/joeskeen>
+//                 Peter Bojanczyk <https://github.com/pbojanczyk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/ui-grid/ui-grid-tests.ts
+++ b/types/ui-grid/ui-grid-tests.ts
@@ -22,6 +22,11 @@ columnDef.cellTooltip = 'blah';
 columnDef.cellTooltip = function (gridRow: uiGrid.IGridRow, gridCol: uiGrid.IGridColumn) {
     return `${gridRow.entity.unknownProperty}-${gridCol.displayName}`;
 };
+columnDef.defaultSort = {
+    direction: 'ASC',
+    ignoreSort: false,
+    priority: 1
+};
 columnDef.displayName = 'Jumper';
 columnDef.enableColumnMenu = false;
 columnDef.enableColumnMenus = false;


### PR DESCRIPTION
supporting ui-grid documentation: http://ui-grid.info/docs/#!/tutorial/324_default_sorting

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://ui-grid.info/docs/#!/tutorial/324_default_sorting
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
