### PR TITLE
[Mongoose] Update pre hooks type definitions

### DIFF
--- a/types/mongoose/index.d.ts
+++ b/types/mongoose/index.d.ts
@@ -618,8 +618,74 @@ declare module "mongoose" {
     /**
      * Defines a pre hook for the document.
      */
-    pre(method: string, parallel: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): this;
-    pre(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): this;
+    pre<T extends Document = Document>(
+      method: "init" | "validate" | "save" | "remove",
+      fn: HookSyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+    pre<T extends Query<any> = Query<any>>(
+      method:
+        | "count"
+        | "find"
+        | "findOne"
+        | "findOneAndRemove"
+        | "findOneAndUpdate"
+        | "update",
+      fn: HookSyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+    pre<T extends Aggregate<any> = Aggregate<any>>(
+      method: "aggregate",
+      fn: HookSyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+    pre<T extends Model<Document> = Model<Document>>(
+      method: "insertMany",
+      fn: HookSyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+    pre<T extends Document | Model<Document> | Query<any> | Aggregate<any>>(
+      method: string,
+      fn: HookSyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+
+    pre<T extends Document = Document>(
+      method: "init" | "validate" | "save" | "remove",
+      parallel: boolean,
+      fn: HookAsyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+    pre<T extends Query<any> = Query<any>>(
+      method:
+        | "count"
+        | "find"
+        | "findOne"
+        | "findOneAndRemove"
+        | "findOneAndUpdate"
+        | "update",
+      parallel: boolean,
+      fn: HookAsyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+    pre<T extends Aggregate<any> = Aggregate<any>>(
+      method: "aggregate",
+      parallel: boolean,
+      fn: HookAsyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+    pre<T extends Model<Document> = Model<Document>>(
+      method: "insertMany",
+      parallel: boolean,
+      fn: HookAsyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
+    pre<T extends Document | Model<Document> | Query<any> | Aggregate<any>>(
+      method: string,
+      parallel: boolean,
+      fn: HookAsyncCallback<T>,
+      errorCb?: HookErrorCallback
+    ): this;
 
     /**
      * Adds a method call to the queue.
@@ -679,12 +745,12 @@ declare module "mongoose" {
   }
 
   // Hook functions: https://github.com/vkarpov15/hooks-fixed
-  interface HookSyncCallback {
-    (next: HookNextFunction): any;
+  interface HookSyncCallback<T> {
+    (this: T, next: HookNextFunction): Promise<any> | void;
   }
 
-  interface HookAsyncCallback {
-    (next: HookNextFunction, done: HookDoneFunction): any;
+  interface HookAsyncCallback<T> {
+    (this: T, next: HookNextFunction, done: HookDoneFunction): Promise<any> | void;
   }
 
   interface HookErrorCallback {

--- a/types/mongoose/mongoose-tests.ts
+++ b/types/mongoose/mongoose-tests.ts
@@ -260,6 +260,118 @@ schema.plugin(function (schema, opts) {
   }
 }).plugin(cb, {opts: true});
 
+/* `.pre` hook tests */
+
+interface PreHookTestDocumentInterface extends mongoose.Document {}
+interface PreHookTestQueryInterface<T> extends mongoose.Query<T> {}
+interface PreHookTestAggregateInterface<T> extends mongoose.Aggregate<T> {}
+interface PreHookTestModelInterface<T extends mongoose.Document> extends mongoose.Model<T> {}
+
+// it is used to ensure that all testing cases return a value of mongoose.Schema type
+const preHookTestSchemaArr: mongoose.Schema[] = [];
+
+// testing order:
+//   serial with default value and returning void
+//   serial with a type argument and returning a promise
+//   parallel with default value and returning void
+//   parallel with a type argument and returning a promise
+
+// Document
+preHookTestSchemaArr.push(
+  schema.pre("init", function (next) {
+    const isDefaultType: mongoose.Document = this;
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre<PreHookTestDocumentInterface>("init", function (next) {
+    const isSpecificType: PreHookTestDocumentInterface = this;
+    return Promise.resolve("");
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre("init", true, function (next, done) {
+    const isDefaultType: mongoose.Document = this;
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre<PreHookTestDocumentInterface>("init", true, function (next, done) {
+    const isSpecificType: PreHookTestDocumentInterface = this;
+    return Promise.resolve("");
+  }, err => {})
+);
+
+// Query
+preHookTestSchemaArr.push(
+  schema.pre("count", function (next) {
+    const isDefaultType: mongoose.Query<any> = this;
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre<PreHookTestQueryInterface<number>>("count", function (next) {
+    const isSpecificType: PreHookTestQueryInterface<number> = this;
+    return Promise.resolve("");
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre("count", true, function (next, done) {
+    const isDefaultType: mongoose.Query<any> = this;
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre<PreHookTestQueryInterface<number>>("count", true, function (next, done) {
+    const isSpecificType: PreHookTestQueryInterface<number> = this;
+    return Promise.resolve("");
+  }, err => {})
+);
+
+// Aggregate
+preHookTestSchemaArr.push(
+  schema.pre("aggregate", function(next) {
+    const isDefaultType: mongoose.Aggregate<any> = this;
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre<PreHookTestAggregateInterface<number>>("aggregate", function(next) {
+    const isSpecificType: PreHookTestAggregateInterface<number> = this;
+    return Promise.resolve("")
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre("aggregate", true, function(next, done) {
+    const isDefaultType: mongoose.Aggregate<any> = this;
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre<PreHookTestAggregateInterface<number>>("aggregate", true, function(next, done) {
+    const isSpecificType: PreHookTestAggregateInterface<number> = this;
+    return Promise.resolve("")
+  }, err => {})
+);
+
+// Model<Document>
+preHookTestSchemaArr.push(
+  schema.pre("insertMany", function(next) {
+    const isDefaultType: mongoose.Model<mongoose.Document> = this;
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre<PreHookTestModelInterface<PreHookTestDocumentInterface>>("insertMany", function(next) {
+    const isSpecificType: PreHookTestModelInterface<PreHookTestDocumentInterface> = this;
+    return Promise.resolve("")
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre("insertMany", true, function(next, done) {
+    const isDefaultType: mongoose.Model<mongoose.Document> = this;
+  }, err => {})
+);
+preHookTestSchemaArr.push(
+  schema.pre<PreHookTestModelInterface<PreHookTestDocumentInterface>>("insertMany", true, function(next, done) {
+    const isSpecificType: PreHookTestModelInterface<PreHookTestDocumentInterface> = this;
+    return Promise.resolve("")
+  }, err => {})
+);
+
 schema
 .post('save', function (error, doc, next) {
   error.stack;


### PR DESCRIPTION
Update pre hooks type definitions to have the opportunity to type `this` inside callback.
Add some tests.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24656
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
