### PR TITLE
[@types/when] Make when.js promises compatible with native promises

### DIFF
--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -287,22 +287,22 @@ declare namespace When {
 
         then(
             onFulfilled?: ((value: T) => T | Thenable<T>) | undefined | null,
-            onRejected?: ((reason: any) => never | Thenable<never>) | undefined | null,
+            onRejected?: ((reason: any) => T | Thenable<T>) | undefined | null,
             onProgress?: (update: any) => void
         ): Promise<T>;
         then<TResult1>(
-            onFulfilled?: ((value: T) => TResult1 | Thenable<TResult1>) | undefined | null,
-            onRejected?: ((reason: any) => never | Thenable<never>) | undefined | null,
+            onFulfilled: ((value: T) => TResult1 | Thenable<TResult1>),
+            onRejected?: ((reason: any) => TResult1 | Thenable<TResult1>) | undefined | null,
             onProgress?: (update: any) => void
-        ): Promise<TResult1 | never>;
+        ): Promise<TResult1>;
         then<TResult2>(
-            onFulfilled?: ((value: T) => T | Thenable<T>) | undefined | null,
-            onRejected?: ((reason: any) => TResult2 | Thenable<TResult2>) | undefined | null,
+            onFulfilled: ((value: T) => T | Thenable<T>) | undefined | null,
+            onRejected: ((reason: any) => TResult2 | Thenable<TResult2>),
             onProgress?: (update: any) => void
         ): Promise<T | TResult2>;
         then<TResult1, TResult2>(
-            onFulfilled?: ((value: T) => TResult1 | Thenable<TResult1>) | undefined | null,
-            onRejected?: ((reason: any) => TResult2 | Thenable<TResult2>) | undefined | null,
+            onFulfilled: ((value: T) => TResult1 | Thenable<TResult1>),
+            onRejected: ((reason: any) => TResult2 | Thenable<TResult2>),
             onProgress?: (update: any) => void
         ): Promise<TResult1 | TResult2>;
 

--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -290,16 +290,16 @@ declare namespace When {
             onRejected?: ((reason: any) => T | Thenable<T>) | undefined | null,
             onProgress?: (update: any) => void
         ): Promise<T>;
-        then<TResult1>(
-            onFulfilled: ((value: T) => TResult1 | Thenable<TResult1>),
-            onRejected?: ((reason: any) => TResult1 | Thenable<TResult1>) | undefined | null,
+        then<TResult>(
+            onFulfilled: ((value: T) => TResult | Thenable<TResult>),
+            onRejected?: ((reason: any) => TResult | Thenable<TResult>) | undefined | null,
             onProgress?: (update: any) => void
-        ): Promise<TResult1>;
-        then<TResult2>(
+        ): Promise<TResult>;
+        then<TResult>(
             onFulfilled: ((value: T) => T | Thenable<T>) | undefined | null,
-            onRejected: ((reason: any) => TResult2 | Thenable<TResult2>),
+            onRejected: ((reason: any) => TResult | Thenable<TResult>),
             onProgress?: (update: any) => void
-        ): Promise<T | TResult2>;
+        ): Promise<T | TResult>;
         then<TResult1, TResult2>(
             onFulfilled: ((value: T) => TResult1 | Thenable<TResult1>),
             onRejected: ((reason: any) => TResult2 | Thenable<TResult2>),

--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -109,7 +109,7 @@ declare namespace When {
      * @returns a promise that will fulfill with an array of mapped values
      *  or reject if any input promise rejects.
      */
-    function map<T>(promisesOrValues: any[], mapFunc: (value: any, index?: Number) => any): Promise<T>;
+    function map<T>(promisesOrValues: any[], mapFunc: (value: any, index: number) => any): Promise<T>;
 
     /**
      * Traditional reduce function, similar to `Array.prototype.reduce()`, but
@@ -118,10 +118,10 @@ declare namespace When {
      * be a promise for the starting value.
      * @param promisesOrValues array or promise for an array of anything,
      *      may contain a mix of promises and values.
-     * @param reduceFunc function(accumulated:*, x:*, index:Number):*} f reduce function
+     * @param reduceFunc function(accumulated:*, x:*, index:number):*} f reduce function
      * @returns a promise that will resolve to the final reduced value
      */
-    function reduce<T>(promisesOrValues: any[], reduceFunc: (reduction: T, value: any, index?: Number) => T | Promise<T>, initialValue: T): Promise<T>;
+    function reduce<T>(promisesOrValues: any[], reduceFunc: (reduction: T, value: any, index: number) => T | Promise<T>, initialValue: T): Promise<T>;
 
     /**
      * Traditional reduce function, similar to `Array.prototype.reduceRight()`, but
@@ -130,22 +130,38 @@ declare namespace When {
      * be a promise for the starting value.
      * @param promisesOrValues array or promise for an array of anything,
      *      may contain a mix of promises and values.
-     * @param reduceFunc function(accumulated:*, x:*, index:Number):*} f reduce function
+     * @param reduceFunc function(accumulated:*, x:*, index:number):*} f reduce function
      * @returns a promise that will resolve to the final reduced value
      */
-    function reduceRight<T>(promisesOrValues: any[], reduceFunc: (reduction: T, value: any, index?: Number) => T | Promise<T>, initialValue: T): Promise<T>;
+    function reduceRight<T>(promisesOrValues: any[], reduceFunc: (reduction: T, value: any, index: number) => T | Promise<T>, initialValue: T): Promise<T>;
 
     /**
-     * Describes the status of a promise.
+     * Describes the outcome of a promise.
      * state may be one of:
      * "fulfilled" - the promise has resolved
-     * "pending" - the promise is still pending to resolve/reject
      * "rejected" - the promise has rejected
      */
-    interface Descriptor<T> {
-        state: string;
-        value?: T;
-        reason?: any;
+    type Descriptor<T> = FulfilledDescriptor<T> | RejectedDescriptor;
+
+    /**
+     * Snapshot which describes the status of a promise.
+     * state may be one of:
+     * "fulfilled" - the promise has resolved
+     * "rejected" - the promise has rejected
+     * "pending" - the promise is still pending to resolve/reject
+     */
+    type Snapshot<T> = FulfilledDescriptor<T> | RejectedDescriptor | PendingDescriptor;
+
+    interface FulfilledDescriptor<T> {
+        state: 'fulfilled';
+        value: T;
+    }
+    interface RejectedDescriptor {
+        state: 'rejected';
+        reason: any;
+    }
+    interface PendingDescriptor {
+        state: 'pending';
     }
 
     /**
@@ -303,13 +319,7 @@ declare namespace When {
     }
 
     interface Thenable<T> {
-        then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => U): Thenable<U>;
-    }
-
-    interface Snapshot<T> {
-        state: string;
-        value?: T;
-        reason?: any;
+        then<U>(onFulfilled?: (value: T) => U, onRejected?: (reason: any) => U): Thenable<U>;
     }
 }
 
@@ -388,8 +398,7 @@ declare module "when/node" {
 
     interface Resolver<T> {
         reject(reason: any): void;
-        resolve(value?: T): void;
-        resolve(value?: when.Promise<T>): void;
+        resolve(value?: T | when.Promise<T>): void;
     }
 
     function createCallback<TArg>(resolver: Resolver<TArg>): (err: any, arg: TArg) => void;

--- a/types/when/index.d.ts
+++ b/types/when/index.d.ts
@@ -269,7 +269,26 @@ declare namespace When {
         // be a constructor with prototype set to an instance of Error.
         otherwise<U>(exceptionType: any, onRejected?: (reason: any) => U | Promise<U>): Promise<U>;
 
-        then<U>(onFulfilled: (value: T) => U | Promise<U>, onRejected?: (reason: any) => U | Promise<U>, onProgress?: (update: any) => void): Promise<U>;
+        then(
+            onFulfilled?: ((value: T) => T | Thenable<T>) | undefined | null,
+            onRejected?: ((reason: any) => never | Thenable<never>) | undefined | null,
+            onProgress?: (update: any) => void
+        ): Promise<T>;
+        then<TResult1>(
+            onFulfilled?: ((value: T) => TResult1 | Thenable<TResult1>) | undefined | null,
+            onRejected?: ((reason: any) => never | Thenable<never>) | undefined | null,
+            onProgress?: (update: any) => void
+        ): Promise<TResult1 | never>;
+        then<TResult2>(
+            onFulfilled?: ((value: T) => T | Thenable<T>) | undefined | null,
+            onRejected?: ((reason: any) => TResult2 | Thenable<TResult2>) | undefined | null,
+            onProgress?: (update: any) => void
+        ): Promise<T | TResult2>;
+        then<TResult1, TResult2>(
+            onFulfilled?: ((value: T) => TResult1 | Thenable<TResult1>) | undefined | null,
+            onRejected?: ((reason: any) => TResult2 | Thenable<TResult2>) | undefined | null,
+            onProgress?: (update: any) => void
+        ): Promise<TResult1 | TResult2>;
 
         spread<T>(onFulfilled: _.Fn0<Promise<T> | T>): Promise<T>;
         spread<A1, T>(onFulfilled: _.Fn1<A1, Promise<T> | T>): Promise<T>;

--- a/types/when/tsconfig.json
+++ b/types/when/tsconfig.json
@@ -6,8 +6,8 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
-        "strictFunctionTypes": false,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/when/when-tests.ts
+++ b/types/when/when-tests.ts
@@ -10,13 +10,14 @@ class ForeignPromise<T> {
 	constructor(private readonly value: T) {
 	}
 
-	then<U>(onFulfilled: (value: T) => U, onRejected?: (reason: any) => U) { return new ForeignPromise<U>(onFulfilled(this.value)); }
+	then<U>(onFulfilled?: (value: T) => U, onRejected?: (reason: any) => U) { return new ForeignPromise<U>(onFulfilled(this.value)); }
 };
 
 var promise: when.Promise<number>;
 var foreign = new ForeignPromise<number>(1);
 var error = new Error("boom!");
 var example: () => void;
+var native: Promise<number>;
 
 /* * * * * * *
  *   Core    *
@@ -174,13 +175,16 @@ deferred.reject(error);
 
 when(1).done();
 when(1).done((val: number) => console.log(val));
+when(1).done(undefined, (err: any) => console.log(err));
 when(1).done((val: number) => console.log(val), (err: any) => console.log(err));
 
 /* promise.then(onFulfilled) */
 
+promise = when(1).then();
 promise = when(1).then((val: number) => val + val);
 promise = when(1).then((val: number) => when(val + val));
 
+promise = when(1).then(undefined, (err: any) => 2);
 promise = when(1).then((val: number) => val + val, (err: any) => 2);
 promise = when(1).then((val: number) => when(val + val), (err: any) => 2);
 
@@ -443,3 +447,10 @@ example = function () {
 			(value: number) => console.log(value),
 			(err: any) => console.error(err));
 };
+
+/* * * * * * * * * * *
+ *  Native Promises  *
+ * * * * * * * * * * */
+
+native = Promise.resolve(when(1));
+native = Promise.all([when(1)]).then(([x]) => x);


### PR DESCRIPTION
This makes when.js promises compatible with native promises, i.e. `Promise.resolve(when(1))` now compiles. This also fixes the optional `onFulfilled` parameter in the `then` function.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/cujojs/when/blob/47c5044c7cc2039b45471d602c4a0da587bd3788/docs/api.md#promisethen>>
<<https://github.com/Microsoft/TypeScript/blob/d4a166dad3644e9a5aab5aa2c9468a5e67ab8d90/lib/lib.es5.d.ts#L1318>>
<<https://promisesaplus.com/#the-then-method>>
