### PR TITLE
Expose the BlockMap type in draft-js

### DIFF
--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -957,6 +957,7 @@ import ContentBlock = Draft.Model.ImmutableData.ContentBlock;
 import ContentState = Draft.Model.ImmutableData.ContentState;
 import SelectionState = Draft.Model.ImmutableData.SelectionState;
 import DraftInlineStyle = Draft.Model.ImmutableData.DraftInlineStyle;
+import BlockMap = Draft.Model.ImmutableData.BlockMap;
 
 import AtomicBlockUtils = Draft.Model.Modifier.AtomicBlockUtils;
 import KeyBindingUtil = Draft.Component.Utils.KeyBindingUtil;
@@ -1005,6 +1006,7 @@ export {
     ContentState,
     SelectionState,
     DraftInlineStyle,
+    BlockMap,
 
     AtomicBlockUtils,
     KeyBindingUtil,


### PR DESCRIPTION
BlockMap is the return/parameter type of several draft functions.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://draftjs.org/docs/api-reference-content-state.html#getblockmap

