### PR TITLE
react-router-dom: Add `innerRef` prop to <Link> component

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/ReactTraining/react-router
 // Definitions by: Tanguy Krotoff <https://github.com/tkrotoff>
 //                 Huy Nguyen <https://github.com/huy-nguyen>
+//                 Philip Jackson <https://github.com/p-jackson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -44,6 +45,7 @@ export class HashRouter extends React.Component<HashRouterProps, any> {}
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
     to: H.LocationDescriptor;
     replace?: boolean;
+    innerRef?: (node: HTMLAnchorElement | null) => void;
 }
 export class Link extends React.Component<LinkProps, any> {}
 

--- a/types/react-router-dom/react-router-dom-tests.tsx
+++ b/types/react-router-dom/react-router-dom-tests.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import {
   NavLink,
   NavLinkProps,
-  match
+  match,
+  Link
 } from 'react-router-dom';
 import * as H from 'history';
 
@@ -19,3 +20,8 @@ export default function(props: Props) {
     <NavLink {...rest} isActive={isActive}/>
   );
 }
+
+<Link to="/url" />;
+
+const acceptRef = (node: HTMLAnchorElement | null) => {};
+<Link to="/url" replace={true} innerRef={acceptRef} />;


### PR DESCRIPTION
An `innerRef` prop was added to <Link> in `react-router-dom@4.2`

The node will be an anchor tag, which is why I made the callback accept
an `HTMLAnchorElement` rather than an `HTMLElement`, however this isn't
explicitly documented.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://reacttraining.com/react-router/web/api/Link/innerref-function

https://github.com/ReactTraining/react-router/pull/5294
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

