### PR TITLE
[react-navigation] Stronger definitions for screen params

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -46,10 +46,10 @@ export interface HeaderProps extends NavigationSceneRendererProps {
   router: NavigationRouter<
     NavigationState,
     NavigationStackScreenOptions
-  >;
+    >;
   getScreenDetails: (navigationScene: NavigationScene) => NavigationScreenDetails<
     NavigationStackScreenOptions
-  >;
+    >;
   style: StyleProp<ViewStyle>;
 }
 
@@ -147,9 +147,9 @@ export interface NavigationRouter<State = NavigationState, Options = {}> {
 export type NavigationScreenOption<T> =
   T
   | ((
-    navigation: NavigationScreenProp<NavigationRoute>,
-    config: T
-  ) => T);
+  navigation: NavigationScreenProp<NavigationRoute>,
+  config: T
+) => T);
 
 export interface NavigationScreenDetails<T> {
   options: T;
@@ -169,26 +169,27 @@ export interface NavigationScreenConfigProps {
 export type NavigationScreenConfig<Options> =
   Options
   | ((navigationOptionsContainer: NavigationScreenConfigProps & {
-      navigationOptions: NavigationScreenProp<NavigationRoute>,
-    }) => Options);
+  navigationOptions: NavigationScreenProp<NavigationRoute>,
+}) => Options);
 
 export type NavigationComponent =
-  NavigationScreenComponent<any, any>
+  NavigationScreenComponent<any, any, any>
   | NavigationNavigator<any, any, any>;
 
 export type NavigationScreenComponent<
-    Options = {},
-    Props = {}
-> = React.ComponentType<NavigationNavigatorProps<Options, NavigationState> & Props> &
-{ navigationOptions?: NavigationScreenConfig<Options> };
+  Params = NavigationParams,
+  Options = {},
+  Props = {}
+  > = React.ComponentType<NavigationScreenProps<Params, Options> & Props> &
+  { navigationOptions?: NavigationScreenConfig<Options> };
 
 export type NavigationNavigator<
-    State = NavigationState,
-    Options = {},
-    Props = {}
-> = React.ComponentType<NavigationNavigatorProps<Options, State> & Props> & {
-    router: NavigationRouter<State, Options>,
-    navigationOptions?: NavigationScreenConfig<Options>,
+  State = NavigationState,
+  Options = {},
+  Props = {}
+  > = React.ComponentType<NavigationNavigatorProps<Options, State> & Props> & {
+  router: NavigationRouter<State, Options>,
+  navigationOptions?: NavigationScreenConfig<Options>,
 };
 
 export interface NavigationParams {
@@ -332,9 +333,9 @@ export type NavigationRouteConfig = NavigationComponent | ({
 } & NavigationScreenRouteConfig);
 
 export type NavigationScreenRouteConfig = NavigationComponent | {
-    screen: NavigationComponent,
+  screen: NavigationComponent,
 } | {
-    getScreen: () => NavigationComponent,
+  getScreen: () => NavigationComponent,
 };
 
 export interface NavigationPathsConfig {
@@ -351,22 +352,22 @@ export interface NavigationTabRouterConfig {
   backBehavior?: 'none' | 'initialRoute'; // defaults `initialRoute`
 }
 export interface TabScene {
-    route: NavigationRoute;
-    focused: boolean;
-    index: number;
-    tintColor?: string;
+  route: NavigationRoute;
+  focused: boolean;
+  index: number;
+  tintColor?: string;
 }
 export interface NavigationTabScreenOptions extends NavigationScreenOptions {
   tabBarIcon?:
     React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-      any
+    any
     > | null));
   tabBarLabel?:
     string
     | React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-      any
+    any
     > | string | null));
   tabBarVisible?: boolean;
   tabBarTestIDProps?: { testID?: string, accessibilityLabel?: string };
@@ -380,13 +381,13 @@ export interface NavigationDrawerScreenOptions extends NavigationScreenOptions {
   drawerIcon?:
     React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-      any
+    any
     > | null));
   drawerLabel?:
     string
     | React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-      any
+    any
     > | null));
 }
 
@@ -402,11 +403,11 @@ export interface NavigationProp<S> {
 }
 
 export type EventType =
-| 'willFocus'
-| 'didFocus'
-| 'willBlur'
-| 'didBlur'
-| 'action';
+  | 'willFocus'
+  | 'didFocus'
+  | 'willBlur'
+  | 'didBlur'
+  | 'action';
 
 export interface NavigationEventPayload {
   type: EventType;
@@ -429,17 +430,17 @@ export interface NavigationScreenProp<S, P = NavigationParams> {
   goBack: (routeKey?: string | null) => boolean;
   navigate(options: {
     routeName: string;
-    params?: P;
+    params?: NavigationParams;
     action?: NavigationAction;
     key?: string;
   }): boolean;
   navigate(
     routeNameOrOptions: string,
-    params?: P,
+    params?: NavigationParams,
     action?: NavigationAction,
   ): boolean;
   getParam: <T extends keyof P>(param: T, fallback?: P[T]) => P[T];
-  setParams: (newParams: NavigationParams) => boolean;
+  setParams: (newParams: P) => boolean;
   addListener: (
     eventName: string,
     callback: NavigationEventCallback
@@ -565,9 +566,9 @@ export interface LayoutEvent {
 }
 
 export type NavigatorType =
-| 'react-navigation/STACK'
-| 'react-navigation/TABS'
-| 'react-navigation/DRAWER';
+  | 'react-navigation/STACK'
+  | 'react-navigation/TABS'
+  | 'react-navigation/DRAWER';
 
 export function addNavigationHelpers<S = {}>(
   navigation: {
@@ -592,7 +593,7 @@ export interface NavigationContainerProps {
 
 export interface NavigationContainer extends React.ComponentClass<
   NavigationContainerProps & NavigationNavigatorProps<any>
-> {
+  > {
   router: NavigationRouter<any, any>;
   screenProps: { [key: string]: any };
   navigationOptions: any;
@@ -657,7 +658,7 @@ export function DrawerNavigator(
  * Tab Navigator
  */
 
-// From views/TabView/TabView.js
+  // From views/TabView/TabView.js
 export interface TabViewConfig {
   tabBarComponent?: React.ReactType;
   tabBarPosition?: 'top' | 'bottom';
@@ -806,7 +807,7 @@ export interface TransitionerState {
 export class Transitioner extends React.Component<
   TransitionerProps,
   TransitionerState
-> { }
+  > { }
 
 /**
  * Tab Router
@@ -859,10 +860,10 @@ export function createNavigationContainer(
  * BEGIN CUSTOM CONVENIENCE INTERFACES
  */
 
-export interface NavigationScreenProps<Params = NavigationParams> {
-  navigation: NavigationScreenProp<NavigationRoute<Params>>;
+export interface NavigationScreenProps<Params = NavigationParams, Options = any> {
+  navigation: NavigationScreenProp<NavigationRoute<Params>, Params>;
   screenProps?: { [key: string]: any };
-  navigationOptions?: NavigationScreenConfig<any>;
+  navigationOptions?: NavigationScreenConfig<Options>;
 }
 
 /**

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -46,10 +46,10 @@ export interface HeaderProps extends NavigationSceneRendererProps {
   router: NavigationRouter<
     NavigationState,
     NavigationStackScreenOptions
-    >;
+  >;
   getScreenDetails: (navigationScene: NavigationScene) => NavigationScreenDetails<
     NavigationStackScreenOptions
-    >;
+  >;
   style: StyleProp<ViewStyle>;
 }
 
@@ -147,9 +147,9 @@ export interface NavigationRouter<State = NavigationState, Options = {}> {
 export type NavigationScreenOption<T> =
   T
   | ((
-  navigation: NavigationScreenProp<NavigationRoute>,
-  config: T
-) => T);
+    navigation: NavigationScreenProp<NavigationRoute>,
+    config: T
+  ) => T);
 
 export interface NavigationScreenDetails<T> {
   options: T;
@@ -169,27 +169,27 @@ export interface NavigationScreenConfigProps {
 export type NavigationScreenConfig<Options> =
   Options
   | ((navigationOptionsContainer: NavigationScreenConfigProps & {
-  navigationOptions: NavigationScreenProp<NavigationRoute>,
-}) => Options);
+      navigationOptions: NavigationScreenProp<NavigationRoute>,
+    }) => Options);
 
 export type NavigationComponent =
   NavigationScreenComponent<any, any, any>
   | NavigationNavigator<any, any, any>;
 
 export type NavigationScreenComponent<
-  Params = NavigationParams,
-  Options = {},
-  Props = {}
-  > = React.ComponentType<NavigationScreenProps<Params, Options> & Props> &
-  { navigationOptions?: NavigationScreenConfig<Options> };
+    Params = NavigationParams,
+    Options = {},
+    Props = {}
+> = React.ComponentType<NavigationScreenProps<Params, Options> & Props> &
+{ navigationOptions?: NavigationScreenConfig<Options> };
 
 export type NavigationNavigator<
-  State = NavigationState,
-  Options = {},
-  Props = {}
-  > = React.ComponentType<NavigationNavigatorProps<Options, State> & Props> & {
-  router: NavigationRouter<State, Options>,
-  navigationOptions?: NavigationScreenConfig<Options>,
+    State = NavigationState,
+    Options = {},
+    Props = {}
+> = React.ComponentType<NavigationNavigatorProps<Options, State> & Props> & {
+    router: NavigationRouter<State, Options>,
+    navigationOptions?: NavigationScreenConfig<Options>,
 };
 
 export interface NavigationParams {
@@ -333,9 +333,9 @@ export type NavigationRouteConfig = NavigationComponent | ({
 } & NavigationScreenRouteConfig);
 
 export type NavigationScreenRouteConfig = NavigationComponent | {
-  screen: NavigationComponent,
+    screen: NavigationComponent,
 } | {
-  getScreen: () => NavigationComponent,
+    getScreen: () => NavigationComponent,
 };
 
 export interface NavigationPathsConfig {
@@ -352,22 +352,22 @@ export interface NavigationTabRouterConfig {
   backBehavior?: 'none' | 'initialRoute'; // defaults `initialRoute`
 }
 export interface TabScene {
-  route: NavigationRoute;
-  focused: boolean;
-  index: number;
-  tintColor?: string;
+    route: NavigationRoute;
+    focused: boolean;
+    index: number;
+    tintColor?: string;
 }
 export interface NavigationTabScreenOptions extends NavigationScreenOptions {
   tabBarIcon?:
     React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-    any
+      any
     > | null));
   tabBarLabel?:
     string
     | React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-    any
+      any
     > | string | null));
   tabBarVisible?: boolean;
   tabBarTestIDProps?: { testID?: string, accessibilityLabel?: string };
@@ -381,13 +381,13 @@ export interface NavigationDrawerScreenOptions extends NavigationScreenOptions {
   drawerIcon?:
     React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-    any
+      any
     > | null));
   drawerLabel?:
     string
     | React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
-    any
+      any
     > | null));
 }
 
@@ -403,11 +403,11 @@ export interface NavigationProp<S> {
 }
 
 export type EventType =
-  | 'willFocus'
-  | 'didFocus'
-  | 'willBlur'
-  | 'didBlur'
-  | 'action';
+| 'willFocus'
+| 'didFocus'
+| 'willBlur'
+| 'didBlur'
+| 'action';
 
 export interface NavigationEventPayload {
   type: EventType;
@@ -566,9 +566,9 @@ export interface LayoutEvent {
 }
 
 export type NavigatorType =
-  | 'react-navigation/STACK'
-  | 'react-navigation/TABS'
-  | 'react-navigation/DRAWER';
+| 'react-navigation/STACK'
+| 'react-navigation/TABS'
+| 'react-navigation/DRAWER';
 
 export function addNavigationHelpers<S = {}>(
   navigation: {
@@ -593,7 +593,7 @@ export interface NavigationContainerProps {
 
 export interface NavigationContainer extends React.ComponentClass<
   NavigationContainerProps & NavigationNavigatorProps<any>
-  > {
+> {
   router: NavigationRouter<any, any>;
   screenProps: { [key: string]: any };
   navigationOptions: any;
@@ -658,7 +658,7 @@ export function DrawerNavigator(
  * Tab Navigator
  */
 
-  // From views/TabView/TabView.js
+// From views/TabView/TabView.js
 export interface TabViewConfig {
   tabBarComponent?: React.ReactType;
   tabBarPosition?: 'top' | 'bottom';
@@ -807,7 +807,7 @@ export interface TransitionerState {
 export class Transitioner extends React.Component<
   TransitionerProps,
   TransitionerState
-  > { }
+> { }
 
 /**
  * Tab Router

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -134,7 +134,12 @@ export const AppNavigator = StackNavigator(
     },
 );
 
-const StatelessScreen: NavigationScreenComponent = () => <View />;
+interface StatelessScreenParams {
+    testID: string;
+}
+
+const StatelessScreen: NavigationScreenComponent<StatelessScreenParams> = (props) =>
+    <View testID={props.navigation.getParam('testID', 'fallback')}/>;
 
 StatelessScreen.navigationOptions = { title: 'Stateless' };
 


### PR DESCRIPTION
**Motivation.** Let's say I have navigation screen like this:
```tsx
interface Params {
  textId?: string;
}

export const PlainTextScreen: NavigationScreenComponent<Params> = (props) => {
  const { textId } = props.navigation.state.params!;
  return (
    <Screen>
      <Text>
        {`Plain text screen for readmes and stuff, id ${textId}`}
      </Text>
    </Screen>
  );
};
```
With current definitions this will yield two typescript errors:
1. props.navigation is possibly undefined
2. property `params` does not exist on type `NavigationState`

Another problem: with current definitions in `react-navigation-tests.tsx', in `NextScreen` class line

```ts
const name = this.props.navigation.getParam('name', 'Peter');
```

typescript infers that name is `any`, but it's string.

So this PR addresses this by changing `NavigationScreenComponent` defintion a bit. Since ` export  NavigationComponent = NavigationScreenComponent | NavigationNavigator` we can use stronger defintions for NavigationScreenComponent. For some reason now it uses defs from NavigationNavigator, where navigation is optional, for example. With this PR problems outlined above are gone.

It also improves definitions for various navigation functions. When we `navigate` or `push` we go anywhere, so particular `params` for current screen do not apply. For `setParams`, on contrary, we can use strong `params` from current screen.

I realize that this PR reflects my personal style of using react-navigation with typescript, but I'm sure we can agree on strong types that suit everyone.



Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

