### PR TITLE
Improve coverage of @types/aws-lambda: Add missing fields to Policy  

### DIFF
--- a/types/aws-lambda/aws-lambda-tests.ts
+++ b/types/aws-lambda/aws-lambda-tests.ts
@@ -260,14 +260,37 @@ statement = {
 };
 
 statement = {
+    Sid: str,
     Action: [str, str],
     Effect: str,
-    Resource: [str, str]
+    Resource: [str, str],
+    Condition: {
+        condition1: { key: "value" },
+        condition2: [{
+                key1: "value",
+                key2: "value"
+        }, {
+            key3: "value"
+        }]
+    },
+    Principal: [str, str],
+    NotPrincipal: [str, str]
+};
+
+statement = {
+    Effect: str,
+    NotAction: str,
+    NotResource: str
 };
 
 policyDocument = {
     Version: str,
     Statement: [statement]
+};
+
+policyDocument = {
+    Version: str,
+    Statement: [statement, statement]
 };
 
 authResponse = {

--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -17,6 +17,7 @@
 //                 Simon Buchan <https://github.com/simonbuchan>
 //                 David Hayden <https://github.com/Haydabase>
 //                 Chris Redekop <https://github.com/repl-chris>
+//                 Aneil Mallavarapu <https://github.com/aneilbaboo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 
@@ -438,27 +439,51 @@ export interface CustomAuthorizerResult {
     principalId: string;
     policyDocument: PolicyDocument;
     context?: AuthResponseContext;
+    usageIdentifierKey?: string;
 }
 export type AuthResponse = CustomAuthorizerResult;
 
 /**
  * API Gateway CustomAuthorizer AuthResponse.PolicyDocument.
- * http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output
+ * https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
+ * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html#Condition
  */
 export interface PolicyDocument {
     Version: string;
-    Statement: [Statement];
+    Id?: string;
+    Statement: Statement[];
+}
+
+/**
+ * API Gateway CustomAuthorizer AuthResponse.PolicyDocument.Condition.
+ * https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-control-access-policy-language-overview.html
+ * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
+ */
+export interface ConditionBlock {
+    [condition: string]: Condition | Condition[];
+}
+
+export interface Condition {
+    [key: string]: string | string[];
 }
 
 /**
  * API Gateway CustomAuthorizer AuthResponse.PolicyDocument.Statement.
- * http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html#api-gateway-custom-authorizer-output
+ * https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-control-access-policy-language-overview.html
+ * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
  */
-export interface Statement {
-    Action: string | string[];
+export type Statement = BaseStatement & StatementAction & StatementResource;
+
+export interface BaseStatement {
     Effect: string;
-    Resource: string | string[];
+    Sid?: string;
+    Condition?: ConditionBlock;
+    Principal?: string | string[];
+    NotPrincipal?: string | string[];
 }
+
+export type StatementAction = { Action: string | string[] } | { NotAction: string | string[] };
+export type StatementResource = { Resource: string | string[] } | { NotResource: string | string[] };
 
 /**
  * API Gateway CustomAuthorizer AuthResponse.PolicyDocument.Statement.


### PR DESCRIPTION
# Improve definition of AWS IAM PolicyDocument type

* Add optional fields: Condition, Principal, NotPrincipal, Sid
* Add ability to use NotAction and NotResource:
  - (Action or NotAction) is required
  - (Resource or NotResource) is required
* Allow >1 statement per PolicyDocument, as per spec

## Checklist

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

## Changing existing definition

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html
  * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html


## Previous authors

@skarum @tobyhede @buggy @y13i @wwwy3y3 @OrthoDex @MichaelMarner @daniel-cottone @kostya-misura @coderbyheart @palmithor @daniloraisi @simonbuchan @Haydabase