### PR TITLE
[Highcharts] Allow area range series

### DIFF
--- a/types/highcharts/index.d.ts
+++ b/types/highcharts/index.d.ts
@@ -5428,8 +5428,14 @@ declare namespace Highcharts {
          *            name: 'Point1',
          *            color: '#FF00FF'
          *        }]
+		 * 4. An array of arrays with 3 values. In this case, the values correspond as x, min, max (arearange). If the first
+		 *    value is a string, it is applied as the name of the point, and the min, max value is inferred.
+         *        data: [
+		 *			[1, 5, 9],
+		 *			[2, 4, 5]
+		 *		  ]    
          */
-        data?: Array<number | [number, number] | [string, number] | DataPoint>;
+        data?: Array<number | [number, number] | [string, number] | [number, number, number] | [string, number, number] | DataPoint>;
         /**
          * A description of the series to add to the screen reader information about the series.
          * @since 5.0.0


### PR DESCRIPTION
This fix fixes the problem that no [number, number, number] or [string, number, number] elements can be added even though they are needed for area range.

Example: https://www.highcharts.com/demo/arearange