### PR TITLE
Fix JsonSchema.type definition in tv4

### DIFF
--- a/types/tv4/index.d.ts
+++ b/types/tv4/index.d.ts
@@ -12,7 +12,7 @@ declare namespace tv4 {
         description?: string;    // used for humans only, and not used for computation
         id?: string;
         $schema?: string;
-        type?: string;
+        type?: string | string[];
         items?: any;
         properties?: any;
         patternProperties?: any;

--- a/types/tv4/tv4-tests.ts
+++ b/types/tv4/tv4-tests.ts
@@ -129,7 +129,7 @@ schema = {
     alert("data 2 error: " + JSON.stringify(validator.error, null, 4));
 
     schema = {
-        "type": "array",
+        "type": ["array"],
         "items": {"$ref": "#"}
     };
 }


### PR DESCRIPTION
`JsonSchema.type` properties have not allowed an array of string now. `type` properties should receive a string and array of a string by a spec of JSON Schema.
> https://github.com/json-schema-org/json-schema-spec/blob/master/schema.json#L151-L161

Test cases of tv4 contain an array of string in `type` properties.
> https://github.com/geraintluff/tv4/blob/master/test/tests/01%20-%20Any%20types/01%20-%20type.js#L10-L22

---

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/json-schema-org/json-schema-spec/blob/master/schema.json#L151-L161
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.