### PR TITLE
[estree] make function declaration id nullable

### DIFF
--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -224,6 +224,7 @@ boolean = memberExpression.computed;
 // Declarations
 var functionDeclaration: ESTree.FunctionDeclaration;
 var identifierOrNull: ESTree.Identifier | null = functionDeclaration.id;
+functionDeclaration.id = null;
 var params: Array<ESTree.Pattern> = functionDeclaration.params;
 blockStatement = functionDeclaration.body;
 booleanMaybe = functionDeclaration.generator;

--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -223,7 +223,7 @@ boolean = memberExpression.computed;
 
 // Declarations
 var functionDeclaration: ESTree.FunctionDeclaration;
-identifier = functionDeclaration.id;
+var identifierOrNull: ESTree.Identifier | null = functionDeclaration.id;
 var params: Array<ESTree.Pattern> = functionDeclaration.params;
 blockStatement = functionDeclaration.body;
 booleanMaybe = functionDeclaration.generator;

--- a/types/estree/estree-tests.ts
+++ b/types/estree/estree-tests.ts
@@ -238,6 +238,10 @@ var variableDeclarator: ESTree.VariableDeclarator;
 pattern = variableDeclarator.id; // Pattern
 expressionMaybe = variableDeclarator.init;
 
+var classDeclaration: ESTree.ClassDeclaration;
+identifierOrNull = classDeclaration.id;
+classDeclaration.id = null;
+
 // Clauses
 // SwitchCase
 string = switchCase.type;

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -474,7 +474,8 @@ export interface MethodDefinition extends BaseNode {
 
 export interface ClassDeclaration extends BaseClass, BaseDeclaration {
   type: "ClassDeclaration";
-  id: Identifier;
+  /** It is null when a class declaration is a part of the `export default class` statement */
+  id: Identifier | null;
 }
 
 export interface ClassExpression extends BaseClass, BaseExpression {

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -196,7 +196,7 @@ interface BaseDeclaration extends BaseStatement { }
 
 export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
   type: "FunctionDeclaration";
-  // `id` is null when a function declaration is a part of the `export default function` statement
+  /** It is null when a function declaration is a part of the `export default function` statement */
   id: Identifier | null;
   body: BlockStatement;
 }

--- a/types/estree/index.d.ts
+++ b/types/estree/index.d.ts
@@ -196,7 +196,8 @@ interface BaseDeclaration extends BaseStatement { }
 
 export interface FunctionDeclaration extends BaseFunction, BaseDeclaration {
   type: "FunctionDeclaration";
-  id: Identifier;
+  // `id` is null when a function declaration is a part of the `export default function` statement
+  id: Identifier | null;
   body: BlockStatement;
 }
 


### PR DESCRIPTION
A `FunctionDeclaration` `id` can be `null` if this function declaration is a part of the `ExportDefaultDeclaration` ([ast explorer gist](https://astexplorer.net/#/gist/bcb2d30873c46351a69473ad91a9cadd/2ccd96c9b4202b442c6f7fae52acc14cd5fca756)):

```javascript
export default function() {}
```

This PR updates the `FunctionDeclaration` interface.