### PR TITLE
Types for amp 0.3

### DIFF
--- a/types/amp/amp-tests.ts
+++ b/types/amp/amp-tests.ts
@@ -1,0 +1,44 @@
+import { decode, encode, Stream } from 'amp';
+
+// $ExpectType Buffer[]
+decode(new Buffer('something'));
+
+// $ExpectType Buffer
+encode([new Buffer('something'), new Buffer('something')]);
+
+// $ExpectError
+decode('');
+
+// $ExpectError
+decode(1);
+
+// $ExpectError
+decode();
+
+// $ExpectError
+encode('');
+
+// $ExpectError
+encode(1);
+
+// $ExpectError
+encode();
+
+// $ExpectType Stream
+new Stream({});
+
+// $ExpectType Stream
+new Stream({
+    highWaterMark: 1,
+    decodeStrings: true,
+    objectMode: true,
+    destroy: (error?: Error) => {
+        return 'handle error';
+    },
+    final: (callback: (error?: Error) => void) => {
+        // do nothing
+    }
+});
+
+// $ExpectError
+new Stream({somethingNoneExisting: true});

--- a/types/amp/index.d.ts
+++ b/types/amp/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for amp 0.3
+// Project: https://github.com/visionmedia/node-amp
+// Definitions by: Vilim Stubičan <https://github.com/jewbre>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="node" />
+
+import * as stream from 'stream';
+
+export function decode(buf: Buffer): Buffer[];
+
+export function encode(args: Buffer[]): Buffer;
+
+export class Stream extends stream.Writable {
+    constructor(opts: stream.WritableOptions);
+
+    _write(chunk: any, encoding: string, fn: () => void): void;
+}

--- a/types/amp/tsconfig.json
+++ b/types/amp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "amp-tests.ts"
+    ]
+}

--- a/types/amp/tslint.json
+++ b/types/amp/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Type definitions for npm package amp 0.3.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.