### PR TITLE
[nock] Add Promise based Nock Back types

### DIFF
--- a/types/nock/index.d.ts
+++ b/types/nock/index.d.ts
@@ -158,6 +158,13 @@ declare namespace nock {
 
         (fixtureName: string, nockedFn: (nockDone: () => void) => void): void;
         (fixtureName: string, options: NockBackOptions, nockedFn: (nockDone: () => void) => void): void;
+        (fixtureName: string, options?: NockBackOptions): Promise<{ nockDone: () => void, context: NockBackContext }>;
+    }
+
+    export interface NockBackContext {
+      scopes: Scope[];
+      assertScopesFinished(): void;
+      isLoaded: boolean;
     }
 
     export interface NockBackOptions {

--- a/types/nock/nock-tests.ts
+++ b/types/nock/nock-tests.ts
@@ -72,10 +72,10 @@ scope = inst.reply(num, str);
 scope = inst.reply(num, str, headers);
 scope = inst.reply(num, obj, headers);
 scope = inst.reply(num, (uri: string, body: string) => {
-	return str;
+  return str;
 });
 scope = inst.reply(num, (uri: string, body: string) => {
-	return str;
+  return str;
 }, headers);
 scope = inst.replyWithFile(num, str);
 
@@ -97,11 +97,11 @@ inst = inst.delayConnection(num);
 
 scope = scope.filteringPath(regex, str);
 scope = scope.filteringPath((path: string) => {
-	return str;
+  return str;
 });
 scope = scope.filteringRequestBody(regex, str);
 scope = scope.filteringRequestBody((path: string) => {
-	return str;
+  return str;
 });
 
 scope = scope.log(() => { });
@@ -126,8 +126,8 @@ scope.restore();
 nock.recorder.rec();
 nock.recorder.rec(true);
 nock.recorder.rec({
-	dont_print: true,
-	output_objects: true
+  dont_print: true,
+  output_objects: true
 });
 nock.recorder.clear();
 strings = nock.recorder.play() as string[];
@@ -713,6 +713,12 @@ nockBack('zomboFixture.json', { before, after }, (nockDone: () => void) => {
   });
 });
 
+// in promise mode
+nockBack('promisedFixture.json')
+  .then(({nockDone, context}) => {
+    context.assertScopesFinished();
 
-
-
+    // do your tests returning a promise and chain it with
+    Promise.resolve('foo')
+      .then(nockDone);
+  });


### PR DESCRIPTION
Documentation:
https://github.com/node-nock/nock#nock-back

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/node-nock/nock#nock-back
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Relevant snippet from [docs](https://github.com/node-nock/nock#nock-back):

```js
return nockBack('promisedFixture.json')
  .then(({nockDone, context}) => {
    //  do your tests returning a promise and chain it with
    //  `.then(nockDone);`
  });
});
```
