### PR TITLE
[koa-session] ContextStore constructr takes argument of type Koa.Context

### DIFF
--- a/types/koa-session/index.d.ts
+++ b/types/koa-session/index.d.ts
@@ -166,7 +166,7 @@ declare namespace session {
          * ContextStore must be a class which claims three instance methods demonstrated above.
          * new ContextStore(ctx) will be executed on every request.
          */
-        ContextStore?: { new(): stores };
+        ContextStore?: { new(ctx: Koa.Context): stores };
 
         /**
          * If you want to add prefix for all external session id, you can use options.prefix, it will not work if options.genid present.


### PR DESCRIPTION
https://github.com/koajs/session/blob/master/lib/context.js#L19

The user-provided ContextStore class is supposed to accept an argument of type Koa.Context.
The current definition only works for ContextStore classes with no constructor arguments.