### PR TITLE
Added base64 and exif booleans to imagepicker options

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1435,6 +1435,8 @@ export namespace ImagePicker {
         aspect?: [number, number];
         quality?: number;
         mediaTypes?: keyof _MediaTypeOptions;
+        base64? boolean; 
+        exif? boolean;                       
     }
 
     function launchImageLibraryAsync(options?: ImageLibraryOptions): Promise<ImageResult>;


### PR DESCRIPTION
Added base64 and exif booleans to imagepicker options, as per docs 
https://docs.expo.io/versions/latest/sdk/imagepicker.html#base64-boolean--whether-to-also-include-the-image-data-in-base64-format

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.expo.io/versions/latest/sdk/imagepicker.html#base64-boolean--whether-to-also-include-the-image-data-in-base64-format>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
