### PR TITLE
[react-map-gl] add proper default export

### DIFF
--- a/types/react-map-gl/index.d.ts
+++ b/types/react-map-gl/index.d.ts
@@ -221,6 +221,8 @@ export class InteractiveMap extends React.Component<InteractiveMapProps> {
     queryRenderedFeatures(geometry?: MapboxGL.PointLike | MapboxGL.PointLike[], parameters?: QueryRenderedFeaturesParams): Array<GeoJSON.Feature<GeoJSON.GeometryObject>>;
 }
 
+export default InteractiveMap;
+
 /**
  *
  * React Map Overlays


### PR DESCRIPTION
Exports InteractiveMap as default export. Forgot this in the previous PR, sorry!