### PR TITLE
[cosmiconfig] cosmiconfig npm module added

### DIFF
--- a/types/cosmiconfig/cosmiconfig-tests.ts
+++ b/types/cosmiconfig/cosmiconfig-tests.ts
@@ -1,6 +1,6 @@
 import cosmiconfig = require("cosmiconfig");
 
-const explorer = cosmiconfig("yourModuleName", {
+const asyncExplorer = cosmiconfig("yourModuleName", {
     packageProp: "yourModuleName",
     rc: ".yourModuleNamerc",
     js: "yourModuleName.config.js",
@@ -14,13 +14,28 @@ const explorer = cosmiconfig("yourModuleName", {
 });
 
 Promise.all([
-    explorer.load(),
-    explorer.load("start/search/here"),
-    explorer.load(null, "load/this/file.json")
+    asyncExplorer.load(),
+    asyncExplorer.load("start/search/here"),
+    asyncExplorer.load(null, "load/this/file.json")
 ]).then(result => result);
 
-explorer.load().then(({ config, filePath }) => ({ config, filePath }));
+asyncExplorer.load().then(({ config, filePath }) => ({ config, filePath }));
 
-explorer.clearFileCache();
-explorer.clearDirectoryCache();
-explorer.clearCaches();
+asyncExplorer.clearFileCache();
+asyncExplorer.clearDirectoryCache();
+asyncExplorer.clearCaches();
+
+const syncExplorer = cosmiconfig("yourModuleName", {
+    packageProp: "yourModuleName",
+    rc: ".yourModuleNamerc",
+    js: "yourModuleName.config.js",
+    rcStrictJson: false,
+    rcExtensions: false,
+    stopDir: "someDir",
+    cache: true,
+    sync: true,
+    transform: ({ config, filePath }) => ({ config, filePath }),
+    format: "js"
+});
+
+const { config, filePath } = syncExplorer.load();

--- a/types/cosmiconfig/cosmiconfig-tests.ts
+++ b/types/cosmiconfig/cosmiconfig-tests.ts
@@ -1,0 +1,26 @@
+import cosmiconfig = require("cosmiconfig");
+
+const explorer = cosmiconfig("yourModuleName", {
+    packageProp: "yourModuleName",
+    rc: ".yourModuleNamerc",
+    js: "yourModuleName.config.js",
+    rcStrictJson: false,
+    rcExtensions: false,
+    stopDir: "someDir",
+    cache: true,
+    sync: false,
+    transform: ({ config, filePath }) => ({ config, filePath }),
+    format: "js"
+});
+
+Promise.all([
+    explorer.load(),
+    explorer.load("start/search/here"),
+    explorer.load(null, "load/this/file.json")
+]).then(result => result);
+
+explorer.load().then(({ config, filePath }) => ({ config, filePath }));
+
+explorer.clearFileCache();
+explorer.clearDirectoryCache();
+explorer.clearCaches();

--- a/types/cosmiconfig/index.d.ts
+++ b/types/cosmiconfig/index.d.ts
@@ -4,6 +4,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+interface Result {
+    config: object;
+    filePath: string;
+}
+
 interface Options {
     packageProp?: string | false;
     rc?: string | false;
@@ -12,27 +17,47 @@ interface Options {
     rcExtensions?: boolean;
     stopDir?: string;
     cache?: boolean;
-    sync?: boolean;
     transform?: (result: Result) => Promise<Result> | Result;
     configPath?: string;
     format?: "json" | "yaml" | "js";
 }
 
-interface Result {
-    config: object;
-    filePath: string;
+// Default is false and makes load() method async
+interface AsyncOptions extends Options {
+    sync?: false;
+}
+
+// Makes load() method sync
+interface SyncOptions extends Options {
+    sync: true;
 }
 
 interface Explorer {
-    // You should provide either searchPath or configPath for load method. To disallow both, overloaded definitions added.
-    load(searchPath?: string): Promise<Result>;
-    load(searchPath: null | undefined, configPath?: string): Promise<Result>;
-
     clearFileCache(): void;
     clearDirectoryCache(): void;
     clearCaches(): void;
 }
 
-declare function cosmiconfig(moduleName: string, options?: Options): Explorer;
+interface AsyncExplorer extends Explorer {
+    // You should provide either searchPath or configPath for load method. To disallow both, overloaded definitions added.
+    load(searchPath?: string): Promise<Result>;
+    load(searchPath: null | undefined, configPath?: string): Promise<Result>;
+}
+
+interface SyncExplorer extends Explorer {
+    // You should provide either searchPath or configPath for load method. To disallow both, overloaded definitions added.
+    load(searchPath?: string): Result;
+    load(searchPath: null | undefined, configPath?: string): Result;
+}
+
+declare function cosmiconfig(
+    moduleName: string,
+    options: SyncOptions
+): SyncExplorer;
+
+declare function cosmiconfig(
+    moduleName: string,
+    options?: AsyncOptions
+): AsyncExplorer;
 
 export = cosmiconfig;

--- a/types/cosmiconfig/index.d.ts
+++ b/types/cosmiconfig/index.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for cosmiconfig 4.0.0
+// Project: https://github.com/davidtheclark/cosmiconfig
+// Definitions by: ozum <https://github.com/ozum>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
 type Options = {
     packageProp?: string | false;
     rc?: string | false;

--- a/types/cosmiconfig/index.d.ts
+++ b/types/cosmiconfig/index.d.ts
@@ -1,0 +1,31 @@
+type Options = {
+    packageProp?: string | false;
+    rc?: string | false;
+    js?: string | false;
+    rcStrictJson?: boolean;
+    rcExtensions?: boolean;
+    stopDir?: string;
+    cache?: boolean;
+    sync?: boolean;
+    transform?: (result: Result) => Promise<Result> | Result;
+    configPath?: string;
+    format?: "json" | "yaml" | "js";
+};
+
+type Result = {
+    config: Object;
+    filePath: string;
+};
+
+declare interface Explorer {
+    load(searchPath?: string): Promise<Result>;
+    load(searchPath?: null | undefined, configPath?: string): Promise<Result>;
+
+    clearFileCache(): void;
+    clearDirectoryCache(): void;
+    clearCaches(): void;
+}
+
+declare function cosmiconfig(moduleName: string, options?: Options): Explorer;
+
+export = cosmiconfig;

--- a/types/cosmiconfig/index.d.ts
+++ b/types/cosmiconfig/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for cosmiconfig 4.0.0
+// Type definitions for cosmiconfig 4.0
 // Project: https://github.com/davidtheclark/cosmiconfig
 // Definitions by: ozum <https://github.com/ozum>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
 
-type Options = {
+interface Options {
     packageProp?: string | false;
     rc?: string | false;
     js?: string | false;
@@ -15,16 +16,17 @@ type Options = {
     transform?: (result: Result) => Promise<Result> | Result;
     configPath?: string;
     format?: "json" | "yaml" | "js";
-};
+}
 
-type Result = {
-    config: Object;
+interface Result {
+    config: object;
     filePath: string;
-};
+}
 
-declare interface Explorer {
+interface Explorer {
+    // You should provide either searchPath or configPath for load method. To disallow both, overloaded definitions added.
     load(searchPath?: string): Promise<Result>;
-    load(searchPath?: null | undefined, configPath?: string): Promise<Result>;
+    load(searchPath: null | undefined, configPath?: string): Promise<Result>;
 
     clearFileCache(): void;
     clearDirectoryCache(): void;

--- a/types/cosmiconfig/tsconfig.json
+++ b/types/cosmiconfig/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "cosmiconfig-tests.ts"
+    ]
+}

--- a/types/cosmiconfig/tsconfig.json
+++ b/types/cosmiconfig/tsconfig.json
@@ -1,22 +1,16 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
+        "lib": ["es6"],
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
-        "typeRoots": [
-            "../"
-        ],
+        "typeRoots": ["../"],
         "types": [],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": [
-        "index.d.ts",
-        "cosmiconfig-tests.ts"
-    ]
+    "files": ["index.d.ts", "cosmiconfig-tests.ts"]
 }

--- a/types/cosmiconfig/tslint.json
+++ b/types/cosmiconfig/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
