### PR TITLE
Bootstrap: update to 4.1

### DIFF
--- a/types/bootstrap/bootstrap-tests.ts
+++ b/types/bootstrap/bootstrap-tests.ts
@@ -43,8 +43,13 @@ $("#carousel").on("slide.bs.carousel", function(ev) {
 $("#carousel").carousel({
     interval: 5000,
     keyboard: true,
+    slide: false,
     pause: "hover",
     wrap: true,
+});
+
+$("#carousel").carousel({
+    slide: "prev",
 });
 
 $("#carousel").carousel({
@@ -96,6 +101,8 @@ $("#dropdown").dropdown({
     offset: 10,
     flip: false,
     boundary: "window",
+    reference: "toggle",
+    display: "dynamic",
 });
 
 $("#dropdown").dropdown({
@@ -112,6 +119,10 @@ $("#dropdown").dropdown({
 
 $("#dropdown").dropdown({
     boundary: document.body,
+});
+
+$("#dropdown").dropdown({
+    reference: document.body,
 });
 
 // --------------------------------------------------------------------------------------

--- a/types/bootstrap/index.d.ts
+++ b/types/bootstrap/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Bootstrap 4.0
+// Type definitions for Bootstrap 4.1
 // Project: https://github.com/twbs/bootstrap/
 // Definitions by: denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -54,6 +54,14 @@ export interface CarouselOption {
      * @default true
      */
     keyboard?: boolean;
+
+    /**
+     * Use to easily control the position of the carousel. It accepts the keywords prev or next, which alters the slide position
+     * relative to its current position. Alternatively, use `data-slide-to` to pass a raw slide index to the carousel.
+     *
+     * @default false
+     */
+    slide?: "next" | "prev" | false;
 
     /**
      * If set to "hover", pauses the cycling of the carousel on mouseenter and resumes the cycling of the carousel on mouseleave.
@@ -116,6 +124,21 @@ export interface DropdownOption {
      * @default "scrollParent"
      */
     boundary?: Popper.Boundary | HTMLElement;
+
+    /**
+     * Reference element of the dropdown menu. Accepts the values of 'toggle', 'parent', or an HTMLElement reference.
+     * For more information refer to Popper.js's referenceObject docs.
+     *
+     * @default "toggle"
+     */
+    reference?: "toggle" | "parent" | HTMLElement;
+
+    /**
+     * By default, we use Popper.js for dynamic positioning. Disable this with 'static'.
+     *
+     * @default "dynamic"
+     */
+    display?: "dynamic" | "static";
 }
 
 export interface ModalOption {
@@ -154,6 +177,8 @@ export interface PopoverOption extends TooltipOption {
      * Default content value if data-content attribute isn't present.
      * If a function is given, it will be called with its this reference
      * set to the element that the popover is attached to.
+     *
+     * @default ""
      */
     content?: string | Element | ((this: Element) => string | Element);
 }
@@ -226,7 +251,7 @@ export interface TooltipOption {
      * the tooltip or popover DOM node as its first argument and the triggering element DOM node as its second.
      * The this context is set to the tooltip or popover instance.
      *
-     * @default "top"
+     * @default tooltip: "top", popover: "right"
      */
     placement?: Placement | ((this: TooltipInstance<this>, node: HTMLElement, trigger: Element) => Placement);
 


### PR DESCRIPTION
Update types according to Bootstrap 4.1.
Add missing `slide` option from 4.0.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://getbootstrap.com/docs/4.1/components/dropdowns/#options
- [x] Increase the version number in the header if appropriate.
