### PR TITLE
Add new RenderProps-style Context from React 16.3

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -240,6 +240,24 @@ declare namespace React {
         props?: Partial<P> & Attributes,
         ...children: ReactNode[]): ReactElement<P>;
 
+    // Context via RenderProps
+    type Provider<T> = ComponentType<{
+        value: T,
+        children?: ReactNode
+    }>;
+    type Consumer<T> = ComponentType<{
+        children: (value: T) => ReactNode,
+        unstable_observedBits?: number
+    }>;
+    interface Context<T> {
+        Provider: Provider<T>;
+        Consumer: Consumer<T>;
+    }
+    function createContext<T>(
+        defaultValue: T,
+        calculateChangedBits?: (prev: T, next: T) => number
+    ): Context<T>;
+
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 
     const Children: ReactChildren;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -257,6 +257,7 @@ declare namespace React {
         defaultValue: T,
         calculateChangedBits?: (prev: T, next: T) => number
     ): Context<T>;
+    function createContext<T>(): Context<T | undefined>
 
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -257,7 +257,7 @@ declare namespace React {
         defaultValue: T,
         calculateChangedBits?: (prev: T, next: T) => number
     ): Context<T>;
-    function createContext<T>(): Context<T | undefined>
+    function createContext<T>(): Context<T | undefined>;
 
     function isValidElement<P>(object: {} | null | undefined): object is ReactElement<P>;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -241,14 +241,18 @@ declare namespace React {
         ...children: ReactNode[]): ReactElement<P>;
 
     // Context via RenderProps
-    type Provider<T> = ComponentType<{
-        value: T,
-        children?: ReactNode
-    }>;
-    type Consumer<T> = ComponentType<{
-        children: (value: T) => ReactNode,
-        unstable_observedBits?: number
-    }>;
+    interface ProviderProps<T> {
+        value: T;
+        children?: ReactNode;
+    }
+
+    interface ConsumerProps<T> {
+        children: (value: T) => ReactNode;
+        unstable_observedBits?: number;
+    }
+
+    type Provider<T> = ComponentType<ProviderProps<T>>;
+    type Consumer<T> = ComponentType<ConsumerProps<T>>;
     interface Context<T> {
         Provider: Provider<T>;
         Consumer: Consumer<T>;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -75,6 +75,9 @@ const StatelessComponentWithoutProps: React.SFC = (props) => {
 };
 <StatelessComponentWithoutProps />;
 
+// React.createContext
+const ContextWithRenderProps = React.createContext('defaultValue');
+
 // Fragments
 <div>
     <React.Fragment>


### PR DESCRIPTION
React 16.3, the latest version, has a new recommended API for Context, with Context, Provider, and Consumer typings.

These changes are merged in this PR to React: 
https://github.com/facebook/react/pull/11818

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.