### PR TITLE
koa - add http2 types for "callback"

### DIFF
--- a/types/koa/index.d.ts
+++ b/types/koa/index.d.ts
@@ -21,6 +21,7 @@ import * as accepts from "accepts";
 import * as Cookies from "cookies";
 import { EventEmitter } from "events";
 import { IncomingMessage, ServerResponse, Server } from "http";
+import { Http2ServerRequest, Http2ServerResponse } from 'http2';
 import httpAssert = require("http-assert");
 import * as Keygrip from "keygrip";
 import * as compose from "koa-compose";
@@ -500,9 +501,9 @@ declare class Application extends EventEmitter {
 
     /**
      * Return a request handler callback
-     * for node's native http server.
+     * for node's native http/http2 server.
      */
-    callback(): (req: IncomingMessage, res: ServerResponse) => void;
+    callback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => void;
 
     /**
      * Initialize a new context.


### PR DESCRIPTION
Currently is typed against IncomingMessage / ServerResponse, changing to be a union type including the new Http2ServerRequest & Http2ServerResponse

Please fill in this template.

- [ ✓ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ✓ ] Test the change in your own code. (Compile and run.)
- [ n/a ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ✓ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ✓ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ✓ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ n/a ] Provide a URL to documentation or source code which provides context for the suggested changes:
    app.callback() works the same with node http and Node http2 - it's just the types of the req/res objects which are different.
- [ unsure ] Increase the version number in the header if appropriate.
- [ n/a ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Not sure about the version number, this could be a breaking change. In particular it adds a dependency on a recent version of Node. A package.json with an engines directive might help in order to be explicit about this?