### PR TITLE
ember-data: Fix DS.Model.belongsTo and DS.Model.hasMany types

### DIFF
--- a/types/ember-data/index.d.ts
+++ b/types/ember-data/index.d.ts
@@ -521,11 +521,11 @@ declare module 'ember-data' {
             /**
              * Get the reference for the specified belongsTo relationship.
              */
-            belongsTo(name: keyof ModelRegistry): BelongsToReference;
+            belongsTo(name: RelationshipsFor<this>): BelongsToReference;
             /**
              * Get the reference for the specified hasMany relationship.
              */
-            hasMany(name: keyof ModelRegistry): HasManyReference<any>;
+            hasMany(name: RelationshipsFor<this>): HasManyReference<any>;
             /**
              * Given a callback, iterates over each of the relationships in the model,
              * invoking the callback with the name of each relationship and its relationship

--- a/types/ember-data/test/relationships.ts
+++ b/types/ember-data/test/relationships.ts
@@ -16,17 +16,23 @@ class Comment extends DS.Model {
     author = DS.attr('string');
 }
 
+class Series extends DS.Model {
+    title = DS.attr('string');
+}
+
 class RelationalPost extends DS.Model {
     title = DS.attr('string');
     tag = DS.attr('string');
     comments = DS.hasMany('comment', { async: true });
     relatedPosts = DS.hasMany('post');
+    series = DS.belongsTo('series');
 }
 
 declare module 'ember-data' {
     interface ModelRegistry {
         'relational-post': RelationalPost;
         comment: Comment;
+        series: Series;
     }
 }
 
@@ -35,3 +41,6 @@ blogPost!.get('comments').then((comments) => {
     // now we can work with the comments
     let author: string = comments.get('firstObject')!.get('author');
 });
+
+blogPost!.hasMany('relatedPosts');
+blogPost!.belongsTo('series');


### PR DESCRIPTION
Fix an error stemming from too many things named `belongsTo` and `hasMany`. The ones on `DS.Model` currently expect the name of a model (like `DS.belongsTo` does), but it should expect the name of a relationship (like `DS.Snapshot.belongsTo` does).

----

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://www.emberjs.com/api/ember-data/release/classes/DS.Model/methods?anchor=belongsTo
https://www.emberjs.com/api/ember-data/3.0/classes/DS.Model/methods/hasMany?anchor=hasMany
- [x] Increase the version number in the header if appropriate.
- [x] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
