### PR TITLE
@types/bigi: Change return type of valueOf to bigi (from number)

### DIFF
--- a/types/bigi/bigi-tests.ts
+++ b/types/bigi/bigi-tests.ts
@@ -7,3 +7,10 @@ const b3 = b1.multiply(b2);
 
 console.log(b3.toHex());
 // => ae499bfe762edfb416d0ce71447af67ff33d1760cbebd70874be1d7a5564b0439a59808cb1856a91974f7023f72132
+
+const b4 = BigInteger.valueOf(42);
+const b5 = BigInteger.valueOf(10);
+const b6 = b4.multiply(b5);
+
+console.log(b6);
+// => BigInteger { '0': 420, '1': 0, t: 1, s: 0 }

--- a/types/bigi/index.d.ts
+++ b/types/bigi/index.d.ts
@@ -87,7 +87,7 @@ declare class bigi {
     static fromDERInteger(byteArray?: any): number;
     static fromHex(hex: string): bigi;
     static isBigInteger(obj: any, check_ver: any): obj is bigi;
-    static valueOf(i: any): number;
+    static valueOf(i: any): bigi;
 }
 declare namespace bigi {
     interface Constants {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).



If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


---
This PR would resolve https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24346. For information why I think the return type should be `bigi` see there.

Hoping I correctly raised this PR. If anything is wrong, please let me know ;)