### PR TITLE
[@types/jest] stringMatching should only accept regexp as input param

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -50,6 +50,12 @@ declare namespace jest {
      */
     function addMatchers(matchers: jasmine.CustomMatcherFactories): typeof jest;
     /**
+     * Advances all timers by msToRun milliseconds. All pending "macro-tasks" that have been
+     * queued via setTimeout() or setInterval(), and would be executed within this timeframe
+     * will be executed.
+     */
+    function advanceTimersByTime(msToRun: number): typeof jest;
+    /**
      * Disables automatic mocking in the module loader.
      */
     function autoMockOff(): typeof jest;
@@ -62,19 +68,6 @@ declare namespace jest {
      * Equivalent to calling .mockClear() on every mocked function.
      */
     function clearAllMocks(): typeof jest;
-    /**
-     * Clears the mock.calls and mock.instances properties of all mocks.
-     * Equivalent to calling .mockClear() on every mocked function.
-     */
-    function resetAllMocks(): typeof jest;
-    /**
-     * available since Jest 21.1.0
-     * Restores all mocks back to their original value.
-     * Equivalent to calling .mockRestore on every mocked function.
-     * Beware that jest.restoreAllMocks() only works when mock was created with
-     * jest.spyOn; other mocks will require you to manually restore them.
-     */
-    function restoreAllMocks(): typeof jest;
     /**
      * Removes any pending timers from the timer system. If any timers have
      * been scheduled, they will be cleared and will never have the opportunity
@@ -121,6 +114,11 @@ declare namespace jest {
      */
     function mock(moduleName: string, factory?: any, options?: MockOptions): typeof jest;
     /**
+     * Clears the mock.calls and mock.instances properties of all mocks.
+     * Equivalent to calling .mockClear() on every mocked function.
+     */
+    function resetAllMocks(): typeof jest;
+    /**
      * Resets the module registry - the cache of all required modules. This is
      * useful to isolate modules where local state might conflict between tests.
      */
@@ -130,6 +128,14 @@ declare namespace jest {
      * useful to isolate modules where local state might conflict between tests.
      */
     function resetModules(): typeof jest;
+    /**
+     * available since Jest 21.1.0
+     * Restores all mocks back to their original value.
+     * Equivalent to calling .mockRestore on every mocked function.
+     * Beware that jest.restoreAllMocks() only works when mock was created with
+     * jest.spyOn; other mocks will require you to manually restore them.
+     */
+    function restoreAllMocks(): typeof jest;
     /**
      * Exhausts tasks queued by setImmediate().
      */
@@ -154,12 +160,6 @@ declare namespace jest {
      * task queue (i.e. all tasks queued by setTimeout() or setInterval() and setImmediate()).
      */
     function runTimersToTime(msToRun: number): typeof jest;
-    /**
-     * Advances all timers by msToRun milliseconds. All pending "macro-tasks" that have been
-     * queued via setTimeout() or setInterval(), and would be executed within this timeframe
-     * will be executed.
-     */
-    function advanceTimersByTime(msToRun: number): typeof jest;
     /**
      * Explicitly supplies the mock object that the module system should return
      * for the specified module.
@@ -304,6 +304,10 @@ declare namespace jest {
      */
     interface Expect {
         /**
+         * Adds a module to format application-specific data structures for serialization.
+         */
+        addSnapshotSerializer(serializer: SnapshotSerializerPlugin): void;
+        /**
          * The `expect` function is used every time you want to test a value.
          * You will rarely call `expect` by itself.
          *
@@ -338,18 +342,14 @@ declare namespace jest {
          */
         extend(obj: ExpectExtendMap): void;
         /**
-         * Adds a module to format application-specific data structures for serialization.
-         */
-        addSnapshotSerializer(serializer: SnapshotSerializerPlugin): void;
-        /**
          * Matches any object that recursively matches the provided keys.
          * This is often handy in conjunction with other asymmetric matchers.
          */
         objectContaining(obj: {}): any;
         /**
-         * Matches any string that contains the exact provided string
+         * Matches any received string that matches the expected RegExp
          */
-        stringMatching(str: string | RegExp): any;
+        stringMatching(regexp: RegExp): any;
         /**
          * Matches any received string that contains the exact expected string
          */
@@ -791,7 +791,9 @@ declare namespace jest {
 
     type ReporterConfig = [string, object];
 
-    type ConfigGlobals = object;
+    interface ConfigGlobals {
+        [key: string]: any;
+    }
 
     type SnapshotUpdateState = 'all' | 'new' | 'none';
 

--- a/types/jest/jest-tests.ts
+++ b/types/jest/jest-tests.ts
@@ -96,9 +96,9 @@ describe('CheckboxWithLabel', () => {
         // Render a checkbox with label in the document
         const checkbox = TestUtils.renderIntoDocument(
             CheckboxWithLabel({
-                    labelOn: "On",
-                    labelOff: "Off"
-                })
+                labelOn: "On",
+                labelOff: "Off"
+            })
         );
 
         // Verify that it's Off by default
@@ -123,25 +123,25 @@ xdescribe('Hooks and Suits', () => {
     });
 
     afterEach(() => {
-       tested = true;
+        tested = true;
     });
 
     test('tested', () => {
-       expect(tested).toBeTruthy();
-       expect(tested).not.toBeFalsy();
+        expect(tested).toBeTruthy();
+        expect(tested).not.toBeFalsy();
     });
 
     fit('tested', () => {
-       expect(tested).toBeDefined();
-       expect(tested).not.toBeUndefined();
+        expect(tested).toBeDefined();
+        expect(tested).not.toBeUndefined();
     });
 
     xit('expect null to be null', () => {
-       expect(null).toBeNull();
+        expect(null).toBeNull();
     });
 
     xit('expect NaN to be NaN', () => {
-       expect(NaN).toBeNaN();
+        expect(NaN).toBeNaN();
     });
 });
 
@@ -149,19 +149,19 @@ describe('compartion', () => {
     const sum: (a: number, b: number) => number = require.requireMock('../sum');
 
     it('compares is 7 + 2 greater than 3', () => {
-       expect(sum(7, 2)).toBeGreaterThan(3);
+        expect(sum(7, 2)).toBeGreaterThan(3);
     });
 
     it('compares is 2 + 7 greater than or equal to 3', () => {
-       expect(sum(2, 7)).toBeGreaterThanOrEqual(3);
+        expect(sum(2, 7)).toBeGreaterThanOrEqual(3);
     });
 
     it('compares is 3 less than 3 + 4', () => {
-       expect(3).toBeLessThan(sum(3, 4));
+        expect(3).toBeLessThan(sum(3, 4));
     });
 
     it('compares is 3 less than or equal to 4 + 3', () => {
-       expect(3).toBeLessThanOrEqual(sum(4, 3));
+        expect(3).toBeLessThanOrEqual(sum(4, 3));
     });
 
     it('works sanely with simple decimals', () => {
@@ -174,41 +174,39 @@ describe('compartion', () => {
 });
 
 describe('toThrow API', () => {
-   function throwTypeError(): void {
-       throw new TypeError('toThrow Definition was out of date');
-   }
+    function throwTypeError(): void {
+        throw new TypeError('toThrow Definition was out of date');
+    }
 
-   it('throws', () => {
-      expect(throwTypeError()).toThrow();
-      expect(throwTypeError()).toThrowError();
-   });
+    it('throws', () => {
+        expect(throwTypeError()).toThrow();
+        expect(throwTypeError()).toThrowError();
+    });
 
-   it('throws TypeError', () => {
-       expect(throwTypeError()).toThrow(TypeError);
-       expect(throwTypeError()).toThrowError(TypeError);
-   });
+    it('throws TypeError', () => {
+        expect(throwTypeError()).toThrow(TypeError);
+        expect(throwTypeError()).toThrowError(TypeError);
+    });
 
-   it('throws \'Definition was out of date\'', () => {
-       expect(throwTypeError()).toThrow(/Definition was out of date/);
-       expect(throwTypeError()).toThrowError(/Definition was out of date/);
-   });
+    it('throws \'Definition was out of date\'', () => {
+        expect(throwTypeError()).toThrow(/Definition was out of date/);
+        expect(throwTypeError()).toThrowError(/Definition was out of date/);
+    });
 
-   it('throws \'toThorow Definition was out of date\'', () => {
-       expect(throwTypeError()).toThrow('toThrow Definition was out of date');
-       expect(throwTypeError()).toThrowError('toThrow Definition was out of date');
-   });
+    it('throws \'toThorow Definition was out of date\'', () => {
+        expect(throwTypeError()).toThrow('toThrow Definition was out of date');
+        expect(throwTypeError()).toThrowError('toThrow Definition was out of date');
+    });
 });
 
 describe('Assymetric matchers', () => {
     it('works', () => {
         expect({
             timestamp: 1480807810388,
-            text: 'Some text content, but we care only about *this part*',
             color: '#bada55',
             greeting: 'hello, world!',
         }).toEqual({
             timestamp: expect.any(Number),
-            text: expect.stringMatching('*this part*'),
             color: expect.stringMatching(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i),
             greeting: expect.stringContaining('hello'),
         });
@@ -289,76 +287,76 @@ describe('Extending extend', () => {
 
 describe('missing tests', () => {
     it('creates closures', () => {
-       class Closure<T> {
-           private arg: T;
+        class Closure<T> {
+            private arg: T;
 
-           constructor(private readonly fn: (arg: T) => void) {
-               this.fn = fn;
-           }
+            constructor(private readonly fn: (arg: T) => void) {
+                this.fn = fn;
+            }
 
-           bind(arg: T): void {
-               this.arg = arg;
-           }
+            bind(arg: T): void {
+                this.arg = arg;
+            }
 
-           call(): void {
-               this.fn(this.arg);
-           }
-       }
+            call(): void {
+                this.fn(this.arg);
+            }
+        }
 
-       type StringClosure = (arg: string) => void;
-       const spy: jest.Mock<StringClosure> = jest.fn<StringClosure>();
-       const closure: Closure<string> = new Closure<string>(spy);
-       closure.bind('jest');
-       closure.call();
-       expect(spy).lastCalledWith('jest');
-       expect(spy).toBeCalledWith('jest');
-       expect(jest.isMockFunction(spy)).toBeTruthy();
+        type StringClosure = (arg: string) => void;
+        const spy: jest.Mock<StringClosure> = jest.fn<StringClosure>();
+        const closure: Closure<string> = new Closure<string>(spy);
+        closure.bind('jest');
+        closure.call();
+        expect(spy).lastCalledWith('jest');
+        expect(spy).toBeCalledWith('jest');
+        expect(jest.isMockFunction(spy)).toBeTruthy();
     });
 
     it('tests all missing Mocks functionality', () => {
-       type FruitsGetter = () => string[];
-       const mock: jest.Mock<FruitsGetter> = jest.fn<FruitsGetter>();
-       mock.mockImplementationOnce(() => ['Orange', 'Apple', 'Plum']);
-       jest.setMock('./../tesks/getFruits', mock);
-       const getFruits: FruitsGetter = require('./../tesks/getFruits');
-       expect(getFruits()).toContain('Orange');
-       mock.mockReturnValueOnce(['Apple', 'Plum']);
-       expect(mock()).not.toContain('Orange');
-       const myBeverage: any = {delicious: true, sour: false};
-       expect(myBeverage).toContainEqual({delicious: true, sour: false});
-       mock.mockReturnValue([]); // Deprecated: Use jest.fn(() => value) instead.
-       mock.mockClear();
-       const thisMock: jest.Mock<any> = jest.fn<any>().mockReturnThis();
-       expect(thisMock()).toBe(this);
-   });
+        type FruitsGetter = () => string[];
+        const mock: jest.Mock<FruitsGetter> = jest.fn<FruitsGetter>();
+        mock.mockImplementationOnce(() => ['Orange', 'Apple', 'Plum']);
+        jest.setMock('./../tesks/getFruits', mock);
+        const getFruits: FruitsGetter = require('./../tesks/getFruits');
+        expect(getFruits()).toContain('Orange');
+        mock.mockReturnValueOnce(['Apple', 'Plum']);
+        expect(mock()).not.toContain('Orange');
+        const myBeverage: any = {delicious: true, sour: false};
+        expect(myBeverage).toContainEqual({delicious: true, sour: false});
+        mock.mockReturnValue([]); // Deprecated: Use jest.fn(() => value) instead.
+        mock.mockClear();
+        const thisMock: jest.Mock<any> = jest.fn<any>().mockReturnThis();
+        expect(thisMock()).toBe(this);
+    });
 
     it('async test with mockResolvedValue and mockResolvedValueOnce', async () => {
-      const asyncMock = jest
-        .fn()
-        .mockResolvedValue('default')
-        .mockResolvedValueOnce('first call')
-        .mockResolvedValueOnce('second call');
+        const asyncMock = jest
+            .fn()
+            .mockResolvedValue('default')
+            .mockResolvedValueOnce('first call')
+            .mockResolvedValueOnce('second call');
 
-      await asyncMock(); // first call
-      await asyncMock(); // second call
-      await asyncMock(); // default
-      await asyncMock(); // default
+        await asyncMock(); // first call
+        await asyncMock(); // second call
+        await asyncMock(); // default
+        await asyncMock(); // default
     });
 
     it('async test with mockRejectedValue', async () => {
-      const asyncMock = jest.fn().mockRejectedValue(new Error('Async error'));
+        const asyncMock = jest.fn().mockRejectedValue(new Error('Async error'));
 
-      await asyncMock(); // throws "Async error"
+        await asyncMock(); // throws "Async error"
     });
 
     it('async test with mockResolvedValueOnce and mockRejectedValueOnce', async () => {
-      const asyncMock = jest
-        .fn()
-        .mockResolvedValueOnce('first call')
-        .mockRejectedValueOnce(new Error('Async error'));
+        const asyncMock = jest
+            .fn()
+            .mockResolvedValueOnce('first call')
+            .mockRejectedValueOnce(new Error('Async error'));
 
-      await asyncMock(); // first call
-      await asyncMock(); // throws "Async error"
+        await asyncMock(); // first call
+        await asyncMock(); // throws "Async error"
     });
 
     it('tests mock name functionality', () => {
@@ -368,10 +366,10 @@ describe('missing tests', () => {
     });
 
     it('creates snapshoter', () => {
-       jest.disableAutomock().mock('./render', () => jest.fn((): string => "{Link to: \"facebook\"}"), { virtual: true });
-       const render: () => string = require('./render');
-       expect(render()).toMatch(/Link/);
-       jest.enableAutomock();
+        jest.disableAutomock().mock('./render', () => jest.fn((): string => "{Link to: \"facebook\"}"), { virtual: true });
+        const render: () => string = require('./render');
+        expect(render()).toMatch(/Link/);
+        jest.enableAutomock();
     });
 
     it('runs only pending timers', () => {
@@ -388,25 +386,25 @@ describe('missing tests', () => {
     });
 
     it('cleares cache', () => {
-       const sum1 = require('../sum');
-       jest.resetModules();
-       const sum2 = require('../sum');
-       expect(sum1).not.toBe(sum2);
+        const sum1 = require('../sum');
+        jest.resetModules();
+        const sum2 = require('../sum');
+        expect(sum1).not.toBe(sum2);
     });
 });
 
 describe('toMatchSnapshot', () => {
-   it('compares snapshots', () => {
+    it('compares snapshots', () => {
         expect({ type: 'a', props: { href: 'https://www.facebook.com/' }, children: [ 'Facebook' ] }).toMatchSnapshot();
     });
 
-   it('can give name to snapshot', () => {
+    it('can give name to snapshot', () => {
         expect({ type: 'a', props: { href: 'https://www.facebook.com/' }, children: [ 'Facebook' ] }).toMatchSnapshot('given name');
-   });
+    });
 });
 
 describe('toThrowErrorMatchingSnapshot', () => {
-   it('compares snapshots', () => {
+    it('compares snapshots', () => {
         expect(() => { throw new Error('descriptiton'); }).toThrowErrorMatchingSnapshot();
     });
 });
@@ -414,14 +412,14 @@ describe('toThrowErrorMatchingSnapshot', () => {
 const testSerializerPluginString = "set by testSerializerPlugin";
 let testSerializerPluginCallCount = 0;
 expect.addSnapshotSerializer({
-  print(val, serialize, indent, opts, colors) {
-    val.willOverwrite = testSerializerPluginString;
-    testSerializerPluginCallCount += 1;
-    return 'plugin called: ' + serialize(val.willOverwrite);
-  },
-  test(val) {
-    return val && val.willOverwrite && val.willOverwrite !== testSerializerPluginString;
-  },
+    print(val, serialize, indent, opts, colors) {
+        val.willOverwrite = testSerializerPluginString;
+        testSerializerPluginCallCount += 1;
+        return 'plugin called: ' + serialize(val.willOverwrite);
+    },
+    test(val) {
+        return val && val.willOverwrite && val.willOverwrite !== testSerializerPluginString;
+    },
 });
 describe('addSnapshotSerializer', () => {
     it('the plugin does its work', () => {
@@ -460,7 +458,7 @@ function testMockImplementation() {
 
 // Test from jest Docs: <http://facebook.github.io/jest/docs/manual-mocks.html#content>
 describe('genMockFromModule', () => {
-   // Interfaces:
+    // Interfaces:
     interface MockFiles {
         [index: string]: string;
     }
@@ -476,10 +474,10 @@ describe('genMockFromModule', () => {
     const fs = require('fs');
 
     function summarizeFilesInDirectorySync(directory: string): string[] {
-      return fs.readdirSync(directory).map((fileName: string) => ({
-        fileName,
-        directory,
-      }));
+        return fs.readdirSync(directory).map((fileName: string) => ({
+            fileName,
+            directory,
+        }));
     }
 
     // export default summarizeFilesInDirectorySync; // For sake of compilation
@@ -493,19 +491,19 @@ describe('genMockFromModule', () => {
 
     let mockFiles: any = Object.create(null);
     function __setMockFiles(newMockFiles: MockFiles): void {
-      mockFiles = Object.create(null);
-      for (const file in newMockFiles) {
-        const dir: string = path.dirname(file);
+        mockFiles = Object.create(null);
+        for (const file in newMockFiles) {
+            const dir: string = path.dirname(file);
 
-        if (!mockFiles[dir]) {
-          mockFiles[dir] = [];
+            if (!mockFiles[dir]) {
+                mockFiles[dir] = [];
+            }
+            mockFiles[dir].push(path.basename(file));
         }
-        mockFiles[dir].push(path.basename(file));
-      }
     }
 
     function readdirSync(directoryPath: string): string[] {
-      return mockFiles[directoryPath] || [];
+        return mockFiles[directoryPath] || [];
     }
 
     mockedFS.readdirSync = readdirSync;
@@ -518,22 +516,22 @@ describe('genMockFromModule', () => {
     jest.mock('fs');
 
     describe('listFilesInDirectorySync', () => {
-      const MOCK_FILE_INFO: MockFiles = {
-        '/path/to/file1.js': 'console.log("file1 contents");',
-        '/path/to/file2.txt': 'file2 contents',
-      };
+        const MOCK_FILE_INFO: MockFiles = {
+            '/path/to/file1.js': 'console.log("file1 contents");',
+            '/path/to/file2.txt': 'file2 contents',
+        };
 
-      beforeEach(() => {
-        // Set up some mocked out file info before each test
-        (require('fs') as MockedFS).__setMockFiles(MOCK_FILE_INFO);
-      });
+        beforeEach(() => {
+            // Set up some mocked out file info before each test
+            (require('fs') as MockedFS).__setMockFiles(MOCK_FILE_INFO);
+        });
 
-      it('includes all files in the directory in the summary', () => {
-        const FileSummarizer: (dir: string) => string[] = require('../FileSummarizer');
-        const fileSummary = FileSummarizer('/path/to');
+        it('includes all files in the directory in the summary', () => {
+            const FileSummarizer: (dir: string) => string[] = require('../FileSummarizer');
+            const fileSummary = FileSummarizer('/path/to');
 
-        expect(fileSummary.length).toBe(2);
-      });
+            expect(fileSummary.length).toBe(2);
+        });
     });
 });
 
@@ -684,10 +682,10 @@ describe('toHaveProperty', () => {
         expect({ a: { b: {}}}).toHaveProperty('a.b');
     });
     it('it accepts a keyPath as an array', () => {
-      expect({ a: { b: {}}}).toHaveProperty(['a', 'b']);
+        expect({ a: { b: {}}}).toHaveProperty(['a', 'b']);
     });
     it('it accepts a keyPath as an array containing non-string values', () => {
-      expect({ a: ['b']}).toHaveProperty(['a', 0]);
+        expect({ a: ['b']}).toHaveProperty(['a', 0]);
     });
 });
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/jest/docs/en/expect.html#expectstringmatchingregexp
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


**Changes:**
- Correct input param type for stringMatching.
- Alphabetically sort for some functions
- Correct tab indent to be 4 for test file and definition file