### PR TITLE
[@types/mathjs] fill out BigNumber and Fraction interfaces

### DIFF
--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -1,8 +1,9 @@
-import { Decimal } from 'decimal.js';
 // Type definitions for mathjs
 // Project: http://mathjs.org/
 // Definitions by: Ilya Shestakov <https://github.com/siavol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import { Decimal } from 'decimal.js';
 
 declare var math: mathjs.IMathJsStatic;
 export as namespace math;

--- a/types/mathjs/index.d.ts
+++ b/types/mathjs/index.d.ts
@@ -1,9 +1,12 @@
+import { Decimal } from 'decimal.js';
 // Type definitions for mathjs
 // Project: http://mathjs.org/
 // Definitions by: Ilya Shestakov <https://github.com/siavol>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare var math: mathjs.IMathJsStatic;
+export as namespace math;
+export = math;
 
 declare namespace mathjs {
 
@@ -304,7 +307,7 @@ declare namespace mathjs {
 		 * @param x The base
 		 * @param y The exponent
 		 */
-		pow(x: number|BigNumber|Complex|MathArray|Matrix, y: number|BigNumber|Complex): number|BigNumber|Complex|MathArray|Matrix;
+		pow(x: MathType, y: number|BigNumber|Complex): MathType;
 
 		/**
 		 * Round a value towards the nearest integer. For matrices, the function is evaluated element wise.
@@ -1333,12 +1336,14 @@ declare namespace mathjs {
 		swapRows(i: number, j: number): Matrix;
 	}
 
-	export interface BigNumber {
+	export interface BigNumber extends Decimal {
 
 	}
 
 	export interface Fraction {
-
+		s: number;
+		n: number;
+		d: number;
 	}
 
 	export interface Complex {
@@ -1349,9 +1354,9 @@ declare namespace mathjs {
 	}
 
 	export interface IPolarCoordinates {
-                r: number;
+        r: number;
 		phi: number;
-        }
+    }
 
 	export interface Unit {
 		to(unit: string): Unit;
@@ -2308,8 +2313,4 @@ declare namespace mathjs {
 		valueOf(): any;
 		toString(): string;
 	}
-}
-
-declare module 'mathjs'{
-	export = math;
 }

--- a/types/mathjs/package.json
+++ b/types/mathjs/package.json
@@ -1,0 +1,6 @@
+{
+    "private": true,
+    "dependencies": {
+        "decimal.js": "^10.0.0"
+    }
+}


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [bignumber docs](http://mathjs.org/docs/datatypes/bignumbers.html)
- [x] Increase the version number in the header if appropriate.

This uses the types that are exported from `decimal.js` to fill out the `BigNumber` interface.

