### PR TITLE
fix(fs-extra): copy can take an async filter function

### DIFF
--- a/types/fs-extra/fs-extra-tests.ts
+++ b/types/fs-extra/fs-extra-tests.ts
@@ -48,7 +48,7 @@ fs.copy(src, dest,
 	{
 		overwrite: true,
 		preserveTimestamps: true,
-		filter: (src: string, dest: string) => false
+		filter: (src: string, dest: string) => Promise.resolve(false)
 	},
 	errorCallback
 );

--- a/types/fs-extra/index.d.ts
+++ b/types/fs-extra/index.d.ts
@@ -3,7 +3,8 @@
 // Definitions by: Alan Agius <https://github.com/alan-agius4>,
 //                 midknight41 <https://github.com/midknight41>,
 //                 Brendan Forster <https://github.com/shiftkey>,
-//                 Mees van Dijk <https://github.com/mees->
+//                 Mees van Dijk <https://github.com/mees->,
+//                 Justin Rockwood <https://github.com/jrockwood>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
@@ -16,7 +17,7 @@ export * from "fs";
 export function copy(src: string, dest: string, options?: CopyOptions): Promise<void>;
 export function copy(src: string, dest: string, callback: (err: Error) => void): void;
 export function copy(src: string, dest: string, options: CopyOptions, callback: (err: Error) => void): void;
-export function copySync(src: string, dest: string, options?: CopyOptions): void;
+export function copySync(src: string, dest: string, options?: CopyOptionsSync): void;
 
 export function move(src: string, dest: string, options?: MoveOptions): Promise<void>;
 export function move(src: string, dest: string, callback: (err: Error) => void): void;
@@ -254,7 +255,8 @@ export interface PathEntryStream {
     read(): PathEntry | null;
 }
 
-export type CopyFilter = (src: string, dest: string) => boolean;
+export type CopyFilterSync = (src: string, dest: string) => boolean;
+export type CopyFilterAsync = (src: string, dest: string) => Promise<boolean>;
 
 export type SymlinkType = "dir" | "file";
 
@@ -263,8 +265,12 @@ export interface CopyOptions {
     overwrite?: boolean;
     preserveTimestamps?: boolean;
     errorOnExist?: boolean;
-    filter?: CopyFilter;
+    filter?: CopyFilterSync | CopyFilterAsync;
     recursive?: boolean;
+}
+
+export interface CopyOptionsSync extends CopyOptions {
+    filter?: CopyFilterSync;
 }
 
 export interface MoveOptions {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/jprichardson/node-fs-extra/blob/master/docs/copy.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


According to the docs, the filter option passed into `copy` can be a promise.

> filter <Function>: Function to filter copied files. Return true to include, false to exclude. Can also return a Promise that resolves to true or false (or pass in an async function).

I verified that the code allows for a Promise also.

Note that this will change the meaning of `CopyOptions` and make it more permissive, which shouldn't be a breaking change. However, I renamed `CopyOptions` to be `CopyOptionsSync` to match the naming of the rest of the file. Again, not a breaking change since there is still a `CopyOptions` that is more permissive.