### PR TITLE
BackHandlerStatic returns NativeEventSubscription

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6550,7 +6550,7 @@ export interface BackAndroidStatic {
  */
 export interface BackHandlerStatic {
     exitApp(): void;
-    addEventListener(eventName: BackPressEventName, handler: () => void): void;
+    addEventListener(eventName: BackPressEventName, handler: () => void): NativeEventSubscription;
     removeEventListener(eventName: BackPressEventName, handler: () => void): void;
 }
 

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -17,6 +17,7 @@ import {
     AppState,
     AppStateIOS,
     BackAndroid,
+    BackHandler,
     Button,
     DataSourceAssetCallback,
     DeviceEventEmitterStatic,
@@ -72,6 +73,8 @@ function testDimensions() {
     Dimensions.addEventListener('change', dimensionsListener);
     Dimensions.removeEventListener('change', dimensionsListener);
 }
+
+BackHandler.addEventListener("hardwareBackPress", () => {}).remove();
 
 BackAndroid.addEventListener("hardwareBackPress", () => {});
 


### PR DESCRIPTION
BackHandler.addEventListener returns NativeEventSubscription. This can be confirmed in https://github.com/facebook/react-native/blob/26684cf3adf4094eb6c405d345a75bf8c7c0bf88/Libraries/Utilities/BackHandler.ios.js#L84