### PR TITLE
Fix missing splat in react-intl types

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -142,7 +142,7 @@ declare namespace ReactIntl {
         interface Props extends MessageDescriptor {
             values?: {[key: string]: MessageValue | JSX.Element};
             tagName?: string;
-            children?: (formattedMessage: string[]) => React.ReactNode;
+            children?: (...formattedMessage: string[]) => React.ReactNode;
         }
     }
     class FormattedMessage extends React.Component<FormattedMessage.Props> { }

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -150,6 +150,20 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 {(text) => <div className="messageDiv">{text}</div>}
             </FormattedMessage>
 
+            <FormattedMessage
+                id="test"
+                description="Test"
+            >
+                {(text) => <input placeholder={text} />}
+            </FormattedMessage>
+
+            <FormattedMessage
+                id="test"
+                description="Test"
+            >
+                {(...text) => <ul>{text.map(t => <li>{t}</li>)}</ul>}
+            </FormattedMessage>
+
             <FormattedHTMLMessage
                 id="test"
                 description="Test"


### PR DESCRIPTION
Fixes the issues discussed in #24670

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
