### PR TITLE
Have quill/core and quill/quill alias to the exports of quill

### DIFF
--- a/types/quill/core.d.ts
+++ b/types/quill/core.d.ts
@@ -1,0 +1,2 @@
+export * from "./index";
+export { default } from "./index";

--- a/types/quill/quill-tests.ts
+++ b/types/quill/quill-tests.ts
@@ -1,4 +1,18 @@
 import { Quill, Delta, DeltaStatic, RangeStatic, StringMap } from 'quill';
+import {
+    Quill as Quill2,
+    Delta as Delta2,
+    DeltaStatic as DeltaStatic2,
+    RangeStatic as RangeStatic2,
+    StringMap as StringMap2
+} from 'quill/core';
+import {
+    Quill as Quill3,
+    Delta as Delta3,
+    DeltaStatic as DeltaStatic3,
+    RangeStatic as RangeStatic3,
+    StringMap as StringMap3
+} from 'quill/quill';
 import { Blot } from 'parchment/src/blot/abstract/blot';
 
 function test_quill() {

--- a/types/quill/quill.d.ts
+++ b/types/quill/quill.d.ts
@@ -1,0 +1,2 @@
+export * from './index';
+export { default } from './index';


### PR DESCRIPTION
I'm planning on following this up with a PR for the rest of "Unbuilt" quill, but the current quill module definition only works for the compiled versions of quill. If you [integrate quill into your built pipeline](https://quilljs.com/guides/adding-quill-to-your-build-pipeline/) then you will likely be importing (and have access to) the same files, but your entrypoint will either be `quill/core` or `quill/quill` instead of `quill`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://quilljs.com/guides/adding-quill-to-your-build-pipeline/
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.