### PR TITLE
reactstrap: Input from StatelessComponent to React.Component subclass

### DIFF
--- a/types/reactstrap/lib/Input.d.ts
+++ b/types/reactstrap/lib/Input.d.ts
@@ -41,5 +41,5 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   cssModule?: CSSModule;
 }
 
-declare const Input: React.StatelessComponent<InputProps>;
+declare const Input: React.ComponentClass<InputProps>;
 export default Input;

--- a/types/reactstrap/lib/Input.d.ts
+++ b/types/reactstrap/lib/Input.d.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CSSModule } from '../index';
 
 export type InputType =
@@ -41,5 +42,5 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   cssModule?: CSSModule;
 }
 
-declare const Input: React.ComponentClass<InputProps>;
+declare class Input extends React.Component<InputProps> {}
 export default Input;

--- a/types/reactstrap/reactstrap-tests.tsx
+++ b/types/reactstrap/reactstrap-tests.tsx
@@ -3676,3 +3676,9 @@ const Example116 = (props: any) => {
     </div>
   );
 };
+
+class Example117 extends React.Component {
+  render() {
+    return <Input ref={e => { console.log(e); }}/>;
+  }
+}


### PR DESCRIPTION
`Input` is a full React component (`ComponentClass`), not a stateless component. In particular, this change allows consumers to pass `ref` to it (not legal with `StatelessComponent`), which useful for e.g. calling `HTMLInputElement#focus()`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: refs + stateless components: https://github.com/facebook/react/issues/4936 ; reactstrap's Input : https://github.com/reactstrap/reactstrap/blob/4dea4a639973918d178ca666c7c85899045a1d03/src/Input.js#L29
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
