### PR TITLE
mysql: added optional 'values' to QueryOptions

### DIFF
--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -244,7 +244,7 @@ export interface QueryOptions {
     /**
      * Values for template query
      */
-    values: any;
+    values?: any;
 
     /**
      * Every operation takes an optional inactivity timeout option. This allows you to specify appropriate timeouts for

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by:  William Johnston <https://github.com/wjohnsto>
 // 	                Kacper Polak <https://github.com/kacepe>
 // 	                Krittanan Pingclasai <https://github.com/kpping>
+// 	                James Munro <https://github.com/jdmunro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 

--- a/types/mysql/index.d.ts
+++ b/types/mysql/index.d.ts
@@ -241,6 +241,11 @@ export interface QueryOptions {
     sql: string;
 
     /**
+     * Values for template query
+     */
+    values: any;
+
+    /**
      * Every operation takes an optional inactivity timeout option. This allows you to specify appropriate timeouts for
      * operations. It is important to note that these timeouts are not part of the MySQL protocol, and rather timeout
      * operations through the client. This means that when a timeout is reached, the connection it occurred on will be

--- a/types/mysql/mysql-tests.ts
+++ b/types/mysql/mysql-tests.ts
@@ -423,6 +423,9 @@ connection.query({
     }
 });
 
+connection.query({sql: '...', values: ['test']}, (err: Error, results: any) => {
+});
+
 connection = mysql.createConnection("mysql://localhost/test?flags=-FOUND_ROWS");
 connection = mysql.createConnection({debug: true});
 connection = mysql.createConnection({debug: ['ComQueryPacket', 'RowDataPacket']});


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mysqljs/mysql/blob/96fdd0566b654436624e2375c7b6604b1f50f825/lib/protocol/sequences/Query.js#L15
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I spotted this when using the types in my project. Here's an example from the official documentation:

```js
connection.query({
  sql: 'SELECT * FROM `books` WHERE `author` = ?',
  timeout: 40000,
  values: ['David'] // values is part of the query options
}, function (error, results, fields) {
  // error will be an Error if one occurred during the query
  // results will contain the results of the query
  // fields will contain information about the returned results fields (if any)
});
```

Also referenced in the source code here: https://github.com/mysqljs/mysql/blob/96fdd0566b654436624e2375c7b6604b1f50f825/lib/protocol/sequences/Query.js#L15
