### PR TITLE
@feathersjs/multiple combined commonJS and ES module default exports.

### DIFF
--- a/types/feathersjs__authentication-client/index.d.ts
+++ b/types/feathersjs__authentication-client/index.d.ts
@@ -3,8 +3,10 @@
 // Definitions by: Abraao Alves <https://github.com/AbraaoAlves>, Jan Lohage <https://github.com/j2L4e>
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
 // TypeScript Version: 2.3
+import * as self from '@feathersjs/authentication-client';
 
-export default function feathersAuthClient(config?: FeathersAuthClientConfig): () => void;
+declare const feathersAuthClient: ((config?: FeathersAuthClientConfig) => () => void) & typeof self;
+export default feathersAuthClient;
 
 export interface FeathersAuthClientConfig {
     storage?: Storage;

--- a/types/feathersjs__authentication-jwt/index.d.ts
+++ b/types/feathersjs__authentication-jwt/index.d.ts
@@ -6,8 +6,10 @@
 
 import { Application } from '@feathersjs/feathers';
 import { Request } from 'express';
+import * as self from '@feathersjs/authentication-jwt';
 
-export default function feathersAuthenticationJwt(options?: FeathersAuthenticationJWTOptions): () => void;
+declare const feathersAuthenticationJwt: ((options?: FeathersAuthenticationJWTOptions) => () => void) & typeof self;
+export default feathersAuthenticationJwt;
 
 export interface FeathersAuthenticationJWTOptions {
     /**

--- a/types/feathersjs__authentication-local/index.d.ts
+++ b/types/feathersjs__authentication-local/index.d.ts
@@ -10,8 +10,10 @@ import {
     Paginated
 } from '@feathersjs/feathers';
 import { Request } from 'express';
+import * as self from '@feathersjs/authentication-local';
 
-export default function feathersAuthenticationLocal(options?: FeathersAuthenticationLocalOptions): () => void;
+declare const feathersAuthenticationLocal: ((options?: FeathersAuthenticationLocalOptions) => () => void) & typeof self;
+export default feathersAuthenticationLocal;
 
 export interface FeathersAuthenticationLocalOptions {
     /**

--- a/types/feathersjs__authentication-oauth1/index.d.ts
+++ b/types/feathersjs__authentication-oauth1/index.d.ts
@@ -9,8 +9,10 @@ import {
     Paginated
 } from '@feathersjs/feathers';
 import { Request } from 'express';
+import * as self from '@feathersjs/authentication-oauth1';
 
-export default function feathersAuthenticationOAuth1(options?: FeathersAuthenticationOAuth1Options): () => void;
+declare const feathersAuthenticationOAuth1: ((options?: FeathersAuthenticationOAuth1Options) => () => void) & typeof self;
+export default feathersAuthenticationOAuth1;
 
 export interface FeathersAuthenticationOAuth1Options {
     /**

--- a/types/feathersjs__authentication-oauth2/index.d.ts
+++ b/types/feathersjs__authentication-oauth2/index.d.ts
@@ -9,8 +9,10 @@ import {
     Paginated
 } from '@feathersjs/feathers';
 import { Request } from 'express';
+import * as self from '@feathersjs/authentication-oauth2';
 
-export default function feathersAuthenticationOAuth2(options?: FeathersAuthenticationOAuth2Options): () => void;
+declare const feathersAuthenticationOAuth2: ((options?: FeathersAuthenticationOAuth2Options) => () => void) & typeof self;
+export default feathersAuthenticationOAuth2;
 
 export interface FeathersAuthenticationOAuth2Options {
     /**

--- a/types/feathersjs__authentication/index.d.ts
+++ b/types/feathersjs__authentication/index.d.ts
@@ -4,8 +4,10 @@
 // Definitions: https://github.com/feathersjs-ecosystem/feathers-typescript
 
 import { Hook } from '@feathersjs/feathers';
+import * as self from '@feathersjs/authentication';
 
-export default function feathersAuthentication(config?: FeathersAuthenticationOptions): () => void;
+declare const feathersAuthentication: ((config?: FeathersAuthenticationOptions) => () => void) & typeof self;
+export default feathersAuthentication;
 
 export const hooks: AuthHooks.Hooks;
 

--- a/types/feathersjs__express/index.d.ts
+++ b/types/feathersjs__express/index.d.ts
@@ -6,8 +6,10 @@
 
 import { Application as FeathersApplication } from '@feathersjs/feathers';
 import * as express from 'express';
+import * as self from '@feathersjs/express';
 
-export default function feathersExpress<T>(app: FeathersApplication<T>): Application<T>;
+declare const feathersExpress: (<T>(app: FeathersApplication<T>) => Application<T>) & typeof self;
+export default feathersExpress;
 export type Application<T> = express.Application & FeathersApplication<T>;
 
 export function errorHandler(options?: any): express.ErrorRequestHandler;

--- a/types/feathersjs__feathers/index.d.ts
+++ b/types/feathersjs__feathers/index.d.ts
@@ -8,8 +8,10 @@
 /// <reference types="node" />
 
 import { EventEmitter } from 'events';
+import * as self from '@feathersjs/feathers';
 
-export default function feathers(): Application<object>;
+declare const feathers: (() => Application<object>) & typeof self;
+export default feathers;
 
 export const version: string;
 

--- a/types/feathersjs__primus/index.d.ts
+++ b/types/feathersjs__primus/index.d.ts
@@ -6,5 +6,7 @@
 
 /// <reference types="feathersjs__socket-commons"/>
 
+/// <reference types="feathersjs__socket-commons"/>
+
 // primus removed its typings from the repo https://github.com/primus/primus/pull/623, as of 01/2018 there are none on DT
 export default function feathersPrimus(options: any, callback?: (primus: any) => void): () => void;

--- a/types/feathersjs__primus/index.d.ts
+++ b/types/feathersjs__primus/index.d.ts
@@ -6,7 +6,5 @@
 
 /// <reference types="feathersjs__socket-commons"/>
 
-/// <reference types="feathersjs__socket-commons"/>
-
 // primus removed its typings from the repo https://github.com/primus/primus/pull/623, as of 01/2018 there are none on DT
 export default function feathersPrimus(options: any, callback?: (primus: any) => void): () => void;


### PR DESCRIPTION
~~Correctly~~ better reflect behavior of combined commonJS and ES module default exports.

```module.exports.default = module.exports```

example: https://github.com/feathersjs/feathers/blob/master/lib/index.js#L23