### PR TITLE
[graphql-relay] Cannot assign to 'fieldName', it is a readonly property.

### DIFF
--- a/types/graphql-relay/graphql-relay-tests.ts
+++ b/types/graphql-relay/graphql-relay-tests.ts
@@ -44,7 +44,7 @@ backwardConnectionArgs.before = "b";
 backwardConnectionArgs.last = 10;
 // connectionDefinitions returns a connectionType and its associated edgeType, given a node type.
 const resolve: GraphQLFieldResolver<any, any> = (source, args, context, info) => {
-    info.fieldName = "f";
+    context.flag = "f";
 };
 const fields: GraphQLFieldConfigMap<any, any> = {};
 let t: GraphQLObjectType;
@@ -118,10 +118,10 @@ const resolver: GraphQLTypeResolver<any, any> = () => {
         fields: {},
     });
 };
-const idFetcher = (id: string, context: number, info: GraphQLResolveInfo) => {
-    info.fieldName = "f";
+const idFetcher = (id: string, context: any, info: GraphQLResolveInfo) => {
+    context.flag = "f";
 };
-const nodeDef = nodeDefinitions<number>(idFetcher, resolver);
+const nodeDef = nodeDefinitions<any>(idFetcher, resolver);
 const nodeFieldConfig: GraphQLFieldConfig<any, any> = nodeDef.nodeField;
 const nodesFieldConfig: GraphQLFieldConfig<any, any> = nodeDef.nodesField;
 const interfaceType: GraphQLInterfaceType = nodeDef.nodeInterface;
@@ -183,10 +183,10 @@ mutationWithClientMutationId({
     inputFields: gifcm,
     mutateAndGetPayload: (
         object: any,
-        ctx: any,
+        context: any,
         info: GraphQLResolveInfo) => {
         return new Promise<string>((resolve) => {
-            resolve(info.fieldName);
+            resolve(context.flag);
         });
     },
     outputFields: gfcm,


### PR DESCRIPTION
`info.fieldName` is readonly, I got an error when upgrading `@types/graphql`:

```
Error: /Users/firede/Workspace/DefinitelyTyped/types/graphql-relay/graphql-relay-tests.ts:47:10
ERROR: 47:10   expect  TypeScript@next compile error:
Cannot assign to 'fieldName' because it is a constant or a read-only property.
ERROR: 122:10  expect  TypeScript@next compile error:
Cannot assign to 'fieldName' because it is a constant or a read-only property.
```

Related PR: #24566

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/graphql/graphql-js/blob/v0.13.2/src/type/definition.js#L808>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
