### PR TITLE
[atom] Updates to AC+ types

### DIFF
--- a/types/atom/autocomplete-plus/index.d.ts
+++ b/types/atom/autocomplete-plus/index.d.ts
@@ -31,10 +31,19 @@ export interface SuggestionInsertedEvent {
 }
 
 /**
+ *  COMPATIBILITY STUB. WILL BE REMOVED
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface Suggestion<
+  T extends { text: string }|{ snippet: string }
+  > extends SuggestionBase {}
+// TODO: Remove on next minor version
+
+/**
  *  An autocompletion suggestion for the user.
  *  Primary data type for the Atom Autocomplete+ service.
  */
-export interface Suggestion<T extends { text: string }|{ snippet: string }> {
+export interface SuggestionBase {
     /**
      *  A string that will show in the UI for this suggestion.
      *  When not set, snippet || text is displayed.
@@ -91,14 +100,20 @@ export interface Suggestion<T extends { text: string }|{ snippet: string }> {
      *  When specified, a More.. link will be displayed in the description area.
      */
     descriptionMoreURL?: string;
+
+    /**
+     *  (experimental) Description with Markdown formatting.
+     *  Takes precedence over plaintext description.
+     */
+    descriptionMarkdown?: string;
 }
 
-export interface TextSuggestion extends Suggestion<TextSuggestion> {
+export interface TextSuggestion extends SuggestionBase {
     /** The text which will be inserted into the editor, in place of the prefix. */
     text: string;
 }
 
-export interface SnippetSuggestion extends Suggestion<SnippetSuggestion> {
+export interface SnippetSuggestion extends SuggestionBase {
     /**
      *  A snippet string. This will allow users to tab through function arguments
      *  or other options.
@@ -106,7 +121,8 @@ export interface SnippetSuggestion extends Suggestion<SnippetSuggestion> {
     snippet: string;
 }
 
-export type Suggestions = Array<TextSuggestion|SnippetSuggestion>;
+export type AnySuggestion = TextSuggestion|SnippetSuggestion;
+export type Suggestions = AnySuggestion[];
 
 /** The interface that all Autocomplete+ providers must implement. */
 export interface AutocompleteProvider {
@@ -154,4 +170,13 @@ export interface AutocompleteProvider {
 
     /** Will be called if your provider is being destroyed by autocomplete+ */
     dispose?(): void;
+
+    /**
+     *  (experimental) Is called when a suggestion is selected by the user for
+     *  the purpose of loading more information about the suggestion. Return a
+     *  Promise of the new suggestion to replace it with or return null if
+     *  no change is needed.
+     */
+    getSuggestionDetailsOnSelect?:
+      (suggestion: AnySuggestion) => Promise<AnySuggestion | null> | AnySuggestion | null;
 }


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - `descriptionMarkdown`: https://github.com/atom/autocomplete-plus/blob/d6558d43657f29b349ce04cd1e9aa6b06f2eedea/lib/suggestion-list-element.js#L137
    - `getSuggestionDetailsOnSelect`: https://github.com/atom/autocomplete-plus/wiki/Provider-API
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

Other changes are because `Suggestion` type is extremely unwieldly and seemingly pointless. I'm leaving a stub in place for the purpose of compatibility, but we better remove it once 1.26 hits.