### PR TITLE
Add types for path-is-inside

### DIFF
--- a/types/path-is-inside/index.d.ts
+++ b/types/path-is-inside/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for path-is-inside 1.0
+// Project: https://github.com/domenic/path-is-inside#readme
+// Definitions by: Alexander Marks <https://github.com/aomarks>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare function pathIsInside(thePath: string,
+                              potentialParent: string): boolean;
+export = pathIsInside;

--- a/types/path-is-inside/path-is-inside-tests.ts
+++ b/types/path-is-inside/path-is-inside-tests.ts
@@ -1,0 +1,3 @@
+import pathIsInside = require('path-is-inside');
+
+pathIsInside('path', 'parent'); // $ExpectType boolean

--- a/types/path-is-inside/tsconfig.json
+++ b/types/path-is-inside/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "path-is-inside-tests.ts"
+    ]
+}

--- a/types/path-is-inside/tslint.json
+++ b/types/path-is-inside/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
