### PR TITLE
[express-jwt] Correct error in callback for secret.

### DIFF
--- a/types/express-jwt/express-jwt-tests.ts
+++ b/types/express-jwt/express-jwt-tests.ts
@@ -13,6 +13,25 @@ app.use(jwt({
     userProperty: 'auth'
 }));
 
+app.use(jwt({
+    secret: (req: express.Request,
+        payload: any,
+        done: (err: any, secret: string) => void) => {
+        done(null, 'shhhhhhared-secret');
+    },
+    userProperty: 'auth'
+}));
+
+app.use(jwt({
+    secret: (req: express.Request,
+        header: any,
+        payload: any,
+        done: (err: any, secret: string) => void) => {
+        done(null, 'shhhhhhared-secret');
+    },
+    userProperty: 'auth'
+}));
+
 var jwtCheck = jwt({
     secret: 'shhhhhhared-secret'
 });

--- a/types/express-jwt/index.d.ts
+++ b/types/express-jwt/index.d.ts
@@ -12,8 +12,10 @@ export = jwt;
 declare function jwt(options: jwt.Options): jwt.RequestHandler;
 declare namespace jwt {
     export type secretType = string | Buffer
+    export interface SecretCallbackLong {
+        (req: express.Request, header: any, payload: any, done: (err: any, secret?: secretType) => void): void;
+    }
     export interface SecretCallback {
-        (req: express.Request, header: any, payload: any, done: (err: any, secret?: boolean) => void): void;
         (req: express.Request, payload: any, done: (err: any, secret?: secretType) => void): void;
     }
 
@@ -25,7 +27,7 @@ declare namespace jwt {
         (req: express.Request): any;
     }
     export interface Options {
-        secret: secretType | SecretCallback;
+        secret: secretType | SecretCallback | SecretCallbackLong;
         userProperty?: string;
         skip?: string[];
         credentialsRequired?: boolean;


### PR DESCRIPTION
Correct error for secret type in long callback.
Split the callbacks in two interfaces.

Add some test case.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/auth0/express-jwt/blob/master/lib/index.js#L91
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
