### PR TITLE
[hapi] Fix: Make server.app non-optional

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2586,7 +2586,7 @@ export interface ServerInjectOptions extends Shot.RequestOptions {
     /**
      * sets the initial value of request.app, defaults to {}.
      */
-    app?: ApplicationState;
+    app: ApplicationState;
     /**
      * sets the initial value of request.plugins, defaults to {}.
      */
@@ -3257,7 +3257,7 @@ export class Server extends Podium {
      * Initialized with an empty object.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverapp)
      */
-    app?: ApplicationState;
+    app: ApplicationState;
 
     /**
      * Server Auth: properties and methods

--- a/types/hapi/test/server/server-app.ts
+++ b/types/hapi/test/server/server-app.ts
@@ -6,20 +6,20 @@ const options: ServerOptions = {
 };
 
 declare module "hapi" {
-	// Demonstrate augmenting the application state.
-	interface ApplicationState {
-		key?: string;
-	}
+    // Demonstrate augmenting the application state.
+    interface ApplicationState {
+        key?: string;
+    }
 }
 
 const server = new Server(options);
-server.app!.key = 'value2';
+server.app.key = 'value2';
 
 const serverRoute: ServerRoute = {
     path: '/',
     method: 'GET',
     handler(request, h) {
-        return 'key: ' + request.server.app!.key;
+        return 'key: ' + request.server.app.key;
     }
 };
 

--- a/types/hapi/test/server/server-table.ts
+++ b/types/hapi/test/server/server-table.ts
@@ -6,7 +6,7 @@ const options: ServerOptions = {
 };
 
 const server = new Server(options);
-server.app!.key = 'value2';
+server.app.key = 'value2';
 
 server.route({
     path: '/',


### PR DESCRIPTION
`server.app` is initialized with an empty object as documented in [Hapi api](https://hapijs.com/api#-serverapp).

This pull request changes `server.app`'s definition from optional to non-optional.
