### PR TITLE
Update atmosphere.js with optional parameter webSocketUrl

### DIFF
--- a/types/atmosphere.js/index.d.ts
+++ b/types/atmosphere.js/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/Atmosphere/atmosphere-javascript
 // Definitions by: Kai Toedter <https://github.com/toedter> 
 //                 Fedor Kirpichev <https://github.com/Mory1879>
+//                 Jorge Beltran <https://github.com/Scipion>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Use this typings in future instead of deprecated 'atmosphere'.
@@ -65,6 +66,7 @@ declare namespace Atmosphere {
         maxReconnectOnClose?: number;
         enableProtocol?: boolean;
         pollingInterval?: number;
+        webSocketUrl?: string;
 
         onError?: (response?:Response) => void;
         onClose?:  (response?:Response)  => void;


### PR DESCRIPTION
   Based on atmoshpere.js code:
   https://github.com/Atmosphere/atmosphere-javascript/blob/master/modules/javascript/src/main/webapp/javascript/atmosphere.js#L1212
   it is possible to add an optional parameter named webSocketUrl

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/Atmosphere/atmosphere-javascript/blob/master/modules/javascript/src/main/webapp/javascript/atmosphere.js#L1212>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
