### PR TITLE
React-Measure: Added missing React.Component state type declaration

### DIFF
--- a/types/react-measure/index.d.ts
+++ b/types/react-measure/index.d.ts
@@ -60,5 +60,5 @@ export interface MeasureProps<T> {
 export declare function withContentRect(types: ReadonlyArray<MeasurementType> | MeasurementType):
     <T extends {}>(fn: MeasuredComponent<T>) => React.ComponentType<T>;
 
-declare class Measure<T> extends React.Component<MeasureProps<T>> {}
+declare class Measure<T> extends React.Component<MeasureProps<T>, {}> {}
 export default Measure;


### PR DESCRIPTION
React Component was missing the state type

Definition can be found at the following <https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts>
