### PR TITLE
[winston] No constructors on instance interfaces

### DIFF
--- a/types/winston/index.d.ts
+++ b/types/winston/index.d.ts
@@ -88,7 +88,6 @@ declare namespace winston {
     interface Winston {
         config: Config;
         transports: Transports;
-        Transport: TransportStatic;
         Logger: LoggerStatic;
         Container: ContainerStatic;
         loggers: ContainerInstance;
@@ -250,11 +249,25 @@ declare namespace winston {
         [optionName: string]: any;
     }
 
+    interface ContainerStatic {
+        new(options: LoggerOptions): ContainerInstance;
+    }
+
+    interface ContainerInstance {
+        get(id: string, options?: LoggerOptions): LoggerInstance;
+        add(id: string, options: LoggerOptions): LoggerInstance;
+        has(id: string): boolean;
+        close(id: string): void;
+        options: LoggerOptions;
+        loggers: {[key: string]: LoggerInstance};
+        default: LoggerOptions;
+    }
+
     interface TransportStatic {
         new(options?: TransportOptions): TransportInstance;
     }
 
-    interface TransportInstance extends TransportStatic, NodeJS.EventEmitter {
+    interface TransportInstance extends NodeJS.EventEmitter {
         silent: boolean;
         raw: boolean;
         name: string;
@@ -270,6 +283,10 @@ declare namespace winston {
         logException(msg: string, meta: Object, callback: () => void): void;
     }
 
+    interface ConsoleTransportStatic {
+        new(options?: ConsoleTransportOptions): ConsoleTransportInstance;
+    }
+
     interface ConsoleTransportInstance extends TransportInstance {
         json: boolean;
         colorize: boolean | 'all' | 'level' | 'message';
@@ -283,12 +300,11 @@ declare namespace winston {
         stderrLevels: { [key: string]: LeveledLogMethod; };
         eol: string;
 
-        new(options?: ConsoleTransportOptions): ConsoleTransportInstance;
         stringify?(obj: Object): string;
     }
 
-    interface DailyRotateFileTransportInstance extends TransportInstance {
-        new(options?: DailyRotateFileTransportOptions): DailyRotateFileTransportInstance;
+    interface FileTransportStatic {
+        new(options?: FileTransportOptions): FileTransportInstance;
     }
 
     interface FileTransportInstance extends TransportInstance {
@@ -309,8 +325,11 @@ declare namespace winston {
         maxRetries: number;
 
         close(): void;
-        new(options?: FileTransportOptions): FileTransportInstance;
         stringify?(obj: Object): string;
+    }
+
+    interface HttpTransportStatic {
+        new(options?: HttpTransportOptions): HttpTransportInstance;
     }
 
     interface HttpTransportInstance extends TransportInstance {
@@ -321,8 +340,10 @@ declare namespace winston {
         auth?: {username: string, password: string};
         path: string;
         agent?: Agent|null;
+    }
 
-        new(options?: HttpTransportOptions): HttpTransportInstance;
+    interface MemoryTransportStatic {
+        new(options?: MemoryTransportOptions): MemoryTransportInstance;
     }
 
     interface MemoryTransportInstance extends TransportInstance {
@@ -337,44 +358,18 @@ declare namespace winston {
         label: string|null;
         depth: string|null;
 
-        new(options?: MemoryTransportOptions): MemoryTransportInstance;
         stringify?(obj: Object): string;
-    }
-
-    interface WebhookTransportInstance extends TransportInstance {
-        new(options?: WebhookTransportOptions): WebhookTransportInstance;
-    }
-
-    interface WinstonModuleTrasportInstance extends TransportInstance {
-        new(options?: WinstonModuleTransportOptions): WinstonModuleTrasportInstance;
-    }
-
-    interface ContainerStatic {
-        new(options: LoggerOptions): ContainerInstance;
-    }
-
-    interface ContainerInstance extends ContainerStatic {
-        get(id: string, options?: LoggerOptions): LoggerInstance;
-        add(id: string, options: LoggerOptions): LoggerInstance;
-        has(id: string): boolean;
-        close(id: string): void;
-        options: LoggerOptions;
-        loggers: {[key: string]: LoggerInstance};
-        default: LoggerOptions;
     }
 
     interface Transports {
         File: FileTransportInstance;
         Console: ConsoleTransportInstance;
-        Loggly: WinstonModuleTrasportInstance;
-        DailyRotateFile: DailyRotateFileTransportInstance;
         Http: HttpTransportInstance;
         Memory: MemoryTransportInstance;
-        Webhook: WebhookTransportInstance;
     }
 
-    type TransportOptions = ConsoleTransportOptions | DailyRotateFileTransportOptions | FileTransportOptions
-        | HttpTransportOptions | MemoryTransportOptions | WebhookTransportOptions | WinstonModuleTransportOptions;
+    type TransportOptions = ConsoleTransportOptions | FileTransportOptions | HttpTransportOptions
+        | MemoryTransportOptions | WinstonModuleTransportOptions;
 
     interface GenericTransportOptions {
         level?: string;
@@ -416,22 +411,6 @@ declare namespace winston {
         debugStdout?: boolean;
     }
 
-    interface DailyRotateFileTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
-        logstash?: boolean;
-        maxsize?: number;
-        maxFiles?: number;
-        eol?: string;
-        maxRetries?: number;
-        datePattern?: string;
-        filename?: string;
-        dirname?: string;
-        options?: {
-            flags?: string;
-            highWaterMark?: number;
-        };
-        stream?: NodeJS.WritableStream;
-    }
-
     interface FileTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
         logstash?: boolean;
         maxsize?: number;
@@ -455,15 +434,6 @@ declare namespace winston {
     }
 
     interface MemoryTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
-    }
-
-    interface WebhookTransportOptions extends GenericTransportOptions, GenericNetworkTransportOptions {
-        method?: string;
-        ssl?: {
-            key?: any;
-            cert?: any;
-            ca: any;
-        };
     }
 
     interface WinstonModuleTransportOptions extends GenericTransportOptions {

--- a/types/winston/index.d.ts
+++ b/types/winston/index.d.ts
@@ -88,6 +88,7 @@ declare namespace winston {
     interface Winston {
         config: Config;
         transports: Transports;
+        Transport: TransportStatic;
         Logger: LoggerStatic;
         Container: ContainerStatic;
         loggers: ContainerInstance;
@@ -249,20 +250,6 @@ declare namespace winston {
         [optionName: string]: any;
     }
 
-    interface ContainerStatic {
-        new(options: LoggerOptions): ContainerInstance;
-    }
-
-    interface ContainerInstance {
-        get(id: string, options?: LoggerOptions): LoggerInstance;
-        add(id: string, options: LoggerOptions): LoggerInstance;
-        has(id: string): boolean;
-        close(id: string): void;
-        options: LoggerOptions;
-        loggers: {[key: string]: LoggerInstance};
-        default: LoggerOptions;
-    }
-
     interface TransportStatic {
         new(options?: TransportOptions): TransportInstance;
     }
@@ -283,10 +270,6 @@ declare namespace winston {
         logException(msg: string, meta: Object, callback: () => void): void;
     }
 
-    interface ConsoleTransportStatic {
-        new(options?: ConsoleTransportOptions): ConsoleTransportInstance;
-    }
-
     interface ConsoleTransportInstance extends TransportInstance {
         json: boolean;
         colorize: boolean | 'all' | 'level' | 'message';
@@ -303,8 +286,12 @@ declare namespace winston {
         stringify?(obj: Object): string;
     }
 
-    interface FileTransportStatic {
-        new(options?: FileTransportOptions): FileTransportInstance;
+    interface ConsoleTransportStatic {
+        new(options?: ConsoleTransportOptions): ConsoleTransportInstance;
+    }
+
+    interface DailyRotateFileTransportStatic {
+        new(options?: DailyRotateFileTransportOptions): TransportInstance;
     }
 
     interface FileTransportInstance extends TransportInstance {
@@ -328,8 +315,8 @@ declare namespace winston {
         stringify?(obj: Object): string;
     }
 
-    interface HttpTransportStatic {
-        new(options?: HttpTransportOptions): HttpTransportInstance;
+    interface FileTransportStatic {
+        new(options?: FileTransportOptions): FileTransportInstance;
     }
 
     interface HttpTransportInstance extends TransportInstance {
@@ -342,8 +329,8 @@ declare namespace winston {
         agent?: Agent|null;
     }
 
-    interface MemoryTransportStatic {
-        new(options?: MemoryTransportOptions): MemoryTransportInstance;
+    interface HttpTransportStatic {
+        new(options?: HttpTransportOptions): HttpTransportInstance;
     }
 
     interface MemoryTransportInstance extends TransportInstance {
@@ -361,6 +348,31 @@ declare namespace winston {
         stringify?(obj: Object): string;
     }
 
+    interface MemoryTransportStatic {
+        new(options?: MemoryTransportOptions): MemoryTransportInstance;
+    }
+
+
+    interface WebhookTransportStatic {
+        new(options?: WebhookTransportOptions): TransportInstance;
+    }
+
+    interface WinstonModuleTrasportStatic {
+        new(options?: WinstonModuleTransportOptions): TransportInstance;
+    }
+    interface ContainerStatic {
+        new(options: LoggerOptions): ContainerInstance;
+    }
+
+    interface ContainerInstance {
+        get(id: string, options?: LoggerOptions): LoggerInstance;
+        add(id: string, options: LoggerOptions): LoggerInstance;
+        has(id: string): boolean;
+        close(id: string): void;
+        options: LoggerOptions;
+        loggers: {[key: string]: LoggerInstance};
+        default: LoggerOptions;
+    }
     interface Transports {
         File: FileTransportInstance;
         Console: ConsoleTransportInstance;
@@ -368,8 +380,8 @@ declare namespace winston {
         Memory: MemoryTransportInstance;
     }
 
-    type TransportOptions = ConsoleTransportOptions | FileTransportOptions | HttpTransportOptions
-        | MemoryTransportOptions | WinstonModuleTransportOptions;
+    type TransportOptions = ConsoleTransportOptions | DailyRotateFileTransportOptions | FileTransportOptions
+        | HttpTransportOptions | MemoryTransportOptions | WebhookTransportOptions | WinstonModuleTransportOptions;
 
     interface GenericTransportOptions {
         level?: string;
@@ -411,6 +423,22 @@ declare namespace winston {
         debugStdout?: boolean;
     }
 
+    interface DailyRotateFileTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
+        logstash?: boolean;
+        maxsize?: number;
+        maxFiles?: number;
+        eol?: string;
+        maxRetries?: number;
+        datePattern?: string;
+        filename?: string;
+        dirname?: string;
+        options?: {
+            flags?: string;
+            highWaterMark?: number;
+        };
+        stream?: NodeJS.WritableStream;
+    }
+
     interface FileTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
         logstash?: boolean;
         maxsize?: number;
@@ -434,6 +462,15 @@ declare namespace winston {
     }
 
     interface MemoryTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
+    }
+
+    interface WebhookTransportOptions extends GenericTransportOptions, GenericNetworkTransportOptions {
+        method?: string;
+        ssl?: {
+            key?: any;
+            cert?: any;
+            ca: any;
+        };
     }
 
     interface WinstonModuleTransportOptions extends GenericTransportOptions {

--- a/types/winston/index.d.ts
+++ b/types/winston/index.d.ts
@@ -88,9 +88,9 @@ declare namespace winston {
     interface Winston {
         config: Config;
         transports: Transports;
-        Transport: TransportStatic;
-        Logger: LoggerStatic;
-        Container: ContainerStatic;
+        Transport: Transport;
+        Logger: Logger;
+        Container: Container;
         loggers: ContainerInstance;
         default: LoggerInstance;
 
@@ -183,7 +183,7 @@ declare namespace winston {
 
     type MetadataFilter = (level: string, msg: string, meta: any) => string | { msg: any; meta: any; };
 
-    interface LoggerStatic {
+    interface Logger {
         new (options?: LoggerOptions): LoggerInstance;
     }
 
@@ -250,7 +250,7 @@ declare namespace winston {
         [optionName: string]: any;
     }
 
-    interface TransportStatic {
+    interface Transport {
         new(options?: TransportOptions): TransportInstance;
     }
 
@@ -286,12 +286,8 @@ declare namespace winston {
         stringify?(obj: Object): string;
     }
 
-    interface ConsoleTransportStatic {
+    interface ConsoleTransport {
         new(options?: ConsoleTransportOptions): ConsoleTransportInstance;
-    }
-
-    interface DailyRotateFileTransportStatic {
-        new(options?: DailyRotateFileTransportOptions): TransportInstance;
     }
 
     interface FileTransportInstance extends TransportInstance {
@@ -315,7 +311,7 @@ declare namespace winston {
         stringify?(obj: Object): string;
     }
 
-    interface FileTransportStatic {
+    interface FileTransport {
         new(options?: FileTransportOptions): FileTransportInstance;
     }
 
@@ -329,7 +325,7 @@ declare namespace winston {
         agent?: Agent|null;
     }
 
-    interface HttpTransportStatic {
+    interface HttpTransport {
         new(options?: HttpTransportOptions): HttpTransportInstance;
     }
 
@@ -348,19 +344,11 @@ declare namespace winston {
         stringify?(obj: Object): string;
     }
 
-    interface MemoryTransportStatic {
+    interface MemoryTransport {
         new(options?: MemoryTransportOptions): MemoryTransportInstance;
     }
 
-
-    interface WebhookTransportStatic {
-        new(options?: WebhookTransportOptions): TransportInstance;
-    }
-
-    interface WinstonModuleTrasportStatic {
-        new(options?: WinstonModuleTransportOptions): TransportInstance;
-    }
-    interface ContainerStatic {
+    interface Container {
         new(options: LoggerOptions): ContainerInstance;
     }
 
@@ -373,15 +361,15 @@ declare namespace winston {
         loggers: {[key: string]: LoggerInstance};
         default: LoggerOptions;
     }
+
     interface Transports {
-        File: FileTransportInstance;
-        Console: ConsoleTransportInstance;
-        Http: HttpTransportInstance;
-        Memory: MemoryTransportInstance;
+        File: FileTransport;
+        Console: ConsoleTransport;
+        Http: HttpTransport;
+        Memory: MemoryTransport;
     }
 
-    type TransportOptions = ConsoleTransportOptions | DailyRotateFileTransportOptions | FileTransportOptions
-        | HttpTransportOptions | MemoryTransportOptions | WebhookTransportOptions | WinstonModuleTransportOptions;
+    type TransportOptions = ConsoleTransportOptions | FileTransportOptions | HttpTransportOptions | MemoryTransportOptions;
 
     interface GenericTransportOptions {
         level?: string;
@@ -423,22 +411,6 @@ declare namespace winston {
         debugStdout?: boolean;
     }
 
-    interface DailyRotateFileTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
-        logstash?: boolean;
-        maxsize?: number;
-        maxFiles?: number;
-        eol?: string;
-        maxRetries?: number;
-        datePattern?: string;
-        filename?: string;
-        dirname?: string;
-        options?: {
-            flags?: string;
-            highWaterMark?: number;
-        };
-        stream?: NodeJS.WritableStream;
-    }
-
     interface FileTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
         logstash?: boolean;
         maxsize?: number;
@@ -462,19 +434,6 @@ declare namespace winston {
     }
 
     interface MemoryTransportOptions extends GenericTransportOptions, GenericTextTransportOptions {
-    }
-
-    interface WebhookTransportOptions extends GenericTransportOptions, GenericNetworkTransportOptions {
-        method?: string;
-        ssl?: {
-            key?: any;
-            cert?: any;
-            ca: any;
-        };
-    }
-
-    interface WinstonModuleTransportOptions extends GenericTransportOptions {
-        [optionName: string]: any;
     }
 
     interface QueryOptions {

--- a/types/winston/winston-tests.ts
+++ b/types/winston/winston-tests.ts
@@ -24,14 +24,14 @@ const loggerOptions: winston.LoggerOptions = {
 
 declare const options: any;
 let value: any;
-let transport: winston.TransportInstance;
+const transport: winston.TransportInstance = new winston.transports.Console();
 let logger: winston.LoggerInstance;
 let profiler: winston.ProfileHandler;
 
 declare const writeableStream: NodeJS.WritableStream;
 let readableStream: NodeJS.ReadableStream;
 
-const transportStatic: winston.TransportStatic = winston.Transport;
+const transportStatic: winston.Transport = winston.Transport;
 
 let transportInstance: winston.TransportInstance = new (winston.Transport)(transportOptions);
 transportInstance = new (winston.Transport)();
@@ -58,14 +58,6 @@ logger = winston.loggers.get('category1');
 bool = containerInstance.has(str);
 logger = containerInstance.get(str, loggerOptions);
 containerInstance.close(str);
-
-transport = winston.transports.Console;
-transport = winston.transports.DailyRotateFile;
-transport = winston.transports.File;
-transport = winston.transports.Http;
-transport = winston.transports.Loggly;
-transport = winston.transports.Memory;
-transport = winston.transports.Webhook;
 
 value = transport.formatQuery({});
 queryOptions = transport.normalizeQuery(queryOptions);
@@ -187,22 +179,6 @@ logger = new (winston.Logger)({
       debugStdout: bool,
       depth: num,
     }),
-    new (winston.transports.DailyRotateFile)({
-      level: str,
-      silent: bool,
-      json: bool,
-      colorize: bool,
-      maxsize: num,
-      maxFiles: num,
-      maxRetries: num,
-      prettyPrint: bool,
-      timestamp: stamp,
-      filename: str,
-      dirname: str,
-      datePattern: str,
-      eol: str,
-      stream: writeableStream,
-    }),
     new (winston.transports.File)({
       level: str,
       silent: bool,
@@ -231,13 +207,6 @@ logger = new (winston.Logger)({
       auth: { username: str, password: str },
       ssl: bool,
     }),
-    new (winston.transports.Loggly)({
-      level: str,
-      subdomain: str,
-      auth: {},
-      inputName: str,
-      json: bool,
-    }),
     new (winston.transports.Memory)({
       level: str,
       json: bool,
@@ -246,16 +215,6 @@ logger = new (winston.Logger)({
       depth: num,
       timestamp: stamp,
       label: str,
-    }),
-    new (winston.transports.Webhook)({
-      level: str,
-      name: str,
-      host: str,
-      port: num,
-      method: str,
-      path: str,
-      auth: { username: str, password: str },
-      ssl: {ca: {}},
     }),
   ]
 });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [No Instance Interfaces with Constructors](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
