### PR TITLE
[react-router] Improve withRouter definition with conditional types

### DIFF
--- a/types/alt/index.d.ts
+++ b/types/alt/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/goatslacker/alt
 // Definitions by: Michael Shearer <https://github.com/Shearerbeard>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 ///<reference types="react"/>
 

--- a/types/aphrodite/index.d.ts
+++ b/types/aphrodite/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Khan/aphrodite
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/assert-equal-jsx/index.d.ts
+++ b/types/assert-equal-jsx/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/thejameskyle/assert-equal-jsx
 // Definitions by: Josh Toft <https://github.com/seryl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/atlaskit__button/index.d.ts
+++ b/types/atlaskit__button/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://bitbucket.org/atlassian/atlaskit-mk-2/
 // Definitions by: Jimmy Luong <https://github.com/dijimsta>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import {
     Component,

--- a/types/braft-editor/index.d.ts
+++ b/types/braft-editor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/margox/braft#readme
 // Definitions by: My Self <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import { RawDraftContentState } from 'draft-js';

--- a/types/catalog/index.d.ts
+++ b/types/catalog/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/interactivethings/catalog/
 // Definitions by: Peter Gassner <https://github.com/grossbart>, Tomas Carnecky <https://github.com/wereHamster>
 // Definitions: https://github.com/interactivethings/catalog/
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/create-react-class/index.d.ts
+++ b/types/create-react-class/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://facebook.github.io/react/
 // Definitions by: John Gozde <https://github.com/jgoz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentSpec, ClassicComponentClass } from "react";
 

--- a/types/d3-collection/index.d.ts
+++ b/types/d3-collection/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/d3/d3-collection/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 // Last module patch version validated against: 1.0.4
 

--- a/types/d3-contour/index.d.ts
+++ b/types/d3-contour/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://d3js.org/d3-contour/
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Hugues Stefanski <https://github.com/Ledragon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 // Last module patch version validated against: 1.2.0
 

--- a/types/d3-fetch/index.d.ts
+++ b/types/d3-fetch/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://d3js.org/d3-fetch/
 // Definitions by: Hugues Stefanski <https://github.com/ledragon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.8
 
 // Last module patch version validated against: 1.1.0
 

--- a/types/d3-geo/index.d.ts
+++ b/types/d3-geo/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/d3/d3-geo/
 // Definitions by: Hugues Stefanski <https://github.com/Ledragon>, Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 // Last module patch version validated against: 1.10.0
 

--- a/types/d3/index.d.ts
+++ b/types/d3/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/d3/d3
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 // Last module patch version validated against: 5.0.0 RC3
 

--- a/types/draft-js/index.d.ts
+++ b/types/draft-js/index.d.ts
@@ -9,7 +9,7 @@
 //                 Santiago Vilar <https://github.com/smvilar>
 //                 Ulf Schwekendiek <https://github.com/sulf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import * as Immutable from 'immutable';

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -8,7 +8,7 @@
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Torgeir Hovden <https://github.com/thovden>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="cheerio" />
 import { ReactElement, Component, AllHTMLAttributes as ReactHTMLAttributes, SVGAttributes as ReactSVGAttributes } from "react";

--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -7,7 +7,7 @@
 //                 Fernando Helwanger <https://github.com/fhelwanger>
 //                 Umidbek Karimov <https://github.com/umidbekkarimov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { EventSubscription } from 'fbemitter';
 import { Component, ComponentClass, Ref, ComponentType } from 'react';

--- a/types/expo/v23/index.d.ts
+++ b/types/expo/v23/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expo/expo-sdk
 // Definitions by: Konstantin Kai <https://github.com/KonstantinKai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { EventSubscription } from 'fbemitter';
 import { Component, Ref } from 'react';

--- a/types/expo/v24/index.d.ts
+++ b/types/expo/v24/index.d.ts
@@ -6,7 +6,7 @@
 //                 Sergio Sánchez <https://github.com/ssanchezmarc>
 //                 Fernando Helwanger <https://github.com/fhelwanger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { EventSubscription } from 'fbemitter';
 import { Component, ComponentClass, Ref, ComponentType } from 'react';

--- a/types/expo__vector-icons/index.d.ts
+++ b/types/expo__vector-icons/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/expo/vector-icons
 // Definitions by: Hyeonsu Lee <https://github.com/incleaf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { TextProperties } from 'react-native';

--- a/types/fixed-data-table-2/index.d.ts
+++ b/types/fixed-data-table-2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/schrodinger/fixed-data-table-2
 // Definitions by: Ilya Petukhov <https://github.com/ilivit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/fixed-data-table/index.d.ts
+++ b/types/fixed-data-table/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/facebook/fixed-data-table
 // Definitions by: Petar Paar <https://github.com/pepaar>, Stephen Jelfs <https://github.com/stephenjelfs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react"/>
 

--- a/types/fluxxor/index.d.ts
+++ b/types/fluxxor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/BinaryMuse/fluxxor
 // Definitions by: Yuichi Murata <https://github.com/mrk21>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as EventEmitter3 from 'eventemitter3';
 import * as React from "react";

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -4,7 +4,7 @@
 //                 Arne Schubert <https://github.com/atd-schubert>
 //                 Jeff Jacobson <https://github.com/JeffJacobson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 // Note: as of the RFC 7946 version of GeoJSON, Coordinate Reference Systems
 // are no longer supported. (See https://tools.ietf.org/html/rfc7946#appendix-B)}

--- a/types/google-map-react/index.d.ts
+++ b/types/google-map-react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/istarkov/google-map-react
 // Definitions by: Honza Brecka <https://github.com/honzabrecka>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/grid-styled/index.d.ts
+++ b/types/grid-styled/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jxnblk/grid-styled
 // Definitions by: Anton Vasin <https://github.com/antonvasin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export type Diff<T extends string, U extends string> = ({ [P in T]: P } &
     { [P in U]: never } & { [x: string]: never })[T];

--- a/types/halogen/index.d.ts
+++ b/types/halogen/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/yuanyan/halogen
 // Definitions by: Vincent Rouffiat <https://github.com/steller>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as react from "react";
 

--- a/types/hedron/index.d.ts
+++ b/types/hedron/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/JSBros/hedron
 // Definitions by: Dmytro Borysov <https://github.com/dborysov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/jquery/index.d.ts
+++ b/types/jquery/index.d.ts
@@ -22,7 +22,7 @@
 //                 Dick van den Brink <https://github.com/DickvdBrink>
 //                 Thomas Schulz <https://github.com/King2500>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 declare module 'jquery' {
     export = jQuery;

--- a/types/jsnox/index.d.ts
+++ b/types/jsnox/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Steve Baker <https://github.com/stkb>
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/json-schema/index.d.ts
+++ b/types/json-schema/index.d.ts
@@ -4,7 +4,7 @@
 //                 Cyrille Tuzi <https://github.com/cyrilletuzi>
 //                 Lucian Buzzo <https://github.com/lucianbuzzo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.8
 
 /* JSON Schema 4 */
 

--- a/types/leaflet/index.d.ts
+++ b/types/leaflet/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alejandro Sánchez <https://github.com/alejo90>
 //                 Arne Schubert <https://github.com/atd-schubert>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 export as namespace L;
 

--- a/types/mapbox-gl/index.d.ts
+++ b/types/mapbox-gl/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mapbox/mapbox-gl-js
 // Definitions by: Dominik Bruderer <https://github.com/dobrud>, Patrick Reames <https://github.com/patrickr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 /// <reference types="geojson" />
 
@@ -26,11 +26,11 @@ declare namespace mapboxgl {
         constructor(options?: MapboxOptions);
 
         addControl(control: Control, position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'): this;
-        
+
         addControl(control: IControl, position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'): this;
 
         removeControl(control: Control): this;
-        
+
         removeControl(control: IControl): this;
 
         addClass(klass: string, options?: mapboxgl.StyleOptions): this;

--- a/types/material-ui-datatables/index.d.ts
+++ b/types/material-ui-datatables/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/hyojin/material-ui-datatables#readme
 // Definitions by: Ravi L. <https://github.com/coding2012>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/material-ui-pagination/index.d.ts
+++ b/types/material-ui-pagination/index.d.ts
@@ -2,8 +2,10 @@
 // Project: https://github.com/lo-tp/material-ui-pagination
 // Definitions by: m0a <https://m0a.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
+
 import * as React from 'react';
+
 export interface PaginationProps {
 	total: number;
 	display: number;

--- a/types/material-ui/index.d.ts
+++ b/types/material-ui/index.d.ts
@@ -12,7 +12,7 @@
 //                 Dan Jones <https://github.com/dan-j>
 //                 Daisuke Mino <https://github.com/minodisk>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react" />
 /// <reference types="react-addons-linked-state-mixin" />

--- a/types/mirrorx/index.d.ts
+++ b/types/mirrorx/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mirrorjs/mirror
 // Definitions by: Aaronphy <https://github.com/aaronphy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as H from 'history';
 

--- a/types/navigation-react/index.d.ts
+++ b/types/navigation-react/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://grahammendick.github.io/navigation/
 // Definitions by: Graham Mendick <https://github.com/grahammendick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { StateNavigator } from 'navigation';
 import { Component, HTMLProps } from 'react';

--- a/types/next-redux-wrapper/index.d.ts
+++ b/types/next-redux-wrapper/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kirill-konshin/next-redux-wrapper
 // Definitions by: Steve <https://github.com/stevegeek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="node" />
 /*~ Note that ES6 modules cannot directly export callable functions.

--- a/types/prop-types/index.d.ts
+++ b/types/prop-types/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/reactjs/prop-types
 // Definitions by: DovydasNavickas <https://github.com/DovydasNavickas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.2
+// TypeScript Version: 2.8
 
 export type Validator<T> = (object: T, key: string, componentName: string, ...rest: any[]) => Error | null;
 

--- a/types/radium/index.d.ts
+++ b/types/radium/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/formidablelabs/radium
 // Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev>, Philipp Holzer <https://github.com/nupplaphil>, Alexey Svetliakov <https://github.com/asvetliakov>, Mikael Hermansson <https://github.com/mihe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/rc-select/index.d.ts
+++ b/types/rc-select/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-component/select
 // Definitions by: Denis Tirilis <https://github.com/DenisTirilis>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react" />
 

--- a/types/rc-slider/index.d.ts
+++ b/types/rc-slider/index.d.ts
@@ -5,7 +5,7 @@
 //                 Austin Turner <https://github.com/paustint>
 //                 Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/rc-tooltip/index.d.ts
+++ b/types/rc-tooltip/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: rhysd <https://rhysd.github.io>
 //                 ahstro <http://ahst.ro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/rc-tree/index.d.ts
+++ b/types/rc-tree/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-component/tree
 // Definitions by: John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import {
     Component,

--- a/types/react-addons-create-fragment/index.d.ts
+++ b/types/react-addons-create-fragment/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-addons-css-transition-group/index.d.ts
+++ b/types/react-addons-css-transition-group/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import 'react-addons-transition-group';
 import { ComponentClass, CSSTransitionGroupProps } from 'react';

--- a/types/react-addons-linked-state-mixin/index.d.ts
+++ b/types/react-addons-linked-state-mixin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Mixin } from 'react';
 

--- a/types/react-addons-pure-render-mixin/index.d.ts
+++ b/types/react-addons-pure-render-mixin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Mixin } from 'react';
 

--- a/types/react-addons-shallow-compare/index.d.ts
+++ b/types/react-addons-shallow-compare/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from 'react';
 

--- a/types/react-addons-test-utils/index.d.ts
+++ b/types/react-addons-test-utils/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { AbstractView, Component, ComponentClass,
     ReactElement, ReactInstance, ClassType,

--- a/types/react-addons-transition-group/index.d.ts
+++ b/types/react-addons-transition-group/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentClass, TransitionGroupProps } from 'react';
 

--- a/types/react-addons-update/index.d.ts
+++ b/types/react-addons-update/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://facebook.github.io/react/
 // Definitions by: Asana <https://asana.com>, AssureSign <http://www.assuresign.com>, Microsoft <https://microsoft.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-alert/index.d.ts
+++ b/types/react-alert/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/schiehll/react-alert
 // Definitions by: Steve Syrell <https://github.com/ssyrell>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-alice-carousel/index.d.ts
+++ b/types/react-alice-carousel/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/maxmarinich/react-alice-carousel
 // Definitions by: endigo <https://github.com/endigo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-app/index.d.ts
+++ b/types/react-app/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kriasoft/react-app#readme
 // Definitions by: Prakarsh Pandey <https://github.com/prakarshpandey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-aria-menubutton/index.d.ts
+++ b/types/react-aria-menubutton/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Muhammad Fawwaz Orabi <https://github.com/forabi>
 //                 Chris Rohlfs <https://github.com/crohlfs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-autosuggest/index.d.ts
+++ b/types/react-autosuggest/index.d.ts
@@ -7,7 +7,7 @@
 //                 Christopher Deutsch <https://github.com/cdeutsch>
 //                 Kevin Ross <https://github.com/rosskevin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-avatar-editor/index.d.ts
+++ b/types/react-avatar-editor/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Diogo Corrêa <https://github.com/diogocorrea>
 //                 Gabriel Prates <https://github.com/gabsprates>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-beautiful-dnd/index.d.ts
+++ b/types/react-beautiful-dnd/index.d.ts
@@ -4,7 +4,7 @@
 //                 Bradley Ayers <https://github.com/bradleyayers>
 //                 Austin Turner <https://github.com/paustint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-big-calendar/index.d.ts
+++ b/types/react-big-calendar/index.d.ts
@@ -4,7 +4,7 @@
 //                 Austin Turner <https://github.com/paustint>
 //                 Krzysztof Bezrąk <https://github.com/pikpok>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-body-classname/index.d.ts
+++ b/types/react-body-classname/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/PactCoffee/react-body-classname
 // Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-bootstrap-date-picker/index.d.ts
+++ b/types/react-bootstrap-date-picker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pushtell/react-bootstrap-date-picker#readme
 // Definitions by: Karol Janyst <https://github.com/LKay>, Antal Bodnar <https://github.com/ssi-hu-antal-bodnar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentClass, StatelessComponent, ReactNode, FocusEventHandler, HTMLAttributes } from "react";
 

--- a/types/react-bootstrap-table/index.d.ts
+++ b/types/react-bootstrap-table/index.d.ts
@@ -6,7 +6,7 @@
 //                 Janeene Beeforth <https://github.com/dawnmist>
 //                 Oscar Andersson <https://github.com/Ogglas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 // documentation taken from http://allenfang.github.io/react-bootstrap-table/docs.html
 

--- a/types/react-bootstrap-table/v2/index.d.ts
+++ b/types/react-bootstrap-table/v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/AllenFang/react-bootstrap-table
 // Definitions by: Frank Laub <https://github.com/flaub>, Aleksander Lode <https://github.com/alelode>, Josué Us <https://github.com/UJosue10>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="node" />
 

--- a/types/react-bootstrap-typeahead/index.d.ts
+++ b/types/react-bootstrap-typeahead/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Guymestef <https://github.com/Guymestef>
 //                 Rajab Shakirov <https://github.com/radziksh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 // TODO: <Highlighter>, <Menu>, <MenuItem>, <Token> components
 
 import * as React from 'react';

--- a/types/react-bootstrap/index.d.ts
+++ b/types/react-bootstrap/index.d.ts
@@ -12,7 +12,7 @@
 //                 Karol Janyst <https://github.com/LKay>
 //                 Aaron Beall <https://github.com/aaronbeall>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-breadcrumbs-dynamic/index.d.ts
+++ b/types/react-breadcrumbs-dynamic/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oklas/react-breadcrumbs-dynamic
 // Definitions by: mitsuruog <https://github.com/mitsuruog>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-breadcrumbs/index.d.ts
+++ b/types/react-breadcrumbs/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/svenanders/react-breadcrumbs
 // Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as ReactRouter from "react-router";

--- a/types/react-broadcast/index.d.ts
+++ b/types/react-broadcast/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ReactTraining/react-broadcast
 // Definitions by: Jaga Santagostino <https://github.com/kandros>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-burger-menu/index.d.ts
+++ b/types/react-burger-menu/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/negomi/react-burger-menu
 // Definitions by: Rajab Shakirov <https://github.com/radziksh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-bytesize-icons/index.d.ts
+++ b/types/react-bytesize-icons/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/abdelhai/react-bytesize-icons
 // Definitions by: rhysd <https://rhysd.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-calendar-heatmap/index.d.ts
+++ b/types/react-calendar-heatmap/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/patientslikeme/react-calendar-heatmap
 // Definitions by: Keisuke Kan <https://github.com/9renpoto>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-click-outside/index.d.ts
+++ b/types/react-click-outside/index.d.ts
@@ -2,7 +2,8 @@
 // Project: https://github.com/kentor/react-click-outside
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
+
 import * as React from "react";
 
 declare function enhanceWithClickOutside<P = {}>(wrappedComponent: React.ComponentClass<P>): React.ComponentClass<P>;

--- a/types/react-collapse/index.d.ts
+++ b/types/react-collapse/index.d.ts
@@ -2,7 +2,8 @@
 // Project: https://github.com/nkbt/react-collapse
 // Definitions by: Adam Binford <https://github.com/Kimahriman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
+
 import * as React from 'react';
 
 export interface CollapseProps extends React.HTMLProps<Collapse> {

--- a/types/react-color/index.d.ts
+++ b/types/react-color/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/casesandberg/react-color/
 // Definitions by: Karol Janyst <https://github.com/LKay>, Marks Polakovs <https://github.com/markspolakovs>, Matthieu Montaudouin <https://github.com/mntdn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentClass, ClassAttributes, StatelessComponent, ReactNode } from "react";
 

--- a/types/react-confirm/index.d.ts
+++ b/types/react-confirm/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/haradakunihiko/react-confirm
 // Definitions by: santiagodoldan <https://github.com/santiagodoldan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-copy-to-clipboard/index.d.ts
+++ b/types/react-copy-to-clipboard/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Meno Abels <https://github.com/mabels>
 //                 Bernabe <https://github.com/BernabeFelix>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-css-transition-replace/index.d.ts
+++ b/types/react-css-transition-replace/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://marnusw.github.io/react-css-transition-replace/
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as CSSTransitionGroup from "react-addons-css-transition-group";

--- a/types/react-custom-scrollbars/index.d.ts
+++ b/types/react-custom-scrollbars/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by:  David-LeBlanc-git <https://github.com/David-LeBlanc-git>
 //                  kittimiyo <https://github.com/kittimiyo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-custom-scrollbars/v3/index.d.ts
+++ b/types/react-custom-scrollbars/v3/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/malte-wessel/react-custom-scrollbars
 // Definitions by: David-LeBlanc-git <https://github.com/David-LeBlanc-git>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-datagrid/index.d.ts
+++ b/types/react-datagrid/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zippyui/react-datagrid.git
 // Definitions by: Stephen Jelfs <https://github.com/stephenjelfs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react"/>
 

--- a/types/react-datepicker/index.d.ts
+++ b/types/react-datepicker/index.d.ts
@@ -7,7 +7,7 @@
 //                 Roy Xue <https://github.com/royxue>
 // 				   Koala Human <https://github.com/KoalaHuman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as moment from "moment";

--- a/types/react-daterange-picker/index.d.ts
+++ b/types/react-daterange-picker/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: UNCOVER TRUTH Inc. <https://github.com/uncovertruth>
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as moment from "moment";

--- a/types/react-dates/index.d.ts
+++ b/types/react-dates/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/airbnb/react-dates
 // Definitions by: Artur Ampilogov <https://github.com/Artur-A>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as moment from "moment";
@@ -166,7 +166,7 @@ declare namespace ReactDates {
         hideKeyboardShortcutsPanel?: boolean,
         daySize?: number,
         isRTL?: boolean,
-        verticalSpacing?: number,        
+        verticalSpacing?: number,
         verticalHeight?: number| null,
 
         // navigation related props

--- a/types/react-dnd-html5-backend/index.d.ts
+++ b/types/react-dnd-html5-backend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-dnd
 // Definitions by: Pedro Pereira <https://github.com/oizie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as ReactDnd from "react-dnd";
 

--- a/types/react-dnd-multi-backend/index.d.ts
+++ b/types/react-dnd-multi-backend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LouisBrunner/react-dnd-multi-backend
 // Definitions by: Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { CSSProperties, PureComponent } from "react";
 import { Backend } from "react-dnd";

--- a/types/react-dnd-test-backend/index.d.ts
+++ b/types/react-dnd-test-backend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-dnd/react-dnd#readme
 // Definitions by: Gustavo Henke <https://github.com/gustavohenke>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as ReactDnd from "react-dnd";
 

--- a/types/react-dnd-touch-backend/index.d.ts
+++ b/types/react-dnd-touch-backend/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/yahoo/react-dnd-touch-backend#readme
 // Definitions by: Daniel Król <https://github.com/mleko>, Janeene Beeforth <https://github.com/dawnmist>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as ReactDnd from "react-dnd";
 

--- a/types/react-dnd/index.d.ts
+++ b/types/react-dnd/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-dnd
 // Definitions by: Asana <https://asana.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 ///<reference types="react" />
 

--- a/types/react-document-title/index.d.ts
+++ b/types/react-document-title/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-document-title
 // Definitions by: Cleve Littlefield <https://github.com/cleverguy25>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-dom-factories/index.d.ts
+++ b/types/react-dom-factories/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://facebook.github.io/react/
 // Definitions by: John Gozde <https://github.com/jgoz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export as namespace ReactDOMFactories;
 export = ReactDOMFactories;

--- a/types/react-dom/index.d.ts
+++ b/types/react-dom/index.d.ts
@@ -6,7 +6,7 @@
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 //                 Josh Rutherford <https://github.com/theruther4d>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export as namespace ReactDOM;
 

--- a/types/react-dom/v15/index.d.ts
+++ b/types/react-dom/v15/index.d.ts
@@ -5,7 +5,7 @@
 //                 Microsoft <https://microsoft.com>
 //                 MartynasZilinskas <https://github.com/MartynasZilinskas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export as namespace ReactDOM;
 

--- a/types/react-dropzone/index.d.ts
+++ b/types/react-dropzone/index.d.ts
@@ -8,7 +8,7 @@
 //                 Andris Causs <https://github.com/codeaid>,
 //                 Juraj Husar <https://github.com/jurosh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { CSSProperties, Component, DragEvent, InputHTMLAttributes } from "react";
 

--- a/types/react-dropzone/v3/index.d.ts
+++ b/types/react-dropzone/v3/index.d.ts
@@ -6,7 +6,7 @@
 //                 Ben Bayard <https://github.com/benbayard>,
 //                 Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { CSSProperties, Component, DragEvent, InputHTMLAttributes } from "react";
 

--- a/types/react-dynamic-number/index.d.ts
+++ b/types/react-dynamic-number/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/uhlryk/react-dynamic-number
 // Definitions by: Eugene Rodin <https://github.com/eugrdn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-event-listener/index.d.ts
+++ b/types/react-event-listener/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/oliviertassinari/react-event-listener
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-fa/index.d.ts
+++ b/types/react-fa/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/andreypopp/react-fa
 // Definitions by: Frank Laub <https://github.com/flaub>, Pat Sissons <https://github.com/patsissons>, Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, ComponentClass, HTMLProps, StatelessComponent, ReactElement } from "react";
 

--- a/types/react-facebook-login/index.d.ts
+++ b/types/react-facebook-login/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/keppelen/react-facebook-login
 // Definitions by: Alexandre Paré <https://github.com/apare>, Jan Karres <https://github.com/jankarres>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-faux-dom/index.d.ts
+++ b/types/react-faux-dom/index.d.ts
@@ -4,7 +4,7 @@
 //                 Cleve Littlefield <https://github.com/cleverguy25>
 //                 Michał Kostrzyński <https://github.com/deviousm>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-file-reader-input/index.d.ts
+++ b/types/react-file-reader-input/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/react-file-reader-input
 // Definitions by: Dmitry Rogozhny <https://github.com/dmitryrogozhny>, Ali Taheri <https://github.com/alitaheri>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-flags-select/index.d.ts
+++ b/types/react-flags-select/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ekwonye-richard/react-flags-select#readme
 // Definitions by: Artur Sianiuk <https://github.com/senukartur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from 'react';
 

--- a/types/react-flatpickr/index.d.ts
+++ b/types/react-flatpickr/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/coderhaoxin/react-flatpickr
 // Definitions by: begincalendar <https://github.com/begincalendar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from 'react';
 import { Options } from 'flatpickr';

--- a/types/react-flex/index.d.ts
+++ b/types/react-flex/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zippyui/react-flex
 // Definitions by: Jeffery Grajkowski <https://github.com/pushplay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-fontawesome/index.d.ts
+++ b/types/react-fontawesome/index.d.ts
@@ -5,7 +5,7 @@
 //                 Vincas Stonys <https://github.com/vincaslt>
 //                 Gavin Gregory <https://github.com/gavingregory>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-form/index.d.ts
+++ b/types/react-form/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Cameron McAteer <https://github.com/cameron-mcateer>
 //                 Mathieu Masy <https://github.com/TiuSh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-form/v1/index.d.ts
+++ b/types/react-form/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tannerlinsley/react-form#readme
 // Definitions by: Cameron McAteer <https://github.com/cameron-mcateer>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-geosuggest/index.d.ts
+++ b/types/react-geosuggest/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ubilabs/react-geosuggest
 // Definitions by: Brad Menchl <https://github.com/brmenchl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="googlemaps" />
 

--- a/types/react-google-recaptcha/index.d.ts
+++ b/types/react-google-recaptcha/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/dozoisch/react-google-recaptcha
 // Definitions by: Koala Human <https://github.com/KoalaHuman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-gravatar/index.d.ts
+++ b/types/react-gravatar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://kyleamathews.github.io/react-gravatar/
 // Definitions by: invliD <https://github.com/invliD>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-grid-layout/index.d.ts
+++ b/types/react-grid-layout/index.d.ts
@@ -5,7 +5,7 @@
 //                 Zheyang Song <https://github.com/ZheyangSong>,
 //                 Andrew Hathaway <https://github.com/andrewhathaway>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-hamburger-menu/index.d.ts
+++ b/types/react-hamburger-menu/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/cameronbourke/react-hamburger-menu
 // Definitions by: Grzegorz Kielak <https://github.com/grzesie2k>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-helmet-async/index.d.ts
+++ b/types/react-helmet-async/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/staylor/react-helmet-async#readme
 // Definitions by: forabi <https://github.com/forabi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-helmet/index.d.ts
+++ b/types/react-helmet/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nfl/react-helmet
 // Definitions by: Evan Bremer <https://github.com/evanbb>, Isman Usoh <https://github.com/isman-usoh>, François Nguyen <https://github.com/lith-light-g>, Kok Sam <https://github.com/sammkj>, Yui T. <https://github.com/yuit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-helmet/v4/index.d.ts
+++ b/types/react-helmet/v4/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/nfl/react-helmet
 // Definitions by: Evan Bremer <https://github.com/evanbb>, Isman Usoh <https://github.com/isman-usoh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react" />
 

--- a/types/react-highlight-words/index.d.ts
+++ b/types/react-highlight-words/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bvaughn/react-highlight-words#readme
 // Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-holder/index.d.ts
+++ b/types/react-holder/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Moeriki/react-holder
 // Definitions by: Isman Usoh <https://github.com/isman-usoh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 ///<reference types="react"/>
 

--- a/types/react-hot-loader/index.d.ts
+++ b/types/react-hot-loader/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-hot-loader
 // Definitions by: Jacek Jagiello <https://github.com/jacekjagiello>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react"
 

--- a/types/react-hyperscript/index.d.ts
+++ b/types/react-hyperscript/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mlmorg/react-hyperscript
 // Definitions by: tock203 <https://github.com/tock203>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentClass, StatelessComponent, ReactElement } from 'react';
 

--- a/types/react-i18next/v1/index.d.ts
+++ b/types/react-i18next/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/i18next/react-i18next
 // Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as I18next from "i18next";
 import * as React from "react";

--- a/types/react-icon-base/index.d.ts
+++ b/types/react-icon-base/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gorangajic/react-icon-base#readme
 // Definitions by: Alexandre Paré <https://github.com/apare>, Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-image-gallery/index.d.ts
+++ b/types/react-image-gallery/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/xiaolin/react-image-gallery
 // Definitions by: Adam Webb <https://github.com/adamwpc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-infinite-calendar/index.d.ts
+++ b/types/react-infinite-calendar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/clauderic/react-infinite-calendar
 // Definitions by: Christian Chown <https://github.com/christianchown>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-infinite-scroller/index.d.ts
+++ b/types/react-infinite-scroller/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Lauri Lavanti <https://github.com/Lapanti>,
 //                 Piotr Srebniak <https://github.com/psrebniak>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-infinite/index.d.ts
+++ b/types/react-infinite/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/seatgeek/react-infinite
 // Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 ///<reference types="react" />
 

--- a/types/react-input-mask/index.d.ts
+++ b/types/react-input-mask/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/sanniassin/react-input-mask
 // Definitions by: Alexandre Paré <https://github.com/apare>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-intl/v1/index.d.ts
+++ b/types/react-intl/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://formatjs.io/react/
 // Definitions by: Bruno Grieder <https://github.com/bgrieder>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 ///<reference types="react" />
 

--- a/types/react-is-deprecated/index.d.ts
+++ b/types/react-is-deprecated/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Aweary/react-is-deprecated
 // Definitions by: Sean Kelley <https://github.com/seansfkelley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 declare module 'react-is-deprecated' {
   import { Validator, Requireable, ValidationMap, ReactPropTypes } from 'react';

--- a/types/react-joyride/index.d.ts
+++ b/types/react-joyride/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gilbarbara/react-joyride
 // Definitions by: Daniel Rosenwasser <https://github.com/DanielRosenwasser>, Ben Dixon <https://github.com/bendxn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-json-pretty/index.d.ts
+++ b/types/react-json-pretty/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chenckang/react-json-pretty
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentClass, HTMLProps } from "react";
 

--- a/types/react-json-tree/index.d.ts
+++ b/types/react-json-tree/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/alexkuz/react-json-tree/
 // Definitions by: Grant Nestor <https://github.com/gnestor>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import {
     Component,

--- a/types/react-json/index.d.ts
+++ b/types/react-json/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/arqex/react-json
 // Definitions by: Christoph Spielmann <https://github.com/spielc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-jsonschema-form/index.d.ts
+++ b/types/react-jsonschema-form/index.d.ts
@@ -5,7 +5,7 @@
 //                 Ivan Jiang <https://github.com/iplus26>
 //                 Kurt Preston <https://github.com/KurtPreston>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 declare module "react-jsonschema-form" {
     import * as React from "react";

--- a/types/react-lazyload/index.d.ts
+++ b/types/react-lazyload/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jasonslyvia/react-lazyload
 // Definitions by: m0a <https://github.com/m0a>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from 'react';
 

--- a/types/react-leaflet/index.d.ts
+++ b/types/react-leaflet/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/PaulLeCam/react-leaflet
 // Definitions by: Dave Leaver <https://github.com/danzel>, David Schneider <https://github.com/davschne>, Yui T. <https://github.com/yuit>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as Leaflet from 'leaflet';
 import * as React from 'react';

--- a/types/react-list/index.d.ts
+++ b/types/react-list/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/orgsync/react-list
 // Definitions by: Yifei Yan <https://github.com/buptyyf>, Tom Shen <https://github.com/tomshen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import {
     Component,

--- a/types/react-loader/index.d.ts
+++ b/types/react-loader/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/quickleft/react-loader
 // Definitions by: Sudarsan Balaji <https://github.com/artfuldev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from 'react';
 

--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/uber/react-map-gl#readme
 // Definitions by: Robert Imig <https://github.com/rimig>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as MapboxGL from "mapbox-gl";

--- a/types/react-maskedinput/index.d.ts
+++ b/types/react-maskedinput/index.d.ts
@@ -4,7 +4,7 @@
 //                 Adam Lavin <https://github.com/lavoaster>
 //                 Carlos Bonetti <https://github.com/CarlosBonetti>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-mce/index.d.ts
+++ b/types/react-mce/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/janstuemmel/react-mce
 // Definitions by: Gavin Heise <https://github.com/morphologue>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import * as ActualTinyMCE from 'tinymce';

--- a/types/react-mdl/index.d.ts
+++ b/types/react-mdl/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tleunen/react-mdl
 // Definitions by: Brad Zacher <https://github.com/bradzacher>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-measure/index.d.ts
+++ b/types/react-measure/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/souporserious/react-measure
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Marc Fallows <https://github.com/marcfallows>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-mixin/index.d.ts
+++ b/types/react-mixin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/brigand/react-mixin
 // Definitions by: Qubo <https://github.com/tkqubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react" />
 

--- a/types/react-modal/index.d.ts
+++ b/types/react-modal/index.d.ts
@@ -7,7 +7,7 @@
 //                 Uwe Wiemer <https://github.com/hallowatcher>,
 //                 Peter Blazejewicz <https://github.com/peterblazejewicz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-monaco-editor/index.d.ts
+++ b/types/react-monaco-editor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/superRaytin/react-monaco-editor
 // Definitions by: Joshua Netterfield <https://github.com/jnetterf>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="monaco-editor" />
 

--- a/types/react-motion-slider/index.d.ts
+++ b/types/react-motion-slider/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/souporserious/react-motion-slider
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 declare module "react-motion-slider" {
     import * as React from "react";

--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -4,7 +4,7 @@
 //                 Alexey Svetliakov <https://github.com/asvetliakov>
 //                 Dimitar Nestorov <https://github.com/dimitarnestorov>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, ReactElement } from 'react';
 

--- a/types/react-native-collapsible/index.d.ts
+++ b/types/react-native-collapsible/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 //                 Umidbek Karimov <https://github.com/umidbekkarimov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-native-datepicker/index.d.ts
+++ b/types/react-native-datepicker/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/xgfe/react-native-datepicker
 // Definitions by: Jacob Baskin <https://github.com/jacobbaskin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ImageURISource } from 'react-native';

--- a/types/react-native-drawer-layout/index.d.ts
+++ b/types/react-native-drawer-layout/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-native-community/react-native-drawer-layout
 // Definitions by: Justin Firth <https://github.com/jmfirth>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ViewProperties } from 'react-native';

--- a/types/react-native-drawer/index.d.ts
+++ b/types/react-native-drawer/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/root-two/react-native-drawer
 // Definitions by: jnbt <https://github.com/jnbt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ViewStyle, ScaledSize } from 'react-native';

--- a/types/react-native-elevated-view/index.d.ts
+++ b/types/react-native-elevated-view/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/alekhurst/react-native-elevated-view
 // Definitions by: fhelwanger <https://github.com/fhelwanger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import * as ReactNative from 'react-native';

--- a/types/react-native-fbsdk/index.d.ts
+++ b/types/react-native-fbsdk/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/facebook/react-native-fbsdk
 // Definitions by: Ifiok Jr. <https://github.com/ifiokjr>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentClass, Component } from 'react';
 import { ViewStyle } from 'react-native';

--- a/types/react-native-google-signin/index.d.ts
+++ b/types/react-native-google-signin/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/devfd/react-native-google-signin
 // Definitions by: Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ViewProperties } from 'react-native';

--- a/types/react-native-keep-awake/index.d.ts
+++ b/types/react-native-keep-awake/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/corbt/react-native-keep-awake
 // Definitions by: huhuanming <https://github.com/huhuanming>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 declare class KeepAwake extends React.Component<{ children?: JSX.Element }> {

--- a/types/react-native-linear-gradient/index.d.ts
+++ b/types/react-native-linear-gradient/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/brentvatne/react-native-linear-gradient#readme
 // Definitions by: Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ViewProperties } from 'react-native';

--- a/types/react-native-loading-spinner-overlay/index.d.ts
+++ b/types/react-native-loading-spinner-overlay/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/joinspontaneous/react-native-loading-spinner-overlay
 // Definitions by: fhelwanger <https://github.com/fhelwanger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as ReactNative from "react-native";

--- a/types/react-native-material-design-searchbar/index.d.ts
+++ b/types/react-native-material-design-searchbar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ananddayalan/react-native-material-design-searchbar
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import {

--- a/types/react-native-material-kit/index.d.ts
+++ b/types/react-native-material-kit/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 //                 Tim Wang <https://github.com/timwangdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import {

--- a/types/react-native-material-ui/index.d.ts
+++ b/types/react-native-material-ui/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/xotahal/react-native-material-ui
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from 'react';
 import { ViewStyle, TextStyle, Image } from 'react-native';

--- a/types/react-native-modalbox/index.d.ts
+++ b/types/react-native-modalbox/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/maxs15/react-native-modalbox#readme
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ViewProperties } from 'react-native';

--- a/types/react-native-navigation/index.d.ts
+++ b/types/react-native-navigation/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wix/react-native-navigation
 // Definitions by: Egor Shulga <https://github.com/egorshulga>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-native-popup-dialog/index.d.ts
+++ b/types/react-native-popup-dialog/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Paito Anderson <https://github.com/PaitoAnderson>
 //                 connectdotz <https://github.com/connectdotz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { GestureResponderEvent, StyleProp, ViewStyle, TextStyle } from 'react-native';

--- a/types/react-native-qrcode/index.d.ts
+++ b/types/react-native-qrcode/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/cssivision/react-native-qrcode
 // Definitions by: York Yao <https://github.com/plantain-00>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-native-safari-view/index.d.ts
+++ b/types/react-native-safari-view/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/naoufal/react-native-safari-view
 // Definitions by: Michael Randolph <https://github.com/mrand01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { EmitterSubscription } from 'react-native';
 

--- a/types/react-native-scrollable-tab-view/index.d.ts
+++ b/types/react-native-scrollable-tab-view/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: CaiHuan <https://github.com/CaiHuan>
 //                 Egor Shulga <https://github.com/egorshulga>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { Animated, ScrollViewProperties, ViewStyle, TextStyle } from 'react-native';

--- a/types/react-native-sensor-manager/index.d.ts
+++ b/types/react-native-sensor-manager/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kprimice/react-native-sensor-manager
 // Definitions by: Sahin Vardar <https://github.com/SahinVardar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react-native" />
 

--- a/types/react-native-snap-carousel/index.d.ts
+++ b/types/react-native-snap-carousel/index.d.ts
@@ -4,7 +4,7 @@
 //                 Jacob Froman <https://github.com/j-fro>
 //                 Nikolay Polukhin <https://github.com/gazaret>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import {

--- a/types/react-native-sortable-grid/index.d.ts
+++ b/types/react-native-sortable-grid/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ollija/react-native-sortable-grid#readme
 // Definitions by: Jacob Froman <https://github.com/j-fro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { StyleProp, ViewStyle, Animated } from 'react-native';

--- a/types/react-native-sortable-list/index.d.ts
+++ b/types/react-native-sortable-list/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gitim/react-native-sortable-list
 // Definitions by: Michael Sivolobov <https://github.com/sivolobov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ViewStyle } from 'react-native';

--- a/types/react-native-star-rating/index.d.ts
+++ b/types/react-native-star-rating/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/djchie/react-native-star-rating
 // Definitions by: iRoachie <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ImageURISource, StyleProp, ViewStyle } from 'react-native';

--- a/types/react-native-svg-uri/index.d.ts
+++ b/types/react-native-svg-uri/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/matiascba/react-native-svg-uri#readme
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ImageURISource } from 'react-native';

--- a/types/react-native-swiper/index.d.ts
+++ b/types/react-native-swiper/index.d.ts
@@ -4,7 +4,7 @@
 //                 HuHuanming <https://github.com/huhuanming>
 //                 mhcgrq <https://github.com/mhcgrq>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import {

--- a/types/react-native-tab-navigator/index.d.ts
+++ b/types/react-native-tab-navigator/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/exponentjs/react-native-tab-navigator#readme
 // Definitions by: My Self <https://github.com/iRoachie>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ViewStyle, TextStyle } from 'react-native';

--- a/types/react-native-tab-view/index.d.ts
+++ b/types/react-native-tab-view/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-native-community/react-native-tab-view
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { PureComponent, ReactNode, ComponentType } from 'react'
 import {

--- a/types/react-native-text-input-mask/index.d.ts
+++ b/types/react-native-text-input-mask/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-native-community/react-native-text-input-mask
 // Definitions by: Rodrigo Weber <https://github.com/RodrigoAWeber>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as ReactNative from "react-native";

--- a/types/react-native-vector-icons/index.d.ts
+++ b/types/react-native-vector-icons/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 //                 Tim Wang <https://github.com/timwangdev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { Icon } from './Icon';

--- a/types/react-native-video/index.d.ts
+++ b/types/react-native-video/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/react-native-community/react-native-video
 // Definitions by: HuHuanming <https://github.com/huhuanming>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8,7 +8,7 @@
 //                 Naoufal El Yousfi <https://github.com/nelyousfi>
 //                 Alex Dunne <https://github.com/alexdunne>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -16,7 +16,7 @@
 //                 Armando Assuncao <https://github.com/ArmandoAssuncao>
 //                 Ciaran Liedeman <https://github.com/cliedeman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /**
  * Reference: https://github.com/react-navigation/react-navigation/tree/a37473c5e4833f48796ee6c7c9cb4a8ac49d9c06

--- a/types/react-notification-system-redux/index.d.ts
+++ b/types/react-notification-system-redux/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gor181/react-notification-system-redux
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from "react";
 import { Action } from "redux";

--- a/types/react-notification-system/index.d.ts
+++ b/types/react-notification-system/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/react-notification-system
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>, Deividas Bakanas <https://github.com/DeividasBakanas>, Karol Janyst <https://github.com/LKay>, Bartosz Szewczyk <https://github.com/sztobar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-numeric-input/index.d.ts
+++ b/types/react-numeric-input/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/vlad-ignatov/react-numeric-input#readme
 // Definitions by: Heather Booker <https://github.com/heatherbooker>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-onclickoutside/index.d.ts
+++ b/types/react-onclickoutside/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Pomax/react-onclickoutside
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-onclickoutside/v5/index.d.ts
+++ b/types/react-onclickoutside/v5/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/Pomax/react-onclickoutside
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-onsenui/index.d.ts
+++ b/types/react-onsenui/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://onsen.io/v2/docs/guide/react/
 // Definitions by: Ozytis <https://ozytis.fr>, Salim <https://github.com/salim7>, Jemmyw <https://github.com/jemmyw>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import Component = React.Component;

--- a/types/react-overlays/index.d.ts
+++ b/types/react-overlays/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Aaron Beall <https://github.com/aaronbeall>
 //                 Vito Samson <https://github.com/vitosamson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-paginate/index.d.ts
+++ b/types/react-paginate/index.d.ts
@@ -5,7 +5,7 @@
 //                 pegel03 <https://github.com/pegel03>
 //                 Simon Archer <https://github.com/archy-bold>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-places-autocomplete/index.d.ts
+++ b/types/react-places-autocomplete/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/kenny-hibino/react-places-autocomplete/
 // Definitions by: Guilherme Hübner <https://github.com/guilhermehubner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 //
 /// <reference types="googlemaps" />
 

--- a/types/react-pointable/index.d.ts
+++ b/types/react-pointable/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Stefan Fochler <https://github.com/istefo>
 //                 Dibyo Majumdar <https://github.com/mdibyo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-portal/index.d.ts
+++ b/types/react-portal/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tajo/react-portal#readme
 // Definitions by: Shun Takahashi <https://github.com/shuntksh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-props-decorators/index.d.ts
+++ b/types/react-props-decorators/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/popkirby/react-props-decorators
 // Definitions by: Qubo <https://github.com/tkqubo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react" />
 

--- a/types/react-recaptcha/index.d.ts
+++ b/types/react-recaptcha/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Mohamed Hegazy <https://github.com/mhegazy>
 //                 Zach <https://github.com/zzanol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from "react";
 

--- a/types/react-redux-epic/index.d.ts
+++ b/types/react-redux-epic/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/BerkeleyTrue/react-redux-epic#readme
 // Definitions by: forabi <https://github.com/forabi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { Observable } from 'rxjs/Observable';

--- a/types/react-redux-i18n/index.d.ts
+++ b/types/react-redux-i18n/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/zoover/react-redux-i18n
 // Definitions by: Clément Devos <https://github.com/clementdevos>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 declare module 'react-redux-i18n' {
   import * as react from "react"

--- a/types/react-redux-toastr/index.d.ts
+++ b/types/react-redux-toastr/index.d.ts
@@ -4,7 +4,7 @@
 //                 Artyom Stukans <https://github.com/artyomsv>
 //                 Mika Kuitunen <https://github.com/kulmajaba>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from 'react';
 import { Action, ActionCreator, Reducer } from 'redux';

--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -9,15 +9,15 @@
 //                 Dibyo Majumdar <https://github.com/mdibyo>
 //                 Prashant Deva <https://github.com/pdeva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
-    
+// TypeScript Version: 2.8
+
 // Known Issue:
-// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes 
+// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @connect() decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use connect() as a function call on
 // a separate line instead of as a decorator. Discussed in this github issue:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20796
-    
+
 import * as React from 'react';
 import * as Redux from 'redux';
 

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -5,7 +5,7 @@
 //                 Eloy Durán <https://github.com/alloy>
 //                 Nicolas Pirotte <https://github.com/npirotte>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export {
     commitLocalUpdate,

--- a/types/react-resize-detector/index.d.ts
+++ b/types/react-resize-detector/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/maslianok/react-resize-detector
 // Definitions by: Matthew James <https://github.com/matthew-matvei>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-resolver/index.d.ts
+++ b/types/react-resolver/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ericclemmons/react-resolver
 // Definitions by: forabi <https://github.com/forabi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentType, StatelessComponent, Factory } from 'react';
 

--- a/types/react-responsive/index.d.ts
+++ b/types/react-responsive/index.d.ts
@@ -4,7 +4,7 @@
 //                 Alec Hill <https://github.com/alechill>
 //                 Javier Gonzalez <https://github.com/xaviergonz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-responsive/v1/index.d.ts
+++ b/types/react-responsive/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/contra/react-responsive
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-router-config/index.d.ts
+++ b/types/react-router-config/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/ReactTraining/react-router/tree/master/packages/react-router-config
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import { RouteComponentProps, match } from "react-router";

--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -4,7 +4,7 @@
 //                 Huy Nguyen <https://github.com/huy-nguyen>
 //                 Philip Jackson <https://github.com/p-jackson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { match } from "react-router";
 import * as React from 'react';

--- a/types/react-router-native/index.d.ts
+++ b/types/react-router-native/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Eduard Zintz <https://github.com/ezintz>
 //                 Fernando Helwanger <https://github.com/fhelwanger>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export {
   match,

--- a/types/react-router-navigation-core/index.d.ts
+++ b/types/react-router-navigation-core/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LeoLeBras/react-router-navigation#readme
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 // High-level wrappers
 import { PureComponent, ReactNode, ComponentClass, ReactElement } from "react";

--- a/types/react-router-navigation/index.d.ts
+++ b/types/react-router-navigation/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LeoLeBras/react-router-navigation#readme
 // Definitions by: Kalle Ott <https://github.com/kaoDev>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, ReactNode, ReactElement, ComponentClass } from "react";
 import { StyleProp, ViewProperties, ViewStyle, TextStyle } from "react-native";

--- a/types/react-router-redux/index.d.ts
+++ b/types/react-router-redux/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
 //                 Shoya Tanaka <https://github.com/8398a7>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import {
     Store,

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -17,7 +17,7 @@
 //                 Youen Toupin <https://github.com/neuoy>
 //                 Rahul Raina <https://github.com/rraina>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import * as H from 'history';
@@ -101,14 +101,14 @@ export interface match<P> {
   url: string;
 }
 
-// Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
-export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
-
 export function matchPath<P>(pathname: string, props: RouteProps): match<P> | null;
+
+type WithRouterInferredProps<T> = T extends RouteComponentProps<any>
+  ? Pick<T, Exclude<keyof T, keyof RouteComponentProps<any>>>
+  : T
 
 // There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @withRouter decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use withRouter() as a function call
 // on a separate line instead of as a decorator.
-export function withRouter<P extends RouteComponentProps<any>>(component: React.ComponentType<P>): React.ComponentClass<Omit<P, keyof RouteComponentProps<any>>>;
+export function withRouter<P>(component: React.ComponentType<P>): React.ComponentClass<WithRouterInferredProps<P>>

--- a/types/react-router/test/WithRouter.tsx
+++ b/types/react-router/test/WithRouter.tsx
@@ -6,19 +6,28 @@ interface TOwnProps extends RouteComponentProps<{}> {
 }
 
 const ComponentFunction = (props: TOwnProps) => (
-    <h2>Welcome {props.username}</h2>
+    <h2>Welcome {props.username} on the {props.location.pathname} page</h2>
+);
+
+// Regression test for https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24070
+const ComponentFunctionWithAnyProps = (props: any) => (
+    <h2>Welcome {props.username} on the {props.location.pathname} page</h2>
 );
 
 class ComponentClass extends React.Component<TOwnProps> {
     render() {
-        return <h2>Welcome {this.props.username}</h2>;
+        return <h2>Welcome {this.props.username} on the {this.props.location.pathname} page</h2>;
     }
 }
 
 const WithRouterComponentFunction = withRouter(ComponentFunction);
+const WithRouterComponentFunctionWithAnyProps = withRouter(ComponentFunctionWithAnyProps);
 const WithRouterComponentClass = withRouter(ComponentClass);
 
 const WithRouterTestFunction = () => (
     <WithRouterComponentFunction username="John" />
+);
+const WithRouterTestFunctionWithAnyProps = () => (
+    <WithRouterComponentFunctionWithAnyProps username="John" />
 );
 const WithRouterTestClass = () => <WithRouterComponentClass username="John" />;

--- a/types/react-router/test/examples-from-react-router-website/Auth.tsx
+++ b/types/react-router/test/examples-from-react-router-website/Auth.tsx
@@ -42,7 +42,7 @@ const fakeAuth = {
   }
 };
 
-const AuthButton = withRouter(({ history }) => (
+const AuthButton = withRouter(({ history }: RouteComponentProps<{}>) => (
   fakeAuth.isAuthenticated ? (
     <p>
       Welcome! <button onClick={() => {

--- a/types/react-router/v2/index.d.ts
+++ b/types/react-router/v2/index.d.ts
@@ -7,7 +7,7 @@
 //                 Alex Wendland <https://github.com/awendland>
 //                 Kostya Esmukov <https://github.com/KostyaEsmukov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export as namespace ReactRouter;
 

--- a/types/react-s-alert/index.d.ts
+++ b/types/react-s-alert/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/juliancwirko/react-s-alert
 // Definitions by: mitsuruog <https://github.com/mitsuruog>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-select/index.d.ts
+++ b/types/react-select/index.d.ts
@@ -13,7 +13,7 @@
 //                 David Schkalee <https://github.com/misantronic>
 //                 Arthur Udalov <https://github.com/darkartur>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-side-effect/index.d.ts
+++ b/types/react-side-effect/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/react-side-effect
 // Definitions by: Remo H. Jansen <https://github.com/remojansen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-sidebar/index.d.ts
+++ b/types/react-sidebar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/balloob/react-sidebar#readme
 // Definitions by: Jeroen Vervaeke <https://github.com/jeroenvervaeke>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from "react";
 

--- a/types/react-sketchapp/index.d.ts
+++ b/types/react-sketchapp/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Rico Kahler <https://github.com/ricokahler>
 //                 DomiR <https://github.com/DomiR>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-slick/index.d.ts
+++ b/types/react-slick/index.d.ts
@@ -4,7 +4,7 @@
 //                 Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Andrew Makarov <https://github.com/r3nya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-smooth-scrollbar/index.d.ts
+++ b/types/react-smooth-scrollbar/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/idiotWu/react-smooth-scrollbar
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import SmoothScrollbar from "smooth-scrollbar";

--- a/types/react-sortable-hoc/index.d.ts
+++ b/types/react-sortable-hoc/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/clauderic/react-sortable-hoc
 // Definitions by: Ivo Stratev <https://github.com/NoHomey>, Charles Rey <https://github.com/charlesrey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-sortable-pane/index.d.ts
+++ b/types/react-sortable-pane/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bokuweb/react-sortable-pane
 // Definitions by: rhysd <https://github.com/rhysd>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-sortable-tree/index.d.ts
+++ b/types/react-sortable-tree/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Wouter Hardeman <https://github.com/wouterhardeman>
 //                 Jovica Zoric <https://github.com/jzoric>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { ListProps, Index } from 'react-virtualized';

--- a/types/react-sticky/index.d.ts
+++ b/types/react-sticky/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/captivationsoftware/react-sticky
 // Definitions by: Matej Lednicky <http://www.thinkcreatix.com/>, Curtis Warren <https://github.com/curtisw0>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-stripe-elements/index.d.ts
+++ b/types/react-stripe-elements/index.d.ts
@@ -6,7 +6,7 @@
 //                 Andrew Goh Yisheng <https://github.com/9y5>
 //                 Thomas Chia <https://github.com/thchia>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="stripe-v3" />
 import * as React from 'react';

--- a/types/react-svg-pan-zoom/index.d.ts
+++ b/types/react-svg-pan-zoom/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chrvadala/react-svg-pan-zoom#readme
 // Definitions by: Huy Nguyen <https://github.com/huy-nguyen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-svg/index.d.ts
+++ b/types/react-svg/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/atomic-app/react-svg
 // Definitions by: Chen Junda <https://github.com/viccrubs>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-swf/index.d.ts
+++ b/types/react-swf/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/syranide/react-swf
 // Definitions by: Stepan Mikhaylyuk <https://github.com/stepancar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 export as namespace ReactSWF;

--- a/types/react-swipe/index.d.ts
+++ b/types/react-swipe/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/voronianski/react-swipe
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="swipe" />
 

--- a/types/react-swipeable-views/index.d.ts
+++ b/types/react-swipeable-views/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Michael Ledin <https://github.com/mxl>
 //                 Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-swipeable/index.d.ts
+++ b/types/react-swipeable/index.d.ts
@@ -4,7 +4,7 @@
 //                 Konstantin Vasilev <https://github.com/mctep>
 //                 Hiroki Horiuchi <https://github.com/horiuchi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-syntax-highlighter/index.d.ts
+++ b/types/react-syntax-highlighter/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/conorhastings/react-syntax-highlighter
 // Definitions by: Ivo Stratev <https://github.com/NoHomey>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 declare module 'react-syntax-highlighter' {
     import SyntaxHighlighter from 'react-syntax-highlighter/light';

--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -2,7 +2,8 @@
 // Project: https://github.com/react-tools/react-table
 // Definitions by: Roy Xue <https://github.com/royxue>, Pavel Sakalo <https://github.com/psakalo>, Krzysztof Porębski <https://github.com/Havret>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
+
 import * as React from 'react';
 
 export type ReactTableFunction = (value?: any) => void;

--- a/types/react-tag-input/index.d.ts
+++ b/types/react-tag-input/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ogglas <https://github.com/Ogglas>
 //                  Jan Karres <https://github.com/jankarres>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-tagsinput/index.d.ts
+++ b/types/react-tagsinput/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/olahol/react-tagsinput
 // Definitions by: Michael Macnair <https://github.com/mykter>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-test-renderer/index.d.ts
+++ b/types/react-test-renderer/index.d.ts
@@ -5,7 +5,7 @@
 //                 John Reilly <https://github.com/johnnyreilly>
 //                 John Gozde <https://github.com/jgoz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ReactElement, ReactType } from "react";
 

--- a/types/react-test-renderer/v15/index.d.ts
+++ b/types/react-test-renderer/v15/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://facebook.github.io/react/
 // Definitions by: Arvitaly <https://github.com/arvitaly>, Lochbrunner <https://github.com/lochbrunner>, Lochbrunner <https://github.com/lochbrunner>, John Reilly <https://github.com/johnnyreilly>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ReactElement } from "react";
 

--- a/types/react-text-mask/index.d.ts
+++ b/types/react-text-mask/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/text-mask/text-mask
 // Definitions by: Guilherme Hübner <https://github.com/guilhermehubner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-textarea-autosize/index.d.ts
+++ b/types/react-textarea-autosize/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/andreypopp/react-textarea-autosize
 // Definitions by: Alexey Svetliakov <https://github.com/asvetliakov>, Jerry Zou <https://github.com/zry656565>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 declare module "react-textarea-autosize" {
     import * as React from "react";

--- a/types/react-toastr/index.d.ts
+++ b/types/react-toastr/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/tomchentw/react-toastr
 // Definitions by: Josh Holmer <https://github.com/shssoichiro>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, ReactHTML } from 'react';
 

--- a/types/react-toggle/index.d.ts
+++ b/types/react-toggle/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/aaronshaf/react-toggle
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, InputHTMLAttributes, ReactNode } from "react";
 

--- a/types/react-toggle/v2/index.d.ts
+++ b/types/react-toggle/v2/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/aaronshaf/react-toggle
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, HTMLAttributes, ReactNode } from "react";
 

--- a/types/react-tooltip/index.d.ts
+++ b/types/react-tooltip/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/wwayne/react-tooltip
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-touch/index.d.ts
+++ b/types/react-touch/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/leonaves/react-touch
 // Definitions by: Grzegorz Kielak <https://github.com/grzesie2k>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-tracking/index.d.ts
+++ b/types/react-tracking/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/NYTimes/react-tracking
 // Definitions by: Eloy Durán <https://github.com/alloy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 

--- a/types/react-transition-group/index.d.ts
+++ b/types/react-transition-group/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import CSSTransition = require("./CSSTransition");
 import Transition from "./Transition";

--- a/types/react-transition-group/v1/index.d.ts
+++ b/types/react-transition-group/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/reactjs/react-transition-group
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { HTMLAttributes, ReactElement, ReactType } from "react";
 

--- a/types/react-treeview/index.d.ts
+++ b/types/react-treeview/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/chenglou/react-treeview
 // Definitions by: Jay Anslow <https://github.com/janslow>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, HTMLAttributes } from 'react';
 

--- a/types/react-truncate/index.d.ts
+++ b/types/react-truncate/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/One-com/react-truncate
 // Definitions by: Matt Perry <https://github.com/mattvperry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-user-tour/index.d.ts
+++ b/types/react-user-tour/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/socialtables/react-user-tour
 // Definitions by: Carlo Cancellieri <https://github.com/ccancellieri>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types='react' />
 

--- a/types/react-virtual-keyboard/index.d.ts
+++ b/types/react-virtual-keyboard/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/react-virtual-keyboard
 // Definitions by: Bogdan Surai <https://github.com/bsurai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component } from "react";
 import { KeyboardOptions, NavigateOptions } from "virtual-keyboard";

--- a/types/react-virtualized-select/index.d.ts
+++ b/types/react-virtualized-select/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/bvaughn/react-virtualized-select
 // Definitions by: Sean Kelley <https://github.com/seansfkelley>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import { ReactSelectProps, ReactAsyncSelectProps, LoadOptionsHandler, OptionValues } from "react-select";

--- a/types/react-virtualized/index.d.ts
+++ b/types/react-virtualized/index.d.ts
@@ -7,7 +7,7 @@
 //                 Kræn Hansen <https://github.com/kraenhansen>
 //                 Steve Zhang <https://github.com/Stevearzh>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 export {
     ArrowKeyStepper,

--- a/types/react-widgets/index.d.ts
+++ b/types/react-widgets/index.d.ts
@@ -5,7 +5,7 @@
 //                 Frode Hansen <https://github.com/frodehansen2>
 //                 Andrew Makarov <https://github.com/r3nya>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/react-youtube/index.d.ts
+++ b/types/react-youtube/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/troybetz/react-youtube
 // Definitions by: kgtkr <https://github.com/kgtkr>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 export default class YouTube extends React.Component<{

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -17,7 +17,7 @@
 //                 Guilherme Hübner <https://github.com/guilhermehubner>
 //                 Josh Goldberg <https://github.com/joshuakgoldberg>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /*
 Known Problems & Workarounds

--- a/types/react/v15/index.d.ts
+++ b/types/react/v15/index.d.ts
@@ -13,7 +13,7 @@
 //                 Dovydas Navickas <https://github.com/DovydasNavickas>
 //                 Stéphane Goetz <https://github.com/onigoetz>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /*
 Known Problems & Workarounds

--- a/types/reactable/index.d.ts
+++ b/types/reactable/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/glittershark/reactable
 // Definitions by: Christoph Spielmann <https://github.com/spielc>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/reactcss/index.d.ts
+++ b/types/reactcss/index.d.ts
@@ -2,7 +2,7 @@
 // Project: http://reactcss.com/
 // Definitions by: Chris Gervang <https://github.com/chrisgervang>, Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react"
 

--- a/types/reapop/index.d.ts
+++ b/types/reapop/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/LouisBarranqueiro/reapop#readme
 // Definitions by: Barrokgl <https://github.com/Barrokgl>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { Dispatch } from 'redux';

--- a/types/rebass/index.d.ts
+++ b/types/rebass/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/jxnblk/rebass
 // Definitions by: rhysd <https://rhysd.github.io>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 ///<reference types="react" />
 

--- a/types/recharts/index.d.ts
+++ b/types/recharts/index.d.ts
@@ -7,7 +7,7 @@
 //                 Rich Baird <https://github.com/richbai90>
 //                 Dan Torberg <https://github.com/caspeco-dan>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { CurveFactory } from 'd3-shape';

--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -5,7 +5,7 @@
 //                 Curtis Layne <https://github.com/clayne11>
 //                 Rasmus Eneman <https://github.com/Pajn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 ///<reference types="react" />
 

--- a/types/redux-auth-wrapper/index.d.ts
+++ b/types/redux-auth-wrapper/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mjrussell/redux-auth-wrapper
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentClass, StatelessComponent, ComponentType, ReactType } from "react";
 

--- a/types/redux-auth-wrapper/v1/index.d.ts
+++ b/types/redux-auth-wrapper/v1/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/mjrussell/redux-auth-wrapper
 // Definitions by: Karol Janyst <https://github.com/LKay>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { ComponentClass, StatelessComponent, ReactType } from "react";
 import { Action } from "redux";

--- a/types/redux-devtools-dock-monitor/index.d.ts
+++ b/types/redux-devtools-dock-monitor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/redux-devtools-dock-monitor
 // Definitions by: Petryshyn Sergii <https://github.com/mc-petry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react" />
 

--- a/types/redux-devtools-log-monitor/index.d.ts
+++ b/types/redux-devtools-log-monitor/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/redux-devtools-log-monitor
 // Definitions by: Petryshyn Sergii <https://github.com/mc-petry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react'
 import { ColorScheme } from 'base16'

--- a/types/redux-devtools/index.d.ts
+++ b/types/redux-devtools/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/gaearon/redux-devtools
 // Definitions by: Petryshyn Sergii <https://github.com/mc-petry>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { GenericStoreEnhancer } from 'redux';

--- a/types/redux-first-router-link/index.d.ts
+++ b/types/redux-first-router-link/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/faceyspacey/redux-first-router-link#readme
 // Definitions by: janb87 <https://github.com/janb87>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import { Location } from 'redux-first-router';

--- a/types/redux-first-router/index.d.ts
+++ b/types/redux-first-router/index.d.ts
@@ -5,7 +5,7 @@
 //                 janb87 <https://github.com/janb87>
 //                 corydeppen <https://github.com/corydeppen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 import {
     Dispatch,

--- a/types/redux-form/index.d.ts
+++ b/types/redux-form/index.d.ts
@@ -8,7 +8,7 @@
 //                 Anton Novik <https://github.com/tehbi4>
 //                 Huw Martin <https://github.com/huwmartin>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import {
   ComponentClass,

--- a/types/redux-form/v4/index.d.ts
+++ b/types/redux-form/v4/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/erikras/redux-form
 // Definitions by: Daniel Lytkin <https://github.com/aikoven>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { Dispatch, ActionCreator, Reducer } from 'redux';

--- a/types/redux-form/v6/index.d.ts
+++ b/types/redux-form/v6/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/erikras/redux-form
 // Definitions by: Carson Full <https://github.com/carsonf>, Daniel Lytkin <https://github.com/aikoven>, Karol Janyst <https://github.com/LKay>, Luka Zakrajsek <https://github.com/bancek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import {
   ComponentClass,

--- a/types/redux-infinite-scroll/index.d.ts
+++ b/types/redux-infinite-scroll/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/RealScout/redux-infinite-scroll
 // Definitions by: Tony Nikolov <https://github.com/silkyfray>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import { Component, HTMLProps } from "react";
 

--- a/types/redux-little-router/index.d.ts
+++ b/types/redux-little-router/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/FormidableLabs/redux-little-router
 // Definitions by: priecint <https://github.com/priecint>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import { Reducer, Middleware, StoreEnhancer } from "redux";

--- a/types/redux-router/index.d.ts
+++ b/types/redux-router/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/rackt/redux-router
 // Definitions by: Stepan Mikhaylyuk <https://github.com/stepancar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import * as ReactRouter from 'react-router';

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Matt Martin <https://github.com/voxmatt>
 //                 Eloy Durán <https://github.com/alloy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 /**
  * SOURCE:

--- a/types/rheostat/index.d.ts
+++ b/types/rheostat/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/airbnb/rheostat
 // Definitions by: Sasha Bayan <https://github.com/SashaBayan>, Wil Lee <https://github.com/kourge>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/rrc/index.d.ts
+++ b/types/rrc/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/pshrmn/rrc#readme
 // Definitions by: Deividas Bakanas <https://github.com/DeividasBakanas>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from "react";
 import * as H from "history";

--- a/types/spectacle/index.d.ts
+++ b/types/spectacle/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/FormidableLabs/victory
 // Definitions by: Zachary Maybury <https://github.com/zmaybury>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react"/>
 

--- a/types/storybook__addon-info/index.d.ts
+++ b/types/storybook__addon-info/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Mark Kornblum <https://github.com/mkornblum>
 //                 Mattias Wikstrom <https://github.com/fyrkant>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { RenderFunction } from '@storybook/react';

--- a/types/storybook__addon-knobs/index.d.ts
+++ b/types/storybook__addon-knobs/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Martynas Kadisa <https://github.com/martynaskadisa>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { RenderFunction } from '@storybook/react';

--- a/types/storybook__addon-links/index.d.ts
+++ b/types/storybook__addon-links/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Joscha Feth <https://github.com/joscha>,
 //                 Jesse Pinho <https://github.com/jessepinho>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 

--- a/types/storybook__addon-notes/index.d.ts
+++ b/types/storybook__addon-notes/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/storybooks/storybook
 // Definitions by: Joscha Feth <https://github.com/joscha>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 import * as React from 'react';
 import { RenderFunction } from '@storybook/react';

--- a/types/storybook__react/index.d.ts
+++ b/types/storybook__react/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Joscha Feth <https://github.com/joscha>
 //                 Anton Izmailov <https://github.com/wapgear>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="webpack-env" />
 

--- a/types/tiny-slider-react/index.d.ts
+++ b/types/tiny-slider-react/index.d.ts
@@ -2,7 +2,8 @@
 // Project: https://github.com/jechav/tiny-slider-react#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
+
 import * as React from "react";
 
 export interface CommonOptions {

--- a/types/tinymce/index.d.ts
+++ b/types/tinymce/index.d.ts
@@ -4,7 +4,7 @@
 //                 Poul Poulsen <https://github.com/ipoul>
 //                 Nico Hartto <https://github.com/nicohartto>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 // Work In Progress
 

--- a/types/victory/index.d.ts
+++ b/types/victory/index.d.ts
@@ -4,7 +4,7 @@
 //                 snerks <https://github.com/snerks>
 //                 Krzysztof Cebula <https://github.com/Havret>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.8
 
 /// <reference types="react"/>
 

--- a/types/virtual-keyboard/index.d.ts
+++ b/types/virtual-keyboard/index.d.ts
@@ -2,7 +2,7 @@
 // Project: https://www.npmjs.com/package/virtual-keyboard
 // Definitions by: Bogdan Surai <https://github.com/bsurai>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.4
+// TypeScript Version: 2.8
 
 /// <reference types="jquery" />
 


### PR DESCRIPTION
⚠️ We have to wait for a compatibility with the new 2.8 TypeScript version

Thanks to conditional types, withRouter definition excludes injected props only when props is assignable to RouteComponentProps.

Fix #24070