### PR TITLE
c3: add missing fields in LegendOptions

### DIFF
--- a/types/c3/c3-tests.ts
+++ b/types/c3/c3-tests.ts
@@ -1798,6 +1798,26 @@ function legend_custom() {
         });
 }
 
+function legend_tiles() {
+    const chart = c3.generate({
+        data: {
+            columns: [
+                ["sample", 30, 200, 100, 400, 150, 250]
+            ]
+        },
+        legend: {
+            // amount of padding to put between each legend element
+            padding: 5,
+            // define custom height and width for the legend item tile
+            item: {
+                tile: {
+                    width: 15,
+                    height: 2
+                }
+            }
+        }});
+}
+
 /////////////////////
 // Tooltip Tests
 /////////////////////

--- a/types/c3/index.d.ts
+++ b/types/c3/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for C3js 0.5
+// Type definitions for C3js 0.6
 // Project: http://c3js.org/
 // Definitions by: Marc Climent <https://github.com/mcliment>
 //                 Gerin Jacob <https://github.com/gerinjacob>
 //                 Bernd Hacker <https://github.com/denyo>
 //                 Dzmitry Shyndzin <https://github.com/dmitryshindin>
+//                 Tim Niemueller <https://github.com/timn>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -700,6 +701,10 @@ export interface LegendOptions {
         y?: number;
         step?: number;
     };
+    /**
+     * Padding between legend elements.
+     */
+    padding?: number;
 
     item?: {
         /**
@@ -714,6 +719,19 @@ export interface LegendOptions {
          * Set mouseout event handler to the legend item.
          */
         onmouseout?(id: any): void;
+        /**
+         * Tile settings for legend color display.
+         */
+        tile?: {
+            /**
+             * Tile width.
+             */
+            width?: number;
+            /**
+             * Tile height
+             */
+            height?: number;
+        }
     };
 }
 


### PR DESCRIPTION
There is configuration for tiles introduced with
https://github.com/c3js/c3/issues/1033 and defined in
spec/legend-spec.js which is missing from types/c3.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
https://github.com/c3js/c3/issues/1033
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
