### PR TITLE
[hapi] Fix: Make  ServerInjectOptions.app optional 

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -2586,7 +2586,7 @@ export interface ServerInjectOptions extends Shot.RequestOptions {
     /**
      * sets the initial value of request.app, defaults to {}.
      */
-    app: ApplicationState;
+    app?: ApplicationState;
     /**
      * sets the initial value of request.plugins, defaults to {}.
      */


### PR DESCRIPTION
Revert a change made on : https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24341
This change had noting to do with the PR and does not align to the documentation few lines above.
see :
 - [hapi doc](https://hapijs.com/api#-await-serverinjectoptions)
 - [line 2561](https://github.com/dcharbonnier/DefinitelyTyped/blob/204e0d396a0bb36c0f1b4b34ad0c939f94bbc273/types/hapi/index.d.ts#L2561)

>  * * app - (optional) sets the initial value of request.app, defaults to {}.
