### PR TITLE
Removed undefined method for NightmareJS

### DIFF
--- a/types/nightmare/index.d.ts
+++ b/types/nightmare/index.d.ts
@@ -12,7 +12,6 @@ declare class Nightmare {
     constructor(options?: Nightmare.IConstructorOptions);
 
     // Interact
-    // userAgent(agent: string): Nightmare;
     end(): Nightmare;
     then<T, R>(fn: (value: T) => R): Promise<R>;
     halt(error: string, cb: () => void): Nightmare;

--- a/types/nightmare/index.d.ts
+++ b/types/nightmare/index.d.ts
@@ -12,7 +12,7 @@ declare class Nightmare {
     constructor(options?: Nightmare.IConstructorOptions);
 
     // Interact
-    userAgent(agent: string): Nightmare;
+    // userAgent(agent: string): Nightmare;
     end(): Nightmare;
     then<T, R>(fn: (value: T) => R): Promise<R>;
     halt(error: string, cb: () => void): Nightmare;


### PR DESCRIPTION
`userAgent()` isnt defined on type Nightmare in the JS version according to the error below. `useragent()` is defined and is probably what people want to use.
```
TypeError: nightmare.userAgent is not a function
    at login (/home/noah/Go/src/github.com/Strum355/UserBenchmark-Scraper/typescript/js/main.js:31:14)
    at Object.<anonymous> (/home/noah/Go/src/github.com/Strum355/UserBenchmark-Scraper/typescript/js/main.js:12:5)
    at Module._compile (module.js:649:30)
    at Object.Module._extensions..js (module.js:660:10)
    at Module.load (module.js:561:32)
    at tryModuleLoad (module.js:501:12)
    at Function.Module._load (module.js:493:3)
    at Function.Module.runMain (module.js:690:10)
    at startup (bootstrap_node.js:194:16)
    at bootstrap_node.js:666:3
```

