### PR TITLE
[graphql-list-fields] Rewrite tests.

### DIFF
--- a/types/graphql-list-fields/graphql-list-fields-tests.ts
+++ b/types/graphql-list-fields/graphql-list-fields-tests.ts
@@ -1,41 +1,31 @@
 import getFieldNames = require("graphql-list-fields");
 
-import {
-    GraphQLID,
-    GraphQLObjectType,
-    GraphQLResolveInfo,
-    GraphQLSchema,
-    GraphQLString
-} from "graphql";
+import { GraphQLID, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
 
-const sampleGraphQLResolveInfo: GraphQLResolveInfo = {
-    fieldName: "",
-    fieldNodes: [],
-    returnType: GraphQLString,
-    parentType: new GraphQLObjectType({
-        name: "Sample",
+const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+        name: "SampleType",
         fields: {
-            name: { type: GraphQLString }
-        }
+            scalarField: {
+                type: GraphQLString,
+                resolve(source, args, context, info) {
+                    const fieldNames: string[] = getFieldNames(info);
+                },
+            },
+            someType: {
+                type: new GraphQLObjectType({
+                    name: "SomeType",
+                    fields: {
+                        a: { type: GraphQLID },
+                        b: { type: GraphQLString },
+                        c: { type: GraphQLString },
+                        d: { type: GraphQLString },
+                    },
+                }),
+                resolve(source, args, context, info) {
+                    const fieldNames: string[] = getFieldNames(info);
+                },
+            },
+        },
     }),
-    path: undefined,
-    schema: new GraphQLSchema({
-        query: new GraphQLObjectType({
-            name: "SampleType",
-            fields: {}
-        })
-    }),
-    fragments: {},
-    rootValue: null,
-    operation: {
-        kind: "OperationDefinition",
-        operation: "query",
-        selectionSet: {
-            kind: "SelectionSet",
-            selections: []
-        }
-    },
-    variableValues: {}
-};
-
-const fieldNames: string[] = getFieldNames(sampleGraphQLResolveInfo);
+});


### PR DESCRIPTION
Rewrite tests, `GraphQLResolveInfo` is usually generated internally by `graphql`.

Related PR: #24566

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24566>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
