### PR TITLE
puppeteer: add missing function setCacheEnable on Page class

### DIFF
--- a/types/puppeteer/index.d.ts
+++ b/types/puppeteer/index.d.ts
@@ -1042,6 +1042,12 @@ export interface Page extends EventEmitter, FrameBase {
   select(selector: string, ...values: string[]): Promise<string[]>;
 
   /**
+   * Determines whether cache is enabled on the page.
+   * @param enabled Whether or not to enable cache on the page.
+   */
+  setCacheEnabled(enabled: boolean): Promise<void>;
+
+  /**
    * Sets the cookies on the page.
    * @param cookies The cookies to set.
    */


### PR DESCRIPTION
setCacheEnable was added puppeteer v1.0, however definition was missing.

Page.setCacheEnable: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetcacheenabledenabled

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

