### PR TITLE
[q] fix Promise not assignable to IWhenable

### DIFF
--- a/types/q/index.d.ts
+++ b/types/q/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for Q 1.0
+// Type definitions for Q 1.5
 // Project: https://github.com/kriskowal/q
 // Definitions by: Barrie Nemetchek <https://github.com/bnemetchek>
 //                 Andrew Gaspar <https://github.com/AndrewGaspar>
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 Michel Boudreau <https://github.com/mboudreau>
+//                 TeamworkGuy2 <https://github.com/TeamworkGuy2>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -28,46 +29,61 @@ declare namespace Q {
 	export interface Deferred<T> {
 		promise: Promise<T>;
 
+		/**
+		 * Calling resolve with a pending promise causes promise to wait on the passed promise, becoming fulfilled with its
+		 * fulfillment value or rejected with its rejection reason (or staying pending forever, if the passed promise does).
+		 * Calling resolve with a rejected promise causes promise to be rejected with the passed promise's rejection reason.
+		 * Calling resolve with a fulfilled promise causes promise to be fulfilled with the passed promise's fulfillment value.
+		 * Calling resolve with a non-promise value causes promise to be fulfilled with that value.
+		 */
 		resolve(value?: IWhenable<T>): void;
 
+		/**
+		 * Calling reject with a reason causes promise to be rejected with that reason.
+		 */
 		reject(reason?: any): void;
 
+		/**
+		 * Calling notify with a value causes promise to be notified of progress with that value. That is, any onProgress
+		 * handlers registered with promise or promises derived from promise will be called with the progress value.
+		 */
 		notify(value: any): void;
 
+		/**
+		 * Returns a function suitable for passing to a Node.js API. That is, it has a signature (err, result) and will
+		 * reject deferred.promise with err if err is given, or fulfill it with result if that is given.
+		 */
 		makeNodeResolver(): (reason: any, value: T) => void;
 	}
 
 	export interface Promise<T> {
 		/**
-		 * Like a finally clause, allows you to observe either the fulfillment or rejection of a promise, but to do so without modifying the final value. This is useful for collecting resources
-		 * regardless of whether a job succeeded, like closing a database connection, shutting a server down, or deleting an unneeded key from an object. finally returns a promise, which will become
-		 * resolved with the same fulfillment value or rejection reason as promise. However, if callback returns a promise, the resolution of the returned promise will be delayed until the promise
-		 * returned from callback is finished.
+		 * The then method from the Promises/A+ specification, with an additional progress handler.
 		 */
-		fin(finallyCallback: () => any): Promise<T>;
+		then<U>(onFulfill?: ((value: T) => IWhenable<U>) | null, onReject?: ((error: any) => IWhenable<U>) | null, onProgress?: ((progress: any) => any) | null): Promise<U>;
 
 		/**
-		 * Like a finally clause, allows you to observe either the fulfillment or rejection of a promise, but to do so without modifying the final value. This is useful for collecting resources
-		 * regardless of whether a job succeeded, like closing a database connection, shutting a server down, or deleting an unneeded key from an object. finally returns a promise, which will become
-		 * resolved with the same fulfillment value or rejection reason as promise. However, if callback returns a promise, the resolution of the returned promise will be delayed until the promise
-		 * returned from callback is finished.
+		 * Like a finally clause, allows you to observe either the fulfillment or rejection of a promise, but to do so
+		 * without modifying the final value. This is useful for collecting resources regardless of whether a job succeeded,
+		 * like closing a database connection, shutting a server down, or deleting an unneeded key from an object.
+		 * finally returns a promise, which will become resolved with the same fulfillment value or rejection reason
+		 * as promise. However, if callback returns a promise, the resolution of the returned promise will be delayed
+		 * until the promise returned from callback is finished. Furthermore, if the returned promise rejects, that
+		 * rejection will be passed down the chain instead of the previous result.
 		 */
 		finally(finallyCallback: () => any): Promise<T>;
 
 		/**
-		 * The then method from the Promises/A+ specification, with an additional progress handler.
+		 * Alias for finally() (for non-ES5 browsers)
 		 */
-		then<U>(onFulfill?: (value: T) => IWhenable<U>, onReject?: (error: any) => IWhenable<U>, onProgress?: (progress: any) => any): Promise<U>;
+		fin(finallyCallback: () => any): Promise<T>;
 
 		/**
-		 * Like then, but "spreads" the array into a variadic fulfillment handler. If any of the promises in the array are rejected, instead calls onRejected with the first rejected promise's
-		 * rejection reason.
-		 *
+		 * Like then, but "spreads" the array into a variadic fulfillment handler. If any of the promises in the array are
+		 * rejected, instead calls onRejected with the first rejected promise's rejection reason.
 		 * This is especially useful in conjunction with all
 		 */
 		spread<U>(onFulfill: (...args: any[]) => IWhenable<U>, onReject?: (reason: any) => IWhenable<U>): Promise<U>;
-
-		fail<U>(onRejected: (reason: any) => IWhenable<U>): Promise<U>;
 
 		/**
 		 * A sugar method, equivalent to promise.then(undefined, onRejected).
@@ -75,27 +91,37 @@ declare namespace Q {
 		catch<U>(onRejected: (reason: any) => IWhenable<U>): Promise<U>;
 
 		/**
+		 * Alias for catch() (for non-ES5 browsers)
+		 */
+		fail<U>(onRejected: (reason: any) => IWhenable<U>): Promise<U>;
+
+		/**
 		 * A sugar method, equivalent to promise.then(undefined, undefined, onProgress).
 		 */
 		progress(onProgress: (progress: any) => any): Promise<T>;
 
 		/**
-		 * Much like then, but with different behavior around unhandled rejection. If there is an unhandled rejection, either because promise is rejected and no onRejected callback was provided, or
-		 * because onFulfilled or onRejected threw an error or returned a rejected promise, the resulting rejection reason is thrown as an exception in a future turn of the event loop.
-		 *
-		 * This method should be used to terminate chains of promises that will not be passed elsewhere. Since exceptions thrown in then callbacks are consumed and transformed into rejections,
-		 * exceptions at the end of the chain are easy to accidentally, silently ignore. By arranging for the exception to be thrown in a future turn of the event loop, so that it won't be caught, it
-		 * causes an onerror event on the browser window, or an uncaughtException event on Node.js's process object.
-		 *
-		 * Exceptions thrown by done will have long stack traces, if Q.longStackSupport is set to true. If Q.onerror is set, exceptions will be delivered there instead of thrown in a future turn.
-		 *
-		 * The Golden Rule of done vs. then usage is: either return your promise to someone else, or if the chain ends with you, call done to terminate it.
+		 * Much like then, but with different behavior around unhandled rejection. If there is an unhandled rejection,
+		 * either because promise is rejected and no onRejected callback was provided, or because onFulfilled or onRejected
+		 * threw an error or returned a rejected promise, the resulting rejection reason is thrown as an exception in a
+		 * future turn of the event loop.
+		 * This method should be used to terminate chains of promises that will not be passed elsewhere. Since exceptions
+		 * thrown in then callbacks are consumed and transformed into rejections, exceptions at the end of the chain are
+		 * easy to accidentally, silently ignore. By arranging for the exception to be thrown in a future turn of the
+		 * event loop, so that it won't be caught, it causes an onerror event on the browser window, or an uncaughtException
+		 * event on Node.js's process object.
+		 * Exceptions thrown by done will have long stack traces, if Q.longStackSupport is set to true. If Q.onerror is set,
+		 * exceptions will be delivered there instead of thrown in a future turn.
+		 * The Golden Rule of done vs. then usage is: either return your promise to someone else, or if the chain ends
+		 * with you, call done to terminate it. Terminating with catch is not sufficient because the catch handler may
+		 * itself throw an error.
 		 */
-		done(onFulfilled?: (value: T) => any, onRejected?: (reason: any) => any, onProgress?: (progress: any) => any): void;
+		done(onFulfilled?: ((value: T) => any) | null, onRejected?: ((reason: any) => any) | null, onProgress?: ((progress: any) => any) | null): void;
 
 		/**
-		 * If callback is a function, assumes it's a Node.js-style callback, and calls it as either callback(rejectionReason) when/if promise becomes rejected, or as callback(null, fulfillmentValue)
-		 * when/if promise becomes fulfilled. If callback is not a function, simply returns promise.
+		 * If callback is a function, assumes it's a Node.js-style callback, and calls it as either callback(rejectionReason)
+		 * when/if promise becomes rejected, or as callback(null, fulfillmentValue) when/if promise becomes fulfilled.
+		 * If callback is not a function, simply returns promise.
 		 */
 		nodeify(callback: (reason: any, value: any) => void): Promise<T>;
 
@@ -112,8 +138,8 @@ declare namespace Q {
 		delete<U>(propertyName: string): Promise<U>;
 
 		/**
-		 * Returns a promise for the result of calling the named method of an object with the given array of arguments. The object itself is this in the function, just like a synchronous method call.
-		 * Essentially equivalent to
+		 * Returns a promise for the result of calling the named method of an object with the given array of arguments.
+		 * The object itself is this in the function, just like a synchronous method call. Essentially equivalent to
 		 *
 		 * @example
 		 * promise.then(function (o) { return o[methodName].apply(o, args); });
@@ -121,13 +147,10 @@ declare namespace Q {
 		post<U>(methodName: string, args: any[]): Promise<U>;
 
 		/**
-		 * Returns a promise for the result of calling the named method of an object with the given variadic arguments. The object itself is this in the function, just like a synchronous method call.
+		 * Returns a promise for the result of calling the named method of an object with the given variadic arguments.
+		 * The object itself is this in the function, just like a synchronous method call.
 		 */
 		invoke<U>(methodName: string, ...args: any[]): Promise<U>;
-
-		fapply<U>(args: any[]): Promise<U>;
-
-		fcall<U>(...args: any[]): Promise<U>;
 
 		/**
 		 * Returns a promise for an array of the property names of an object. Essentially equivalent to
@@ -136,6 +159,35 @@ declare namespace Q {
 		 * promise.then(function (o) { return Object.keys(o); });
 		 */
 		keys(): Promise<string[]>;
+
+		/**
+		 * Returns a promise for the result of calling a function, with the given array of arguments. Essentially equivalent to
+		 *
+		 * @example
+		 * promise.then(function (f) {
+		 *     return f.apply(undefined, args);
+		 * });
+		 */
+		fapply<U>(args: any[]): Promise<U>;
+
+		/**
+		 * Returns a promise for the result of calling a function, with the given variadic arguments. Has the same return
+		 * value/thrown exception translation as explained above for fbind.
+		 * In its static form, it is aliased as Q.try, since it has semantics similar to a try block (but handling both
+		 * synchronous exceptions and asynchronous rejections). This allows code like
+		 *
+		 * @example
+		 * Q.try(function () {
+		 *     if (!isConnectedToCloud()) {
+		 *         throw new Error("The cloud is down!");
+		 *     }
+		 *     return syncToCloud();
+		 * })
+		 * .catch(function (error) {
+		 *     console.error("Couldn't sync to the cloud", error);
+		 * });
+		 */
+		fcall<U>(...args: any[]): Promise<U>;
 
 		/**
 		 * A sugar method, equivalent to promise.then(function () { return value; }).
@@ -148,30 +200,39 @@ declare namespace Q {
 		thenReject<U = T>(reason?: any): Promise<U>;
 
 		/**
-		 * Attaches a handler that will observe the value of the promise when it becomes fulfilled, returning a promise for that same value, perhaps deferred but not replaced by the promise returned
-		 * by the onFulfilled handler.
+		 * Attaches a handler that will observe the value of the promise when it becomes fulfilled, returning a promise for
+		 * that same value, perhaps deferred but not replaced by the promise returned by the onFulfilled handler.
 		 */
 		tap(onFulfilled: (value: T) => any): Promise<T>;
 
+		/**
+		 * Returns a promise that will have the same result as promise, except that if promise is not fulfilled or rejected
+		 * before ms milliseconds, the returned promise will be rejected with an Error with the given message. If message
+		 * is not supplied, the message will be "Timed out after " + ms + " ms".
+		 */
 		timeout(ms: number, message?: string): Promise<T>;
 
 		/**
-		 * Returns a promise that will have the same result as promise, but will only be fulfilled or rejected after at least ms milliseconds have passed.
+		 * Returns a promise that will have the same result as promise, but will only be fulfilled or rejected after at least
+		 * ms milliseconds have passed.
 		 */
 		delay(ms: number): Promise<T>;
 
 		/**
-		 * Returns whether a given promise is in the fulfilled state. When the static version is used on non-promises, the result is always true.
+		 * Returns whether a given promise is in the fulfilled state. When the static version is used on non-promises, the
+		 * result is always true.
 		 */
 		isFulfilled(): boolean;
 
 		/**
-		 * Returns whether a given promise is in the rejected state. When the static version is used on non-promises, the result is always false.
+		 * Returns whether a given promise is in the rejected state. When the static version is used on non-promises, the
+		 * result is always false.
 		 */
 		isRejected(): boolean;
 
 		/**
-		 * Returns whether a given promise is in the pending state. When the static version is used on non-promises, the result is always false.
+		 * Returns whether a given promise is in the pending state. When the static version is used on non-promises, the
+		 * result is always false.
 		 */
 		isPending(): boolean;
 
@@ -193,6 +254,30 @@ declare namespace Q {
 		reason?: any;
 	}
 
+	/**
+	 * Returns a "deferred" object with a:
+	 * promise property
+	 * resolve(value) method
+	 * reject(reason) method
+	 * notify(value) method
+	 * makeNodeResolver() method
+	 */
+	export function defer<T>(): Deferred<T>;
+
+	/**
+	 * Calling resolve with a pending promise causes promise to wait on the passed promise, becoming fulfilled with its
+	 * fulfillment value or rejected with its rejection reason (or staying pending forever, if the passed promise does).
+	 * Calling resolve with a rejected promise causes promise to be rejected with the passed promise's rejection reason.
+	 * Calling resolve with a fulfilled promise causes promise to be fulfilled with the passed promise's fulfillment value.
+	 * Calling resolve with a non-promise value causes promise to be fulfilled with that value.
+	 */
+	export function resolve<T>(object?: IWhenable<T>): Promise<T>;
+
+	/**
+	 * Returns a promise that is rejected with reason.
+	 */
+	export function reject<T>(reason?: any): Promise<T>;
+
 	// If no value provided, returned promise will be of void type
 	export function when(): Promise<void>;
 
@@ -200,38 +285,168 @@ declare namespace Q {
 	export function when<T>(value: IWhenable<T>): Promise<T>;
 
 	// If a non-promise value is provided, it will not reject or progress
-	export function when<T, U>(value: IWhenable<T>, onFulfilled: (val: T) => IWhenable<U>, onRejected?: (reason: any) => IWhenable<U>, onProgress?: (progress: any) => any): Promise<U>;
+	export function when<T, U>(value: IWhenable<T>, onFulfilled: (val: T) => IWhenable<U>, onRejected?: ((reason: any) => IWhenable<U>) | null, onProgress?: ((progress: any) => any) | null): Promise<U>;
 
+	/**
+	 * (Deprecated) Returns a new function that calls a function asynchronously with the given variadic arguments, and returns a promise.
+	 * Notably, any synchronous return values or thrown exceptions are transformed, respectively, into fulfillment values
+	 * or rejection reasons for the promise returned by this new function.
+	 * This method is especially useful in its static form for wrapping functions to ensure that they are always
+	 * asynchronous, and that any thrown exceptions (intentional or accidental) are appropriately transformed into a
+	 * returned rejected promise. For example:
+	 *
+	 * @example
+	 * var getUserData = Q.fbind(function (userName) {
+	 *     if (!userName) {
+	 *         throw new Error("userName must be truthy!");
+	 *     }
+	 *     if (localCache.has(userName)) {
+	 *         return localCache.get(userName);
+	 *     }
+	 *     return getUserFromCloud(userName);
+	 * });
+	 */
 	export function fbind<T>(method: (...args: any[]) => IWhenable<T>, ...args: any[]): (...args: any[]) => Promise<T>;
 
+	/**
+	 * Returns a promise for the result of calling a function, with the given variadic arguments. Has the same return
+	 * value/thrown exception translation as explained above for fbind.
+	 * In its static form, it is aliased as Q.try, since it has semantics similar to a try block (but handling both synchronous
+	 * exceptions and asynchronous rejections). This allows code like
+	 *
+	 * @example
+	 * Q.try(function () {
+	 *     if (!isConnectedToCloud()) {
+	 *         throw new Error("The cloud is down!");
+	 *     }
+	 *     return syncToCloud();
+	 * })
+	 * .catch(function (error) {
+	 *     console.error("Couldn't sync to the cloud", error);
+	 * });
+	 */
 	export function fcall<T>(method: (...args: any[]) => T, ...args: any[]): Promise<T>;
 
-	// Try is an alias for fcall, but 'try' is a reserved word.  This is the only way to get around this
+	// but 'try' is a reserved word.  This is the only way to get around this
+	/**
+	 * Alias for fcall()
+	 */
 	export {fcall as try};
 
-	export function send<T>(obj: any, functionName: string, ...args: any[]): Promise<T>;
-
+	/**
+	 * Returns a promise for the result of calling the named method of an object with the given variadic arguments.
+	 * The object itself is this in the function, just like a synchronous method call.
+	 */
 	export function invoke<T>(obj: any, functionName: string, ...args: any[]): Promise<T>;
 
+	/**
+	 * Alias for invoke()
+	 */
+	export function send<T>(obj: any, functionName: string, ...args: any[]): Promise<T>;
+
+	/**
+	 * Alias for invoke()
+	 */
 	export function mcall<T>(obj: any, functionName: string, ...args: any[]): Promise<T>;
 
-	export function denodeify<T>(nodeFunction: (...args: any[]) => any, ...args: any[]): (...args: any[]) => Promise<T>;
-
-	export function nbind<T>(nodeFunction: (...args: any[]) => any, thisArg: any, ...args: any[]): (...args: any[]) => Promise<T>;
-
+	/**
+	 * Creates a promise-returning function from a Node.js-style function, optionally binding it with the given
+	 * variadic arguments. An example:
+	 *
+	 * @example
+	 * var readFile = Q.nfbind(FS.readFile);
+	 * readFile("foo.txt", "utf-8").done(function (text) {
+	 *     //...
+	 * });
+	 *
+	 * Note that if you have a method that uses the Node.js callback pattern, as opposed to just a function, you will
+	 * need to bind its this value before passing it to nfbind, like so:
+	 *
+	 * @example
+	 * var Kitty = mongoose.model("Kitty");
+	 * var findKitties = Q.nfbind(Kitty.find.bind(Kitty));
+	 *
+	 * The better strategy for methods would be to use Q.nbind, as shown below.
+	 */
 	export function nfbind<T>(nodeFunction: (...args: any[]) => any, ...args: any[]): (...args: any[]) => Promise<T>;
 
-	export function nfcall<T>(nodeFunction: (...args: any[]) => any, ...args: any[]): Promise<T>;
+	/**
+	 * Alias for nfbind()
+	 */
+	export function denodeify<T>(nodeFunction: (...args: any[]) => any, ...args: any[]): (...args: any[]) => Promise<T>;
 
+	/**
+	 * Creates a promise-returning function from a Node.js-style method, optionally binding it with the given
+	 * variadic arguments. An example:
+	 *
+	 * @example
+	 * var Kitty = mongoose.model("Kitty");
+	 * var findKitties = Q.nbind(Kitty.find, Kitty);
+	 * findKitties({ cute: true }).done(function (theKitties) {
+	 *     //...
+	 * });
+	 */
+	export function nbind<T>(nodeFunction: (...args: any[]) => any, thisArg: any, ...args: any[]): (...args: any[]) => Promise<T>;
+
+	/**
+	 * Calls a Node.js-style function with the given array of arguments, returning a promise that is fulfilled if the
+	 * Node.js function calls back with a result, or rejected if it calls back with an error
+	 * (or throws one synchronously). An example:
+	 *
+	 * @example
+	 * Q.nfapply(FS.readFile, ["foo.txt", "utf-8"]).done(function (text) {
+	 * });
+	 *
+	 * Note that this example only works because FS.readFile is a function exported from a module, not a method on
+	 * an object. For methods, e.g. redisClient.get, you must bind the method to an instance before passing it to
+	 * Q.nfapply (or, generally, as an argument to any function call):
+	 *
+	 * @example
+	 * Q.nfapply(redisClient.get.bind(redisClient), ["user:1:id"]).done(function (user) {
+	 * });
+	 *
+	 * The better strategy for methods would be to use Q.npost, as shown below.
+	 */
 	export function nfapply<T>(nodeFunction: (...args: any[]) => any, args: any[]): Promise<T>;
 
-	export function ninvoke<T>(nodeModule: any, functionName: string, ...args: any[]): Promise<T>;
+	/**
+	 * Calls a Node.js-style function with the given variadic arguments, returning a promise that is fulfilled if the
+	 * Node.js function calls back with a result, or rejected if it calls back with an error
+	 * (or throws one synchronously). An example:
+	 *
+	 * @example
+	 * Q.nfcall(FS.readFile, "foo.txt", "utf-8").done(function (text) {
+	 * });
+	 *
+	 * The same warning about functions vs. methods applies for nfcall as it does for nfapply. In this case, the better
+	 * strategy would be to use Q.ninvoke.
+	 */
+	export function nfcall<T>(nodeFunction: (...args: any[]) => any, ...args: any[]): Promise<T>;
 
+	/**
+	 * Calls a Node.js-style method with the given arguments array, returning a promise that is fulfilled if the method
+	 * calls back with a result, or rejected if it calls back with an error (or throws one synchronously). An example:
+	 *
+	 * @example
+	 * Q.npost(redisClient, "get", ["user:1:id"]).done(function (user) {
+	 * });
+	 */
 	export function npost<T>(nodeModule: any, functionName: string, args: any[]): Promise<T>;
 
-	export function nsend<T>(nodeModule: any, functionName: string, ...args: any[]): Promise<T>;
+	/**
+	 * Calls a Node.js-style method with the given variadic arguments, returning a promise that is fulfilled if the
+	 * method calls back with a result, or rejected if it calls back with an error (or throws one synchronously). An example:
+	 *
+	 * @example
+	 * Q.ninvoke(redisClient, "get", "user:1:id").done(function (user) {
+	 * });
+	 */
+	export function ninvoke<T>(nodeModule: any, functionName: string, ...args: any[]): Promise<T>;
 
-	export function nmcall<T>(nodeModule: any, functionName: string, ...args: any[]): Promise<T>;
+	/**
+	 * Alias for ninvoke()
+	 */
+	export function nsend<T>(nodeModule: any, functionName: string, ...args: any[]): Promise<T>;
 
 	/**
 	 * Returns a promise that is fulfilled with an array containing the fulfillment value of each promise, or is rejected with the same rejection reason as the first promise to be rejected.
@@ -267,21 +482,27 @@ declare namespace Q {
 	export function race<T>(promises: Array<IWhenable<T>>): Promise<T>;
 
 	/**
-	 * Returns a promise that is fulfilled with an array of promise state snapshots, but only after all the original promises have settled, i.e. become either fulfilled or rejected.
+	 * Returns a promise that is fulfilled with an array of promise state snapshots, but only after all the original promises
+	 * have settled, i.e. become either fulfilled or rejected.
 	 */
 	export function allSettled<T>(promises: IWhenable<Array<IWhenable<T>>>): Promise<Array<PromiseState<T>>>;
 
+	/**
+	 * Deprecated Alias for allSettled()
+	 */
 	export function allResolved<T>(promises: IWhenable<Array<IWhenable<T>>>): Promise<Array<Promise<T>>>;
 
 	/**
-	 * Like then, but "spreads" the array into a variadic fulfillment handler. If any of the promises in the array are rejected, instead calls onRejected with the first rejected promise's rejection
-	 * reason. This is especially useful in conjunction with all.
+	 * Like then, but "spreads" the array into a variadic fulfillment handler. If any of the promises in the array are
+	 * rejected, instead calls onRejected with the first rejected promise's rejection reason. This is especially useful
+	 * in conjunction with all.
 	 */
 	export function spread<T, U>(promises: Array<IWhenable<T>>, onFulfilled: (...args: T[]) => IWhenable<U>, onRejected?: (reason: any) => IWhenable<U>): Promise<U>;
 
 	/**
-	 * Returns a promise that will have the same result as promise, except that if promise is not fulfilled or rejected before ms milliseconds, the returned promise will be rejected with an Error
-	 * with the given message. If message is not supplied, the message will be "Timed out after " + ms + " ms".
+	 * Returns a promise that will have the same result as promise, except that if promise is not fulfilled or rejected
+	 * before ms milliseconds, the returned promise will be rejected with an Error with the given message. If message
+	 * is not supplied, the message will be "Timed out after " + ms + " ms".
 	 */
 	export function timeout<T>(promise: Promise<T>, ms: number, message?: string): Promise<T>;
 
@@ -310,74 +531,63 @@ declare namespace Q {
 	export function isPending(promiseOrObject: Promise<any> | any): boolean;
 
 	/**
-	 * Returns a "deferred" object with a:
-	 * promise property
-	 * resolve(value) method
-	 * reject(reason) method
-	 * notify(value) method
-	 * makeNodeResolver() method
+	 * Synchronously calls resolver(resolve, reject, notify) and returns a promise whose state is controlled by the
+	 * functions passed to resolver. This is an alternative promise-creation API that has the same power as the deferred
+	 * concept, but without introducing another conceptual entity.
+	 * If resolver throws an exception, the returned promise will be rejected with that thrown exception as the rejection reason.
+	 * note: In the latest github, this method is called Q.Promise, but if you are using the npm package version 0.9.7
+	 * or below, the method is called Q.promise (lowercase vs uppercase p).
 	 */
-	export function defer<T>(): Deferred<T>;
-
-	/**
-	 * Returns a promise that is rejected with reason.
-	 */
-	export function reject<T>(reason?: any): Promise<T>;
-
 	export function Promise<T>(resolver: (resolve: (val?: IWhenable<T>) => void, reject: (reason?: any) => void, notify: (progress: any) => void) => void): Promise<T>;
 
 	/**
-	 * Creates a new version of func that accepts any combination of promise and non-promise values, converting them to their fulfillment values before calling the original func. The returned version
-	 * also always returns a promise: if func does a return or throw, then Q.promised(func) will return fulfilled or rejected promise, respectively.
-	 *
-	 * This can be useful for creating functions that accept either promises or non-promise values, and for ensuring that the function always returns a promise even in the face of unintentional
-	 * thrown exceptions.
+	 * Creates a new version of func that accepts any combination of promise and non-promise values, converting them to their
+	 * fulfillment values before calling the original func. The returned version also always returns a promise: if func does
+	 * a return or throw, then Q.promised(func) will return fulfilled or rejected promise, respectively.
+	 * This can be useful for creating functions that accept either promises or non-promise values, and for ensuring that
+	 * the function always returns a promise even in the face of unintentional thrown exceptions.
 	 */
 	export function promised<T>(callback: (...args: any[]) => T): (...args: any[]) => Promise<T>;
 
 	/**
 	 * Returns whether the given value is a Q promise.
 	 */
-	export function isPromise(object: any): boolean;
+	export function isPromise(object: any): object is Promise<any>;
 
 	/**
 	 * Returns whether the given value is a promise (i.e. it's an object with a then function).
 	 */
-	export function isPromiseAlike(object: any): boolean;
+    export function isPromiseAlike(object: any): object is IPromise<any>;
 
 	/**
 	 * If an object is not a promise, it is as "near" as possible.
 	 * If a promise is rejected, it is as "near" as possible too.
-	 * If it’s a fulfilled promise, the fulfillment value is nearer.
-	 * If it’s a deferred promise and the deferred has been resolved, the
+	 * If it's a fulfilled promise, the fulfillment value is nearer.
+	 * If it's a deferred promise and the deferred has been resolved, the
 	 * resolution is "nearer".
 	 */
 	export function nearer<T>(promise: Promise<T>): T;
 
 	/**
-	 * This is an experimental tool for converting a generator function into a deferred function. This has the potential of reducing nested callbacks in engines that support yield.
+	 * This is an experimental tool for converting a generator function into a deferred function. This has the potential
+	 * of reducing nested callbacks in engines that support yield.
 	 */
 	export function async<T>(generatorFunction: any): (...args: any[]) => Promise<T>;
 
 	export function nextTick(callback: (...args: any[]) => any): void;
 
 	/**
-	 * A settable property that will intercept any uncaught errors that would otherwise be thrown in the next tick of the event loop, usually as a result of done. Can be useful for getting the full
+	 * A settable property that will intercept any uncaught errors that would otherwise be thrown in the next tick of the
+	 * event loop, usually as a result of done. Can be useful for getting the full
 	 * stack trace of an error in browsers, which is not usually possible with window.onerror.
 	 */
 	export let onerror: (reason: any) => void;
 	/**
-	 * A settable property that lets you turn on long stack trace support. If turned on, "stack jumps" will be tracked across asynchronous promise operations, so that if an uncaught error is thrown
-	 * by done or a rejection reason's stack property is inspected in a rejection callback, a long stack trace is produced.
+	 * A settable property that lets you turn on long stack trace support. If turned on, "stack jumps" will be tracked
+	 * across asynchronous promise operations, so that if an uncaught error is thrown by done or a rejection reason's stack
+	 * property is inspected in a rejection callback, a long stack trace is produced.
 	 */
 	export let longStackSupport: boolean;
-
-	/**
-	 * Calling resolve with a pending promise causes promise to wait on the passed promise, becoming fulfilled with its fulfillment value or rejected with its rejection reason (or staying pending
-	 * forever, if the passed promise does). Calling resolve with a rejected promise causes promise to be rejected with the passed promise's rejection reason. Calling resolve with a fulfilled promise
-	 * causes promise to be fulfilled with the passed promise's fulfillment value. Calling resolve with a non-promise value causes promise to be fulfilled with that value.
-	 */
-	export function resolve<T>(object?: IWhenable<T>): Promise<T>;
 
 	/**
 	 * Resets the global "Q" variable to the value it has before Q was loaded.

--- a/types/q/q-tests.ts
+++ b/types/q/q-tests.ts
@@ -1,18 +1,20 @@
 /// <reference types="jquery" />
 
-import Q = require('q');
+import Q = require("q");
 
-Q(8).then(x => console.log(x.toExponential()));
+const _when: Q.IWhenable<number> = Q.resolve(0); // was an issue when strictFunctionTypes were enforced on all of DefinitelyTyped
+
+Q(8).then((x) => console.log(x.toExponential()));
 Q().then(() => console.log("nothing"));
 
-const delay = (delay: number) => {
+function delay(delay: number): Q.Promise<void> {
 	const d = Q.defer<void>();
 	setTimeout(d.resolve, delay);
 	return d.promise;
-};
+}
 
 Q.when(delay(1000), (val) => {
-	console.log('Hello, World!');
+	console.log("Hello, World!");
 	return;
 });
 
@@ -20,15 +22,15 @@ Q.when(delay(1000), (val) => {
 const otherPromise = Q.defer<string>().promise;
 Q.defer<string>().resolve(otherPromise);
 
-Q.timeout(Q(new Date()), 1000, "My dates never arrived. :(").then(d => d.toJSON());
+Q.timeout(Q(new Date()), 1000, "My dates never arrived. :(").then((d) => d.toJSON());
 
-Q.delay(Q(8), 1000).then(x => x.toExponential());
-Q.delay(8, 1000).then(x => x.toExponential());
-Q.delay(Q("asdf"), 1000).then(x => x.length);
-Q.delay("asdf", 1000).then(x => x.length);
+Q.delay(Q(8), 1000).then((x) => x.toExponential());
+Q.delay(8, 1000).then((x) => x.toExponential());
+Q.delay(Q("asdf"), 1000).then((x) => x.length);
+Q.delay("asdf", 1000).then((x) => x.length);
 
-const eventualAdd = Q.promised((a?: number, b?: number) => a + b);
-eventualAdd(Q(1), Q(2)).then(x => x.toExponential());
+const eventualAdd = Q.promised((a?: number, b?: number) => <number> a + <number> b);
+eventualAdd(Q(1), Q(2)).then((x) => x.toExponential());
 
 function eventually<T>(eventually: T) {
 	return Q.delay(eventually, 1000);
@@ -36,6 +38,7 @@ function eventually<T>(eventually: T) {
 
 const x = Q.all([1, 2, 3].map(eventually));
 Q.when(x, (x) => {
+	const _x: number[] = x;
 	console.log(x);
 });
 
@@ -81,10 +84,11 @@ Q.allResolved([])
 
 Q(42)
 	.tap(() => "hello")
-	.tap(x => {
+	.tap((x) => {
 		console.log(x);
 	})
-	.then(x => {
+	.then((x) => {
+		const _x: number = x;
 		console.log("42 == " + x);
 	});
 
@@ -94,34 +98,34 @@ declare let stringPromise: Q.IPromise<string>;
 declare function returnsNumPromise(text: string): Q.Promise<number>;
 declare function returnsNumPromise(text: string): JQueryPromise<number>;
 
-Q<number[]>(arrayPromise) // type specification required
-	.then(arr => arr.join(','))
-	.then<number>(returnsNumPromise) // requires specification
-	.then(num => num.toFixed());
+Q(arrayPromise)
+	.then((arr) => arr.join(','))
+	.then(returnsNumPromise) // requires specification
+	.then((num) => num.toFixed());
 
 declare let jPromise: JQueryPromise<string>;
 
 // if jQuery promises definition supported generics, this could be more interesting example
-Q<string>(jPromise).then(str => str.split(','));
+Q<string>(jPromise).then((str) => str.split(','));
 jPromise.then(returnsNumPromise);
 
 // watch the typing flow through from jQueryPromise to Q.Promise
-Q(jPromise).then(str => str.split(','));
+Q(jPromise).then((str) => str.split(','));
 
 declare let promiseArray: Array<Q.IPromise<number>>;
-const qPromiseArray = promiseArray.map(p => {
+const qPromiseArray = promiseArray.map((p) => {
 	return Q<number>(p);
 });
 const myNums: any[] = [2, 3, Q(4), 5, Q(6), Q(7)];
 
-Q.all(promiseArray).then(nums => nums.map(num => num.toPrecision(2)).join(','));
+Q.all(promiseArray).then((nums) => nums.map((num) => num.toPrecision(2)).join(','));
 
-Q.all<number>(myNums).then(nums => nums.map(Math.round));
+Q.all<number>(myNums).then((nums) => nums.map(Math.round));
 
-Q.fbind((dateString?: string) => new Date(dateString), "11/11/1991")().then(d => d.toLocaleDateString());
+Q.fbind((dateString?: string) => new Date(<string> dateString), "11/11/1991")().then((d) => d.toLocaleDateString());
 
-Q.when(8, num => num + "!");
-Q.when(Q(8), num => num + "!").then(str => str.split(','));
+Q.when(8, (num) => num + "!");
+Q.when(Q(8), (num) => num + "!").then((str) => str.split(','));
 const voidPromise: Q.Promise<void> = Q.when();
 
 declare function saveToDisk(): Q.Promise<any>;
@@ -147,22 +151,27 @@ Q.nfapply<string>(nodeStyle, ["foo"]).done((result: string) => {
 });
 Q.nfcall<string>(nodeStyle, "foo").done((result: string) => {
 });
-Q.denodeify<string>(nodeStyle)('foo').done((result: string) => {
+Q.denodeify<string>(nodeStyle)("foo").done((result: string) => {
 });
-Q.nfbind<string>(nodeStyle)('foo').done((result: string) => {
+Q.nfbind<string>(nodeStyle)("foo").done((result: string) => {
 });
+
+interface Kitty {
+	name: string;
+	cute: boolean;
+}
 
 class Repo {
-	private readonly items: any[] = [
-		{name: 'Max', cute: false},
-		{name: 'Annie', cute: true}
+	private readonly items: Kitty[] = [
+		{name: "Max", cute: false},
+		{name: "Annie", cute: true}
 	];
 
-	find(options: any): Q.Promise<any[]> {
+	find(options: {[K in keyof Kitty]: Kitty[K] }): Q.Promise<Kitty[]> {
 		let result = this.items;
 
 		for (const key in options) {
-			result = result.filter(i => i[key] === options[key]);
+			result = result.filter((i) => i[<keyof Kitty> key] === options[<keyof Kitty> key]);
 		}
 
 		return Q(result);
@@ -170,7 +179,8 @@ class Repo {
 }
 
 const kitty = new Repo();
-Q.nbind<any[]>(kitty.find, kitty)({cute: true}).done((kitties: any[]) => {
+Q.nbind<Kitty[]>(kitty.find, kitty)({ cute: true }).done((kitties) => {
+	const _kitties: Kitty[] = kitties;
 });
 
 /**
@@ -194,10 +204,6 @@ function TestCanRethrowRejectedPromises() {
 			.fail((error) => {
 				console.log("Intermediate error handling");
 
-				/*
-				 * Cannot do this, because:
-				 *     error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<Foo>'
-				 */
 				return Q.reject<Foo>(error);
 			});
 	}
@@ -206,10 +212,14 @@ function TestCanRethrowRejectedPromises() {
 		.finally(() => {
 			console.log("Cleanup");
 		})
-		.done();
+		.done((foo) => {
+			const _foo: Foo = foo;
+		});
 }
 
-// test Q.Promise.all
+/**
+ * test Q.Promise.all
+ */
 const y1 = Q().then(() => {
 	const s = Q("hello");
 	const n = Q(1);
@@ -222,9 +232,9 @@ const y2 = Q().then(() => {
 	return <[typeof s, typeof n]> [s, n];
 });
 
-const p2: Q.Promise<[string, number]> = y1.then(val => Q.all(val));
+const p2: Q.Promise<[string, number]> = y1.then((val) => Q.all(val));
 const p3: Q.Promise<[string, number]> = Q.all(y1);
-const p5: Q.Promise<[string, number]> = y2.then(val => Q.all(val));
+const p5: Q.Promise<[string, number]> = y2.then((val) => Q.all(val));
 const p6: Q.Promise<[string, number]> = Q.all(y2);
 
 Q.try(() => {
@@ -238,8 +248,8 @@ Q.try(() => {
 // thenReject, returning a Promise of the same type as the Promise it is called on
 function thenRejectSameType(arg: any): Q.Promise<number> {
 	if (!arg) {
-		return returnsNumPromise('')
-			.thenReject(new Error('failed'));
+		return returnsNumPromise("")
+			.thenReject(new Error("failed"));
 	}
 	return Q.resolve(2);
 }
@@ -248,10 +258,10 @@ function thenRejectSameType(arg: any): Q.Promise<number> {
 // The generic type argument is specified.
 function thenRejectSpecificOtherType(arg: any): Q.Promise<string> {
 	if (!arg) {
-		return returnsNumPromise('')
-			.thenReject<string>(new Error('failed'));
+		return returnsNumPromise("")
+			.thenReject<string>(new Error("failed"));
 	}
-	return Q.resolve('');
+	return Q.resolve("");
 }
 
 // thenReject, returning a Promise of a different type to the Promise it is called on.
@@ -262,9 +272,9 @@ function thenRejectSpecificOtherType(arg: any): Q.Promise<string> {
 /*
 function thenRejectInferredOtherType(arg: any): Q.Promise<string> {
 	if (!arg) {
-		return returnsNumPromise('')
-			.thenReject(new Error('failed'));
+		return returnsNumPromise("")
+			.thenReject(new Error("failed"));
 	}
-	return Q.resolve('');
+	return Q.resolve("");
 }
 */

--- a/types/q/tsconfig.json
+++ b/types/q/tsconfig.json
@@ -7,8 +7,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
-        "strictFunctionTypes": false,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"


### PR DESCRIPTION
Fixes Q.Promise<T> not being assignable to Q.IWhenable<T> with strictFunctionTypes enabled repository wide on DefinitelyTyped.
* Fix required `| null` on promise.then(`onFulfill`, `onReject`, `onProgress`) parameters
* Updated index.d.ts Version `1.0` -> `1.5`
* Updated documentation based on <https://github.com/kriskowal/q/wiki/API-Reference>
* Updated tsconfig.json:
  "strictNullChecks": true,
  "strictFunctionTypes": true,

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] **won't run because of error in uglify-js about whitelisted packages...** Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/kriskowal/q/wiki/API-Reference>
- [x] Increase the version number in the header if appropriate.
