### PR TITLE
Fix blunder in #24691 related to @types/react

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -3200,6 +3200,7 @@ declare namespace React {
         crossOrigin?: string;
         defer?: boolean;
         integrity?: string;
+        noModule?: boolean;
         nonce?: string;
         src?: string;
         type?: string;
@@ -3211,7 +3212,6 @@ declare namespace React {
         form?: string;
         multiple?: boolean;
         name?: string;
-        noModule?: boolean;
         required?: boolean;
         size?: number;
         value?: string | string[] | number;


### PR DESCRIPTION
noModule got added to the wrong element (doh)

I definitely don't have an explanation for this one (would probably be avoided if I added a test) 😅 

Sorry @johnnyreilly!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24691
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
