### PR TITLE
Added new type definition for npm package strong-error-handler v2.3

### DIFF
--- a/types/strong-error-handler/index.d.ts
+++ b/types/strong-error-handler/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for strong-error-handler 2.3
+// Project: https://github.com/strongloop/strong-error-handler
+// Definitions by: Jacob Copeland <https://github.com/blankstar85>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+import express = require('express');
+
+declare namespace StrongErrorHandler {
+    interface options {
+        /***
+         * HTTP responses include all error properties, including sensitive data such as file paths,
+         * URLs and stack traces, defaults to false.
+         */
+        debug?: boolean;
+
+        /***
+         *If true, all errors are printed via console.error, including an array of fields (custom error properties)
+         *that are safe to include in response messages (both 4xx and 5xx).
+         *If false, sends only the error back in the response.
+         * Defaults to true
+         */
+        log?: boolean;
+
+        /***
+         * Specifies property names on errors that are allowed to be passed through in 4xx and 5xx responses.
+         */
+        safeFields?: [string];
+
+        /***
+         * Specify the default response content type to use when the client does not provide any Accepts header.
+         * Defaults to 'json'.
+         */
+        defaultType?: string;
+
+        /***
+         * Negotiate the response content type via Accepts request header.
+         * When disabled, strong-error-handler will always use the default content type when producing responses.
+         * Disabling content type negotiation is useful if you want to see JSON-formatted
+         * error responses in browsers, because browsers usually prefer HTML and XML over other content types.
+         */
+        negotiateContentType?: boolean;
+    }
+}
+
+/***
+ * Create a new strong error middleware funciton using the given options.
+ * @param options
+ */
+declare function createStrongErrorHandler(options?: StrongErrorHandler.options): express.RequestHandler;
+
+export = createStrongErrorHandler;

--- a/types/strong-error-handler/strong-error-handler-tests.ts
+++ b/types/strong-error-handler/strong-error-handler-tests.ts
@@ -1,0 +1,10 @@
+import express = require('express');
+import errorHandler = require('strong-error-handler');
+
+errorHandler({
+    debug: false,
+    log: false,
+    safeFields: ['test'],
+    defaultType: 'json',
+    negotiateContentType: true,
+});

--- a/types/strong-error-handler/tsconfig.json
+++ b/types/strong-error-handler/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [

--- a/types/strong-error-handler/tsconfig.json
+++ b/types/strong-error-handler/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": false,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "strong-error-handler-tests.ts"
+    ]
+}

--- a/types/strong-error-handler/tslint.json
+++ b/types/strong-error-handler/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dt.json"
+}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

