### PR TITLE
Updated types for noble advertisement data

### DIFF
--- a/types/noble/index.d.ts
+++ b/types/noble/index.d.ts
@@ -6,6 +6,7 @@
 //                 Luke Libraro <https://github.com/lukel99>
 //                 Dan Chao <https://github.com/bioball>
 //                 Michal Lower <https://github.com/keton>
+//                 Rob Moran <https://github.com/thegecko>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -63,7 +64,10 @@ export declare class Peripheral extends events.EventEmitter {
 
 export interface Advertisement {
     localName: string;
-    serviceData: Buffer;
+    serviceData: {
+        uuid: string,
+        data: Buffer
+    };
     txPowerLevel: number;
     manufacturerData: Buffer;
     serviceUuids: string[];

--- a/types/noble/noble-tests.ts
+++ b/types/noble/noble-tests.ts
@@ -39,7 +39,10 @@ var peripheral: noble.Peripheral = new noble.Peripheral();
 peripheral.uuid = "12ad4e81";
 peripheral.advertisement = {
     localName:        "device",
-    serviceData:      new Buffer(1),
+    serviceData:      {
+        uuid: "180a",
+        data: new Buffer(1)
+    },
     txPowerLevel:     1,
     manufacturerData: new Buffer(1),
     serviceUuids:     ["0x180a", "0x180d"]


### PR DESCRIPTION
As part of my web-bluetooth shim, I decode BLE advertisement packets. The type information for the service data (on Mac OS at least) is incorrect as the advertised data looks like:

```bash
[ { uuid: 'fe9f',
    data: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00> } ]
```

From the template:

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/thegecko/webbluetooth/blob/master/src/adapter.ts#L143
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

