### PR TITLE
Activate strict null check in d3-format

### DIFF
--- a/types/d3-format/d3-format-tests.ts
+++ b/types/d3-format/d3-format-tests.ts
@@ -12,6 +12,20 @@ import * as d3Format from 'd3-format';
 // Preparatory Steps
 // ----------------------------------------------------------------------
 
+class NumCoercible {
+  a: number;
+
+  constructor(a: number) {
+    this.a = a;
+  }
+
+  valueOf() {
+    return this.a;
+  }
+}
+
+const numeric: NumCoercible = new NumCoercible(10);
+
 let num: number;
 
 let formatFn: (n: number) => string;
@@ -30,6 +44,12 @@ formatFn = d3Format.format('.0%');
 
 formatFn = d3Format.formatPrefix(',.0', 1e-6);
 
+d3Format.format('.0%')(10);
+d3Format.format('.0%')(numeric);
+
+d3Format.formatPrefix(',.0', 1e-6)(10);
+d3Format.formatPrefix(',.0', 1e-6)(numeric);
+
 // ----------------------------------------------------------------------
 // Test Format Specifier
 // ----------------------------------------------------------------------
@@ -43,7 +63,7 @@ const symbol: '$' | '#' | '' = specifier.symbol;
 const zero: boolean = specifier.zero;
 const width: number | undefined = specifier.width;
 const comma: boolean = specifier.comma;
-const precision: number = specifier.precision;
+const precision: number | undefined = specifier.precision;
 const type: 'e' | 'f' | 'g' | 'r' | 's' | '%' | 'p' | 'b' | 'o' | 'd' | 'x' | 'X' | 'c' | '' | 'n' = specifier.type;
 
 const formatString: string = specifier.toString();
@@ -63,10 +83,10 @@ num = d3Format.precisionRound(0.0005, 3000);
 // ----------------------------------------------------------------------
 
 localeDef = {
-    decimal: ',',
-    thousands: '.',
-    grouping: [3],
-    currency: ['EUR', '']
+  decimal: ',',
+  thousands: '.',
+  grouping: [3],
+  currency: ['EUR', '']
 };
 
 localeDef = {

--- a/types/d3-format/index.d.ts
+++ b/types/d3-format/index.d.ts
@@ -1,6 +1,9 @@
 // Type definitions for D3JS d3-format module 1.2
 // Project: https://github.com/d3/d3-format/
-// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>
+//             Alex Ford <https://github.com/gustavderdrache>
+//             Boris Yankov <https://github.com/borisyankov>
+//             denisname <https://github.com/denisname>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // Last module patch version validated against: 1.2.0
@@ -23,7 +26,7 @@ export interface FormatLocaleDefinition {
      */
     grouping: number[];
     /**
-     * The currency prefix and suffix (e.g., ["$", ""])
+     * The currency prefix and suffix (e.g., ["$", ""]).
      */
     currency: [string, string];
     /**
@@ -31,7 +34,7 @@ export interface FormatLocaleDefinition {
      */
     numerals?: string[];
     /**
-     * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%")
+     * An optional symbol to replace the `percent` suffix; the percent suffix (defaults to "%").
      */
     percent?: string;
 }
@@ -44,9 +47,10 @@ export interface FormatLocaleObject {
      * Returns a new format function for the given string specifier. The returned function
      * takes a number as the only argument, and returns a string representing the formatted number.
      *
-     * @param specifier A Specifier string
+     * @param specifier A Specifier string.
+     * @throws Error on invalid format specifier.
      */
-    format(specifier: string): (n: number) => string;
+    format(specifier: string): (n: number | { valueOf(): number }) => string;
 
     /**
      * Returns a new format function for the given string specifier. The returned function
@@ -54,10 +58,11 @@ export interface FormatLocaleObject {
      * The returned function will convert values to the units of the appropriate SI prefix for the
      * specified numeric reference value before formatting in fixed point notation.
      *
-     * @param specifier A Specifier string
+     * @param specifier A Specifier string.
      * @param value The reference value to determine the appropriate SI prefix.
+     * @throws Error on invalid format specifier.
      */
-    formatPrefix(specifier: string, value: number): (n: number) => string;
+    formatPrefix(specifier: string, value: number): (n: number | { valueOf(): number }) => string;
 }
 
 /**
@@ -71,7 +76,7 @@ export interface FormatSpecifier {
      */
     fill: string;
     /**
-     * Alignment used for format, as set by choosing one of the following
+     * Alignment used for format, as set by choosing one of the following:
      *
      * '>' - Forces the field to be right-aligned within the available space. (Default behavior).
      * '<' - Forces the field to be left-aligned within the available space.
@@ -83,9 +88,9 @@ export interface FormatSpecifier {
      * The sign can be:
      *
      * '-' - nothing for positive and a minus sign for negative. (Default behavior.)
-     * '+' -  a plus sign for positive and a minus sign for negative.
+     * '+' - a plus sign for positive and a minus sign for negative.
      * '(' - nothing for positive and parentheses for negative.
-     * ' '(space) -  a space for positive and a minus sign for negative.
+     * ' ' (space) - a space for positive and a minus sign for negative.
      *
      */
     sign: '-' | '+' | '(' | ' ';
@@ -94,7 +99,7 @@ export interface FormatSpecifier {
      *
      * '$' - apply currency symbols per the locale definition.
      * '#' - for binary, octal, or hexadecimal notation, prefix by 0b, 0o, or 0x, respectively.
-     * ''(none) - no symbol.
+     * '' (none) - no symbol. (Default behavior.)
      */
     symbol: '$' | '#' | '';
     /**
@@ -116,9 +121,9 @@ export interface FormatSpecifier {
      * it defaults to 6 for all types except '' (none), which defaults to 12.
      * Precision is ignored for integer formats (types 'b', 'o', 'd', 'x', 'X' and 'c').
      *
-     * See precisionFixed and precisionRound for help picking an appropriate precision
+     * See precisionFixed and precisionRound for help picking an appropriate precision.
      */
-    precision: number;
+    precision: number | undefined;
     /**
      * The available type values are:
      *
@@ -137,7 +142,7 @@ export interface FormatSpecifier {
      * 'c' - converts the integer to the corresponding unicode character before printing.
      * '' (none) - like g, but trim insignificant trailing zeros.
      *
-     * The type 'n' is also supported as shorthand for ',g'. For the 'g', 'n' and ''(none) types,
+     * The type 'n' is also supported as shorthand for ',g'. For the 'g', 'n' and '' (none) types,
      * decimal notation is used if the resulting string would have precision or fewer digits; otherwise, exponent notation is used.
      */
     type: 'e' | 'f' | 'g' | 'r' | 's' | '%' | 'p' | 'b' | 'o' | 'd' | 'x' | 'X' | 'c' | '' | 'n';
@@ -173,9 +178,10 @@ export function formatDefaultLocale(defaultLocale: FormatLocaleDefinition): Form
  * The general form of a specifier is [[fill]align][sign][symbol][0][width][,][.precision][type].
  * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
  *
- * @param specifier A Specifier string
+ * @param specifier A Specifier string.
+ * @throws Error on invalid format specifier.
  */
-export function format(specifier: string): (n: number) => string;
+export function format(specifier: string): (n: number | { valueOf(): number }) => string;
 
 /**
  * Returns a new format function for the given string specifier. The returned function
@@ -183,15 +189,16 @@ export function format(specifier: string): (n: number) => string;
  * The returned function will convert values to the units of the appropriate SI prefix for the
  * specified numeric reference value before formatting in fixed point notation.
  *
- *  Uses the current default locale.
+ * Uses the current default locale.
  *
  * The general form of a specifier is [[fill]align][sign][symbol][0][width][,][.precision][type].
  * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
  *
- * @param specifier A Specifier string
+ * @param specifier A Specifier string.
  * @param value The reference value to determine the appropriate SI prefix.
+ * @throws Error on invalid format specifier.
  */
-export function formatPrefix(specifier: string, value: number): (n: number) => string;
+export function formatPrefix(specifier: string, value: number): (n: number | { valueOf(): number }) => string;
 
 /**
  * Parses the specified specifier, returning an object with exposed fields that correspond to the
@@ -201,6 +208,7 @@ export function formatPrefix(specifier: string, value: number): (n: number) => s
  * For reference, an explanation of the segments of the specifier string, refer to the FormatSpecifier interface properties.
  *
  * @param specifier A specifier string.
+ * @throws Error on invalid format specifier.
  */
 export function formatSpecifier(specifier: string): FormatSpecifier;
 

--- a/types/d3-format/tsconfig.json
+++ b/types/d3-format/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "noImplicitAny": true,
         "noImplicitThis": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [


### PR DESCRIPTION
This follows pull request #24305. Code changes here are exactly like last commit it that PR for d3-format. I will push changes for d3-axis ~later today~ once this will be merged. As adding `valueOf` in d3-format is required for d3-axis `strictFunctionTypes`...

With this, d3-format validated for `strictNullChecks`, `strictFunctionTypes` and TS 2.3.

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/d3/d3-format/blob/b6e3ea116cc6262cee7abcc12fc30bdb31fe579e/README.md
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
