### PR TITLE
knockout: Typeof T is still valid for isObservable / isWriteableObservable

### DIFF
--- a/types/knockout/index.d.ts
+++ b/types/knockout/index.d.ts
@@ -444,10 +444,10 @@ interface KnockoutStatic {
     toJS(viewModel: any): any;
 
     isObservable(instance: any): instance is KnockoutObservable<any>;
-    isObservable<T>(instance: KnockoutObservable<T>): instance is KnockoutObservable<T>;
+    isObservable<T>(instance: KnockoutObservable<T> | T): instance is KnockoutObservable<T>;
 
     isWriteableObservable(instance: any): instance is KnockoutObservable<any>;
-    isWriteableObservable<T>(instance: KnockoutObservable<T>): instance is KnockoutObservable<T>;
+    isWriteableObservable<T>(instance: KnockoutObservable<T> | T): instance is KnockoutObservable<T>;
 
     isComputed(instance: any): instance is KnockoutComputed<any>;
     isComputed<T>(instance: KnockoutObservable<T> | T): instance is KnockoutComputed<T>;


### PR DESCRIPTION
The change from #23478 breaks existing code because T is still a valid input for isObservable/isWriteableObservable.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X]  Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23478/files 
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
