### PR TITLE
[recharts] Updates dataKey type to allow functions in Lines and Tooltips

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -401,7 +401,7 @@ export interface LineProps extends EventAttributes, Partial<PresentationAttribut
     left?: number;
     width?: number;
     height?: number;
-    dataKey: string | number; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
+    dataKey: DataKey; // As the source code states, dataKey will replace valueKey in 1.1.0 and it'll be required (it's already required in current implementation).
     label?: boolean | object | React.ReactElement<any> | LabelProps['content'];
     points?: Point[];
 }
@@ -782,7 +782,7 @@ export interface TooltipPayload {
     unit?: string;
     color?: string;
     fill?: string;
-    dataKey?: string;
+    dataKey?: DataKey;
     formatter?: TooltipFormatter;
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
  - [Documentation](http://recharts.org/#/en-US/api/Line) > see `dataKey`
  - The `TooltipPayload` props are a bit harder to track down because they are computed around [here](https://github.com/recharts/recharts/blob/master/src/chart/generateCategoricalChart.js#L554). But this change makes `dataKey` consistent across all type definitions
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
