### PR TITLE
[recompose] Add aliases to recompose sub modules.

### DIFF
--- a/types/recompose/index.d.ts
+++ b/types/recompose/index.d.ts
@@ -1,9 +1,10 @@
-// Type definitions for Recompose 0.24
+// Type definitions for Recompose 0.26
 // Project: https://github.com/acdlite/recompose
 // Definitions by: Iskander Sierra <https://github.com/iskandersierra>
 //                 Samuel DeSota <https://github.com/mrapogee>
 //                 Curtis Layne <https://github.com/clayne11>
 //                 Rasmus Eneman <https://github.com/Pajn>
+//                 Lucas Terra <https://github.com/lucasterra>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.6
 
@@ -452,4 +453,250 @@ declare module 'recompose/kefirObservableConfig' {
     const kefirConfig: ObservableConfig;
 
     export default kefirConfig;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#mapprops
+declare module 'recompose/mapProps' {
+    import { mapProps } from 'recompose';
+    export default mapProps;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#withprops
+declare module 'recompose/withProps' {
+    import { withProps } from 'recompose';
+    export default withProps;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#withpropsonchange
+declare module 'recompose/withPropsOnChange' {
+    import { withPropsOnChange } from 'recompose';
+    export default withPropsOnChange;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#withhandlers
+declare module 'recompose/withHandlers' {
+    import { withHandlers } from 'recompose';
+    export default withHandlers;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#defaultprops
+declare module 'recompose/defaultProps' {
+    import { defaultProps } from 'recompose';
+    export default defaultProps;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#renameprop
+declare module 'recompose/renameProp' {
+    import { renameProp } from 'recompose';
+    export default renameProp;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#renameprops
+declare module 'recompose/renameProps' {
+    import { renameProps } from 'recompose';
+    export default renameProps;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#flattenprop
+declare module 'recompose/flattenProp' {
+    import { flattenProp } from 'recompose';
+    export default flattenProp;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#withstate
+declare module 'recompose/withState' {
+    import { withState } from 'recompose';
+    export default withState;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#withstatehandlers
+declare module 'recompose/withStateHandlers' {
+    import { withStateHandlers } from 'recompose';
+    export default withStateHandlers;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#withreducer
+declare module 'recompose/withReducer' {
+    import { withReducer } from 'recompose';
+    export default withReducer;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#branch
+declare module 'recompose/branch' {
+    import { branch } from 'recompose';
+    export default branch;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#rendercomponent
+declare module 'recompose/renderComponent' {
+    import { renderComponent } from 'recompose';
+    export default renderComponent;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#rendernothing
+declare module 'recompose/renderNothing' {
+    import { renderNothing } from 'recompose';
+    export default renderNothing;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#shouldupdate
+declare module 'recompose/shouldUpdate' {
+    import { shouldUpdate } from 'recompose';
+    export default shouldUpdate;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#pure
+declare module 'recompose/pure' {
+    import { pure } from 'recompose';
+    export default pure;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#onlyupdateforkeys
+declare module 'recompose/onlyUpdateForKeys' {
+    import { onlyUpdateForKeys } from 'recompose';
+    export default onlyUpdateForKeys;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#onlyupdateforproptypes
+declare module 'recompose/onlyUpdateForPropTypes' {
+    import { onlyUpdateForPropTypes } from 'recompose';
+    export default onlyUpdateForPropTypes;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#withcontext
+declare module 'recompose/withContext' {
+    import { withContext } from 'recompose';
+    export default withContext;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#getcontext
+declare module 'recompose/getContext' {
+    import { getContext } from 'recompose';
+    export default getContext;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#lifecycle
+declare module 'recompose/lifecycle' {
+    import { lifecycle } from 'recompose';
+    export default lifecycle;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#toclass
+declare module 'recompose/toClass' {
+    import { toClass } from 'recompose';
+    export default toClass;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#setstatic
+declare module 'recompose/setStatic' {
+    import { setStatic } from 'recompose';
+    export default setStatic;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#setproptypes
+declare module 'recompose/setPropTypes' {
+    import { setPropTypes } from 'recompose';
+    export default setPropTypes;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#setdisplayname
+declare module 'recompose/setDisplayName' {
+    import { setDisplayName } from 'recompose';
+    export default setDisplayName;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#compose
+declare module 'recompose/compose' {
+    import { compose } from 'recompose';
+    export default compose;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#getdisplayname
+declare module 'recompose/getDisplayName' {
+    import { getDisplayName } from 'recompose';
+    export default getDisplayName;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#wrapdisplayname
+declare module 'recompose/wrapDisplayName' {
+    import { wrapDisplayName } from 'recompose';
+    export default wrapDisplayName;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#shallowequal
+declare module 'recompose/shallowEqual' {
+    import { shallowEqual } from 'recompose';
+    export default shallowEqual;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#isclasscomponent
+declare module 'recompose/isClassComponent' {
+    import { isClassComponent } from 'recompose';
+    export default isClassComponent;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#createsink
+declare module 'recompose/createSink' {
+    import { createSink } from 'recompose';
+    export default createSink;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#componentfromprop
+declare module 'recompose/componentFromProp' {
+    import { componentFromProp } from 'recompose';
+    export default componentFromProp;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#nest
+declare module 'recompose/nest' {
+    import { nest } from 'recompose';
+    export default nest;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#hoiststatics
+declare module 'recompose/hoistStatics' {
+    import { hoistStatics } from 'recompose';
+    export default hoistStatics;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#componentfromstream
+declare module 'recompose/componentFromStream' {
+    import { componentFromStream } from 'recompose';
+    export default componentFromStream;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#componentfromstreamwithconfig
+declare module 'recompose/componentFromStreamWithConfig' {
+    import { componentFromStreamWithConfig } from 'recompose';
+    export default componentFromStreamWithConfig;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#mappropsstream
+declare module 'recompose/mapPropsStream' {
+    import { mapPropsStream } from 'recompose';
+    export default mapPropsStream;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#mappropsstreamwithconfig
+declare module 'recompose/mapPropsStreamWithConfig' {
+    import { mapPropsStreamWithConfig } from 'recompose';
+    export default mapPropsStreamWithConfig;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#createeventhandler
+declare module 'recompose/createEventHandler' {
+    import { createEventHandler } from 'recompose';
+    export default createEventHandler;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#createeventhandlerwithconfig
+declare module 'recompose/createEventHandlerWithConfig' {
+    import { createEventHandlerWithConfig } from 'recompose';
+    export default createEventHandlerWithConfig;
+}
+
+// https://github.com/acdlite/recompose/blob/master/docs/API.md#setobservableconfig
+declare module 'recompose/setObservableConfig' {
+    import { setObservableConfig } from 'recompose';
+    export default setObservableConfig;
 }

--- a/types/recompose/recompose-tests.tsx
+++ b/types/recompose/recompose-tests.tsx
@@ -28,6 +28,48 @@ import xstreamConfig from "recompose/xstreamObservableConfig";
 import baconConfig from "recompose/baconObservableConfig";
 import kefirConfig from "recompose/kefirObservableConfig";
 
+import mapPropsStandalone from "recompose/mapProps";
+import withPropsStandalone from "recompose/withProps";
+import withPropsOnChangeStandalone from "recompose/withPropsOnChange";
+import withHandlersStandalone from "recompose/withHandlers";
+import defaultPropsStandalone from "recompose/defaultProps";
+import renamePropStandalone from "recompose/renameProp";
+import renamePropsStandalone from "recompose/renameProps";
+import flattenPropStandalone from "recompose/flattenProp";
+import withStateStandalone from "recompose/withState";
+import withStateHandlersStandalone from "recompose/withStateHandlers";
+import withReducerStandalone from "recompose/withReducer";
+import branchStandalone from "recompose/branch";
+import renderComponentStandalone from "recompose/renderComponent";
+import renderNothingStandalone from "recompose/renderNothing";
+import shouldUpdateStandalone from "recompose/shouldUpdate";
+import pureStandalone from "recompose/pure";
+import onlyUpdateForKeysStandalone from "recompose/onlyUpdateForKeys";
+import onlyUpdateForPropTypesStandalone from "recompose/onlyUpdateForPropTypes";
+import withContextStandalone from "recompose/withContext";
+import getContextStandalone from "recompose/getContext";
+import lifecycleStandalone from "recompose/lifecycle";
+import toClassStandalone from "recompose/toClass";
+import setStaticStandalone from "recompose/setStatic";
+import setPropTypesStandalone from "recompose/setPropTypes";
+import setDisplayNameStandalone from "recompose/setDisplayName";
+import composeStandalone from "recompose/compose";
+import getDisplayNameStandalone from "recompose/getDisplayName";
+import wrapDisplayNameStandalone from "recompose/wrapDisplayName";
+import shallowEqualStandalone from "recompose/shallowEqual";
+import isClassComponentStandalone from "recompose/isClassComponent";
+import createSinkStandalone from "recompose/createSink";
+import componentFromPropStandalone from "recompose/componentFromProp";
+import nestStandalone from "recompose/nest";
+import hoistStaticsStandalone from "recompose/hoistStatics";
+import componentFromStreamStandalone from "recompose/componentFromStream";
+import componentFromStreamWithConfigStandalone from "recompose/componentFromStreamWithConfig";
+import mapPropsStreamStandalone from "recompose/mapPropsStream";
+import mapPropsStreamWithConfigStandalone from "recompose/mapPropsStreamWithConfig";
+import createEventHandlerStandalone from "recompose/createEventHandler";
+import createEventHandlerWithConfigStandalone from "recompose/createEventHandlerWithConfig";
+import setObservableConfigStandalone from "recompose/setObservableConfig";
+
 function testMapProps() {
     interface InnerProps {
         inn: number


### PR DESCRIPTION
This PR adds aliases for importing submodules from [recompose](https://github.com/acdlite/recompose).
Basically, you can import a function like this:
```js
import { compose } from 'recompose'; // this works currently
import compose from 'recompose/compose'; // this does not work at the moment, this PR fixes it
```

-------


Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: [modules aliasing](https://github.com/acdlite/recompose#build-your-own-libraries) and [optimizing bundle size](https://github.com/acdlite/recompose#optimizing-bundle-size)
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
