### PR TITLE
Update to auth0-lock / Auth0LockConstructorOptions

### DIFF
--- a/types/auth0-lock/index.d.ts
+++ b/types/auth0-lock/index.d.ts
@@ -118,7 +118,7 @@ interface Auth0LockConstructorOptions {
     auth?: Auth0LockAuthOptions;
     autoclose?: boolean;
     autofocus?: boolean;
-    avatar?: Auth0LockAvatarOptions;
+    avatar?: Auth0LockAvatarOptions | null;
     clientBaseUrl?: string;
     closable?: boolean;
     configurationBaseUrl?: string;


### PR DESCRIPTION
The member 'avatar' should allow 'null', to be consistent with the documentation at:
https://auth0.com/docs/libraries/lock/v11/configuration#avatar-object-

I discovered this when I was trying to figure out why I was seeing 404 errors to gravitar.com in my browser console when logging in - setting avatar to 'null' fixes it.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).


If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://auth0.com/docs/libraries/lock/v11/configuration#avatar-object-
- [?] Increase the version number in the header if appropriate.
- [n/a] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.