### PR TITLE
[react] Add comment about removed index signature

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -897,7 +897,16 @@ declare namespace React {
         onTransitionEndCapture?: TransitionEventHandler<T>;
     }
 
-    export interface CSSProperties extends CSS.Properties<string | number> {}
+    export interface CSSProperties extends CSS.Properties<string | number> {
+        /**
+         * The index signature was removed to enable closed typing for style
+         * using CSSType. You're able to use type assertion or module augmentation
+         * to add properties or an index signature of your own.
+         *
+         * For examples and more information, visit:
+         * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+         */
+    }
 
     interface HTMLAttributes<T> extends DOMAttributes<T> {
         // React-specific Attributes


### PR DESCRIPTION
The [index signature for `React.CSSProperties` was removed](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24911) to enable closed typing. In this PR I just added a comment about that and how to use module augmentation to add CSS custom properties or a index signature of their own.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
