### PR TITLE
sequelize: fix: model update method was typed incorrectly

### DIFF
--- a/types/sequelize/index.d.ts
+++ b/types/sequelize/index.d.ts
@@ -4046,7 +4046,7 @@ declare namespace sequelize {
          * elements. The first element is always the number of affected rows, while the second element is the actual
          * affected rows (only supported in postgres with `options.returning` true.)
          */
-        update(values: TAttributes, options: UpdateOptions): Promise<[number, TInstance[]]>;
+        update(values: TAttributes, options?: UpdateOptions): Promise<[number, TInstance[]]>;
 
         /**
          * Run a describe query on the table. The result will be return to the listener as a hash of attributes and


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

## Sequelize official documentation about update method.

http://docs.sequelizejs.com/manual/tutorial/instances.html#updating-saving-persisting-an-instance

Code example in the doc:

```
Task.create({ title: 'foo', description: 'bar', deadline: new Date() }).then(task => {
  ...
})

/* Though second argument option is optional,
current typing forces the optional argument to be passed and the example in the doc fails to compile in Typescript.
*/
...
task.update({
  title: 'a very different title now'
}).then(() => {})
```

![sc](https://user-images.githubusercontent.com/3450879/38170243-e3787310-35ba-11e8-8e02-2d73ff7552c4.png)
