### PR TITLE
Fix react-i18next typings

### DIFF
--- a/types/react-i18next/src/I18n.d.ts
+++ b/types/react-i18next/src/I18n.d.ts
@@ -8,7 +8,7 @@ export interface Options {
 
 export interface i18nProps {
     wait?: boolean;
-    ns: string | string[];
+    ns?: string | string[];
     nsMode?: string;
     bindI18n?: string;
     bindStore?: string;


### PR DESCRIPTION
I18n ns property fallback to the defaultNS, so it is not mandatory and can be left undefined.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/i18next/react-i18next/blob/1503902275de6e39f31cd36c19e85224c9ff2e41/src/I18n.js#L12
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
