### PR TITLE
Type definitions for command-line-usage 5.0

### DIFF
--- a/types/command-line-usage/command-line-usage-tests.ts
+++ b/types/command-line-usage/command-line-usage-tests.ts
@@ -1,4 +1,4 @@
-import * as commandLineUsage from "command-line-usage";
+import commandLineUsage = require("command-line-usage");
 
 const sections = [
     {

--- a/types/command-line-usage/command-line-usage-tests.ts
+++ b/types/command-line-usage/command-line-usage-tests.ts
@@ -1,0 +1,24 @@
+import * as commandLineUsage from "command-line-usage";
+
+const sections = [
+    {
+        header: 'A typical app',
+        content: 'Generates something {italic very} important.'
+    },
+    {
+        header: 'Options',
+        optionList: [
+            {
+                name: 'input',
+                typeLabel: '{underline file}',
+                description: 'The input to process.'
+            },
+            {
+                name: 'help',
+                description: 'Print this usage guide.'
+            }
+        ]
+    }
+];
+
+const usage = commandLineUsage(sections);

--- a/types/command-line-usage/index.d.ts
+++ b/types/command-line-usage/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for command-line-usage 5.0
+// Project: https://github.com/75lb/command-line-usage#readme
+// Definitions by: Andrija Dvorski <https://github.com/Dvorsky>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+declare namespace commandLineUsage {
+    interface Section {
+        list: string[];
+
+        add(content: object): void;
+        emptyLine(): void;
+        header(text: string): void;
+        toString(): string;
+    }
+
+    interface SectionData {
+        optionList?: OptionListData[];
+        hide?: string[];
+        group?: string[];
+        header?: string;
+        reverseNameOrder?: boolean;
+        tableOptions?: any;
+    }
+
+    interface OptionListData extends SectionData {
+        name: string;
+        typeLabel?: string;
+        description?: string;
+    }
+
+    interface ContentSectionData extends SectionData {
+        content: string;
+        raw?: boolean;
+    }
+
+    type CommandLineUsageInput =
+        SectionData
+        | SectionData[]
+        | OptionListData
+        | OptionListData[]
+        | ContentSectionData
+        | ContentSectionData[];
+}
+
+declare function commandLineUsage(sections: commandLineUsage.CommandLineUsageInput): string | undefined | commandLineUsage.Section;
+
+export = commandLineUsage;

--- a/types/command-line-usage/tsconfig.json
+++ b/types/command-line-usage/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "command-line-usage-tests.ts"
+    ]
+}

--- a/types/command-line-usage/tslint.json
+++ b/types/command-line-usage/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
These are type definitions for npm library command-line-usage (https://www.npmjs.com/package/command-line-usage). Since original package does not have its own typings, here are they.

Required checklist:
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.