### PR TITLE
[minio] Update set/getBucketPolicy definitions to 5.0

### DIFF
--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -84,8 +84,8 @@ export class Client {
     listBuckets(callback: ResultCallback<BucketItemFromList[]>): void;
     listBuckets(): Promise<BucketItemFromList>;
 
-    bucketExists(bucketName: string, callback: NoResultCallback): void;
-    bucketExists(bucketName: string): Promise<void>;
+    bucketExists(bucketName: string, callback: ResultCallback<boolean>): void;
+    bucketExists(bucketName: string): Promise<boolean>;
 
     removeBucket(bucketName: string, callback: NoResultCallback): void;
     removeBucket(bucketName: string): Promise<void>;

--- a/types/minio/index.d.ts
+++ b/types/minio/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for minio 4.0
+// Type definitions for minio 5.0
 // Project: https://github.com/minio/minio-js#readme
 // Definitions by: Barin Britva <https://github.com/barinbritva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -11,7 +11,6 @@ import EventEmitter = NodeJS.EventEmitter;
 
 // Exports only from typings
 export type Region = 'us-east-1'|'us-west-1'|'us-west-2'|'eu-west-1'|'eu-central-1'|'ap-southeast-1'|'ap-northeast-1'|'ap-southeast-2'|'sa-east-1'|'cn-north-1'|string;
-export type PolicyValue = 'none'|'readonly'|'writeonly'|'readwrite';
 export type NoResultCallback = (error: Error|null) => void;
 export type ResultCallback<T> = (error: Error|null, result: T) => void;
 
@@ -158,11 +157,11 @@ export class Client {
     // todo #low Specify events
     listenBucketNotification(bucketName: string, prefix: string, suffix: string, events: string[]): EventEmitter;
 
-    getBucketPolicy(bucketName: string, objectPrefix: string, callback: ResultCallback<PolicyValue>): void;
-    getBucketPolicy(bucketName: string, objectPrefix: string): Promise<PolicyValue>;
+    getBucketPolicy(bucketName: string, callback: ResultCallback<string>): void;
+    getBucketPolicy(bucketName: string): Promise<string>;
 
-    setBucketPolicy(bucketName: string, objectPrefix: string, bucketPolice: PolicyValue, callback: NoResultCallback): void;
-    setBucketPolicy(bucketName: string, objectPrefix: string, bucketPolice: PolicyValue): Promise<void>;
+    setBucketPolicy(bucketName: string, bucketPolicy: string, callback: NoResultCallback): void;
+    setBucketPolicy(bucketName: string, bucketPolicy: string): Promise<void>;
 
     // Other
     newPostPolicy(): PostPolicy;

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -16,7 +16,7 @@ minio.makeBucket('testBucket', 'region-not-from-list');
 minio.listBuckets((error: Error|null, bucketList: Minio.BucketItemFromList[]) => { console.log(error, bucketList); });
 minio.listBuckets();
 
-minio.bucketExists('testBucket', (error: Error|null) => { console.log(error); });
+minio.bucketExists('testBucket', (error: Error|null, exists: boolean) => { console.log(error, exists); });
 minio.bucketExists('testBucket');
 
 minio.removeBucket('testBucket', (error: Error|null) => { console.log(error); });

--- a/types/minio/minio-tests.ts
+++ b/types/minio/minio-tests.ts
@@ -106,8 +106,14 @@ minio.removeAllBucketNotification('testBucket');
 
 minio.listenBucketNotification('testBucket', 'pref_', '_suf', [ Minio.ObjectCreatedAll ]);
 
-minio.getBucketPolicy('testBucket', 'pref_', (error: Error|null, policy: Minio.PolicyValue) => { console.log(error, policy); });
-minio.getBucketPolicy('testBucket', '');
+minio.getBucketPolicy('testBucket', (error: Error|null, policy: string) => { console.log(error, policy); });
+minio.getBucketPolicy('testBucket');
 
-minio.setBucketPolicy('testBucket', '', Minio.Policy.READWRITE, (error: Error|null) => { console.log(error); });
-minio.setBucketPolicy('testBucket', 'pref_', Minio.Policy.WRITEONLY);
+const testPolicy = `{"Version":"2012-10-17","Statement":[{"Action":["s3:GetBucketLocation"],"Effect":"Allow",
+"Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::bucketName"],"Sid":""},{"Action":["s3:ListBucket"],
+"Condition":{"StringEquals":{"s3:prefix":["foo","prefix/"]}},"Effect":"Allow","Principal":{"AWS":["*"]},
+"Resource":["arn:aws:s3:::bucketName"],"Sid":""},{"Action":["s3:GetObject"],"Effect":"Allow",
+"Principal":{"AWS":["*"]},"Resource":["arn:aws:s3:::bucketName/foo*","arn:aws:s3:::bucketName/prefix/*"],"Sid":""}]}
+`;
+minio.setBucketPolicy('testBucket',  testPolicy, (error: Error|null) => { console.log(error); });
+minio.setBucketPolicy('testBucket', testPolicy);


### PR DESCRIPTION
This PR updates `getBucketPolicy`, `setBucketPolicy` and `bucketExists` definitions from v 4.0 to v 5.0

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://docs.minio.io/docs/javascript-client-api-reference#getBucketPolicy
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
