### PR TITLE
Chart.js :: Added a missing type for beginAtZero for TickOptions.

### DIFF
--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -396,6 +396,7 @@ declare namespace Chart {
     interface TickOptions {
         autoSkip?: boolean;
         autoSkipPadding?: number;
+        beginAtZero?: boolean;
         callback?(value: any, index: any, values: any): string|number;
         display?: boolean;
         fontColor?: ChartColor;

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -439,6 +439,7 @@ declare namespace Chart {
         suggestedMax?: number;
     }
 
+    // tslint:disable-next-line no-empty-interface
     interface LogarithmicTickOptions extends TickOptions {
     }
 

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -396,6 +396,9 @@ declare namespace Chart {
     interface TickOptions {
         autoSkip?: boolean;
         autoSkipPadding?: number;
+        backdropColor?: ChartColor;
+        backdropPaddingX?: number;
+        backdropPaddingY?: number;
         beginAtZero?: boolean;
         callback?(value: any, index: any, values: any): string|number;
         display?: boolean;
@@ -404,14 +407,17 @@ declare namespace Chart {
         fontSize?: number;
         fontStyle?: string;
         labelOffset?: number;
+        max?: any;
         maxRotation?: number;
+        maxTicksLimit?: number;
+        min?: any;
         minRotation?: number;
         mirror?: boolean;
         padding?: number;
         reverse?: boolean;
-        min?: any;
-        max?: any;
+        showLabelBackdrop?: boolean;
     }
+
     interface AngleLineOptions {
         display?: boolean;
         color?: ChartColor;
@@ -426,17 +432,7 @@ declare namespace Chart {
         fontStyle?: string;
     }
 
-    interface TickOptions {
-        backdropColor?: ChartColor;
-        backdropPaddingX?: number;
-        backdropPaddingY?: number;
-        maxTicksLimit?: number;
-        showLabelBackdrop?: boolean;
-    }
     interface LinearTickOptions extends TickOptions {
-        beginAtZero?: boolean;
-        min?: number;
-        max?: number;
         maxTicksLimit?: number;
         stepSize?: number;
         suggestedMin?: number;
@@ -444,8 +440,6 @@ declare namespace Chart {
     }
 
     interface LogarithmicTickOptions extends TickOptions {
-        min?: number;
-        max?: number;
     }
 
     type ChartColor = string | CanvasGradient | CanvasPattern | string[];


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- You will see that there is a field when creating charts for beginAtZero, this type is missing for TickOptions
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: (https://www.chartjs.org/docs/latest/getting-started/usage.html?h=zero)