### PR TITLE
[React-native] Fix type for Stylesheet.flatten

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4804,10 +4804,7 @@ export namespace StyleSheet {
      * their respective objects, merged as one and then returned. This also explains
      * the alternative use.
      */
-    export function flatten<T>(style?: RegisteredStyle<T>): T;
-    export function flatten(style?: StyleProp<ViewStyle>): ViewStyle;
-    export function flatten(style?: StyleProp<TextStyle>): TextStyle;
-    export function flatten(style?: StyleProp<ImageStyle>): ImageStyle;
+    export function flatten<T>(style?: StyleProp<T>): T;
 
     /**
      * This is defined as the width of a thin line on the platform. It can be

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -4804,7 +4804,10 @@ export namespace StyleSheet {
      * their respective objects, merged as one and then returned. This also explains
      * the alternative use.
      */
-    export function flatten<T>(style?: StyleProp<T>): T;
+    export function flatten<T>(style?: RegisteredStyle<T>): T;
+    export function flatten(style?: StyleProp<TextStyle>): TextStyle;
+    export function flatten(style?: StyleProp<ImageStyle>): ImageStyle;
+    export function flatten(style?: StyleProp<ViewStyle>): ViewStyle;
 
     /**
      * This is defined as the width of a thin line on the platform. It can be

--- a/types/react-native/test/index.tsx
+++ b/types/react-native/test/index.tsx
@@ -22,10 +22,12 @@ import {
     DataSourceAssetCallback,
     DeviceEventEmitterStatic,
     Dimensions,
+    ImageStyle,
     InteractionManager,
     ListView,
     ListViewDataSource,
     StyleSheet,
+    StyleProp,
     Systrace,
     Text,
     TextStyle,
@@ -124,6 +126,20 @@ const stylesAlt = StyleSheet.create({
 });
 
 const welcomeFontSize = StyleSheet.flatten(styles.welcome).fontSize;
+
+const viewStyle: StyleProp<ViewStyle> = {
+  backgroundColor: "#F5FCFF",
+}
+const textStyle: StyleProp<TextStyle> = {
+  fontSize: 20,
+}
+const imageStyle: StyleProp<ImageStyle> = {
+  resizeMode: 'contain',
+}
+
+const viewProperty = StyleSheet.flatten(viewStyle).backgroundColor;
+const textProperty = StyleSheet.flatten(textStyle).fontSize;
+const imageProperty = StyleSheet.flatten(imageStyle).resizeMode;
 
 class CustomView extends React.Component {
     render() {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Hello, I got this issue with StyleSheet.flatten
```
const something = { color: 'red' } as TextStyle;
const somethingElse = StyleSheet.flatten(something);
const color = somethingElse.color; // Property color does not exist on ViewStyle
```

So I tried to fix it