### PR TITLE
[react-overlays] Fixed Overlay class definition

### DIFF
--- a/types/react-overlays/lib/Overlay.d.ts
+++ b/types/react-overlays/lib/Overlay.d.ts
@@ -4,7 +4,7 @@ import { TransitionProps } from 'react-transition-group/Transition';
 import { PortalProps } from './Portal';
 import { PositionProps } from './Position';
 
-declare class Overlay extends React.Component<OverlayProps> { }
+declare class Overlay extends React.Component<Overlay.OverlayProps> { }
 export = Overlay;
 
 declare namespace Overlay {


### PR DESCRIPTION
The Overlay class definition is currently broken for Typescript 2.8.1 because OverlayProps has recently been moved into the Overlay namespace. This updates the class definition to reflect that.

Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <>
- [X] Increase the version number in the header if appropriate.
- [X] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

PR of recent change to Overlay.d.ts: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24881
