### PR TITLE
[react] Add suppressHydrationWarning to React.HTMLAttributes interface

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React 16.0
+// Type definitions for React 16.1
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>
 //                 AssureSign <http://www.assuresign.com>

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -2450,6 +2450,7 @@ declare namespace React {
         defaultChecked?: boolean;
         defaultValue?: string | string[];
         suppressContentEditableWarning?: boolean;
+        suppressHydrationWarning?: boolean;
 
         // Standard HTML Attributes
         accessKey?: string;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -37,6 +37,7 @@ StatelessComponent2.defaultProps = {
     defaultValue="some value"
     contentEditable
     suppressContentEditableWarning
+    suppressHydrationWarning
 >
     <b>foo</b>
 </div>;


### PR DESCRIPTION
Add support for the `suppressHydrationWarning` attribute that was added in React v16.1.0 (see https://github.com/facebook/react/releases/tag/v16.1.0), and bump minor version from 16.0 to 16.1.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/dom-elements.html#suppresshydrationwarning
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
