### PR TITLE
Allow omit second key argument in crypto-js Hash functions

### DIFF
--- a/types/crypto-js/crypto-js-tests.ts
+++ b/types/crypto-js/crypto-js-tests.ts
@@ -4,9 +4,11 @@ import CryptoJS = require('crypto-js');
 var wordArray: CryptoJS.WordArray;
 wordArray = CryptoJS.MD5('some message');
 wordArray = CryptoJS.MD5('some message', 'some key');
+wordArray = CryptoJS.MD5('some message', { any: true });
 
 wordArray = CryptoJS.SHA1('some message');
 wordArray = CryptoJS.SHA1('some message', 'some key', { any: true });
+wordArray = CryptoJS.SHA1('some message', { any: true });
 
 wordArray = CryptoJS.format.OpenSSL('some message');
 wordArray = CryptoJS.format.OpenSSL('some message', 'some key');

--- a/types/crypto-js/index.d.ts
+++ b/types/crypto-js/index.d.ts
@@ -8,7 +8,6 @@ export as namespace CryptoJS;
 
 declare var CryptoJS: CryptoJS.Hashes;
 declare namespace CryptoJS {
-	type Hash = (message: string | LibWordArray, key?: string | WordArray, ...options: any[]) => WordArray;
 	interface Cipher {
 		encrypt(message: string, secretPassphrase: string | WordArray, option?: CipherOption): WordArray;
 		decrypt(encryptedMessage: string | WordArray, secretPassphrase: string | WordArray, option?: CipherOption): DecryptedMessage;
@@ -54,23 +53,40 @@ declare namespace CryptoJS {
 	interface Padding {}
 
 	export interface Hashes {
-		MD5: Hash;
-		SHA1: Hash;
-		SHA256: Hash;
-		SHA224: Hash;
-		SHA512: Hash;
-		SHA384: Hash;
-		SHA3: Hash;
-		RIPEMD160: Hash;
-		HmacMD5: Hash;
-		HmacSHA1: Hash;
-		HmacSHA256: Hash;
-		HmacSHA224: Hash;
-		HmacSHA512: Hash;
-		HmacSHA384: Hash;
-		HmacSHA3: Hash;
-		HmacRIPEMD160: Hash;
-		PBKDF2: Hash;
+		MD5(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		MD5(message: string | LibWordArray, ...options: any[]): WordArray;
+		SHA1(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		SHA1(message: string | LibWordArray, ...options: any[]): WordArray;
+		SHA256(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		SHA256(message: string | LibWordArray, ...options: any[]): WordArray;
+		SHA224(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		SHA224(message: string | LibWordArray, ...options: any[]): WordArray;
+		SHA512(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		SHA512(message: string | LibWordArray, ...options: any[]): WordArray;
+		SHA384(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		SHA384(message: string | LibWordArray, ...options: any[]): WordArray;
+		SHA3(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		SHA3(message: string | LibWordArray, ...options: any[]): WordArray;
+		RIPEMD160(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		RIPEMD160(message: string | LibWordArray, ...options: any[]): WordArray;
+		HmacMD5(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		HmacMD5(message: string | LibWordArray, ...options: any[]): WordArray;
+		HmacSHA1(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		HmacSHA1(message: string | LibWordArray, ...options: any[]): WordArray;
+		HmacSHA256(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		HmacSHA256(message: string | LibWordArray, ...options: any[]): WordArray;
+		HmacSHA224(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		HmacSHA224(message: string | LibWordArray, ...options: any[]): WordArray;
+		HmacSHA512(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		HmacSHA512(message: string | LibWordArray, ...options: any[]): WordArray;
+		HmacSHA384(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		HmacSHA384(message: string | LibWordArray, ...options: any[]): WordArray;
+		HmacSHA3(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		HmacSHA3(message: string | LibWordArray, ...options: any[]): WordArray;
+		HmacRIPEMD160(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		HmacRIPEMD160(message: string | LibWordArray, ...options: any[]): WordArray;
+		PBKDF2(message: string | LibWordArray, key?: string | WordArray, ...options: any[]): WordArray;
+		PBKDF2(message: string | LibWordArray, ...options: any[]): WordArray;
 		AES: Cipher;
 		DES: Cipher;
 		TripleDES: Cipher;


### PR DESCRIPTION
* Fixes DefinitelyTyped/DefinitelyTyped#24425

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stackoverflow.com/questions/49396548/cant-add-option-object-to-the-sha3-function-with-typescript
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
