### PR TITLE
Update type react-toastr: Allow JSX to be used for title and message content.

### DIFF
--- a/types/react-toastr/index.d.ts
+++ b/types/react-toastr/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-toastr 3.0
+// Type definitions for react-toastr 3.1
 // Project: https://github.com/tomchentw/react-toastr
 // Definitions by: Josh Holmer <https://github.com/shssoichiro>, Dan Regazzi <https://github.com/DanRegazzi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/types/react-toastr/index.d.ts
+++ b/types/react-toastr/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-toastr 3.1
+// Type definitions for react-toastr 3.0
 // Project: https://github.com/tomchentw/react-toastr
 // Definitions by: Josh Holmer <https://github.com/shssoichiro>, Dan Regazzi <https://github.com/DanRegazzi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -10,10 +10,10 @@ export class ToastContainer extends Component<{
     toastMessageFactory: any;
     className?: string;
 }> {
-    error: (message: any, title: any, optionsOverride?: any) => void;
-    info: (message: any, title: any, optionsOverride?: any) => void;
-    success: (message: any, title: any, optionsOverride?: any) => void;
-    warning: (message: any, title: any, optionsOverride?: any) => void;
+    error: (message: string | React.ReactNode, title: string | React.ReactNode, optionsOverride?: {}) => void;
+    info: (message: string | React.ReactNode, title: string | React.ReactNode, optionsOverride?: {}) => void;
+    success: (message: string | React.ReactNode, title: string | React.ReactNode, optionsOverride?: {}) => void;
+    warning: (message: string | React.ReactNode, title: string | React.ReactNode, optionsOverride?: {}) => void;
     clear: () => void;
 }
 export const ToastMessageAnimated: keyof ReactHTML;

--- a/types/react-toastr/index.d.ts
+++ b/types/react-toastr/index.d.ts
@@ -10,10 +10,10 @@ export class ToastContainer extends Component<{
     toastMessageFactory: any;
     className?: string;
 }> {
-    error: (message: string | React.ReactNode, title: string | React.ReactNode, optionsOverride?: {}) => void;
-    info: (message: string | React.ReactNode, title: string | React.ReactNode, optionsOverride?: {}) => void;
-    success: (message: string | React.ReactNode, title: string | React.ReactNode, optionsOverride?: {}) => void;
-    warning: (message: string | React.ReactNode, title: string | React.ReactNode, optionsOverride?: {}) => void;
+    error: (message: React.ReactNode, title: React.ReactNode, optionsOverride?: {}) => void;
+    info: (message: React.ReactNode, title: React.ReactNode, optionsOverride?: {}) => void;
+    success: (message: React.ReactNode, title: React.ReactNode, optionsOverride?: {}) => void;
+    warning: (message: React.ReactNode, title: React.ReactNode, optionsOverride?: {}) => void;
     clear: () => void;
 }
 export const ToastMessageAnimated: keyof ReactHTML;

--- a/types/react-toastr/index.d.ts
+++ b/types/react-toastr/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for react-toastr 3.0
 // Project: https://github.com/tomchentw/react-toastr
-// Definitions by: Josh Holmer <https://github.com/shssoichiro>
+// Definitions by: Josh Holmer <https://github.com/shssoichiro>, Dan Regazzi <https://github.com/DanRegazzi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -10,10 +10,10 @@ export class ToastContainer extends Component<{
     toastMessageFactory: any;
     className?: string;
 }> {
-    error: (message: string, title: string, optionsOverride?: {}) => void;
-    info: (message: string, title: string, optionsOverride?: {}) => void;
-    success: (message: string, title: string, optionsOverride?: {}) => void;
-    warning: (message: string, title: string, optionsOverride?: {}) => void;
+    error: (message: any, title: any, optionsOverride?: any) => void;
+    info: (message: any, title: any, optionsOverride?: any) => void;
+    success: (message: any, title: any, optionsOverride?: any) => void;
+    warning: (message: any, title: any, optionsOverride?: any) => void;
     clear: () => void;
 }
 export const ToastMessageAnimated: keyof ReactHTML;


### PR DESCRIPTION
The type definition only allowed strings to be used for the toast title and message content, but react-toastr should also allow JSX elements to be used. Updated the type definition to allow 'any' type for the toast title and message content to allow for strings or JSX Elements.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://tomchentw.github.io/react-toastr/
- [x] Increase the version number in the header if appropriate.
