### PR TITLE
fix(hapi): allow passing object to toolkit `state`, fix `tags` index signature, fix route `ext`

### DIFF
--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -1725,7 +1725,7 @@ export interface RouteOptions {
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#request-lifecycle)
      */
     ext?: {
-        [key in RouteRequestExtType]?: RouteExtObject;
+        [key in RouteRequestExtType]?: RouteExtObject | RouteExtObject[];
     };
 
     /**

--- a/types/hapi/index.d.ts
+++ b/types/hapi/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Marc Bornträger <https://github.com/BorntraegerMarc>
 //                 Rafael Souza Fijalkowski <https://github.com/rafaelsouzaf>
 //                 Justin Simms <https://github.com/jhsimms>
+//                 Simon Schick <https://github.com/SimonSchick>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.4
 
@@ -1008,7 +1009,7 @@ export interface ResponseToolkit {
      * @return Return value: none.
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-hstatename-value-options)
      */
-    state(name: string, value: string, options?: ServerStateCookieOptions): void;
+    state(name: string, value: string | object, options?: ServerStateCookieOptions): void;
 
     /**
      * Used by the [authentication] method to indicate authentication failed and pass back the credentials received where:
@@ -1724,12 +1725,7 @@ export interface RouteOptions {
      * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#request-lifecycle)
      */
     ext?: {
-        onPreAuth?: Lifecycle.Method;
-        onCredentials?: Lifecycle.Method;
-        onPostAuth?: Lifecycle.Method;
-        onPreHandler?: Lifecycle.Method;
-        onPostHandler?: Lifecycle.Method;
-        onPreResponse?: Lifecycle.Method;
+        [key in RouteRequestExtType]?: RouteExtObject;
     };
 
     /**
@@ -2229,8 +2225,8 @@ export interface RequestEvent {
     error: object;
 }
 
-export type LogEventHandler = (event: LogEvent, tags: object) => void;
-export type RequestEventHandler = (request: Request, event: RequestEvent, tags: object) => void;
+export type LogEventHandler = (event: LogEvent, tags: { [key: string]: true }) => void;
+export type RequestEventHandler = (request: Request, event: RequestEvent, tags: { [key: string]: true }) => void;
 export type ResponseEventHandler = (request: Request) => void;
 export type RouteEventHandler = (route: ServerRoute) => void;
 export type StartEventHandler = () => void;
@@ -2354,14 +2350,16 @@ export interface ServerEvents extends Podium {
  * For context [See docs](https://github.com/hapijs/hapi/blob/master/API.md#request-lifecycle)
  */
 export type ServerExtType = 'onPreStart' | 'onPostStart' | 'onPreStop' | 'onPostStop';
-export type ServerRequestExtType =
-    'onRequest'
-    | 'onPreAuth'
+export type RouteRequestExtType = 'onPreAuth'
     | 'onCredentials'
     | 'onPostAuth'
     | 'onPreHandler'
     | 'onPostHandler'
     | 'onPreResponse';
+
+export type ServerRequestExtType =
+    RouteRequestExtType
+    | 'onRequest';
 
 /**
  * [See docs](https://github.com/hapijs/hapi/blob/master/API.md#-serverextevents)
@@ -2401,14 +2399,11 @@ export interface ServerExtEventsObject {
      * * request extension points: a lifecycle method.
      */
     method: ServerExtPointFunction | ServerExtPointFunction[];
-    /**
-     * options - (optional) an object with the following:
-     * * before - a string or array of strings of plugin names this method must execute before (on the same event). Otherwise, extension methods are executed in the order added.
-     * * after - a string or array of strings of plugin names this method must execute after (on the same event). Otherwise, extension methods are executed in the order added.
-     * * bind - a context object passed back to the provided method (via this) when called. Ignored if the method is an arrow function.
-     * * sandbox - if set to 'plugin' when adding a request extension points the extension is only added to routes defined by the current plugin. Not allowed when configuring route-level extensions,
-     * or when adding server extensions. Defaults to 'server' which applies to any route added to the server the extension is added to.
-     */
+    options?: ServerExtOptions;
+}
+
+export interface RouteExtObject {
+    method: Lifecycle.Method;
     options?: ServerExtOptions;
 }
 

--- a/types/hapi/test/route/ext.ts
+++ b/types/hapi/test/route/ext.ts
@@ -12,6 +12,11 @@ server.route({
                     return h.continue;
                 },
             },
+            onPostHandler: [{
+                method(_request, h) {
+                    return h.continue;
+                },
+            }],
         }
     }
 });

--- a/types/hapi/test/route/ext.ts
+++ b/types/hapi/test/route/ext.ts
@@ -7,8 +7,10 @@ server.route({
     path: "/test",
     options: {
         ext: {
-            onPreResponse(request, h) {
-                return h.continue;
+            onPreResponse: {
+                method(_request, h) {
+                    return h.continue;
+                },
             },
         }
     }

--- a/types/hapi/test/server/server-state.ts
+++ b/types/hapi/test/server/server-state.ts
@@ -1,5 +1,5 @@
 // from https://hapijs.com/tutorials/cookies?lang=en_US
-import { Request, ResponseToolkit, Server, ServerOptions, ServerRoute, ServerStateCookieOptions } from "hapi";
+import { Server, ServerOptions, ServerRoute, ServerStateCookieOptions } from "hapi";
 
 const options: ServerOptions = {
     port: 8000,
@@ -8,7 +8,8 @@ const options: ServerOptions = {
 const serverRoute: ServerRoute = {
     path: '/say-hello',
     method: 'GET',
-    handler(request, h) {
+    handler(_request, h) {
+        h.state('test', { test: true });
         return h.response('Hello').state('data', { firstVisit: false });
     }
 };


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [ ] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [ ] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [ ] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
  - `tags`: https://hapijs.com/api#-log-event 
  - `ext`: https://hapijs.com/api#-routeoptionsext (doc is vague, see code: https://github.com/hapijs/hapi/blob/master/lib/config.js#L115)
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

If removing a declaration:
- [ ] If a package was never on DefinitelyTyped, you don't need to do anything. (If you wrote a package and provided types, you don't need to register it with us.)
- [ ] Delete the package's directory.
- [ ] Add it to `notNeededPackages.json`.

@jhsimms I removed some redundant documentation as well, hope that's ok.
