### PR TITLE
Fixes types for `args` and `OnChallangeHandler`

### DIFF
--- a/types/autobahn/index.d.ts
+++ b/types/autobahn/index.d.ts
@@ -25,7 +25,7 @@ declare namespace autobahn {
 
         leave(reason: string, message: string): void;
 
-        call<TResult>(procedure: string, args?: any[], kwargs?: any, options?: ICallOptions): When.Promise<TResult>;
+        call<TResult>(procedure: string, args?: any[] | any, kwargs?: any, options?: ICallOptions): When.Promise<TResult>;
 
         publish(topic: string, args?: any[], kwargs?: any, options?: IPublishOptions): When.Promise<IPublication>;
 
@@ -96,7 +96,7 @@ declare namespace autobahn {
         kwargs: any;
     }
 
-    type SubscribeHandler = (args?: any[], kwargs?: any, details?: IEvent) => void;
+    type SubscribeHandler = (args?: any[] | any, kwargs?: any, details?: IEvent) => void;
 
     interface ISubscription {
         topic: string;
@@ -206,7 +206,7 @@ declare namespace autobahn {
 
     type DeferFactory = () => When.Promise<any>;
 
-    type OnChallengeHandler = (session: Session, method: string, extra: any) => string;
+    type OnChallengeHandler = (session: Session, method: string, extra: any) => string | When.Promise<string>;
 
     interface IConnectionOptions {
         use_es6_promises?: boolean;


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24408

The Subscribe Handler and the call may use send an `any` if args only contain one element.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
