### PR TITLE
Hackily added toMatch to expect-puppeteer

### DIFF
--- a/types/expect-puppeteer/expect-puppeteer-tests.ts
+++ b/types/expect-puppeteer/expect-puppeteer-tests.ts
@@ -10,6 +10,9 @@ const testGlobal = async (instance: ElementHandle | Page) => {
     await expect(instance).toFill("selector", "value");
     await expect(instance).toFill("selector", "value", { polling: 777 });
 
+    await expect(instance).toMatch("selector");
+    await expect(instance).toMatch("selector", { timeout: 777 });
+
     await expect(instance).toMatchElement("selector", "value");
     await expect(instance).toMatchElement("selector", "value", { polling: "mutation" });
 

--- a/types/expect-puppeteer/index.d.ts
+++ b/types/expect-puppeteer/index.d.ts
@@ -36,9 +36,12 @@ interface ExpectToClickOptions extends ExpectTimingActions {
 }
 
 interface ExpectPuppeteer {
+    // These must all match the ExpectPuppeteer interface above.
+    // We can't extend from it directly because some method names conflict in type-incompatible ways.
     toClick(selector: string, options?: ExpectToClickOptions): Promise<void>;
     toDisplayDialog(block: () => Promise<void>): Promise<void>;
     toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
+    toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
     toMatchElement(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
     toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
     toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;
@@ -47,7 +50,17 @@ interface ExpectPuppeteer {
 declare global {
     namespace jest {
         // tslint:disable-next-line no-empty-interface
-        interface Matchers<R> extends ExpectPuppeteer { }
+        interface Matchers<R> {
+            // These must all match the ExpectPuppeteer interface above.
+            // We can't extend from it directly because some method names conflict in type-incompatible ways.
+            toClick(selector: string, options?: ExpectToClickOptions): Promise<void>;
+            toDisplayDialog(block: () => Promise<void>): Promise<void>;
+            toFill(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
+            toMatch(selector: string, options?: ExpectTimingActions): Promise<void>;
+            toMatchElement(selector: string, value: string, options?: ExpectTimingActions): Promise<void>;
+            toSelect(selector: string, valueOrText: string, options?: ExpectTimingActions): Promise<void>;
+            toUploadFile(selector: string, filePath: string, options?: ExpectTimingActions): Promise<void>;
+        }
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/smooth-code/jest-puppeteer/issues/26
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I dislike this solution... but don't see a way around it.