### PR TITLE
Add 2 missing functions in office-js

### DIFF
--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -183,15 +183,15 @@ declare namespace Office {
         messageParent(messageObject: any): void;
         /**
          * Closes the UI container where the JavaScript is executing.
-         * 
+         *
          * Supported hosts: Outlook - Minimum requirement set: Mailbox 1.5
-         * 
+         *
          * The behavior of this method is specified by the following:
-         * 
+         *
          * Called from a UI-less command button: No effect. Any dialog opened by displayDialogAsync will remain open.
-         * 
+         *
          * Called from a taskpane: The taskpane will close. Any dialog opened by displayDialogAsync will also close. If the taskpane supports pinning and was pinned by the user, it will be un-pinned.
-         * 
+         *
          * Called from a module extension: No effect.
          */
         closeContainer(): void;
@@ -2102,6 +2102,15 @@ declare namespace Office {
          * Returns string values that match the named regular expression defined in the manifest XML file
          */
         getRegExMatchesByName(name: string): Array<string>;
+        /**
+        * Gets the entities found in the selected item that are currently selected (1.6 and up)
+        */
+        getSelectedEntities(): Entities;
+        /**
+         * Returns string values in the currently selected message object that match the regular expressions defined in the manifest XML file and
+         * are selected in the current item (1.6 and up)
+         */
+        getSelectedRegExMatches(): any;
     }
     export interface LocalClientTime {
         month: number;
@@ -2608,12 +2617,12 @@ declare namespace OfficeExtension {
     }
 
     export interface EmbeddedOptions {
-		sessionKey?: string,
-		container?: HTMLElement,
-		id?: string;
-		timeoutInMilliseconds?: number;
-		height?: string;
-		width?: string;
+        sessionKey?: string,
+        container?: HTMLElement,
+        id?: string;
+        timeoutInMilliseconds?: number;
+        height?: string;
+        width?: string;
     }
 
     class EmbeddedSession {

--- a/types/office-js/index.d.ts
+++ b/types/office-js/index.d.ts
@@ -2103,12 +2103,16 @@ declare namespace Office {
          */
         getRegExMatchesByName(name: string): Array<string>;
         /**
-        * Gets the entities found in the selected item that are currently selected (1.6 and up)
+        * Gets the entities found in the selected item that are currently selected
+        *
+        * [Api set: Mailbox 1.6]
         */
         getSelectedEntities(): Entities;
         /**
          * Returns string values in the currently selected message object that match the regular expressions defined in the manifest XML file and
-         * are selected in the current item (1.6 and up)
+         * are selected in the current item
+         *
+         * [Api set: Mailbox 1.6]
          */
         getSelectedRegExMatches(): any;
     }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.) [there was no test for Outlook]
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://dev.office.com/reference/add-ins/outlook/1.6/Office.context.mailbox.item#getselectedentities--entities and next function in there
- [x] Increase the version number in the header if appropriate. [don't seem appropriate]
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`. [not making substantial changes]

