### PR TITLE
webgl2: Allow for better type union with `WebGLRenderingContext`

### DIFF
--- a/types/webgl2/index.d.ts
+++ b/types/webgl2/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for WebGL 2, Editor's Draft Fri Feb 24 16:10:18 2017 -0800
 // Project: https://www.khronos.org/registry/webgl/specs/latest/2.0/
 // Definitions by: Nico Kemnitz <https://github.com/nkemnitz>
+//                 Adrian Blumer <https://github.com/karhu>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 interface HTMLCanvasElement extends HTMLElement {
@@ -12,6 +13,12 @@ interface ImageBitmap {
     readonly height: number;
     close(): void;
 }
+
+type BufferData = Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array |
+                  Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | null;
+
+type PixelData = Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array |
+                 Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | null;
 
 interface WebGL2RenderingContext extends WebGLRenderingContext {
     readonly READ_BUFFER: number;                                   // 0x0C02
@@ -286,11 +293,13 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
 
     /* Buffer objects */
     // WebGL1:
-    bufferData(target: number, size: number, usage: number): void;
-    bufferData(target: number, srcData: ArrayBuffer | ArrayBufferView | null, usage: number): void;
-    bufferSubData(target: number, dstByteOffset: number, srcData: ArrayBuffer | ArrayBufferView | null): void;
+    bufferData(target: number, sizeOrData: number | BufferData, usage: number): void;
+    bufferSubData(target: number, dstByteOffset: number, srcData: BufferData): void;
+    // For compatibility with WebGL 1 context in older Typescript versions.
+    bufferData(target: number, data: ArrayBufferView, usage: number): void;
+    bufferSubData(target: number, dstByteOffset: number, srcData: ArrayBufferView): void;
     // WebGL2:
-    bufferData(target: number, srcData: ArrayBufferView, usage: number, srcOffset: number,
+    bufferData(target: number, srcData: BufferData, usage: number, srcOffset: number,
         length?: number): void;
     bufferSubData(target: number, dstByteOffset: number, srcData: ArrayBufferView,
         srcOffset: number, length?: number): void;
@@ -387,17 +396,31 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     compressedTexImage2D(target: number, level: number, internalformat: number, width: number,
         height: number, border: number, imageSize: number, offset: number): void;
     compressedTexImage2D(target: number, level: number, internalformat: number, width: number,
-        height: number, border: number, srcData: ArrayBufferView | null,
+        height: number, border: number, srcData: PixelData,
+        srcOffset?: number, srcLengthOverride?: number): void;
+    // For compatibility with WebGL 1 context in older Typescript versions.
+    compressedTexImage2D(target: number, level: number, internalformat: number, width: number,
+        height: number, border: number, srcData: ArrayBufferView,
         srcOffset?: number, srcLengthOverride?: number): void;
 
     compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
         height: number, depth: number, border: number, imageSize: number, offset: number): void;
+    compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
+        height: number, depth: number, border: number, srcData: PixelData,
+        srcOffset?: number, srcLengthOverride?: number): void;
+    // For compatibility with WebGL 1 context in older Typescript versions.
     compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
         height: number, depth: number, border: number, srcData: ArrayBufferView,
         srcOffset?: number, srcLengthOverride?: number): void;
 
     compressedTexSubImage2D(target: number, level: number, xoffset: number, yoffset: number,
         width: number, height: number, format: number, imageSize: number, offset: number): void;
+    compressedTexSubImage2D(target: number, level: number, xoffset: number, yoffset: number,
+        width: number, height: number, format: number,
+        srcData: PixelData | null,
+        srcOffset?: number,
+        srcLengthOverride?: number): void;
+    // For compatibility with WebGL 1 context in older Typescript versions.
     compressedTexSubImage2D(target: number, level: number, xoffset: number, yoffset: number,
         width: number, height: number, format: number,
         srcData: ArrayBufferView | null,
@@ -407,6 +430,12 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     compressedTexSubImage3D(target: number, level: number, xoffset: number, yoffset: number,
         zoffset: number, width: number, height: number, depth: number,
         format: number, imageSize: number, offset: number): void;
+    compressedTexSubImage3D(target: number, level: number, xoffset: number, yoffset: number,
+        zoffset: number, width: number, height: number, depth: number,
+        format: number, srcData: PixelData,
+        srcOffset?: number,
+        srcLengthOverride?: number): void;
+    // For compatibility with WebGL 1 context in older Typescript versions.
     compressedTexSubImage3D(target: number, level: number, xoffset: number, yoffset: number,
         zoffset: number, width: number, height: number, depth: number,
         format: number, srcData: ArrayBufferView,
@@ -422,59 +451,59 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     uniform3ui(location: WebGLUniformLocation | null, v0: number, v1: number, v2: number): void;
     uniform4ui(location: WebGLUniformLocation | null, v0: number, v1: number, v2: number, v3: number): void;
 
-    uniform1fv(location: WebGLUniformLocation | null, data: Float32Array | number[], srcOffset?: number,
+    uniform1fv(location: WebGLUniformLocation | null, data: Float32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
-    uniform2fv(location: WebGLUniformLocation | null, data: Float32Array | number[], srcOffset?: number,
+    uniform2fv(location: WebGLUniformLocation, data: Float32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
-    uniform3fv(location: WebGLUniformLocation | null, data: Float32Array | number[], srcOffset?: number,
+    uniform3fv(location: WebGLUniformLocation | null, data: Float32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
-    uniform4fv(location: WebGLUniformLocation | null, data: Float32Array | number[], srcOffset?: number,
-        srcLength?: number): void;
-
-    uniform1iv(location: WebGLUniformLocation | null, data: Int32Array | number[], srcOffset?: number,
-        srcLength?: number): void;
-    uniform2iv(location: WebGLUniformLocation | null, data: Int32Array | number[], srcOffset?: number,
-        srcLength?: number): void;
-    uniform3iv(location: WebGLUniformLocation | null, data: Int32Array | number[], srcOffset?: number,
-        srcLength?: number): void;
-    uniform4iv(location: WebGLUniformLocation | null, data: Int32Array | number[], srcOffset?: number,
+    uniform4fv(location: WebGLUniformLocation | null, data: Float32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
 
-    uniform1uiv(location: WebGLUniformLocation | null, data: Uint32Array | number[], srcOffset?: number,
+    uniform1iv(location: WebGLUniformLocation | null, data: Int32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
-    uniform2uiv(location: WebGLUniformLocation | null, data: Uint32Array | number[], srcOffset?: number,
+    uniform2iv(location: WebGLUniformLocation | null, data: Int32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
-    uniform3uiv(location: WebGLUniformLocation | null, data: Uint32Array | number[], srcOffset?: number,
+    uniform3iv(location: WebGLUniformLocation | null, data: Int32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
-    uniform4uiv(location: WebGLUniformLocation | null, data: Uint32Array | number[], srcOffset?: number,
+    uniform4iv(location: WebGLUniformLocation | null, data: Int32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
 
-    uniformMatrix2fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniform1uiv(location: WebGLUniformLocation | null, data: Uint32Array | ArrayLike<number>, srcOffset?: number,
+        srcLength?: number): void;
+    uniform2uiv(location: WebGLUniformLocation | null, data: Uint32Array | ArrayLike<number>, srcOffset?: number,
+        srcLength?: number): void;
+    uniform3uiv(location: WebGLUniformLocation | null, data: Uint32Array | ArrayLike<number>, srcOffset?: number,
+        srcLength?: number): void;
+    uniform4uiv(location: WebGLUniformLocation | null, data: Uint32Array | ArrayLike<number>, srcOffset?: number,
+        srcLength?: number): void;
+
+    uniformMatrix2fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
-    uniformMatrix3x2fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniformMatrix3x2fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
-    uniformMatrix4x2fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniformMatrix4x2fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
 
-    uniformMatrix2x3fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniformMatrix2x3fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
-    uniformMatrix3fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniformMatrix3fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
-    uniformMatrix4x3fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniformMatrix4x3fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
 
-    uniformMatrix2x4fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniformMatrix2x4fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
-    uniformMatrix3x4fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniformMatrix3x4fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
-    uniformMatrix4fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | number[],
+    uniformMatrix4fv(location: WebGLUniformLocation | null, transpose: boolean, data: Float32Array | ArrayLike<number>,
         srcOffset?: number, srcLength?: number): void;
 
     /* Vertex attribs */
     vertexAttribI4i(index: number, x: number, y: number, z: number, w: number): void;
-    vertexAttribI4iv(index: number, values: Int32Array | number[]): void;
+    vertexAttribI4iv(index: number, values: Int32Array | ArrayLike<number>): void;
     vertexAttribI4ui(index: number, x: number, y: number, z: number, w: number): void;
-    vertexAttribI4uiv(index: number, values: Uint32Array | number[]): void;
+    vertexAttribI4uiv(index: number, values: Uint32Array | ArrayLike<number>): void;
     vertexAttribIPointer(index: number, size: number, type: number, stride: number, offset: number): void;
 
     /* Writing to the drawing buffer */
@@ -486,21 +515,22 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     /* Reading back pixels */
     // WebGL1:
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
-        dstData: ArrayBufferView | null): void;
+        dstData: PixelData): void;
+
     // WebGL2:
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
         offset: number): void;
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
-        dstData: ArrayBufferView, dstOffset: number): void;
+        dstData: PixelData, dstOffset: number): void;
 
     /* Multiple Render Targets */
     drawBuffers(buffers: number[]): void;
 
-    clearBufferfv(buffer: number, drawbuffer: number, values: Float32Array | number[],
+    clearBufferfv(buffer: number, drawbuffer: number, values: Float32Array | ArrayLike<number>,
         srcOffset?: number): void;
-    clearBufferiv(buffer: number, drawbuffer: number, values: Int32Array | number[],
+    clearBufferiv(buffer: number, drawbuffer: number, values: Int32Array | ArrayLike<number>,
         srcOffset?: number): void;
-    clearBufferuiv(buffer: number, drawbuffer: number, values: Uint32Array | number[],
+    clearBufferuiv(buffer: number, drawbuffer: number, values: Uint32Array | ArrayLike<number>,
         srcOffset?: number): void;
 
     clearBufferfi(buffer: number, drawbuffer: number, depth: number, stencil: number): void;

--- a/types/webgl2/index.d.ts
+++ b/types/webgl2/index.d.ts
@@ -14,12 +14,6 @@ interface ImageBitmap {
     close(): void;
 }
 
-type BufferData = Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array |
-                  Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | null;
-
-type PixelData = Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array |
-                 Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | null;
-
 interface WebGL2RenderingContext extends WebGLRenderingContext {
     readonly READ_BUFFER: number;                                   // 0x0C02
     readonly UNPACK_ROW_LENGTH: number;                             // 0x0CF2
@@ -293,14 +287,16 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
 
     /* Buffer objects */
     // WebGL1:
-    bufferData(target: number, sizeOrData: number | BufferData, usage: number): void;
-    bufferSubData(target: number, dstByteOffset: number, srcData: BufferData): void;
+    bufferData(target: number, sizeOrData: number | Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array |
+        Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | null, usage: number): void;
+    bufferSubData(target: number, dstByteOffset: number, srcData: Int8Array | Int16Array | Int32Array | Uint8Array |
+        Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | null): void;
     // For compatibility with WebGL 1 context in older Typescript versions.
     bufferData(target: number, data: ArrayBufferView, usage: number): void;
     bufferSubData(target: number, dstByteOffset: number, srcData: ArrayBufferView): void;
     // WebGL2:
-    bufferData(target: number, srcData: BufferData, usage: number, srcOffset: number,
-        length?: number): void;
+    bufferData(target: number, srcData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array |
+        Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | null, usage: number, srcOffset: number, length?: number): void;
     bufferSubData(target: number, dstByteOffset: number, srcData: ArrayBufferView,
         srcOffset: number, length?: number): void;
 
@@ -396,8 +392,8 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     compressedTexImage2D(target: number, level: number, internalformat: number, width: number,
         height: number, border: number, imageSize: number, offset: number): void;
     compressedTexImage2D(target: number, level: number, internalformat: number, width: number,
-        height: number, border: number, srcData: PixelData,
-        srcOffset?: number, srcLengthOverride?: number): void;
+        height: number, border: number, srcData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array |
+        Uint8ClampedArray | Float32Array | Float64Array | DataView | null, srcOffset?: number, srcLengthOverride?: number): void;
     // For compatibility with WebGL 1 context in older Typescript versions.
     compressedTexImage2D(target: number, level: number, internalformat: number, width: number,
         height: number, border: number, srcData: ArrayBufferView,
@@ -406,8 +402,8 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
         height: number, depth: number, border: number, imageSize: number, offset: number): void;
     compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
-        height: number, depth: number, border: number, srcData: PixelData,
-        srcOffset?: number, srcLengthOverride?: number): void;
+        height: number, depth: number, border: number, srcData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array |
+        Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | null, srcOffset?: number, srcLengthOverride?: number): void;
     // For compatibility with WebGL 1 context in older Typescript versions.
     compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
         height: number, depth: number, border: number, srcData: ArrayBufferView,
@@ -417,9 +413,8 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
         width: number, height: number, format: number, imageSize: number, offset: number): void;
     compressedTexSubImage2D(target: number, level: number, xoffset: number, yoffset: number,
         width: number, height: number, format: number,
-        srcData: PixelData | null,
-        srcOffset?: number,
-        srcLengthOverride?: number): void;
+        srcData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array |
+        Uint8ClampedArray | Float32Array | Float64Array | DataView | null | null, srcOffset?: number, srcLengthOverride?: number): void;
     // For compatibility with WebGL 1 context in older Typescript versions.
     compressedTexSubImage2D(target: number, level: number, xoffset: number, yoffset: number,
         width: number, height: number, format: number,
@@ -432,7 +427,7 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
         format: number, imageSize: number, offset: number): void;
     compressedTexSubImage3D(target: number, level: number, xoffset: number, yoffset: number,
         zoffset: number, width: number, height: number, depth: number,
-        format: number, srcData: PixelData,
+        format: number, srcData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | null,
         srcOffset?: number,
         srcLengthOverride?: number): void;
     // For compatibility with WebGL 1 context in older Typescript versions.
@@ -515,13 +510,14 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     /* Reading back pixels */
     // WebGL1:
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
-        dstData: PixelData): void;
-
+        dstData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray |
+        Float32Array | Float64Array | DataView | null): void;
     // WebGL2:
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
         offset: number): void;
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
-        dstData: PixelData, dstOffset: number): void;
+        dstData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray |
+        Float32Array | Float64Array | DataView | null, dstOffset: number): void;
 
     /* Multiple Render Targets */
     drawBuffers(buffers: number[]): void;

--- a/types/webgl2/index.d.ts
+++ b/types/webgl2/index.d.ts
@@ -402,10 +402,6 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
         height: number, depth: number, border: number, imageSize: number, offset: number): void;
     compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
-        height: number, depth: number, border: number, srcData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array |
-        Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | null, srcOffset?: number, srcLengthOverride?: number): void;
-    // For compatibility with WebGL 1 context in older Typescript versions.
-    compressedTexImage3D(target: number, level: number, internalformat: number, width: number,
         height: number, depth: number, border: number, srcData: ArrayBufferView,
         srcOffset?: number, srcLengthOverride?: number): void;
 
@@ -414,7 +410,7 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     compressedTexSubImage2D(target: number, level: number, xoffset: number, yoffset: number,
         width: number, height: number, format: number,
         srcData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array |
-        Uint8ClampedArray | Float32Array | Float64Array | DataView | null | null, srcOffset?: number, srcLengthOverride?: number): void;
+        Uint8ClampedArray | Float32Array | Float64Array | DataView | null, srcOffset?: number, srcLengthOverride?: number): void;
     // For compatibility with WebGL 1 context in older Typescript versions.
     compressedTexSubImage2D(target: number, level: number, xoffset: number, yoffset: number,
         width: number, height: number, format: number,
@@ -425,12 +421,6 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     compressedTexSubImage3D(target: number, level: number, xoffset: number, yoffset: number,
         zoffset: number, width: number, height: number, depth: number,
         format: number, imageSize: number, offset: number): void;
-    compressedTexSubImage3D(target: number, level: number, xoffset: number, yoffset: number,
-        zoffset: number, width: number, height: number, depth: number,
-        format: number, srcData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | null,
-        srcOffset?: number,
-        srcLengthOverride?: number): void;
-    // For compatibility with WebGL 1 context in older Typescript versions.
     compressedTexSubImage3D(target: number, level: number, xoffset: number, yoffset: number,
         zoffset: number, width: number, height: number, depth: number,
         format: number, srcData: ArrayBufferView,
@@ -448,7 +438,7 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
 
     uniform1fv(location: WebGLUniformLocation | null, data: Float32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
-    uniform2fv(location: WebGLUniformLocation, data: Float32Array | ArrayLike<number>, srcOffset?: number,
+    uniform2fv(location: WebGLUniformLocation | null, data: Float32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
     uniform3fv(location: WebGLUniformLocation | null, data: Float32Array | ArrayLike<number>, srcOffset?: number,
         srcLength?: number): void;
@@ -512,12 +502,14 @@ interface WebGL2RenderingContext extends WebGLRenderingContext {
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
         dstData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray |
         Float32Array | Float64Array | DataView | null): void;
+    // For compatibility with WebGL 1 context in older Typescript versions.
+    readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
+        dstData: ArrayBufferView | null): void;
     // WebGL2:
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
         offset: number): void;
     readPixels(x: number, y: number, width: number, height: number, format: number, type: number,
-        dstData: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray |
-        Float32Array | Float64Array | DataView | null, dstOffset: number): void;
+        dstData: ArrayBufferView, dstOffset: number): void;
 
     /* Multiple Render Targets */
     drawBuffers(buffers: number[]): void;


### PR DESCRIPTION
This PR adjusts the typings for WebGL2 to allow for better merging of method declarations between `WebGLRenderingContext` and `WebGL2RenderingContext` (which extends the former). 

Part of the problem here is that `WebGLRenderingContext` typings are generated automatically (as part of `lib.dom.d.ts`), and over time, some of the method signatures of `WebGLRenderingContext` have changed between typescript versions, e.g.:

```
compressedTexImage2D(target: number, level: number, internalformat: number, width: number, height: number, border: number, data: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | null): void;
``` 
in `typescript@2.8` and
```
compressedTexImage2D(target: number, level: number, internalformat: number, width: number, height: number, border: number, data: ArrayBufferView): void;
```
in `typescript@2.0`.

Without these changes, when working with union types like in the following example, the typescript compiler fails to merge the (intended) to be same method declarations between the two contexts:

```
type WebGLContext = WebGLRenderingContext | WebGL2RenderingContext;

const gl: WebGLContext = ...;

gl.compressedTexImage2D(...); // compile error here, failing to resolve the method signature
```