### PR TITLE
express-winston: relax types on meta object

### DIFF
--- a/types/express-winston/express-winston-tests.ts
+++ b/types/express-winston/express-winston-tests.ts
@@ -6,7 +6,7 @@ const app = express();
 
 // Logger with all options
 app.use(expressWinston.logger({
-  baseMeta: { foo: 'foo' },
+  baseMeta: { foo: 'foo', nested: { bar: 'baz' } },
   bodyBlacklist: ['foo'],
   bodyWhitelist: ['bar'],
   colorize: true,
@@ -47,7 +47,7 @@ app.use(expressWinston.logger({
 
 // Error Logger with all options
 app.use(expressWinston.errorLogger({
-  baseMeta: { foo: 'foo' },
+  baseMeta: { foo: 'foo', nested: { bar: 'baz' } },
   dynamicMeta: (req, res, err) => ({ foo: 'bar' }),
   level: (req, res) => 'level',
   metaField: 'metaField',

--- a/types/express-winston/index.d.ts
+++ b/types/express-winston/index.d.ts
@@ -7,14 +7,14 @@
 import { ErrorRequestHandler, Handler, Request, Response } from 'express';
 import { TransportInstance, Winston } from 'winston';
 
-export type DynamicMetaFunction = (req: Request, res: Response, err: Error) => any;
+export type DynamicMetaFunction = (req: Request, res: Response, err: Error) => object;
 export type DynamicLevelFunction = (req: Request, res: Response, err: Error) => string;
 export type RequestFilter = (req: Request, propName: string) => boolean;
 export type ResponseFilter = (res: Response, propName: string) => boolean;
 export type RouteFilter = (req: Request, res: Response) => boolean;
 
 export interface BaseLoggerOptions {
-  baseMeta?: any;
+  baseMeta?: object;
   bodyBlacklist?: string[];
   bodyWhitelist?: string[];
   colorize?: boolean;
@@ -51,7 +51,7 @@ export type LoggerOptions = LoggerOptionsWithTransports | LoggerOptionsWithWinst
 export function logger(options: LoggerOptions): Handler;
 
 export interface BaseErrorLoggerOptions {
-  baseMeta?: any;
+  baseMeta?: object;
   dynamicMeta?: DynamicMetaFunction;
   level?: string | DynamicLevelFunction;
   metaField?: string;

--- a/types/express-winston/index.d.ts
+++ b/types/express-winston/index.d.ts
@@ -7,18 +7,14 @@
 import { ErrorRequestHandler, Handler, Request, Response } from 'express';
 import { TransportInstance, Winston } from 'winston';
 
-export interface MetaObject {
-  [field: string]: string;
-}
-
-export type DynamicMetaFunction = (req: Request, res: Response, err: Error) => MetaObject | undefined;
+export type DynamicMetaFunction = (req: Request, res: Response, err: Error) => any;
 export type DynamicLevelFunction = (req: Request, res: Response, err: Error) => string;
 export type RequestFilter = (req: Request, propName: string) => boolean;
 export type ResponseFilter = (res: Response, propName: string) => boolean;
 export type RouteFilter = (req: Request, res: Response) => boolean;
 
 export interface BaseLoggerOptions {
-  baseMeta?: MetaObject;
+  baseMeta?: any;
   bodyBlacklist?: string[];
   bodyWhitelist?: string[];
   colorize?: boolean;
@@ -55,7 +51,7 @@ export type LoggerOptions = LoggerOptionsWithTransports | LoggerOptionsWithWinst
 export function logger(options: LoggerOptions): Handler;
 
 export interface BaseErrorLoggerOptions {
-  baseMeta?: MetaObject;
+  baseMeta?: any;
   dynamicMeta?: DynamicMetaFunction;
   level?: string | DynamicLevelFunction;
   metaField?: string;


### PR DESCRIPTION
Relaxes the type of the metadata object in express-winston. Winston's [own typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/winston/index.d.ts#L182) use `any` for the meta object and there are cases where you may want nested metadata. In my case I'm using the dynamic meta function to set http request metadata in a [specific format](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#httprequest) to be consumed by a [specific transport](https://github.com/googleapis/nodejs-logging-winston#formatting-request-logs) and can't express this with the current types.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/winston/index.d.ts#L182
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.