### PR TITLE
Fix Publisher#publish signature for @google-cloud/pubsub

### DIFF
--- a/types/google-cloud__pubsub/index.d.ts
+++ b/types/google-cloud__pubsub/index.d.ts
@@ -111,7 +111,7 @@ declare namespace PubSub {
     interface Publisher {
         publish(data: Buffer, callback: Publisher.PublishCallback): void;
         publish(data: Buffer, attributes: object, callback: Publisher.PublishCallback): void;
-        publish(data: Buffer, attributes?: object): Promise<any[]>;
+        publish(data: Buffer, attributes?: object): Promise<string>;
     }
     namespace Publisher {
         type PublishCallback = (error: Error | null, messageId: string) => void;


### PR DESCRIPTION
Fix Publisher#publish signature, so that it returns a promise 
to messageId (string): https://cloud.google.com/nodejs/docs/reference/pubsub/0.18.x/Publisher#publish

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [ ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://cloud.google.com/nodejs/docs/reference/pubsub/0.18.x/Publisher#publish
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
