### PR TITLE
[plupload] Additional Documentation and .features type fix

### DIFF
--- a/types/plupload/index.d.ts
+++ b/types/plupload/index.d.ts
@@ -143,8 +143,21 @@ declare namespace plupload {
 
         constructor(settings: plupload_settings);
 
-        /** Properties */
+        /**
+		 * Unique id for the Uploader instance.
+		 *
+		 * @property id
+		 * @type String
+		 */
         id: string;
+
+        /**
+		 * Current state of the total uploading progress. This one can either be plupload.STARTED or plupload.STOPPED.
+		 * These states are controlled by the stop/start methods. The default value is STOPPED.
+		 *
+		 * @property state
+		 * @type Number
+		 */
         state: number;
 
         /**
@@ -156,24 +169,146 @@ declare namespace plupload {
 		 * @type Object
 		 */
         features: any;
+
+        /**
+		 * Current runtime name.
+		 *
+		 * @property runtime
+		 * @type String
+		 */
         runtime: string;
-        files: any;
+
+        /**
+		 * Current upload queue, an array of File instances.
+		 *
+		 * @property files
+		 * @type Array
+		 * @see plupload.File
+		 */
+        files: Array<any>;
+
+        /**
+		 * Object with name/value settings.
+		 *
+		 * @property settings
+		 * @type Object
+		 */
         settings: any;
+
+        /**
+		 * Total progess information. How many files has been uploaded, total percent etc.
+		 *
+		 * @property total
+		 * @type plupload.QueueProgress
+		 */
         total: plupload_queue_progress;
 
-        /** Methods */
-        init(): any;
-        setOption(option: string | any, value?: any): any;
+        /**
+		 * Initializes the Uploader instance and adds internal event listeners.
+		 *
+		 * @method init
+		 */
+        init(): void;
+
+        /**
+		 * Set the value for the specified option(s).
+		 *
+		 * @method setOption
+		 * @since 2.1
+		 * @param {String|Object} option Name of the option to change or the set of key/value pairs
+		 * @param {Mixed} [value] Value for the option (is ignored, if first argument is object)
+		 */
+        setOption(option: string | any, value?: any): void;
+
+        /**
+		 * Get the value for the specified option or the whole configuration, if not specified.
+		 *
+		 * @method getOption
+		 * @since 2.1
+		 * @param {String} [option] Name of the option to get
+		 * @return {Mixed} Value for the option or the whole set
+		 */
         getOption(option?: string): any;
-        refresh(): any;
-        start(): any;
-        stop(): any;
-        disableBrowse(disable: boolean): any;
+
+        /**
+		 * Refreshes the upload instance by dispatching out a refresh event to all runtimes.
+		 * This would for example reposition flash/silverlight shims on the page.
+		 *
+		 * @method refresh
+		 */
+        refresh(): void;
+
+        /**
+		 * Starts uploading the queued files.
+		 *
+		 * @method start
+		 */
+        start(): void;
+
+        /**
+		 * Stops the upload of the queued files.
+		 *
+		 * @method stop
+		 */
+        stop(): void;
+
+        /**
+		 * Disables/enables browse button on request.
+		 *
+		 * @method disableBrowse
+		 * @param {Boolean} disable Whether to disable or enable (default: true)
+		 */
+        disableBrowse(disable: boolean): void;
+
+        // TODO: Make plupload.File typing
+        /**
+		 * Returns the specified file object by id.
+		 *
+		 * @method getFile
+		 * @param {String} id File id to look for.
+		 * @return {plupload.File} File object or undefined if it wasn't found;
+		 */
         getFile(id: string): any;
-        addFile(file: any, fileName?: string): any;
+
+        /**
+		 * Adds file to the queue programmatically. Can be native file, instance of Plupload.File,
+		 * instance of mOxie.File, input[type="file"] element, or array of these. Fires FilesAdded,
+		 * if any files were added to the queue. Otherwise nothing happens.
+		 *
+		 * @method addFile
+		 * @since 2.0
+		 * @param {plupload.File|mOxie.File|File|Node|Array} file File or files to add to the queue.
+		 * @param {String} [fileName] If specified, will be used as a name for the file
+		 */
+        addFile(file: any, fileName?: string): void;
+
+        /**
+		 * Removes a specific file.
+		 *
+		 * @method removeFile
+		 * @param {plupload.File|String} file File to remove from queue.
+		 */
         removeFile(file: any): any;
+
+        /**
+		 * Removes part of the queue and returns the files removed. This will also trigger the
+		 * FilesRemoved and QueueChanged events.
+		 *
+		 * @method splice
+		 * @param {Number} [start=0] Start index to remove from.
+		 * @param {Number} [length] Number of files to remove (defaults to number of files in the queue).
+		 * @return {Array} Array of files that was removed.
+		 */
         splice(start?: number, length?: number): any;
+
+        /**
+		 * Dispatches the specified event name and its arguments to all listeners.
+		 * @method trigger
+	 	 * @param {String} name Event name to fire.
+         * @param {Object..} Multiple arguments to pass along to the listener functions.
+		*/
         trigger(name: string, Multiple: any): any;
+        
         hasEventListener(name: string): any;
         bind(name: string, func: any, scope?: any): any;
         unbind(name: string, func: any): any;

--- a/types/plupload/index.d.ts
+++ b/types/plupload/index.d.ts
@@ -146,7 +146,16 @@ declare namespace plupload {
         /** Properties */
         id: string;
         state: number;
-        features: string;
+
+        /**
+		 * Map of features that are available for the uploader runtime. Features will be filled
+		 * before the init event is called, these features can then be used to alter the UI for the end user.
+		 * Some of the current features that might be in this map is: dragdrop, chunks, jpgresize, pngresize.
+		 *
+		 * @property features
+		 * @type Object
+		 */
+        features: any;
         runtime: string;
         files: any;
         settings: any;

--- a/types/plupload/index.d.ts
+++ b/types/plupload/index.d.ts
@@ -174,22 +174,157 @@ declare namespace plupload {
 
     export const VERSION: string;
 
+    /**
+	 * The state of the queue before it has started and after it has finished
+	 *
+	 * @property STOPPED
+	 * @static
+	 * @final
+	 */
     export const STOPPED: number;
+
+    /**
+	 * Upload process is running
+	 *
+	 * @property STARTED
+	 * @static
+	 * @final
+	 */
     export const STARTED: number;
+
+    /**
+	 * File is queued for upload
+	 *
+	 * @property QUEUED
+	 * @static
+	 * @final
+	 */
     export const QUEUED: number;
+
+    /**
+	 * File is being uploaded
+	 *
+	 * @property UPLOADING
+	 * @static
+	 * @final
+	 */
     export const UPLOADING: number;
+
+    /**
+	 * File has failed to be uploaded
+	 *
+	 * @property FAILED
+	 * @static
+	 * @final
+	 */
     export const FAILED: number;
+
+    /**
+	 * File has been uploaded successfully
+	 *
+	 * @property DONE
+	 * @static
+	 * @final
+	 */
     export const DONE: number;
+
+    /**
+	 * Generic error for example if an exception is thrown inside Silverlight.
+	 *
+	 * @property GENERIC_ERROR
+	 * @static
+	 * @final
+	 */
     export const GENERIC_ERROR: number;
+
+    /**
+	 * HTTP transport error. For example if the server produces a HTTP status other than 200.
+	 *
+	 * @property HTTP_ERROR
+	 * @static
+	 * @final
+	 */
     export const HTTP_ERROR: number;
+
+    /**
+	 * Generic I/O error. For example if it wasn't possible to open the file stream on local machine.
+	 *
+	 * @property IO_ERROR
+	 * @static
+	 * @final
+	 */
     export const IO_ERROR: number;
+
+    /**
+	 * @property SECURITY_ERROR
+	 * @static
+	 * @final
+	 */
     export const SECURITY_ERROR: number;
+
+    /**
+	 * Initialization error. Will be triggered if no runtime was initialized.
+	 *
+	 * @property INIT_ERROR
+	 * @static
+	 * @final
+	 */
     export const INIT_ERROR: number;
+
+    /**
+	 * File size error. If the user selects a file that is too large or is empty it will be blocked and
+	 * an error of this type will be triggered.
+	 *
+	 * @property FILE_SIZE_ERROR
+	 * @static
+	 * @final
+	 */
     export const FILE_SIZE_ERROR: number;
+
+    /**
+	 * File extension error. If the user selects a file that isn't valid according to the filters setting.
+	 *
+	 * @property FILE_EXTENSION_ERROR
+	 * @static
+	 * @final
+	 */
     export const FILE_EXTENSION_ERROR: number;
+
+    /**
+	 * Duplicate file error. If prevent_duplicates is set to true and user selects the same file again.
+	 *
+	 * @property FILE_DUPLICATE_ERROR
+	 * @static
+	 * @final
+	 */
     export const FILE_DUPLICATE_ERROR: number;
+
+    /**
+	 * Runtime will try to detect if image is proper one. Otherwise will throw this error.
+	 *
+	 * @property IMAGE_FORMAT_ERROR
+	 * @static
+	 * @final
+	 */
     export const IMAGE_FORMAT_ERROR: number;
+
+    /**
+	 * While working on files runtime may run out of memory and will throw this error.
+	 *
+	 * @since 2.1.2
+	 * @property MEMORY_ERROR
+	 * @static
+	 * @final
+	 */
     export const MEMORY_ERROR: number;
+
+    /**
+	 * Each runtime has an upper limit on a dimension of the image it can handle. If bigger, will throw this error.
+	 *
+	 * @property IMAGE_DIMENSIONS_ERROR
+	 * @static
+	 * @final
+	 */
     export const IMAGE_DIMENSIONS_ERROR: number;
 
     export const mimeTypes: any;

--- a/types/plupload/plupload-tests.ts
+++ b/types/plupload/plupload-tests.ts
@@ -24,7 +24,6 @@ import 'plupload';
     if (!uploader.features.chunks || !uploader.features.multipart) {
         window.alert('Your browser does not support a feature required for uploads.  Try installing Flash or Silverlight.');
     }
-
 }
 
 {

--- a/types/plupload/plupload-tests.ts
+++ b/types/plupload/plupload-tests.ts
@@ -21,6 +21,10 @@ import 'plupload';
         document.getElementById('console').innerHTML += "\nError #" + err.code + ": " + err.message;
     });
 
+    if (!uploader.features.chunks || !uploader.features.multipart) {
+        window.alert('Your browser does not support a feature required for uploads.  Try installing Flash or Silverlight.');
+    }
+
 }
 
 {


### PR DESCRIPTION
Features property is not a string, but instead a map.  For the time being I've simply widened its typing, because I can't find all of the potential items that are currently supported in it for its "type" in the documentation.

Also, I added some more documentation to help with intellisense.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [plupload uploader features-property docs](https://www.plupload.com/docs/v2/Uploader#features-property)
