### PR TITLE
Types for JQuery Focusable

### DIFF
--- a/types/jquery-focusable/index.d.ts
+++ b/types/jquery-focusable/index.d.ts
@@ -1,0 +1,25 @@
+// Type definitions for JQuery Focusable 1.0
+// Project: https://github.com/makeup-jquery/jquery-focusable
+// Definitions by: Anderson Friaça <https://github.com/AndersonFriaca>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+/// <reference types="jquery" />
+
+export type Options = Partial<{
+    /**
+     * Find elements with tabindex equal to -1
+     */
+    findNegativeTabindex: boolean;
+
+    /**
+     * Find elements with tabindex greater than 0
+     */
+    findPositiveTabindex: true;
+}>;
+
+declare global {
+    interface JQuery {
+        focusable(options?: Options): JQuery;
+    }
+}

--- a/types/jquery-focusable/jquery-focusable-tests.ts
+++ b/types/jquery-focusable/jquery-focusable-tests.ts
@@ -1,0 +1,12 @@
+import { Options } from "jquery-focusable";
+
+// Basic usage
+$('body').focusable();
+
+// With options
+const options: Options = {
+    findNegativeTabindex: true,
+    findPositiveTabindex: true
+  };
+
+$('body').focusable(options);

--- a/types/jquery-focusable/tsconfig.json
+++ b/types/jquery-focusable/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true
+    },
+    "files": [
+        "index.d.ts",
+        "jquery-focusable-tests.ts"
+    ]
+}

--- a/types/jquery-focusable/tslint.json
+++ b/types/jquery-focusable/tslint.json
@@ -1,0 +1,1 @@
+{"extends": "dtslint/dt.json"}


### PR DESCRIPTION
Types creation of [https://github.com/makeup-jquery/jquery-focusable](https://github.com/makeup-jquery/jquery-focusable)
NPM: [https://www.npmjs.com/package/jquery-focusable](https://www.npmjs.com/package/jquery-focusable)

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Add or edit tests to reflect the change. (Run with `npm test`.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [X] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [X] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [ ] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [X] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.