### PR TITLE
[JSS] Update JSS.use to work with varargs

### DIFF
--- a/types/jss/index.d.ts
+++ b/types/jss/index.d.ts
@@ -125,7 +125,7 @@ declare class JSS {
 	): StyleSheet<T>;
 	removeStyleSheet(sheet: StyleSheet<any>): this;
 	setup(options?: Partial<JSSOptions>): this;
-	use(plugin: JSSPlugin): this;
+	use(...plugins: JSSPlugin[]): this;
 	createRule(style: Style, options?: Partial<RuleFactoryOptions>): Rule;
 	createRule(name: string, style: Style, options?: Partial<RuleFactoryOptions>): Rule;
 }

--- a/types/jss/jss-tests.ts
+++ b/types/jss/jss-tests.ts
@@ -7,6 +7,7 @@ import {
 } from 'jss';
 
 const jss = createJSS().setup({});
+jss.use({}, {}); // $ExpectType JSS
 
 const styleSheet = jss.createStyleSheet(
 	{


### PR DESCRIPTION
From [the docs](http://cssinjs.org/js-api/?v=v9.8.1#create-an-own-jss-instance) and [soure-code](https://github.com/cssinjs/jss/blob/master/src/Jss.js#L144).