### PR TITLE
Fix https.globalAgent.options in node package

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1768,6 +1768,7 @@ declare module "https" {
 
     export class Agent extends http.Agent {
         constructor(options?: AgentOptions);
+        options: AgentOptions;
     }
 
     export class Server extends tls.Server {

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -1497,6 +1497,8 @@ namespace https_tests {
 
     https.request('http://www.example.com/xyz');
 
+    https.globalAgent.options.ca = [];
+
     {
         const server = new https.Server();
 

--- a/types/node/v4/index.d.ts
+++ b/types/node/v4/index.d.ts
@@ -1081,7 +1081,9 @@ declare module "https" {
         secureProtocol?: string;
     }
 
-    export interface Agent extends http.Agent { }
+    export interface Agent extends http.Agent {
+        options?: AgentOptions;
+    }
 
     export interface AgentOptions extends http.AgentOptions {
         pfx?: any;

--- a/types/node/v4/node-tests.ts
+++ b/types/node/v4/node-tests.ts
@@ -561,6 +561,8 @@ namespace https_tests {
     });
 
     https.request('http://www.example.com/xyz');
+
+    https.globalAgent.options.ca = [];
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/v6/index.d.ts
+++ b/types/node/v6/index.d.ts
@@ -1468,7 +1468,9 @@ declare module "https" {
         secureProtocol?: string;
     }
 
-    export interface Agent extends http.Agent { }
+    export interface Agent extends http.Agent {
+        options?: AgentOptions;
+    }
 
     export interface AgentOptions extends http.AgentOptions {
         pfx?: any;

--- a/types/node/v6/node-tests.ts
+++ b/types/node/v6/node-tests.ts
@@ -1015,6 +1015,8 @@ namespace https_tests {
     });
 
     https.request('http://www.example.com/xyz');
+
+    https.globalAgent.options.ca = [];
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/v7/index.d.ts
+++ b/types/node/v7/index.d.ts
@@ -1528,7 +1528,9 @@ declare module "https" {
         secureProtocol?: string;
     }
 
-    export interface Agent extends http.Agent { }
+    export interface Agent extends http.Agent {
+        options?: AgentOptions;
+    }
 
     export interface AgentOptions extends http.AgentOptions {
         pfx?: any;

--- a/types/node/v7/node-tests.ts
+++ b/types/node/v7/node-tests.ts
@@ -1093,6 +1093,8 @@ namespace https_tests {
     });
 
     https.request('http://www.example.com/xyz');
+
+    https.globalAgent.options.ca = [];
 }
 
 ////////////////////////////////////////////////////

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -1757,6 +1757,7 @@ declare module "https" {
 
     export class Agent extends http.Agent {
         constructor(options?: AgentOptions);
+        options: AgentOptions;
     }
 
     export class Server extends tls.Server {

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -1471,6 +1471,8 @@ namespace https_tests {
 
     https.request('http://www.example.com/xyz');
 
+    https.globalAgent.options.ca = [];
+
     {
         const server = new https.Server();
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: **see below**.
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`

### Context
Setting certificate authorities for https requests is usually done in the following way (see e.g. [stackoverflow](https://stackoverflow.com/a/39113115):
```
https.globalAgent.options.ca = [ "cert1", "cert2" ];
```
However this is not possible with correct typings, because the property `options` is missing on the type for `https.globalAgent`.  The pull request fixes this issue.