### PR TITLE
[react-navigation] Loosen navigator navigationOptions

### DIFF
--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -158,9 +158,7 @@ export interface NavigationScreenDetails<T> {
   navigation: NavigationScreenProp<NavigationRoute>;
 }
 
-export interface NavigationScreenOptions {
-  title?: string;
-}
+export type NavigationScreenOptions = NavigationStackScreenOptions & NavigationTabScreenOptions & NavigationDrawerScreenOptions;
 
 export interface NavigationScreenConfigProps {
   navigation: NavigationScreenProp<NavigationRoute>;
@@ -289,7 +287,8 @@ export interface NavigationStackViewConfig {
   onTransitionEnd?: () => void;
 }
 
-export type NavigationStackScreenOptions = NavigationScreenOptions & {
+export interface NavigationStackScreenOptions {
+  title?: string;
   header?: (React.ReactElement<any> | ((headerProps: HeaderProps) => React.ReactElement<any>)) | null;
   headerTransparent?: boolean;
   headerTitle?: string | React.ReactElement<any>;
@@ -312,7 +311,7 @@ export interface NavigationStackRouterConfig {
   initialRouteName?: string;
   initialRouteParams?: NavigationParams;
   paths?: NavigationPathsConfig;
-  navigationOptions?: NavigationScreenConfig<NavigationStackScreenOptions>;
+  navigationOptions?: NavigationScreenConfig<NavigationScreenOptions>;
 }
 
 export type NavigationStackAction =
@@ -352,7 +351,7 @@ export interface NavigationPathsConfig {
 export interface NavigationTabRouterConfig {
   initialRouteName?: string;
   paths?: NavigationPathsConfig;
-  navigationOptions?: NavigationScreenConfig<NavigationTabScreenOptions>;
+  navigationOptions?: NavigationScreenConfig<NavigationScreenOptions>;
   order?: string[]; // todo: type these as the real route names rather than 'string'
 
   // Does the back button cause the router to switch to the initial tab
@@ -364,7 +363,8 @@ export interface TabScene {
     index: number;
     tintColor?: string;
 }
-export interface NavigationTabScreenOptions extends NavigationScreenOptions {
+export interface NavigationTabScreenOptions {
+  title?: string;
   tabBarIcon?:
     React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<
@@ -384,7 +384,8 @@ export interface NavigationTabScreenOptions extends NavigationScreenOptions {
   }) => void;
 }
 
-export interface NavigationDrawerScreenOptions extends NavigationScreenOptions {
+export interface NavigationDrawerScreenOptions {
+  title?: string;
   drawerIcon?:
     React.ReactElement<any>
     | ((options: { tintColor: (string | null), focused: boolean }) => (React.ReactElement<

--- a/types/react-navigation/index.d.ts
+++ b/types/react-navigation/index.d.ts
@@ -304,7 +304,7 @@ export interface NavigationStackScreenOptions {
   headerBackground?: React.ReactNode | React.ReactType;
   gesturesEnabled?: boolean;
   gestureResponseDistance?: { vertical?: number; horizontal?: number };
-};
+}
 
 export interface NavigationStackRouterConfig {
   headerTransitionPreset?: 'fade-in-place' | 'uikit';

--- a/types/react-navigation/react-navigation-tests.tsx
+++ b/types/react-navigation/react-navigation-tests.tsx
@@ -193,7 +193,10 @@ const tabNavigatorConfigWithNavigationOptions: TabNavigatorConfig = {
     navigationOptions: {
         tabBarOnPress: ({scene, jumpToIndex}) => {
             jumpToIndex(scene.index);
-        }
+        },
+        headerStyle: {
+            backgroundColor: 'red',
+        },
     },
 };
 


### PR DESCRIPTION
This is a common use case for me. I have `TabNavigator` inside `StackNavigator` and I want to set `navigationOptions` on tab navigator as If it is just a regular screen of stack. Current definitions won't let me do that, because `NavigationTabRouterConfig` limits `navigationOptions`. This problem is illustrated by lines added to test file.

This PR resolves this problem by loosening `navigationOptions` on tab and stack router. I took a liberty here and completely redefined `NavigationScreenOptions` type to be a union type, because 1) It's the best name for union type 2) Previous NavigationScreenOptions were just one-liner `{title?: string} and they're highly unlikely to be used on it's own, outside tab or stack navigator options.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.