### PR TITLE
Fix export issue so the module is actually recognized on import in TypeScript 2.7 in ES6 without requiring esModuleInterop flag

### DIFF
--- a/types/react-scrollbar/index.d.ts
+++ b/types/react-scrollbar/index.d.ts
@@ -1,8 +1,9 @@
-// Type definitions for react-scrollbar 0.4.1
+// Type definitions for react-scrollbar 0.5.0
 // Project: https://github.com/souhe/reactScrollbar
 // Definitions by: Stephen Jelfs <https://github.com/stephenjelfs>
+//                 Jason Salzman <https://github.com/jasonsalzman>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.6
+// TypeScript Version: 2.7
 
 /// <reference types="react" />
 

--- a/types/react-scrollbar/index.d.ts
+++ b/types/react-scrollbar/index.d.ts
@@ -31,5 +31,5 @@ declare module "react-scrollbar" {
 
   class ScrollArea extends React.Component<ScrollAreaProps> {}
 
-  export = ScrollArea;
+  export default ScrollArea;
 }

--- a/types/react-scrollbar/react-scrollbar-tests.tsx
+++ b/types/react-scrollbar/react-scrollbar-tests.tsx
@@ -1,4 +1,4 @@
-import ScrollArea = require('react-scrollbar');
+import ScrollArea from 'react-scrollbar';
 import * as React from 'react';
 
 let scrollArea =  <ScrollArea


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/issues/5073
- [X] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
