### PR TITLE
fix(restangular): remove duplicate IScopedService

### DIFF
--- a/types/restangular/index.d.ts
+++ b/types/restangular/index.d.ts
@@ -107,15 +107,6 @@ declare namespace restangular {
     getList<T>(queryParams?: any, headers?: any): ICollectionPromise<T>;
   }
 
-  interface IScopedService extends IService {
-    one(id: number): IElement;
-    one(id: string): IElement;
-    post(elementToPost: any, queryParams?: any, headers?: any): IPromise<any>;
-    post<T>(elementToPost: T, queryParams?: any, headers?: any): IPromise<T>;
-    getList(queryParams?: any, headers?: any): ICollectionPromise<any>;
-    getList<T>(queryParams?: any, headers?: any): ICollectionPromise<T>;
-  }
-
   interface IElement extends IService {
     get(queryParams?: any, headers?: any): IPromise<any>;
     get<T>(queryParams?: any, headers?: any): IPromise<T>;


### PR DESCRIPTION
Seems that during the "types-2" refactoring, the "IScopedService" interface of restangular definitions got accidentally duplicated. (https://github.com/DefinitelyTyped/DefinitelyTyped/commit/983c93531a0a732f2d0eca0148ac255ede0d40a6)
I removed that to avoid confusion.
This resolves #13863
