### PR TITLE
js-yaml: more strict loader return types

### DIFF
--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -28,8 +28,12 @@ export class Schema implements SchemaDefinition {
 	static create(schemas: Schema[] | Schema, types: Type[] | Type): Schema;
 }
 
-export function safeLoadAll(str: string, iterator?: (doc: any) => void, opts?: LoadOptions): DocumentLoadResult[] | undefined;
-export function loadAll(str: string, iterator?: (doc: any) => void, opts?: LoadOptions): DocumentLoadResult[] | undefined;
+export function safeLoadAll(str: string, iterator?: undefined, opts?: LoadOptions): DocumentLoadResult[];
+export function safeLoadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): undefined;
+
+export function loadAll(str: string, iterator?: undefined, opts?: LoadOptions): DocumentLoadResult[];
+
+export function loadAll(str: string, iterator: (doc: any) => void, opts?: LoadOptions): undefined;
 
 export function safeDump(obj: any, opts?: DumpOptions): string;
 export function dump(obj: any, opts?: DumpOptions): string;

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -4,8 +4,10 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
-export function safeLoad(str: string, opts?: LoadOptions): any;
-export function load(str: string, opts?: LoadOptions): any;
+export type DocumentLoadResult = object | undefined;
+
+export function safeLoad(str: string, opts?: LoadOptions): DocumentLoadResult;
+export function load(str: string, opts?: LoadOptions): DocumentLoadResult;
 
 export class Type {
 	constructor(tag: string, opts?: TypeConstructorOptions);
@@ -26,8 +28,8 @@ export class Schema implements SchemaDefinition {
 	static create(schemas: Schema[] | Schema, types: Type[] | Type): Schema;
 }
 
-export function safeLoadAll(str: string, iterator?: (doc: any) => void, opts?: LoadOptions): any;
-export function loadAll(str: string, iterator?: (doc: any) => void, opts?: LoadOptions): any;
+export function safeLoadAll(str: string, iterator?: (doc: any) => void, opts?: LoadOptions): DocumentLoadResult[] | undefined;
+export function loadAll(str: string, iterator?: (doc: any) => void, opts?: LoadOptions): DocumentLoadResult[] | undefined;
 
 export function safeDump(obj: any, opts?: DumpOptions): string;
 export function dump(obj: any, opts?: DumpOptions): string;

--- a/types/js-yaml/index.d.ts
+++ b/types/js-yaml/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for js-yaml 3.10
+// Type definitions for js-yaml 3.11
 // Project: https://github.com/nodeca/js-yaml
 // Definitions by: Bart van der Schoor <https://github.com/Bartvds>, Sebastian Clausen <https://github.com/sclausen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/js-yaml/js-yaml-tests.ts
+++ b/types/js-yaml/js-yaml-tests.ts
@@ -109,40 +109,44 @@ type.styleAliases;
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-// $ExpectType any
+// $ExpectType DocumentLoadResult
 yaml.safeLoad(str);
-// $ExpectType any
+// $ExpectType DocumentLoadResult
 yaml.safeLoad(str, loadOpts);
 
-// $ExpectType any
+// $ExpectType DocumentLoadResult
 yaml.load(str);
-// $ExpectType any
+// $ExpectType DocumentLoadResult
 yaml.load(str, loadOpts);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-// $ExpectType any
+// $ExpectType DocumentLoadResult[]
 yaml.safeLoadAll(str);
-// $ExpectType any
+
+// $ExpectType undefined
 yaml.safeLoadAll(str, (doc) => {
 	value = doc;
 });
-// $ExpectType any
+// $ExpectType undefined
 yaml.safeLoadAll(str, (doc) => {
 	value = doc;
 }, loadOpts);
+// $ExpectType DocumentLoadResult[]
 value = yaml.safeLoadAll(str, undefined, loadOpts);
 
-// $ExpectType any
+// $ExpectType DocumentLoadResult[]
 value = yaml.loadAll(str);
-// $ExpectType any
+
+// $ExpectType undefined
 yaml.loadAll(str, (doc) => {
 	value = doc;
 });
-// $ExpectType any
+// $ExpectType undefined
 yaml.loadAll(str, (doc) => {
 	value = doc;
 }, loadOpts);
+// $ExpectType DocumentLoadResult[]
 value = yaml.loadAll(str, undefined, loadOpts);
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

**If changing an existing definition:**

- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - https://github.com/nodeca/js-yaml#safeload-string---options-
  - https://github.com/nodeca/js-yaml/blob/573ba47ba1a70b56ae0e60e04ed23164f0c05341/lib/js-yaml/loader.js#L1573
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

**Rationale:**

A typescript consumer should be responsible for typing the output of `load()`, `safeLoad()`, etc. However, with the current `any` return type, it's easy for the user to assume that these methods always return an object or an array of objects. With this fix, TS will now warn if the user defines their own return type without handling for `undefined`.