### PR TITLE
[expo]: Add missing SvgCommonProps

### DIFF
--- a/types/expo/index.d.ts
+++ b/types/expo/index.d.ts
@@ -1873,6 +1873,7 @@ export namespace SQLite {
 export interface SvgCommonProps {
     fill?: string;
     fillOpacity?: number | string;
+    fillRule?: 'nonzero' | 'evenodd';
     stroke?: string;
     strokeWidth?: number | string;
     strokeOpacity?: number | string;
@@ -1883,6 +1884,7 @@ export interface SvgCommonProps {
     x?: number | string;
     y?: number | string;
     rotate?: number | string;
+    rotation?: number | string;
     scale?: number | string;
     origin?: number | string;
     originX?: number | string;


### PR DESCRIPTION
Expo uses 'react-native-svg' to provide svg capabilities.

This adds the common props:
* fillRule
* rotation (both 'rotate' and 'rotation' are currently supported, but
  documentation specifies 'rotation' as the current version to use).

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/react-native-community/react-native-svg#common-props
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

