### PR TITLE
[@types/twit] change Response type to 'any'

### DIFF
--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -259,7 +259,7 @@ declare module 'twit' {
       lat?: number,
       long?: number,
       follow?: boolean,
-      include_email?: boolean
+      include_email?: boolean,
     }
     export interface PromiseResponse {
       data: Response,

--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -260,6 +260,7 @@ declare module 'twit' {
       long?: number,
       follow?: boolean,
       include_email?: boolean,
+      cursor?: number
     }
     export interface PromiseResponse {
       data: Response,

--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -224,7 +224,7 @@ declare module 'twit' {
       }
     }
 
-    export type Response = object
+    export type Response = any
 
     interface MediaParam {
       file_path: string
@@ -259,8 +259,7 @@ declare module 'twit' {
       lat?: number,
       long?: number,
       follow?: boolean,
-      include_email?: boolean,
-      cursor?: number
+      include_email?: boolean
     }
     export interface PromiseResponse {
       data: Response,

--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -224,7 +224,7 @@ declare module 'twit' {
       }
     }
 
-    export type Response = object
+    export type Response = any
 
     interface MediaParam {
       file_path: string

--- a/types/twit/index.d.ts
+++ b/types/twit/index.d.ts
@@ -224,7 +224,7 @@ declare module 'twit' {
       }
     }
 
-    export type Response = any
+    export type Response = object
 
     interface MediaParam {
       file_path: string


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/axios/axios/blob/master/index.d.ts#L52>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

The 'object' type is causing an issue with the noImplicitAny option. Changing to the type 'any' resolves the issue. Axios defaults to the 'any' type in the response, so I took it from there. Ideally the approach in Axios could be implemented fully but it's a bigger task and this fixes the issue with a minor change.
