### PR TITLE
[react] Update type inference for setState

### DIFF
--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -285,8 +285,8 @@ declare namespace React {
         // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
         // Also, the ` | S` allows intellisense to not be dumbisense
-        setState<K extends keyof S>(
-            state: ((prevState: Readonly<S>, props: P) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
+        setState<K extends keyof this["state"]>(
+            state: ((prevState: Readonly<this["state"]>, props: P) => (Pick<this["state"], K> | this["state"] | null)) | (Pick<this["state"], K> | this["state"] | null),
             callback?: () => void
         ): void;
 

--- a/types/react/index.d.ts
+++ b/types/react/index.d.ts
@@ -286,7 +286,7 @@ declare namespace React {
         // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
         // Also, the ` | S` allows intellisense to not be dumbisense
         setState<K extends keyof this["state"]>(
-            state: ((prevState: Readonly<this["state"]>, props: P) => (Pick<this["state"], K> | this["state"] | null)) | (Pick<this["state"], K> | this["state"] | null),
+            state: ((prevState: Readonly<this["state"]>, props: P) => (Pick<this["state"], K> | this["state"] | S | null)) | (Pick<this["state"], K> | this["state"] | S | null),
             callback?: () => void
         ): void;
 


### PR DESCRIPTION
Infer keys and type from `this.state` to allow implicit type annotation.

This change allows declaring type in constructor or within a class field initializer.

```
class Example extends React.Component { // implicit <{}, {}>
  state = {
    toggle: false // as boolean
  }

  toggle = () => {
    this.setState({toggle: !this.state.toggle}) // property toggle: boolean
    this.setState(state => ({toggle: !state.toggle})) // does not exist on type Readonly<{}>
  }
```

https://github.com/Microsoft/TypeScript/issues/23088

Please fill in this template.

- [🗸] Use a meaningful title for the pull request. Include the name of the package modified.
- [🗸] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
- [🗸] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [🗸] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [🗸] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [🗸] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/Microsoft/TypeScript/issues/23088
- [?] Increase the version number in the header if appropriate.
- [?] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.