### PR TITLE
React intl JSX.Element values

### DIFF
--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -142,7 +142,7 @@ declare namespace ReactIntl {
         interface Props extends MessageDescriptor {
             values?: {[key: string]: MessageValue | JSX.Element};
             tagName?: string;
-            children?: (...formattedMessage: string[]) => React.ReactNode;
+            children?: (...formattedMessage: (string | JSX.Element)[]) => React.ReactNode;
         }
     }
     class FormattedMessage extends React.Component<FormattedMessage.Props> { }

--- a/types/react-intl/index.d.ts
+++ b/types/react-intl/index.d.ts
@@ -142,7 +142,7 @@ declare namespace ReactIntl {
         interface Props extends MessageDescriptor {
             values?: {[key: string]: MessageValue | JSX.Element};
             tagName?: string;
-            children?: (...formattedMessage: (string | JSX.Element)[]) => React.ReactNode;
+            children?: (...formattedMessage: Array<string | JSX.Element>) => React.ReactNode;
         }
     }
     class FormattedMessage extends React.Component<FormattedMessage.Props> { }

--- a/types/react-intl/react-intl-tests.tsx
+++ b/types/react-intl/react-intl-tests.tsx
@@ -154,7 +154,7 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 id="test"
                 description="Test"
             >
-                {(text) => <input placeholder={text} />}
+                {(text) => <input placeholder={text as string} />}
             </FormattedMessage>
 
             <FormattedMessage
@@ -162,6 +162,24 @@ class SomeComponent extends React.Component<SomeComponentProps & InjectedIntlPro
                 description="Test"
             >
                 {(...text) => <ul>{text.map(t => <li>{t}</li>)}</ul>}
+            </FormattedMessage>
+
+            <FormattedMessage
+                id="legal-statement"
+                values={{
+                    privacy_policy: (
+                        <a href="/privacy-policy">
+                            <FormattedMessage id="request_invite.privacy_policy" />
+                        </a>
+                    ),
+                    terms_of_service: (
+                        <a href="/terms-of-service">
+                            <FormattedMessage id="request_invite.terms_of_service" />
+                        </a>
+                    )
+                }}
+            >
+                {(...messages) => messages.map(message => <>{message}</>)}
             </FormattedMessage>
 
             <FormattedHTMLMessage


### PR DESCRIPTION
This documentation says that children can be React Elements:

https://github.com/yahoo/react-intl/wiki/Components#formattedmessage

I also saw this working code in a repo I'm working on, which doesn't use string values, and therefore gets rendered not as strings either:

```
          <FormattedMessage
            id="request_invite.terms"
            values={{
              code_of_conduct: (
                <a href="/code-of-conduct">
                  <FormattedMessage id="request_invite.code_of_conduct" />
                </a>
              ),
              privacy_policy: (
                <a href="/privacy-policy">
                  <FormattedMessage id="request_invite.privacy_policy" />
                </a>
              ),
              terms_of_service: (
                <a href="/terms-of-service">
                  <FormattedMessage id="request_invite.terms_of_service" />
                </a>
              )
            }}
          />
```

When I changed that to have a custom render function passed in thru children, the messages were a combination of strings and JSX elements.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [N/A] Increase the version number in the header if appropriate.
- [N/A] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
