### PR TITLE
[chart.js] the `text` property of title options can be `string[]`

### DIFF
--- a/types/chart.js/chart.js-tests.ts
+++ b/types/chart.js/chart.js-tests.ts
@@ -24,6 +24,9 @@ const chart: Chart = new Chart(new CanvasRenderingContext2D(), {
         onHover(ev: MouseEvent, points: any[]) {
           return;
         },
+        title: {
+            text: ["foo", "bar"]
+        },
         tooltips: {
             filter: data => Number(data.yLabel) > 0,
             intersect: true,

--- a/types/chart.js/index.d.ts
+++ b/types/chart.js/index.d.ts
@@ -219,7 +219,7 @@ declare namespace Chart {
         fontColor?: ChartColor;
         fontStyle?: string;
         padding?: number;
-        text?: string;
+        text?: string | string[];
     }
 
     interface ChartLegendOptions {


### PR DESCRIPTION
See the [chart.js documentation](http://www.chartjs.org/docs/latest/configuration/title.html): "if specified as an array, text is rendered on multiple lines.". This is an [new feature of chart.js 2.7.0](https://github.com/chartjs/Chart.js/releases/tag/v2.7.0).

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.chartjs.org/docs/latest/configuration/title.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
