### PR TITLE
[luxon] Splitted min and max

### DIFF
--- a/types/luxon/index.d.ts
+++ b/types/luxon/index.d.ts
@@ -135,8 +135,10 @@ declare module 'luxon' {
                 second?: number,
                 millisecond?: number
             ): DateTime;
-            static max(...dateTimes: DateTime[]): DateTime | undefined;
-            static min(...dateTimes: DateTime[]): DateTime | undefined;
+            static max(): undefined;
+            static max(...dateTimes: DateTime[]): DateTime;
+            static min(): undefined;
+            static min(...dateTimes: DateTime[]): DateTime;
             static utc(
                 year?: number,
                 month?: number,


### PR DESCRIPTION
Splitted min and max in a function that only returns undefined and a function that only returnes a DateTime.

https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#static-method-max
Min and max only return undefined when called without input.