### PR TITLE
fixes @types/chai-things import issues

### DIFF
--- a/types/chai-things/chai-things-tests.ts
+++ b/types/chai-things/chai-things-tests.ts
@@ -1,8 +1,7 @@
 
 
-import chai = require('chai');
-import chaiThings = require('chai-things');
-
+import * as chai from 'chai';
+import * as chaiThings from 'chai-things';
 chai.use(chaiThings);
 
 function test_somethingSyntax() {

--- a/types/chai-things/index.d.ts
+++ b/types/chai-things/index.d.ts
@@ -60,5 +60,6 @@ interface Array<T> {
 
 declare module "chai-things" {
     function chaiThings(chai: any, utils: any): void;
+    namespace chaiThings { }
     export = chaiThings;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: 
    - https://www.typescriptlang.org/docs/handbook/namespaces-and-modules.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.


@broder 
adding "namespace chaiThings {}" to be able to use
import * as chaiThings from 'chai-things'
instead of using the require()

The error typescript was giving:
[ts] Module '"chai-things"' resolves to a non-module entity and cannot be imported using this construct.
