### PR TITLE
[redux-pack]: add key signature to ActionMeta interface

### DIFF
--- a/types/redux-pack/index.d.ts
+++ b/types/redux-pack/index.d.ts
@@ -4,9 +4,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 import {
-    Action as ReduxAction,
     Middleware,
     Reducer,
+    Action as ReduxAction,
 } from 'redux';
 
 export const KEY: {
@@ -39,6 +39,7 @@ export interface ActionMeta<TState = {}, TSuccessPayload = {}, TErrorPayload = {
     onFailure?(error: TErrorPayload, getState: GetState<TState>): void;
     ['redux-pack/LIFECYCLE']?: keyof LIFECYCLEValues;
     ['redux-pack/TRANSACTION']?: string;
+    [key: string]: any;
 }
 export interface Action<TState = {}, TSuccessPayload = {}, TErrorPayload = {}, TStartPayload = {}> extends ReduxAction {
     promise?: Promise<TSuccessPayload>;

--- a/types/redux-pack/index.d.ts
+++ b/types/redux-pack/index.d.ts
@@ -1,53 +1,77 @@
 // Type definitions for redux-pack 0.1
 // Project: https://github.com/lelandrichardson/redux-pack
 // Definitions by: tansongyang <https://github.com/tansongyang>
+//                 dschuman <https://github.com/quicksnap>
+//                 pweinberg <https://github.com/no-stack-dub-sack>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
+
 import {
-    Middleware,
-    Reducer,
     Action as ReduxAction,
+    Middleware,
+    Reducer
 } from 'redux';
 
 export const KEY: {
-    readonly LIFECYCLE: 'redux-pack/LIFECYCLE'
-    readonly TRANSACTION: 'redux-pack/TRANSACTION'
+    readonly LIFECYCLE: 'redux-pack/LIFECYCLE';
+    readonly TRANSACTION: 'redux-pack/TRANSACTION';
 };
 
 export const LIFECYCLE: {
-    readonly START: 'start'
-    readonly SUCCESS: 'success'
-    readonly FAILURE: 'failure'
+    readonly START: 'start';
+    readonly SUCCESS: 'success';
+    readonly FAILURE: 'failure';
 };
-export type LIFECYCLEValues = 'start'| 'succes'| 'failure';
+
+export type LIFECYCLEValues = 'start' | 'succes' | 'failure';
 
 export const middleware: Middleware;
 
-export interface Handlers<S> {
-    start?: Reducer<S>;
-    finish?: Reducer<S>;
-    failure?: Reducer<S>;
-    success?: Reducer<S>;
-    always?: Reducer<S>;
-}
-export type GetState<S> = () => S;
-export interface ActionMeta<TState = {}, TSuccessPayload = {}, TErrorPayload = {}, TStartPayload = {}> {
-    startPayload?: TStartPayload;
-    onStart?(payload: TStartPayload, getState: GetState<TState>): void;
-    onFinish?(resolved: boolean, getState: GetState<TState>): void;
-    onSuccess?(response: TSuccessPayload, getState: GetState<TState>): void;
-    onFailure?(error: TErrorPayload, getState: GetState<TState>): void;
-    ['redux-pack/LIFECYCLE']?: keyof LIFECYCLEValues;
+// MetaPayload differs from ActionMeta in that it is the object that the reducers
+// receive, instead of what is dispatched
+export type MetaPayload<M> = M & {
+    ['redux-pack/LIFECYCLE']?: LIFECYCLEValues;
     ['redux-pack/TRANSACTION']?: string;
-    [key: string]: any;
+};
+
+// Incomplete typing
+export type PackActionPayload<Payload, M> = ReduxAction & {
+    payload: Payload;
+    meta: MetaPayload<M>;
+};
+
+export type handlerReducer<S, A> = (state: S, action: A) => S;
+export interface Handlers<S, TSuccessPayload, TErrorPayload, TStartPayload, TMetaPayload> {
+    start?: handlerReducer<S, PackActionPayload<TStartPayload, TMetaPayload>>;
+    finish?: handlerReducer<S, ReduxAction>;
+    failure?: handlerReducer<S, PackActionPayload<TErrorPayload, TMetaPayload>>;
+    success?: handlerReducer<S, PackActionPayload<TSuccessPayload, TMetaPayload>>;
+    always?: handlerReducer<S, ReduxAction>;
 }
-export interface Action<TState = {}, TSuccessPayload = {}, TErrorPayload = {}, TStartPayload = {}> extends ReduxAction {
+
+export type GetState<S> = () => S;
+export interface ActionMeta<TFullState = {}, TSuccessPayload = {}, TErrorPayload = {}, TStartPayload = {}> {
+    startPayload?: TStartPayload;
+    onStart?(payload: TStartPayload, getState: GetState<TFullState>): void;
+    onFinish?(resolved: boolean, getState: GetState<TFullState>): void;
+    onSuccess?(response: TSuccessPayload, getState: GetState<TFullState>): void;
+    onFailure?(error: TErrorPayload, getState: GetState<TFullState>): void;
+    ['redux-pack/LIFECYCLE']?: LIFECYCLEValues;
+    ['redux-pack/TRANSACTION']?: string;
+}
+
+export interface PackError { error: boolean; payload: any; }
+export interface Action<TFullState = {}, TSuccessPayload = {}, TErrorPayload = PackError, TStartPayload = {}, TMetaPayload = {}> extends ReduxAction {
     promise?: Promise<TSuccessPayload>;
     payload?: TSuccessPayload | TErrorPayload | TStartPayload;
-    meta?: ActionMeta<TState, TSuccessPayload, TErrorPayload, TStartPayload>;
+    meta?: ActionMeta<TFullState, TSuccessPayload, TErrorPayload, TStartPayload> & TMetaPayload;
+    // add optional error key to conform to FSA design: https://github.com/redux-utilities/flux-standard-action
+    // note that users of this middleware (using our types) must conform to FSA shaped actions or code will not compile
+    error?: boolean | null;
 }
-export function handle<TState>(
+
+export function handle<TState, TSuccessPayload, TErrorPayload, TStartPayload, TFullState, TMetaPayload>(
     state: TState,
-    action: Action<TState, any, any, any>,
-    handlers: Handlers<TState>)
-    : TState;
+    action: Action<TFullState, TSuccessPayload, TErrorPayload, TStartPayload, TMetaPayload>,
+    handlers: Handlers<TState, TSuccessPayload, TErrorPayload, TStartPayload, TMetaPayload>,
+): TState;

--- a/types/redux-pack/index.d.ts
+++ b/types/redux-pack/index.d.ts
@@ -70,7 +70,8 @@ export interface Action<TFullState = {}, TSuccessPayload = {}, TErrorPayload = P
     error?: boolean | null;
 }
 
-export function handle<TState, TSuccessPayload, TErrorPayload, TStartPayload, TFullState, TMetaPayload>(
+export interface TFullState { [key: string]: any; }
+export function handle<TState, TSuccessPayload, TErrorPayload, TStartPayload, TMetaPayload>(
     state: TState,
     action: Action<TFullState, TSuccessPayload, TErrorPayload, TStartPayload, TMetaPayload>,
     handlers: Handlers<TState, TSuccessPayload, TErrorPayload, TStartPayload, TMetaPayload>,

--- a/types/redux-pack/redux-pack-tests.ts
+++ b/types/redux-pack/redux-pack-tests.ts
@@ -1,44 +1,87 @@
-import { handle, Action } from 'redux-pack';
+import { handle, Action, GetState } from 'redux-pack';
 
 interface Foo {
-    id: string;
+  id: string;
 }
 interface FooState {
-    foo: Foo | null;
-    error: string | null;
-    isLoading: boolean;
-    currentUser: {
-        id: string;
-    };
+  foo: Foo | null;
+  bar: string;
+  error: boolean;
+  errorMsg: string;
+  isLoading: boolean;
+  metaPropOne: string;
+  metaPropTwo: string;
+  currentUser: {
+    id: string;
+  };
 }
 
 // https://github.com/lelandrichardson/redux-pack/tree/v0.1.5#logging-beforeafter
 declare const Api: {
-    getFoo(id: string): Promise<Foo>;
+  getFoo(id: string): Promise<Foo>;
 };
+
 declare function logSuccess(foo: Foo): void;
-function loadFoo(id: string): Action<FooState, Foo> {
+
+interface MetaOne { propOne: string; }
+function loadFoo(id: string): Action<FooState, Foo, {}, {}, MetaOne> {
   return {
     type: LOAD_FOO,
     promise: Api.getFoo(id),
     meta: {
-      onSuccess: logSuccess
+      onSuccess: logSuccess,
+      // pass custom metadata through to reducer
+      // allowed by library, and a common redux pattern
+      // https://github.com/lelandrichardson/redux-pack/blob/7818ffd4304d5f0e2c94056f3626a399fc9a5a10/src/middleware.js#L44
+      propOne: 'some meta'
     },
+  };
+}
+
+interface MetaTwo { propTwo: string; }
+function barError(): Action<FooState, Foo, {}, {}, MetaTwo> {
+  return {
+    type: BAR_ERROR,
+    error: true,
+    payload: new Error('this is an error action'),
+    meta: {
+      propTwo: 'other meta'
+    }
+  };
+}
+
+// bad (non-FSA action):
+function baz(baz: string): Action<FooState, Foo> {
+  return {
+    type: 'BAZ',
+    // boo: baz // <-- will not compile, shape of action is not FSA
+    // see line 62 & 63 of index.d.ts
   };
 }
 
 // https://github.com/lelandrichardson/redux-pack/tree/v0.1.5#using-the-handle-helper
 const LOAD_FOO = 'LOAD_FOO';
+const BAR_ERROR = 'BAR_ERROR';
 declare const initialState: FooState;
-function fooReducer(state = initialState, action: Action<FooState, Foo, string | null>) {
+function fooReducer(state = initialState, action: Action<FooState, Foo, string | null, {}, MetaOne & MetaTwo>) {
   const { type, payload } = action;
   switch (type) {
+    // example of non-redux-pack action
+    // works as long as action is FSA compliant
+    case BAR_ERROR:
+      return {
+        ...state,
+        error: action.error,
+        errorMsg: action.payload,
+        metaPropTwo: action.meta && action.meta.propTwo
+      };
     case LOAD_FOO:
       return handle(state, action, {
-        start: prevState => ({ ...prevState, isLoading: true, error: null, foo: null }),
+        start: prevState => ({ ...prevState, isLoading: true, error: false, foo: null }),
         finish: prevState => ({ ...prevState, isLoading: false }),
-        failure: prevState => ({ ...prevState, error: payload as string }),
-        success: prevState => ({ ...prevState, foo: payload as Foo }),
+        failure: prevState => ({ ...prevState, error: true, errorMsg: payload as string }),
+        // must define both state and action params to correctly scope action (to access custom meta)
+        success: (prevState, action) => ({ ...prevState, foo: payload as Foo, metaPropOne: action.meta.propOne }),
         always: prevState => prevState, // unnecessary, for the sake of example
       });
     default:
@@ -50,8 +93,8 @@ function fooReducer(state = initialState, action: Action<FooState, Foo, string |
 const DO_FOO = 'DO_FOO';
 declare function doFoo(): Promise<Foo>;
 declare function sendAnalytics(action: string, data: {
-    userId: string,
-    fooId: string,
+  userId: string,
+  fooId: string,
 }): void;
 function userDoesFoo(): Action<FooState, Foo> {
   return {


### PR DESCRIPTION
@tansongyang @andy-ms This is a PR to add a key signature to the `ActionMeta` interface of the redux-pack module. This will allow redux-pack / TypeScript users to pass custom metadata through their actions beyond just the allowed keys. There are valid use-cases for this, however the current typings do not allow it. [This line](https://github.com/lelandrichardson/redux-pack/blob/7818ffd4304d5f0e2c94056f3626a399fc9a5a10/src/middleware.js#L44) of the redux-pack source code shows any keys passed through the `meta` object will be available in the returned action after passing through the middleware, not just keys that share the shape of the state object or are meta handlers.
 
As this is a very minor change, I did not see a need to modify the current tests.

**NOTE**: `npm run lint redux-pack` was failing on my machine before adding the key signature but everything seems to pass CI fine:
![image](https://user-images.githubusercontent.com/18563015/38450271-06dc7086-39e9-11e8-8013-83f1c7a8ab84.png)

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/lelandrichardson/redux-pack/blob/7818ffd4304d5f0e2c94056f3626a399fc9a5a10/src/middleware.js#L44>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
