### PR TITLE
Enforce package.json checkout with LF line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Checkout NPM package files with forced LF lineendings
+# to prevent git conflicts when running npm commands
+package.json text eol=lf
+package-lock.json text eol=lf


### PR DESCRIPTION
NPM always touches the `package.json` file when running commands like `npm install`. On Windows this causes git to show pending changes even if the `package.json` has not been changed.

This issue occurs because NPM will write back the contents of `package.json` with LF line-endings, while git by default will checkout files with Windows-common CRLF line-endings.

Adding appropiate directives in the `.gitattributes` file should fix this.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).