### PR TITLE
Fix async-retry's exports

### DIFF
--- a/types/async-retry/async-retry-tests.ts
+++ b/types/async-retry/async-retry-tests.ts
@@ -1,4 +1,5 @@
-import { Options, RetryFunction, retry } from 'async-retry';
+import { Options, RetryFunction } from 'async-retry';
+import retry = require("async-retry");
 
 const o: Options = {
   retries: 1,

--- a/types/async-retry/index.d.ts
+++ b/types/async-retry/index.d.ts
@@ -10,8 +10,6 @@ declare function AsyncRetry<A>(
 ): Promise<A>;
 
 declare namespace AsyncRetry {
-	function retry<A>(fn: RetryFunction<A>, opts: Options): Promise<A>;
-
 	interface Options {
 		retries?: number;
 		factor?: number;

--- a/types/async-retry/index.d.ts
+++ b/types/async-retry/index.d.ts
@@ -1,17 +1,27 @@
-// Type definitions for async-retry 1.1
+// Type definitions for async-retry 1.2
 // Project: https://github.com/zeit/async-retry#readme
 // Definitions by: Albert Wu <https://github.com/albertywu>
+//                 Pablo Rodríguez <https://github.com/MeLlamoPablo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function retry<A>(fn: RetryFunction<A>, opts: Options): Promise<A>;
+declare function AsyncRetry<A>(
+	fn: AsyncRetry.RetryFunction<A>,
+	opts: AsyncRetry.Options
+): Promise<A>;
 
-export interface Options {
-    retries?: number;
-    factor?: number;
-    minTimeout?: number;
-    maxTimeout?: number;
-    randomize?: boolean;
-    onRetry?: (e: Error) => any;
+declare namespace AsyncRetry {
+	function retry<A>(fn: RetryFunction<A>, opts: Options): Promise<A>;
+
+	interface Options {
+		retries?: number;
+		factor?: number;
+		minTimeout?: number;
+		maxTimeout?: number;
+		randomize?: boolean;
+		onRetry?: (e: Error) => any;
+	}
+
+	type RetryFunction<A> = (bail: (e: Error) => A, attempt: number) => A|Promise<A>;
 }
 
-export type RetryFunction<A> = (bail: (e: Error) => A, attempt: number) => A|Promise<A>;
+export = AsyncRetry;


### PR DESCRIPTION
Hi there!

The exports of `async-retry`'s typings are misrepresenting the exports of the original package. As you can see in the package's [source code](https://github.com/zeit/async-retry/blob/bcc9ed59355145b6733a825031ab1fcd9554b75d/lib/index.js), the export is just a single function. However the typings describe the export as being an object, which contains the `retry` function (the standard way to import/export in ES6). Sadly ES6 doesn't support function exports, so the only way this package can be imported is though `require`.

Here is a code sample using the export described by the typings:

```typescript
import {retry} from "async-retry"

async function main() {
	await retry(
		() => new Promise(r => setTimeout(r, 1)),
		{
			retries: 2
		}
	)
	console.log("All good!")
}

main().catch(console.error)
```

This code compiles just fine, but errors at runtime:

```
TypeError: async_retry_1.retry is not a function
    at /home/pablo/Projects/foo/foo.js:43:60
    at step (/home/pablo/Projects/foo/foo.js:32:23)
    at Object.next (/home/pablo/Projects/foo/foo.js:13:53)
    at /home/pablo/Projects/foo/foo.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (/home/pablo/Projects/foo/foo.js:3:12)
    at main (/home/pablo/Projects/foo/foo.js:40:12)
    at Object.<anonymous> (/home/pablo/Projects/foo/foo.js:55:1)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
```

Here is a code sample showing the correct way to import this package:

```typescript
import retry = require("async-retry")

async function main() {
	await retry(
		() => new Promise(r => setTimeout(r, 1)),
		{
			retries: 2
		}
	)
	console.log("All good!")
}

main().catch(console.error)
```

This code doesn't compile:

```
foo.ts(4,8): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'typeof "/home/pablo/Projects/foo/node_modules/@types/async-retry/index"' has no compatible call signatures.
```

However, if we ignore the error:

```typescript
import retry = require("async-retry")

async function main() {
	// @ts-ignore
	await retry(
		() => new Promise(r => setTimeout(r, 10)),
		{
			retries: 3
		}
	)
	console.log("All good!")
}

main().catch(console.error)
```

Then the code executes just fine:

```
All good!
```

This PR fixes the typings so that the second code sample works as intended.

=================

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zeit/async-retry/blob/bcc9ed59355145b6733a825031ab1fcd9554b75d/lib/index.js
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
