### PR TITLE
@types/redux-form FieldArray type fix

### DIFF
--- a/types/redux-form/lib/FieldArray.d.ts
+++ b/types/redux-form/lib/FieldArray.d.ts
@@ -1,9 +1,9 @@
 import { Component, ComponentType } from "react";
 import { Validator } from "../index";
 
-interface BaseFieldArrayProps<P = {}> {
+interface BaseFieldArrayProps<FieldValue, P = {}> {
     name: string;
-    component: ComponentType<P>;
+    component: ComponentType<WrappedFieldArrayProps<FieldValue> & P>;
     validate?: Validator | Validator[];
     warn?: Validator | Validator[];
     withRef?: boolean;
@@ -11,20 +11,20 @@ interface BaseFieldArrayProps<P = {}> {
     rerenderOnEveryChange?: boolean;
 }
 
-export interface GenericFieldArray<Field, P = {}> extends Component<BaseFieldArrayProps<P> & P> {
+export interface GenericFieldArray<Field, P = {}> extends Component<BaseFieldArrayProps<Field, P> & P> {
     name: string;
     valid: boolean;
     getRenderedComponent(): Component<WrappedFieldArrayProps<Field> & P>;
 }
 
-export class FieldArray<P = {}> extends Component<BaseFieldArrayProps<P> & P> implements GenericFieldArray<any, P> {
+export class FieldArray<FieldValue, P = {}> extends Component<BaseFieldArrayProps<FieldValue, P> & P> implements GenericFieldArray<FieldValue, P> {
     name: string;
     valid: boolean;
-    getRenderedComponent(): Component<WrappedFieldArrayProps<any> & P>;
+    getRenderedComponent(): Component<WrappedFieldArrayProps<FieldValue> & P>;
 }
 
 interface WrappedFieldArrayProps<FieldValue> {
-    fields: FieldsProps<FieldValue>;
+    fields: FieldsProps<FieldValue & any>;
     meta: FieldArrayMetaProps;
 }
 


### PR DESCRIPTION
Closes #23592. See issue for more details about the issue.

Authors: @CarsonF @aikoven @LKay @bancek @alsiola @tehbi4 @huwmartin
Issue contributors: @n06rin @lukx @mattdell @henrikra

Regarding this solution: I'm not entirely sure if this solution is 100% correct. Especially the `fields: FieldsProps<FieldValue & any>` change feels very suspicious. Can someone look whether this is the correct solution or if we can avoid the `& any` in some way (because I wasn't able to...)?