### PR TITLE
CropperJS - Use partials for setting methods which take options

### DIFF
--- a/types/cropperjs/index.d.ts
+++ b/types/cropperjs/index.d.ts
@@ -312,19 +312,19 @@ declare namespace cropperjs {
         /**
          * the offset left of the crop box
          */
-        left?: number;
+        left: number;
         /**
          * the offset top of the crop box
          */
-        top?: number;
+        top: number;
         /**
          * the width of the crop box
          */
-        width?: number;
+        width: number;
         /**
          * the height of the crop box
          */
-        height?: number;
+        height: number;
     }
     interface CanvasData {
         /**
@@ -516,7 +516,7 @@ declare class cropperjs {
     /**
      * Change the cropped area position and size with new data (base on the original image).
      */
-    setData(data: cropperjs.Data): void;
+    setData(data: Partial<cropperjs.Data>): void;
 
     /**
      * Output the container size data.
@@ -545,7 +545,7 @@ declare class cropperjs {
     /**
      * Change the canvas (image wrapper) position and size with new data.
      */
-    setCanvasData(data: cropperjs.CanvasData): void;
+    setCanvasData(data: Partial<cropperjs.CanvasData>): void;
 
     /**
      * Output the crop box position and size data.
@@ -555,7 +555,7 @@ declare class cropperjs {
     /**
      * Change the crop box position and size with new data.
      */
-    setCropBoxData(data: cropperjs.CropBoxData): void;
+    setCropBoxData(data: Partial<cropperjs.CropBoxData>): void;
 
     /**
      * Get a canvas drawn the cropped image.


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/fengyuanchen/cropperjs/blob/f6aff442b5579ff6457a0b995c0a2fe7673b9965/test/methods/setCanvasData.js#L12>
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


This commit addresses a problem where the following would produce a type
error, even though it was valid code:

```typescript
setCanvasData({left: 23})
```

I have changed the argument type for all of the `setXXX` methods which
accept an object as their argument. In the spec files for cropperjs,
@fengyuanchen uses these objects as partials for setters. So I have
made the type definitions follow that same pattern.

I changed the `cropperjs.CropBoxData` type to act the same way as well.
It looks like  it was changed at some point, I am guessing to allow it
to be used as a partial in the `setCropBoxData` method. Since, like all
the other data structures here, it contains all members when you `get`
it, I have made all members required parts of the object and changed
the setter method to accept a partial.

I hope this all makes sense. Basically, I went from the first line below
to the second.

```typescript
setXXXXX(thing: cropperjs.SomeInterface): void

setXXXXX(thing: Partial<cropperjs.SomeInterface>): void
```

Then I changed `cropperjs.CropBoxData` to fit this new system.
