### PR TITLE
Remove "Office.cast.item", since it's not useful in TypeScript

### DIFF
--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -1666,18 +1666,6 @@ declare namespace Office {
             Beta
         }
     }
-    export module cast {
-        export module item {
-            function toAppointmentCompose(item: Office.Item): Office.AppointmentCompose;
-            function toAppointmentRead(item: Office.Item): Office.AppointmentRead;
-            function toAppointment(item: Office.Item): Office.Appointment;
-            function toMessageCompose(item: Office.Item): Office.MessageCompose;
-            function toMessageRead(item: Office.Item): Office.MessageRead;
-            function toMessage(item: Office.Item): Office.Message;
-            function toItemCompose(item: Office.Item): Office.ItemCompose;
-            function toItemRead(item: Office.Item): Office.ItemRead;
-        }
-    }
     export interface AsyncContextOptions {
         asyncContext?: any;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [N/A] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

"Office.cast.item" was erroneously included in the D.ts.  However, it is not actually needed for TypeScript, as it was only a crutch for the old VSDOC IntelliSense.