### PR TITLE
use npm export syntax in adal-angular

### DIFF
--- a/types/adal-angular/adal-angular-tests.ts
+++ b/types/adal-angular/adal-angular-tests.ts
@@ -1,4 +1,4 @@
-import * as AuthenticationContext from "adal-angular";
+import AuthenticationContext = require("adal-angular");
 
 const onLogin: AuthenticationContext.TokenCallback = (errorDescription, idToken, error) => {
     if (error) {

--- a/types/adal-angular/adal-angular-tests.ts
+++ b/types/adal-angular/adal-angular-tests.ts
@@ -1,10 +1,6 @@
-import AuthenticationContext, {
-    AuthenticationContextOptions,
-    TokenCallback,
-    UserCallback
-} from "adal-angular";
+import * as AuthenticationContext from "adal-angular";
 
-const onLogin: TokenCallback = (errorDescription, idToken, error) => {
+const onLogin: AuthenticationContext.TokenCallback = (errorDescription, idToken, error) => {
     if (error) {
         console.error(errorDescription, error);
         return;
@@ -14,7 +10,7 @@ const onLogin: TokenCallback = (errorDescription, idToken, error) => {
     }
 };
 
-const onToken: TokenCallback = (errorDesc, token, error) => {
+const onToken: AuthenticationContext.TokenCallback = (errorDesc, token, error) => {
     if (error) {
         console.error(error);
         return;
@@ -22,7 +18,7 @@ const onToken: TokenCallback = (errorDesc, token, error) => {
     console.log('Making request with token:', token);
 };
 
-const onUser: UserCallback = (error, user) => {
+const onUser: AuthenticationContext.UserCallback = (error, user) => {
     if (error) {
         console.error(error);
         return;
@@ -57,7 +53,7 @@ const acquireAnAccessToken = () => {
     );
 };
 
-const config: AuthenticationContextOptions = {
+const config: AuthenticationContext.Options = {
     clientId: "7cee0f68-5051-41f6-9e45-80463d21d65d",
     redirectUri: "http://localhost:16969/",
     instance: "https://login.microsoftonline.com/",
@@ -70,6 +66,7 @@ const config: AuthenticationContextOptions = {
 };
 
 const authenticationContext = new AuthenticationContext(config);
+window.Logging.level = authenticationContext.CONSTANTS.LOGGING_LEVEL.ERROR;
 
 if (authenticationContext.isCallback(window.location.hash)) {
     authenticationContext.handleWindowCallback();
@@ -78,6 +75,11 @@ if (authenticationContext.isCallback(window.location.hash)) {
 } else {
     acquireAnAccessToken();
 }
+
+const injectedContext = AuthenticationContext.inject({
+    clientId: "7cee0f68-5051-41f6-9e45-80463d21d65d",
+});
+injectedContext.handleWindowCallback();
 
 setTimeout(() => {
     authenticationContext.logOut();

--- a/types/adal-angular/index.d.ts
+++ b/types/adal-angular/index.d.ts
@@ -3,140 +3,14 @@
 // Definitions by: Daniel Perez Alvarez <https://github.com/unindented>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export enum LoggingLevel {
-    ERROR = 0,
-    WARNING = 1,
-    INFO = 2,
-    VERBOSE = 3
-}
+// In module contexts the class constructor function is the exported object
+export = AuthenticationContext;
 
-export type RequestType = "LOGIN" | "RENEW_TOKEN" | "UNKNOWN";
+// This class is defined globally in not in a module context
+declare class AuthenticationContext {
+    config: AuthenticationContext.Options;
 
-export type ResponseType = "id_token token" | "token";
-
-export interface RequestInfo {
-    /**
-     * Object comprising of fields such as id_token/error, session_state, state, e.t.c.
-     */
-    parameters: any;
-    /**
-     * Request type.
-     */
-    requestType: RequestType;
-    /**
-     * Whether state is valid.
-     */
-    stateMatch: boolean;
-    /**
-     * Unique guid used to match the response with the request.
-     */
-    stateResponse: string;
-    /**
-     * Whether `requestType` contains `id_token`, `access_token` or error.
-     */
-    valid: boolean;
-}
-
-export interface UserInfo {
-    /**
-     * Username assigned from UPN or email.
-     */
-    userName: string;
-    /**
-     * Properties parsed from `id_token`.
-     */
-    profile: any;
-}
-
-export type TokenCallback = (
-    errorDesc: string | null,
-    token: string,
-    error: any
-) => void;
-
-export type UserCallback = (errorDesc: string | null, user: UserInfo) => void;
-
-export interface AuthenticationContextOptions {
-    /**
-     * Client ID assigned to your app by Azure Active Directory.
-     */
-    clientId: string;
-    /**
-     * Endpoint at which you expect to receive tokens.Defaults to `window.location.href`.
-     */
-    redirectUri: string;
-    /**
-     * Azure Active Directory instance. Defaults to `https://login.microsoftonline.com/`.
-     */
-    instance?: string;
-    /**
-     * Your target tenant. Defaults to `common`.
-     */
-    tenant?: string;
-    /**
-     * Query parameters to add to the authentication request.
-     */
-    extraQueryParameter?: string;
-    /**
-     * Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
-     */
-    correlationId?: string;
-    /**
-     * User defined function of handling the navigation to Azure AD authorization endpoint in case of login.
-     */
-    displayCall?: (url: string) => void;
-    /**
-     * Set this to true to enable login in a popup winodow instead of a full redirect. Defaults to `false`.
-     */
-    popUp?: boolean;
-    /**
-     * Set this to the resource to request on login. Defaults to `clientId`.
-     */
-    loginResource?: string;
-    /**
-     * Set this to redirect the user to a custom login page.
-     */
-    localLoginUrl?: string;
-    /**
-     * Redirects to start page after login. Defaults to `true`.
-     */
-    navigateToLoginRequestUrl?: boolean;
-    /**
-     * Set this to redirect the user to a custom logout page.
-     */
-    logOutUri?: string;
-    /**
-     * Redirects the user to postLogoutRedirectUri after logout. Defaults to `redirectUri`.
-     */
-    postLogoutRedirectUri?: string;
-    /**
-     * Sets browser storage to either 'localStorage' or sessionStorage'. Defaults to `sessionStorage`.
-     */
-    cacheLocation?: "localStorage" | "sessionStorage";
-    /**
-     * Array of keywords or URIs. Adal will attach a token to outgoing requests that have these keywords or URIs.
-     */
-    endpoints?: { [resource: string]: string };
-    /**
-     * Array of keywords or URIs. Adal will not attach a token to outgoing requests that have these keywords or URIs.
-     */
-    anonymousEndpoints?: string[];
-    /**
-     * If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 300 seconds.
-     */
-    expireOffsetSeconds?: number;
-    /**
-     * The number of milliseconds of inactivity before a token renewal response from AAD should be considered timed out. Defaults to 6 seconds.
-     */
-    loadFrameTimeout?: number;
-    /**
-     * Callback to be invoked when a token is acquired.
-     */
-    callback?: TokenCallback;
-}
-
-export default class AuthenticationContext {
-    constructor(options: AuthenticationContextOptions);
+    constructor(options: AuthenticationContext.Options);
     /**
      * Initiates the login process by redirecting the user to Azure AD authorization endpoint.
      */
@@ -153,7 +27,7 @@ export default class AuthenticationContext {
     /**
      * If user object exists, returns it. Else creates a new user object by decoding `id_token` from the cache.
      */
-    getCachedUser(): UserInfo;
+    getCachedUser(): AuthenticationContext.UserInfo;
     /**
      * Adds the passed callback to the array of callbacks for the specified resource.
      * @param resource A URI that identifies the resource for which the token is requested.
@@ -163,14 +37,14 @@ export default class AuthenticationContext {
     registerCallback(
         expectedState: string,
         resource: string,
-        callback: TokenCallback
+        callback: AuthenticationContext.TokenCallback
     ): void;
     /**
      * Acquires token from the cache if it is not expired. Otherwise sends request to AAD to obtain a new token.
      * @param resource Resource URI identifying the target resource.
      * @param callback The callback provided by the caller. It will be called with token or error.
      */
-    acquireToken(resource: string, callback: TokenCallback): void;
+    acquireToken(resource: string, callback: AuthenticationContext.TokenCallback): void;
     /**
      * Acquires token (interactive flow using a popup window) by sending request to AAD to obtain a new token.
      * @param resource Resource URI identifying the target resource.
@@ -182,7 +56,7 @@ export default class AuthenticationContext {
         resource: string,
         extraQueryParameters: string | null | undefined,
         claims: string | null | undefined,
-        callback: TokenCallback
+        callback: AuthenticationContext.TokenCallback
     ): void;
     /**
      * Acquires token (interactive flow using a redirect) by sending request to AAD to obtain a new token. In this case the callback passed in the authentication request constructor will be called.
@@ -217,7 +91,7 @@ export default class AuthenticationContext {
      * Calls the passed in callback with the user object or error message related to the user.
      * @param callback The callback provided by the caller. It will be called with user or error.
      */
-    getUser(callback: UserCallback): void;
+    getUser(callback: AuthenticationContext.UserCallback): void;
     /**
      * Checks if the URL fragment contains access token, id token or error description.
      * @param hash Hash passed from redirect page.
@@ -252,7 +126,7 @@ export default class AuthenticationContext {
      * @param message Message to log.
      * @param error Error to log.
      */
-    log(level: LoggingLevel, message: string, error: any): void;
+    log(level: AuthenticationContext.LoggingLevel, message: string, error: any): void;
     /**
      * Logs messages when logging level is set to 0.
      * @param message Message to log.
@@ -274,4 +148,153 @@ export default class AuthenticationContext {
      * @param message Message to log.
      */
     verbose(message: string): void;
+}
+
+declare namespace AuthenticationContext {
+
+  export function inject(config: Options): AuthenticationContext;
+
+  export enum LoggingLevel {
+    ERROR = 0,
+    WARNING = 1,
+    INFO = 2,
+    VERBOSE = 3
+  }
+
+  export type RequestType = "LOGIN" | "RENEW_TOKEN" | "UNKNOWN";
+
+  export type ResponseType = "id_token token" | "token";
+
+  export interface RequestInfo {
+      /**
+       * Object comprising of fields such as id_token/error, session_state, state, e.t.c.
+       */
+      parameters: any;
+      /**
+       * Request type.
+       */
+      requestType: RequestType;
+      /**
+       * Whether state is valid.
+       */
+      stateMatch: boolean;
+      /**
+       * Unique guid used to match the response with the request.
+       */
+      stateResponse: string;
+      /**
+       * Whether `requestType` contains `id_token`, `access_token` or error.
+       */
+      valid: boolean;
+  }
+
+  export interface UserInfo {
+      /**
+       * Username assigned from UPN or email.
+       */
+      userName: string;
+      /**
+       * Properties parsed from `id_token`.
+       */
+      profile: any;
+  }
+
+  export type TokenCallback = (
+      errorDesc: string | null,
+      token: string,
+      error: any
+  ) => void;
+
+  export type UserCallback = (errorDesc: string | null, user: UserInfo) => void;
+
+  export interface Options {
+      /**
+       * Client ID assigned to your app by Azure Active Directory.
+       */
+      clientId: string;
+      /**
+       * Endpoint at which you expect to receive tokens.Defaults to `window.location.href`.
+       */
+      redirectUri?: string;
+      /**
+       * Azure Active Directory instance. Defaults to `https://login.microsoftonline.com/`.
+       */
+      instance?: string;
+      /**
+       * Your target tenant. Defaults to `common`.
+       */
+      tenant?: string;
+      /**
+       * Query parameters to add to the authentication request.
+       */
+      extraQueryParameter?: string;
+      /**
+       * Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
+       */
+      correlationId?: string;
+      /**
+       * User defined function of handling the navigation to Azure AD authorization endpoint in case of login.
+       */
+      displayCall?: (url: string) => void;
+      /**
+       * Set this to true to enable login in a popup winodow instead of a full redirect. Defaults to `false`.
+       */
+      popUp?: boolean;
+      /**
+       * Set this to the resource to request on login. Defaults to `clientId`.
+       */
+      loginResource?: string;
+      /**
+       * Set this to redirect the user to a custom login page.
+       */
+      localLoginUrl?: string;
+      /**
+       * Redirects to start page after login. Defaults to `true`.
+       */
+      navigateToLoginRequestUrl?: boolean;
+      /**
+       * Set this to redirect the user to a custom logout page.
+       */
+      logOutUri?: string;
+      /**
+       * Redirects the user to postLogoutRedirectUri after logout. Defaults to `redirectUri`.
+       */
+      postLogoutRedirectUri?: string;
+      /**
+       * Sets browser storage to either 'localStorage' or sessionStorage'. Defaults to `sessionStorage`.
+       */
+      cacheLocation?: "localStorage" | "sessionStorage";
+      /**
+       * Array of keywords or URIs. Adal will attach a token to outgoing requests that have these keywords or URIs.
+       */
+      endpoints?: { [resource: string]: string };
+      /**
+       * Array of keywords or URIs. Adal will not attach a token to outgoing requests that have these keywords or URIs.
+       */
+      anonymousEndpoints?: string[];
+      /**
+       * If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 300 seconds.
+       */
+      expireOffsetSeconds?: number;
+      /**
+       * The number of milliseconds of inactivity before a token renewal response from AAD should be considered timed out. Defaults to 6 seconds.
+       */
+      loadFrameTimeout?: number;
+      /**
+       * Callback to be invoked when a token is acquired.
+       */
+      callback?: TokenCallback;
+  }
+
+  export interface LoggingConfig {
+    level: LoggingLevel;
+    log: (message: string) => void;
+    piiLoggingEnabled: boolean;
+  }
+}
+
+declare global {
+  interface Window {
+    Logging: AuthenticationContext.LoggingConfig;
+  }
 }

--- a/types/adal-angular/index.d.ts
+++ b/types/adal-angular/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for adal-angular 1.0
 // Project: https://github.com/AzureAD/azure-activedirectory-library-for-js#readme
 // Definitions by: Daniel Perez Alvarez <https://github.com/unindented>
+//                 Anthony Ciccarello <https://github.com/aciccarello>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // In module contexts the class constructor function is the exported object
@@ -8,7 +9,18 @@ export = AuthenticationContext;
 
 // This class is defined globally in not in a module context
 declare class AuthenticationContext {
+    instance: string;
     config: AuthenticationContext.Options;
+    callback: AuthenticationContext.TokenCallback;
+    popUp: boolean;
+    isAngular: boolean;
+
+    /**
+     * Enum for request type
+     * @enum {string}
+     */
+    REQUEST_TYPE: AuthenticationContext.RequestType
+    CONSTANTS: AuthenticationContext.Constants;
 
     constructor(options: AuthenticationContext.Options);
     /**
@@ -148,18 +160,38 @@ declare class AuthenticationContext {
      * @param message Message to log.
      */
     verbose(message: string): void;
+
+    /**
+    * Logs Pii messages when Logging Level is set to 0 and window.piiLoggingEnabled is set to true.
+    * @param message Message to log.
+    * @param error Error to log.
+    */
+    errorPii(message: string, error: any): void;
+
+    /**
+     * Logs  Pii messages when Logging Level is set to 1 and window.piiLoggingEnabled is set to true.
+     * @param message Message to log.
+     */
+    warnPii(message: string): void;
+
+    /**
+     * Logs messages when Logging Level is set to 2 and window.piiLoggingEnabled is set to true.
+     * @param message Message to log.
+     */
+    infoPii(message: string): void;
+
+    /**
+     * Logs messages when Logging Level is set to 3 and window.piiLoggingEnabled is set to true.
+     * @param message Message to log.
+     */
+    verbosePii(message: string): void;
 }
 
 declare namespace AuthenticationContext {
 
   export function inject(config: Options): AuthenticationContext;
 
-  export enum LoggingLevel {
-    ERROR = 0,
-    WARNING = 1,
-    INFO = 2,
-    VERBOSE = 3
-  }
+  export type LoggingLevel = 0 | 1 | 2 | 3;
 
   export type RequestType = "LOGIN" | "RENEW_TOKEN" | "UNKNOWN";
 
@@ -201,12 +233,15 @@ declare namespace AuthenticationContext {
 
   export type TokenCallback = (
       errorDesc: string | null,
-      token: string,
+      token: string | null,
       error: any
   ) => void;
 
-  export type UserCallback = (errorDesc: string | null, user: UserInfo) => void;
+  export type UserCallback = (errorDesc: string | null, user: UserInfo | null) => void;
 
+  /**
+   * Configuration options for Authentication Context
+   */
   export interface Options {
       /**
        * Client ID assigned to your app by Azure Active Directory.
@@ -290,6 +325,53 @@ declare namespace AuthenticationContext {
     level: LoggingLevel;
     log: (message: string) => void;
     piiLoggingEnabled: boolean;
+  }
+
+  /**
+   * Enum for storage constants
+   * @enum {string}
+   */
+  export interface Constants {
+    ACCESS_TOKEN: 'access_token',
+    EXPIRES_IN: 'expires_in',
+    ID_TOKEN: 'id_token',
+    ERROR_DESCRIPTION: 'error_description',
+    SESSION_STATE: 'session_state',
+    STORAGE: {
+        TOKEN_KEYS: 'adal.token.keys',
+        ACCESS_TOKEN_KEY: 'adal.access.token.key',
+        EXPIRATION_KEY: 'adal.expiration.key',
+        STATE_LOGIN: 'adal.state.login',
+        STATE_RENEW: 'adal.state.renew',
+        NONCE_IDTOKEN: 'adal.nonce.idtoken',
+        SESSION_STATE: 'adal.session.state',
+        USERNAME: 'adal.username',
+        IDTOKEN: 'adal.idtoken',
+        ERROR: 'adal.error',
+        ERROR_DESCRIPTION: 'adal.error.description',
+        LOGIN_REQUEST: 'adal.login.request',
+        LOGIN_ERROR: 'adal.login.error',
+        RENEW_STATUS: 'adal.token.renew.status'
+    },
+    RESOURCE_DELIMETER: '|',
+    LOADFRAME_TIMEOUT: '6000',
+    TOKEN_RENEW_STATUS_CANCELED: 'Canceled',
+    TOKEN_RENEW_STATUS_COMPLETED: 'Completed',
+    TOKEN_RENEW_STATUS_IN_PROGRESS: 'In Progress',
+    LOGGING_LEVEL: {
+        ERROR: 0,
+        WARN: 1,
+        INFO: 2,
+        VERBOSE: 3
+    },
+    LEVEL_STRING_MAP: {
+        0: 'ERROR:',
+        1: 'WARNING:',
+        2: 'INFO:',
+        3: 'VERBOSE:'
+    },
+    POPUP_WIDTH: 483,
+    POPUP_HEIGHT: 600
   }
 }
 

--- a/types/adal-angular/index.d.ts
+++ b/types/adal-angular/index.d.ts
@@ -17,7 +17,6 @@ declare class AuthenticationContext {
 
     /**
      * Enum for request type
-     * @enum {string}
      */
     REQUEST_TYPE: AuthenticationContext.RequestType;
     RESPONSE_TYPE: AuthenticationContext.ResponseType;
@@ -117,11 +116,11 @@ declare class AuthenticationContext {
     /**
      * Creates a request info object from the URL fragment and returns it.
      */
-    getRequestInfo(hash: string): RequestInfo;
+    getRequestInfo(hash: string): AuthenticationContext.RequestInfo;
     /**
      * Saves token or error received in the response from AAD in the cache. In case of `id_token`, it also creates the user object.
      */
-    saveTokenFromHash(requestInfo: RequestInfo): void;
+    saveTokenFromHash(requestInfo: AuthenticationContext.RequestInfo): void;
     /**
      * Gets resource for given endpoint if mapping is provided with config.
      * @param endpoint Resource URI identifying the target resource.
@@ -163,10 +162,10 @@ declare class AuthenticationContext {
     verbose(message: string): void;
 
     /**
-    * Logs Pii messages when Logging Level is set to 0 and window.piiLoggingEnabled is set to true.
-    * @param message Message to log.
-    * @param error Error to log.
-    */
+     * Logs Pii messages when Logging Level is set to 0 and window.piiLoggingEnabled is set to true.
+     * @param message Message to log.
+     * @param error Error to log.
+     */
     errorPii(message: string, error: any): void;
 
     /**
@@ -189,190 +188,188 @@ declare class AuthenticationContext {
 }
 
 declare namespace AuthenticationContext {
+    function inject(config: Options): AuthenticationContext;
 
-    export function inject(config: Options): AuthenticationContext;
+    type LoggingLevel = 0 | 1 | 2 | 3;
 
-    export type LoggingLevel = 0 | 1 | 2 | 3;
+    type RequestType = "LOGIN" | "RENEW_TOKEN" | "UNKNOWN";
 
-    export type RequestType = "LOGIN" | "RENEW_TOKEN" | "UNKNOWN";
+    type ResponseType = "id_token token" | "token";
 
-    export type ResponseType = "id_token token" | "token";
-
-    export interface RequestInfo {
+    interface RequestInfo {
         /**
-        * Object comprising of fields such as id_token/error, session_state, state, e.t.c.
-        */
+         * Object comprising of fields such as id_token/error, session_state, state, e.t.c.
+         */
         parameters: any;
         /**
-        * Request type.
-        */
+         * Request type.
+         */
         requestType: RequestType;
         /**
-        * Whether state is valid.
-        */
+         * Whether state is valid.
+         */
         stateMatch: boolean;
         /**
-        * Unique guid used to match the response with the request.
-        */
+         * Unique guid used to match the response with the request.
+         */
         stateResponse: string;
         /**
-        * Whether `requestType` contains `id_token`, `access_token` or error.
-        */
+         * Whether `requestType` contains `id_token`, `access_token` or error.
+         */
         valid: boolean;
     }
 
-    export interface UserInfo {
+    interface UserInfo {
         /**
-        * Username assigned from UPN or email.
-        */
+         * Username assigned from UPN or email.
+         */
         userName: string;
         /**
-        * Properties parsed from `id_token`.
-        */
+         * Properties parsed from `id_token`.
+         */
         profile: any;
     }
 
-    export type TokenCallback = (
+    type TokenCallback = (
         errorDesc: string | null,
         token: string | null,
         error: any
     ) => void;
 
-    export type UserCallback = (errorDesc: string | null, user: UserInfo | null) => void;
+    type UserCallback = (errorDesc: string | null, user: UserInfo | null) => void;
 
     /**
-    * Configuration options for Authentication Context
-    */
-    export interface Options {
+     * Configuration options for Authentication Context
+     */
+    interface Options {
         /**
-        * Client ID assigned to your app by Azure Active Directory.
-        */
+         * Client ID assigned to your app by Azure Active Directory.
+         */
         clientId: string;
         /**
-        * Endpoint at which you expect to receive tokens.Defaults to `window.location.href`.
-        */
+         * Endpoint at which you expect to receive tokens.Defaults to `window.location.href`.
+         */
         redirectUri?: string;
         /**
-        * Azure Active Directory instance. Defaults to `https://login.microsoftonline.com/`.
-        */
+         * Azure Active Directory instance. Defaults to `https://login.microsoftonline.com/`.
+         */
         instance?: string;
         /**
-        * Your target tenant. Defaults to `common`.
-        */
+         * Your target tenant. Defaults to `common`.
+         */
         tenant?: string;
         /**
-        * Query parameters to add to the authentication request.
-        */
+         * Query parameters to add to the authentication request.
+         */
         extraQueryParameter?: string;
         /**
-        * Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
-        */
+         * Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
+         */
         correlationId?: string;
         /**
-        * User defined function of handling the navigation to Azure AD authorization endpoint in case of login.
-        */
+         * User defined function of handling the navigation to Azure AD authorization endpoint in case of login.
+         */
         displayCall?: (url: string) => void;
         /**
-        * Set this to true to enable login in a popup winodow instead of a full redirect. Defaults to `false`.
-        */
+         * Set this to true to enable login in a popup winodow instead of a full redirect. Defaults to `false`.
+         */
         popUp?: boolean;
         /**
-        * Set this to the resource to request on login. Defaults to `clientId`.
-        */
+         * Set this to the resource to request on login. Defaults to `clientId`.
+         */
         loginResource?: string;
         /**
-        * Set this to redirect the user to a custom login page.
-        */
+         * Set this to redirect the user to a custom login page.
+         */
         localLoginUrl?: string;
         /**
-        * Redirects to start page after login. Defaults to `true`.
-        */
+         * Redirects to start page after login. Defaults to `true`.
+         */
         navigateToLoginRequestUrl?: boolean;
         /**
-        * Set this to redirect the user to a custom logout page.
-        */
+         * Set this to redirect the user to a custom logout page.
+         */
         logOutUri?: string;
         /**
-        * Redirects the user to postLogoutRedirectUri after logout. Defaults to `redirectUri`.
-        */
+         * Redirects the user to postLogoutRedirectUri after logout. Defaults to `redirectUri`.
+         */
         postLogoutRedirectUri?: string;
         /**
-        * Sets browser storage to either 'localStorage' or sessionStorage'. Defaults to `sessionStorage`.
-        */
+         * Sets browser storage to either 'localStorage' or sessionStorage'. Defaults to `sessionStorage`.
+         */
         cacheLocation?: "localStorage" | "sessionStorage";
         /**
-        * Array of keywords or URIs. Adal will attach a token to outgoing requests that have these keywords or URIs.
-        */
+         * Array of keywords or URIs. Adal will attach a token to outgoing requests that have these keywords or URIs.
+         */
         endpoints?: { [resource: string]: string };
         /**
-        * Array of keywords or URIs. Adal will not attach a token to outgoing requests that have these keywords or URIs.
-        */
+         * Array of keywords or URIs. Adal will not attach a token to outgoing requests that have these keywords or URIs.
+         */
         anonymousEndpoints?: string[];
         /**
-        * If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 300 seconds.
-        */
+         * If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 300 seconds.
+         */
         expireOffsetSeconds?: number;
         /**
-        * The number of milliseconds of inactivity before a token renewal response from AAD should be considered timed out. Defaults to 6 seconds.
-        */
+         * The number of milliseconds of inactivity before a token renewal response from AAD should be considered timed out. Defaults to 6 seconds.
+         */
         loadFrameTimeout?: number;
         /**
-        * Callback to be invoked when a token is acquired.
-        */
+         * Callback to be invoked when a token is acquired.
+         */
         callback?: TokenCallback;
     }
 
-    export interface LoggingConfig {
+    interface LoggingConfig {
         level: LoggingLevel;
         log: (message: string) => void;
         piiLoggingEnabled: boolean;
     }
 
     /**
-    * Enum for storage constants
-    * @enum {string}
-    */
-    export interface Constants {
-        ACCESS_TOKEN: 'access_token',
-        EXPIRES_IN: 'expires_in',
-        ID_TOKEN: 'id_token',
-        ERROR_DESCRIPTION: 'error_description',
-        SESSION_STATE: 'session_state',
+     * Enum for storage constants
+     */
+    interface Constants {
+        ACCESS_TOKEN: 'access_token';
+        EXPIRES_IN: 'expires_in';
+        ID_TOKEN: 'id_token';
+        ERROR_DESCRIPTION: 'error_description';
+        SESSION_STATE: 'session_state';
         STORAGE: {
-            TOKEN_KEYS: 'adal.token.keys',
-            ACCESS_TOKEN_KEY: 'adal.access.token.key',
-            EXPIRATION_KEY: 'adal.expiration.key',
-            STATE_LOGIN: 'adal.state.login',
-            STATE_RENEW: 'adal.state.renew',
-            NONCE_IDTOKEN: 'adal.nonce.idtoken',
-            SESSION_STATE: 'adal.session.state',
-            USERNAME: 'adal.username',
-            IDTOKEN: 'adal.idtoken',
-            ERROR: 'adal.error',
-            ERROR_DESCRIPTION: 'adal.error.description',
-            LOGIN_REQUEST: 'adal.login.request',
-            LOGIN_ERROR: 'adal.login.error',
-            RENEW_STATUS: 'adal.token.renew.status'
-        },
-        RESOURCE_DELIMETER: '|',
-        LOADFRAME_TIMEOUT: '6000',
-        TOKEN_RENEW_STATUS_CANCELED: 'Canceled',
-        TOKEN_RENEW_STATUS_COMPLETED: 'Completed',
-        TOKEN_RENEW_STATUS_IN_PROGRESS: 'In Progress',
+            TOKEN_KEYS: 'adal.token.keys';
+            ACCESS_TOKEN_KEY: 'adal.access.token.key';
+            EXPIRATION_KEY: 'adal.expiration.key';
+            STATE_LOGIN: 'adal.state.login';
+            STATE_RENEW: 'adal.state.renew';
+            NONCE_IDTOKEN: 'adal.nonce.idtoken';
+            SESSION_STATE: 'adal.session.state';
+            USERNAME: 'adal.username';
+            IDTOKEN: 'adal.idtoken';
+            ERROR: 'adal.error';
+            ERROR_DESCRIPTION: 'adal.error.description';
+            LOGIN_REQUEST: 'adal.login.request';
+            LOGIN_ERROR: 'adal.login.error';
+            RENEW_STATUS: 'adal.token.renew.status';
+        };
+        RESOURCE_DELIMETER: '|';
+        LOADFRAME_TIMEOUT: '6000';
+        TOKEN_RENEW_STATUS_CANCELED: 'Canceled';
+        TOKEN_RENEW_STATUS_COMPLETED: 'Completed';
+        TOKEN_RENEW_STATUS_IN_PROGRESS: 'In Progress';
         LOGGING_LEVEL: {
-            ERROR: 0,
-            WARN: 1,
-            INFO: 2,
-            VERBOSE: 3
-        },
+            ERROR: 0;
+            WARN: 1;
+            INFO: 2;
+            VERBOSE: 3;
+        };
         LEVEL_STRING_MAP: {
-            0: 'ERROR:',
-            1: 'WARNING:',
-            2: 'INFO:',
-            3: 'VERBOSE:'
-        },
-        POPUP_WIDTH: 483,
-        POPUP_HEIGHT: 600
+            0: 'ERROR:';
+            1: 'WARNING:';
+            2: 'INFO:';
+            3: 'VERBOSE:';
+        };
+        POPUP_WIDTH: 483;
+        POPUP_HEIGHT: 600;
     }
 }
 

--- a/types/adal-angular/index.d.ts
+++ b/types/adal-angular/index.d.ts
@@ -19,7 +19,8 @@ declare class AuthenticationContext {
      * Enum for request type
      * @enum {string}
      */
-    REQUEST_TYPE: AuthenticationContext.RequestType
+    REQUEST_TYPE: AuthenticationContext.RequestType;
+    RESPONSE_TYPE: AuthenticationContext.ResponseType;
     CONSTANTS: AuthenticationContext.Constants;
 
     constructor(options: AuthenticationContext.Options);
@@ -191,11 +192,7 @@ declare namespace AuthenticationContext {
 
     export function inject(config: Options): AuthenticationContext;
 
-<<<<<<< HEAD
     export type LoggingLevel = 0 | 1 | 2 | 3;
-=======
-  export type LoggingLevel = 0 | 1 | 2 | 3;
->>>>>>> cbea76b638b14254183d26e5fc281a80303a5768
 
     export type RequestType = "LOGIN" | "RENEW_TOKEN" | "UNKNOWN";
 
@@ -235,7 +232,6 @@ declare namespace AuthenticationContext {
         profile: any;
     }
 
-<<<<<<< HEAD
     export type TokenCallback = (
         errorDesc: string | null,
         token: string | null,
@@ -378,150 +374,6 @@ declare namespace AuthenticationContext {
         POPUP_WIDTH: 483,
         POPUP_HEIGHT: 600
     }
-=======
-  export type TokenCallback = (
-      errorDesc: string | null,
-      token: string | null,
-      error: any
-  ) => void;
-
-  export type UserCallback = (errorDesc: string | null, user: UserInfo | null) => void;
-
-  /**
-   * Configuration options for Authentication Context
-   */
-  export interface Options {
-      /**
-       * Client ID assigned to your app by Azure Active Directory.
-       */
-      clientId: string;
-      /**
-       * Endpoint at which you expect to receive tokens.Defaults to `window.location.href`.
-       */
-      redirectUri?: string;
-      /**
-       * Azure Active Directory instance. Defaults to `https://login.microsoftonline.com/`.
-       */
-      instance?: string;
-      /**
-       * Your target tenant. Defaults to `common`.
-       */
-      tenant?: string;
-      /**
-       * Query parameters to add to the authentication request.
-       */
-      extraQueryParameter?: string;
-      /**
-       * Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
-       */
-      correlationId?: string;
-      /**
-       * User defined function of handling the navigation to Azure AD authorization endpoint in case of login.
-       */
-      displayCall?: (url: string) => void;
-      /**
-       * Set this to true to enable login in a popup winodow instead of a full redirect. Defaults to `false`.
-       */
-      popUp?: boolean;
-      /**
-       * Set this to the resource to request on login. Defaults to `clientId`.
-       */
-      loginResource?: string;
-      /**
-       * Set this to redirect the user to a custom login page.
-       */
-      localLoginUrl?: string;
-      /**
-       * Redirects to start page after login. Defaults to `true`.
-       */
-      navigateToLoginRequestUrl?: boolean;
-      /**
-       * Set this to redirect the user to a custom logout page.
-       */
-      logOutUri?: string;
-      /**
-       * Redirects the user to postLogoutRedirectUri after logout. Defaults to `redirectUri`.
-       */
-      postLogoutRedirectUri?: string;
-      /**
-       * Sets browser storage to either 'localStorage' or sessionStorage'. Defaults to `sessionStorage`.
-       */
-      cacheLocation?: "localStorage" | "sessionStorage";
-      /**
-       * Array of keywords or URIs. Adal will attach a token to outgoing requests that have these keywords or URIs.
-       */
-      endpoints?: { [resource: string]: string };
-      /**
-       * Array of keywords or URIs. Adal will not attach a token to outgoing requests that have these keywords or URIs.
-       */
-      anonymousEndpoints?: string[];
-      /**
-       * If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 300 seconds.
-       */
-      expireOffsetSeconds?: number;
-      /**
-       * The number of milliseconds of inactivity before a token renewal response from AAD should be considered timed out. Defaults to 6 seconds.
-       */
-      loadFrameTimeout?: number;
-      /**
-       * Callback to be invoked when a token is acquired.
-       */
-      callback?: TokenCallback;
-  }
-
-  export interface LoggingConfig {
-    level: LoggingLevel;
-    log: (message: string) => void;
-    piiLoggingEnabled: boolean;
-  }
-
-  /**
-   * Enum for storage constants
-   * @enum {string}
-   */
-  export interface Constants {
-    ACCESS_TOKEN: 'access_token',
-    EXPIRES_IN: 'expires_in',
-    ID_TOKEN: 'id_token',
-    ERROR_DESCRIPTION: 'error_description',
-    SESSION_STATE: 'session_state',
-    STORAGE: {
-        TOKEN_KEYS: 'adal.token.keys',
-        ACCESS_TOKEN_KEY: 'adal.access.token.key',
-        EXPIRATION_KEY: 'adal.expiration.key',
-        STATE_LOGIN: 'adal.state.login',
-        STATE_RENEW: 'adal.state.renew',
-        NONCE_IDTOKEN: 'adal.nonce.idtoken',
-        SESSION_STATE: 'adal.session.state',
-        USERNAME: 'adal.username',
-        IDTOKEN: 'adal.idtoken',
-        ERROR: 'adal.error',
-        ERROR_DESCRIPTION: 'adal.error.description',
-        LOGIN_REQUEST: 'adal.login.request',
-        LOGIN_ERROR: 'adal.login.error',
-        RENEW_STATUS: 'adal.token.renew.status'
-    },
-    RESOURCE_DELIMETER: '|',
-    LOADFRAME_TIMEOUT: '6000',
-    TOKEN_RENEW_STATUS_CANCELED: 'Canceled',
-    TOKEN_RENEW_STATUS_COMPLETED: 'Completed',
-    TOKEN_RENEW_STATUS_IN_PROGRESS: 'In Progress',
-    LOGGING_LEVEL: {
-        ERROR: 0,
-        WARN: 1,
-        INFO: 2,
-        VERBOSE: 3
-    },
-    LEVEL_STRING_MAP: {
-        0: 'ERROR:',
-        1: 'WARNING:',
-        2: 'INFO:',
-        3: 'VERBOSE:'
-    },
-    POPUP_WIDTH: 483,
-    POPUP_HEIGHT: 600
-  }
->>>>>>> cbea76b638b14254183d26e5fc281a80303a5768
 }
 
 declare global {

--- a/types/adal-angular/index.d.ts
+++ b/types/adal-angular/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for adal-angular 1.0
 // Project: https://github.com/AzureAD/azure-activedirectory-library-for-js#readme
 // Definitions by: Daniel Perez Alvarez <https://github.com/unindented>
+//                 Anthony Ciccarello <https://github.com/aciccarello>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // In module contexts the class constructor function is the exported object
@@ -8,7 +9,18 @@ export = AuthenticationContext;
 
 // This class is defined globally in not in a module context
 declare class AuthenticationContext {
+    instance: string;
     config: AuthenticationContext.Options;
+    callback: AuthenticationContext.TokenCallback;
+    popUp: boolean;
+    isAngular: boolean;
+
+    /**
+     * Enum for request type
+     * @enum {string}
+     */
+    REQUEST_TYPE: AuthenticationContext.RequestType
+    CONSTANTS: AuthenticationContext.Constants;
 
     constructor(options: AuthenticationContext.Options);
     /**
@@ -148,153 +160,223 @@ declare class AuthenticationContext {
      * @param message Message to log.
      */
     verbose(message: string): void;
+
+    /**
+    * Logs Pii messages when Logging Level is set to 0 and window.piiLoggingEnabled is set to true.
+    * @param message Message to log.
+    * @param error Error to log.
+    */
+    errorPii(message: string, error: any): void;
+
+    /**
+     * Logs  Pii messages when Logging Level is set to 1 and window.piiLoggingEnabled is set to true.
+     * @param message Message to log.
+     */
+    warnPii(message: string): void;
+
+    /**
+     * Logs messages when Logging Level is set to 2 and window.piiLoggingEnabled is set to true.
+     * @param message Message to log.
+     */
+    infoPii(message: string): void;
+
+    /**
+     * Logs messages when Logging Level is set to 3 and window.piiLoggingEnabled is set to true.
+     * @param message Message to log.
+     */
+    verbosePii(message: string): void;
 }
 
 declare namespace AuthenticationContext {
 
-  export function inject(config: Options): AuthenticationContext;
+    export function inject(config: Options): AuthenticationContext;
 
-  export enum LoggingLevel {
-    ERROR = 0,
-    WARNING = 1,
-    INFO = 2,
-    VERBOSE = 3
-  }
+    export type LoggingLevel = 0 | 1 | 2 | 3;
 
-  export type RequestType = "LOGIN" | "RENEW_TOKEN" | "UNKNOWN";
+    export type RequestType = "LOGIN" | "RENEW_TOKEN" | "UNKNOWN";
 
-  export type ResponseType = "id_token token" | "token";
+    export type ResponseType = "id_token token" | "token";
 
-  export interface RequestInfo {
-      /**
-       * Object comprising of fields such as id_token/error, session_state, state, e.t.c.
-       */
-      parameters: any;
-      /**
-       * Request type.
-       */
-      requestType: RequestType;
-      /**
-       * Whether state is valid.
-       */
-      stateMatch: boolean;
-      /**
-       * Unique guid used to match the response with the request.
-       */
-      stateResponse: string;
-      /**
-       * Whether `requestType` contains `id_token`, `access_token` or error.
-       */
-      valid: boolean;
-  }
+    export interface RequestInfo {
+        /**
+        * Object comprising of fields such as id_token/error, session_state, state, e.t.c.
+        */
+        parameters: any;
+        /**
+        * Request type.
+        */
+        requestType: RequestType;
+        /**
+        * Whether state is valid.
+        */
+        stateMatch: boolean;
+        /**
+        * Unique guid used to match the response with the request.
+        */
+        stateResponse: string;
+        /**
+        * Whether `requestType` contains `id_token`, `access_token` or error.
+        */
+        valid: boolean;
+    }
 
-  export interface UserInfo {
-      /**
-       * Username assigned from UPN or email.
-       */
-      userName: string;
-      /**
-       * Properties parsed from `id_token`.
-       */
-      profile: any;
-  }
+    export interface UserInfo {
+        /**
+        * Username assigned from UPN or email.
+        */
+        userName: string;
+        /**
+        * Properties parsed from `id_token`.
+        */
+        profile: any;
+    }
 
-  export type TokenCallback = (
-      errorDesc: string | null,
-      token: string,
-      error: any
-  ) => void;
+    export type TokenCallback = (
+        errorDesc: string | null,
+        token: string | null,
+        error: any
+    ) => void;
 
-  export type UserCallback = (errorDesc: string | null, user: UserInfo) => void;
+    export type UserCallback = (errorDesc: string | null, user: UserInfo | null) => void;
 
-  export interface Options {
-      /**
-       * Client ID assigned to your app by Azure Active Directory.
-       */
-      clientId: string;
-      /**
-       * Endpoint at which you expect to receive tokens.Defaults to `window.location.href`.
-       */
-      redirectUri?: string;
-      /**
-       * Azure Active Directory instance. Defaults to `https://login.microsoftonline.com/`.
-       */
-      instance?: string;
-      /**
-       * Your target tenant. Defaults to `common`.
-       */
-      tenant?: string;
-      /**
-       * Query parameters to add to the authentication request.
-       */
-      extraQueryParameter?: string;
-      /**
-       * Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
-       */
-      correlationId?: string;
-      /**
-       * User defined function of handling the navigation to Azure AD authorization endpoint in case of login.
-       */
-      displayCall?: (url: string) => void;
-      /**
-       * Set this to true to enable login in a popup winodow instead of a full redirect. Defaults to `false`.
-       */
-      popUp?: boolean;
-      /**
-       * Set this to the resource to request on login. Defaults to `clientId`.
-       */
-      loginResource?: string;
-      /**
-       * Set this to redirect the user to a custom login page.
-       */
-      localLoginUrl?: string;
-      /**
-       * Redirects to start page after login. Defaults to `true`.
-       */
-      navigateToLoginRequestUrl?: boolean;
-      /**
-       * Set this to redirect the user to a custom logout page.
-       */
-      logOutUri?: string;
-      /**
-       * Redirects the user to postLogoutRedirectUri after logout. Defaults to `redirectUri`.
-       */
-      postLogoutRedirectUri?: string;
-      /**
-       * Sets browser storage to either 'localStorage' or sessionStorage'. Defaults to `sessionStorage`.
-       */
-      cacheLocation?: "localStorage" | "sessionStorage";
-      /**
-       * Array of keywords or URIs. Adal will attach a token to outgoing requests that have these keywords or URIs.
-       */
-      endpoints?: { [resource: string]: string };
-      /**
-       * Array of keywords or URIs. Adal will not attach a token to outgoing requests that have these keywords or URIs.
-       */
-      anonymousEndpoints?: string[];
-      /**
-       * If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 300 seconds.
-       */
-      expireOffsetSeconds?: number;
-      /**
-       * The number of milliseconds of inactivity before a token renewal response from AAD should be considered timed out. Defaults to 6 seconds.
-       */
-      loadFrameTimeout?: number;
-      /**
-       * Callback to be invoked when a token is acquired.
-       */
-      callback?: TokenCallback;
-  }
+    /**
+    * Configuration options for Authentication Context
+    */
+    export interface Options {
+        /**
+        * Client ID assigned to your app by Azure Active Directory.
+        */
+        clientId: string;
+        /**
+        * Endpoint at which you expect to receive tokens.Defaults to `window.location.href`.
+        */
+        redirectUri?: string;
+        /**
+        * Azure Active Directory instance. Defaults to `https://login.microsoftonline.com/`.
+        */
+        instance?: string;
+        /**
+        * Your target tenant. Defaults to `common`.
+        */
+        tenant?: string;
+        /**
+        * Query parameters to add to the authentication request.
+        */
+        extraQueryParameter?: string;
+        /**
+        * Unique identifier used to map the request with the response. Defaults to RFC4122 version 4 guid (128 bits).
+        */
+        correlationId?: string;
+        /**
+        * User defined function of handling the navigation to Azure AD authorization endpoint in case of login.
+        */
+        displayCall?: (url: string) => void;
+        /**
+        * Set this to true to enable login in a popup winodow instead of a full redirect. Defaults to `false`.
+        */
+        popUp?: boolean;
+        /**
+        * Set this to the resource to request on login. Defaults to `clientId`.
+        */
+        loginResource?: string;
+        /**
+        * Set this to redirect the user to a custom login page.
+        */
+        localLoginUrl?: string;
+        /**
+        * Redirects to start page after login. Defaults to `true`.
+        */
+        navigateToLoginRequestUrl?: boolean;
+        /**
+        * Set this to redirect the user to a custom logout page.
+        */
+        logOutUri?: string;
+        /**
+        * Redirects the user to postLogoutRedirectUri after logout. Defaults to `redirectUri`.
+        */
+        postLogoutRedirectUri?: string;
+        /**
+        * Sets browser storage to either 'localStorage' or sessionStorage'. Defaults to `sessionStorage`.
+        */
+        cacheLocation?: "localStorage" | "sessionStorage";
+        /**
+        * Array of keywords or URIs. Adal will attach a token to outgoing requests that have these keywords or URIs.
+        */
+        endpoints?: { [resource: string]: string };
+        /**
+        * Array of keywords or URIs. Adal will not attach a token to outgoing requests that have these keywords or URIs.
+        */
+        anonymousEndpoints?: string[];
+        /**
+        * If the cached token is about to be expired in the expireOffsetSeconds (in seconds), Adal will renew the token instead of using the cached token. Defaults to 300 seconds.
+        */
+        expireOffsetSeconds?: number;
+        /**
+        * The number of milliseconds of inactivity before a token renewal response from AAD should be considered timed out. Defaults to 6 seconds.
+        */
+        loadFrameTimeout?: number;
+        /**
+        * Callback to be invoked when a token is acquired.
+        */
+        callback?: TokenCallback;
+    }
 
-  export interface LoggingConfig {
-    level: LoggingLevel;
-    log: (message: string) => void;
-    piiLoggingEnabled: boolean;
-  }
+    export interface LoggingConfig {
+        level: LoggingLevel;
+        log: (message: string) => void;
+        piiLoggingEnabled: boolean;
+    }
+
+    /**
+    * Enum for storage constants
+    * @enum {string}
+    */
+    export interface Constants {
+        ACCESS_TOKEN: 'access_token',
+        EXPIRES_IN: 'expires_in',
+        ID_TOKEN: 'id_token',
+        ERROR_DESCRIPTION: 'error_description',
+        SESSION_STATE: 'session_state',
+        STORAGE: {
+            TOKEN_KEYS: 'adal.token.keys',
+            ACCESS_TOKEN_KEY: 'adal.access.token.key',
+            EXPIRATION_KEY: 'adal.expiration.key',
+            STATE_LOGIN: 'adal.state.login',
+            STATE_RENEW: 'adal.state.renew',
+            NONCE_IDTOKEN: 'adal.nonce.idtoken',
+            SESSION_STATE: 'adal.session.state',
+            USERNAME: 'adal.username',
+            IDTOKEN: 'adal.idtoken',
+            ERROR: 'adal.error',
+            ERROR_DESCRIPTION: 'adal.error.description',
+            LOGIN_REQUEST: 'adal.login.request',
+            LOGIN_ERROR: 'adal.login.error',
+            RENEW_STATUS: 'adal.token.renew.status'
+        },
+        RESOURCE_DELIMETER: '|',
+        LOADFRAME_TIMEOUT: '6000',
+        TOKEN_RENEW_STATUS_CANCELED: 'Canceled',
+        TOKEN_RENEW_STATUS_COMPLETED: 'Completed',
+        TOKEN_RENEW_STATUS_IN_PROGRESS: 'In Progress',
+        LOGGING_LEVEL: {
+            ERROR: 0,
+            WARN: 1,
+            INFO: 2,
+            VERBOSE: 3
+        },
+        LEVEL_STRING_MAP: {
+            0: 'ERROR:',
+            1: 'WARNING:',
+            2: 'INFO:',
+            3: 'VERBOSE:'
+        },
+        POPUP_WIDTH: 483,
+        POPUP_HEIGHT: 600
+    }
 }
 
 declare global {
-  interface Window {
-    Logging: AuthenticationContext.LoggingConfig;
-  }
+    interface Window {
+        Logging: AuthenticationContext.LoggingConfig;
+    }
 }

--- a/types/adal-angular/tsconfig.json
+++ b/types/adal-angular/tsconfig.json
@@ -15,7 +15,8 @@
         ],
         "types": [],
         "noEmit": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
     },
     "files": [
         "index.d.ts",


### PR DESCRIPTION
Changes the `adal-angular` type definition to match the library export implementation. See #12586 for discussion.

### Changes
- make `redirectUrl` config property optional
- add config and other properties to `AuthenticationContext` class
- export `import` helper
- define global `Logging` config object on `window`

This does not add the angular.js types that were previously removed.

### Issue Template Checklist
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
_getting a `stdout maxBuffer exceeded` error_
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
[node module export syntax](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/f20a0ddde2faef87f87aae8e6aafe4de2c6b7a50/lib/adal.js#L1930-L1935)
[additional properties](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/f20a0ddde2faef87f87aae8e6aafe4de2c6b7a50/lib/adal.js#L121-L125)
[define constants types](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/f20a0ddde2faef87f87aae8e6aafe4de2c6b7a50/lib/adal.js#L69-L113)
[logging config](https://github.com/AzureAD/azure-activedirectory-library-for-js/blob/f20a0ddde2faef87f87aae8e6aafe4de2c6b7a50/lib/adal.js#L193-L197)
- [ ] Increase the version number in the header if appropriate.
_N/A_
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
_already existing_
