### PR TITLE
Added react-native AppRegistry registerHeadlessTask typing

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -340,6 +340,9 @@ export function createElement<P>(
 
 export type Runnable = (appParameters: any) => void;
 
+type Task = (taskData: any) => Promise<void>;
+type TaskProvider = () => Task;
+
 type NodeHandle = number;
 
 // Similar to React.SyntheticEvent except for nativeEvent
@@ -468,7 +471,7 @@ export namespace AppRegistry {
 
     function runApplication(appKey: string, appParameters: any): void;
 
-    function registerHeadlessTask(appKey: string, task: any): void;
+    function registerHeadlessTask(appKey: string, task: TaskProvider): void;
 }
 
 export interface LayoutAnimationTypes {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -466,6 +466,8 @@ export namespace AppRegistry {
     function unmountApplicationComponentAtRootTag(rootTag: number): void;
 
     function runApplication(appKey: string, appParameters: any): void;
+
+    function registerHeadlessTask(appKey: string, task: any): void;
 }
 
 export interface LayoutAnimationTypes {

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7,6 +7,7 @@
 //                 Kamal Mahyuddin <https://github.com/kamal>
 //                 Naoufal El Yousfi <https://github.com/nelyousfi>
 //                 Alex Dunne <https://github.com/alexdunne>
+//                 Michele Bombardi <https://github.com/bm-software>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 


### PR DESCRIPTION
Changing an existing definition:
URL to documentation or source code which provides context for the suggested changes: [AppRegistry#registerHeadlessTask](https://facebook.github.io/react-native/docs/appregistry.html#registerheadlesstask)