### PR TITLE
[BSON] add types for missing `calculateObjectSize` method

### DIFF
--- a/types/bson/bson-tests.ts
+++ b/types/bson/bson-tests.ts
@@ -6,7 +6,7 @@ bson.ObjectID.cacheHexString = true
 let BSON = new bson.BSON();
 let Long = bson.Long;
 
-let doc = {long: Long.fromNumber(100)}
+let doc = { long: Long.fromNumber(100) }
 
 // Serialize a document
 let data = BSON.serialize(doc, false, true, false);
@@ -19,3 +19,10 @@ console.log("doc_2:", doc_2);
 BSON = new bson.BSON();
 data = BSON.serialize(doc);
 doc_2 = BSON.deserialize(data);
+
+
+// Calculate Object Size
+BSON = new bson.BSON();
+console.log("Calculated Object size - no options object:", BSON.calculateObjectSize(doc));
+console.log("Calculated Object size - empty options object:", BSON.calculateObjectSize(doc, {}));
+console.log("Calculated Object size - custom options object:", BSON.calculateObjectSize(doc, { ignoreUndefined: false, serializeFunctions: true }));

--- a/types/bson/index.d.ts
+++ b/types/bson/index.d.ts
@@ -16,6 +16,14 @@ export interface DeserializeOptions {
     /** {Boolean, default:false}, deserialize Binary data directly into node.js Buffer object. */
     promoteBuffers?: boolean;
 }
+
+export interface CalculateObjectSizeOptions {
+    /** {Boolean, default:false}, serialize the javascript functions */
+    serializeFunctions?: boolean;
+    /** {Boolean, default:true}, ignore undefined fields. */
+    ignoreUndefined?: boolean;
+}
+
 export class BSON {
     /**
      * @param {Object} object the Javascript object to serialize.
@@ -26,6 +34,14 @@ export class BSON {
      */
     serialize(object: any, checkKeys?: boolean, asBuffer?: boolean, serializeFunctions?: boolean): Buffer;
     deserialize(buffer: Buffer, options?: DeserializeOptions, isArray?: boolean): any;
+    /**
+     * Calculate the bson size for a passed in Javascript object.
+     *
+     * @param {Object} object the Javascript object to calculate the BSON byte size for.
+     * @param {CalculateObjectSizeOptions} Options
+     * @return {Number} returns the number of bytes the BSON object will take up.
+     */
+    calculateObjectSize(object: any, options?: CalculateObjectSizeOptions): number;
 }
 
 export class Binary {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/mongodb/js-bson#bsoncalculateobjectsize
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

