### PR TITLE
[react-native] Added missing ReactART types

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -6,6 +6,7 @@
 //                 Tim Wang <https://github.com/timwangdev>
 //                 Kamal Mahyuddin <https://github.com/kamal>
 //                 Naoufal El Yousfi <https://github.com/nelyousfi>
+//                 Alex Dunne <https://github.com/alexdunne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -8258,26 +8259,71 @@ interface ImageEditorStatic {
     ): void;
 }
 
-export interface ARTShapeProps {
-    d: string;
-    strokeWidth: number;
+export interface ARTNodeMixin {
+    opacity?: number;
+    originX?: number;
+    originY?: number;
+    scaleX?: number;
+    scaleY?: number;
+    scale?: number;
+    title?: string;
+    x?: number;
+    y?: number;
+    visible?: boolean;
+}
+
+export interface ARTGroupProps extends ARTNodeMixin {
+    width?: number;
+    height?: number;
+}
+
+export interface ARTClippingRectangleProps extends ARTNodeMixin {
+    width?: number;
+    height?: number;
+}
+
+export interface ARTRenderableMixin extends ARTNodeMixin {
+    fill?: string;
+    stroke?: string;
+    strokeCap?: "butt" | "square" | "round";
     strokeDash?: number[];
-    stroke: string;
+    strokeJoin?: "bevel" | "miter" | "round";
+    strokeWidth?: number;
+}
+
+export interface ARTShapeProps extends ARTRenderableMixin {
+    d: string;
+    width?: number;
+    height?: number;
+}
+
+export interface ARTTextProps extends ARTRenderableMixin {
+    font?: string;
+    alignment?: string;
 }
 
 export interface ARTSurfaceProps {
-    style: StyleProp<ViewStyle>;
+    style?: StyleProp<ViewStyle>;
     width: number;
     height: number;
 }
+
+export interface ClippingRectangleStatic extends React.ComponentClass<ARTClippingRectangleProps> {}
+
+export interface GroupStatic extends React.ComponentClass<ARTGroupProps> {}
 
 export interface ShapeStatic extends React.ComponentClass<ARTShapeProps> {}
 
 export interface SurfaceStatic extends React.ComponentClass<ARTSurfaceProps> {}
 
+export interface ARTTextStatic extends React.ComponentClass<ARTTextProps> {}
+
 export interface ARTStatic {
+    ClippingRectangle: ClippingRectangleStatic;
+    Group: GroupStatic;
     Shape: ShapeStatic;
     Surface: SurfaceStatic;
+    Text: ARTTextStatic;
 }
 
 export interface KeyboardStatic extends NativeEventEmitter {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/reactjs/react-art/blob/2d532945189ad079f167c3130551404f050a882e/src/ReactART.js

I derived the typings by looking at what props the `mixins` used and added any props used by the concrete components to the relevant type.

[NodeMixin](https://github.com/reactjs/react-art/blob/2d532945189ad079f167c3130551404f050a882e/src/ReactART.js#L261) is the top level Mixin where the generic props are found. The [Group](https://github.com/reactjs/react-art/blob/2d532945189ad079f167c3130551404f050a882e/src/ReactART.js#L370) and [ClippingRectangle](https://github.com/reactjs/react-art/blob/2d532945189ad079f167c3130551404f050a882e/src/ReactART.js#L407) components are both based on this.

Additionally, there is a [RenderableMixin](https://github.com/reactjs/react-art/blob/2d532945189ad079f167c3130551404f050a882e/src/ReactART.js#L449) which is used by the Shape and Text components.

First time doing `typings` publicly so let me know if they can be improved 😄

I am also happy to be notified by any updates to this package.