### PR TITLE
radium: update typings to fit with new default export in radium >= 0.22.0

### DIFF
--- a/types/radium/index.d.ts
+++ b/types/radium/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for radium 0.18.1
+// Type definitions for radium 0.24.0
 // Project: https://github.com/formidablelabs/radium
 // Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev>, Philipp Holzer <https://github.com/nupplaphil>, Alexey Svetliakov <https://github.com/asvetliakov>, Mikael Hermansson <https://github.com/mihe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/radium/index.d.ts
+++ b/types/radium/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for radium 0.18.1
+// Type definitions for radium 0.23.0
 // Project: https://github.com/formidablelabs/radium
 // Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev>, Philipp Holzer <https://github.com/nupplaphil>, Alexey Svetliakov <https://github.com/asvetliakov>, Mikael Hermansson <https://github.com/mihe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,7 +6,7 @@
 
 import * as React from 'react';
 
-export = Radium;
+export default Radium;
 
 // @Radium decorator
 declare function Radium<TElement extends Function>(component: TElement): TElement;

--- a/types/radium/index.d.ts
+++ b/types/radium/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for radium 0.23.0
+// Type definitions for radium 0.18.1
 // Project: https://github.com/formidablelabs/radium
 // Definitions by: Alex Gorbatchev <https://github.com/alexgorbatchev>, Philipp Holzer <https://github.com/nupplaphil>, Alexey Svetliakov <https://github.com/asvetliakov>, Mikael Hermansson <https://github.com/mihe>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/radium/radium-tests.tsx
+++ b/types/radium/radium-tests.tsx
@@ -1,17 +1,16 @@
 import * as React from "react";
-import { StyleRoot, Style } from "radium";
-import Radium = require('radium');
+import Radium from "radium";
 
 @Radium
-class TestComponent extends React.Component<{ a: number }> {
+export class TestComponent extends React.Component<{ a: number }> {
 
-    render() {
-        return (
-            <div >
-                Test with Radium
+	render() {
+		return (
+			<div >
+				Test with Radium
 			</div>
-        );
-    }
+		);
+	}
 }
 
 let TestStatelessComponent = (props: { a: number }) => <div />;
@@ -21,68 +20,68 @@ TestStatelessComponent = Radium(TestStatelessComponent);
 
 
 @Radium({
-    userAgent: "test",
-    matchMedia: window.matchMedia
-})
+			userAgent: "test",
+			matchMedia: window.matchMedia
+		})
 class TestComponentWithConfig extends React.Component<{ a?: number }> {
-    render() {
-        return (
-            <div>
-                <Radium.StyleRoot >
-                    <Style scopeSelector="test"
-                        rules={{
-                            a: {
-                                background: "green"
-                            },
-                            body: {
-                                textAlign: "center"
-                            }
-                        }}
-                    >
-                    </Style>
-                    <Style scopeSelector="test"
-                        rules={{
-                            background: "green"
-                        }}
-                    >
-                    </Style>
-                </Radium.StyleRoot>
-            </div>
-        )
-    }
+	render() {
+		return (
+			<div>
+				<Radium.StyleRoot >
+					<Radium.Style scopeSelector="test"
+								  rules={{
+									  a: {
+										  background: "green"
+									  },
+									  body: {
+										  textAlign: "center"
+									  }
+								  }}
+					>
+					</Radium.Style>
+					<Radium.Style scopeSelector="test"
+								  rules={{
+									  background: "green"
+								  }}
+					>
+					</Radium.Style>
+				</Radium.StyleRoot>
+			</div>
+		)
+	}
 }
 <TestComponentWithConfig a={5} />
 
 class TestComponentWithConfigInStyleRoot
-    extends React.Component<{ a?: number }> {
-    render() {
-        return (
-            <div>
-                <Radium.StyleRoot radiumConfig={{
-                    userAgent: "test",
-                    matchMedia: window.matchMedia
-                }} >
-                    <Style scopeSelector="test"
-                        rules={{
-                            a: {
-                                background: "green"
-                            },
-                            body: {
-                                textAlign: "center"
-                            }
-                        }}
-                    >
-                    </Style>
-                    <Style scopeSelector="test"
-                        rules={{
-                            background: "green"
-                        }}
-                    >
-                    </Style>
-                </Radium.StyleRoot>
-            </div>
-        )
-    }
+	extends React.Component<{ a?: number }> {
+	render() {
+		return (
+			<div>
+				<Radium.StyleRoot radiumConfig={{
+					userAgent: "test",
+					matchMedia: window.matchMedia
+				}} >
+					<Radium.Style scopeSelector="test"
+								  rules={{
+									  a: {
+										  background: "green"
+									  },
+									  body: {
+										  textAlign: "center"
+									  }
+								  }}
+					>
+					</Radium.Style>
+					<Radium.Style scopeSelector="test"
+								  rules={{
+									  background: "green"
+								  }}
+					>
+					</Radium.Style>
+				</Radium.StyleRoot>
+			</div>
+		)
+	}
 }
 <TestComponentWithConfigInStyleRoot a={5} />
 

--- a/types/radium/radium-tests.tsx
+++ b/types/radium/radium-tests.tsx
@@ -1,16 +1,17 @@
 import * as React from "react";
 import Radium from "radium";
 
-@Radium
-export class TestComponent extends React.Component<{ a: number }> {
 
-	render() {
-		return (
-			<div >
-				Test with Radium
+@Radium
+class TestComponent extends React.Component<{ a: number }> {
+
+    render() {
+        return (
+            <div >
+                Test with Radium
 			</div>
-		);
-	}
+        );
+    }
 }
 
 let TestStatelessComponent = (props: { a: number }) => <div />;
@@ -20,68 +21,68 @@ TestStatelessComponent = Radium(TestStatelessComponent);
 
 
 @Radium({
-			userAgent: "test",
-			matchMedia: window.matchMedia
-		})
+    userAgent: "test",
+    matchMedia: window.matchMedia
+})
 class TestComponentWithConfig extends React.Component<{ a?: number }> {
-	render() {
-		return (
-			<div>
-				<Radium.StyleRoot >
-					<Radium.Style scopeSelector="test"
-								  rules={{
-									  a: {
-										  background: "green"
-									  },
-									  body: {
-										  textAlign: "center"
-									  }
-								  }}
-					>
-					</Radium.Style>
-					<Radium.Style scopeSelector="test"
-								  rules={{
-									  background: "green"
-								  }}
-					>
-					</Radium.Style>
-				</Radium.StyleRoot>
-			</div>
-		)
-	}
+    render() {
+        return (
+            <div>
+                <Radium.StyleRoot >
+                    <Radium.Style scopeSelector="test"
+                        rules={{
+                            a: {
+                                background: "green"
+                            },
+                            body: {
+                                textAlign: "center"
+                            }
+                        }}
+                    >
+                    </Radium.Style>
+                    <Radium.Style scopeSelector="test"
+                        rules={{
+                            background: "green"
+                        }}
+                    >
+                    </Radium.Style>
+                </Radium.StyleRoot>
+            </div>
+        )
+    }
 }
 <TestComponentWithConfig a={5} />
 
 class TestComponentWithConfigInStyleRoot
-	extends React.Component<{ a?: number }> {
-	render() {
-		return (
-			<div>
-				<Radium.StyleRoot radiumConfig={{
-					userAgent: "test",
-					matchMedia: window.matchMedia
-				}} >
-					<Radium.Style scopeSelector="test"
-								  rules={{
-									  a: {
-										  background: "green"
-									  },
-									  body: {
-										  textAlign: "center"
-									  }
-								  }}
-					>
-					</Radium.Style>
-					<Radium.Style scopeSelector="test"
-								  rules={{
-									  background: "green"
-								  }}
-					>
-					</Radium.Style>
-				</Radium.StyleRoot>
-			</div>
-		)
-	}
+    extends React.Component<{ a?: number }> {
+    render() {
+        return (
+            <div>
+                <Radium.StyleRoot radiumConfig={{
+                    userAgent: "test",
+                    matchMedia: window.matchMedia
+                }} >
+                    <Radium.Style scopeSelector="test"
+                        rules={{
+                            a: {
+                                background: "green"
+                            },
+                            body: {
+                                textAlign: "center"
+                            }
+                        }}
+                    >
+                    </Radium.Style>
+                    <Radium.Style scopeSelector="test"
+                        rules={{
+                            background: "green"
+                        }}
+                    >
+                    </Radium.Style>
+                </Radium.StyleRoot>
+            </div>
+        )
+    }
 }
 <TestComponentWithConfigInStyleRoot a={5} />
 


### PR DESCRIPTION
* Authors: @alexgorbatchev, @nupplaphil, @asvetliakov, @mihe

From radium >= 0.22.0 the export has changed to default export.
See 0.22.0 here: https://github.com/FormidableLabs/radium/blob/master/CHANGELOG.md

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.