### PR TITLE
Add new type definition for toobusy-js

### DIFF
--- a/types/toobusy-js/index.d.ts
+++ b/types/toobusy-js/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for toobusy-js 0.5
+// Project: https://github.com/STRML/node-toobusy
+// Definitions by: Arne Schubert <https://github.com/atd-schubert>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export = toobusy_js;
+
+declare function toobusy_js(): boolean;
+
+declare namespace toobusy_js {
+    function interval(newInterval: number): number;
+    function lag(): number;
+    function maxLag(newLag: number): number;
+    function smmothingFactor(newFactor: number): number;
+    function shutdown(): void;
+    function onLag(fn: (lag: number) => void, threshold?: number): void;
+
+    function started(): boolean;
+}

--- a/types/toobusy-js/toobusy-js-tests.ts
+++ b/types/toobusy-js/toobusy-js-tests.ts
@@ -1,0 +1,17 @@
+import * as toobusy from "toobusy-js";
+
+let numberValue = 1;
+let booleanValue = true;
+
+booleanValue = toobusy();
+booleanValue = toobusy.started();
+
+numberValue = toobusy.interval(numberValue);
+numberValue = toobusy.lag();
+numberValue = toobusy.maxLag(numberValue);
+numberValue = toobusy.smmothingFactor(numberValue);
+
+toobusy.onLag((duration: number) => {});
+toobusy.onLag((duration: number) => {}, numberValue);
+
+toobusy.shutdown();

--- a/types/toobusy-js/toobusy-js-tests.ts
+++ b/types/toobusy-js/toobusy-js-tests.ts
@@ -1,4 +1,4 @@
-import * as toobusy from "toobusy-js";
+import toobusy = require("toobusy-js");
 
 let numberValue = 1;
 let booleanValue = true;

--- a/types/toobusy-js/tsconfig.json
+++ b/types/toobusy-js/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": "../",
+        "typeRoots": [
+            "../"
+        ],
+        "types": [],
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.d.ts",
+        "toobusy-js-tests.ts"
+    ]
+}

--- a/types/toobusy-js/tslint.json
+++ b/types/toobusy-js/tslint.json
@@ -1,0 +1,1 @@
+{ "extends": "dtslint/dt.json" }


### PR DESCRIPTION
### Add new type definition for npm package `toobusy-js`.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Adding a new definition:
- [x] The package does not already provide its own types, or cannot have its `.d.ts` files generated via `--declaration`
- [x] If this is for an NPM package, match the name. If not, do not conflict with the name of an NPM package.
- [x] Create it with `dts-gen --dt`, not by basing it on an existing project.
- [x] `tslint.json` should be present, and `tsconfig.json` should have `noImplicitAny`, `noImplicitThis`, `strictNullChecks`, and `strictFunctionTypes` set to `true`.

---

Type defintion is based on: https://github.com/STRML/node-toobusy/blob/master/toobusy.js