### PR TITLE
[stripe] Fix typo in `IProductCreationOptions`.

### DIFF
--- a/types/stripe/index.d.ts
+++ b/types/stripe/index.d.ts
@@ -3029,7 +3029,7 @@ declare namespace Stripe {
              * A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g. ["color", "size"]).
              * Applicable to both service and good types.
              */
-            attribute?: Array<string>;
+            attributes?: Array<string>;
 
             /**
              * A short one-line description of the product, meant to be displayable to the customer. May only be set if type=good.

--- a/types/stripe/stripe-tests.ts
+++ b/types/stripe/stripe-tests.ts
@@ -796,13 +796,15 @@ stripe.accounts.createExternalAccount("", { external_account: "tok_15V2YhEe31JkL
 
 stripe.products.create({
     name: "My amazing product",
-    type: "service"
+    type: "service",
+    attributes: ["color"]
 }, function (err, coupon) {
     // asynchronously called
 });
 stripe.products.create({
     name: "My amazing product",
-    type: "service"
+    type: "service",
+    attributes: ["color"]
 }).then(function (product) {
     // asynchronously called
     const prodType: "service" | "good" = product.type;


### PR DESCRIPTION
The `IProductCreationOptions` interface mistakenly lists `attribute` instead of `attributes` as a property.

This does not not match [the API specification for product creation](https://stripe.com/docs/api#create_product), and attempting to actually populate this field results in: `Error: Received unknown parameter: attribute`.

Changing this value to `attributes` successfully allows `stripe.products.create()` calls to succeed in populating attributes.

----
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://stripe.com/docs/api#create_product
- ~Increase the version number in the header if appropriate.~
- ~If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.~
