### PR TITLE
Change AngularJS Scope $id from number to string.

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -524,7 +524,7 @@ declare namespace angular {
 
         $parent: IScope;
         $root: IRootScopeService;
-        $id: number;
+        $id: string;
 
         // Hidden members
         $$isolateBindings: any;


### PR DESCRIPTION
Based on discussion with evmar and mhevery, this should be a string, not a number.

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
  - I'm not sure how to write a test that reflects this change. Is this necessary?
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://github.com/google/closure-compiler/blob/6797f5b2932c4dcdc12a3d4f9580d7fb9ae4bbf8/contrib/externs/angular-1.6.js#L930
     The current angularjs 1.6 externs specify that this is a string, not a number. This being correct was confirmed by Misko (mhevery).
- [ ] Increase the version number in the header if appropriate.
