### PR TITLE
add react-mailchimp-subscribe typings

### DIFF
--- a/types/react-mailchimp-subscribe/index.d.ts
+++ b/types/react-mailchimp-subscribe/index.d.ts
@@ -1,0 +1,51 @@
+// Type definitions for react-mailchimp-subscribe 2.0
+// Project: https://revolunet.github.io/react-mailchimp-subscribe/
+// Definitions by: Omar Diab <https://github.com/osdiab>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+import { Component, ReactNode } from "react";
+
+// A few common set of form fields, based on defaults in Mailchimp's website
+export interface EmailFormFields {
+    EMAIL: string;
+}
+
+export interface NameFormFields extends EmailFormFields {
+    FNAME: string;
+    LNAME: string;
+}
+
+export interface ClassicFormFields extends NameFormFields {
+    "BIRTHDAY[month]": number;
+    "BIRTHDAY[day]": number;
+}
+
+// library default form just sends EMAIL
+export type DefaultFormFields = EmailFormFields;
+
+export interface ResponseArgs {
+    status: "success" | "error";
+    message: string;
+}
+
+export interface PendingArgs {
+    status: "sending" | null;
+    message: null;
+}
+
+export interface SubscribeArg<FormFields> {
+    subscribe: (data: FormFields) => void;
+}
+
+export type FormHooks<FormFields> = SubscribeArg<FormFields> &
+    (ResponseArgs | PendingArgs);
+
+export interface Props<FormFields> {
+    render?: (hooks: FormHooks<FormFields>) => ReactNode;
+    url: string;
+}
+
+export default class MailchimpSubscribe<FormFields = DefaultFormFields> extends Component<
+    Props<FormFields>
+> {}

--- a/types/react-mailchimp-subscribe/react-mailchimp-subscribe-tests.tsx
+++ b/types/react-mailchimp-subscribe/react-mailchimp-subscribe-tests.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import MailchimpSubscribe, {
+  NameFormFields
+} from "react-mailchimp-subscribe";
+
+const Example: React.StatelessComponent = () => (
+  <>
+    <MailchimpSubscribe
+      render={(hooks) => (<>
+        { hooks.status === "error" &&
+          <span>hooks.message</span>
+        }
+        { hooks.status === "sending" &&
+          <span>Sending!</span>
+        }
+        { hooks.status === "success" &&
+          <span>It's been sent! {hooks.message}</span>
+        }
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            hooks.subscribe({ EMAIL: "8675309@aol.com" });
+          }}
+        />
+      </>)}
+      url="spam.biz/subscribe"
+    />
+    { /* once Typescript 2.9 is out, generics in components will be allowed, at that point uncomment these. */ }
+    { /* https://github.com/Microsoft/TypeScript/pull/22415 */ }
+    {/* <MailchimpSubscribe<any>
+      render={(hooks) => (
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            hooks.subscribe({ myArbitraryData: "is here!" });
+          }}
+        />
+      )}
+      url="spam.biz/subscribe"
+    />
+    <MailchimpSubscribe<NameFormFields>
+      render={(hooks) => (
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            hooks.subscribe({
+              FNAME: "大",
+              LNAME: "哥",
+              EMAIL: "da.ge@qq.com",
+            });
+          }}
+        />
+      )}
+      url="spam.biz/subscribe"
+    /> */}
+  </>
+);

--- a/types/react-mailchimp-subscribe/tsconfig.json
+++ b/types/react-mailchimp-subscribe/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "jsx": "react",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "react-mailchimp-subscribe-tests.tsx"
+    ]
+}

--- a/types/react-mailchimp-subscribe/tslint.json
+++ b/types/react-mailchimp-subscribe/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.