### PR TITLE
add definition for mini-css-extract-plugin

### DIFF
--- a/types/mini-css-extract-plugin/index.d.ts
+++ b/types/mini-css-extract-plugin/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for mini-css-extract-plugin 0.2
+// Project: https://github.com/webpack-contrib/mini-css-extract-plugin
+// Definitions by: JounQin <https://github.com/JounQin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Loader, Plugin } from 'webpack';
+
+/**
+ * Lightweight CSS extraction webpack plugin
+ * This plugin extract CSS into separate files. It creates a CSS file per JS file which contains CSS. It supports On-Demand-Loading of CSS and SourceMaps.
+ * Configuration Detail: https://github.com/webpack-contrib/mini-css-extract-plugin#configuration
+ */
+declare class MiniCssExtractPlugin extends Plugin {
+    /** webpack loader used always at the end of loaders list */
+    static loader: Loader;
+
+    constructor(options?: MiniCssExtractPlugin.PluginOptions);
+}
+
+declare namespace MiniCssExtractPlugin {
+    interface PluginOptions {
+        /**
+         * Options similar to the same options in webpackOptions.output, both options are optional
+         * May contain `[name]`, `[id]`, `hash` and `[chunkhash]`
+         */
+        filename?: string;
+        chunkFilename?: string;
+    }
+}
+
+export = MiniCssExtractPlugin;

--- a/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
+++ b/types/mini-css-extract-plugin/mini-css-extract-plugin-tests.ts
@@ -1,0 +1,58 @@
+import webpack = require('webpack');
+import MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+let configuration: webpack.Configuration;
+
+configuration = {
+    // The standard entry point and output config
+    entry: {
+        posts: './posts',
+        post: './post',
+        about: './about',
+    },
+    output: {
+        filename: '[name].js',
+        chunkFilename: '[id].js',
+    },
+    module: {
+        rules: [
+            // Extract css files
+            {
+                test: /\.css$/,
+                use: [MiniCssExtractPlugin.loader, 'css-loader'],
+            },
+            // Optionally extract less files
+            // or any other compile-to-css language
+            {
+                test: /\.less$/,
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    'css-loader',
+                    'style-loader',
+                ],
+            },
+            // You could also use other loaders the same way. I. e. the autoprefixer-loader
+        ],
+    },
+    // Use the plugin to specify the resulting filename (and add needed behavior to the compiler)
+    plugins: [
+        new MiniCssExtractPlugin({
+            filename: '[name].css',
+        }),
+    ],
+};
+
+configuration = {
+    // ...
+    plugins: [new MiniCssExtractPlugin()],
+};
+
+configuration = {
+    // ...
+    plugins: [
+        new MiniCssExtractPlugin({
+            filename: 'styles.css',
+            chunkFilename: 'style.css',
+        }),
+    ],
+};

--- a/types/mini-css-extract-plugin/tsconfig.json
+++ b/types/mini-css-extract-plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "mini-css-extract-plugin-tests.ts"
+    ]
+}

--- a/types/mini-css-extract-plugin/tslint.json
+++ b/types/mini-css-extract-plugin/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
https://github.com/webpack-contrib/mini-css-extract-plugin

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
