### PR TITLE
Added document-promises types

### DIFF
--- a/types/document-promises/document-promises-tests.ts
+++ b/types/document-promises/document-promises-tests.ts
@@ -1,0 +1,16 @@
+import { parsed, contentLoaded, loaded } from 'document-promises';
+
+let promise: Promise<void>;
+promise = parsed;
+promise = contentLoaded;
+promise = loaded;
+
+parsed.then(() => {
+    // Document parsed
+});
+contentLoaded.then(() => {
+    // Document is ready
+});
+loaded.then(() => {
+    // Document loaded
+});

--- a/types/document-promises/index.d.ts
+++ b/types/document-promises/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for document-promises 3.1
+// Project: https://github.com/jonathantneal/document-promises#readme
+// Definitions by: Tiger Oakes <https://github.com/NotWoods>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * document.parsed is a promise that fulfills when the document is parsed
+ * and `readyState` is `interactive`, before deferred and async scripts have run.
+ */
+export const parsed: Promise<void>;
+
+/**
+ * document.contentLoaded is a promise that fulfills when the document is
+ * parsed, blocking scripts have completed, and `DOMContentLoaded` fires.
+ */
+export const contentLoaded: Promise<void>;
+
+/**
+ * document.loaded is a promise that fulfills when the document is parsed,
+ * blocking scripts have completed, images, scripts, links and sub-frames
+ * have finished loading, and `readyState` is `complete`.
+ */
+export const loaded: Promise<void>;

--- a/types/document-promises/tsconfig.json
+++ b/types/document-promises/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "document-promises-tests.ts"
+    ]
+}

--- a/types/document-promises/tslint.json
+++ b/types/document-promises/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
New typings for the [document-promises](https://github.com/jonathantneal/document-promises) package. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
