### PR TITLE
[react-motion] change TransitionPlainStyle key type to string

### DIFF
--- a/types/react-motion/index.d.ts
+++ b/types/react-motion/index.d.ts
@@ -94,7 +94,7 @@ interface TransitionStyle {
  * Default style for transition
  */
 interface TransitionPlainStyle {
-    key: any;
+    key: string;
     data?: any;
     // same as TransitionStyle, passed as argument to style/children function
     style: PlainStyle;


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
- [ ] Test the change in your own code. (Compile and run.)

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/chenglou/react-motion/blob/master/src/Types.js#L51
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

I don't use TypeScript yet, that's why I didn't test my own code as the checklist suggests. I've noticed the type mismatch between Flow and TypeScript as I was figuring out the API of react-motion, and I guess it should be corrected.