### PR TITLE
[diff] update diffArrays return value type to support arrays

### DIFF
--- a/types/diff/diff-tests.ts
+++ b/types/diff/diff-tests.ts
@@ -5,8 +5,16 @@ const other = 'beep boob blah';
 let diff = jsdiff.diffChars(one, other);
 printDiff(diff);
 
-diff = jsdiff.diffArrays(['a', 'b', 'c'], ['a', 'c', 'd']);
-printDiff(diff);
+const diffArraysResult = jsdiff.diffArrays<string>(['a', 'b', 'c'], ['a', 'c', 'd']);
+diffArraysResult.forEach(result => {
+    if (result.added) {
+        console.log(`added ${result.value.length} line(s):`, ...result.value);
+    } else if (result.removed) {
+        console.log(`removed ${result.value.length} line(s):`, ...result.value);
+    } else {
+        console.log(`no changes`);
+    }
+});
 
 // --------------------------
 

--- a/types/diff/index.d.ts
+++ b/types/diff/index.d.ts
@@ -29,6 +29,13 @@ declare namespace JsDiff {
         removed?: boolean;
     }
 
+    interface IDiffArraysResult<T> {
+        value: T[];
+        count?: number;
+        added?: boolean;
+        removed?: boolean;
+    }
+
     interface IBestPath {
         newPos: number;
         componenets: IDiffResult[];
@@ -85,7 +92,7 @@ declare namespace JsDiff {
 
     function diffSentences(oldStr: string, newStr: string, options?: IOptions): IDiffResult[];
 
-    function diffArrays(oldArr: any[], newArr: any[], options?: IArrayOptions): IDiffResult[];
+    function diffArrays<T>(oldArr: T[], newArr: T[], options?: IArrayOptions): Array<IDiffArraysResult<T>>;
 
     function createPatch(fileName: string, oldStr: string, newStr: string, oldHeader: string, newHeader: string, options?: {context: number}): string;
 


### PR DESCRIPTION
I mistyped the return value for the `diffArrays` method in my last PR - this fixes that and updates the test file to accordingly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kpdecker/jsdiff#api
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
