### PR TITLE
Fix jwplayer project url and improve indent 

### DIFF
--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for JW Player V8.0
-// Project: http://developer.longtailvideo.com/trac/
+// Project: https://github.com/jwplayer/jwplayer/
 // Definitions by: Martin Duparc <https://github.com/martinduparc>
 //                 Tomer Kruvi <https://github.com/kutomer>
 //                 Philipp Gürtler <https://github.com/philippguertler>

--- a/types/jwplayer/index.d.ts
+++ b/types/jwplayer/index.d.ts
@@ -255,8 +255,8 @@ interface JWPlayer {
 	getSafeRegion(): Region;
 	getState(): string;
 	getVolume(): number;
-  getContainer(): HTMLElement;
-  getEnvironment(): Environment;
+	getContainer(): HTMLElement;
+	getEnvironment(): Environment;
 	getWidth(): number;
 	load(playlist: any[]): void;
 	load(playlist: string): void;


### PR DESCRIPTION
This Pull Request will improve jwplayer `index.d.ts` file project url - it seems to be last updated 5 years ago (trac/svn? url) - project code is meantime moved to [github](https://github.com/jwplayer/jwplayer/).

Also fixing small indent error (tabs vs spaces).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
