### PR TITLE
[@types/passport-local] Added session property to strategy options

### DIFF
--- a/types/passport-local/index.d.ts
+++ b/types/passport-local/index.d.ts
@@ -6,20 +6,20 @@
 
 /// <reference types="passport"/>
 
-
-
-import { Strategy as PassportStrategy } from 'passport-strategy';
-import express = require('express');
+import { Strategy as PassportStrategy } from "passport-strategy";
+import express = require("express");
 
 interface IStrategyOptions {
     usernameField?: string;
     passwordField?: string;
+    session?: boolean;
     passReqToCallback?: false;
 }
 
 interface IStrategyOptionsWithRequest {
     usernameField?: string;
     passwordField?: string;
+    session?: boolean;
     passReqToCallback: true;
 }
 
@@ -28,15 +28,27 @@ interface IVerifyOptions {
 }
 
 interface VerifyFunctionWithRequest {
-    (req: express.Request, username: string, password: string, done: (error: any, user?: any, options?: IVerifyOptions) => void): void;
+    (
+        req: express.Request,
+        username: string,
+        password: string,
+        done: (error: any, user?: any, options?: IVerifyOptions) => void
+    ): void;
 }
 
 interface VerifyFunction {
-    (username: string, password: string, done: (error: any, user?: any, options?: IVerifyOptions) => void): void;
+    (
+        username: string,
+        password: string,
+        done: (error: any, user?: any, options?: IVerifyOptions) => void
+    ): void;
 }
 
 declare class Strategy extends PassportStrategy {
-    constructor(options: IStrategyOptionsWithRequest, verify: VerifyFunctionWithRequest);
+    constructor(
+        options: IStrategyOptionsWithRequest,
+        verify: VerifyFunctionWithRequest
+    );
     constructor(options: IStrategyOptions, verify: VerifyFunction);
     constructor(verify: VerifyFunction);
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
`passport-local` supports passing a `session` option when constructing the strategy. With the current version, it won't let you add this property.
Resource: https://github.com/jaredhanson/passport-local#parameters
