### PR TITLE
Added AWSLambda.KinesisDataStream event type definitions (aws-lambda)

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -572,6 +572,28 @@ const CloudFrontResponseEvent: AWSLambda.CloudFrontResponseEvent = {
     ]
 };
 
+/* Kinesis Data Stream Events */
+declare let kinesisStreamEvent: AWSLambda.KinesisStreamEvent;
+declare let kinesisStreamRecord: AWSLambda.KinesisStreamRecord;
+declare let kinesisStreamRecordPayload: AWSLambda.KinesisStreamRecordPayload;
+
+kinesisStreamRecord = kinesisStreamEvent.Records[0];
+
+str = kinesisStreamRecord.awsRegion;
+str = kinesisStreamRecord.eventID;
+str = kinesisStreamRecord.eventName;
+str = kinesisStreamRecord.eventSource;
+str = kinesisStreamRecord.eventSourceARN;
+str = kinesisStreamRecord.eventVersion;
+str = kinesisStreamRecord.invokeIdentityArn;
+kinesisStreamRecordPayload = kinesisStreamRecord.kinesis;
+
+num = kinesisStreamRecordPayload.approximateArrivalTimestamp;
+str = kinesisStreamRecordPayload.data;
+str = kinesisStreamRecordPayload.kinesisSchemaVersion;
+str = kinesisStreamRecordPayload.partitionKey;
+str = kinesisStreamRecordPayload.sequenceNumber;
+
 /* Compatibility functions */
 context.done();
 context.done(error);
@@ -661,3 +683,5 @@ let customHandler: AWSLambda.Handler<CustomEvent, CustomResult> = (event, contex
     // $ExpectError
     cb(null, { resultString: bool });
 };
+
+let kinesisStreamHandler: AWSLambda.KinesisStreamHandler = (event: AWSLambda.KinesisStreamEvent, context: AWSLambda.Context, cb: AWSLambda.Callback<void>) => { };

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -16,6 +16,7 @@
 //                 Danilo Raisi <https://github.com/daniloraisi>
 //                 Simon Buchan <https://github.com/simonbuchan>
 //                 David Hayden <https://github.com/Haydabase>
+//                 Chris Redekop <https://github.com/repl-chris>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -529,6 +530,31 @@ export interface CloudFrontRequestEvent {
 
 export type CloudFrontResponseResult = undefined | null | CloudFrontResultResponse;
 
+// Kinesis Streams
+// https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-kinesis-streams
+export interface KinesisStreamRecordPayload {
+    approximateArrivalTimestamp: number;
+    data: string;
+    kinesisSchemaVersion: string;
+    partitionKey: string;
+    sequenceNumber: string;
+}
+
+export interface KinesisStreamRecord {
+    awsRegion: string;
+    eventID: string;
+    eventName: string;
+    eventSource: string;
+    eventSourceARN: string;
+    eventVersion: string;
+    invokeIdentityArn: string;
+    kinesis: KinesisStreamRecordPayload;
+}
+
+export interface KinesisStreamEvent {
+    Records: KinesisStreamRecord[];
+}
+
 /**
  * AWS Lambda handler function.
  * http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html
@@ -595,7 +621,9 @@ export type CloudFrontRequestCallback = Callback<CloudFrontRequestResult>;
 export type CloudFrontResponseHandler = Handler<CloudFrontResponseEvent, CloudFrontResponseResult>;
 export type CloudFrontResponseCallback = Callback<CloudFrontResponseResult>;
 
-// TODO: Kinesis (should be very close to DynamoDB stream?)
+export type KinesisStreamHandler = Handler<KinesisStreamEvent, void>;
+
+// TODO: Kinesis Firehose
 
 export type CustomAuthorizerHandler = Handler<CustomAuthorizerEvent, CustomAuthorizerResult>;
 export type CustomAuthorizerCallback = Callback<CustomAuthorizerResult>;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-kinesis-streams>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

