### PR TITLE
Update package.json to depend on @types/meteor

### DIFF
--- a/types/meteor-collection-hooks/package.json
+++ b/types/meteor-collection-hooks/package.json
@@ -1,6 +1,6 @@
 {
     "private": true,
     "dependencies": {
-        "meteor-typings": "^1.3.1"
+        "@types/meteor": "^1.4.13"
     }
 }


### PR DESCRIPTION
Remove old dependency of meteor-typings as this caused errors in compiling with Angular Meteor

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [NA] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [NA] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
No changes made to .ts files

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 

Using meteor-typings in the package.json dependencies gives these errors on compiling of any project using @types/meteor-collection-hooks. Replacing meteor-typings with @types/meteor resolves these missing property errors.
node_modules/meteor-typings/1.4/test/test.ts (467, 8): Property '_localStorage' does not exist on type 'typeof Meteor'.
node_modules/meteor-typings/1.4/test/test.ts (468, 8): Property '_localStorage' does not exist on type 'typeof Meteor'.
node_modules/meteor-typings/1.4/test/test.ts (469, 8): Property '_localStorage' does not exist on type 'typeof Meteor'.
node_modules/meteor-typings/1.4/test/test.ts (737, 24): Type '(userId: string) => boolean' has no properties in common with type 'Matcher'.
client/imports/app/app.states.ts (100, 11): Property 'callLoginMethod' does not exist on type 'typeof Accounts'.


No changes made to .ts files
- [ NA ] Increase the version number in the header if appropriate.
- [ NA ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


