### PR TITLE
Prop `label` is a valid property on the component ReferenceLine

### DIFF
--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -652,6 +652,7 @@ export interface ReferenceDotProps extends EventAttributes, Partial<Presentation
     y?: number | string;
     xAxisId?: string | number;
     yAxisId?: string | number;
+    label?: string | number;
     shape?: ContentRenderer<
         EventAttributes
         & Partial<PresentationAttributes<number | string, number | string>>


### PR DESCRIPTION
The ReferenceLine component can have a `label` prop, as exampled here: http://recharts.org/#/en-US/api/ReferenceLine

Please fill in this template.

- [*] Use a meaningful title for the pull request. Include the name of the package modified.
- [*] Test the change in your own code. (Compile and run.)
- [] Add or edit tests to reflect the change. (Run with `npm test`.)
- [*] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [*] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [*] Provide a URL to documentation or source code which provides context for the suggested changes: http://recharts.org/#/en-US/api/ReferenceLine
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
