### PR TITLE
Topojson: extract topojson-client, topojson-simplify, topojson-specification

### DIFF
--- a/types/topojson-client/index.d.ts
+++ b/types/topojson-client/index.d.ts
@@ -1,0 +1,43 @@
+// Type definitions for topojson-client 3.0
+// Project: https://github.com/topojson/topojson-client
+// Definitions by: denisname <https://github.com/denisname>
+//                 Ricardo Mello <https://github.com/ricardo-mello>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.5
+
+import * as GeoJSON from "geojson";
+import {
+    GeometryCollection, GeometryObject, LineString,
+    MultiLineString, MultiPoint, MultiPolygon,
+    Objects, Point, Polygon, Topology, Transform
+} from "topojson-specification";
+
+export type Transformer = (point: number[], index?: boolean) => number[];
+
+export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: Point<P>): GeoJSON.Feature<GeoJSON.Point, P>;
+export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: MultiPoint<P>): GeoJSON.Feature<GeoJSON.MultiPoint, P>;
+export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: LineString<P>): GeoJSON.Feature<GeoJSON.LineString, P>;
+export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: MultiLineString<P>): GeoJSON.Feature<GeoJSON.MultiLineString, P>;
+export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: Polygon<P>): GeoJSON.Feature<GeoJSON.Polygon, P>;
+export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: MultiPolygon<P>): GeoJSON.Feature<GeoJSON.MultiPolygon, P>;
+export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: GeometryCollection<P>): GeoJSON.FeatureCollection<GeoJSON.GeometryObject, P>;
+export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: GeometryObject<P>)
+    : GeoJSON.Feature<GeoJSON.GeometryObject, P> | GeoJSON.FeatureCollection<GeoJSON.GeometryObject, P>;
+
+export function merge(topology: Topology, objects: Array<Polygon | MultiPolygon>): GeoJSON.MultiPolygon;
+
+export function mergeArcs(topology: Topology, objects: Array<Polygon | MultiPolygon>): MultiPolygon;
+
+export function mesh(topology: Topology, obj?: GeometryObject, filter?: (a: GeometryObject, b: GeometryObject) => boolean): GeoJSON.MultiLineString;
+
+export function meshArcs(topology: Topology, obj?: GeometryObject, filter?: (a: GeometryObject, b: GeometryObject) => boolean): MultiLineString;
+
+export function neighbors(objects: GeometryObject[]): number[][];
+
+export function bbox(topology: Topology): GeoJSON.BBox;
+
+export function quantize<T extends Objects>(topology: Topology<T>, transform: Transform | number): Topology<T>;
+
+export function transform(transform: Transform | null): Transformer;
+
+export function untransform(transform: Transform | null): Transformer;

--- a/types/topojson-client/topojson-client-tests.ts
+++ b/types/topojson-client/topojson-client-tests.ts
@@ -1,9 +1,20 @@
-// Tests for: https://github.com/topojson/topojson-client
+import * as topojson from "topojson-client";
+import { UsAtlas, WorldAtlas } from "topojson";
+
+declare let us: UsAtlas;
+declare let world: WorldAtlas;
+
+interface UsAtlasObjects extends TopoJSON.Objects {
+    counties: {type: "GeometryCollection", geometries: Array<TopoJSON.Polygon | TopoJSON.MultiPolygon>};
+    states: {type: "GeometryCollection", geometries: Array<TopoJSON.Polygon | TopoJSON.MultiPolygon>};
+    nation: TopoJSON.GeometryCollection;
+}
 
 let geoMP: GeoJSON.MultiPolygon;
 let geoMLS: GeoJSON.MultiLineString;
-let topoMP: topojson.MultiPolygon;
-let topoMLS: topojson.MultiLineString;
+let topoMP: TopoJSON.MultiPolygon;
+let topoMLS: TopoJSON.MultiLineString;
+let newUs: TopoJSON.Topology<UsAtlasObjects>;
 let bbox: GeoJSON.BBox;
 let transformer: topojson.Transformer;
 let color: string;
@@ -14,7 +25,7 @@ interface TestProp {
     size: number;
 }
 
-const selectedGeometries: Array<topojson.Polygon | topojson.MultiPolygon> =
+const selectedGeometries: Array<TopoJSON.Polygon | TopoJSON.MultiPolygon> =
     us.objects.states.geometries.filter((g) => ["be", 2, undefined].indexOf(g.id) >= 0);
 
 const topoWithProp = {
@@ -49,7 +60,7 @@ const featureCollection: GeoJSON.FeatureCollection<GeoJSON.GeometryObject> =
     topojson.feature(us, us.objects.counties);
 
 const featureObject: GeoJSON.Feature<GeoJSON.GeometryObject> | GeoJSON.FeatureCollection<GeoJSON.GeometryObject, {}> =
-    topojson.feature(topoWithProp, topoWithProp.objects.foo as topojson.GeometryObject);
+    topojson.feature(topoWithProp, topoWithProp.objects.foo as TopoJSON.GeometryObject);
 
 const propColor = topojson.feature(topoWithProp, topoWithProp.objects.foo).properties;
 color = propColor.color;
@@ -79,7 +90,7 @@ topoMLS = topojson.meshArcs(us, us.objects.states, (a, b) => a !== b);
 const n: number[][] = topojson.neighbors(world.objects.countries.geometries);
 
 // Transforms
-const usTransform: topojson.Transform = us.transform;
+const usTransform: TopoJSON.Transform = us.transform;
 
 bbox = topojson.bbox(us);
 bbox = topojson.bbox({type: "Topology", objects: {}, arcs: []});

--- a/types/topojson-client/tsconfig.json
+++ b/types/topojson-client/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
@@ -19,8 +18,6 @@
     },
     "files": [
         "index.d.ts",
-        "topojson-tests.ts",
-        "test/atlas-tests.ts",
-        "test/server-tests.ts"
+        "topojson-client-tests.ts"
     ]
 }

--- a/types/topojson-client/tslint.json
+++ b/types/topojson-client/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/topojson-simplify/index.d.ts
+++ b/types/topojson-simplify/index.d.ts
@@ -1,0 +1,37 @@
+// Type definitions for topojson-simplify 3.0
+// Project: https://github.com/topojson/topojson-simplify
+// Definitions by: denisname <https://github.com/denisname>
+//                 Ricardo Mello <https://github.com/ricardo-mello>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.5
+
+import * as GeoJSON from "geojson";
+import { Objects, OrNull, Topology } from "topojson-specification";
+
+export type Triangle = [[number, number], [number, number], [number, number]];
+export type TriangleWeighter = (triangle: Triangle) => number;
+export type Ring = Array<[number, number]>;
+export type RingWeighter = (triangle: Ring) => number;
+export type Filter = (ring: Ring, interior: boolean) => boolean;
+
+export function presimplify<T extends Objects>(topology: Topology<T>, weight?: TriangleWeighter): Topology<T>;
+
+export function simplify<T extends Objects>(topology: Topology<T>, minWeight?: number): Topology<T>;
+
+export function quantile(topology: Topology, p: number): number;
+
+export function filter<K extends Objects>(topology: Topology<K>, filter: Filter): Topology<OrNull<K>>;
+
+export function filterAttached(topology: Topology): Filter;
+
+export function filterAttachedWeight(topology: Topology, minWeight?: number, weight?: RingWeighter): Filter;
+
+export function filterWeight(topology: Topology, minWeight?: number, weight?: RingWeighter): Filter;
+
+export function planarRingArea(ring: Ring): number;
+
+export function planarTriangleArea(triangle: Triangle): number;
+
+export function sphericalRingArea(ring: Ring, interior: boolean): number;
+
+export function sphericalTriangleArea(triangle: Triangle): number;

--- a/types/topojson-simplify/topojson-simplify-tests.ts
+++ b/types/topojson-simplify/topojson-simplify-tests.ts
@@ -1,24 +1,28 @@
-// Tests for: https://github.com/topojson/topojson-simplify
+import * as topojson from "topojson-simplify";
+import { UsAtlas, WorldAtlas } from "topojson";
 
-interface UsAtlasObjects extends topojson.Objects {
-    counties: {type: "GeometryCollection", geometries: Array<topojson.Polygon | topojson.MultiPolygon>};
-    states: {type: "GeometryCollection", geometries: Array<topojson.Polygon | topojson.MultiPolygon>};
-    nation: topojson.GeometryCollection;
+declare let us: UsAtlas;
+declare let world: WorldAtlas;
+
+interface UsAtlasObjects extends TopoJSON.Objects {
+    counties: {type: "GeometryCollection", geometries: Array<TopoJSON.Polygon | TopoJSON.MultiPolygon>};
+    states: {type: "GeometryCollection", geometries: Array<TopoJSON.Polygon | TopoJSON.MultiPolygon>};
+    nation: TopoJSON.GeometryCollection;
 }
 
-interface UsEmpty extends topojson.Objects {
-    counties: topojson.NullObject;
-    states: topojson.NullObject;
-    nation: topojson.NullObject;
+interface UsEmpty extends TopoJSON.Objects {
+    counties: TopoJSON.NullObject;
+    states: TopoJSON.NullObject;
+    nation: TopoJSON.NullObject;
 }
 
-let aTopology: topojson.Topology;
-let presimplifiedUs: topojson.Topology<UsAtlasObjects>;
-let newUs: topojson.Topology<UsAtlasObjects>;
-let emptyUs: topojson.Topology<UsEmpty>;
-let geomCollection: topojson.GeometryCollection;
-let geomCollectionOrNull: topojson.GeometryCollection | topojson.NullObject;
-let aNullObject: topojson.NullObject;
+let aTopology: TopoJSON.Topology;
+let presimplifiedUs: TopoJSON.Topology<UsAtlasObjects>;
+let newUs: TopoJSON.Topology<UsAtlasObjects>;
+let emptyUs: TopoJSON.Topology<UsEmpty>;
+let geomCollection: TopoJSON.GeometryCollection;
+let geomCollectionOrNull: TopoJSON.GeometryCollection | TopoJSON.NullObject;
+let aNullObject: TopoJSON.NullObject;
 let filter: topojson.Filter;
 
 presimplifiedUs = topojson.presimplify(us);
@@ -30,7 +34,7 @@ geomCollection = topojson.presimplify(us).objects.counties;
 geomCollection = topojson.presimplify(us).objects.nation;
 geomCollection = topojson.presimplify(us).objects.states;
 
-let minWeight = topojson.quantile(presimplifiedUs, 0.5);
+const minWeight = topojson.quantile(presimplifiedUs, 0.5);
 
 newUs = topojson.simplify(presimplifiedUs);
 newUs = topojson.simplify(presimplifiedUs, 1.23);
@@ -55,12 +59,12 @@ filter = topojson.filterWeight(us, 0.5, topojson.planarRingArea);
 filter = topojson.filterWeight(us, 0.5, (points: Array<[number, number]>) => 1.5);
 
 aTopology = topojson.filter(us, filter);
-newUs = topojson.filter(us, (ring: topojson.Ring, interior: boolean) => true) as topojson.UsAtlas;
-emptyUs = topojson.filter(us, () => false) as topojson.Topology<UsEmpty>;
+newUs = topojson.filter(us, (ring: topojson.Ring, interior: boolean) => true) as UsAtlas;
+emptyUs = topojson.filter(us, () => false) as TopoJSON.Topology<UsEmpty>;
 
 geomCollectionOrNull = topojson.filter(us, () => Math.random() > 0.9).objects.nation;
-aNullObject = topojson.filter(us, () => false).objects.nation as topojson.NullObject;
-geomCollection = topojson.filter(us, () => true).objects.nation as topojson.GeometryCollection;
+aNullObject = topojson.filter(us, () => false).objects.nation as TopoJSON.NullObject;
+geomCollection = topojson.filter(us, () => true).objects.nation as TopoJSON.GeometryCollection;
 
 // Geometry
 
@@ -72,14 +76,14 @@ area = topojson.sphericalTriangleArea([[0, 0], [0, 90], [90, 180]]);
 
 // Fails
 
-interface MyAtlas extends topojson.Topology {
+interface MyAtlas extends TopoJSON.Topology {
     objects: {
-        obj: topojson.GeometryCollection;
+        obj: TopoJSON.GeometryCollection;
     };
     more: "hello";
 }
 
-let myAtlas: MyAtlas = null as any; // shortcut...
+declare let myAtlas: MyAtlas;
 console.log(myAtlas.more);
 
 let s: string;

--- a/types/topojson-simplify/tsconfig.json
+++ b/types/topojson-simplify/tsconfig.json
@@ -19,8 +19,6 @@
     },
     "files": [
         "index.d.ts",
-        "topojson-tests.ts",
-        "test/atlas-tests.ts",
-        "test/server-tests.ts"
+        "topojson-simplify-tests.ts"
     ]
 }

--- a/types/topojson-simplify/tslint.json
+++ b/types/topojson-simplify/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/topojson-specification/index.d.ts
+++ b/types/topojson-specification/index.d.ts
@@ -1,0 +1,118 @@
+// Type definitions for topojson-specification 1.0
+// Project: https://github.com/topojson/topojson-specification
+// Definitions by: denisname <https://github.com/denisname>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+// Last revision validated against: commit 90ed973 (2017-08-02)
+
+import * as GeoJSON from "geojson";
+
+export as namespace TopoJSON;
+
+// ---------------------------------------------------------------
+// TopoJSON Format Specification
+// ---------------------------------------------------------------
+
+// See: https://github.com/topojson/topojson-specification/
+
+// 2. TopoJSON Objects
+export interface TopoJSON {
+    type: "Topology" | GeoJSON.GeoJsonGeometryTypes | null;
+    bbox?: GeoJSON.BBox;
+}
+
+// 2.1. Topology Objects
+export interface Topology<T extends Objects<Properties> = Objects<Properties>> extends TopoJSON {
+    type: "Topology";
+    objects: T;
+    arcs: Arc[];
+    transform?: Transform;
+}
+
+// 2.1.1. Positions
+export type Positions = number[]; // at least two elements
+
+// 2.1.2. Transforms
+export interface Transform {
+    scale: [number, number];
+    translate: [number, number];
+}
+
+// 2.1.3. Arcs
+export type Arc = Positions[]; // at least two elements
+
+// 2.1.4. Arc Indexes
+export type ArcIndexes = number[];
+
+// 2.1.5. Objects
+export type Properties = GeoJSON.GeoJsonProperties;
+
+export interface Objects<P extends Properties = {}> {
+    [key: string]: GeometryObject<P>;
+}
+
+// 2.2. Geometry Objects
+export interface GeometryObjectA<P extends Properties = {}> extends TopoJSON {
+    type: GeoJSON.GeoJsonGeometryTypes | null;
+    id?: number | string;
+    properties?: P;
+}
+
+export type GeometryObject<P extends Properties = {}> =
+    Point<P> | MultiPoint<P> |
+    LineString<P> | MultiLineString<P> |
+    Polygon<P> | MultiPolygon<P> |
+    GeometryCollection<P> |
+    NullObject;
+
+// 2.2.1. Point
+export interface Point<P extends Properties = {}> extends GeometryObjectA<P> {
+    type: "Point";
+    coordinates: Positions;
+}
+
+// 2.2.2. MultiPoint
+export interface MultiPoint<P extends Properties = {}> extends GeometryObjectA<P> {
+    type: "MultiPoint";
+    coordinates: Positions[];
+}
+
+// 2.2.3. LineString
+export interface LineString<P extends Properties = {}> extends GeometryObjectA<P> {
+    type: "LineString";
+    arcs: ArcIndexes;
+}
+
+// 2.2.4. MultiLineString
+export interface MultiLineString<P extends Properties = {}> extends GeometryObjectA<P> {
+    type: "MultiLineString";
+    arcs: ArcIndexes[];
+}
+
+// 2.2.5. Polygon
+export interface Polygon<P extends Properties = {}> extends GeometryObjectA<P> {
+    type: "Polygon";
+    arcs: ArcIndexes[];
+}
+
+// 2.2.6. MultiPolygon
+export interface MultiPolygon<P extends Properties = {}> extends GeometryObjectA<P> {
+    type: "MultiPolygon";
+    arcs: ArcIndexes[][];
+}
+
+// 2.2.7. Geometry Collection
+export interface GeometryCollection<P extends Properties = {}> extends GeometryObjectA<P> {
+    type: "GeometryCollection";
+    geometries: Array<GeometryObject<P>>;
+}
+
+// More
+export interface NullObject extends GeometryObjectA {
+    type: null;
+}
+
+export type OrNull<T extends Objects> = {
+    [P in keyof T]: T[P] | NullObject;
+};

--- a/types/topojson-specification/topojson-specification-tests.ts
+++ b/types/topojson-specification/topojson-specification-tests.ts
@@ -1,38 +1,36 @@
-// Tests for: https://github.com/topojson/topojson-specification
-
 // Geometry Objects
 
-const point: topojson.Point = {
+const point: TopoJSON.Point = {
     type: "Point",
     coordinates: [0, 0],
 };
 
-const multiPoint: topojson.MultiPoint = {
+const multiPoint: TopoJSON.MultiPoint = {
     type: "MultiPoint",
     coordinates: [[0, 0]],
 };
 
-const lineString: topojson.LineString = {
+const lineString: TopoJSON.LineString = {
     type: "LineString",
     arcs: [0],
 };
 
-const multiLineString: topojson.MultiLineString = {
+const multiLineString: TopoJSON.MultiLineString = {
     type: "MultiLineString",
     arcs: [[3], [4]],
 };
 
-const polygon: topojson.Polygon = {
+const polygon: TopoJSON.Polygon = {
     type: "Polygon",
     arcs: [[0]],
 };
 
-const multiPolygon: topojson.MultiPolygon = {
+const multiPolygon: TopoJSON.MultiPolygon = {
     type: "MultiPolygon",
     arcs: [[[0]]],
 };
 
-const geometryCollection: topojson.GeometryCollection = {
+const geometryCollection: TopoJSON.GeometryCollection = {
     type: "GeometryCollection",
     geometries: [
         {type: "Polygon", arcs: [[0]]},
@@ -43,7 +41,7 @@ const geometryCollection: topojson.GeometryCollection = {
     ],
 };
 
-const nullObject: topojson.NullObject = {
+const nullObject: TopoJSON.NullObject = {
     type: null,
 };
 
@@ -54,7 +52,7 @@ interface TestProp {
     size: number;
 }
 
-const pointWithProp: topojson.Point<TestProp> = {
+const pointWithProp: TopoJSON.Point<TestProp> = {
     type: "Point",
     coordinates: [0, 0],
     properties: {color: "orange", size: 42},
@@ -65,7 +63,7 @@ const nbr: number = pointWithProp.properties!.size;
 
 // Topology
 
-let topology: topojson.Topology;
+let topology: TopoJSON.Topology;
 
 topology = {
     type: "Topology",

--- a/types/topojson-specification/tsconfig.json
+++ b/types/topojson-specification/tsconfig.json
@@ -2,8 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "lib": [
-            "es6",
-            "dom"
+            "es6"
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
@@ -19,8 +18,6 @@
     },
     "files": [
         "index.d.ts",
-        "topojson-tests.ts",
-        "test/atlas-tests.ts",
-        "test/server-tests.ts"
+        "topojson-specification-tests.ts"
     ]
 }

--- a/types/topojson-specification/tslint.json
+++ b/types/topojson-specification/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }

--- a/types/topojson/index.d.ts
+++ b/types/topojson/index.d.ts
@@ -7,211 +7,51 @@
 // TypeScript Version: 2.5
 
 import * as GeoJSON from "geojson";
+import * as TopoJSON from "topojson-specification";
 
 export as namespace topojson;
-
-// ---------------------------------------------------------------
-// TopoJSON Format Specification
-// ---------------------------------------------------------------
-
-// See: https://github.com/topojson/topojson-specification/
-
-// 2. TopoJSON Objects
-export interface TopoJSON {
-    type: "Topology" | GeoJSON.GeoJsonGeometryTypes | null;
-    bbox?: GeoJSON.BBox;
-}
-
-// 2.1. Topology Objects
-export interface Topology<T extends Objects<Properties> = Objects<Properties>> extends TopoJSON {
-    type: "Topology";
-    objects: T;
-    arcs: Arc[];
-    transform?: Transform;
-}
-
-// 2.1.1. Positions
-export type Positions = number[]; // at least two elements
-
-// 2.1.2. Transforms
-export interface Transform {
-    scale: [number, number];
-    translate: [number, number];
-}
-
-// 2.1.3. Arcs
-export type Arc = Positions[]; // at least two elements
-
-// 2.1.4. Arc Indexes
-export type ArcIndexes = number[];
-
-// 2.1.5. Objects
-export type Properties = GeoJSON.GeoJsonProperties;
-
-export interface Objects<P extends Properties = {}> {
-    [key: string]: GeometryObject<P>;
-}
-
-// 2.2. Geometry Objects
-export interface GeometryObjectA<P extends Properties = {}> extends TopoJSON {
-    type: GeoJSON.GeoJsonGeometryTypes | null;
-    id?: number | string;
-    properties?: P;
-}
-
-export type GeometryObject<P extends Properties = {}> =
-    Point<P> | MultiPoint<P> |
-    LineString<P> | MultiLineString<P> |
-    Polygon<P> | MultiPolygon<P> |
-    GeometryCollection<P> |
-    NullObject;
-
-// 2.2.1. Point
-export interface Point<P extends Properties = {}> extends GeometryObjectA<P> {
-    type: "Point";
-    coordinates: Positions;
-}
-
-// 2.2.2. MultiPoint
-export interface MultiPoint<P extends Properties = {}> extends GeometryObjectA<P> {
-    type: "MultiPoint";
-    coordinates: Positions[];
-}
-
-// 2.2.3. LineString
-export interface LineString<P extends Properties = {}> extends GeometryObjectA<P> {
-    type: "LineString";
-    arcs: ArcIndexes;
-}
-
-// 2.2.4. MultiLineString
-export interface MultiLineString<P extends Properties = {}> extends GeometryObjectA<P> {
-    type: "MultiLineString";
-    arcs: ArcIndexes[];
-}
-
-// 2.2.5. Polygon
-export interface Polygon<P extends Properties = {}> extends GeometryObjectA<P> {
-    type: "Polygon";
-    arcs: ArcIndexes[];
-}
-
-// 2.2.6. MultiPolygon
-export interface MultiPolygon<P extends Properties = {}> extends GeometryObjectA<P> {
-    type: "MultiPolygon";
-    arcs: ArcIndexes[][];
-}
-
-// 2.2.7. Geometry Collection
-export interface GeometryCollection<P extends Properties = {}> extends GeometryObjectA<P> {
-    type: "GeometryCollection";
-    geometries: Array<GeometryObject<P>>;
-}
-
-// More
-export interface NullObject extends GeometryObjectA {
-    type: null;
-}
-
-export type OrNull<T extends Objects> = {
-    [P in keyof T]: T[P] | NullObject;
-};
 
 // ---------------------------------------------------------------
 // TopoJSON Server
 // ---------------------------------------------------------------
 
-export function topology(objects: {[k: string]: GeoJSON.GeoJsonObject}, quantization?: number): Topology;
+export function topology(objects: {[k: string]: GeoJSON.GeoJsonObject}, quantization?: number): TopoJSON.Topology;
 
 // ---------------------------------------------------------------
 // TopoJSON Simplify
 // ---------------------------------------------------------------
 
-export type Triangle = [[number, number], [number, number], [number, number]];
-export type TriangleWeighter = (triangle: Triangle) => number;
-export type Ring = Array<[number, number]>;
-export type RingWeighter = (triangle: Ring) => number;
-export type Filter = (ring: Ring, interior: boolean) => boolean;
-
-export function presimplify<T extends Objects>(topology: Topology<T>, weight?: TriangleWeighter): Topology<T>;
-
-export function simplify<T extends Objects>(topology: Topology<T>, minWeight?: number): Topology<T>;
-
-export function quantile(topology: Topology, p: number): number;
-
-export function filter<K extends Objects>(topology: Topology<K>, filter: Filter): Topology<OrNull<K>>;
-
-export function filterAttached(topology: Topology): Filter;
-
-export function filterAttachedWeight(topology: Topology, minWeight?: number, weight?: RingWeighter): Filter;
-
-export function filterWeight(topology: Topology, minWeight?: number, weight?: RingWeighter): Filter;
-
-export function planarRingArea(ring: Ring): number;
-
-export function planarTriangleArea(triangle: Triangle): number;
-
-export function sphericalRingArea(ring: Ring, interior: true): number;
-
-export function sphericalTriangleArea(triangle: Triangle): number;
+export * from 'topojson-simplify';
 
 // ---------------------------------------------------------------
 // TopoJSON Client
 // ---------------------------------------------------------------
 
-export type Transformer = (point: number[], index?: boolean) => number[];
-
-export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: Point<P>): GeoJSON.Feature<GeoJSON.Point, P>;
-export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: MultiPoint<P>): GeoJSON.Feature<GeoJSON.MultiPoint, P>;
-export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: LineString<P>): GeoJSON.Feature<GeoJSON.LineString, P>;
-export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: MultiLineString<P>): GeoJSON.Feature<GeoJSON.MultiLineString, P>;
-export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: Polygon<P>): GeoJSON.Feature<GeoJSON.Polygon, P>;
-export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: MultiPolygon<P>): GeoJSON.Feature<GeoJSON.MultiPolygon, P>;
-export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: GeometryCollection<P>): GeoJSON.FeatureCollection<GeoJSON.GeometryObject, P>;
-export function feature<P = GeoJSON.GeoJsonProperties>(topology: Topology, object: GeometryObject<P>)
-    : GeoJSON.Feature<GeoJSON.GeometryObject, P> | GeoJSON.FeatureCollection<GeoJSON.GeometryObject, P>;
-
-export function merge(topology: Topology, objects: Array<Polygon | MultiPolygon>): GeoJSON.MultiPolygon;
-
-export function mergeArcs(topology: Topology, objects: Array<Polygon | MultiPolygon>): MultiPolygon;
-
-export function mesh(topology: Topology, obj?: GeometryObject, filter?: (a: GeometryObject, b: GeometryObject) => boolean): GeoJSON.MultiLineString;
-
-export function meshArcs(topology: Topology, obj?: GeometryObject, filter?: (a: GeometryObject, b: GeometryObject) => boolean): MultiLineString;
-
-export function neighbors(objects: GeometryObject[]): number[][];
-
-export function bbox(topology: Topology): GeoJSON.BBox;
-
-export function quantize<T extends Objects>(topology: Topology<T>, transform: Transform | number): Topology<T>;
-
-export function transform(transform: Transform | null): Transformer;
-
-export function untransform(transform: Transform | null): Transformer;
+export * from 'topojson-client';
 
 // ---------------------------------------------------------------
 // U.S. Atlas TopoJSON
 // ---------------------------------------------------------------
 
-export interface UsAtlas extends topojson.Topology {
+export interface UsAtlas extends TopoJSON.Topology {
     objects: {
-        counties: {type: "GeometryCollection", geometries: Array<Polygon | MultiPolygon>};
-        states: {type: "GeometryCollection", geometries: Array<Polygon | MultiPolygon>};
-        nation: topojson.GeometryCollection;
+        counties: {type: "GeometryCollection", geometries: Array<TopoJSON.Polygon | TopoJSON.MultiPolygon>};
+        states: {type: "GeometryCollection", geometries: Array<TopoJSON.Polygon | TopoJSON.MultiPolygon>};
+        nation: TopoJSON.GeometryCollection;
     };
     bbox: [number, number, number, number];
-    transform: topojson.Transform;
+    transform: TopoJSON.Transform;
 }
 
 // ---------------------------------------------------------------
 // World Atlas TopoJSON
 // ---------------------------------------------------------------
 
-export interface WorldAtlas extends topojson.Topology {
+export interface WorldAtlas extends TopoJSON.Topology {
     objects: {
-        countries: {type: "GeometryCollection", geometries: Array<Polygon | MultiPolygon>};
-        land: topojson.GeometryCollection;
+        countries: {type: "GeometryCollection", geometries: Array<TopoJSON.Polygon | TopoJSON.MultiPolygon>};
+        land: TopoJSON.GeometryCollection;
     };
     bbox: [number, number, number, number];
-    transform: topojson.Transform;
+    transform: TopoJSON.Transform;
 }

--- a/types/topojson/test/server-tests.ts
+++ b/types/topojson/test/server-tests.ts
@@ -1,6 +1,6 @@
 // Tests for: https://github.com/topojson/topojson-server
 
-let topo: topojson.Topology;
+let topo: TopoJSON.Topology;
 
 const aPoint: GeoJSON.Point = {type: "Point", coordinates: [30, 10]};
 const aPolygon: GeoJSON.Polygon = {type: "Polygon", coordinates: [[[30, 10], [40, 40], [20, 40], [30, 10]]]};

--- a/types/topojson/topojson-tests.ts
+++ b/types/topojson/topojson-tests.ts
@@ -1,4 +1,5 @@
-const hello = "world";
+// Export topojson-simplify functions
+topojson.planarRingArea([]);
 
-// NOTE: The standard bundle definition has no particular function.
-// See ./test/ for per bundle tests.
+// Export topojson-client functions
+topojson.transform(null);


### PR DESCRIPTION
Topojson regroup several libraries (topojson, topojson-server, topojson-simplify, topojson-client, topojson-specification). The actual typing definition contain them all making it immpossible to use them separately (#24941). This PR extract topojson-client, topojson-simplify and topojson-specification in their own type definition.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.
