### PR TITLE
Added jsoneditor-for-react types

### DIFF
--- a/types/jsoneditor-for-react/index.d.ts
+++ b/types/jsoneditor-for-react/index.d.ts
@@ -1,17 +1,17 @@
-// Type definitions for jsoneditor-for-react 0.0.1
+// Type definitions for jsoneditor-for-react 0.0
 // Project: https://github.com/mixj93/jsoneditor-for-react#readme
 // Definitions by: JoshGoldberg <https://github.com/joshuakgoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
-import * as React from "react"
-import JSONEditor, { JSONEditorOptions } from "jsoneditor"
+import * as React from "react";
+import JSONEditor, { JSONEditorOptions } from "jsoneditor";
 
-export interface IReactJsoneditorProps {
-    values: Object
+export interface ReactJsonEditorProps {
+    values: {};
 }
 
-export default class ReactJsoneditor extends React.Component<IReactJsoneditorProps> {
-    private editor?: JSONEditor
-    private options?: JSONEditorOptions
+export default class ReactJsoneditor extends React.Component<ReactJsonEditorProps> {
+    private editor?: JSONEditor;
+    private options?: JSONEditorOptions;
 }

--- a/types/jsoneditor-for-react/index.d.ts
+++ b/types/jsoneditor-for-react/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/mixj93/jsoneditor-for-react#readme
 // Definitions by: JoshGoldberg <https://github.com/joshuakgoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
 
 import * as React from "react"
 import JSONEditor, { JSONEditorOptions } from "jsoneditor"

--- a/types/jsoneditor-for-react/index.d.ts
+++ b/types/jsoneditor-for-react/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for jsoneditor-for-react 0.0.1
+// Project: https://github.com/mixj93/jsoneditor-for-react#readme
+// Definitions by: JoshGoldberg <https://github.com/joshuakgoldberg>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from "react"
+import JSONEditor, { JSONEditorOptions } from "jsoneditor"
+
+export interface IReactJsoneditorProps {
+    values: Object
+}
+
+export default class ReactJsoneditor extends React.Component<IReactJsoneditorProps> {
+    private editor?: JSONEditor
+    private options?: JSONEditorOptions
+}

--- a/types/jsoneditor-for-react/jsoneditor-for-react-tests.tsx
+++ b/types/jsoneditor-for-react/jsoneditor-for-react-tests.tsx
@@ -1,0 +1,4 @@
+import * as React from "react";
+import ReactJsonEditor from "jsoneditor-for-react";
+
+const component = <ReactJsonEditor values={{}} />;

--- a/types/jsoneditor-for-react/tsconfig.json
+++ b/types/jsoneditor-for-react/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "jsx": "react",
         "typeRoots": [

--- a/types/jsoneditor-for-react/tsconfig.json
+++ b/types/jsoneditor-for-react/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "jsoneditor-for-react-tests.tsx"
+    ]
+}

--- a/types/jsoneditor-for-react/tslint.json
+++ b/types/jsoneditor-for-react/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

Fixes #22840

Based on a PR I sent to the repository a bit back that hasn't been responded to. https://github.com/mixj93/jsoneditor-for-react/pull/3