### PR TITLE
[Vis] Edge->arrows->from is optional in EdgeOptions

### DIFF
--- a/types/vis/index.d.ts
+++ b/types/vis/index.d.ts
@@ -1861,7 +1861,7 @@ export interface EdgeOptions {
       enabled?: boolean,
       scaleFactor?: number,
     },
-    from: boolean | {
+    from?: boolean | {
       enabled?: boolean,
       scaleFactor?: number,
     }


### PR DESCRIPTION
network.setOptions({edges: {arrows: {to: true}}}); should be accepted since it works properly in vis, but previous @types/vis will fail type-checking.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
http://visjs.org/docs/network/edges.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.