### PR TITLE
React: add missing 'indeterminate' attribute for checkboxes

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1209,6 +1209,7 @@ declare namespace React {
         hrefLang?: string;
         htmlFor?: string;
         httpEquiv?: string;
+        indeterminate?: boolean;
         integrity?: string;
         keyParams?: string;
         keyType?: string;
@@ -1423,6 +1424,7 @@ declare namespace React {
         formNoValidate?: boolean;
         formTarget?: string;
         height?: number | string;
+        indeterminate?: boolean;
         list?: string;
         max?: number | string;
         maxLength?: number;

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -1209,6 +1209,8 @@ declare namespace React {
         hrefLang?: string;
         htmlFor?: string;
         httpEquiv?: string;
+        // Note: indeterminate can only be set in JavaScript,
+        // it cannot be set using an HTML attribute
         indeterminate?: boolean;
         integrity?: string;
         keyParams?: string;
@@ -1424,6 +1426,8 @@ declare namespace React {
         formNoValidate?: boolean;
         formTarget?: string;
         height?: number | string;
+        // Note: indeterminate can only be set in JavaScript,
+        // it cannot be set using an HTML attribute
         indeterminate?: boolean;
         list?: string;
         max?: number | string;


### PR DESCRIPTION
Note that `indeterminate` is not an HTML attribute, as it can only be set via JS.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox

For that reason, I'm not 100% sure this PR should be merged. Reviewers are welcome to pitch in!

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox
