### PR TITLE
Change 'promiseTypeSeparator' to 'promiseTypeDelimiter' in redux-promise-middleware config

### DIFF
--- a/types/redux-promise-middleware/index.d.ts
+++ b/types/redux-promise-middleware/index.d.ts
@@ -5,4 +5,4 @@
 
 import { Middleware } from 'redux';
 
-export default function promiseMiddleware(config?: { promiseTypeSuffixes?: string[], promiseTypeSeparator?: string }): Middleware;
+export default function promiseMiddleware(config?: { promiseTypeSuffixes?: string[], promiseTypeDelimiter?: string }): Middleware;


### PR DESCRIPTION
On 20 Nov 2017, redux-promise-middleware made version up to 5.0.0. There is changes the config name of promiseTypeSeparator to promiseTypeDelimiter.

Below is URL of version 5.0.0 breaking changes.
https://github.com/pburtchaell/redux-promise-middleware/releases/tag/5.0.0
