### PR TITLE
Fix tapable definition

### DIFF
--- a/types/tapable/index.d.ts
+++ b/types/tapable/index.d.ts
@@ -276,6 +276,7 @@ export class HookInterceptor {
     tap: (tap: Tap) => void;
     register: (tap: Tap) => Tap | undefined;
     context: boolean;
+    name: string;
 }
 
 /** A HookMap is a helper class for a Map with Hooks */


### PR DESCRIPTION
Add missing field in `tapable` definitions. This is require to use TypeScript on webpack.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [ ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
