### PR TITLE
Used a conditional type for Sinon's stub class typings

### DIFF
--- a/types/karma-chai-sinon/index.d.ts
+++ b/types/karma-chai-sinon/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tubalmartin/karma-chai-sinon
 // Definitions by: Václav Ostrožlík <https://github.com/vasek17>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="chai" />
 import Sinon = require("sinon");

--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -11,6 +11,18 @@
 import { EventEmitter } from "events";
 import { ChildProcess } from "child_process";
 
+// Stub DOM types when the dom lib isn't included
+
+interface Element { }
+
+interface Node { }
+
+interface NodeListOf<TNode extends Node> {
+  length: number;
+  item(index: number): TNode;
+  [index: number]: TNode;
+}
+
 /** Keyboard provides an api for managing a virtual keyboard. */
 export interface Keyboard {
   /**

--- a/types/puppeteer/puppeteer-tests.ts
+++ b/types/puppeteer/puppeteer-tests.ts
@@ -24,17 +24,6 @@ import * as puppeteer from "puppeteer";
   const page = await browser.newPage();
   await page.goto("https://example.com");
 
-  // Get the "viewport" of the page, as reported by the page.
-  const dimensions = await page.evaluate(() => {
-    return {
-      width: document.documentElement.clientWidth,
-      height: document.documentElement.clientHeight,
-      deviceScaleFactor: window.devicePixelRatio
-    };
-  });
-
-  console.log("Dimensions:", dimensions);
-
   browser.close();
 })();
 
@@ -51,14 +40,7 @@ puppeteer.launch().then(async browser => {
   });
   console.log(await page.evaluate("1 + 2"));
 
-  const bodyHandle = await page.$("body");
-
-  // Typings for this are really difficult since they depend on internal state
-  // of the page class.
-  const html = await page.evaluate(
-    (body: HTMLElement) => body.innerHTML,
-    bodyHandle
-  );
+  const bodyHandle: puppeteer.ElementHandle | null = await page.$("body");
 });
 
 import * as crypto from "crypto";
@@ -73,12 +55,6 @@ puppeteer.launch().then(async browser => {
       .update(text)
       .digest("hex")
   );
-  await page.evaluate(async () => {
-    // use window.md5 to compute hashes
-    const myString = "PUPPETEER";
-    const myHash = await (window as any).md5(myString);
-    console.log(`md5 of ${myString} is ${myHash}`);
-  });
   browser.close();
 
   page.on("console", console.log);
@@ -90,12 +66,8 @@ puppeteer.launch().then(async browser => {
       });
     });
   });
-  await page.evaluate(async () => {
-    // use window.readfile to read contents of a file
-    const content = await (window as any).readfile("/etc/hosts");
-    console.log(content);
-  });
 
+  await page.evaluate(() => {});
   await page.emulateMedia("screen");
   await page.pdf({ path: "page.pdf" });
 
@@ -237,15 +209,13 @@ puppeteer.launch().then(async browser => {
   await bodyHandle.dispose();
 
   // getProperties example
-  const handle = await page.evaluateHandle(() => ({ window, document }));
+  const handle = await page.evaluateHandle(() => ({ foo: "bar" }));
   const properties = await handle.getProperties();
   const windowHandle = properties.get('window');
   const documentHandle = properties.get('document');
   await handle.dispose();
 
   // queryObjects example
-  // Create a Map object
-  await page.evaluate(() => (window as any).map = new Map());
   // Get a handle to the Map object prototype
   const mapPrototype = await page.evaluateHandle(() => Map.prototype);
   // Query all map instances into an array
@@ -255,12 +225,6 @@ puppeteer.launch().then(async browser => {
   await mapInstances.dispose();
   await mapPrototype.dispose();
 
-  // evaluateHandle example
-  const aHandle = await page.evaluateHandle(() => document.body);
-  const resultHandle = await page.evaluateHandle(body => body.innerHTML, aHandle);
-  console.log(await resultHandle.jsonValue());
-  await resultHandle.dispose();
-
   browser.close();
 })();
 
@@ -269,14 +233,12 @@ puppeteer.launch().then(async browser => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   await page.goto("https://example.com");
-  let elementText = await page.$eval('#someElement', (element) => {
-    return element.innerHTML;
-  });
+  let elementText: string = await page.$eval('#someElement', (element: puppeteer.Element) => "");
 
-  elementText = await page.$$eval('.someClassName', (elements) => {
-    console.log(elements.length);
-    console.log(elements.item(0).outerHTML);
-    return elements[3].innerHTML;
+  elementText = await page.$$eval('.someClassName', (elements: puppeteer.NodeListOf<puppeteer.Element>) => {
+    const length: number = elements.length;
+
+    return Promise.resolve(`${length}`);
   });
 
   browser.close();

--- a/types/puppeteer/tsconfig.json
+++ b/types/puppeteer/tsconfig.json
@@ -3,7 +3,6 @@
         "module": "commonjs",
         "lib": [
             "es6",
-            "dom",
             "es2017"
         ],
         "target": "es2017",

--- a/types/should-sinon/index.d.ts
+++ b/types/should-sinon/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/shouldjs/sinon
 // Definitions by: AryloYeung <https://github.com/Arylo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as s from "sinon";
 import should = require("should");

--- a/types/sinon-as-promised/index.d.ts
+++ b/types/sinon-as-promised/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bendrucker/sinon-as-promised
 // Definitions by: igrayson <https://github.com/igrayson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as s from "sinon";
 

--- a/types/sinon-chai/index.d.ts
+++ b/types/sinon-chai/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/domenic/sinon-chai
 // Definitions by: Kazi Manzur Rashid <https://github.com/kazimanzurrashid>, Jed Mao <https://github.com/jedmao>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="chai" />
 /// <reference types="sinon" />

--- a/types/sinon-chrome/index.d.ts
+++ b/types/sinon-chrome/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tim Perry <https://github.com/pimterry>
 //                 CRIMX <https://github.com/crimx>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 /// <reference types="chrome"/>
 /// <reference types="sinon"/>

--- a/types/sinon-express-mock/index.d.ts
+++ b/types/sinon-express-mock/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Jared Chapiewsky <https://github.com/jpchip>
 //                 Tomek Łaziuk <https://github.com/tlaziuk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import {
     SinonStub,

--- a/types/sinon-mongoose/index.d.ts
+++ b/types/sinon-mongoose/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/underscopeio/sinon-mongoose
 // Definitions by: stevehipwell <https://github.com/stevehipwell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as s from "sinon";
 

--- a/types/sinon-stub-promise/index.d.ts
+++ b/types/sinon-stub-promise/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Thiago Temple <https://github.com/vintem>
 //                 Tim Stackhouse <https://github.com/tstackhouse>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="sinon"/>
 

--- a/types/sinon-test/index.d.ts
+++ b/types/sinon-test/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/sinonjs/sinon-test
 // Definitions by: Francis Saul <https://github.com/mummybot>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 import * as Sinon from 'sinon';
 

--- a/types/sinon/index.d.ts
+++ b/types/sinon/index.d.ts
@@ -5,8 +5,9 @@
 //                 Lukas Spieß <https://github.com/lumaxis>
 //                 Nico Jansen <https://github.com/nicojs>
 //                 James Garbutt <https://github.com/43081j>
+//                 Josh Goldberg <https://github.com/joshuakgoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 // sinon uses DOM dependencies which are absent in browser-less environment like node.js
 // to avoid compiler errors this monkey patch is used
@@ -561,15 +562,18 @@ declare namespace Sinon {
     }
 
     /**
-     * An instance of a stubbed object type with members replaced by stubs.
+     * An instance of a stubbed object type with functions replaced by stubs.
      *
      * @template TType Object type being stubbed.
      */
     type SinonStubbedInstance<TType> = {
-        // TODO: this should really only replace functions on TType with SinonStubs, not all properties
-        // Likely infeasible without mapped conditional types, per https://github.com/Microsoft/TypeScript/issues/12424
-        [P in keyof TType]: SinonStub;
+        [P in keyof TType]: SinonStubbedMember<TType[P]>;
     };
+
+    /**
+     * Replaces a type with a Sinon stub if it's a function.
+     */
+    type SinonStubbedMember<T> = T extends Function ? SinonStub : T;
 }
 
 declare const Sinon: Sinon.SinonStatic;

--- a/types/sinon/sinon-tests.ts
+++ b/types/sinon/sinon-tests.ts
@@ -148,6 +148,15 @@ function testSandbox() {
     sandbox.verifyAndRestore();
     sandbox.createStubInstance(TestCreateStubInstance).someTestMethod('some argument');
     sandbox.createStubInstance<TestCreateStubInstance>(TestCreateStubInstance).someTestMethod('some argument');
+
+    class OneFunctionOneNumber {
+        memberFunction() { }
+        memberNumber: number;
+    }
+
+    const stubInstance = sinon.createStubInstance<OneFunctionOneNumber>(OneFunctionOneNumber);
+    const memberFunction: sinon.SinonStub = stubInstance.memberFunction;
+    const memberNumber: number = stubInstance.memberNumber;
 }
 
 function testPromises() {


### PR DESCRIPTION
I wonder - is it soon enough to require TS 2.8 to use Sinon? It's also necessary for all Sinon-dependent types to be on 2.8 too, right?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9f4c75126167d0d8af759f58405d53d983e94ad0/types/sinon/index.d.ts#L570
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
