### PR TITLE
[graphql-list-fields] parentType is a GraphQLObjectType.

### DIFF
--- a/types/graphql-list-fields/graphql-list-fields-tests.ts
+++ b/types/graphql-list-fields/graphql-list-fields-tests.ts
@@ -2,7 +2,6 @@ import getFieldNames = require("graphql-list-fields");
 
 import {
     GraphQLID,
-    GraphQLInterfaceType,
     GraphQLObjectType,
     GraphQLResolveInfo,
     GraphQLSchema,
@@ -13,7 +12,7 @@ const sampleGraphQLResolveInfo: GraphQLResolveInfo = {
     fieldName: "",
     fieldNodes: [],
     returnType: GraphQLString,
-    parentType: new GraphQLInterfaceType({
+    parentType: new GraphQLObjectType({
         name: "Sample",
         fields: {
             name: { type: GraphQLString }


### PR DESCRIPTION
Correct types for `parentType` (see https://github.com/graphql/graphql-js/pull/1033), I got an error when upgrading `@types/graphql`:

```
Error: /Users/firede/Workspace/DefinitelyTyped/types/graphql-list-fields/graphql-list-fields-tests.ts:12:7
ERROR: 12:7  expect  TypeScript@next compile error:
Type '{ fieldName: string; fieldNodes: never[]; returnType: GraphQLScalarType; parentType: GraphQLInter...' is not assignable to type 'GraphQLResolveInfo'.
  Types of property 'parentType' are incompatible.
    Type 'GraphQLInterfaceType' is not assignable to type 'GraphQLObjectType'.
      Property 'isTypeOf' is missing in type 'GraphQLInterfaceType'.
```

Related PR: <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24532>

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/graphql/graphql-js/pull/1033>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
