### PR TITLE
webvr-api: Make webvr-api consistent with latest lib.es6.d.ts

### DIFF
--- a/types/webvr-api/index.d.ts
+++ b/types/webvr-api/index.d.ts
@@ -241,8 +241,14 @@ interface Window {
     onvrdisplaypointerrestricted: ((this: Window, ev: Event) => any) | null;
     onvrdisplaypointerunrestricted: ((this: Window, ev: Event) => any) | null;
     onvrdisplaypresentchange: ((this: Window, ev: Event) => any) | null;
+    addEventListener(type: "vrdisplayactivate", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "vrdisplayblur", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "vrdisplayconnect", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "vrdisplaydeactivate", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "vrdisplaydisconnect", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "vrdisplayfocus", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "vrdisplaypointerrestricted", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "vrdisplaypointerunrestricted", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "vrdisplaypresentchange", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
 }
 

--- a/types/webvr-api/index.d.ts
+++ b/types/webvr-api/index.d.ts
@@ -3,6 +3,13 @@
 // Definitions by: six a <https://github.com/lostfictions>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
+// Typescript doesn't allow redefinition of type aliases even if they match,
+// thus the _dt_alias to signal this being an alias for the use of DefinitelyTyped
+type VRDisplayEventReason_dt_alias = "mounted" | "navigation" | "requested" | "unmounted";
+
+// Typescript doesn't allow redefinition of type aliases even if they match,
+// thus the _dt_alias to signal this being an alias for the use of DefinitelyTyped
+type VREye_dt_alias = "left" | "right";
 
 interface VRDisplay extends EventTarget {
     /**
@@ -55,7 +62,7 @@ interface VRDisplay extends EventTarget {
     exitPresent(): Promise<void>;
 
     /* Return the current VREyeParameters for the given eye. */
-    getEyeParameters(whichEye: string): VREyeParameters;
+    getEyeParameters(whichEye: VREye_dt_alias): VREyeParameters;
 
     /**
      * Populates the passed VRFrameData with the information required to render
@@ -69,6 +76,7 @@ interface VRDisplay extends EventTarget {
     getLayers(): VRLayer[];
 
     /**
+     * @deprecated
      * Return a VRPose containing the future predicted pose of the VRDisplay
      * when the current frame will be presented. The value returned will not
      * change until JavaScript has returned control to the browser.
@@ -138,6 +146,11 @@ interface VRDisplayCapabilities {
     readonly maxLayers: number;
 }
 
+declare var VRDisplayCapabilities: {
+    prototype: VRDisplayCapabilities;
+    new(): VRDisplayCapabilities;
+};
+
 interface VREyeParameters {
     /** @deprecated */
     readonly fieldOfView: VRFieldOfView;
@@ -146,12 +159,22 @@ interface VREyeParameters {
     readonly renderWidth: number;
 }
 
+declare var VREyeParameters: {
+    prototype: VREyeParameters;
+    new(): VREyeParameters;
+};
+
 interface VRFieldOfView {
     readonly downDegrees: number;
     readonly leftDegrees: number;
     readonly rightDegrees: number;
     readonly upDegrees: number;
 }
+
+declare var VRFieldOfView: {
+    prototype: VRFieldOfView;
+    new(): VRFieldOfView;
+};
 
 interface VRFrameData {
     readonly leftProjectionMatrix: Float32Array;
@@ -163,9 +186,9 @@ interface VRFrameData {
 }
 
 declare var VRFrameData: {
-    prototype: VRFrameData
-    new(): VRFrameData
-}
+    prototype: VRFrameData;
+    new(): VRFrameData;
+};
 
 interface VRPose {
     readonly angularAcceleration: Float32Array | null;
@@ -176,6 +199,11 @@ interface VRPose {
     readonly position: Float32Array | null;
     readonly timestamp: number;
 }
+
+declare var VRPose: {
+    prototype: VRPose;
+    new(): VRPose;
+};
 
 interface VRStageParameters {
     sittingToStandingTransform?: Float32Array;
@@ -188,13 +216,34 @@ interface Navigator {
     readonly activeVRDisplays: ReadonlyArray<VRDisplay>;
 }
 
+interface VRDisplayEventInit extends EventInit {
+    display: VRDisplay;
+    reason?: VRDisplayEventReason_dt_alias;
+}
+
+interface VRDisplayEvent extends Event {
+    readonly display: VRDisplay;
+    readonly reason: VRDisplayEventReason_dt_alias | null;
+}
+
+declare var VRDisplayEvent: {
+    prototype: VRDisplayEvent;
+    new(type: string, eventInitDict: VRDisplayEventInit): VRDisplayEvent;
+};
+
 interface Window {
-    onvrdisplayconnected: ((this: Window, ev: Event) => any) | null;
-    onvrdisplaydisconnected: ((this: Window, ev: Event) => any) | null;
+    onvrdisplayactivate: ((this: Window, ev: Event) => any) | null;
+    onvrdisplayblur: ((this: Window, ev: Event) => any) | null;
+    onvrdisplayconnect: ((this: Window, ev: Event) => any) | null;
+    onvrdisplaydeactivate: ((this: Window, ev: Event) => any) | null;
+    onvrdisplaydisconnect: ((this: Window, ev: Event) => any) | null;
+    onvrdisplayfocus: ((this: Window, ev: Event) => any) | null;
+    onvrdisplaypointerrestricted: ((this: Window, ev: Event) => any) | null;
+    onvrdisplaypointerunrestricted: ((this: Window, ev: Event) => any) | null;
     onvrdisplaypresentchange: ((this: Window, ev: Event) => any) | null;
-    addEventListener(type: "vrdisplayconnected", listener: (ev: Event) => any, useCapture?: boolean): void;
-    addEventListener(type: "vrdisplaydisconnected", listener: (ev: Event) => any, useCapture?: boolean): void;
-    addEventListener(type: "vrdisplaypresentchange", listener: (ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "vrdisplayconnect", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "vrdisplaydisconnect", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "vrdisplaypresentchange", listener: (this: Window, ev: Event) => any, useCapture?: boolean): void;
 }
 
 interface Gamepad {

--- a/types/webvr-api/index.d.ts
+++ b/types/webvr-api/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for WebVR API
 // Project: https://w3c.github.io/webvr/
-// Definitions by: six a <https://github.com/lostfictions>
+// Definitions by: efokschaner <https://github.com/efokschaner>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Typescript doesn't allow redefinition of type aliases even if they match,


### PR DESCRIPTION
The old definition for `addEventListener(type: "vrdisplaypresentchange"` had tsc errors because it did not match the latest lib.es6.d.ts 's `this` declaration.

This alerted me to some other inconsistencies which the spec and with the builtin declarations that I've also fixed.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
This change should be consistent with both:
  - https://github.com/Microsoft/TypeScript/blob/master/lib/lib.es6.d.ts
  - https://immersive-web.github.io/webvr/spec/1.1/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
