### PR TITLE
react-native-navigation: update setTabBadge typings

### DIFF
--- a/types/react-native-navigation/index.d.ts
+++ b/types/react-native-navigation/index.d.ts
@@ -128,7 +128,7 @@ export class Navigator {
     toggleDrawer(params: { side: 'left' | 'right'; animated?: boolean; to?: 'open' | 'closed' }): void;
     setDrawerEnabled(params: { side: 'left' | 'right'; enabled: boolean }): void;
     toggleTabs(params: { to: 'hidden' | 'shown'; animated?: boolean }): void;
-    setTabBadge(params?: { tabIndex?: number; badge?: number; badgeColor?: string; }): void;
+    setTabBadge(params?: { tabIndex?: number; badge: number | null; badgeColor?: string; }): void;
     setTabButton(params?: { tabIndex?: number; icon?: any; selectedIcon?: any; label?: string; }): void;
     switchToTab(params?: { tabIndex?: number }): void;
     toggleNavBar(params: { to: 'hidden' | 'shown'; animated?: boolean }): void;

--- a/types/react-native-navigation/react-native-navigation-tests.tsx
+++ b/types/react-native-navigation/react-native-navigation-tests.tsx
@@ -11,6 +11,7 @@ class Screen1 extends React.Component<NavigationComponentProps & { height: numbe
 
     componentDidMount() {
         this.props.navigator.push({ screen: 'example.Screen2' });
+        this.props.navigator.setTabBadge({ badge: null });
     }
 
     render() {


### PR DESCRIPTION
According to [docs](https://github.com/wix/react-native-navigation/blob/master/docs/screen-api.md#settabbadgeparams--) the `badge` parameter to `setTabBadge` is mandatory
and can be set to `null` to remove the badge.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix/react-native-navigation/blob/master/docs/screen-api.md#settabbadgeparams--
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.