### PR TITLE
[@types/simple-oauth2] Set proper type for AccessToken.token.

### DIFF
--- a/types/simple-oauth2/index.d.ts
+++ b/types/simple-oauth2/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for simple-oauth2 1.0
+// Type definitions for simple-oauth2 1.1
 // Project: https://github.com/lelylan/simple-oauth2
 // Definitions by: [Michael Müller] <https://github.com/mad-mike>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/simple-oauth2/index.d.ts
+++ b/types/simple-oauth2/index.d.ts
@@ -44,8 +44,12 @@ export interface ModuleOptions {
 
 export type TokenType = "access_token" | "refresh_token";
 
+export interface Token {
+    [x: string]: any;
+}
+
 export interface AccessToken {
-    token: {};
+    token: Token;
 
     /** Check if the access token is expired or not */
     expired(): boolean;
@@ -56,9 +60,6 @@ export interface AccessToken {
     revoke(tokenType: TokenType, callback?: (error: any) => void): Bluebird<void>;
 }
 
-export interface Token {
-    [x: string]: any;
-}
 export type AuthorizationCode = string;
 export interface AuthorizationTokenConfig {
     code: AuthorizationCode;


### PR DESCRIPTION
In the current definition, `AccessToken.token` is set to always be `{}`, while it really should be a `Token` hash.  This PR fixes this, and also move the definition of `Token` above its first use for better readability.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/lelylan/simple-oauth2/blob/master/lib/client/access-token.js#L17>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
