### PR TITLE
Node: Added missing windowsHide properties to SpawnOptions

### DIFF
--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -20,6 +20,7 @@
 //                 Klaus Meinhardt <https://github.com/ajafff>
 //                 Huw <https://github.com/hoo29>
 //                 Nicolas Even <https://github.com/n-e>
+//                 Bruno Scheufler <https://github.com/brunoscheufler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /** inspector module types */
@@ -2093,6 +2094,7 @@ declare module "child_process" {
         gid?: number;
         shell?: boolean | string;
         windowsVerbatimArguments?: boolean;
+        windowsHide?: boolean;
     }
 
     export function spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess;

--- a/types/node/node-tests.ts
+++ b/types/node/node-tests.ts
@@ -2056,7 +2056,8 @@ namespace string_decoder_tests {
 namespace child_process_tests {
     {
         childProcess.exec("echo test");
-        childProcess.exec("echo test", {windowsHide: true});
+        childProcess.exec("echo test", { windowsHide: true });
+        childProcess.spawn("echo", ["test"], {windowsHide: true});
         childProcess.spawnSync("echo test");
         childProcess.spawnSync("echo test", {windowsVerbatimArguments: false});
     }

--- a/types/node/v8/index.d.ts
+++ b/types/node/v8/index.d.ts
@@ -19,6 +19,7 @@
 //                 Alberto Schiabel <https://github.com/jkomyno>
 //                 Huw <https://github.com/hoo29>
 //                 Nicolas Even <https://github.com/n-e>
+//                 Bruno Scheufler <https://github.com/brunoscheufler>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
 
@@ -2082,6 +2083,7 @@ declare module "child_process" {
         gid?: number;
         shell?: boolean | string;
         windowsVerbatimArguments?: boolean;
+        windowsHide?: boolean;
     }
 
     export function spawn(command: string, args?: string[], options?: SpawnOptions): ChildProcess;

--- a/types/node/v8/node-tests.ts
+++ b/types/node/v8/node-tests.ts
@@ -2030,6 +2030,7 @@ namespace string_decoder_tests {
 namespace child_process_tests {
     {
         childProcess.exec("echo test");
+        childProcess.spawn("echo", ["test"], { windowsHide: true });
         childProcess.spawnSync("echo test");
     }
 


### PR DESCRIPTION
Added missing `windowsHide` property to SpawnOptions interface of the child_process module

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [child_process SpawnOptions](https://nodejs.org/dist/latest-v9.x/docs/api/child_process.html#child_process_child_process_spawn_command_args_options)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
