### PR TITLE
[react-table] bring back RowInfo.original

### DIFF
--- a/types/react-table/index.d.ts
+++ b/types/react-table/index.d.ts
@@ -642,6 +642,9 @@ export interface RowInfo {
 
     /** An array of any expandable sub-rows contained in this row */
     subRows: any[];
+
+    /** Original object passed to row */
+    original: any;
 }
 
 export interface FinalState extends TableProps {


### PR DESCRIPTION
This reverts commit e35d00d7f5d0264c2dd1e2c926e8aced03237041, reversing
changes made to 3ecef66f942b23ef4dc037f4791955b8563d81c2.

There were 2 different commits that ended up removing both `original` from `RowInfo`

e35d00d
7a1603d

This brings back one of them.