### PR TITLE
enzyme: Fix `find` override for components with strict null checks.

### DIFF
--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -102,7 +102,7 @@ function ShallowWrapperTest() {
         elementWrapper = shallowWrapper.find('.selector');
         // Since AnotherComponent does not have a constructor, it cannot match the
         // previous selector overload of ComponentClass { new(props?, contenxt? ) }
-        const selector: EnzymeComponentClass<AnotherComponentProps> = AnotherComponent;
+        const s1: EnzymeComponentClass<AnotherComponentProps> = AnotherComponent;
     }
 
     function test_findWhere() {

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -8,13 +8,14 @@ import {
     configure,
     EnzymeAdapter,
     ShallowRendererProps,
+    ComponentClass as EnzymeComponentClass
 } from "enzyme";
 import { Component, ReactElement, HTMLAttributes, ComponentClass, StatelessComponent } from "react";
 
 // Help classes/interfaces
 interface MyComponentProps {
-    stringProp?: string;
-    numberProp?: number;
+    stringProp: string;
+    numberProp: number;
 }
 
 interface AnotherComponentProps {
@@ -65,27 +66,27 @@ function configureTest() {
 // ShallowWrapper
 function ShallowWrapperTest() {
     let shallowWrapper: ShallowWrapper<MyComponentProps, MyComponentState> =
-        shallow<MyComponentProps, MyComponentState>(<MyComponent stringProp="value" />);
+        shallow<MyComponentProps, MyComponentState>(<MyComponent stringProp="value" numberProp={1} />);
 
     let reactElement: ReactElement<any>;
     let reactElements: Array<ReactElement<any>>;
     let domElement: Element;
     let boolVal: boolean;
     let stringVal: string;
-    let numOrStringVal: number | string;
+    let numOrStringVal: number | string | undefined;
     let elementWrapper: ShallowWrapper<HTMLAttributes<{}>>;
     let anotherStatelessWrapper: ShallowWrapper<AnotherStatelessProps, never>;
     let anotherComponentWrapper: ShallowWrapper<AnotherComponentProps, any>;
 
     function test_props_state_inferring() {
         let wrapper: ShallowWrapper<MyComponentProps, MyComponentState>;
-        wrapper = shallow(<MyComponent stringProp="value" />);
+        wrapper = shallow(<MyComponent stringProp="value" numberProp={1} />);
         wrapper.state().stateProperty;
         wrapper.props().stringProp.toUpperCase();
     }
 
     function test_shallow_options() {
-        shallow(<MyComponent stringProp="1" />, {
+        shallow(<MyComponent stringProp="1" numberProp={1} />, {
             context: {
                 test: "a",
             },
@@ -99,6 +100,9 @@ function ShallowWrapperTest() {
         anotherStatelessWrapper = shallowWrapper.find(AnotherStatelessComponent);
         shallowWrapper = shallowWrapper.find({ prop: 'value' });
         elementWrapper = shallowWrapper.find('.selector');
+        // Since AnotherComponent does not have a constructor, it cannot match the
+        // previous selector overload of ComponentClass { new(props?, contenxt? ) }
+        let selector: EnzymeComponentClass<AnotherComponentProps> = AnotherComponent;
     }
 
     function test_findWhere() {
@@ -155,7 +159,7 @@ function ShallowWrapperTest() {
     }
 
     function test_hostNodes() {
-	    shallowWrapper.hostNodes();
+        shallowWrapper.hostNodes();
     }
 
     function test_equals() {
@@ -411,20 +415,19 @@ function ShallowWrapperTest() {
 
     function test_constructor() {
         let anyWrapper: ShallowWrapper;
-        anyWrapper = new ShallowWrapper(<MyComponent />);
-        anyWrapper = new ShallowWrapper<MyComponentProps>(<MyComponent />);
-        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent />);
-        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>([<MyComponent />, <MyComponent />]);
-        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent />, shallowWrapper);
-        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent />, null, { lifecycleExperimental: true });
-        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent />, shallowWrapper, { lifecycleExperimental: true });
+        anyWrapper = new ShallowWrapper(<MyComponent stringProp="1" numberProp={1} />);
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />);
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>([<MyComponent stringProp="1" numberProp={1} />, <MyComponent stringProp="1" numberProp={1} />]);
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, shallowWrapper);
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, undefined, { lifecycleExperimental: true });
+        shallowWrapper = new ShallowWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, shallowWrapper, { lifecycleExperimental: true });
     }
 }
 
 // ReactWrapper
 function ReactWrapperTest() {
     let reactWrapper: ReactWrapper<MyComponentProps, MyComponentState> =
-        mount<MyComponentProps, MyComponentState>(<MyComponent stringProp="value" />);
+        mount<MyComponentProps, MyComponentState>(<MyComponent stringProp="value" numberProp={1} />);
 
     let reactElement: ReactElement<any>;
     let reactElements: Array<ReactElement<any>>;
@@ -437,7 +440,7 @@ function ReactWrapperTest() {
 
     function test_prop_state_inferring() {
         let wrapper: ReactWrapper<MyComponentProps, MyComponentState>;
-        wrapper = mount(<MyComponent stringProp="value" />);
+        wrapper = mount(<MyComponent stringProp="value" numberProp={1} />);
         wrapper.state().stateProperty;
         wrapper.props().stringProp.toUpperCase();
     }
@@ -449,7 +452,7 @@ function ReactWrapperTest() {
     function test_mount() {
         reactWrapper = reactWrapper.mount();
 
-        mount(<MyComponent stringProp='1' />, {
+        mount(<MyComponent stringProp='1' numberProp={1} />, {
             attachTo: document.getElementById('test'),
             context: {
                 a: "b"
@@ -685,7 +688,7 @@ function ReactWrapperTest() {
     }
 
     function test_setProps() {
-        reactWrapper = reactWrapper.setProps({ stringProp: 'foo' }, () => {});
+        reactWrapper = reactWrapper.setProps({ stringProp: 'foo' }, () => { });
     }
 
     function test_setContext() {
@@ -764,13 +767,12 @@ function ReactWrapperTest() {
 
     function test_constructor() {
         let anyWrapper: ReactWrapper;
-        anyWrapper = new ReactWrapper(<MyComponent />);
-        anyWrapper = new ReactWrapper<MyComponentProps>(<MyComponent />);
-        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent />);
-        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>([<MyComponent />, <MyComponent />]);
-        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent />, reactWrapper);
-        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent />, null, { attachTo: document.createElement('div') });
-        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent />, reactWrapper, { attachTo: document.createElement('div') });
+        anyWrapper = new ReactWrapper(<MyComponent stringProp="1" numberProp={1} />);
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />);
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>([<MyComponent stringProp="1" numberProp={1} />, <MyComponent stringProp="1" numberProp={1} />]);
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, reactWrapper);
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, undefined, { attachTo: document.createElement('div') });
+        reactWrapper = new ReactWrapper<MyComponentProps, MyComponentState>(<MyComponent stringProp="1" numberProp={1} />, reactWrapper, { attachTo: document.createElement('div') });
     }
 }
 

--- a/types/enzyme/enzyme-tests.tsx
+++ b/types/enzyme/enzyme-tests.tsx
@@ -102,7 +102,7 @@ function ShallowWrapperTest() {
         elementWrapper = shallowWrapper.find('.selector');
         // Since AnotherComponent does not have a constructor, it cannot match the
         // previous selector overload of ComponentClass { new(props?, contenxt? ) }
-        let selector: EnzymeComponentClass<AnotherComponentProps> = AnotherComponent;
+        const selector: EnzymeComponentClass<AnotherComponentProps> = AnotherComponent;
     }
 
     function test_findWhere() {

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -23,7 +23,7 @@ export class ElementClass extends Component<any, any> {
  * all specified in the implementation. TS chooses the EnzymePropSelector overload and loses the generics
  */
 export interface ComponentClass<Props> {
-    new(props: Props, context?: any): Component<Props, {}>;
+    new(props: Props, context?: any): Component<Props>;
 }
 
 export type StatelessComponent<Props> = (props: Props, context?: any) => JSX.Element;

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -21,10 +21,22 @@ export class ElementClass extends Component<any, any> {
 /* These are purposefully stripped down versions of React.ComponentClass and React.StatelessComponent.
  * The optional static properties on them break overload ordering for wrapper methods if they're not
  * all specified in the implementation. TS chooses the EnzymePropSelector overload and loses the generics
+ *
+ * The Class1/2/3 is kind of ugly, but we need to allow any of the variations of no-constructor,
+ * one-arg constructor, and two-arg constructor. We can't do this with a single definition like
+ * `new(props?, context?)` because `props | undefined` is actually a wider type definition than
+ * just `constructor(props, context)`.
  */
-export interface ComponentClass<Props> {
-    new(props?: Props, context?: any): Component<Props, any>;
+export interface ComponentClass1<Props> {
+    new(): Component<Props, any>;
 }
+export interface ComponentClass2<Props> {
+    new(props: Props): Component<Props, any>;
+}
+export interface ComponentClass3<Props> {
+    new(props: Props, context: any): Component<Props, any>;
+}
+export type ComponentClass<Props> = ComponentClass1<Props> | ComponentClass2<Props> | ComponentClass3<Props>;
 
 export type StatelessComponent<Props> = (props: Props, context?: any) => JSX.Element;
 
@@ -354,7 +366,7 @@ export interface CommonWrapper<P = {}, S = {}> {
 }
 
 // tslint:disable-next-line no-empty-interface
-export interface ShallowWrapper<P = {}, S = {}> extends CommonWrapper<P, S> {}
+export interface ShallowWrapper<P = {}, S = {}> extends CommonWrapper<P, S> { }
 export class ShallowWrapper<P = {}, S = {}> {
     constructor(nodes: JSX.Element[] | JSX.Element, root?: ShallowWrapper<any, any>, options?: ShallowRendererProps);
     shallow(options?: ShallowRendererProps): ShallowWrapper<P, S>;
@@ -440,7 +452,7 @@ export class ShallowWrapper<P = {}, S = {}> {
 }
 
 // tslint:disable-next-line no-empty-interface
-export interface ReactWrapper<P = {}, S = {}> extends CommonWrapper<P, S> {}
+export interface ReactWrapper<P = {}, S = {}> extends CommonWrapper<P, S> { }
 export class ReactWrapper<P = {}, S = {}> {
     constructor(nodes: JSX.Element | JSX.Element[], root?: ReactWrapper<any, any>, options?: MountRendererProps);
 
@@ -577,7 +589,7 @@ export interface MountRendererProps {
     /**
      * DOM Element to attach the component to
      */
-    attachTo?: HTMLElement;
+    attachTo?: HTMLElement | null;
     /**
      * Merged contextTypes for all children of the wrapper
      */

--- a/types/enzyme/index.d.ts
+++ b/types/enzyme/index.d.ts
@@ -21,22 +21,10 @@ export class ElementClass extends Component<any, any> {
 /* These are purposefully stripped down versions of React.ComponentClass and React.StatelessComponent.
  * The optional static properties on them break overload ordering for wrapper methods if they're not
  * all specified in the implementation. TS chooses the EnzymePropSelector overload and loses the generics
- *
- * The Class1/2/3 is kind of ugly, but we need to allow any of the variations of no-constructor,
- * one-arg constructor, and two-arg constructor. We can't do this with a single definition like
- * `new(props?, context?)` because `props | undefined` is actually a wider type definition than
- * just `constructor(props, context)`.
  */
-export interface ComponentClass1<Props> {
-    new(): Component<Props, any>;
+export interface ComponentClass<Props> {
+    new(props: Props, context?: any): Component<Props, {}>;
 }
-export interface ComponentClass2<Props> {
-    new(props: Props): Component<Props, any>;
-}
-export interface ComponentClass3<Props> {
-    new(props: Props, context: any): Component<Props, any>;
-}
-export type ComponentClass<Props> = ComponentClass1<Props> | ComponentClass2<Props> | ComponentClass3<Props>;
 
 export type StatelessComponent<Props> = (props: Props, context?: any) => JSX.Element;
 

--- a/types/enzyme/tsconfig.json
+++ b/types/enzyme/tsconfig.json
@@ -7,7 +7,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "jsx": "react",


### PR DESCRIPTION
With strict null checks enabled, code like:

   shallow(...).find(SomeComponent)

Would return ShallowWrapper<any, any>.

This is because the `find` override:

   find<P2>(component: ComponentClass<P2>): ShallowWrapper<P2, any>;

Would not match, and instead fallback on find(EnzymePropSelector).

The ComponentClass<P2> did not match because the `new(props?, context?)`
does not actually match to `new(props)`, as polymorphically `props` is
a restriction on `props?`.

Instead, we explicitly model each potential constructor pattern,
no-arg, 1-arg, 2-arg, and union them together.

This also allows enabling strict null checks for the entire enzyme
typings.

This required a few tangential changes, e.g. changing the test's
numberProp?/stringProp? to non-optional, as with null checking
enabled several of the existing tests were making non-null safe
accesses (e.g. the reduce/map/etc. checks).

Please fill in this template.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not provide its own types, and you can not add them.
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.
