### PR TITLE
Add gulp-responsive-images types

### DIFF
--- a/types/gulp-responsive-images/gulp-responsive-images-tests.ts
+++ b/types/gulp-responsive-images/gulp-responsive-images-tests.ts
@@ -1,0 +1,63 @@
+import gulpResponsiveImages = require('gulp-responsive-images');
+
+gulpResponsiveImages(); // $ExpectError
+
+gulpResponsiveImages({});       // $ExpectType Transform
+
+gulpResponsiveImages({ 1: "abcd" }); // $ExpectError
+
+gulpResponsiveImages({
+    'hero.png': [
+        {
+        }
+    ]
+}
+);
+
+gulpResponsiveImages({
+    'hero.png': [
+        {
+            crop: false,
+            gravity: 'Center',
+            height: 100,
+            overwrite: true,
+            quality: 100,
+            sharpen: false,
+            suffix: '-100',
+            upscale: false,
+            width: 100
+        }
+    ]
+}
+);
+
+gulpResponsiveImages({
+    'hero.png': [
+        {
+            format: "jpeg",
+            rename: "image.jpg",
+            percentage: 50
+        }
+    ]
+}
+);
+
+gulpResponsiveImages({
+    'hero.png': [
+        {
+            crop: undefined,
+            gravity: undefined,
+            height: undefined,
+            overwrite: undefined,
+            quality: undefined,
+            sharpen: undefined,
+            suffix: undefined,
+            upscale: undefined,
+            width: undefined,
+            format: undefined,
+            rename: undefined,
+            percentage: undefined
+        }
+    ]
+}
+);

--- a/types/gulp-responsive-images/index.d.ts
+++ b/types/gulp-responsive-images/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for gulp-responsive-images 0.0
+// Project: https://github.com/dcgauld/gulp-responsive-images#readme
+// Definitions by: Aankhen <https://github.com/aankhen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import * as stream from "stream";
+import * as gm from "gm";
+import { ParsedPath, Options as RenameOptions } from "gulp-rename";
+
+export = GulpResponsiveImage;
+
+declare function GulpResponsiveImage(configs: GulpResponsiveImage.Matchers): stream.Transform;
+
+declare namespace GulpResponsiveImage {
+    type SamplingFactor = [number, number];
+
+    type Rename = string
+        | ((path: ParsedPath) => any)
+        | RenameOptions;
+
+    interface Settings {
+        crop?: boolean;
+        format?: string;
+        gravity?: gm.GravityDirection;
+        overwrite?: boolean;
+        quality?: number;
+        rename?: Rename;
+        percentage?: number;
+        sharpen?: boolean;
+        upscale?: boolean;
+        filter?: gm.FilterType;
+        height?: number;
+        width?: number;
+        samplingFactor?: SamplingFactor;
+        suffix?: string;
+    }
+
+    interface Matchers {
+        [index: string]: ReadonlyArray<Settings>;
+    }
+}

--- a/types/gulp-responsive-images/tsconfig.json
+++ b/types/gulp-responsive-images/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gulp-responsive-images-tests.ts"
+    ]
+}

--- a/types/gulp-responsive-images/tslint.json
+++ b/types/gulp-responsive-images/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
