### PR TITLE
firefox-webext-browser: remove bookmark.import/export

### DIFF
--- a/types/firefox-webext-browser/firefox-webext-browser-tests.ts
+++ b/types/firefox-webext-browser/firefox-webext-browser-tests.ts
@@ -12,3 +12,5 @@ browser._manifest.NativeManifest; // $ExpectError
 // browser.runtime
 const port = browser.runtime.connect();
 port.postMessage(); // $ExpectError
+
+browser.bookmarks.getTree();

--- a/types/firefox-webext-browser/index.d.ts
+++ b/types/firefox-webext-browser/index.d.ts
@@ -3915,10 +3915,6 @@ declare namespace browser.bookmarks {
         type?: BookmarkTreeNodeType;
     }
 
-    export {_import as import};
-
-    export {_export as export};
-
     /* bookmarks functions */
     /**
      * Retrieves the specified BookmarkTreeNode(s).
@@ -3985,18 +3981,6 @@ declare namespace browser.bookmarks {
 
     /** Recursively removes a bookmark folder. */
     function removeTree(id: string): Promise<void>;
-
-    /**
-     * Imports bookmarks from an html bookmark file
-     * @deprecated Unsupported on Firefox at this time.
-     */
-    function _import(): Promise<void>;
-
-    /**
-     * Exports bookmarks to an html bookmark file
-     * @deprecated Unsupported on Firefox at this time.
-     */
-    function _export(): Promise<void>;
 
     /* bookmarks events */
     /** Fired when a bookmark or folder is created. */


### PR DESCRIPTION
They aren't used by any browser and break the bookmarks namespace (no other properties are accessible on completion)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/bookmarks
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.