### PR TITLE
[styled-jsx] Adjust css export

### DIFF
--- a/types/styled-jsx/css.d.ts
+++ b/types/styled-jsx/css.d.ts
@@ -1,4 +1,4 @@
 type Tag = (chunks: TemplateStringsArray, ...args: any[]) => string;
 
 declare let css: Tag;
-export default css;
+export = css;

--- a/types/styled-jsx/styled-jsx-tests.tsx
+++ b/types/styled-jsx/styled-jsx-tests.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import css from 'styled-jsx/css';
+import * as css from 'styled-jsx/css';
 import flushToReact, { flushToHTML } from 'styled-jsx/server';
 
 const styled = (


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes:
  - `import * as css from 'styled-jsx/css'` gives TypeScript error "cannot invoke an expression whose type lacks a call signature ": https://github.com/bensaufley/styled-jsx-example-issues/tree/2a2bef3c9de07a759363577c8cf0cb9f099b57d6 (reproduce by checking out that commit and running `npm run lint`)
  - `import css from 'styled-jsx/css'` says `css_1.default is not a function`: https://github.com/bensaufley/styled-jsx-example-issues/tree/06221d87582353ef9fbcfaea01e15b3e665c68da
- [ ] Increase the version number in the header if appropriate.  
  _Looks like this package is at version 2.2.2 but I can't find reference to that anywhere?_
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.  
  _I'm not making substantial changes_

# Description of change

`styled-jsx` uses Babel to transpile `` css`…` `` template literals. In practice, this appears to mean that TypeScript never compiles the export of `css`. Except I'm encountering a _separate_ issue currently wherein I can't get `babel-register` to intercept and properly interpolate and this code, and so it's making its way to the TypeScript, where I encounter one of two things (mentioned briefly above):

1. `import css from 'styled-jsx/css'`, which doesn't show any errors in Visual Studio Code, throws `css_1.default is not a function` when TypeScript tries to execute it. This is true: [the dummy file for `styled-jsx/css` uses `module.exports = function () { throw … }`](https://github.com/zeit/styled-jsx/blob/2bf539d4052b472adfbe6c05c48a27e177f334ea/css.js#L1) so there is no `.default` export.
2. `import * as css from 'styled-jsx/css'`, commonly used in TypeScript, gives me an error in Visual Studio Code, passed along from `[ts]`: "cannot invoke an expression whose type lacks a call signature".

In a browser, either `import css` or `import * as css` appears to work, with _and_ without this change—type-checking is apparently ignored and the files make it through Next.js's pipeline just fine. But in mocha, where I'm currently encountering issues hooking in the babel plugin, these changes seem to be the best way to make the Types match up to the output.