### PR TITLE
add definition for memoizeWith in ramda

### DIFF
--- a/types/ramda/index.d.ts
+++ b/types/ramda/index.d.ts
@@ -16,6 +16,7 @@
 //                 Nikita Moshensky <https://github.com/moshensky>
 //                 Ethan Resnick <https://github.com/ethanresnick>
 //                 Jack Leigh <https://github.com/leighman>
+//                 Gian Marco Toso <https://github.com/gianmarcotoso>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -1021,6 +1022,14 @@ declare namespace R {
          * additional call to fn; instead, the cached result for that set of arguments will be returned.
          */
         memoize<T = any>(fn: (...a: any[]) => T): (...a: any[]) => T;
+
+        /**
+         * A customisable version of R.memoize. memoizeWith takes an additional function that will be applied
+         * to a given argument set and used to create the cache key under which the results of the function to
+         * be memoized will be stored. Care must be taken when implementing key generation to avoid clashes
+         * that may overwrite previous entries erroneously.
+         */
+        memoizeWith<T = any>(id: (...a: any[]) => string, fn: (...a: any[]) => T): (...a: any[]) => T;
 
         /**
          * Create a new object with the own properties of a

--- a/types/ramda/ramda-tests.ts
+++ b/types/ramda/ramda-tests.ts
@@ -310,6 +310,34 @@ R.times(i, 5);
 })();
 
 (() => {
+    let numberOfCalls = 0;
+
+    function trackedAdd(a: number, b: number) {
+        numberOfCalls += 1;
+        return a + b;
+    }
+
+    const memoTrackedAdd = R.memoizeWith(R.identity, trackedAdd);
+
+    memoTrackedAdd(1, 2); // => 3
+    numberOfCalls; // => 1
+    memoTrackedAdd(1, 2); // => 3
+    numberOfCalls; // => 1
+    memoTrackedAdd(2, 3); // => 5
+    numberOfCalls; // => 2
+
+    // Note that argument order matters
+    memoTrackedAdd(2, 1); // => 3
+    numberOfCalls; // => 3
+
+    function stringLength(str: string): number {
+      return str.length;
+    }
+    const memoStringLength = R.memoizeWith<number>(R.identity, stringLength);
+    const isLong = memoStringLength('short') > 10; // false
+})();
+
+(() => {
     const addOneOnce = R.once((x: number) => x + 1);
     addOneOnce(10); // => 11
     addOneOnce(addOneOnce(50)); // => 11


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://ramdajs.com/docs/#memoizeWith
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

Adding a definition for `memoizeWith`, which was introduced in Ramda 0.24 and should be preferred to the now deprecated `memoize` (as of 0.25). 

Note: the tests file does not compile with typescript@next due to issues outside of the scope of this PR (it fails on the tests for code written more than 8 months ago). I will try to see if I can fix those in another PR, but this does not really have anything to do with that and should be merged regardless. 
