### PR TITLE
Add missing argument for Screen (react-native-navigation)

### DIFF
--- a/types/react-native-navigation/index.d.ts
+++ b/types/react-native-navigation/index.d.ts
@@ -70,6 +70,7 @@ export interface Screen {
     title?: string;
     navigatorStyle?: NavigatorStyle;
     navigatorButtons?: NavigatorButtons;
+    overrideBackPress?: boolean;
 }
 
 export interface ModalScreen extends Screen {

--- a/types/react-native-navigation/react-native-navigation-tests.tsx
+++ b/types/react-native-navigation/react-native-navigation-tests.tsx
@@ -10,7 +10,7 @@ class Screen1 extends React.Component<NavigationComponentProps & { height: numbe
     };
 
     componentDidMount() {
-        this.props.navigator.push({ screen: 'example.Screen2' });
+        this.props.navigator.push({ screen: 'example.Screen2', overrideBackPress: false });
         this.props.navigator.setTabBadge({ badge: null });
     }
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wix/react-native-navigation/issues/250
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

React-native-navigation has prop `overrideBackPress` which can be passed as argument when for example pushing new screen. The purpose of the argument is to control what happens when user presses back button on Android. More info on this here: https://github.com/wix/react-native-navigation/issues/250
