### PR TITLE
[mongodb] Fixed generic type bug in Collection.find

### DIFF
--- a/types/mongodb/index.d.ts
+++ b/types/mongodb/index.d.ts
@@ -509,9 +509,9 @@ export interface Collection<TSchema = Default> {
     dropIndexes(callback?: MongoCallback<any>): void;
     dropIndexes(options: {session?: ClientSession, maxTimeMS?: number}, callback: MongoCallback<any>): void;
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#find */
-    find<T = TSchema>(query?: FilterQuery<T>): Cursor<T>;
+    find<T = TSchema>(query?: FilterQuery<TSchema>): Cursor<T>;
     /** @deprecated */
-    find<T = TSchema>(query: FilterQuery<T>, options?: FindOneOptions): Cursor<T>;
+    find<T = TSchema>(query: FilterQuery<TSchema>, options?: FindOneOptions): Cursor<T>;
     /** http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#findOne */
     findOne<T = TSchema>(filter: FilterQuery<TSchema>, callback: MongoCallback<T | null>): void;
     findOne<T = TSchema>(filter: FilterQuery<TSchema>, options?: FindOneOptions): Promise<T | null>;

--- a/types/mongodb/mongodb-tests.ts
+++ b/types/mongodb/mongodb-tests.ts
@@ -113,5 +113,7 @@ MongoClient.connect('mongodb://127.0.0.1:27017/test', options, function (err: mo
                 $and: [{ $gt: 0, $lt: 100 }]
             }
         });
+
+        const res: mongodb.Cursor<TestCollection> = testCollection.find({ _id: 123 });
     }
 })


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

The generic type of `FilterQuery` in `find` should be the `TSchema` instead of `T`.
Thanks to @shivanshu3 for finding this bug in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/23577#commitcomment-28365273