### PR TITLE
ember: mismatched get/set

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -71,7 +71,7 @@ declare module 'ember-data' {
                 inverse?: string | null;
                 polymorphic?: boolean;
             }
-        ): Ember.ComputedProperty<ModelRegistry[K] & PromiseObject<ModelRegistry[K]>>;
+        ): Ember.ComputedProperty<ModelRegistry[K] & PromiseObject<ModelRegistry[K]>, ModelRegistry[K]>;
         /**
          * `DS.hasMany` is used to define One-To-Many and Many-To-Many
          * relationships on a [DS.Model](/api/data/classes/DS.Model.html).
@@ -91,7 +91,7 @@ declare module 'ember-data' {
                 inverse?: string | null;
                 polymorphic?: boolean;
             }
-        ): Ember.ComputedProperty<PromiseManyArray<ModelRegistry[K]>>;
+        ): Ember.ComputedProperty<PromiseManyArray<ModelRegistry[K]>, Ember.Array<ModelRegistry[K]>>;
         /**
          * This method normalizes a modelName into the format Ember Data uses
          * internally.

--- a/types/ember-data/test/belongs-to.ts
+++ b/types/ember-data/test/belongs-to.ts
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 import { assertType } from './lib/assert';
 
+declare const store: DS.Store;
+
 class Folder extends DS.Model {
     name = DS.attr('string');
     children = DS.hasMany('folder', { inverse: 'parent' });
@@ -19,4 +21,9 @@ assertType<string>(folder.get('parent').get('name'));
 folder.get('parent').then(parent => {
     assertType<Folder>(parent);
     assertType<string>(parent.get('name'));
+    folder.set('parent', parent);
 });
+
+folder.set('parent', folder);
+folder.set('parent', folder.get('parent'));
+folder.set('parent', store.findRecord('folder', 3));

--- a/types/ember-data/test/has-many.ts
+++ b/types/ember-data/test/has-many.ts
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 import { assertType } from './lib/assert';
 
@@ -43,6 +44,10 @@ blogPost.get('commentsAsync').then(comments => {
     assertType<BlogComment | undefined>(comments.get('firstObject'));
     assertType<string>(comments.get('firstObject')!.get('text'));
 });
+
+blogPost.set('commentsAsync', blogPost.get('commentsAsync'));
+blogPost.set('commentsAsync', Ember.A());
+blogPost.set('commentsAsync', Ember.A([ comment! ]));
 
 class PaymentMethod extends DS.Model {}
 declare module 'ember-data' {

--- a/types/ember/index.d.ts
+++ b/types/ember/index.d.ts
@@ -28,7 +28,8 @@ declare module 'ember' {
     /**
      * Deconstructs computed properties into the types which would be returned by `.get()`.
      */
-    type ComputedProperties<T> = { [K in keyof T]: Ember.ComputedProperty<T[K]> | ModuleComputed<T[K]> | T[K] };
+    type ComputedPropertyGetters<T> = { [K in keyof T]: Ember.ComputedProperty<T[K], any> | ModuleComputed<T[K], any> | T[K] };
+    type ComputedPropertySetters<T> = { [K in keyof T]: Ember.ComputedProperty<any, T[K]> | ModuleComputed<any, T[K]> | T[K] };
 
     /**
      * Check that any arguments to `create()` match the type's properties.
@@ -683,7 +684,7 @@ declare module 'ember' {
         will be cached. You can specify various properties that your computed property is dependent on.
         This will force the cached result to be recomputed if the dependencies are modified.
         **/
-        class ComputedProperty<T> {
+        class ComputedProperty<Get, Set = Get> {
             /**
              * Call on a computed property to set it into non-cached mode. When in this
              * mode the computed property will not automatically cache the return value.
@@ -812,7 +813,7 @@ declare module 'ember' {
             static create<Instance>(this: EmberClassConstructor<Instance>): Fix<Instance>;
 
             static create<Instance, Args, T1 extends EmberInstanceArguments<Args>>(
-                this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
+                this: EmberClassConstructor<Instance & ComputedPropertyGetters<Args>>,
                 arg1: T1 & ThisType<Fix<T1 & Instance>>
             ): Fix<Instance & T1>;
 
@@ -822,7 +823,7 @@ declare module 'ember' {
                 T1 extends EmberInstanceArguments<Args>,
                 T2 extends EmberInstanceArguments<Args>
             >(
-                this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
+                this: EmberClassConstructor<Instance & ComputedPropertyGetters<Args>>,
                 arg1: T1 & ThisType<Fix<Instance & T1>>,
                 arg2: T2 & ThisType<Fix<Instance & T1 & T2>>
             ): Fix<Instance & T1 & T2>;
@@ -834,7 +835,7 @@ declare module 'ember' {
                 T2 extends EmberInstanceArguments<Args>,
                 T3 extends EmberInstanceArguments<Args>
             >(
-                this: EmberClassConstructor<Instance & ComputedProperties<Args>>,
+                this: EmberClassConstructor<Instance & ComputedPropertyGetters<Args>>,
                 arg1: T1 & ThisType<Fix<Instance & T1>>,
                 arg2: T2 & ThisType<Fix<Instance & T1 & T2>>,
                 arg3: T3 & ThisType<Fix<Instance & T1 & T2 & T3>>
@@ -1641,27 +1642,27 @@ declare module 'ember' {
             /**
              * Retrieves the value of a property from the object.
              */
-            get<T, K extends keyof T>(this: ComputedProperties<T>, key: K): T[K];
+            get<T, K extends keyof T>(this: ComputedPropertyGetters<T>, key: K): T[K];
             /**
              * To get the values of multiple properties at once, call `getProperties`
              * with a list of strings or an array:
              */
-            getProperties<T, K extends keyof T>(this: ComputedProperties<T>, list: K[]): Pick<T, K>;
+            getProperties<T, K extends keyof T>(this: ComputedPropertyGetters<T>, list: K[]): Pick<T, K>;
             getProperties<T, K extends keyof T>(
-                this: ComputedProperties<T>,
+                this: ComputedPropertyGetters<T>,
                 ...list: K[]
             ): Pick<T, K>;
             /**
              * Sets the provided key or path to the value.
              */
-            set<T, K extends keyof T>(this: ComputedProperties<T>, key: K, value: T[K]): T[K];
+            set<T, K extends keyof T>(this: ComputedPropertySetters<T>, key: K, value: T[K]): T[K];
             /**
              * Sets a list of properties at once. These properties are set inside
              * a single `beginPropertyChanges` and `endPropertyChanges` batch, so
              * observers will be buffered.
              */
             setProperties<T, K extends keyof T>(
-                this: ComputedProperties<T>,
+                this: ComputedPropertySetters<T>,
                 hash: Pick<T, K>
             ): Pick<T, K>;
             /**
@@ -1692,7 +1693,7 @@ declare module 'ember' {
              * property returns `undefined`.
              */
             getWithDefault<T, K extends keyof T>(
-                this: ComputedProperties<T>,
+                this: ComputedPropertyGetters<T>,
                 key: K,
                 defaultValue: T[K]
             ): T[K];
@@ -1715,7 +1716,7 @@ declare module 'ember' {
              * without accidentally invoking it if it is intended to be
              * generated lazily.
              */
-            cacheFor<T, K extends keyof T>(this: ComputedProperties<T>, key: K): T[K] | undefined;
+            cacheFor<T, K extends keyof T>(this: ComputedPropertyGetters<T>, key: K): T[K] | undefined;
         }
         const Observable: Mixin<Observable, Ember.CoreObject>;
         /**
@@ -2989,7 +2990,7 @@ declare module 'ember' {
          * it to be created.
          */
         function cacheFor<T, K extends keyof T>(
-            obj: ComputedProperties<T>,
+            obj: ComputedPropertyGetters<T>,
             key: K
         ): T[K] | undefined;
         /**
@@ -3028,12 +3029,12 @@ declare module 'ember' {
          * with an object followed by a list of strings or an array:
          */
         function getProperties<T, K extends keyof T>(
-            obj: ComputedProperties<T>,
+            obj: ComputedPropertyGetters<T>,
             list: K[]
         ): Pick<T, K>;
         function getProperties<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K>; // for dynamic K
         function getProperties<T, K extends keyof T>(
-            obj: ComputedProperties<T>,
+            obj: ComputedPropertyGetters<T>,
             ...list: K[]
         ): Pick<T, K>;
         function getProperties<T, K extends keyof T>(obj: T, ...list: K[]): Pick<T, K>; // for dynamic K
@@ -3120,14 +3121,14 @@ declare module 'ember' {
          * the function will be invoked. If the property is not defined but the
          * object implements the `unknownProperty` method then that will be invoked.
          */
-        function get<T, K extends keyof T>(obj: ComputedProperties<T>, key: K): T[K];
+        function get<T, K extends keyof T>(obj: ComputedPropertyGetters<T>, key: K): T[K];
         function get<T, K extends keyof T>(obj: T, key: K): T[K]; // for dynamic K
         /**
          * Retrieves the value of a property from an Object, or a default value in the
          * case that the property returns `undefined`.
          */
         function getWithDefault<T, K extends keyof T>(
-            obj: ComputedProperties<T>,
+            obj: ComputedPropertyGetters<T>,
             key: K,
             defaultValue: T[K]
         ): T[K];
@@ -3139,7 +3140,7 @@ declare module 'ember' {
          * method then that will be invoked as well.
          */
         function set<T, K extends keyof T, V extends T[K]>(
-            obj: ComputedProperties<T>,
+            obj: ComputedPropertySetters<T>,
             key: K,
             value: V
         ): V;
@@ -3155,7 +3156,7 @@ declare module 'ember' {
          * observers will be buffered.
          */
         function setProperties<T, K extends keyof T>(
-            obj: ComputedProperties<T>,
+            obj: ComputedPropertySetters<T>,
             hash: Pick<T, K>
         ): Pick<T, K>;
         function setProperties<T, K extends keyof T>(obj: T, hash: Pick<T, K>): Pick<T, K>; // for dynamic K
@@ -3534,7 +3535,7 @@ declare module '@ember/object' {
 
 declare module '@ember/object/computed' {
     import Ember from 'ember';
-    export default class ComputedProperty<T> extends Ember.ComputedProperty<T> { }
+    export default class ComputedProperty<Get, Set = Get> extends Ember.ComputedProperty<Get, Set> { }
     export const alias: typeof Ember.computed.alias;
     export const and: typeof Ember.computed.and;
     export const bool: typeof Ember.computed.bool;


### PR DESCRIPTION
This change allows `Ember.get` and `Ember.set` to have different type declarations.

For example ember-data `model.get('manyArray')` may return a promise proxy, but `model.set('manyArray, ???)` will accept a plain array.