### PR TITLE
[decompress] fix return value to be array instead of single instance

### DIFF
--- a/types/decompress/decompress-tests.ts
+++ b/types/decompress/decompress-tests.ts
@@ -1,13 +1,13 @@
 import decompress = require('decompress');
 import * as path from "path";
 
-decompress('unicorn.zip', 'dist').then(files => {
+decompress('unicorn.zip', 'dist').then((files: decompress.File[]) => {
 	console.log('done!');
 });
 
 decompress('unicorn.zip', 'dist', {
 	filter: file => path.extname(file.path) !== '.exe'
-}).then(files => {
+}).then((files: decompress.File[]) => {
 	console.log('done!');
 });
 
@@ -16,6 +16,6 @@ decompress('unicorn.zip', 'dist', {
 		file.path = `unicorn-${file.path}`;
 		return file;
 	}
-}).then(files => {
+}).then((files: decompress.File[]) => {
 	console.log('done!');
 });

--- a/types/decompress/index.d.ts
+++ b/types/decompress/index.d.ts
@@ -7,7 +7,7 @@
 
 export = decompress;
 
-declare function decompress(input: string | Buffer, output: string, opts?: decompress.DecompressOptions): Promise<decompress.File>;
+declare function decompress(input: string | Buffer, output: string, opts?: decompress.DecompressOptions): Promise<decompress.File[]>;
 
 declare namespace decompress {
     interface File {


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/kevva/decompress#decompressinput-output-options
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
