### PR TITLE
[RRN] Change Link.component to ComponentType

### DIFF
--- a/types/react-router-native/index.d.ts
+++ b/types/react-router-native/index.d.ts
@@ -33,7 +33,7 @@ export class AndroidBackButton extends React.Component<BackButtonProps> {}
 export class DeepLinking extends React.Component {}
 
 export interface LinkProps {
-  component?: React.Component | React.ComponentClass;
+  component?: React.ComponentType<any>;
   replace?: boolean;
   style?: any;
   to: H.LocationDescriptor;

--- a/types/react-router-native/react-router-native-tests.tsx
+++ b/types/react-router-native/react-router-native-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import { NativeRouter as Router, Route, Link, AndroidBackButton, BackButton } from 'react-router-native';
+import { StyleSheet, Text, TouchableOpacity, TouchableOpacityProperties, View } from 'react-native';
+import { AndroidBackButton, BackButton, Link, NativeRouter as Router, Route } from 'react-router-native';
 
 const Home: React.SFC = () => {
   return (
@@ -24,6 +24,14 @@ const About: React.SFC = () => {
  );
 };
 
+interface ButtonTextProps extends TouchableOpacityProperties {
+    text: string;
+}
+
+const ButtonText: React.SFC<ButtonTextProps> = ({ text, ...props }) => (
+  <TouchableOpacity {...props}><Text>{text}</Text></TouchableOpacity>
+);
+
 export default class App extends React.Component {
   render() {
     return (
@@ -35,9 +43,7 @@ export default class App extends React.Component {
               <Link to="/" style={styles.navItem}>
                 <Text>Home</Text>
               </Link>
-              <Link to="/about" style={styles.navItem}>
-                <Text>About</Text>
-              </Link>
+              <Link to="/about" style={styles.navItem} component={ButtonText} text="About" />
             </View>
             <Route exact path="/" component={Home} />
             <Route path="/about" component={About} />


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

With ˙component˙ prop of ˙Link˙ being `React.Component | React.ComponentClass` it's not possible to use stateless component. Using `React.ComponentType<any>` should solve this.