### PR TITLE
Expo - Included result.type, base64, exif in ImageLibrary API as per docs

### DIFF
--- a/types/expo/expo-tests.tsx
+++ b/types/expo/expo-tests.tsx
@@ -289,14 +289,37 @@ async () => {
 };
 
 async () => {
+    // Video test
     const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Videos
+        mediaTypes: ImagePicker.MediaTypeOptions.Videos,
     });
 
     if (!result.cancelled) {
         result.uri;
         result.width;
         result.height;
+        result.duration;
+        result.type;
+    }
+};
+
+async () => {
+    // Image test
+    const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        base64: true,
+        aspect: [4, 3],
+        quality: 1,
+        exif: true,
+    });
+
+    if (!result.cancelled) {
+        result.uri;
+        result.width;
+        result.height;
+        result.exif;
+        result.base64;
+        result.type;
     }
 };
 

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1418,6 +1418,10 @@ export namespace ImagePicker {
         uri: string;
         width: number;
         height: number;
+        type: 'video' | 'image';
+        base64?: string;
+        exif?: object;
+        duration?: number;
     }
 
     type ImageResult = { cancelled: true } | ({ cancelled: false } & ImageInfo);
@@ -1434,6 +1438,8 @@ export namespace ImagePicker {
         allowsEditing?: boolean;
         aspect?: [number, number];
         quality?: number;
+        base64?: boolean;
+        exif?: boolean;
         mediaTypes?: keyof _MediaTypeOptions;
     }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://docs.expo.io/versions/latest/sdk/imagepicker.html#base64-boolean--whether-to-also-include-the-image-data-in-base64-format-1>>
- [x] Increase the version number in the header if appropriate.