### PR TITLE
[types/ejs] Also return undefined in Cache.get()

### DIFF
--- a/types/ejs/index.d.ts
+++ b/types/ejs/index.d.ts
@@ -108,7 +108,7 @@ export function escapeRegexChars(s: string): string;
 export function escapeXML(markup: string): string;
 export interface Cache {
     set(key: string, val: TemplateFunction): void;
-    get(key: string): TemplateFunction;
+    get(key: string): TemplateFunction | undefined;
 }
 export let delimiter: string;
 


### PR DESCRIPTION
As lru-cache has `V | undefined` as [`get()` return](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lru-cache/index.d.ts#L118), this `get()` function should also mark undefined as possible return type to allow assigning an LRU to `cache`.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.