### PR TITLE
Marked lolex clock methods as bound

### DIFF
--- a/types/lolex/index.d.ts
+++ b/types/lolex/index.d.ts
@@ -75,14 +75,14 @@ export interface LolexClock<TTimerId extends TimerId> {
      * @param args   Any extra arguments to pass to the callback.
      * @returns Time identifier for cancellation.
      */
-    setTimeout(callback: () => any, timeout: number, ...args: any[]): TTimerId;
+    setTimeout: (callback: () => any, timeout: number, ...args: any[]) => TTimerId;
 
     /**
      * Clears a timer, as long as it was created using setTimeout.
      *
      * @param id   Timer ID or object.
      */
-    clearTimeout(id: TTimerId): void;
+    clearTimeout: (id: TTimerId) => void;
 
     /**
      * Schedules a callback to be fired every time timeout milliseconds have ticked by.
@@ -92,14 +92,14 @@ export interface LolexClock<TTimerId extends TimerId> {
      * @param args   Any extra arguments to pass to the callback.
      * @returns Time identifier for cancellation.
      */
-    setInterval(callback: () => any, timeout: number, ...args: any[]): TTimerId;
+    setInterval: (callback: () => any, timeout: number, ...args: any[]) => TTimerId;
 
     /**
      * Clears a timer, as long as it was created using setInterval.
      *
      * @param id   Timer ID or object.
      */
-    clearInterval(id: TTimerId): void;
+    clearInterval: (id: TTimerId) => void;
 
     /**
      * Schedules the callback to be fired once 0 milliseconds have ticked by.
@@ -108,44 +108,44 @@ export interface LolexClock<TTimerId extends TimerId> {
      * @remarks You'll still have to call clock.tick() for the callback to fire.
      * @remarks If called during a tick the callback won't fire until 1 millisecond has ticked by.
      */
-    setImmediate(callback: () => any): TTimerId;
+    setImmediate: (callback: () => any) => TTimerId;
 
     /**
      * Clears a timer, as long as it was created using setImmediate.
      *
      * @param id   Timer ID or object.
      */
-    clearImmediate(id: TTimerId): void;
+    clearImmediate: (id: TTimerId) => void;
 
     /**
      * Simulates process.nextTick();
      */
-    nextTick(callback: () => void): void;
+    nextTick: (callback: () => void) => void;
 
     /**
      * Advances the clock to the the moment of the first scheduled timer, firing it.
      */
-    next(): void;
+    next: () => void;
 
     /**
      * Advance the clock, firing callbacks if necessary.
      *
      * @param time   How many ticks to advance by.
      */
-    tick(time: number | string): void;
+    tick: (time: number | string) => void;
 
     /**
      * Runs all pending timers until there are none remaining.
      *
      * @remarks  If new timers are added while it is executing they will be run as well.
      */
-    runAll(): void;
+    runAll: () => void;
 
     /**
      * Takes note of the last scheduled timer when it is run, and advances the clock to
      * that time firing callbacks as necessary.
      */
-    runToLast(): void;
+    runToLast: () => void;
 
     /**
      * Simulates a user changing the system clock.
@@ -153,13 +153,13 @@ export interface LolexClock<TTimerId extends TimerId> {
      * @param now   New system time.
      * @remarks This affects the current time but it does not in itself cause timers to fire.
      */
-    setSystemTime(now?: number | Date): void;
+    setSystemTime: (now?: number | Date) => void;
 
     /**
      * Restores the original methods on the context that was passed to lolex.install,
      * or the native timers if no context was given.
      */
-    uninstall(): void;
+    uninstall: () => void;
 }
 
 /**

--- a/types/lolex/lolex-tests.ts
+++ b/types/lolex/lolex-tests.ts
@@ -73,3 +73,7 @@ nodeClock.nextTick(() => undefined);
 
 browserClock.uninstall();
 nodeClock.uninstall();
+
+// Clocks should be typed to have unbound method signatures that can be passed around
+const { clearTimeout } = browserClock;
+clearTimeout(0);

--- a/types/lolex/tslint.json
+++ b/types/lolex/tslint.json
@@ -43,6 +43,7 @@
         "no-self-import": false,
         "no-single-declare-module": false,
         "no-string-throw": false,
+        "no-unbound-method": true,
         "no-unnecessary-callback-wrapper": false,
         "no-unnecessary-class": false,
         "no-unnecessary-generics": false,


### PR DESCRIPTION
TSLint's [`no-unbound-method`](https://palantir.github.io/tslint/rules/no-unbound-method/) cares about the difference between class-style unbound methods and bound member properties.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/sinonjs/lolex/blob/41789fb14bcb79075ac27c1fcf63094ee4eedab2/src/lolex-src.js

Fixes #24193
