### PR TITLE
Jest: Update `MockInstance` to use `ReturnType`

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -14,7 +14,7 @@
 //                 Josh Goldberg <https://github.com/joshuakgoldberg>
 //                 Bradley Ayers <https://github.com/bradleyayers>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.3
+// TypeScript Version: 2.8
 
 declare var beforeAll: jest.Lifecycle;
 declare var beforeEach: jest.Lifecycle;
@@ -538,16 +538,16 @@ declare namespace jest {
         mock: MockContext<T>;
         mockClear(): void;
         mockReset(): void;
-        mockImplementation(fn: (...args: any[]) => any): Mock<T>;
-        mockImplementationOnce(fn: (...args: any[]) => any): Mock<T>;
+        mockImplementation(fn: (...args: any[]) => ReturnType<T>): Mock<T>;
+        mockImplementationOnce(fn: (...args: any[]) => ReturnType<T>): Mock<T>;
         mockName(name: string): Mock<T>;
         mockReturnThis(): Mock<T>;
-        mockReturnValue(value: any): Mock<T>;
-        mockReturnValueOnce(value: any): Mock<T>;
-        mockResolvedValue(value: any): Mock<T>;
-        mockResolvedValueOnce(value: any): Mock<T>;
-        mockRejectedValue(value: any): Mock<T>;
-        mockRejectedValueOnce(value: any): Mock<T>;
+        mockReturnValue(value: ReturnType<T>): Mock<T>;
+        mockReturnValueOnce(value: ReturnType<T>): Mock<T>;
+        mockResolvedValue(value: ReturnType<T>): Mock<T>;
+        mockResolvedValueOnce(value: ReturnType<T>): Mock<T>;
+        mockRejectedValue(value: ReturnType<T>): Mock<T>;
+        mockRejectedValueOnce(value: ReturnType<T>): Mock<T>;
     }
 
     interface MockContext<T> {


### PR DESCRIPTION
This PR updates `MockInstance` to use `ReturnType` (new in TypeScript 2.8).

See: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
