### PR TITLE
[atom] Clean up FilesystemChangeEvent

### DIFF
--- a/types/atom/atom-tests.ts
+++ b/types/atom/atom-tests.ts
@@ -3310,7 +3310,7 @@ const pathWatcherPromise = Atom.watchPath("/var/test", {}, (events) => {
     for (const event of events) {
         str = event.path;
         str = event.action;
-        if (event.oldPath) str = event.oldPath;
+        if (event.action === "renamed") str = event.oldPath;
     }
 });
 

--- a/types/atom/index.d.ts
+++ b/types/atom/index.d.ts
@@ -5647,19 +5647,28 @@ export interface FileSavedEvent {
     path: string;
 }
 
-export type FilesystemChangeEvent = Array<{
+export interface FilesystemChangeBasic<
+  Action extends "created"|"modified"|"deleted"|"renamed"
+  = "created"|"modified"|"deleted"
+> {
     /** A string describing the filesystem action that occurred. */
-    action: "created"|"modified"|"deleted"|"renamed";
+    action: Action;
 
     /** The absolute path to the filesystem entry that was acted upon. */
     path: string;
+}
 
+export interface FilesystemChangeRename extends FilesystemChangeBasic<"renamed"> {
     /**
      *  For rename events, a string containing the filesystem entry's former
      *  absolute path.
      */
-    oldPath?: string;
-}>;
+    oldPath: string;
+}
+
+export type FilesystemChange = FilesystemChangeBasic|FilesystemChangeRename;
+
+export type FilesystemChangeEvent = FilesystemChange[];
 
 export interface FullKeybindingMatchEvent {
   /** The string of keystrokes that matched the binding. */


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: https://atom.io/docs/api/v1.25.1/PathWatcher
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

This does two things:

1. Adds a separate type for a single filesystem event (because otherwise the whole thing is unwieldly, I had to resort to code like this at some point:
    ```ts
    type FilesystemChange = FilesystemChangeEvent extends Array<infer T> ? T : never;
    ```
2. Makes `oldPath` only a property of `rename`-typed changes, i.e. when `action` is `"rename"`. The way it does it might seem a bit convoluted though, but that's to avoid unnecessary code duplication. As a nice bonus, it allows refining the `FilesystemChange` type, e.g. `FilesystemChangeBasic<"created">` will only match `"created"` events -- could be useful in some cases, I think.

This change is potentially breaking, although the code that would be broken by this *is* currently broken somewhat anyway (since it uses `oldPath !== undefined` check to check if `action==="rename"`... which is basically backwards)