### PR TITLE
@types/grecaptcha: add missing properties and function parameters

### DIFF
--- a/types/grecaptcha/index.d.ts
+++ b/types/grecaptcha/index.d.ts
@@ -78,7 +78,7 @@ declare namespace ReCaptchaV2 {
      * where reCAPTCHA is rendered.
      * Attribute: data-bind.
      */
-    bind?: string | HTMLElement
+    bind?: string | HTMLElement;
     /**
      * Optional. The badge location for g-recaptcha with size of "invisible".
      * If isolated this value is ignored and "none" is used instead.
@@ -86,13 +86,13 @@ declare namespace ReCaptchaV2 {
      * Attribute: data-badge.
      * @default "bottomright"
      */
-    badge?: Badge
+    badge?: Badge;
     /**
      * Optional preload(probably challenge).
      * Defaults to true if recaptcha is invisible.
      * Attribute: data-preload
      */
-    preload?: boolean
+    preload?: boolean;
     /**
      * Optional. Your callback function that's executed when the user submits a successful CAPTCHA response.
      * Attribute: data-callback.
@@ -116,27 +116,27 @@ declare namespace ReCaptchaV2 {
      * Optional.
      * Attribute: data-stoken.
      */
-    stoken?: any
+    stoken?: any;
     /**
      * Optional.
      * Attribute: data-s.
      */
-    s?: any
+    s?: any;
     /**
      * Optional.
      * Attribute: data-pool.
      */
-    pool?: any
+    pool?: any;
     /**
      * Optional.
      * Attribute: data-action.
      */
-    action?: any
+    action?: any;
     /**
      * Optional.
      * Attribute: data-content-binding.
      */
-    "content-binding"?: any
+    "content-binding"?: any;
     /**
      * Optional.
      * If true, this reCAPTCHA instance will be part of a separate ID space and badge value will be set to "none".
@@ -144,22 +144,22 @@ declare namespace ReCaptchaV2 {
      * Has no corresponding attribute.
      * @default false
      */
-    isolated?: boolean
+    isolated?: boolean;
     /**
      * Optional.
      * Has no corresponding attribute.
      */
-    origin?: any
+    origin?: any;
     /**
      * Optional. Defaults to language specified in script(hl query parameter) or browser language.
      * Has no corresponding attribute.
      * Accepted values: https://developers.google.com/recaptcha/docs/language .
      */
-    hl?: string
+    hl?: string;
     /**
      * Optional.
      * @default v1520836262157
      */
-    version?: string
+    version?: string;
   }
 }

--- a/types/grecaptcha/index.d.ts
+++ b/types/grecaptcha/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for Google Recaptcha 2.0
 // Project: https://www.google.com/recaptcha
-// Definitions by: Kristof Mattei <http://kristofmattei.be>, Martin Costello <https://martincostello.com/>, Ruslan Arkhipau <https://github.com/DethAriel>
+// Definitions by: Kristof Mattei <http://kristofmattei.be>, Martin Costello <https://martincostello.com/>, Ruslan Arkhipau <https://github.com/DethAriel>, Pavel Levchuk <https://github.com/Spaier>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var grecaptcha: ReCaptchaV2.ReCaptcha;

--- a/types/grecaptcha/index.d.ts
+++ b/types/grecaptcha/index.d.ts
@@ -11,23 +11,25 @@ declare namespace ReCaptchaV2 {
      * Renders the container as a reCAPTCHA widget and returns the ID of the newly created widget.
      * @param container The HTML element to render the reCAPTCHA widget. Specify either the ID of the container (string) or the DOM element itself.
      * @param parameters An object containing parameters as key=value pairs, for example, {"sitekey": "your_site_key", "theme": "light"}. See @see render parameters.
+     * @param useContainerAttributes Defaults to true. If true, merges parameters with data-* attributes of container. The values in parameters will take precedence over the attributes.
      * @return the ID of the newly created widget.
      */
-    render(container: (string | HTMLElement), parameters?: Parameters): number;
+    render(container: (string | HTMLElement), parameters?: Parameters, useContainerAttributes?: boolean): number;
     /**
      * Resets the reCAPTCHA widget.
-     * @param opt_widget_id Optional widget ID, defaults to the first widget created if unspecified.
+     * @param opt_widget_id Optional widget ID, defaults to 0 if unspecified. (Not the first recaptcha rendered because if recaptcha is isolated id starts with 1E5)
+     * @param parameters If specified, rerenders recaptcha in this element with new parameters.
      */
-    reset(opt_widget_id?: number): void;
+    reset(opt_widget_id?: number, parameters?: Parameters): void;
     /**
      * Gets the response for the reCAPTCHA widget.
-     * @param opt_widget_id Optional widget ID, defaults to the first widget created if unspecified.
+     * @param opt_widget_id Optional widget ID, defaults to 0 if unspecified. (Not the first recaptcha rendered because if recaptcha is isolated id starts with 1E5)
      * @return the response of the reCAPTCHA widget.
      */
     getResponse(opt_widget_id?: number): string;
     /**
      * Programatically invoke the reCAPTCHA check. Used if the invisible reCAPTCHA is on a div instead of a button.
-     * @param opt_widget_id Optional widget ID, defaults to the first widget created if unspecified.
+     * @param opt_widget_id Optional widget ID, defaults to 0 if unspecified. (Not the first recaptcha rendered because if recaptcha is isolated id starts with 1E5)
      */
     execute(opt_widget_id?: number): void;
   }
@@ -35,52 +37,129 @@ declare namespace ReCaptchaV2 {
   type Theme = "light" | "dark";
   type Type = "image" | "audio";
   type Size = "normal" | "compact" | "invisible";
-  type Badge = "bottomright" | "bottomleft" | "inline";
+  type Badge = "bottomright" | "bottomleft" | "inline" | "none";
 
   interface Parameters {
     /**
-     * Your sitekey.
+     * Your sitekey. Attribute: data-sitekey.
      */
     sitekey: string;
     /**
-     * Optional. The color theme of the widget.
-     * Accepted values: "light", "dark"
-     * @default "light"
-     */
-    theme?: Theme;
-    /**
-     * Optional. The type of CAPTCHA to serve.
+     * Optional. The type of CAPTCHA to serve. Attribute: data-type.
      * Accepted values: "audio", "image"
      * @default "image"
      */
     type?: Type;
     /**
+     * Optional. The color theme of the widget.
+     * Attribute: data-theme.
+     * Accepted values: "light", "dark"
+     * @default "light"
+     */
+    theme?: Theme;
+    /**
      * Optional. The size of the widget.
+     * Attribute: data-size.
      * Accepted values: "compact", "normal", "invisible".
-     * @default "compact"
+     * if bind is provided defaults to "invisible". Otherwise "normal"
      */
     size?: Size;
     /**
      * Optional. The tabindex of the widget and challenge.
+     * Attribute: data-tabindex.
      * If other elements in your page use tabindex, it should be set to make user navigation easier.
+     * @default 0
      */
     tabindex?: number;
     /**
+     * Optional. Specify either the ID of the container (string) or the DOM element itself if you
+     * want to trigger validation of this reCAPTCHA instance by button click or input events.
+     * By default if reCAPTCHA is rendered in a button or input with type submit/button then bind is set to an element
+     * where reCAPTCHA is rendered.
+     * Attribute: data-bind.
+     */
+    bind?: string | HTMLElement
+    /**
+     * Optional. The badge location for g-recaptcha with size of "invisible".
+     * If isolated this value is ignored and "none" is used instead.
+     * Accepted values: "none", "inline", "bottomright", "bottomleft"
+     * Attribute: data-badge.
+     * @default "bottomright"
+     */
+    badge?: Badge
+    /**
+     * Optional preload(probably challenge).
+     * Defaults to true if recaptcha is invisible.
+     * Attribute: data-preload
+     */
+    preload?: boolean
+    /**
      * Optional. Your callback function that's executed when the user submits a successful CAPTCHA response.
+     * Attribute: data-callback.
      * The user's response, g-recaptcha-response, will be the input for your callback function.
      */
     callback?(response: string): void;
     /**
-     * Optional. The badge location for g-recaptcha with size of "invisible".
-     *
-     * @default "bottomright"
-     */
-    badge?: Badge;
-    /**
      * Optional. Your callback function that's executed when the recaptcha response expires and the user needs to solve a new CAPTCHA.
+     * Attribute: data-expired-callback.
      */
     // Notice to the reader
     // I need to surround this object with quotes, this will however break intellisense in VS 2013.
     "expired-callback"?(): void;
+    /**
+     * Optional. Your callback function that's executed when reCAPTCHA encounters an error (usually network connectivity)
+     * and cannot continue until connectivity is restored.
+     * Attribute: data-error-callback.
+     */
+    "error-callback"?(): void;
+    /**
+     * Optional.
+     * Attribute: data-stoken.
+     */
+    stoken?: any
+    /**
+     * Optional.
+     * Attribute: data-s.
+     */
+    s?: any
+    /**
+     * Optional.
+     * Attribute: data-pool.
+     */
+    pool?: any
+    /**
+     * Optional.
+     * Attribute: data-action.
+     */
+    action?: any
+    /**
+     * Optional.
+     * Attribute: data-content-binding.
+     */
+    "content-binding"?: any
+    /**
+     * Optional.
+     * If true, this reCAPTCHA instance will be part of a separate ID space and badge value will be set to "none".
+     * Id starts with 1E5 instead of 0.
+     * Has no corresponding attribute.
+     * @default false
+     */
+    isolated?: boolean
+    /**
+     * Optional.
+     * Has no corresponding attribute.
+     */
+    origin?: any
+    /**
+     * Optional. Defaults to language specified in script(hl query parameter) or browser language.
+     * Has no corresponding attribute.
+     * Accepted values: https://developers.google.com/recaptcha/docs/language .
+     */
+    hl?: string
+    /**
+     * Optional.
+     * @default v1520836262157
+     */
+    version?: string
   }
 }


### PR DESCRIPTION
This PR adds missing properties to Parameters, missing function parameters to grecaptcha.reset and grecaptcha.execute. This is based on the source code: https://www.gstatic.com/recaptcha/api2/v1520836262157/recaptcha__ru.js
Somewhat readable form: https://gist.github.com/Spaier/902a5410607515e396515e6ea09adb9a

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).