### PR TITLE
Add type definition for is-ci

### DIFF
--- a/types/is-ci/index.d.ts
+++ b/types/is-ci/index.d.ts
@@ -1,0 +1,8 @@
+// Type definitions for is-ci 1.1
+// Project: https://github.com/watson/is-ci
+// Definitions by: Arne Schubert <https://github.com/atd-schubert>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare const isACi: boolean;
+
+export = isACi;

--- a/types/is-ci/index.d.ts
+++ b/types/is-ci/index.d.ts
@@ -1,9 +1,8 @@
 // Type definitions for is-ci 1.1
 // Project: https://github.com/watson/is-ci
-// Definitions by: My Self <https://github.com/me>
+// Definitions by: Arne Schubert <https://github.com/atd-schubert>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export = is_ci;
 
 declare const is_ci: boolean;
-

--- a/types/is-ci/index.d.ts
+++ b/types/is-ci/index.d.ts
@@ -1,8 +1,9 @@
 // Type definitions for is-ci 1.1
 // Project: https://github.com/watson/is-ci
-// Definitions by: Arne Schubert <https://github.com/atd-schubert>
+// Definitions by: My Self <https://github.com/me>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare const isACi: boolean;
+export = is_ci;
 
-export = isACi;
+declare const is_ci: boolean;
+

--- a/types/is-ci/is-ci-tests.ts
+++ b/types/is-ci/is-ci-tests.ts
@@ -1,0 +1,5 @@
+import isCi = require('is-ci');
+
+let booleanValue: boolean;
+
+booleanValue = isCi;

--- a/types/is-ci/tsconfig.json
+++ b/types/is-ci/tsconfig.json
@@ -7,6 +7,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/is-ci/tsconfig.json
+++ b/types/is-ci/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "is-ci-tests.ts"
+    ]
+}

--- a/types/is-ci/tsconfig.json
+++ b/types/is-ci/tsconfig.json
@@ -7,7 +7,6 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "strictFunctionTypes": true,
         "baseUrl": "../",
         "typeRoots": [
             "../"

--- a/types/is-ci/tslint.json
+++ b/types/is-ci/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
### Adding a type definition for npm package `is-ci`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

Type definition according to the documentation of the package taken from: https://github.com/watson/is-ci/blob/master/README.md