### PR TITLE
pouchdb-core: adding size option to LocalDatabaseConfiguration

### DIFF
--- a/types/pouchdb-core/index.d.ts
+++ b/types/pouchdb-core/index.d.ts
@@ -514,6 +514,12 @@ declare namespace PouchDB {
              * How many old revisions we keep track (not a copy) of.
              */
             revs_limit?: number;
+            /**
+             * Size of the database (Most significant for Safari)
+             * option to set the max size in MB that Safari will grant to the local database. Valid options are: 10, 50, 100, 500 and 1000
+             * ex_ new PouchDB("dbName", {size:100});
+             */
+            size?: number;
         }
 
         interface RemoteRequesterConfiguration {


### PR DESCRIPTION
Added size option for local database constructor. The size option is important to avoid Safari isse described in [pouchdb docs](https://pouchdb.com/errors.html#not_enough_space) .

example:
`new PouchDb("dbName", {size:100});`

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://pouchdb.com/errors.html#not_enough_space>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

