### PR TITLE
Enhance definition for heapdump

### DIFF
--- a/types/heapdump/heapdump-tests.ts
+++ b/types/heapdump/heapdump-tests.ts
@@ -1,9 +1,9 @@
 import * as heapdump from 'heapdump';
 
-let strValue: string = "";
-let errValue: Error = new Error(strValue);
-let nullValue: null = null;
-let undefinedValue: undefined = undefined;
+let strValue = "";
+let errValue = new Error(strValue);
+let nullValue = null;
+let undefinedValue;
 
 heapdump.writeSnapshot(strValue, (err, filename) => {
   errValue = err as Error;

--- a/types/heapdump/heapdump-tests.ts
+++ b/types/heapdump/heapdump-tests.ts
@@ -1,9 +1,20 @@
 import * as heapdump from 'heapdump';
 
-heapdump.writeSnapshot('/tmp/myDump', (err) => {
-  if (err) {
-    console.log('Failed to dump heap: ' + err);
-  } else {
-    console.log('Successfully dumped heap!');
-  }
+let strValue: string = "";
+let errValue: Error = new Error(strValue);
+let nullValue: null = null;
+let undefinedValue: undefined = undefined;
+
+heapdump.writeSnapshot(strValue, (err, filename) => {
+  errValue = err as Error;
+  nullValue = err as null;
+  strValue = filename as string;
+  undefinedValue = filename as undefined;
+});
+
+heapdump.writeSnapshot((err, filename) => {
+  errValue = err as Error;
+  nullValue = err as null;
+  strValue = filename as string;
+  undefinedValue = filename as undefined;
 });

--- a/types/heapdump/index.d.ts
+++ b/types/heapdump/index.d.ts
@@ -2,6 +2,7 @@
 // Project: https://github.com/bnoordhuis/node-heapdump
 // Definitions by: weekens <https://github.com/weekens>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
 
 export function writeSnapshot(dumpFileName?: string, callback?: (err: Error | null, filename: string | undefined) => void): void;
 export function writeSnapshot(callback: (err: Error | null, filename: string | undefined) => void): void;

--- a/types/heapdump/index.d.ts
+++ b/types/heapdump/index.d.ts
@@ -3,4 +3,5 @@
 // Definitions by: weekens <https://github.com/weekens>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-export function writeSnapshot(dumpFileName: string, callback: (err?: Error) => void): void;
+export function writeSnapshot(dumpFileName?: string, callback?: (err: Error | null, filename: string | undefined) => void): void;
+export function writeSnapshot(callback: (err: Error | null, filename: string | undefined) => void): void;


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [source-code](https://github.com/bnoordhuis/node-heapdump/blob/master/lib/main.js#L39) and [usage section of the README.md](https://github.com/bnoordhuis/node-heapdump#usage)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

---

See also #23891:

> According to the [source-code](https://github.com/bnoordhuis/node-heapdump/blob/master/lib/main.js#L39) of `heapdump` the error is of type `Error | null`.
>
>In addition, according to the [usage section of the README.md](https://github.com/bnoordhuis/node-heapdump#usage) there is also the possibility to call the function without a filename.

---

Closes #23891