### PR TITLE
fix(zapier-platform-core): add missing HTTP verb

### DIFF
--- a/types/zapier-platform-core/index.d.ts
+++ b/types/zapier-platform-core/index.d.ts
@@ -15,7 +15,7 @@ export const version: string;
 
 export interface HttpRequestOptions {
     url?: string;
-    method?: "POST" | "GET" | "OPTIONS" | "HEAD" | "DELETE" | "PATCH";
+    method?: "POST" | "GET" | "OPTIONS" | "HEAD" | "DELETE" | "PATCH" | "PUT";
     body?: string | Buffer | NodeJS.ReadableStream | object | null;
     headers?: { [name: string]: string };
     json?: object | any[] | null;


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/zapier/zapier-platform-core/blob/master/src/tools/fetch.js
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
