### PR TITLE
[react-redux] Update for redux@4.0.0-beta.2

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -10,14 +10,14 @@
 //                 Prashant Deva <https://github.com/pdeva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
-    
+
 // Known Issue:
-// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes 
+// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @connect() decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use connect() as a function call on
 // a separate line instead of as a decorator. Discussed in this github issue:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20796
-    
+
 import * as React from 'react';
 import * as Redux from 'redux';
 
@@ -25,16 +25,17 @@ type ComponentClass<P> = React.ComponentClass<P>;
 type StatelessComponent<P> = React.StatelessComponent<P>;
 type Component<P> = React.ComponentType<P>;
 type ReactNode = React.ReactNode;
+type Action = Redux.Action;
 type Store<S> = Redux.Store<S>;
-type Dispatch<S> = Redux.Dispatch<S>;
+type Dispatch<A extends Action = Redux.AnyAction> = Redux.Dispatch<A>;
 type ActionCreator<A> = Redux.ActionCreator<A>;
 
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
 type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
 type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
-export interface DispatchProp<S> {
-  dispatch?: Dispatch<S>;
+export interface DispatchProp<A extends Action = Redux.AnyAction> {
+  dispatch?: Dispatch<A>;
 }
 
 interface AdvancedComponentDecorator<TProps, TOwnProps> {
@@ -76,11 +77,11 @@ export type InferableComponentEnhancer<TInjectedProps> =
  * @param options
  */
 export interface Connect {
-    (): InferableComponentEnhancer<DispatchProp<any>>;
+    (): InferableComponentEnhancer<DispatchProp>;
 
     <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = {}>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
-    ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp<any>, TOwnProps>;
+    ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp, TOwnProps>;
 
     <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
         mapStateToProps: null | undefined,
@@ -121,7 +122,7 @@ export interface Connect {
         mapDispatchToProps: null | undefined,
         mergeProps: null | undefined,
         options: Options<State, TStateProps, TOwnProps>
-    ): InferableComponentEnhancerWithProps<DispatchProp<any> & TStateProps, TOwnProps>;
+    ): InferableComponentEnhancerWithProps<DispatchProp & TStateProps, TOwnProps>;
 
     <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}>(
         mapStateToProps: null | undefined,
@@ -161,14 +162,14 @@ interface MapStateToPropsFactory<TStateProps, TOwnProps, State> {
 type MapStateToPropsParam<TStateProps, TOwnProps, State> = MapStateToPropsFactory<TStateProps, TOwnProps, State> | MapStateToProps<TStateProps, TOwnProps, State> | null | undefined;
 
 interface MapDispatchToPropsFunction<TDispatchProps, TOwnProps> {
-    (dispatch: Dispatch<any>, ownProps: TOwnProps): TDispatchProps;
+    (dispatch: Dispatch, ownProps: TOwnProps): TDispatchProps;
 }
 
 type MapDispatchToProps<TDispatchProps, TOwnProps> =
     MapDispatchToPropsFunction<TDispatchProps, TOwnProps> | TDispatchProps;
 
 interface MapDispatchToPropsFactory<TDispatchProps, TOwnProps> {
-    (dispatch: Dispatch<any>, ownProps: TOwnProps): MapDispatchToProps<TDispatchProps, TOwnProps>;
+    (dispatch: Dispatch, ownProps: TOwnProps): MapDispatchToProps<TDispatchProps, TOwnProps>;
 }
 
 type MapDispatchToPropsParam<TDispatchProps, TOwnProps> = MapDispatchToPropsFactory<TDispatchProps, TOwnProps> | MapDispatchToProps<TDispatchProps, TOwnProps>;
@@ -236,7 +237,7 @@ export declare function connectAdvanced<S, TProps, TOwnProps, TFactoryOptions = 
  * previous object when appropriate.
  */
 export interface SelectorFactory<S, TProps, TOwnProps, TFactoryOptions> {
-    (dispatch: Dispatch<S>, factoryOptions: TFactoryOptions): Selector<S, TProps, TOwnProps>
+    (dispatch: Dispatch, factoryOptions: TFactoryOptions): Selector<S, TProps, TOwnProps>
 }
 
 export interface Selector<S, TProps, TOwnProps> {

--- a/types/react-redux/package.json
+++ b/types/react-redux/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "redux": "^3.6.0"
+        "redux": "^4.0.0-beta.2"
     }
 }

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -1,7 +1,7 @@
 import { Component, ReactElement } from 'react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Store, Dispatch, ActionCreator, createStore, bindActionCreators, ActionCreatorsMapObject } from 'redux';
+import { Store, Dispatch, AnyAction, ActionCreator, createStore, bindActionCreators, ActionCreatorsMapObject } from 'redux';
 import { Connect, connect, createProvider, Provider, DispatchProp, MapStateToProps, Options } from 'react-redux';
 import objectAssign = require('object-assign');
 
@@ -14,7 +14,7 @@ import objectAssign = require('object-assign');
 // output of `connect` to make sure the signature is what is expected
 
 namespace Empty {
-    interface OwnProps { foo: string, dispatch: Dispatch<any> }
+    interface OwnProps { foo: string, dispatch: Dispatch }
 
     class TestComponent extends Component<OwnProps> {}
 
@@ -42,7 +42,7 @@ namespace MapState {
 
 namespace MapStateWithDispatchProp {
     interface OwnProps { foo: string }
-    interface StateProps { bar: number, dispatch: Dispatch<any> }
+    interface StateProps { bar: number, dispatch: Dispatch }
 
     class TestComponent extends Component<OwnProps & StateProps> {}
 
@@ -250,7 +250,7 @@ namespace MapStateAndOptions {
     interface State { state: string; }
     interface OwnProps { foo: string }
     interface StateProps { bar: number }
-    interface DispatchProps { dispatch: Dispatch<any> }
+    interface DispatchProps { dispatch: Dispatch }
 
     class TestComponent extends Component<OwnProps & StateProps & DispatchProps> {}
 
@@ -295,7 +295,7 @@ function mapStateToProps(state: CounterState) {
 }
 
 // Which action creators does it want to receive by props?
-function mapDispatchToProps(dispatch: Dispatch<CounterState>) {
+function mapDispatchToProps(dispatch: Dispatch) {
     return {
         onIncrement: () => dispatch(increment())
     };
@@ -327,7 +327,7 @@ connect<ICounterStateProps, ICounterDispatchProps, {}, CounterState>(
 // with higher order functions using parameters
 connect<ICounterStateProps, ICounterDispatchProps, {}, CounterState>(
     (initialState: CounterState, ownProps) => mapStateToProps,
-    (dispatch: Dispatch<CounterState>, ownProps) => mapDispatchToProps
+    (dispatch: Dispatch, ownProps) => mapDispatchToProps
 )(Counter);
 // only first argument
 connect<ICounterStateProps, {}, {}, CounterState>(
@@ -446,7 +446,7 @@ connect(mapStateToProps2, actionCreators)(TodoApp);
 //    return { todos: state.todos };
 //}
 
-function mapDispatchToProps2(dispatch: Dispatch<TodoState>) {
+function mapDispatchToProps2(dispatch: Dispatch) {
     return { actions: bindActionCreators(actionCreators, dispatch) };
 }
 
@@ -458,7 +458,7 @@ connect(mapStateToProps2, mapDispatchToProps2)(TodoApp);
 //    return { todos: state.todos };
 //}
 
-function mapDispatchToProps3(dispatch: Dispatch<TodoState>) {
+function mapDispatchToProps3(dispatch: Dispatch) {
     return bindActionCreators({ addTodo }, dispatch);
 }
 
@@ -470,7 +470,7 @@ connect(mapStateToProps2, mapDispatchToProps3)(TodoApp);
 //    return { todos: state.todos };
 //}
 
-function mapDispatchToProps4(dispatch: Dispatch<TodoState>) {
+function mapDispatchToProps4(dispatch: Dispatch) {
     return {
         todoActions: bindActionCreators(todoActionCreators, dispatch),
         counterActions: bindActionCreators(counterActionCreators, dispatch)
@@ -485,7 +485,7 @@ connect(mapStateToProps2, mapDispatchToProps4)(TodoApp);
 //    return { todos: state.todos };
 //}
 
-function mapDispatchToProps5(dispatch: Dispatch<TodoState>) {
+function mapDispatchToProps5(dispatch: Dispatch) {
     return {
         actions: bindActionCreators(objectAssign({}, todoActionCreators, counterActionCreators), dispatch)
     };
@@ -499,7 +499,7 @@ connect(mapStateToProps2, mapDispatchToProps5)(TodoApp);
 //    return { todos: state.todos };
 //}
 
-function mapDispatchToProps6(dispatch: Dispatch<TodoState>) {
+function mapDispatchToProps6(dispatch: Dispatch) {
     return bindActionCreators(objectAssign({}, todoActionCreators, counterActionCreators), dispatch);
 }
 
@@ -559,7 +559,7 @@ class NonComponent {}
 
 // stateless functions
 interface HelloMessageProps {
-    dispatch: Dispatch<any>
+    dispatch: Dispatch
     name: string;
  }
 const HelloMessage: React.StatelessComponent<HelloMessageProps> = (props) => {
@@ -585,7 +585,7 @@ namespace TestStatelessFunctionWithMapArguments {
         };
     };
 
-    const mapDispatchToProps = (dispatch: Dispatch<any>, ownProps: GreetingProps) => {
+    const mapDispatchToProps = (dispatch: Dispatch, ownProps: GreetingProps) => {
         return {
             onClick: () => {
                 dispatch({ type: 'GREETING', name: ownProps.name });
@@ -691,7 +691,7 @@ namespace TestMergedPropsInference {
         return { state: 'string' };
     }
 
-    function mapDispatchToProps(dispatch: Dispatch<any>): DispatchProps {
+    function mapDispatchToProps(dispatch: Dispatch): DispatchProps {
         return { dispatch: 'string' };
     }
 
@@ -877,8 +877,8 @@ namespace TestCreateProvider {
     };
 
     interface State { a: number };
-    const store = createStore<State>(() => ({ a: 1 }));
-    const myStore = createStore<State>(() => ({ a: 2 }));
+    const store = createStore<State, AnyAction, {}, {}>(() => ({ a: 1 }));
+    const myStore = createStore<State, AnyAction, {}, {}>(() => ({ a: 2 }));
 
     interface AProps { a: number };
     const A = (props: AProps) => (<h1>A is {props.a}</h1>);


### PR DESCRIPTION
Hi, could I update a package for a beta version?

Currently [Redux][redux] is bumping up its major version to 4.0.0, and it published the latest version [`4.0.0-beta.2`][redux-4beta2] last month. Though it is still a beta version, I want to use it with `react-redux`. However current `@types/react-redux` type definitions are only for `redux@3.x` so I created this PR.

[redux]: https://github.com/reactjs/redux
[redux-4beta2]: https://github.com/reactjs/redux/releases/tag/v4.0.0-beta.2

(There is a similar PR #22953, but it updates `@types/react-redux` for `redux@4.0.0-beta.1`, not `4.0.0-beta.2`)

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/reactjs/redux/blob/8c5fbc10bdc3114883/index.d.ts>
- [ ] Increase the version number in the header if appropriate.
    - The current version seems wrong. `types/react-redux/index.d.ts` says `5.0.8` but the actual latest version is `5.0.7` ([react-redux on npmjs](https://www.npmjs.com/package/react-redux)). Should I decrease the version number?
   https://github.com/DefinitelyTyped/DefinitelyTyped/blob/c895c48502fcad26bb2caa00b0db0c603089f4b7/types/react-redux/index.d.ts#L1

- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

