### PR TITLE
[aws-lambda] Rutime node8.10 support.

### DIFF
--- a/types/aws-lambda/index.d.ts
+++ b/types/aws-lambda/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for AWS Lambda
+// Type definitions for AWS Lambda 8.10
 // Project: http://docs.aws.amazon.com/lambda
 // Definitions by: James Darbyshire <https://github.com/darbio/aws-lambda-typescript>
 //                 Michael Skarum <https://github.com/skarum>
@@ -562,8 +562,13 @@ export interface KinesisStreamEvent {
  * @param event – event data.
  * @param context – runtime information of the Lambda function that is executing.
  * @param callback – optional callback to return information to the caller, otherwise return value is null.
+ * @return In the node8.10 runtime, a promise for the lambda result.
  */
-export type Handler<TEvent = any, TResult = any> = (event: TEvent, context: Context, callback: Callback<TResult>) => void;
+export type Handler<TEvent = any, TResult = any> = (
+    event: TEvent,
+    context: Context,
+    callback: Callback<TResult>,
+) => void | Promise<TResult>;
 
 /**
  * Optional callback parameter.


### PR DESCRIPTION
Bump version to 8.10 to match current runtime, allow returning result promises in handlers.

There is a tiny paragraph in [the documentation](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html) describing this new feature, but it is much better described in [the blog post announcing it](https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/)

There is a type-breaking change that should be rare for most users, where previously valid `async` handlers returning void would be accepted (and their results ignored), I chose to keep this rather than, e.g. also allowing `Promise<void>` as experimentation shows if the async function returns before the callback is invoked the lambda runtime will return a `null` value, and it is all too easy to do so. Because of this I chose to (finally!) set the type package version to the runtime version - but I would be happy to back this out if others think it's a minor enough break that needing a package.json update is unnecessary.

Not sure if this should change to referencing/depending on node typings specifically at v8 as well - I think that would cause most users lots of type conflicts right now, but longer term it could catch people using node APIs their runtime doesn't have? If that's happening it should probably happen now so the breaking change can ride the major version bump.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (see description above)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.