### PR TITLE
Types for express-flash 0.0.2

### DIFF
--- a/types/express-flash/express-flash-tests.ts
+++ b/types/express-flash/express-flash-tests.ts
@@ -1,0 +1,12 @@
+import express = require('express');
+import flash = require('express-flash');
+
+const app = express();
+
+app.use(flash());
+
+app.use((req) => {
+  req.flash();
+  req.flash('message');
+  req.flash('event', 'message');
+});

--- a/types/express-flash/index.d.ts
+++ b/types/express-flash/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for express-flash 0.0
+// Project: https://github.com/RGBboy/express-flash
+// Definitions by: Ian Mobley <https://github.com/iMobs>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+/// <reference types="connect-flash" />
+
+import express = require('express');
+declare function flash(): express.RequestHandler;
+export = flash;

--- a/types/express-flash/tsconfig.json
+++ b/types/express-flash/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-flash-tests.ts"
+    ]
+}

--- a/types/express-flash/tslint.json
+++ b/types/express-flash/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

express-flash just implements connenct-flash so there is no need to define anything beside the single RequestHandler function that it exports. express-flash hasn't been updated since 2013 but it still has more downloads in comparison to any of its forks.