### PR TITLE
fix(fs-extra): fix Typings issue object instead of Object.

### DIFF
--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -274,7 +274,7 @@ export interface MoveOptions {
 
 export interface ReadOptions {
     throws?: boolean;
-    fs?: object;
+    fs?: Object;
     reviver?: any;
     encoding?: string;
     flag?: string;
@@ -287,7 +287,7 @@ export interface WriteFileOptions {
 }
 
 export interface WriteOptions extends WriteFileOptions {
-    fs?: object;
+    fs?: Object;
     replacer?: any;
     spaces?: number | string;
     EOL?: string;


### PR DESCRIPTION
Hello, 

I had an issue with this package when I used @angular/cli to build my application. 

Angular CLI: 1.7.3
Node: 8.9.4
OS: darwin x64
Angular: 2.4.6
... common, compiler, compiler-cli, core, forms, http
... platform-browser, platform-browser-dynamic

@angular/cli: 1.7.3
@angular/router: 3.4.6
@angular-devkit/build-optimizer: 0.3.2
@angular-devkit/core: 0.3.2
@angular-devkit/schematics: 0.3.2
@ngtools/json-schema: 1.0.2
@ngtools/webpack: 1.10.2
@schematics/angular: 0.3.2
@schematics/package-update: 0.3.2
typescript: 2.1.5
webpack: 3.11.0

version of this package :  `@types/fs-extra: "^5.0.0"`

```
ERROR in node_modules/@types/fs-extra/index.d.ts (281,10): Cannot find name 'object'.
ERROR in node_modules/@types/fs-extra/index.d.ts (288,10): Cannot find name 'object'.
```

Solution: Rename 'object' to 'Object'. 

Have a nice day.