### PR TITLE
[agenda] Support custom job.attrs.data types

### DIFF
--- a/types/agenda/agenda-tests.ts
+++ b/types/agenda/agenda-tests.ts
@@ -5,8 +5,8 @@ var mongoConnectionString = "mongodb://127.0.0.1/agenda";
 
 var agenda = new Agenda({ db: { address: mongoConnectionString } });
 
-agenda.define('delete old users', (job, done) => {
-
+agenda.define<{ foo: Error }>('delete old users', (job, done) => {
+    done(job.attrs.data.foo)
 });
 
 agenda.on('ready', () => {
@@ -62,7 +62,7 @@ agenda.schedule('tomorrow at noon', ['printAnalyticsReport', 'sendNotifications'
 
 agenda.now('do the hokey pokey');
 
-var job = agenda.create('printAnalyticsReport', { userCount: 100 });
+var job = agenda.create<{ userCount: number }>('printAnalyticsReport', { userCount: 100 });
 job.save(function(err) {
     console.log("Job successfully saved");
 });

--- a/types/agenda/index.d.ts
+++ b/types/agenda/index.d.ts
@@ -1,6 +1,7 @@
-// Type definitions for Agenda v1.0.0
-// Project: https://github.com/rschmukler/agenda
+// Type definitions for Agenda v1.0.3
+// Project: https://github.com/agenda/agenda
 // Definitions by: Meir Gottlieb <https://github.com/meirgottlieb>
+//                 Jeff Principe <https://github.com/princjef>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -89,14 +90,14 @@ declare class Agenda extends EventEmitter {
      * @param name The name of the job.
      * @param data Data to associated with the job.
      */
-    create(name: string, data?: any): Agenda.Job;
+    create<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(name: string, data?: T): Agenda.Job<T>;
 
     /**
      * Find all Jobs matching `query` and pass same back in cb().
      * @param query
      * @param cb
      */
-    jobs(query: any, cb: ResultCallback<Agenda.Job[]>): void;
+    jobs<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(query: any, cb: ResultCallback<Agenda.Job<T>[]>): void;
 
     /**
      * Removes all jobs in the database without defined behaviors. Useful if you change a definition name and want
@@ -113,8 +114,8 @@ declare class Agenda extends EventEmitter {
      * @param options The options for the job.
      * @param handler The handler to execute.
      */
-    define(name: string, handler: (job: Agenda.Job, done: (err?: Error) => void) => void): void;
-    define(name: string, options: Agenda.JobOptions, handler: (job: Agenda.Job, done: (err?: Error) => void) => void): void;
+    define<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(name: string, handler: (job: Agenda.Job<T>, done: (err?: Error) => void) => void): void;
+    define<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(name: string, options: Agenda.JobOptions, handler: (job: Agenda.Job<T>, done: (err?: Error) => void) => void): void;
 
     /**
      * Runs job name at the given interval. Optionally, data and options can be passed in.
@@ -124,8 +125,8 @@ declare class Agenda extends EventEmitter {
      * @param options An optional argument that will be passed to job.repeatEvery.
      * @param cb An optional callback function which will be called when the job has been persisted in the database.
      */
-    every(interval: number | string, names: string, data?: any, options?: any, cb?: ResultCallback<Agenda.Job>): Agenda.Job;
-    every(interval: number | string, names: string[], data?: any, options?: any, cb?: ResultCallback<Agenda.Job[]>): Agenda.Job[];
+    every<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(interval: number | string, names: string, data?: T, options?: any, cb?: ResultCallback<Agenda.Job<T>>): Agenda.Job<T>;
+    every<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(interval: number | string, names: string[], data?: T, options?: any, cb?: ResultCallback<Agenda.Job<T>[]>): Agenda.Job<T>[];
 
     /**
      * Schedules a job to run name once at a given time.
@@ -134,8 +135,8 @@ declare class Agenda extends EventEmitter {
      * @param data An optional argument that will be passed to the processing function under job.attrs.data.
      * @param cb An optional callback function which will be called when the job has been persisted in the database.
      */
-    schedule(when: Date | string, names: string, data?: any, cb?: ResultCallback<Agenda.Job>): Agenda.Job;
-    schedule(when: Date | string, names: string[], data?: any, cb?: ResultCallback<Agenda.Job[]>): Agenda.Job[];
+    schedule<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(when: Date | string, names: string, data?: T, cb?: ResultCallback<Agenda.Job<T>>): Agenda.Job<T>;
+    schedule<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(when: Date | string, names: string[], data?: T, cb?: ResultCallback<Agenda.Job<T>[]>): Agenda.Job<T>[];
 
     /**
      * Schedules a job to run name once immediately.
@@ -143,7 +144,7 @@ declare class Agenda extends EventEmitter {
      * @param data An optional argument that will be passed to the processing function under job.attrs.data.
      * @param cb An optional callback function which will be called when the job has been persisted in the database.
      */
-    now(name: string, data?: any, cb?: ResultCallback<Agenda.Job>): Agenda.Job;
+    now<T extends Agenda.JobAttributesData = Agenda.JobAttributesData>(name: string, data?: T, cb?: ResultCallback<Agenda.Job<T>>): Agenda.Job<T>;
 
     /**
      * Cancels any jobs matching the passed mongodb-native query, and removes them from the database.
@@ -242,10 +243,14 @@ declare namespace Agenda {
         }
     }
 
+    interface JobAttributesData {
+        [key: string]: any;
+    }
+
     /**
      * The database record associated with a job.
      */
-    interface JobAttributes {
+    interface JobAttributes<T extends JobAttributesData = JobAttributesData> {
         /**
          * The record identity.
          */
@@ -264,7 +269,7 @@ declare namespace Agenda {
         /**
          * The job details.
          */
-        data: { [name: string]: any };
+        data: T;
 
         /**
          * The priority of the job.
@@ -330,12 +335,12 @@ declare namespace Agenda {
     /**
      * A scheduled job.
      */
-    interface Job {
+    interface Job<T extends JobAttributesData = JobAttributesData> {
 
         /**
          * The database record associated with the job.
          */
-        attrs: JobAttributes;
+        attrs: JobAttributes<T>;
 
         /**
          * The agenda that created the job.
@@ -348,54 +353,54 @@ declare namespace Agenda {
          * @param options An optional argument that can include a timezone field. The timezone should be a string as
          * accepted by moment-timezone and is considered when using an interval in the cron string format.
          */
-        repeatEvery(interval: string | number, options?: { timezone?: string }): Job
+        repeatEvery(interval: string | number, options?: { timezone?: string }): Job<T>
 
         /**
          * Specifies a time when the job should repeat. [Possible values](https://github.com/matthewmueller/date#examples).
          * @param time
          */
-        repeatAt(time: string): Job
+        repeatAt(time: string): Job<T>
 
         /**
          * Disables the job.
          */
-        disable(): Job;
+        disable(): Job<T>;
 
         /**
          * Enables the job.
          */
-        enable(): Job;
+        enable(): Job<T>;
 
         /**
          * Ensure that only one instance of this job exists with the specified properties
          * @param value The properties associated with the job that must be unqiue.
          * @param opts
          */
-        unique(value: any, opts?: { insertOnly?: boolean }): Job;
+        unique(value: any, opts?: { insertOnly?: boolean }): Job<T>;
 
         /**
          * Specifies the next time at which the job should run.
          * @param time The next time at which the job should run.
          */
-        schedule(time: string | Date): Job;
+        schedule(time: string | Date): Job<T>;
 
         /**
          * Specifies the priority weighting of the job.
          * @param value The priority of the job (lowest|low|normal|high|highest|number).
          */
-        priority(value: string | number): Job;
+        priority(value: string | number): Job<T>;
 
         /**
          * Sets job.attrs.failedAt to now, and sets job.attrs.failReason to reason.
          * @param reason A message or Error object that indicates why the job failed.
          */
-        fail(reason: string | Error): Job;
+        fail(reason: string | Error): Job<T>;
 
         /**
          * Runs the given job and calls callback(err, job) upon completion. Normally you never need to call this manually
          * @param cb Called when the job is completed.
          */
-        run(cb?: ResultCallback<Job>): Job;
+        run(cb?: ResultCallback<Job<T>>): Job<T>;
 
         /**
          * Returns true if the job is running; otherwise, returns false.
@@ -406,7 +411,7 @@ declare namespace Agenda {
          * Saves the job into the database.
          * @param cb  Called when the job is saved.
          */
-        save(cb?: ResultCallback<Job>): Job;
+        save(cb?: ResultCallback<Job<T>>): Job<T>;
 
         /**
          * Removes the job from the database and cancels the job.
@@ -424,7 +429,7 @@ declare namespace Agenda {
         /**
          * Calculates next time the job should run
          */
-        computeNextRunAt(): Job;
+        computeNextRunAt(): Job<T>;
     }
 
     interface JobOptions {


### PR DESCRIPTION
The `data` field under the `attrs` group of a Job in agenda is used for storing freeform user data. It currently defaults to the type `{ [name: string]: any }` and isn't generic. This change makes the enclosing types generic with a default of the existing type (which is now named `JobAttributesData` for dryness). This prevents existing users from breaking while allowing richer types to be used moving forward.

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/agenda/agenda#creating-jobs
- [x] Increase the version number in the header if appropriate.
- [ ] ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~