### PR TITLE
Add new React 16.3 lifecycle events

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -280,6 +280,13 @@ declare namespace React {
     // tslint:disable-next-line:no-empty-interface
     interface Component<P = {}, S = {}> extends ComponentLifecycle<P, S> { }
     class Component<P, S> {
+        /**
+         * Returns an update to a component's state based on its new props and old state.
+         *
+         * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+         */
+        static getDerivedStateFromProps?<P, S, K extends keyof S = keyof S>(nextProps: Readonly<P>, prevState: Readonly<S>): Pick<S, K> | S | null;
+
         constructor(props: P, context?: any);
 
         // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
@@ -331,7 +338,7 @@ declare namespace React {
         displayName?: string;
     }
 
-    interface ComponentClass<P = {}> {
+    interface ComponentClass<P = {}> extends StaticLifecycle<P, any> {
         new (props: P, context?: any): Component<P, ComponentState>;
         propTypes?: ValidationMap<P>;
         contextTypes?: ValidationMap<any>;
@@ -359,24 +366,14 @@ declare namespace React {
     // Component Specs and Lifecycle
     // ----------------------------------------------------------------------
 
-    interface ComponentLifecycle<P, S> {
-        /**
-         * Called immediately before mounting occurs, and before `Component#render`.
-         * Avoid introducing any side-effects or subscriptions in this method.
-         */
-        componentWillMount?(): void;
+    // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
+    // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
+    // methods are present.
+    interface ComponentLifecycle<P, S> extends NewLifecycle<P, S>, DeprecatedLifecycle<P, S> {
         /**
          * Called immediately after a compoment is mounted. Setting state here will trigger re-rendering.
          */
         componentDidMount?(): void;
-        /**
-         * Called when the component may be receiving new props.
-         * React may call this even if props have not changed, so be sure to compare new and existing
-         * props if you only want to handle changes.
-         *
-         * Calling `Component#setState` generally does not trigger this method.
-         */
-        componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
         /**
          * Called to determine whether the change in props and state should trigger a re-render.
          *
@@ -389,16 +386,6 @@ declare namespace React {
          */
         shouldComponentUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): boolean;
         /**
-         * Called immediately before rendering when new props or state is received. Not called for the initial render.
-         *
-         * Note: You cannot call `Component#setState` here.
-         */
-        componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
-        /**
-         * Called immediately after updating occurs. Not called for the initial render.
-         */
-        componentDidUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>, prevContext: any): void;
-        /**
          * Called immediately before a component is destroyed. Perform any necessary cleanup in this method, such as
          * cancelled network requests, or cleaning up any DOM elements created in `componentDidMount`.
          */
@@ -408,6 +395,124 @@ declare namespace React {
          * the entire component tree to unmount.
          */
         componentDidCatch?(error: Error, errorInfo: ErrorInfo): void;
+    }
+
+    // Unfortunately, we have no way of declaring that the component constructor must implement this
+    interface StaticLifecycle<P, S> {
+        /**
+         * Returns an update to a component's state based on its new props and old state.
+         *
+         * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
+         */
+        getDerivedStateFromProps?<K extends keyof S>(nextProps: Readonly<P>, prevState: Readonly<S>): Pick<S, K> | S | null;
+    }
+
+    // This should be "infer SS" but can't use it yet
+    interface NewLifecycle<P, S, SS extends object = any> {
+        /**
+         * Runs before React applies the result of `render` to the document, and
+         * returns an object to be given to componentDidUpdate. Useful for saving
+         * things such as scroll position before `render` causes changes to it.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate prevents any of the deprecated
+         * lifecycle events from running.
+         */
+        getSnapshotBeforeUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>): SS|null
+        /**
+         * Called immediately after updating occurs. Not called for the initial render.
+         *
+         * The snapshot is only present if getSnapshotBeforeUpdate is present and returns non-null.
+         */
+        componentDidUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>, snapshot?: SS): void;
+    }
+
+    interface DeprecatedLifecycle<P, S> {
+        /**
+         * Called immediately before mounting occurs, and before `Component#render`.
+         * Avoid introducing any side-effects or subscriptions in this method.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use componentDidMount or the constructor instead; will stop working in React 17
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillMount?(): void;
+        /**
+         * Called immediately before mounting occurs, and before `Component#render`.
+         * Avoid introducing any side-effects or subscriptions in this method.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use componentDidMount or the constructor instead
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillMount?(): void;
+        /**
+         * Called when the component may be receiving new props.
+         * React may call this even if props have not changed, so be sure to compare new and existing
+         * props if you only want to handle changes.
+         *
+         * Calling `Component#setState` generally does not trigger this method.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use static getDerivedStateFromProps instead; will stop working in React 17
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
+        /**
+         * Called when the component may be receiving new props.
+         * React may call this even if props have not changed, so be sure to compare new and existing
+         * props if you only want to handle changes.
+         *
+         * Calling `Component#setState` generally does not trigger this method.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use static getDerivedStateFromProps instead
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#updating-state-based-on-props
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
+        /**
+         * Called immediately before rendering when new props or state is received. Not called for the initial render.
+         *
+         * Note: You cannot call `Component#setState` here.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use getSnapshotBeforeUpdate instead; will stop working in React 17
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
+        /**
+         * Called immediately before rendering when new props or state is received. Not called for the initial render.
+         *
+         * Note: You cannot call `Component#setState` here.
+         *
+         * This method will not stop working in React 17.
+         *
+         * Note: the presence of getSnapshotBeforeUpdate or getDerivedStateFromProps
+         * prevents this from being invoked.
+         *
+         * @deprecated 16.3, use getSnapshotBeforeUpdate instead
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#reading-dom-properties-before-an-update
+         * @see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path
+         */
+        UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
 
     interface Mixin<P, S> extends ComponentLifecycle<P, S> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -401,7 +401,7 @@ declare namespace React {
          *
          * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
          */
-        <K extends keyof S>(nextProps: Readonly<P>, prevState: Readonly<S>) => Pick<S, K> | S | null;
+        (nextProps: Readonly<P>, prevState: Readonly<S>) => Partial<S> | S | null;
 
     // This should be "infer SS" but can't use it yet
     interface NewLifecycle<P, S, SS> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -280,13 +280,6 @@ declare namespace React {
     // tslint:disable-next-line:no-empty-interface
     interface Component<P = {}, S = {}> extends ComponentLifecycle<P, S> { }
     class Component<P, S> {
-        /**
-         * Returns an update to a component's state based on its new props and old state.
-         *
-         * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
-         */
-        static getDerivedStateFromProps?<P, S, K extends keyof S = keyof S>(nextProps: Readonly<P>, prevState: Readonly<S>): Pick<S, K> | S | null;
-
         constructor(props: P, context?: any);
 
         // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
@@ -399,13 +392,16 @@ declare namespace React {
 
     // Unfortunately, we have no way of declaring that the component constructor must implement this
     interface StaticLifecycle<P, S> {
+        getDerivedStateFromProps?: GetDerivedStateFromProps<P, S>;
+    }
+
+    type GetDerivedStateFromProps<P, S> =
         /**
          * Returns an update to a component's state based on its new props and old state.
          *
          * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
          */
-        getDerivedStateFromProps?<K extends keyof S>(nextProps: Readonly<P>, prevState: Readonly<S>): Pick<S, K> | S | null;
-    }
+        <K extends keyof S>(nextProps: Readonly<P>, prevState: Readonly<S>) => Pick<S, K> | S | null;
 
     // This should be "infer SS" but can't use it yet
     interface NewLifecycle<P, S, SS extends object = any> {
@@ -417,7 +413,7 @@ declare namespace React {
          * Note: the presence of getSnapshotBeforeUpdate prevents any of the deprecated
          * lifecycle events from running.
          */
-        getSnapshotBeforeUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>): SS|null
+        getSnapshotBeforeUpdate?(prevProps: Readonly<P>, prevState: Readonly<S>): SS | null;
         /**
          * Called immediately after updating occurs. Not called for the initial render.
          *

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for React 16.1
+// Type definitions for React 16.3
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>
 //                 AssureSign <http://www.assuresign.com>

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -278,7 +278,7 @@ declare namespace React {
 
     // Base component for plain JS classes
     // tslint:disable-next-line:no-empty-interface
-    interface Component<P = {}, S = {}> extends ComponentLifecycle<P, S> { }
+    interface Component<P = {}, S = {}, SS = never> extends ComponentLifecycle<P, S, SS> { }
     class Component<P, S> {
         constructor(props: P, context?: any);
 
@@ -362,7 +362,7 @@ declare namespace React {
     // This should actually be something like `Lifecycle<P, S> | DeprecatedLifecycle<P, S>`,
     // as React will _not_ call the deprecated lifecycle methods if any of the new lifecycle
     // methods are present.
-    interface ComponentLifecycle<P, S> extends NewLifecycle<P, S>, DeprecatedLifecycle<P, S> {
+    interface ComponentLifecycle<P, S, SS = never> extends NewLifecycle<P, S, SS>, DeprecatedLifecycle<P, S> {
         /**
          * Called immediately after a compoment is mounted. Setting state here will trigger re-rendering.
          */
@@ -404,7 +404,7 @@ declare namespace React {
         <K extends keyof S>(nextProps: Readonly<P>, prevState: Readonly<S>) => Pick<S, K> | S | null;
 
     // This should be "infer SS" but can't use it yet
-    interface NewLifecycle<P, S, SS extends object = any> {
+    interface NewLifecycle<P, S, SS> {
         /**
          * Runs before React applies the result of `render` to the document, and
          * returns an object to be given to componentDidUpdate. Useful for saving
@@ -511,7 +511,7 @@ declare namespace React {
         UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
 
-    interface Mixin<P, S> extends ComponentLifecycle<P, S> {
+    interface Mixin<P, S> extends ComponentLifecycle<P, S, never> {
         mixins?: Array<Mixin<P, S>>;
         statics?: {
             [key: string]: any;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -401,7 +401,7 @@ declare namespace React {
          *
          * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
          */
-        (nextProps: Readonly<P>, prevState: Readonly<S>) => Partial<S> | S | null;
+        (nextProps: Readonly<P>, prevState: Readonly<S>) => Partial<S> | null;
 
     // This should be "infer SS" but can't use it yet
     interface NewLifecycle<P, S, SS> {

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -511,7 +511,7 @@ declare namespace React {
         UNSAFE_componentWillUpdate?(nextProps: Readonly<P>, nextState: Readonly<S>, nextContext: any): void;
     }
 
-    interface Mixin<P, S> extends ComponentLifecycle<P, S, never> {
+    interface Mixin<P, S> extends ComponentLifecycle<P, S> {
         mixins?: Array<Mixin<P, S>>;
         statics?: {
             [key: string]: any;

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -150,12 +150,10 @@ class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', st
     }
 }
 
-class ComponentWithBadLifecycle extends React.Component<{}, {}, number> {
-    getSnapshotBeforeUpdate() { // $ExpectError
-        return 'number';
-    }
-
-    componentDidUpdate(prevProps: {}, prevState: {}, snapshot?: string) { // $ExpectError
-        return;
-    }
-}
+const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> {})({});
+componentWithBadLifecycle.getSnapshotBeforeUpdate = () => { // $ExpectError
+    return 'number';
+};
+componentWithBadLifecycle.componentDidUpdate = (prevProps: {}, prevState: {}, snapshot?: string) => { // $ExpectError
+    return;
+};

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -122,3 +122,24 @@ export abstract class SetStateTestForAndedState<P, S> extends React.Component<P,
 		this.setState({ baseProp: 'foobar' });
 	}
 }
+
+interface NewProps { foo: string; }
+interface NewState { bar: string; }
+
+class ComponentWithNewLifecycles extends React.Component<NewProps, NewState> {
+    static getDerivedStateFromProps: React.GetDerivedStateFromProps<NewProps, NewState> = (nextProps) => {
+        return { bar: `${nextProps.foo}bar` };
+    }
+
+    getSnapshotBeforeUpdate(prevProps: Readonly<NewProps>): { baz: string } | null {
+        return { baz: `${prevProps.foo}baz` };
+    }
+
+    componentDidUpdate(prevProps: Readonly<NewProps>, prevState: Readonly<NewState>, snapshot: { baz: string }) {
+        return;
+    }
+
+    render() {
+        return this.state.bar;
+    }
+}

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -144,6 +144,12 @@ class ComponentWithNewLifecycles extends React.Component<NewProps, NewState, { b
     }
 }
 
+class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', string>> {
+    static getDerivedStateFromProps: React.GetDerivedStateFromProps<{}, Record<'a'|'b'|'c', string>> = () => {
+        return { a: 'a' };
+    }
+}
+
 class ComponentWithBadLifecycle extends React.Component<{}, {}, number> {
     getSnapshotBeforeUpdate() { // $ExpectError
         return 'number';

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -126,12 +126,12 @@ export abstract class SetStateTestForAndedState<P, S> extends React.Component<P,
 interface NewProps { foo: string; }
 interface NewState { bar: string; }
 
-class ComponentWithNewLifecycles extends React.Component<NewProps, NewState> {
+class ComponentWithNewLifecycles extends React.Component<NewProps, NewState, { baz: string }> {
     static getDerivedStateFromProps: React.GetDerivedStateFromProps<NewProps, NewState> = (nextProps) => {
         return { bar: `${nextProps.foo}bar` };
     }
 
-    getSnapshotBeforeUpdate(prevProps: Readonly<NewProps>): { baz: string } | null {
+    getSnapshotBeforeUpdate(prevProps: Readonly<NewProps>) {
         return { baz: `${prevProps.foo}baz` };
     }
 
@@ -141,5 +141,15 @@ class ComponentWithNewLifecycles extends React.Component<NewProps, NewState> {
 
     render() {
         return this.state.bar;
+    }
+}
+
+class ComponentWithBadLifecycle extends React.Component<{}, {}, number> {
+    getSnapshotBeforeUpdate() { // $ExpectError
+        return 'number';
+    }
+
+    componentDidUpdate(prevProps: {}, prevState: {}, snapshot?: string) { // $ExpectError
+        return;
     }
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
- [x] Increase the version number in the header if appropriate.

I tried my best to keep backwards compatibility with existing types.

The new @deprecated annotations will annoy those that use tslint's `deprecation` rule (as is intended).

Unfortunately, there does not seem to be any way to use apply an interface to a class' _constructor_. It's also not acceptable, to the compiler, to depend on a class' generic arguments in a static method, when that is exactly the correct thing to use in this instance.

I tried to make it slightly safer to use by providing a `type` for the static method, but I'm not sure if there _is_ a good way to express this correctly in TypeScript.

It's also not possible to have mutually-exclusive methods. The mere presence of either of the two new lifecycle methods will prevent all of the `@deprecated` lifecycle methods from being invoked at runtime, which I did my best to document in the JSDoc comments.