### PR TITLE
Add discriminated unions for GeoJSON types

### DIFF
--- a/types/geojson/geojson-tests.ts
+++ b/types/geojson/geojson-tests.ts
@@ -306,6 +306,11 @@ const collectionNoNull: FeatureCollection<Point, TestProperty> = {
     features: [featureNoNull],
 };
 
+const collectionDefault: FeatureCollection = {
+    type: "FeatureCollection",
+    features: []
+};
+
 isNull = featureAllNull.geometry;
 isPoint = featurePropertyNull.geometry;
 isNull = featureAllNull.properties;
@@ -322,3 +327,18 @@ isPropertyOrNull = collectionMaybeNull.features[0].properties;
 isPropertyOrNull = collectionPropertyMaybeNull.features[0].properties;
 isProperty = collectionGeometryMaybeNull.features[0].properties;
 isProperty = collectionNoNull.features[0].properties;
+
+for (const { geometry } of collectionDefault.features) {
+    switch (geometry.type) {
+        case "Point":
+            isPoint = geometry;
+            break;
+        case "GeometryCollection":
+            for (const child of geometry.geometries) {
+                if (child.type === "Point") {
+                    isPoint = child;
+                }
+            }
+            break;
+    }
+}

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -66,7 +66,7 @@ export interface GeoJsonObject {
 /**
  * Union of GeoJSON objects.
  */
-export type Object = Geometry | Feature | FeatureCollection;
+export type GeoJSON = Geometry | Feature | FeatureCollection;
 
 /**
  * A geometry object.

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -86,70 +86,63 @@ export type Geometry = Point | MultiPoint | LineString | Polygon | MultiPolygon 
  * Point geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.2
  */
-export interface Point {
+export interface Point extends GeometryObject {
     type: "Point";
     coordinates: Position;
-    bbox?: BBox;
 }
 
 /**
  * MultiPoint geometry object.
  *  https://tools.ietf.org/html/rfc7946#section-3.1.3
  */
-export interface MultiPoint {
+export interface MultiPoint extends GeometryObject {
     type: "MultiPoint";
     coordinates: Position[];
-    bbox?: BBox;
 }
 
 /**
  * LineString geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.4
  */
-export interface LineString {
+export interface LineString extends GeometryObject {
     type: "LineString";
     coordinates: Position[];
-    bbox?: BBox;
 }
 
 /**
  * MultiLineString geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.5
  */
-export interface MultiLineString {
+export interface MultiLineString extends GeometryObject {
     type: "MultiLineString";
     coordinates: Position[][];
-    bbox?: BBox;
 }
 
 /**
  * Polygon geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.6
  */
-export interface Polygon {
+export interface Polygon extends GeometryObject {
     type: "Polygon";
     coordinates: Position[][];
-    bbox?: BBox;
 }
 
 /**
  * MultiPolygon geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.7
  */
-export interface MultiPolygon {
+export interface MultiPolygon extends GeometryObject {
     type: "MultiPolygon";
     coordinates: Position[][][];
-    bbox?: BBox;
 }
 
 /**
  * Geometry Collection
  * https://tools.ietf.org/html/rfc7946#section-3.1.8
  */
-export interface GeometryCollection {
+export interface GeometryCollection extends GeometryObject {
     type: "GeometryCollection";
     geometries: Geometry[];
-    bbox?: BBox;
 }
 
 export type GeoJsonProperties = { [name: string]: any; } | null;
@@ -158,7 +151,7 @@ export type GeoJsonProperties = { [name: string]: any; } | null;
  * A feature object which contains a geometry and associated properties.
  * https://tools.ietf.org/html/rfc7946#section-3.2
  */
-export interface Feature<G extends GeometryObject | null = Geometry, P = GeoJsonProperties> {
+export interface Feature<G extends GeometryObject | null = Geometry, P = GeoJsonProperties> extends GeoJsonObject {
     type: "Feature";
     /**
      * The feature's geometry
@@ -173,18 +166,13 @@ export interface Feature<G extends GeometryObject | null = Geometry, P = GeoJson
      * Properties associated with this feature.
      */
     properties: P;
-    /**
-     * Bounding Box
-     */
-    bbox?: BBox;
 }
 
 /**
  * A collection of feature objects.
  *  https://tools.ietf.org/html/rfc7946#section-3.3
  */
-export interface FeatureCollection<G extends GeometryObject | null = Geometry, P = GeoJsonProperties> {
+export interface FeatureCollection<G extends GeometryObject | null = Geometry, P = GeoJsonProperties> extends GeoJsonObject {
     type: "FeatureCollection";
     features: Array<Feature<G, P>>;
-    bbox?: BBox;
 }

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Jacob Bruun <https://github.com/cobster>
 //                 Arne Schubert <https://github.com/atd-schubert>
 //                 Jeff Jacobson <https://github.com/JeffJacobson>
+//                 Ilia Choly <https://github.com/icholy>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.3
 

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -63,12 +63,23 @@ export interface GeoJsonObject {
 }
 
 /**
+ * Union of GeoJSON objects.
+ */
+export type Object = Geometry | Feature | FeatureCollection;
+
+/**
  * A geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3
  */
 export interface GeometryObject extends GeoJsonObject {
     type: GeoJsonGeometryTypes;
 }
+
+/**
+ * Union of geometry objects.
+ * https://tools.ietf.org/html/rfc7946#section-3
+ */
+export type Geometry = Point | MultiPoint | LineString | Polygon | MultiPolygon | GeometryCollection;
 
 /**
  * Point geometry object.
@@ -136,7 +147,7 @@ export interface MultiPolygon {
  */
 export interface GeometryCollection {
     type: "GeometryCollection";
-    geometries: Array<Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon>;
+    geometries: Geometry[];
     bbox?: BBox;
 }
 
@@ -146,7 +157,7 @@ export type GeoJsonProperties = { [name: string]: any; } | null;
  * A feature object which contains a geometry and associated properties.
  * https://tools.ietf.org/html/rfc7946#section-3.2
  */
-export interface Feature<G extends GeometryObject | null, P = GeoJsonProperties> {
+export interface Feature<G extends GeometryObject | null = Geometry, P = GeoJsonProperties> {
     type: "Feature";
     /**
      * The feature's geometry
@@ -171,7 +182,7 @@ export interface Feature<G extends GeometryObject | null, P = GeoJsonProperties>
  * A collection of feature objects.
  *  https://tools.ietf.org/html/rfc7946#section-3.3
  */
-export interface FeatureCollection<G extends GeometryObject | null, P = GeoJsonProperties> {
+export interface FeatureCollection<G extends GeometryObject | null = Geometry, P = GeoJsonProperties> {
     type: "FeatureCollection";
     features: Array<Feature<G, P>>;
     bbox?: BBox;

--- a/types/geojson/index.d.ts
+++ b/types/geojson/index.d.ts
@@ -74,63 +74,70 @@ export interface GeometryObject extends GeoJsonObject {
  * Point geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.2
  */
-export interface Point extends GeometryObject {
+export interface Point {
     type: "Point";
     coordinates: Position;
+    bbox?: BBox;
 }
 
 /**
  * MultiPoint geometry object.
  *  https://tools.ietf.org/html/rfc7946#section-3.1.3
  */
-export interface MultiPoint extends GeometryObject {
+export interface MultiPoint {
     type: "MultiPoint";
     coordinates: Position[];
+    bbox?: BBox;
 }
 
 /**
  * LineString geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.4
  */
-export interface LineString extends GeometryObject {
+export interface LineString {
     type: "LineString";
     coordinates: Position[];
+    bbox?: BBox;
 }
 
 /**
  * MultiLineString geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.5
  */
-export interface MultiLineString extends GeometryObject {
+export interface MultiLineString {
     type: "MultiLineString";
     coordinates: Position[][];
+    bbox?: BBox;
 }
 
 /**
  * Polygon geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.6
  */
-export interface Polygon extends GeometryObject {
+export interface Polygon {
     type: "Polygon";
     coordinates: Position[][];
+    bbox?: BBox;
 }
 
 /**
  * MultiPolygon geometry object.
  * https://tools.ietf.org/html/rfc7946#section-3.1.7
  */
-export interface MultiPolygon extends GeometryObject {
+export interface MultiPolygon {
     type: "MultiPolygon";
     coordinates: Position[][][];
+    bbox?: BBox;
 }
 
 /**
  * Geometry Collection
  * https://tools.ietf.org/html/rfc7946#section-3.1.8
  */
-export interface GeometryCollection extends GeometryObject {
+export interface GeometryCollection {
     type: "GeometryCollection";
     geometries: Array<Point | LineString | Polygon | MultiPoint | MultiLineString | MultiPolygon>;
+    bbox?: BBox;
 }
 
 export type GeoJsonProperties = { [name: string]: any; } | null;
@@ -139,7 +146,7 @@ export type GeoJsonProperties = { [name: string]: any; } | null;
  * A feature object which contains a geometry and associated properties.
  * https://tools.ietf.org/html/rfc7946#section-3.2
  */
-export interface Feature<G extends GeometryObject | null, P = GeoJsonProperties> extends GeoJsonObject {
+export interface Feature<G extends GeometryObject | null, P = GeoJsonProperties> {
     type: "Feature";
     /**
      * The feature's geometry
@@ -154,13 +161,18 @@ export interface Feature<G extends GeometryObject | null, P = GeoJsonProperties>
      * Properties associated with this feature.
      */
     properties: P;
+    /**
+     * Bounding Box
+     */
+    bbox?: BBox;
 }
 
 /**
  * A collection of feature objects.
  *  https://tools.ietf.org/html/rfc7946#section-3.3
  */
-export interface FeatureCollection<G extends GeometryObject | null, P = GeoJsonProperties> extends GeoJsonObject {
+export interface FeatureCollection<G extends GeometryObject | null, P = GeoJsonProperties> {
     type: "FeatureCollection";
     features: Array<Feature<G, P>>;
+    bbox?: BBox;
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: http://www.typescriptlang.org/docs/handbook/advanced-types.html
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
