### PR TITLE
Callback function typings for PushNotificationIOS

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7313,7 +7313,11 @@ export interface PushNotificationIOSStatic {
      * Removes the event listener. Do this in `componentWillUnmount` to prevent
      * memory leaks
      */
-    removeEventListener(type: PushNotificationEventName, handler: ((notification: PushNotification) => void) | ((deviceToken: string) => void) | ((error: { message: string, code: number, details: any }) => void)): void;
+    removeEventListener(type: PushNotificationEventName,
+        handler: ((notification: PushNotification) => void)
+            | ((deviceToken: string) => void)
+            | ((error: { message: string, code: number, details: any }) => void)
+    ): void;
 
     /**
      * Requests all notification permissions from iOS, prompting the user's

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7291,8 +7291,8 @@ export interface PushNotificationIOSStatic {
     addEventListener(type: "notification" | "localNotification", handler: (notification: PushNotification) => void): void;
 
     /**
-     * Fired when the user registers for remote notifications. 
-     * 
+     * Fired when the user registers for remote notifications.
+     *
      * The handler will be invoked with a hex string representing the deviceToken.
      *
      * The type MUST be 'register'
@@ -7300,9 +7300,9 @@ export interface PushNotificationIOSStatic {
     addEventListener(type: "register", handler: (deviceToken: string) => void): void;
 
     /**
-     * Fired when the user fails to register for remote notifications. 
-     * Typically occurs when APNS is having issues, or the device is a simulator. 
-     * 
+     * Fired when the user fails to register for remote notifications.
+     * Typically occurs when APNS is having issues, or the device is a simulator.
+     *
      * The handler will be invoked with {message: string, code: number, details: any}.
      *
      * The type MUST be 'registrationError'

--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -7288,13 +7288,32 @@ export interface PushNotificationIOSStatic {
      *
      * The type MUST be 'notification'
      */
-    addEventListener(type: PushNotificationEventName, handler: (notification: PushNotification) => void): void;
+    addEventListener(type: "notification" | "localNotification", handler: (notification: PushNotification) => void): void;
+
+    /**
+     * Fired when the user registers for remote notifications. 
+     * 
+     * The handler will be invoked with a hex string representing the deviceToken.
+     *
+     * The type MUST be 'register'
+     */
+    addEventListener(type: "register", handler: (deviceToken: string) => void): void;
+
+    /**
+     * Fired when the user fails to register for remote notifications. 
+     * Typically occurs when APNS is having issues, or the device is a simulator. 
+     * 
+     * The handler will be invoked with {message: string, code: number, details: any}.
+     *
+     * The type MUST be 'registrationError'
+     */
+    addEventListener(type: "registrationError", handler: (error: { message: string, code: number, details: any }) => void): void;
 
     /**
      * Removes the event listener. Do this in `componentWillUnmount` to prevent
      * memory leaks
      */
-    removeEventListener(type: PushNotificationEventName, handler: (notification: PushNotification) => void): void;
+    removeEventListener(type: PushNotificationEventName, handler: ((notification: PushNotification) => void) | ((deviceToken: string) => void) | ((error: { message: string, code: number, details: any }) => void)): void;
 
     /**
      * Requests all notification permissions from iOS, prompting the user's


### PR DESCRIPTION
Allow the different kind of callback functions for different events in the `PushNotificationIOS` class, according to the specification in https://facebook.github.io/react-native/docs/pushnotificationios.html#addeventlistener

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://facebook.github.io/react-native/docs/pushnotificationios.html#addeventlistener
