### PR TITLE
Improve type inference of react-redux

### DIFF
--- a/types/react-redux/index.d.ts
+++ b/types/react-redux/index.d.ts
@@ -10,14 +10,14 @@
 //                 Prashant Deva <https://github.com/pdeva>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
-    
+
 // Known Issue:
-// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes 
+// There is a known issue in TypeScript, which doesn't allow decorators to change the signature of the classes
 // they are decorating. Due to this, if you are using @connect() decorator in your code,
 // you will see a bunch of errors from TypeScript. The current workaround is to use connect() as a function call on
 // a separate line instead of as a decorator. Discussed in this github issue:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20796
-    
+
 import * as React from 'react';
 import * as Redux from 'redux';
 
@@ -80,17 +80,17 @@ export interface Connect {
 
     <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, State = {}>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>
-    ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp<any>, TOwnProps>;
+    ): InferableComponentEnhancerWithProps<TStateProps & DispatchProp<any> & TOwnProps, TOwnProps>;
 
     <no_state = {}, TDispatchProps = {}, TOwnProps = {}>(
         mapStateToProps: null | undefined,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-    ): InferableComponentEnhancerWithProps<TDispatchProps, TOwnProps>;
+    ): InferableComponentEnhancerWithProps<TDispatchProps & TOwnProps, TOwnProps>;
 
     <TStateProps = {}, TDispatchProps = {}, TOwnProps = {}, State = {}>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
         mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps, TOwnProps>
-    ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps, TOwnProps>;
+    ): InferableComponentEnhancerWithProps<TStateProps & TDispatchProps & TOwnProps, TOwnProps>;
 
     <TStateProps = {}, no_dispatch = {}, TOwnProps = {}, TMergedProps = {}, State = {}>(
         mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,

--- a/types/react-redux/react-redux-tests.tsx
+++ b/types/react-redux/react-redux-tests.tsx
@@ -899,3 +899,25 @@ namespace TestCreateProvider {
     // <h1>A is 2</h1>
     ReactDOM.render(<Combined />, document.body);
 }
+
+namespace TestTypeInference {
+    interface State { a: number };
+
+    const OnlyState = connect(
+        (state: {a: number}, props: {b: number}) => ({a: state.a, c: state.a + props.b})
+    )(props => <span>{props.a} + {props.b} = {props.c}</span>)
+    interface State { a: number };
+    ReactDOM.render(<OnlyState b={1} />, document.body);
+
+    const OnlyDispatch = connect(
+        undefined,
+        (dispatch, props: {b: number}) => ({action: () => dispatch({type: 'action', b: props.b})})
+    )(props => <span onClick={props.action}>{props.b}</span>)
+    ReactDOM.render(<OnlyDispatch b={1} />, document.body);
+
+    const StateAndDispatch = connect(
+        (state: {a: number}, props: {b: number}) => ({a: state.a, c: state.a + props.b}),
+        (dispatch, props: {b: number}) => ({action: () => dispatch({type: 'action', b: props.b})})
+    )(props => <span>{props.a} + {props.b} = {props.c}</span>)
+    ReactDOM.render(<StateAndDispatch b={1} />, document.body);
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

react-redux allows you to access passed in props as well as those it gives you but the types did restrict this to only allow you to access extracted props.