### PR TITLE
Updated DbCreateOptions.promoteBuffers to be boolean, updated docs

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -93,7 +93,7 @@ export interface MongoClientOptions extends
     logger?: Object;
     // Default: false;
     validateOptions?: Object;
-    // The name of the application that created this MongoClient instance. 
+    // The name of the application that created this MongoClient instance.
     appname?: string;
 }
 
@@ -160,8 +160,8 @@ export interface DbCreateOptions extends CommonOptions {
     raw?: boolean;
     // Default: true; Promotes Long values to number if they fit inside the 53 bits resolution.
     promoteLongs?: boolean;
-    // Default: -1 (unlimited); Amount of operations the driver buffers up untill discard any new ones
-    promoteBuffers?: number;
+    // Default: false; Promotes Binary BSON values to native Node Buffers
+    promoteBuffers?: boolean;
     // the prefered read preference. use 'ReadPreference' class.
     readPreference?: ReadPreference | string;
     // Default: true; Promotes BSON values to native types where possible, set to false to only receive wrapper types.
@@ -1495,7 +1495,7 @@ export interface ChangeStreamOptions {
 }
 
 type GridFSBucketWriteStreamId = string | number | Object | ObjectID;
-               
+
 export interface LoggerOptions {
     loggerLevel?: string // Custom logger function
     logger?: log // Override default global log level.

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -25,7 +25,8 @@ let options: mongodb.MongoClientOptions = {
     sslCA: ['str'],
     sslCert: new Buffer(999),
     sslKey: new Buffer(999),
-    sslPass: new Buffer(999)
+    sslPass: new Buffer(999),
+    promoteBuffers: false
 }
 MongoClient.connect('mongodb://127.0.0.1:27017/test', options, function (err: mongodb.MongoError, client: mongodb.MongoClient) {
     if (err) throw err;


### PR DESCRIPTION
Existing value was a number and the comment associated was not the
correct information.  Updated to be a boolean and updated comment
to be from [MongoClient.connect docs](https://mongodb.github.io/node-mongodb-native/3.0/api/MongoClient.html#.connect)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
