### PR TITLE
lodash: Remove clear() method from memoize's `MapCache`

### DIFF
--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -150,11 +150,6 @@ declare module "../index" {
          * @return Returns the cache object.
          */
         set(key: string, value: any): Dictionary<any>;
-
-        /**
-         * Removes all key-value entries from the map.
-         */
-        clear(): void;
     }
     interface MapCacheConstructor {
         new (): MapCache;

--- a/types/lodash/common/common.d.ts
+++ b/types/lodash/common/common.d.ts
@@ -127,21 +127,21 @@ declare module "../index" {
          * @param key The key of the value to remove.
          * @return Returns `true` if the entry was removed successfully, else `false`.
          */
-        delete(key: string): boolean;
+        delete(key: any): boolean;
 
         /**
          * Gets the cached value for `key`.
          * @param key The key of the value to get.
          * @return Returns the cached value.
          */
-        get(key: string): any;
+        get(key: any): any;
 
         /**
          * Checks if a cached value for `key` exists.
          * @param key The key of the entry to check.
          * @return Returns `true` if an entry for `key` exists, else `false`.
          */
-        has(key: string): boolean;
+        has(key: any): boolean;
 
         /**
          * Sets `value` to `key` of the cache.
@@ -149,7 +149,7 @@ declare module "../index" {
          * @param value The value to cache.
          * @return Returns the cache object.
          */
-        set(key: string, value: any): Dictionary<any>;
+        set(key: any, value: any): void;
     }
     interface MapCacheConstructor {
         new (): MapCache;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3691,7 +3691,6 @@ fp.now(); // $ExpectType number
         get(key: string): any { return 1; },
         has(key: string) { return true; },
         set(key: string, value: any): _.Dictionary<any> { return {}; },
-        clear() { },
     };
 
     const memoizeFn = (a1: string, a2: number): boolean => true;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -3706,6 +3706,12 @@ fp.now(); // $ExpectType number
 
     // $ExpectType MapCache
     new _.memoize.Cache();
+    _.memoize.Cache = WeakMap;
+    _.memoize.Cache = Map;
+
+    const memoizedFn = _.memoize(memoizeFn);
+    memoizedFn.cache = new WeakMap();
+    memoizedFn.cache = new Map();
 }
 
 // _.overArgs


### PR DESCRIPTION
`clear()` is unnecessary as confirmed here: lodash/lodash#3705
WeakMap doesn't have a clear() method, so the `clear` requirement was preventing `memoize(foo).cache = new WeakMap()`

The only gotcha I could think of:
People who are doing `myMemoizedFunction.cache.clear()` will need to add a type assertion.  But that seems rare and easy to deal with.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/lodash/lodash/issues/3705
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.