### PR TITLE
[react-overlays] Expose the Overlay.OverlayProps interface as a public API

### DIFF
--- a/types/react-overlays/lib/Overlay.d.ts
+++ b/types/react-overlays/lib/Overlay.d.ts
@@ -5,30 +5,31 @@ import { PortalProps } from './Portal';
 import { PositionProps } from './Position';
 
 declare class Overlay extends React.Component<OverlayProps> { }
-declare namespace Overlay { }
 export = Overlay;
 
-interface OverlayProps extends TransitionCallbacks, PortalProps, PositionProps {
-  /**
-   * Set the visibility of the Overlay
-   */
-  show?: boolean;
+declare namespace Overlay {
+  interface OverlayProps extends TransitionCallbacks, PortalProps, PositionProps {
+    /**
+     * Set the visibility of the Overlay
+     */
+    show?: boolean;
 
-  /**
-   * Specify whether the overlay should trigger `onHide` when the user clicks outside the overlay
-   */
-  rootClose?: boolean;
+    /**
+     * Specify whether the overlay should trigger `onHide` when the user clicks outside the overlay
+     */
+    rootClose?: boolean;
 
-  /**
-   * A Callback fired by the Overlay when it wishes to be hidden.
-   *
-   * __required__ when `rootClose` is `true`.
-   */
-  onHide?(props: PortalProps, ...args: any[]): any;
+    /**
+     * A Callback fired by the Overlay when it wishes to be hidden.
+     *
+     * __required__ when `rootClose` is `true`.
+     */
+    onHide?(props: PortalProps, ...args: any[]): any;
 
-  /**
-   * A `react-transition-group@2.0.0` `<Transition/>` component
-   * used to animate the overlay as it changes visibility.
-   */
-  transition?: React.ComponentType<TransitionProps>;
+    /**
+     * A `react-transition-group@2.0.0` `<Transition/>` component
+     * used to animate the overlay as it changes visibility.
+     */
+    transition?: React.ComponentType<TransitionProps>;
+  }
 }

--- a/types/react-overlays/test/react-overlays-tests-individual.tsx
+++ b/types/react-overlays/test/react-overlays-tests-individual.tsx
@@ -22,6 +22,10 @@ class TestAffix extends React.Component {
   }
 }
 
+interface OverlayTriggerProps extends Overlay.OverlayProps {
+  overlay: any;
+}
+
 class TestOverlay extends React.Component<{}, {open: boolean}> {
   target: HTMLElement | null = null;
   state = {open: false};


### PR DESCRIPTION
We wanted to use the `Overlay.OverlayProps` interface to define [an `interface` that accepts our own custom properties as well as the props that `Overlay.OverlayProps` accepts](https://github.com/artsy/reaction/blob/f5541e8d3cd23b2ffb624086a376867b54e5bf82/src/Components/OverlayTrigger/types.ts#L7-L18). As of writing the `Overlay.OverlayProps` is not exposed, so we just copy-&-pasted the entire interface to our repo. This PR updates the `Overlay.d.ts` so it'll be exposed as a public API and we can DRY up the interface definition.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.