### PR TITLE
[trash] export = instead of export default for module.exports

### DIFF
--- a/types/trash/index.d.ts
+++ b/types/trash/index.d.ts
@@ -9,4 +9,4 @@ interface TrashOptions {
 
 declare function trash(iterable: Iterable<string>, opts?: TrashOptions): Promise<void>;
 
-export default trash;
+export = trash;

--- a/types/trash/index.d.ts
+++ b/types/trash/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for trash 4.2
 // Project: https://github.com/sindresorhus/trash#readme
 // Definitions by: Matthew James <https://github.com/matthew-matvei>
+//                 Keiichiro Amemiya <https://github.com/hoishin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface TrashOptions {

--- a/types/trash/index.d.ts
+++ b/types/trash/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for trash 4.2
+// Type definitions for trash 4.3
 // Project: https://github.com/sindresorhus/trash#readme
 // Definitions by: Matthew James <https://github.com/matthew-matvei>
 //                 Keiichiro Amemiya <https://github.com/hoishin>

--- a/types/trash/trash-tests.ts
+++ b/types/trash/trash-tests.ts
@@ -1,4 +1,4 @@
-import trash from "trash";
+import trash = require("trash");
 
 async function testTrashNoArgs() {
     await trash(["/path/to/item1", "/path/to/item2"]);


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/sindresorhus/trash/blob/master/index.js#L10>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
