### PR TITLE
[d3-axis and d3-format] activate strictNullChecks and strictFunctionTypes

### DIFF
--- a/types/d3-axis/d3-axis-tests.ts
+++ b/types/d3-axis/d3-axis-tests.ts
@@ -76,14 +76,14 @@ let leftAxis: d3Axis.Axis<number | { valueOf(): number }> = d3Axis.axisLeft(scal
 // scale(...) ----------------------------------------------------------------
 
 leftAxis = leftAxis.scale(scalePow());
-const powerScale: ScalePower<number, number> = leftAxis.scale<ScalePower<number, number>>();
+const powerScale: ScalePower<number, number> = leftAxis.scale() as ScalePower<number, number>;
 // powerScale = leftAxis.scale(); // fails, without casting as AxisScale is purposely  generic
 
 bottomAxis = bottomAxis.scale(scaleOrdinal<number>());
 // bottomAxis = bottomAxis.scale(scalePow()) // fails, domain of scale incompatible with domain of axis
 
 const axisScale: d3Axis.AxisScale<string> = bottomAxis.scale();
-const ordinalScale: ScaleOrdinal<string, number> = bottomAxis.scale<ScaleOrdinal<string, number>>();
+const ordinalScale: ScaleOrdinal<string, number> = bottomAxis.scale() as ScaleOrdinal<string, number>;
 // ordinalScale = bottomAxis.scale(); // fails, without casting as AxisScale is purposely  generic
 
 // ticks(...) ----------------------------------------------------------------

--- a/types/d3-axis/d3-axis-tests.ts
+++ b/types/d3-axis/d3-axis-tests.ts
@@ -153,11 +153,19 @@ const gTransition = gSelection.transition();
 gSelection.call(topAxis);
 gTransition.call(topAxis);
 
-const svgSelection: Selection<SVGSVGElement, any, any, any> = select<SVGSVGElement, any>('g');
+const svgSelection: Selection<SVGSVGElement, any, any, any> = select<SVGSVGElement, any>('svg');
 const svgTransition = svgSelection.transition();
 
 svgSelection.call(leftAxis);
 svgTransition.call(leftAxis);
+
+const pathSelection: Selection<SVGPathElement, any, any, any> = select<SVGPathElement, any>('path');
+const pathTransition = svgSelection.transition();
+
+// $ExpectError
+pathSelection.call(bottomAxis);
+// $ExpectError
+pathSelection.call(bottomAxis);
 
 const canvasSelection: Selection<HTMLCanvasElement, any, any, any> = select<HTMLCanvasElement, any>('canvas');
 const canvasTransition = canvasSelection.transition();
@@ -167,3 +175,30 @@ canvasSelection.call(rightAxis); // fails, incompatible context container elemen
 // $ExpectError
 canvasTransition.call(rightAxis); // fails, incompatible context container element
 
+// --------------------------------------------------------------------------
+// Strict Function Types
+// --------------------------------------------------------------------------
+
+interface Animal {
+    Die: () => void;
+}
+
+interface Dog extends Animal {
+    Bark: () => string;
+}
+
+declare let animalScale: d3Axis.AxisScale<Animal>;
+declare let dogScale: d3Axis.AxisScale<Dog>;
+
+// $ExpectError
+animalScale = dogScale;
+// $ExpectError
+dogScale = animalScale;
+
+declare let animalAxis: d3Axis.Axis<Animal>;
+declare let dogAxis: d3Axis.Axis<Dog>;
+
+// $ExpectError
+animalAxis = dogAxis;
+// $ExpectError
+dogAxis = animalAxis;

--- a/types/d3-axis/d3-axis-tests.ts
+++ b/types/d3-axis/d3-axis-tests.ts
@@ -78,18 +78,18 @@ let leftAxis: d3Axis.Axis<number | { valueOf(): number }> = d3Axis.axisLeft(scal
 // scale(...) ----------------------------------------------------------------
 
 leftAxis = leftAxis.scale(scalePow());
-const powerScale: ScalePower<number, number> = leftAxis.scale() as ScalePower<number, number>;
+const powerScale: ScalePower<number, number> = leftAxis.scale<ScalePower<number, number>>();
 // $ExpectError
-powerScale = leftAxis.scale(); // fails, without casting as AxisScale is purposely generic
+const powerScale2 = leftAxis.scale(); // fails, without casting as AxisScale is purposely generic
 
 bottomAxis = bottomAxis.scale(scaleOrdinal<number>());
 // $ExpectError
 bottomAxis = bottomAxis.scale(scalePow()); // fails, domain of scale incompatible with domain of axis
 
 const axisScale: d3Axis.AxisScale<string> = bottomAxis.scale();
-const ordinalScale: ScaleOrdinal<string, number> = bottomAxis.scale() as ScaleOrdinal<string, number>;
+const ordinalScale: ScaleOrdinal<string, number> = bottomAxis.scale<ScaleOrdinal<string, number>>();
 // $ExpectError
-ordinalScale = bottomAxis.scale(); // fails, without casting as AxisScale is purposely generic
+const ordinalScale2 = bottomAxis.scale(); // fails, without casting as AxisScale is purposely generic
 
 // ticks(...) ----------------------------------------------------------------
 
@@ -176,31 +176,3 @@ const canvasTransition = canvasSelection.transition();
 canvasSelection.call(rightAxis); // fails, incompatible context container element
 // $ExpectError
 canvasTransition.call(rightAxis); // fails, incompatible context container element
-
-// --------------------------------------------------------------------------
-// Strict Function Types
-// --------------------------------------------------------------------------
-
-interface Animal {
-    Die: () => void;
-}
-
-interface Dog extends Animal {
-    Bark: () => string;
-}
-
-declare let animalScale: d3Axis.AxisScale<Animal>;
-declare let dogScale: d3Axis.AxisScale<Dog>;
-
-// $ExpectError
-animalScale = dogScale;
-// $ExpectError
-dogScale = animalScale;
-
-declare let animalAxis: d3Axis.Axis<Animal>;
-declare let dogAxis: d3Axis.Axis<Dog>;
-
-// $ExpectError
-animalAxis = dogAxis;
-// $ExpectError
-dogAxis = animalAxis;

--- a/types/d3-axis/d3-axis-tests.ts
+++ b/types/d3-axis/d3-axis-tests.ts
@@ -47,6 +47,7 @@ axisScaleNumber = scaleBand<number>();
 axisScaleNumber = scalePoint<number>();
 axisScaleString = scaleBand();
 axisScaleString = scalePoint();
+
 // --------------------------------------------------------------------------
 // Test AxisContainerElement
 // --------------------------------------------------------------------------
@@ -123,6 +124,7 @@ const formatFn: ((domainValue: string, index: number) => string) | null = bottom
 
 bottomAxis.tickFormat((d, i) => '#' + i);
 bottomAxis.tickFormat(d => d + '!');
+
 // tickSize(...) ----------------------------------------------------------------
 
 rightAxis = rightAxis.tickSize(5);

--- a/types/d3-axis/d3-axis-tests.ts
+++ b/types/d3-axis/d3-axis-tests.ts
@@ -58,7 +58,8 @@ const canvas: HTMLCanvasElement = select<HTMLCanvasElement, any>('canvas').node(
 
 containerElement = svg;
 containerElement = g;
-// containerElement = canvas; // fails, incompatible type
+// $ExpectError
+containerElement = canvas; // fails, incompatible type
 
 // --------------------------------------------------------------------------
 // Test Axis Generators
@@ -77,14 +78,17 @@ let leftAxis: d3Axis.Axis<number | { valueOf(): number }> = d3Axis.axisLeft(scal
 
 leftAxis = leftAxis.scale(scalePow());
 const powerScale: ScalePower<number, number> = leftAxis.scale() as ScalePower<number, number>;
-// powerScale = leftAxis.scale(); // fails, without casting as AxisScale is purposely  generic
+// $ExpectError
+powerScale = leftAxis.scale(); // fails, without casting as AxisScale is purposely generic
 
 bottomAxis = bottomAxis.scale(scaleOrdinal<number>());
-// bottomAxis = bottomAxis.scale(scalePow()) // fails, domain of scale incompatible with domain of axis
+// $ExpectError
+bottomAxis = bottomAxis.scale(scalePow()); // fails, domain of scale incompatible with domain of axis
 
 const axisScale: d3Axis.AxisScale<string> = bottomAxis.scale();
 const ordinalScale: ScaleOrdinal<string, number> = bottomAxis.scale() as ScaleOrdinal<string, number>;
-// ordinalScale = bottomAxis.scale(); // fails, without casting as AxisScale is purposely  generic
+// $ExpectError
+ordinalScale = bottomAxis.scale(); // fails, without casting as AxisScale is purposely generic
 
 // ticks(...) ----------------------------------------------------------------
 
@@ -158,5 +162,8 @@ svgTransition.call(leftAxis);
 const canvasSelection: Selection<HTMLCanvasElement, any, any, any> = select<HTMLCanvasElement, any>('canvas');
 const canvasTransition = canvasSelection.transition();
 
-// canvasSelection.call(rightAxis); // fails, incompatible context container element
-// canvasTransition.call(rightAxis); // fails, incompatible context container element
+// $ExpectError
+canvasSelection.call(rightAxis); // fails, incompatible context container element
+// $ExpectError
+canvasTransition.call(rightAxis); // fails, incompatible context container element
+

--- a/types/d3-axis/index.d.ts
+++ b/types/d3-axis/index.d.ts
@@ -29,7 +29,7 @@ export interface AxisTimeInterval {
 
 /**
  * A helper interface to which a scale passed into axis must conform (at a minimum)
- * for axis to use the scale without error
+ * for axis to use the scale without error.
  */
 export interface AxisScale<Domain> {
     (x: Domain): number | undefined;
@@ -37,7 +37,7 @@ export interface AxisScale<Domain> {
     range(): number[];
     copy(): this;
     bandwidth?(): number;
-    // TODO: Reconsider the below, note that the compiler does not  differentiate the overloads w.r.t. optionality
+    // TODO: Reconsider the below, note that the compiler does not differentiate the overloads w.r.t. optionality
     // ticks?(count?: number): Domain[];
     // ticks?(count?: AxisTimeInterval): Date[];
     // tickFormat?(count?: number, specifier?: string): ((d: number) => string);
@@ -45,12 +45,12 @@ export interface AxisScale<Domain> {
 }
 
 /**
- * A helper type to alias elements which can serve as a container for an axis
+ * A helper type to alias elements which can serve as a container for an axis.
  */
 export type AxisContainerElement = SVGSVGElement | SVGGElement;
 
 /**
- * Interface defining an axis generator. The generic <Domain> is the type of the axis domain
+ * Interface defining an axis generator. The generic <Domain> is the type of the axis domain.
  */
 export interface Axis<Domain> {
     /**
@@ -75,7 +75,7 @@ export interface Axis<Domain> {
     /**
      * Sets the scale and returns the axis.
      *
-     * @param scale  The scale to be used for axis generation
+     * @param scale The scale to be used for axis generation.
      */
     scale(scale: AxisScale<Domain>): this;
 
@@ -86,7 +86,7 @@ export interface Axis<Domain> {
      *
      * This method is also a convenience function for axis.tickArguments.
      *
-     * @param count Number of ticks that should be rendered
+     * @param count Number of ticks that should be rendered.
      * @param specifier An optional format specifier to customize how the tick values are formatted.
      */
     ticks(count: number, specifier?: string): this;
@@ -178,7 +178,7 @@ export interface Axis<Domain> {
      *
      * See also axis.ticks.
      *
-     * @param args An array with arguments suitable for the scale to be used for tick generation
+     * @param args An array with arguments suitable for the scale to be used for tick generation.
      */
     tickArguments(args: any[]): this;
 
@@ -210,7 +210,7 @@ export interface Axis<Domain> {
     tickFormat(): ((domainValue: Domain, index: number) => string) | null;
 
     /**
-     *  Sets the tick format function and returns the axis.
+     * Sets the tick format function and returns the axis.
      *
      * @param format A function mapping a value from the axis Domain to a formatted string
      * for display purposes. When invoked, the format function is also passed a second argument representing the zero-based index
@@ -287,7 +287,7 @@ export interface Axis<Domain> {
     /**
      * Set the current padding and return the axis.
      *
-     * @param padding Padding in pixels  (Default is 3).
+     * @param padding Padding in pixels (Default is 3).
      */
     tickPadding(padding: number): this;
 }
@@ -296,7 +296,7 @@ export interface Axis<Domain> {
  * Constructs a new top-oriented axis generator for the given scale, with empty tick arguments,
  * a tick size of 6 and padding of 3. In this orientation, ticks are drawn above the horizontal domain path.
  *
- * @param scale The scale to be used for axis generation
+ * @param scale The scale to be used for axis generation.
  */
 export function axisTop<Domain>(scale: AxisScale<Domain>): Axis<Domain>;
 
@@ -304,7 +304,7 @@ export function axisTop<Domain>(scale: AxisScale<Domain>): Axis<Domain>;
  * Constructs a new right-oriented axis generator for the given scale, with empty tick arguments,
  * a tick size of 6 and padding of 3. In this orientation, ticks are drawn to the right of the vertical domain path.
  *
- * @param scale The scale to be used for axis generation
+ * @param scale The scale to be used for axis generation.
  */
 export function axisRight<Domain>(scale: AxisScale<Domain>): Axis<Domain>;
 
@@ -312,7 +312,7 @@ export function axisRight<Domain>(scale: AxisScale<Domain>): Axis<Domain>;
  * Constructs a new bottom-oriented axis generator for the given scale, with empty tick arguments,
  * a tick size of 6 and padding of 3. In this orientation, ticks are drawn below the horizontal domain path.
  *
- * @param scale The scale to be used for axis generation
+ * @param scale The scale to be used for axis generation.
  */
 export function axisBottom<Domain>(scale: AxisScale<Domain>): Axis<Domain>;
 
@@ -320,6 +320,6 @@ export function axisBottom<Domain>(scale: AxisScale<Domain>): Axis<Domain>;
  * Constructs a new left-oriented axis generator for the given scale, with empty tick arguments,
  * a tick size of 6 and padding of 3. In this orientation, ticks are drawn to the left of the vertical domain path.
  *
- * @param scale The scale to be used for axis generation
+ * @param scale The scale to be used for axis generation.
  */
 export function axisLeft<Domain>(scale: AxisScale<Domain>): Axis<Domain>;

--- a/types/d3-axis/index.d.ts
+++ b/types/d3-axis/index.d.ts
@@ -70,7 +70,7 @@ export interface Axis<Domain> {
     /**
      * Gets the current scale underlying the axis.
      */
-    scale<A extends AxisScale<Domain>>(): A;
+    scale(): AxisScale<Domain>;
 
     /**
      * Sets the scale and returns the axis.

--- a/types/d3-axis/index.d.ts
+++ b/types/d3-axis/index.d.ts
@@ -70,7 +70,7 @@ export interface Axis<Domain> {
     /**
      * Gets the current scale underlying the axis.
      */
-    scale(): AxisScale<Domain>;
+    scale<A extends AxisScale<Domain>>(): A;
 
     /**
      * Sets the scale and returns the axis.

--- a/types/d3-axis/index.d.ts
+++ b/types/d3-axis/index.d.ts
@@ -58,14 +58,14 @@ export interface Axis<Domain> {
      *
      * @param context A selection of SVG containers (either SVG or G elements).
      */
-    (context: Selection<AxisContainerElement, any, any, any>): void;
+    (context: Selection<SVGSVGElement, any, any, any> | Selection<SVGGElement, any, any, any>): void;
 
     /**
      * Render the axis to the given context.
      *
      * @param context A transition defined on SVG containers (either SVG or G elements).
      */
-    (context: TransitionLike<AxisContainerElement, any>): void;
+    (context: TransitionLike<SVGSVGElement, any> | TransitionLike<SVGGElement, any>): void;
 
     /**
      * Gets the current scale underlying the axis.

--- a/types/d3-axis/tsconfig.json
+++ b/types/d3-axis/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": false,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/d3-axis/tslint.json
+++ b/types/d3-axis/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "unified-signatures": false
+        "unified-signatures": false,
+        "no-unnecessary-generics": false
     }
 }

--- a/types/d3-axis/tslint.json
+++ b/types/d3-axis/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "dtslint/dt.json",
     "rules": {
-        "unified-signatures": false,
-        "no-unnecessary-generics": false
+        "unified-signatures": false
     }
 }

--- a/types/d3-format/d3-format-tests.ts
+++ b/types/d3-format/d3-format-tests.ts
@@ -45,12 +45,9 @@ formatFn = d3Format.formatPrefix(',.0', 1e-6);
 
 d3Format.format('.0%')(10);
 d3Format.format('.0%')(numeric);
-d3Format.format("$c")("☃");
 
 d3Format.formatPrefix(',.0', 1e-6)(10);
 d3Format.formatPrefix(',.0', 1e-6)(numeric);
-// $ExpectError
-d3Format.formatPrefix(',.0', 1e-6)("☃");
 
 // ----------------------------------------------------------------------
 // Test Format Specifier

--- a/types/d3-format/d3-format-tests.ts
+++ b/types/d3-format/d3-format-tests.ts
@@ -43,7 +43,7 @@ const symbol: '$' | '#' | '' = specifier.symbol;
 const zero: boolean = specifier.zero;
 const width: number | undefined = specifier.width;
 const comma: boolean = specifier.comma;
-const precision: number = specifier.precision;
+const precision: number | undefined = specifier.precision;
 const type: 'e' | 'f' | 'g' | 'r' | 's' | '%' | 'p' | 'b' | 'o' | 'd' | 'x' | 'X' | 'c' | '' | 'n' = specifier.type;
 
 const formatString: string = specifier.toString();

--- a/types/d3-format/d3-format-tests.ts
+++ b/types/d3-format/d3-format-tests.ts
@@ -12,6 +12,19 @@ import * as d3Format from 'd3-format';
 // Preparatory Steps
 // ----------------------------------------------------------------------
 
+class NumCoercible {
+  a: number;
+
+  constructor(a: number) {
+      this.a = a;
+  }
+  valueOf() {
+      return this.a;
+  }
+}
+
+const numeric: NumCoercible = new NumCoercible(10);
+
 let num: number;
 
 let formatFn: (n: number) => string;
@@ -29,6 +42,15 @@ let localeObj: d3Format.FormatLocaleObject;
 formatFn = d3Format.format('.0%');
 
 formatFn = d3Format.formatPrefix(',.0', 1e-6);
+
+d3Format.format('.0%')(10);
+d3Format.format('.0%')(numeric);
+d3Format.format("$c")("☃");
+
+d3Format.formatPrefix(',.0', 1e-6)(10);
+d3Format.formatPrefix(',.0', 1e-6)(numeric);
+// $ExpectError
+d3Format.formatPrefix(',.0', 1e-6)("☃");
 
 // ----------------------------------------------------------------------
 // Test Format Specifier

--- a/types/d3-format/index.d.ts
+++ b/types/d3-format/index.d.ts
@@ -29,7 +29,7 @@ export interface FormatLocaleDefinition {
     /**
      * An optional array of ten strings to replace the numerals 0-9.
      */
-    numerals?: [string, string, string, string, string, string, string, string, string, string];
+    numerals?: string[];
     /**
      * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%").
      */
@@ -47,7 +47,7 @@ export interface FormatLocaleObject {
      * @param specifier A Specifier string.
      * @throws Error on invalid format specifier.
      */
-    format(specifier: string): (n: { valueOf(): number; } | string) => string;
+    format(specifier: string): (n: number | { valueOf(): number }) => string;
 
     /**
      * Returns a new format function for the given string specifier. The returned function
@@ -59,7 +59,7 @@ export interface FormatLocaleObject {
      * @param value The reference value to determine the appropriate SI prefix.
      * @throws Error on invalid format specifier.
      */
-    formatPrefix(specifier: string, value: number): (n: { valueOf(): number; }) => string;
+    formatPrefix(specifier: string, value: number): (n: number | { valueOf(): number }) => string;
 }
 
 /**
@@ -178,7 +178,7 @@ export function formatDefaultLocale(defaultLocale: FormatLocaleDefinition): Form
  * @param specifier A Specifier string.
  * @throws Error on invalid format specifier.
  */
-export function format(specifier: string): (n: { valueOf(): number; } | string) => string;
+export function format(specifier: string): (n: number | { valueOf(): number }) => string;
 
 /**
  * Returns a new format function for the given string specifier. The returned function
@@ -195,7 +195,7 @@ export function format(specifier: string): (n: { valueOf(): number; } | string) 
  * @param value The reference value to determine the appropriate SI prefix.
  * @throws Error on invalid format specifier.
  */
-export function formatPrefix(specifier: string, value: number): (n: { valueOf(): number; }) => string;
+export function formatPrefix(specifier: string, value: number): (n: number | { valueOf(): number }) => string;
 
 /**
  * Parses the specified specifier, returning an object with exposed fields that correspond to the

--- a/types/d3-format/index.d.ts
+++ b/types/d3-format/index.d.ts
@@ -46,7 +46,7 @@ export interface FormatLocaleObject {
      *
      * @param specifier A Specifier string
      */
-    format(specifier: string): (n: number) => string;
+    format(specifier: string): (n: { valueOf(): number; } | string) => string;
 
     /**
      * Returns a new format function for the given string specifier. The returned function
@@ -57,7 +57,7 @@ export interface FormatLocaleObject {
      * @param specifier A Specifier string
      * @param value The reference value to determine the appropriate SI prefix.
      */
-    formatPrefix(specifier: string, value: number): (n: number) => string;
+    formatPrefix(specifier: string, value: number): (n: { valueOf(): number; }) => string;
 }
 
 /**
@@ -175,7 +175,7 @@ export function formatDefaultLocale(defaultLocale: FormatLocaleDefinition): Form
  *
  * @param specifier A Specifier string
  */
-export function format(specifier: string): (n: number) => string;
+export function format(specifier: string): (n: { valueOf(): number; } | string) => string;
 
 /**
  * Returns a new format function for the given string specifier. The returned function
@@ -191,7 +191,7 @@ export function format(specifier: string): (n: number) => string;
  * @param specifier A Specifier string
  * @param value The reference value to determine the appropriate SI prefix.
  */
-export function formatPrefix(specifier: string, value: number): (n: number) => string;
+export function formatPrefix(specifier: string, value: number): (n: { valueOf(): number; }) => string;
 
 /**
  * Parses the specified specifier, returning an object with exposed fields that correspond to the

--- a/types/d3-format/index.d.ts
+++ b/types/d3-format/index.d.ts
@@ -23,7 +23,7 @@ export interface FormatLocaleDefinition {
      */
     grouping: number[];
     /**
-     * The currency prefix and suffix (e.g., ["$", ""])
+     * The currency prefix and suffix (e.g., ["$", ""]).
      */
     currency: [string, string];
     /**
@@ -31,7 +31,7 @@ export interface FormatLocaleDefinition {
      */
     numerals?: string[];
     /**
-     * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%")
+     * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%").
      */
     percent?: string;
 }
@@ -44,7 +44,8 @@ export interface FormatLocaleObject {
      * Returns a new format function for the given string specifier. The returned function
      * takes a number as the only argument, and returns a string representing the formatted number.
      *
-     * @param specifier A Specifier string
+     * @param specifier A Specifier string.
+     * @throws Error on invalid format specifier.
      */
     format(specifier: string): (n: { valueOf(): number; } | string) => string;
 
@@ -54,8 +55,9 @@ export interface FormatLocaleObject {
      * The returned function will convert values to the units of the appropriate SI prefix for the
      * specified numeric reference value before formatting in fixed point notation.
      *
-     * @param specifier A Specifier string
+     * @param specifier A Specifier string.
      * @param value The reference value to determine the appropriate SI prefix.
+     * @throws Error on invalid format specifier.
      */
     formatPrefix(specifier: string, value: number): (n: { valueOf(): number; }) => string;
 }
@@ -71,7 +73,7 @@ export interface FormatSpecifier {
      */
     fill: string;
     /**
-     * Alignment used for format, as set by choosing one of the following
+     * Alignment used for format, as set by choosing one of the following:
      *
      * '>' - Forces the field to be right-aligned within the available space. (Default behavior).
      * '<' - Forces the field to be left-aligned within the available space.
@@ -83,9 +85,9 @@ export interface FormatSpecifier {
      * The sign can be:
      *
      * '-' - nothing for positive and a minus sign for negative. (Default behavior.)
-     * '+' -  a plus sign for positive and a minus sign for negative.
+     * '+' - a plus sign for positive and a minus sign for negative.
      * '(' - nothing for positive and parentheses for negative.
-     * ' '(space) -  a space for positive and a minus sign for negative.
+     * ' ' (space) - a space for positive and a minus sign for negative.
      *
      */
     sign: '-' | '+' | '(' | ' ';
@@ -94,7 +96,7 @@ export interface FormatSpecifier {
      *
      * '$' - apply currency symbols per the locale definition.
      * '#' - for binary, octal, or hexadecimal notation, prefix by 0b, 0o, or 0x, respectively.
-     * ''(none) - no symbol.
+     * '' (none) - no symbol. (Default behavior.)
      */
     symbol: '$' | '#' | '';
     /**
@@ -116,7 +118,7 @@ export interface FormatSpecifier {
      * it defaults to 6 for all types except '' (none), which defaults to 12.
      * Precision is ignored for integer formats (types 'b', 'o', 'd', 'x', 'X' and 'c').
      *
-     * See precisionFixed and precisionRound for help picking an appropriate precision
+     * See precisionFixed and precisionRound for help picking an appropriate precision.
      */
     precision: number | undefined;
     /**
@@ -137,7 +139,7 @@ export interface FormatSpecifier {
      * 'c' - converts the integer to the corresponding unicode character before printing.
      * '' (none) - like g, but trim insignificant trailing zeros.
      *
-     * The type 'n' is also supported as shorthand for ',g'. For the 'g', 'n' and ''(none) types,
+     * The type 'n' is also supported as shorthand for ',g'. For the 'g', 'n' and '' (none) types,
      * decimal notation is used if the resulting string would have precision or fewer digits; otherwise, exponent notation is used.
      */
     type: 'e' | 'f' | 'g' | 'r' | 's' | '%' | 'p' | 'b' | 'o' | 'd' | 'x' | 'X' | 'c' | '' | 'n';
@@ -173,7 +175,8 @@ export function formatDefaultLocale(defaultLocale: FormatLocaleDefinition): Form
  * The general form of a specifier is [[fill]align][sign][symbol][0][width][,][.precision][type].
  * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
  *
- * @param specifier A Specifier string
+ * @param specifier A Specifier string.
+ * @throws Error on invalid format specifier.
  */
 export function format(specifier: string): (n: { valueOf(): number; } | string) => string;
 
@@ -183,13 +186,14 @@ export function format(specifier: string): (n: { valueOf(): number; } | string) 
  * The returned function will convert values to the units of the appropriate SI prefix for the
  * specified numeric reference value before formatting in fixed point notation.
  *
- *  Uses the current default locale.
+ * Uses the current default locale.
  *
  * The general form of a specifier is [[fill]align][sign][symbol][0][width][,][.precision][type].
  * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
  *
- * @param specifier A Specifier string
+ * @param specifier A Specifier string.
  * @param value The reference value to determine the appropriate SI prefix.
+ * @throws Error on invalid format specifier.
  */
 export function formatPrefix(specifier: string, value: number): (n: { valueOf(): number; }) => string;
 
@@ -201,6 +205,7 @@ export function formatPrefix(specifier: string, value: number): (n: { valueOf():
  * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
  *
  * @param specifier A specifier string.
+ * @throws Error on invalid format specifier.
  */
 export function formatSpecifier(specifier: string): FormatSpecifier;
 

--- a/types/d3-format/index.d.ts
+++ b/types/d3-format/index.d.ts
@@ -29,7 +29,7 @@ export interface FormatLocaleDefinition {
     /**
      * An optional array of ten strings to replace the numerals 0-9.
      */
-    numerals?: string[];
+    numerals?: [string, string, string, string, string, string, string, string, string, string];
     /**
      * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%").
      */

--- a/types/d3-format/index.d.ts
+++ b/types/d3-format/index.d.ts
@@ -118,7 +118,7 @@ export interface FormatSpecifier {
      *
      * See precisionFixed and precisionRound for help picking an appropriate precision
      */
-    precision: number;
+    precision: number | undefined;
     /**
      * The available type values are:
      *

--- a/types/d3-format/tsconfig.json
+++ b/types/d3-format/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/d3-format/tslint.json
+++ b/types/d3-format/tslint.json
@@ -1,3 +1,1 @@
-{
-    "extends": "dtslint/dt.json"
-}
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
In this PR, I activated strictFunctionTypes in d3-axis. To get it work I also needed to update d3-format.

In d3-format:
- Activate strictNullChecks in d3-format, just needed to change FormatSpecifier#precision.
- Use type `{ valueOf(): number; }` in `format` and `formatPrefix`.
- Function `format` can take a string, see [format-type-c-test.js](https://github.com/d3/d3-format/blob/master/test/format-type-c-test.js).
- Add `@throws` in JsDoc.

In d3-axis:
- Remove `"unified-signatures": false` from `tslint.json`.
- Use `$ExpectError` for failing tests.
- Activate strictFunctionTypes in d3-axis: change `Selection<SVGSVGElement | SVGGElement, any, any, any>` by `Selection<SVGSVGElement, any, any, any> | Selection<SVGGElement, any, any, any>`.

I add a test for `strictFunctionTypes`. Not sure if it is the best way to do it. Also CI build fail for them because some `$ExpectError` lines are not detected as failing. I'm wondering if `dtslint` test the code with [TS 2.7](https://github.com/Microsoft/definitelytyped-header-parser/blob/master/index.ts#L13) or not.

Finally, I don't think any new features from TS 2.3 may improve those definitions. So I kept the minimum version to 2.0.

Related: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23611.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [d3-format](https://github.com/d3/d3-format/blob/master/README.md) and [d3-axis](https://github.com/d3/d3-axis/blob/master/README.md)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
