### PR TITLE
@types/fabric: Add getActiveObjects() Definition for Canvas Class

### DIFF
--- a/types/fabric/fabric-impl.d.ts
+++ b/types/fabric/fabric-impl.d.ts
@@ -1428,6 +1428,11 @@ export class Canvas {
 	 */
 	getActiveObject(): Object;
 	/**
+	 * Returns an array with the current selected objects
+	 * @return {Object[]} array of active objects
+	 */
+	getActiveObjects(): Object[];
+	/**
 	 * Returns pointer coordinates relative to canvas.
 	 * @return object with "x" and "y" number values
 	 */

--- a/types/fabric/index.d.ts
+++ b/types/fabric/index.d.ts
@@ -4,6 +4,7 @@
 //                 Joseph Livecchi <https://github.com/joewashear007>
 //                 Michael Randolph <https://github.com/mrand01>
 //                 Tiger Oakes <https://github.com/NotWoods>
+//                 Brian Martinson <https://github.com/bmartinson>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 export import fabric = require("./fabric-impl");

--- a/types/fabric/test/index.ts
+++ b/types/fabric/test/index.ts
@@ -1032,3 +1032,32 @@ function sample9() {
   canvas.setBackgroundImage('yolo.jpg', () => { "a"; }, { opacity: 45 });
   canvas.setBackgroundImage('yolo.jpg', () => { "a"; });
 }
+
+function sample10() {
+  const canvas = new fabric.Canvas('c');
+  const objR = new fabric.Rect({
+    top: 10,
+    left: 10,
+    width: 10,
+    height: 10,
+    fill: "#FF0000",
+  });
+  const objG = new fabric.Rect({
+    top: 15,
+    left: 15,
+    width: 10,
+    height: 10,
+    fill: "#00FF00",
+  });
+  const objB = new fabric.Rect({
+    top: 20,
+    left: 20,
+    width: 10,
+    height: 10,
+    fill: "#0000FF",
+  });
+  canvas.add(objR);
+  canvas.add(objG);
+  canvas.add(objB);
+  const objArray = canvas.getActiveObjects();
+}


### PR DESCRIPTION
# Overview
This update provides a definition for the `getActiveObjects()` function on the `fabric.Canvas` object as defined by fabric-js' JSDocs [here](http://fabricjs.com/docs/fabric.Canvas.html#getActiveObjects).

# Guidelines Template

## Main Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

## Changing Existing Definition Checklist
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [Fabric.js - (JSDoc: Class: Canvas)](http://fabricjs.com/docs/fabric.Canvas.html#getActiveObjects)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
