### PR TITLE
Types for named regexp group

### DIFF
--- a/types/named-regexp-groups/index.d.ts
+++ b/types/named-regexp-groups/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for named-regexp-groups 1.0
+// Project: https://github.com/commenthol/named-regexp-groups/
+// Definitions by: Vilim Stubičan <https://github.com/jewbre>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+interface NamedRegExpExecArray extends RegExpExecArray {
+    groups: { [propName: string]: string };
+}
+
+declare class NamedRegExp {
+    constructor(pattern?: string | RegExp, flags?: string);
+
+    /**
+     * Executes a search on a string using a regular expression pattern, and returns an array containing the results of that search.
+     * @param string The String object or string literal on which to perform the search.
+     */
+    exec(string: string): NamedRegExpExecArray | null;
+
+    /**
+     * Returns a Boolean value that indicates whether or not a pattern exists in a searched string.
+     * @param string String on which to perform the search.
+     */
+    test(string: string): boolean;
+
+    // Non-standard extensions
+    toString(): string;
+
+    [Symbol.replace](str: string, replacement: string | ((match: string, ...capturedGroups: string[]) => string)): string;
+
+    [Symbol.match](str: string): NamedRegExpExecArray;
+
+    [Symbol.split](str: string): string[];
+
+    [Symbol.search](str: string): number;
+}
+
+export = NamedRegExp;

--- a/types/named-regexp-groups/named-regexp-groups-tests.ts
+++ b/types/named-regexp-groups/named-regexp-groups-tests.ts
@@ -1,0 +1,19 @@
+import NamedRegExp = require("named-regexp-groups");
+
+// $ExpectType NamedRegExp
+new NamedRegExp('aaa', 'gi');
+
+// $ExpectType NamedRegExp
+new NamedRegExp(/aaa/gi);
+
+// $ExpectType NamedRegExp
+new NamedRegExp();
+
+// $ExpectError
+new NamedRegExp(1);
+
+// $ExpectError
+new NamedRegExp({});
+
+// $ExpectError
+new NamedRegExp([]);

--- a/types/named-regexp-groups/tsconfig.json
+++ b/types/named-regexp-groups/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts",
+    "named-regexp-groups-tests.ts"
+  ]
+}

--- a/types/named-regexp-groups/tslint.json
+++ b/types/named-regexp-groups/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Types for NPM package named-regexp-groups 1.0.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.