### PR TITLE
winston: add 'all', 'level' and	'message' as valid colorize values.

### DIFF
--- a/types/winston/index.d.ts
+++ b/types/winston/index.d.ts
@@ -272,7 +272,7 @@ declare namespace winston {
 
     interface ConsoleTransportInstance extends TransportInstance {
         json: boolean;
-        colorize: boolean;
+        colorize: boolean | 'all' | 'level' | 'message';
         prettyPrint: boolean;
         timestamp: boolean | (() => string | boolean);
         showLevel: boolean;
@@ -294,7 +294,7 @@ declare namespace winston {
     interface FileTransportInstance extends TransportInstance {
         json: boolean;
         logstash: boolean;
-        colorize: boolean;
+        colorize: boolean | 'all' | 'level' | 'message';
         maxsize: number|null;
         rotationFormat: boolean;
         zippedArchive: boolean;
@@ -330,7 +330,7 @@ declare namespace winston {
         writeOutput: GenericTextTransportOptions[];
 
         json: boolean;
-        colorize: boolean;
+        colorize: boolean | 'all' | 'level' | 'message';
         prettyPrint: boolean;
         timestamp: boolean | (() => string | boolean);
         showLevel: boolean;
@@ -390,7 +390,7 @@ declare namespace winston {
 
     interface GenericTextTransportOptions {
         json?: boolean;
-        colorize?: boolean;
+        colorize?: boolean | 'all' | 'level' | 'message';
         colors?: any;
         prettyPrint?: boolean;
         showLevel?: boolean;


### PR DESCRIPTION
Supports https://github.com/winstonjs/winston/commit/72273b1 .

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/winstonjs/winston/commit/72273b1
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
