### PR TITLE
[@types/newrelic] Add startSegment.

### DIFF
--- a/types/newrelic/index.d.ts
+++ b/types/newrelic/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for newrelic 2.7
+// Type definitions for newrelic 3.3
 // Project: http://github.com/newrelic/node-newrelic
 // Definitions by: Matt R. Wilson <https://github.com/mastermatt>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -148,6 +148,23 @@ declare namespace newrelic {
         getBrowserTimingHeader(): string;
 
         /**
+         * Instrument a particular method to improve visibility into a transaction,
+         * or optionally turn it into a metric.
+         *
+         * The name defines a name for the segment. This name will be visible in transaction traces and
+         * as a new metric in the New Relic UI.
+         * The record flag defines whether the segment should be recorded as a metric.
+         * The handler is the function you want to track as a segment.
+         * The optional callback is a function passed to the handler to fire after its work is done.
+         *
+         * The agent begins timing the segment when startSegment is called.
+         * The segment is ended when either the handler finishes executing, or callback is fired, if it is provided.
+         * If a promise is returned from the handler, the segment's ending will be tied to that promise resolving or rejecting.
+         */
+        startSegment<T extends PromiseLike<any>>(name: string, record: boolean, handler: T): T;
+        startSegment<T, C extends (...args: any[]) => any>(name: string, record: boolean, handler: (cb?: C) => T, callback?: C): T;
+
+        /**
          * Instrument a particular callback to improve visibility into a transaction.
          *
          * Use this API call to improve instrumentation of a particular method, or to track work across asynchronous
@@ -157,6 +174,9 @@ declare namespace newrelic {
          *
          * The agent begins timing the segment when createTracer is called, and ends the segment when the callback
          * defined by the callback argument finishes executing.
+         *
+         * @deprecated
+         * This method has been deprecated in favor of newrelic.startSegment()
          */
         createTracer<T extends (...args: any[]) => any>(name: string, handle: T): T;
 

--- a/types/newrelic/newrelic-tests.ts
+++ b/types/newrelic/newrelic-tests.ts
@@ -29,6 +29,12 @@ newrelic.addIgnoringRule(/^[0-9]+$/); // $ExpectType void
 
 newrelic.getBrowserTimingHeader(); // $ExpectType string
 
+newrelic.startSegment('foo', false, () => "bar"); // $ExpectType string
+newrelic.startSegment('foo', false, () => "bar", () => "baz"); // $ExpectType string
+newrelic.startSegment('foo', false, Promise.all([5, 7])).then(([a, b]: [number, number]) => {
+    console.log(a, b);
+});
+
 const wrappedFn = newrelic.createTracer("foo", (x: number) => {
     return x * x;
 });


### PR DESCRIPTION

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - [Docs](https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#startSegment)
  - [Changelog](https://github.com/newrelic/node-newrelic/blob/master/NEWS.md#330-2018-03-27)
  - [Provided examples](https://github.com/newrelic/node-newrelic/tree/master/examples/api/segments)
- [x] Increase the version number in the header if appropriate.
  - The new method was added in 3.3.0 so I updated the version in the header. While it is a major update, the [backward breaking](https://github.com/newrelic/node-newrelic/blob/master/NEWS.md#300-2018-03-06) are not related to the API of the lib, but are based on settings in their app.

