### PR TITLE
[sharp] Add SharpInstance#toBuffer({ resolveWithObject: boolean }) overloads

### DIFF
--- a/types/sharp/index.d.ts
+++ b/types/sharp/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for sharp 0.17
 // Project: https://github.com/lovell/sharp
 // Definitions by: François Nguyen <https://github.com/lith-light-g>
+//                 Wooseop Kim <https://github.com/wooseopkim>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
@@ -359,9 +360,16 @@ declare namespace sharp {
         toBuffer(callback: (err: Error, buffer: Buffer, info: OutputInfo) => void): SharpInstance;
         /**
          * Write output to a Buffer. JPEG, PNG, WebP, and RAW output are supported. By default, the format will match the input image, except GIF and SVG input which become PNG output.
+         * @param options resolve options
          * @returns A promise that fulfills with the resulting Buffer
          */
-        toBuffer(): Promise<Buffer>;
+        toBuffer(options?: { resolveWithObject: false }): Promise<Buffer>;
+        /**
+         * Write output to a Buffer. JPEG, PNG, WebP, and RAW output are supported. By default, the format will match the input image, except GIF and SVG input which become PNG output.
+         * @param options resolve options
+         * @returns A promise that fulfills with an object containing the Buffer data and an info object containing the output image format, size (bytes), width, height and channels
+         */
+        toBuffer(options: { resolveWithObject: true }): Promise<{ data: Buffer, info: OutputInfo }>;
         /**
          * Use these JPEG options for output image.
          * @param options Output options.

--- a/types/sharp/sharp-tests.ts
+++ b/types/sharp/sharp-tests.ts
@@ -183,6 +183,21 @@ sharp(input)
         // than 200 pixels regardless of the inputBuffer image dimensions
     });
 
+sharp(input)
+    .resize(100, 100)
+    .toBuffer({ resolveWithObject: false })
+    .then((outputBuffer: Buffer) => {
+        // Resolves with a Buffer object when resolveWithObject is false
+    });
+
+sharp(input)
+    .resize(100, 100)
+    .toBuffer({ resolveWithObject: true })
+    .then((object: { data: Buffer, info: sharp.OutputInfo }) => {
+        // Resolve with an object containing data Buffer and an OutputInfo object
+        // when resolveWithObject is true
+    });
+
 const stats = sharp.cache();
 
 sharp.cache({ items: 200 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <http://sharp.pixelplumbing.com/en/stable/api-output/#tobuffer>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I used object literal types because
- For return value, I thought `{ data, info }` object is too simple to have a new type.
- For the parameter, `resolveWithObject: boolean` property alters return type and AFAIK using literal type is the only way to handle that case properly.
