### PR TITLE
[Cucumber] Fix tags property definition in Pickle interface

### DIFF
--- a/types/cucumber/index.d.ts
+++ b/types/cucumber/index.d.ts
@@ -95,7 +95,7 @@ export namespace pickle {
         locations: Location[];
         name: string;
         steps: Step[];
-        tags: string[];
+        tags: Tag[];
     }
 
     interface Location {
@@ -116,6 +116,11 @@ export namespace pickle {
     interface Cell {
         location: Location;
         value: string;
+    }
+
+    interface Tag {
+        name: string;
+        location: Location;
     }
 }
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes:

cucumber-js [api-reference.md](https://github.com/cucumber/cucumber-js/blob/master/docs/support_files/api_reference.md#afteroptions-fn) points at Gherkin library to define a `pickle` object:
> The pickle object comes from the [gherkin](https://github.com/cucumber/cucumber/tree/gherkin-v4.1.3/gherkin) library. See `testdata/good/*.pickles.ndjson` for examples of its structure.

Found example of a pickle with tags within [`tags.feature.pickles.ndjson`](https://github.com/cucumber/cucumber/blob/gherkin-v4.1.3/gherkin/testdata/good/tags.feature.pickles.ndjson)

- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.