### PR TITLE
raven: Add definitions for transports

### DIFF
--- a/types/raven/index.d.ts
+++ b/types/raven/index.d.ts
@@ -7,7 +7,9 @@
 
 /// <reference types="node" />
 
-import { IncomingMessage, ServerResponse } from 'http';
+import { 
+  IncomingMessage, ServerResponse, OutgoingHttpHeaders, Agent, ClientRequest
+} from 'http';
 import { EventEmitter } from 'events';
 
 // expose all methods of `Client` class since raven exposes a singleton instance
@@ -122,4 +124,40 @@ export interface CaptureOptions {
     level?: string;
     req?: IncomingMessage;
     user?: any;
+}
+
+export namespace transports {
+  interface HTTPTransportOptions {
+    hostname?: string;
+    path?: string;
+    headers?: OutgoingHttpHeaders;
+    method?: 'POST' | 'GET';
+    port?: number;
+    ca?: string;
+    agent?: Agent;
+  }
+  abstract class Transport extends EventEmitter {
+    abstract send(
+      client: Client,
+      message: any,
+      headers: OutgoingHttpHeaders,
+      eventId: string,
+      cb: CaptureCallback
+    ): void;
+  }
+  class HTTPTransport extends Transport {
+    defaultPort: string;
+    options: HTTPTransportOptions;
+    agent: Agent;
+    constructor(options?: HTTPTransportOptions);
+    send(
+      client: Client,
+      message: any,
+      headers: OutgoingHttpHeaders,
+      eventId: string,
+      cb: CaptureCallback
+    ): void;
+  }
+  class HTTPSTransport extends HTTPTransport {
+  }
 }

--- a/types/raven/index.d.ts
+++ b/types/raven/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for raven 2.1
+// Type definitions for raven 2.5
 // Project: https://github.com/getsentry/raven-node
 // Definitions by: Scott Cooper <https://github.com/scttcper>
 //                 Dmitrii Sorin <https://github.com/1999>

--- a/types/raven/index.d.ts
+++ b/types/raven/index.d.ts
@@ -83,7 +83,7 @@ export interface ConstructorOptions {
     sampleRate?: number;
     sendTimeout?: number;
     shouldSendCallback?: ShouldSendCallback;
-    transport?: TransportCallback;
+    transport?: transports.Transport;
     captureUnhandledRejections?: boolean;
     maxBreadcrumbs?: number;
     autoBreadcrumbs?: boolean | { [breadcrumbType: string]: boolean };
@@ -114,8 +114,6 @@ export type CaptureCallback = (sendErr: Error | null | undefined, eventId: any) 
 export type DataCallback = (data: { [key: string]: any }) => any;
 
 export type ShouldSendCallback = (data: { [key: string]: any }) => boolean;
-
-export type TransportCallback = (options: { [key: string]: any }) => void;
 
 export interface CaptureOptions {
     tags?: { [key: string]: string };

--- a/types/raven/index.d.ts
+++ b/types/raven/index.d.ts
@@ -7,7 +7,7 @@
 
 /// <reference types="node" />
 
-import { 
+import {
   IncomingMessage, ServerResponse, OutgoingHttpHeaders, Agent, ClientRequest
 } from 'http';
 import { EventEmitter } from 'events';

--- a/types/raven/raven-tests.ts
+++ b/types/raven/raven-tests.ts
@@ -10,8 +10,11 @@ Raven.config(dsn, {
 });
 console.log(Raven.version);
 
+const transport = new Raven.transports.HTTPTransport();
+
 Raven.config({
-    release: 'foobar'
+    release: 'foobar',
+    transport
 });
 client.setContext({});
 client.on('logged', () => { });


### PR DESCRIPTION
The module [exports transports](https://github.com/getsentry/raven-node/blob/master/index.js#L6) so they should be defined in the types.

The client's `transport` is no longer a function but an object with a `send` method: https://github.com/getsentry/raven-node/blob/master/lib/client.js#L327

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/getsentry/raven-node/
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.