### PR TITLE
[electron-devtools-installer] Add Missing Constants

### DIFF
--- a/types/electron-devtools-installer/electron-devtools-installer-tests.ts
+++ b/types/electron-devtools-installer/electron-devtools-installer-tests.ts
@@ -3,6 +3,8 @@ import installExtension, {
     BACKBONE_DEBUGGER, JQUERY_DEBUGGER,
     ANGULARJS_BATARANG, VUEJS_DEVTOOLS,
     REDUX_DEVTOOLS, REACT_PERF,
+    CYCLEJS_DEVTOOL, APOLLO_DEVELOPER_TOOLS,
+    MOBX_DEVTOOLS
 } from 'electron-devtools-installer';
 
 
@@ -14,4 +16,7 @@ installExtension(ANGULARJS_BATARANG);
 installExtension(VUEJS_DEVTOOLS);
 installExtension(REDUX_DEVTOOLS);
 installExtension(REACT_PERF);
+installExtension(CYCLEJS_DEVTOOL);
+installExtension(APOLLO_DEVELOPER_TOOLS);
+installExtension(MOBX_DEVTOOLS);
 installExtension('abcdefghijkl');

--- a/types/electron-devtools-installer/index.d.ts
+++ b/types/electron-devtools-installer/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for electron-devtools-installer v2.0.1
 // Project: https://github.com/MarshallOfSound/electron-devtools-installer
 // Definitions by: Robin Van den Broeck <https://github.com/gamesmaxed>
+//                 M. Fatih Mar <https://github.com/mfatihmar>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 declare module "electron-devtools-installer" {
@@ -21,4 +22,7 @@ declare module "electron-devtools-installer" {
     export const VUEJS_DEVTOOLS: ExtensionReference;
     export const REDUX_DEVTOOLS: ExtensionReference;
     export const REACT_PERF: ExtensionReference;
+    export const CYCLEJS_DEVTOOL: ExtensionReference;
+    export const APOLLO_DEVELOPER_TOOLS: ExtensionReference;
+    export const MOBX_DEVTOOLS: ExtensionReference;
 }


### PR DESCRIPTION
Added missing `CYCLEJS_DEVTOOL`, `APOLLO_DEVELOPER_TOOLS` and `MOBX_DEVTOOLS` constants and updated test script.

----

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/MarshallOfSound/electron-devtools-installer/blob/master/src/index.js
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.