### PR TITLE
[react] Add boxSizing to CSS.

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1306,6 +1306,13 @@ declare namespace React {
         boxShadow?: CSSWideKeyword | any;
 
         /**
+         * Specify whether borders and padding are included in box size.
+         * Not inherited.
+         * MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
+         */
+        boxSizing?: "content-box" | "border-box";
+
+        /**
          * The CSS break-after property allows you to force a break on multi-column layouts.
          * More specifically, it allows you to force a break after an element.
          * It allows you to determine if a break should occur, and what type of break it should be.


### PR DESCRIPTION
It's really surprising that the otherwise-comprehensive CSS definition is missing this.
Note that the usual "initial", "inherit", "unset" aren't valid for boxSizing, because it doesn't inherit.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

