### PR TITLE
bootstrap-datepicker: missing orientation options

### DIFF
--- a/types/bootstrap-datepicker/index.d.ts
+++ b/types/bootstrap-datepicker/index.d.ts
@@ -10,7 +10,20 @@ type DatepickerEvents = "show"|"hide"|"clearDate"|"changeDate"|"changeMonth"|"ch
 
 type DatepickerViewModes = 0|"days"|1|"months"|2|"years"|3|"decades"|4|"centuries"|"millenium";
 
-type DatepickerOrientations = "auto"|"left top"|"left bottom"|"right top"|"right bottom";
+type DatepickerOrientations =
+    "auto"
+    | "left top"
+    | "left bottom"
+    | "right top"
+    | "right bottom"
+    | "top auto"
+    | "bottom auto"
+    | "auto left"
+    | "top left"
+    | "bottom left"
+    | "auto right"
+    | "top right"
+    | "bottom right"
 
 /**
  * All options that take a “Date” can handle a Date object; a String


### PR DESCRIPTION
https://bootstrap-datepicker.readthedocs.io/en/stable/options.html#orientation
taken from author's online demo:
https://uxsolutions.github.io/bootstrap-datepicker/