### PR TITLE
added new type definition for npm package express-xml-bodyparser v0.3

### DIFF
--- a/types/express-xml-bodyparser/express-xml-bodyparser-tests.ts
+++ b/types/express-xml-bodyparser/express-xml-bodyparser-tests.ts
@@ -1,0 +1,10 @@
+import express = require('express');
+import xmlparser = require('express-xml-bodyparser');
+
+const app: express.Express = express();
+
+app.use(xmlparser());
+
+app.post("/auth", xmlparser({explicitArray: false}), (req, res, next) => {
+    res.send("Success!");
+});

--- a/types/express-xml-bodyparser/index.d.ts
+++ b/types/express-xml-bodyparser/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for express-xml-bodyparser 0.3
+// Project: https://github.com/macedigital/express-xml-bodyparser
+// Definitions by: Notice Maker <https://github.com/noticeMaker>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import { Request, Response, NextFunction } from 'express';
+
+declare function xmlparser(options?: xmlparser.XmlparserOptions): (req: Request, res: Response, next: NextFunction) => void;
+
+declare namespace xmlparser {
+    let regexp: RegExp;
+
+    interface XmlparserOptions {
+        async?: boolean;
+        explicitArray?: boolean;
+        normalize?: boolean;
+        normalizeTags?: boolean;
+        trim?: boolean;
+    }
+}
+
+export = xmlparser;

--- a/types/express-xml-bodyparser/tsconfig.json
+++ b/types/express-xml-bodyparser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "express-xml-bodyparser-tests.ts"
+    ]
+}

--- a/types/express-xml-bodyparser/tslint.json
+++ b/types/express-xml-bodyparser/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/macedigital/express-xml-bodyparser>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
