### PR TITLE
hset can have an array as the 1st param

### DIFF
--- a/types/redis/index.d.ts
+++ b/types/redis/index.d.ts
@@ -514,6 +514,8 @@ export interface Commands<R> {
      */
     hset(key: string, field: string, value: string, cb?: Callback<number>): R;
     HSET(key: string, field: string, value: string, cb?: Callback<number>): R;
+    hset(setArr:Array<string>,cb? Callback<number>): R;
+    HSET(setArr:Array<string>,cb? Callback<number>): R;
 
     /**
      * Set the value of a hash field, only if the field does not exist.


### PR DESCRIPTION
hset can have an array as the 1st param as the offical example shows.
