### PR TITLE
highland: add the definition for the new isNil() for type guarding

### DIFF
--- a/types/highland/highland-tests.ts
+++ b/types/highland/highland-tests.ts
@@ -337,6 +337,8 @@ fooStream.toCallback((err: Error) => {});
 // UTILS
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+bool = _.isNil(x);
+
 bool = _.isStream(x);
 bool = _.isStream(fooStream);
 

--- a/types/highland/index.d.ts
+++ b/types/highland/index.d.ts
@@ -89,6 +89,17 @@ interface HighlandStatic {
 	// UTILS
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+  /**
+	 * Returns true if `x` is the end of stream marker.
+	 *
+	 * @id isNil
+	 * @section Streams
+	 * @name _.isNil(x)
+	 * @param x - the object to test
+	 * @api public
+	 */
+  isNil<R>(x: R | Highland.Nil): x is Highland.Nil;
+
 	/**
 	 * Returns true if `x` is a Highland Stream.
 	 *


### PR DESCRIPTION
This commit add the definition for the a very simple, and yet essential, isNil
function for type checking. This function is particularly useful in a consume
handler.

Example:
```typescript
source.consume(function (err, x, push, next) {
  if (err) {
    // pass errors along the stream and consume next value
    push(err);
    next();
  } else if (_.isNil(x)) { // type guard is made possible with this function
    // pass nil (end event) along the stream
    push(null, x);
  } else {
    // pass on the value only if the value passes the predicate
    if (f(x)) {
      push(null, x);
    }
    next();
  }
});
```

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/caolan/highland/pull/645
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.