### PR TITLE
Add gulp-image-resize types

### DIFF
--- a/types/gulp-image-resize/gulp-image-resize-tests.ts
+++ b/types/gulp-image-resize/gulp-image-resize-tests.ts
@@ -1,0 +1,40 @@
+import resize = require('gulp-image-resize');
+
+resize();                       // $ExpectType Transform
+resize(undefined);
+resize("1");                  // $ExpectError
+
+resize({                        // $ExpectType Transform
+    width: 100,
+    height: 100,
+    crop: true,
+    upscale: false
+});
+
+resize({
+    widt: 5                     // $ExpectError
+});
+
+resize({
+    width: undefined,
+    height: undefined,
+    upscale: undefined,
+    crop: undefined,
+    gravity: undefined,
+    quality: undefined,
+    format: undefined,
+    filter: undefined,
+    sharpen: undefined,
+    samplingFactor: undefined,
+    noProfile: undefined,
+    interlace: undefined,
+    imageMagick: undefined,
+    background: undefined,
+    flatten: undefined,
+    percentage: undefined,
+    cover: undefined
+});
+
+resize({ format: 'jpeg' });
+resize({ width: 100 });
+resize({ percentage: 50 });

--- a/types/gulp-image-resize/index.d.ts
+++ b/types/gulp-image-resize/index.d.ts
@@ -1,0 +1,38 @@
+// Type definitions for gulp-image-resize 0.13
+// Project: https://github.com/scalableminds/gulp-image-resize
+// Definitions by: Aankhen <https://github.com/Aankhen>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.4
+
+/// <reference types="node" />
+
+import * as stream from "stream";
+import * as gm from "gm";
+
+export = GulpImageResize;
+
+declare function GulpImageResize(options?: GulpImageResize.Options): stream.Transform;
+
+declare namespace GulpImageResize {
+    type SamplingFactor = [number, number];
+
+    interface Options {
+        width?: number;
+        height?: number;
+        upscale?: boolean;
+        crop?: boolean;
+        gravity?: gm.GravityDirection;
+        quality?: number;
+        format?: string;
+        filter?: gm.FilterType;
+        sharpen?: boolean | string;
+        samplingFactor?: SamplingFactor;
+        noProfile?: boolean;
+        interlace?: boolean;
+        imageMagick?: boolean;
+        background?: string;
+        flatten?: boolean;
+        percentage?: number;
+        cover?: boolean;
+    }
+}

--- a/types/gulp-image-resize/tsconfig.json
+++ b/types/gulp-image-resize/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "gulp-image-resize-tests.ts"
+    ]
+}

--- a/types/gulp-image-resize/tslint.json
+++ b/types/gulp-image-resize/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not provide its own types, and you can not add them.
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.