### PR TITLE
puppeteer: add missing function setCacheEnable on Page class

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1042,6 +1042,12 @@ export interface Page extends EventEmitter, FrameBase {
   select(selector: string, ...values: string[]): Promise<string[]>;
 
   /**
+   * Determines whether cache is enabled on the page.
+   * @param enabled Whether or not to enable cache on the page.
+   */
+  setCacheEnabled(enabled: boolean): Promise<void>;
+
+  /**
    * Sets the cookies on the page.
    * @param cookies The cookies to set.
    */


### PR DESCRIPTION
Page.setCacheEnable: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetcacheenabledenabled