### PR TITLE
[react-transition-group] Add missing constants for the Transition component

### DIFF
--- a/types/react-transition-group/Transition.d.ts
+++ b/types/react-transition-group/Transition.d.ts
@@ -4,6 +4,12 @@ export type EndHandler = (node: HTMLElement, done: () => void) => void;
 export type EnterHandler = (node: HTMLElement, isAppearing: boolean) => void;
 export type ExitHandler = (node: HTMLElement) => void;
 
+export const UNMOUNTED = 'unmounted';
+export const EXITED = 'exited';
+export const ENTERING = 'entering';
+export const ENTERED = 'entered';
+export const EXITING = 'exiting';
+
 export interface TransitionActions {
     appear?: boolean;
     enter?: boolean;

--- a/types/react-transition-group/react-transition-group-tests.tsx
+++ b/types/react-transition-group/react-transition-group-tests.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import CSSTransition = require("react-transition-group/CSSTransition");
-import Transition from "react-transition-group/Transition";
+import Transition, { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING } from "react-transition-group/Transition";
 import TransitionGroup = require("react-transition-group/TransitionGroup");
 import Components = require("react-transition-group");
 


### PR DESCRIPTION
This fixes the following TS errors:

```ts
import Transition, { ENTERED, ENTERING } from 'react-transition-group/Transition'
// => Module '"./node_modules/@types/react-transition-group/Transition"' has no exported member 'ENTERED'.
// => Module '"./node_modules/@types/react-transition-group/Transition"' has no exported member 'ENTERING'.
```

There are [5 constants available in the `react-transition-group` repo](https://github.com/reactjs/react-transition-group/blob/v2.3.0/src/Transition.js#L7-L11) but they are missing in the `@types` repo.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.