### PR TITLE
lodash: isFinite should be a type guard

### DIFF
--- a/types/lodash/common/lang.d.ts
+++ b/types/lodash/common/lang.d.ts
@@ -823,7 +823,7 @@ declare module "../index" {
          * @param value The value to check.
          * @return Returns true if value is a finite number, else false.
          */
-        isFinite(value?: any): boolean;
+        isFinite(value?: any): value is number;
     }
 
     interface LoDashImplicitWrapper<TValue> {

--- a/types/lodash/fp/isFinite.d.ts
+++ b/types/lodash/fp/isFinite.d.ts
@@ -11,7 +11,7 @@ type IsFinite =
      * @param value The value to check.
      * @return Returns true if value is a finite number, else false.
      */
-    (value: any) => boolean;
+    (value: any) => value is number;
 
 declare const isFinite: IsFinite;
 export = isFinite;

--- a/types/lodash/lodash-tests.ts
+++ b/types/lodash/lodash-tests.ts
@@ -4326,6 +4326,20 @@ fp.now(); // $ExpectType number
 
 // _.isFinite
 {
+    const value: string | number = 0;
+
+    if (_.isFinite(value)) {
+        const result: number = value;
+    } else {
+        const result: string = value;
+    }
+
+    if (fp.isFinite(value)) {
+        const result: number = value;
+    } else {
+        const result: string = value;
+    }
+
     _.isFinite(NaN); // $ExpectType boolean
     _(42).isFinite(); // $ExpectType boolean
     _.chain([]).isFinite(); // $ExpectType LoDashExplicitWrapper<boolean>


### PR DESCRIPTION
`isFinite` is a more-restrictive version of `isNumber` and should have an equally narrow return type that can be used in a type guard.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/67ff0213632be98f732e9c95d3812d069affe174/types/lodash/common/lang.d.ts#L1200
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.