### PR TITLE
Add io:any to boardoptions interface to allow passing in io at board init

### DIFF
--- a/types/johnny-five/index.d.ts
+++ b/types/johnny-five/index.d.ts
@@ -102,6 +102,7 @@ export interface BoardOption {
     repl?: boolean;
     debug?: boolean;
     timeout?: number;
+    io?: any;
 }
 
 export declare class Board {


### PR DESCRIPTION
When using the using the Board class it was not possible to pass io into the ctor, this is now possible.
