### PR TITLE
declare so you can now do the required 'new VRFrameData()'

### DIFF
--- a/types/webvr-api/index.d.ts
+++ b/types/webvr-api/index.d.ts
@@ -162,6 +162,11 @@ interface VRFrameData {
     readonly timestamp: number;
 }
 
+declare var VRFrameData: {
+    prototype: VRFrameData
+    new(): VRFrameData
+}
+
 interface VRPose {
     readonly angularAcceleration: Float32Array | null;
     readonly angularVelocity: Float32Array | null;


### PR DESCRIPTION
This enable you to create a new VRFrameData object for use with the getFrameData call.

```
var frameData = new VRFrameData();
vrDisplay.getFrameData(frameData);
```