### PR TITLE
stylus: fix incorrect method signature

### DIFF
--- a/types/stylus/index.d.ts
+++ b/types/stylus/index.d.ts
@@ -1190,7 +1190,7 @@ declare namespace Stylus {
             /**
              * Merges this query list with the `other`.
              */
-            merge(other: MediaQueryList): MediaQueryList;
+            merge(other: QueryList): QueryList;
 
             /**
              * Return a JSON representation of this node.


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/stylus/stylus/blob/63e0cbece8de572c1e80ef1f50b967c87fadd97d/lib/nodes/query-list.js#L68-L78
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

---

This PR includes a minor change to a method signature to correct an incorrect and missing type.

The current definition results in the following error in a project:
```
node_modules/@types/stylus/index.d.ts(1193,26): error TS2304: Cannot find name 'MediaQueryList'.
node_modules/@types/stylus/index.d.ts(1193,43): error TS2304: Cannot find name 'MediaQueryList'.
```

The following linked method definition mentions `MediaQueryList`, but that type is not present in the file, nor is it imported. It appears to have meant to reference `QueryList`, which is the class this method is contained within (merge another QueryList with this QueryList).

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/80c15edab765cb175b1fa96e18a331faa65b3d1f/types/stylus/index.d.ts#L1190-L1193