### PR TITLE
Add stricter type guard for isFinite

### DIFF
--- a/types/lodash/fp/isFinite.d.ts
+++ b/types/lodash/fp/isFinite.d.ts
@@ -11,7 +11,7 @@ type IsFinite =
      * @param value The value to check.
      * @return Returns true if value is a finite number, else false.
      */
-    (value: any) => boolean;
+    (value: any) => value is number;
 
 declare const isFinite: IsFinite;
 export = isFinite;


### PR DESCRIPTION
Following this change, `if (isFinite(value)) {}` ensures that value is of type `number` inside of the if block.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://lodash.com/docs/4.17.4#isFinite>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.