### PR TITLE
react: change default type value of snapshot to any

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -255,7 +255,7 @@ declare namespace React {
 
     // Base component for plain JS classes
     // tslint:disable-next-line:no-empty-interface
-    interface Component<P = {}, S = {}, SS = never> extends ComponentLifecycle<P, S, SS> { }
+    interface Component<P = {}, S = {}, SS = any> extends ComponentLifecycle<P, S, SS> { }
     class Component<P, S> {
         constructor(props: P, context?: any);
 
@@ -283,7 +283,7 @@ declare namespace React {
         };
     }
 
-    class PureComponent<P = {}, S = {}> extends Component<P, S> { }
+    class PureComponent<P = {}, S = {}, SS = any> extends Component<P, S, SS> { }
 
     interface ClassicComponent<P = {}, S = {}> extends Component<P, S> {
         replaceState(nextState: S, callback?: () => void): void;

--- a/types/react/test/index.ts
+++ b/types/react/test/index.ts
@@ -25,6 +25,10 @@ interface State {
     seconds?: number;
 }
 
+interface Snapshot {
+    baz: string;
+}
+
 interface Context {
     someValue?: string;
 }
@@ -51,7 +55,7 @@ declare const container: Element;
 // Top-Level API
 // --------------------------------------------------------------------------
 
-class ModernComponent extends React.Component<Props, State>
+class ModernComponent extends React.Component<Props, State, Snapshot>
     implements MyComponent, React.ChildContextProvider<ChildContext> {
     static propTypes: React.ValidationMap<Props> = {
         foo: PropTypes.number
@@ -102,6 +106,14 @@ class ModernComponent extends React.Component<Props, State>
 
     shouldComponentUpdate(nextProps: Props, nextState: State, nextContext: any): boolean {
         return shallowCompare(this, nextProps, nextState);
+    }
+
+    getSnapshotBeforeUpdate(prevProps: Readonly<Props>) {
+        return { baz: `${prevProps.foo}baz` };
+    }
+
+    componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>, snapshot: Snapshot) {
+        return;
     }
 }
 

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -152,6 +152,24 @@ class ComponentWithNewLifecycles extends React.Component<NewProps, NewState, { b
 }
 <ComponentWithNewLifecycles foo="bar" />;
 
+class PureComponentWithNewLifecycles extends React.PureComponent<NewProps, NewState, { baz: string }> {
+    static getDerivedStateFromProps: React.GetDerivedStateFromProps<NewProps, NewState> = (nextProps) => {
+        return { bar: `${nextProps.foo}bar` };
+    }
+
+    getSnapshotBeforeUpdate(prevProps: Readonly<NewProps>) {
+        return { baz: `${prevProps.foo}baz` };
+    }
+
+    componentDidUpdate(prevProps: Readonly<NewProps>, prevState: Readonly<NewState>, snapshot: { baz: string }) {
+        return;
+    }
+
+    render() {
+        return this.state.bar;
+    }
+}
+<PureComponentWithNewLifecycles foo="bar" />;
 
 class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', string>> {
     static getDerivedStateFromProps: React.GetDerivedStateFromProps<{}, Record<'a'|'b'|'c', string>> = () => {

--- a/types/react/test/tsx.tsx
+++ b/types/react/test/tsx.tsx
@@ -150,6 +150,8 @@ class ComponentWithNewLifecycles extends React.Component<NewProps, NewState, { b
         return this.state.bar;
     }
 }
+<ComponentWithNewLifecycles foo="bar" />;
+
 
 class ComponentWithLargeState extends React.Component<{}, Record<'a'|'b'|'c', string>> {
     static getDerivedStateFromProps: React.GetDerivedStateFromProps<{}, Record<'a'|'b'|'c', string>> = () => {


### PR DESCRIPTION
In the `react` types, the definition of `React.Component` is `React.Component<P = {}, S = {}, SS = never>`, meaning that type-wise, props defaults to `{}`, state defaults to `{}`, and snapshot defaults to `never`.  Snapshot is used as the return value of the new React `getSnapshotBeforeUpdate` lifecycle method, whose return type is `SS | null`.

What that means, however, is that unless the third generic type parameter is overridden, the return value of `getSnapshotBeforeUpdate` is resolved to `never | null`, which is resolved to `null`.  This causes an issue where any components that do define `getSnapshotBeforeUpdate` are unable to be used by something expecting a `React.Component`, because `getSnapshotBeforeUpdate` returns something other than null.

This PR changes the default to be `SS = any`, which allows other libraries to do things like the following:

```typescript
const func = (comp: React.Component<any>) => {...}
```

There are many third-party libraries that do something similar, which I believe necessitates this change.  Additionally, at the moment it is not possible to even use a component that uses the new lifecycle method as it is not considered to be a valid JSX component type (for the same reason, see #24820).

I have added several test cases to catch actually using components that contain `getSnapshotBeforeUpdate`, using them with `React.createElement`, and using the new lifecycle method on `PureComponent`, which previously did not accept the `SS` type param.

Fixes #24820.  See #24820 for more context.  Replaces #24985.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://reactjs.org/docs/react-component.html#getsnapshotbeforeupdate
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
