### PR TITLE
Types for escape-regexp 0.0

### DIFF
--- a/types/escape-regexp/escape-regexp-tests.ts
+++ b/types/escape-regexp/escape-regexp-tests.ts
@@ -1,0 +1,22 @@
+import escapeRegExp = require('escape-regexp');
+
+// $ExpectType string
+escapeRegExp('aaa');
+
+// $ExpectError
+escapeRegExp();
+
+// $ExpectError
+escapeRegExp({});
+
+// $ExpectError
+escapeRegExp(1);
+
+// $ExpectError
+escapeRegExp([]);
+
+// $ExpectError
+escapeRegExp(null);
+
+// $ExpectError
+escapeRegExp(undefined);

--- a/types/escape-regexp/index.d.ts
+++ b/types/escape-regexp/index.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for escape-regexp 0.0
+// Project: https://github.com/baz/foo (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
+// Definitions by: Vilim Stubičan <https://github.com/jewbre>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+declare function escapeRegExp(str: string): string;
+
+export = escapeRegExp;

--- a/types/escape-regexp/index.d.ts
+++ b/types/escape-regexp/index.d.ts
@@ -1,5 +1,5 @@
 // Type definitions for escape-regexp 0.0
-// Project: https://github.com/baz/foo (Does not have to be to GitHub, but prefer linking to a source code repository rather than to a project website.)
+// Project: https://www.npmjs.com/package/escape-regexp
 // Definitions by: Vilim Stubičan <https://github.com/jewbre>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4

--- a/types/escape-regexp/tsconfig.json
+++ b/types/escape-regexp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "escape-regexp-tests.ts"
+    ]
+}

--- a/types/escape-regexp/tslint.json
+++ b/types/escape-regexp/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Type definitions for npm package escape-regexp 0.0

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.