### PR TITLE
chart.js: add ChartOptions.onHover alias and amend type

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -21,6 +21,9 @@ const chart: Chart = new Chart(new CanvasRenderingContext2D(), {
         hover: {
             intersect: true
         },
+        onHover(ev: MouseEvent, points: any[]) {
+          return;
+        },
         tooltips: {
             filter: data => Number(data.yLabel) > 0,
             intersect: true,

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -184,6 +184,7 @@ declare namespace Chart {
         aspectRatio?: number;
         maintainAspectRatio?: boolean;
         events?: string[];
+        onHover?(this: Chart, event: MouseEvent, activeElements: Array<{}>): any;
         onClick?(event?: MouseEvent, activeElements?: Array<{}>): any;
         title?: ChartTitleOptions;
         legend?: ChartLegendOptions;
@@ -291,7 +292,7 @@ declare namespace Chart {
         mode?: string;
         animationDuration?: number;
         intersect?: boolean;
-        onHover?(active: any): void;
+        onHover?(this: Chart, event: MouseEvent, activeElements: Array<{}>): any;
     }
 
     interface ChartAnimationObject {


### PR DESCRIPTION
Present in 2.7 as per docs and code. `ChartOptions.onHover` and `ChartHoverOptions.onHover` are equivalent.  Also added this type for these function (could be added for others -- not done here -- though different callbacks are called in different contexts).

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.chartjs.org/docs/latest/general/interactions/events.html https://github.com/chartjs/Chart.js/blob/v2.7.0/src/core/core.controller.js#L840
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.