### PR TITLE
[react] Workaround for --strictFunctionTypes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -404,7 +404,7 @@ declare namespace React {
          *
          * Note: its presence prevents any of the deprecated lifecycle methods from being invoked
          */
-        (nextProps: Readonly<P>, prevState: Readonly<S>) => Partial<S> | null;
+        (nextProps: Readonly<P>, prevState: S) => Partial<S> | null;
 
     // This should be "infer SS" but can't use it yet
     interface NewLifecycle<P, S, SS> {

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -156,6 +156,7 @@ class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', st
         return { a: 'a' };
     }
 }
+const AssignedComponentWithLargeState: React.ComponentClass<{}> = ComponentWithLargeState;
 
 const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> {})({});
 componentWithBadLifecycle.getSnapshotBeforeUpdate = () => { // $ExpectError

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -156,7 +156,7 @@ class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', st
         return { a: 'a' };
     }
 }
-const AssignedComponentWithLargeState: React.ComponentClass<{}> = ComponentWithLargeState;
+const AssignedComponentWithLargeState: React.ComponentClass = ComponentWithLargeState;
 
 const componentWithBadLifecycle = new (class extends React.Component<{}, {}, number> {})({});
 componentWithBadLifecycle.getSnapshotBeforeUpdate = () => { // $ExpectError


### PR DESCRIPTION
Under --strictFunctionTypes, when assigning a class with `getDerivedStateFromProps` to `React.ComponentClass` or `React.ComponentType`, the type of the second argument was expected to be `Readonly<any>`, which is, actually, the same as `Readonly<{}>`.

This was preventing using classes that try to refer to the previous state in `getDerivedStateFromProps` from being given to HOC factories.

There are no tests as testing this change is only possible with `--strictFunctionTypes`, and the `tsconfig.json` here specifically disables it. Perhaps another PR should enable it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
