### PR TITLE
[hubot] Add type for Robot.adapter

### DIFF
--- a/types/hubot/hubot-tests.ts
+++ b/types/hubot/hubot-tests.ts
@@ -4,11 +4,12 @@ const brain = new Hubot.Brain();
 brain; // $ExpectType Brain
 brain.userForName('someone'); // $ExpectType any
 
-const robot = new Hubot.Robot(
+const robot = new Hubot.Robot<{}>(
   'src/adapters',
   'slack',
   false,
   'hubot',
 );
-robot; // $ExpectType Robot
+robot; // $ExpectType Robot<{}>
+robot.adapter; // $ExpectType {}
 robot.hear(/hello/, () => null); // $ExpectType void

--- a/types/hubot/index.d.ts
+++ b/types/hubot/index.d.ts
@@ -20,26 +20,27 @@ declare namespace Hubot {
         id: string;
     }
 
-    class Response {
+    class Response<R> {
         match: RegExpMatchArray;
         message: Message;
 
-        constructor(robot: Robot, message: Message, match: RegExpMatchArray);
+        constructor(robot: R, message: Message, match: RegExpMatchArray);
         send(...strings: string[]): void;
         reply(...strings: string[]): void;
         random<T>(items: T[]): T;
     }
 
-    type ListenerCallback = (response: Response) => void;
+    type ListenerCallback<R> = (response: Response<R>) => void;
 
-    class Robot {
+    class Robot<A> {
         brain: Brain;
+        readonly adapter: A;
 
         constructor(adapterPath: string, adapter: string, httpd: boolean, name: string, alias?: string);
-        hear(regex: RegExp, callback: ListenerCallback): void;
-        hear(regex: RegExp, options: any, callback: ListenerCallback): void;
-        respond(regex: RegExp, callback: ListenerCallback): void;
-        respond(regex: RegExp, options: any, callback: ListenerCallback): void;
+        hear(regex: RegExp, callback: ListenerCallback<this>): void;
+        hear(regex: RegExp, options: any, callback: ListenerCallback<this>): void;
+        respond(regex: RegExp, callback: ListenerCallback<this>): void;
+        respond(regex: RegExp, options: any, callback: ListenerCallback<this>): void;
     }
 }
 


### PR DESCRIPTION
Hubot adapters are available on the Robot type as `robot.adapter`.
This is used, for example, by Slack, to access the Web API.
This commit adds a type parameter to Robot and the Robot.adapter member.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://slackapi.github.io/hubot-slack/basic_usage#general-web-api-patterns
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
