### PR TITLE
Avoid error with XMLHttpRequest = originalXMLHttpRequest || XMLHttpRe…

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -8792,7 +8792,7 @@ declare global {
      *
      * @see https://github.com/facebook/react-native/issues/934
      */
-    var originalXMLHttpRequest: Object;
+    var originalXMLHttpRequest: any;
 
     var __BUNDLE_START_TIME__: number;
     var ErrorUtils: ErrorUtils;


### PR DESCRIPTION
…quest

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

I've got an issue writting
```
if (window.__REDUX_DEVTOOLS_EXTENSION__) {
  XMLHttpRequest = originalXMLHttpRequest || XMLHttpRequest;
}
```

Indeed originalXMLHttpRequest is typed as an object which is not compatible with the type of XMLHttpRequest.