### PR TITLE
Add 'cache' options for got

### DIFF
--- a/types/got/got-tests.ts
+++ b/types/got/got-tests.ts
@@ -1,10 +1,12 @@
 import got = require('got');
 import cookie = require('cookie');
 import FormData = require('form-data');
+import Keyv = require('keyv');
 import * as fs from 'fs';
 import * as http from 'http';
 import * as https from 'https';
 import * as url from 'url';
+import QuickLRU = require('quick-lru');
 
 let str: string;
 let buf: Buffer;
@@ -242,7 +244,15 @@ got('todomvc', {
 });
 
 got('todomvc', {
-    cache: new Map()
+    cache: new Map(),
+}).then(res => res.fromCache);
+
+got('todomvc', {
+    cache: new Keyv(),
+}).then(res => res.fromCache);
+
+got('todomvc', {
+    cache: new QuickLRU(),
 }).then(res => res.fromCache);
 
 got(new url.URL('http://todomvc.com'));

--- a/types/got/index.d.ts
+++ b/types/got/index.d.ts
@@ -119,7 +119,7 @@ declare namespace got {
         followRedirect?: boolean;
         decompress?: boolean;
         useElectronNet?: boolean;
-        cache?: Map<string, any>;
+        cache?: Cache;
         agent?: http.Agent | boolean | AgentOptions;
         throwHttpErrors?: boolean;
     }
@@ -136,6 +136,12 @@ declare namespace got {
     }
 
     type RetryFunction = (retry: number, error: any) => number;
+
+    interface Cache {
+        set(key: string, value: any, ttl?: number): any;
+        get(key: string): any;
+        delete(key: string): any;
+    }
 
     interface Response<B extends Buffer | string | object> extends http.IncomingMessage {
         body: B;

--- a/types/keyv/index.d.ts
+++ b/types/keyv/index.d.ts
@@ -35,6 +35,9 @@ declare class Keyv extends NodeJS.EventEmitter {
      * @param opts The options object is also passed through to the storage adapter. Check your storage adapter docs for any extra options.
      */
     constructor(uri?: string, opts?: KeyvOptions);
+    /** Returns the namespace of a key **/
+    _getKeyPrefix(key: string): string;
+
     /** Returns the value. */
     get(key: string): Promise<any>;
     /**

--- a/types/keyv/index.d.ts
+++ b/types/keyv/index.d.ts
@@ -3,9 +3,7 @@
 // Definitions by: AryloYeung <https://github.com/Arylo>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.1
-
 /// <reference types="node" />
-
 interface KeyvOptions {
     /** Namespace for the current instance. */
     namespace?: string;
@@ -45,7 +43,7 @@ declare class Keyv extends NodeJS.EventEmitter {
      *
      * By default keys are persistent. You can set an expiry TTL in milliseconds.
      */
-    set(key: string, value: any, ttl?: number): Promise<boolean>;
+    set(key: string, value: any, ttl?: number): (Promise<boolean> | undefined);
     /**
      * Deletes an entry.
      *

--- a/types/keyv/index.d.ts
+++ b/types/keyv/index.d.ts
@@ -33,7 +33,7 @@ declare class Keyv extends NodeJS.EventEmitter {
      * @param opts The options object is also passed through to the storage adapter. Check your storage adapter docs for any extra options.
      */
     constructor(uri?: string, opts?: KeyvOptions);
-    /** Returns the namespace of a key **/
+    /** Returns the namespace of a key */
     _getKeyPrefix(key: string): string;
 
     /** Returns the value. */


### PR DESCRIPTION
This PR
1. Updated the type definitions for [Keyv](https://github.com/lukechilds/keyv). c70333e
2. Modified the `cache` option's interface for [got](https://github.com/sindresorhus/got). Specifically, got uses a package named [cacheable-request](https://github.com/lukechilds/cacheable-request), in which `set`, `get`, and `delete` method is required for the passed in cache adapter. 6701185e16fe2f625e754d88b736e286a51bbe4e