### PR TITLE
Add '_enableIdPInitiatedLogin' to auth0-lock constructor's type definition

### DIFF
--- a/types/auth0-lock/auth0-lock-tests.ts
+++ b/types/auth0-lock/auth0-lock-tests.ts
@@ -124,7 +124,9 @@ const otherOptions : Auth0LockConstructorOptions = {
   configurationBaseUrl: "https://cdn.auth0.com",
   languageBaseUrl: "http://www.example.com",
   hashCleanup: false,
-  leeway: 30
+  leeway: 30,
+  _enableImpersonation: true,
+  _enableIdPInitiatedLogin: false
 };
 
 new Auth0Lock(CLIENT_ID, DOMAIN, otherOptions);

--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -144,6 +144,7 @@ interface Auth0LockConstructorOptions {
     theme?: Auth0LockThemeOptions;
     usernameStyle?: string;
     _enableImpersonation?: boolean;
+    _enableIdPInitiatedLogin?: boolean;
 }
 
 interface Auth0LockFlashMessageOptions {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Increase the version number in the header if appropriate.
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [documentation](https://auth0.com/docs/user-profile/user-impersonation#enable-impersonation)
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Reason for change:
In order to enable IdP-initiated logins (login sessions that begin from a customer's identity provider instead of via redirection from our login screen to their identity provider), this flag must be enabled in the auth0 lock's constructor. While its actual behavior is redundant with the `_enableImpersonation` flag ([source](https://github.com/auth0/lock/blob/b427f5663706330708963eada292a3588ea4f80e/src/core/web_api/p2_api.js#L15)) which is already enabled in the typescript definition, this appears to be the intended flag for this purposes based upon the documentation I linked above.