### PR TITLE
[rename] Remove minimum version

### DIFF
--- a/types/rename/index.d.ts
+++ b/types/rename/index.d.ts
@@ -2,7 +2,6 @@
 // Project: https://github.com/popomore/rename
 // Definitions by: Aankhen <https://github.com/Aankhen>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.5
 
 /// <reference types="node" />
 

--- a/types/rename/rename-tests.ts
+++ b/types/rename/rename-tests.ts
@@ -3,9 +3,12 @@ import rename = require('rename');
 rename();                       // $ExpectError
 rename('a.js');                 // $ExpectError
 rename(undefined, undefined);   // $ExpectError
-rename(1, 2);                   // $ExpectError
-rename('a.js', () => { });       // $ExpectError
-rename('a.js', (obj) => { });    // $ExpectError
+
+// These fail to produce errors on 2.4
+// rename(1, 2);                   // $ExpectError
+// rename('a.js', () => { });       // $ExpectError
+// rename('a.js', (obj) => { });    // $ExpectError
+
 rename({ non: "existent" }, 'b.js'); // $ExpectError
 
 rename('a.js', 'b.js');         // $ExpectType FilePath
@@ -40,7 +43,10 @@ rename.parse({});               // $ExpectError
 rename.parse("p.js");
 
 rename.stringify();             // $ExpectError
-rename.stringify("abcd.js");    // $ExpectError
+
+// This fails to produce an error on 2.4
+// rename.stringify("abcd.js");    // $ExpectError
+
 rename.stringify({});
 rename.stringify({ suffix: ".js" }); // $ExpectError
 rename.stringify({ extname: ".js" });


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This is just removing the minimum version that I included in [the type definitions for rename](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24887). I added that because a few `$ExpectError` tests fail under 2.4, but as @mhegazy [pointed out](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24887#discussion_r180860237), the types themselves don’t require 2.5, so I’ve commented out the failing tests.