### PR TITLE
Add INgModelController to IDirectiveLinkFn Controller (#19933)

### DIFF
--- a/types/angular/index.d.ts
+++ b/types/angular/index.d.ts
@@ -1998,7 +1998,7 @@ declare namespace angular {
             scope: TScope,
             instanceElement: JQLite,
             instanceAttributes: IAttributes,
-            controller?: IController | IController[] | {[key: string]: IController},
+            controller?: IController | IController[] | {[key: string]: IController} | INgModelController | INgModelController[] | {[key: string]: INgModelController},
             transclude?: ITranscludeFunction
         ): void;
     }


### PR DESCRIPTION
Allow `IDirectiveLinkFn` controller type to be `INgModelController`.

Fixes: Issue #19933

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19933