### PR TITLE
pngjs: Fixed PNG.sync.write method signature

### DIFF
--- a/types/pngjs/index.d.ts
+++ b/types/pngjs/index.d.ts
@@ -24,7 +24,7 @@ export class PNG extends Duplex {
 
 	static sync: {
 		read(buffer: Buffer, options?: ParserOptions): PNG;
-		write(buffer: Buffer, options?: PackerOptions): PNG;
+		write(png: PNG, options?: PackerOptions): Buffer;
 	};
 
 	constructor(options?: PNGOptions);


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 

  https://github.com/lukeapage/pngjs/blob/master/examples/sync.js

With the example from the original library, it is clear that the first parameter of PNG.write.sync is a PNG object and the return value is a Buffer.
